### PR TITLE
feat(ir): add TensorExpr base class with TensorVar support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,4 @@ repos:
       hooks:
       - id: pyright
         additional_dependencies: [pytest==7.0.0]
+        exclude: ^tests/

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_EXPR_H_
 
 #include <memory>
+#include <utility>
 
 #include "pypto/ir/core.h"
 
@@ -52,4 +53,3 @@ using ExprPtr = std::shared_ptr<const Expr>;
 }  // namespace pypto
 
 #endif  // PYPTO_IR_EXPR_H_
-

--- a/include/pypto/ir/reflection/field_visitor.h
+++ b/include/pypto/ir/reflection/field_visitor.h
@@ -39,8 +39,8 @@ struct IsExprField : std::false_type {};
 
 // Generic specialization for any shared_ptr<const T> where T derives from Expr
 template <typename ExprType>
-struct IsExprField<std::shared_ptr<const ExprType>, 
-                   std::enable_if_t<std::is_base_of_v<Expr, ExprType>>> : std::true_type {};
+struct IsExprField<std::shared_ptr<const ExprType>, std::enable_if_t<std::is_base_of_v<Expr, ExprType>>>
+    : std::true_type {};
 
 /**
  * @brief Type trait to check if a type is std::vector of expression pointers

--- a/include/pypto/ir/scalar_expr.h
+++ b/include/pypto/ir/scalar_expr.h
@@ -95,7 +95,8 @@ class Var : public ScalarExpr {
    * @param span Source location
    * @return Shared pointer to const Var expression
    */
-  Var(std::string name, DataType dtype, Span span) : ScalarExpr(std::move(span), dtype), name_(std::move(name)) {}
+  Var(std::string name, DataType dtype, Span span)
+      : ScalarExpr(std::move(span), dtype), name_(std::move(name)) {}
 
   [[nodiscard]] const char* type_name() const override { return "Var"; }
 
@@ -151,7 +152,7 @@ using ConstIntPtr = std::shared_ptr<const ConstInt>;
  */
 class Call : public ScalarExpr {
  public:
-  OpPtr op_;                          // Operation/function
+  OpPtr op_;                         // Operation/function
   std::vector<ScalarExprPtr> args_;  // Arguments
 
   /**
@@ -209,15 +210,15 @@ using BinaryExprPtr = std::shared_ptr<const BinaryExpr>;
 
 // Macro to define binary expression node classes
 // Usage: DEFINE_BINARY_EXPR_NODE(Add, "Addition expression (left + right)")
-#define DEFINE_BINARY_EXPR_NODE(OpName, Description)                                       \
-  /* Description */                                                                        \
-  class OpName : public BinaryExpr {                                                       \
-   public:                                                                                 \
-    OpName(ScalarExprPtr left, ScalarExprPtr right, DataType dtype, Span span)             \
-        : BinaryExpr(std::move(left), std::move(right), dtype, std::move(span)) {}         \
-    [[nodiscard]] const char* type_name() const override { return #OpName; }               \
-  };                                                                                       \
-                                                                                           \
+#define DEFINE_BINARY_EXPR_NODE(OpName, Description)                               \
+  /* Description */                                                                \
+  class OpName : public BinaryExpr {                                               \
+   public:                                                                         \
+    OpName(ScalarExprPtr left, ScalarExprPtr right, DataType dtype, Span span)     \
+        : BinaryExpr(std::move(left), std::move(right), dtype, std::move(span)) {} \
+    [[nodiscard]] const char* type_name() const override { return #OpName; }       \
+  };                                                                               \
+                                                                                   \
   using OpName##Ptr = std::shared_ptr<const OpName>;
 
 DEFINE_BINARY_EXPR_NODE(Add, "Addition expression (left + right)");

--- a/include/pypto/ir/tensor_expr.h
+++ b/include/pypto/ir/tensor_expr.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TENSOR_EXPR_H_
+#define PYPTO_IR_TENSOR_EXPR_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/ir/core.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/reflection/field_traits.h"
+#include "pypto/ir/scalar_expr.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Base class for tensor expressions in the IR
+ *
+ * Tensor expressions represent computations that produce tensor values.
+ * All expressions are immutable.
+ */
+class TensorExpr : public Expr {
+ public:
+  DataType dtype_;                    // Element data type
+  std::vector<ScalarExprPtr> shape_;  // Shape dimensions (symbolic or constant)
+
+  /**
+   * @brief Create a tensor expression
+   *
+   * @param span Source location
+   * @param dtype Element data type
+   * @param shape Shape dimensions
+   */
+  TensorExpr(Span s, DataType dtype, std::vector<ScalarExprPtr> shape)
+      : Expr(std::move(s)), dtype_(dtype), shape_(std::move(shape)) {}
+  ~TensorExpr() override = default;
+
+  /**
+   * @brief Get the type name of this expression
+   *
+   * @return Human-readable type name (e.g., "TensorAdd", "TensorVar")
+   */
+  [[nodiscard]] const char* type_name() const override { return "TensorExpr"; }
+
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Expr::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&TensorExpr::dtype_, "dtype"),
+                                          reflection::UsualField(&TensorExpr::shape_, "shape")));
+  }
+};
+
+using TensorExprPtr = std::shared_ptr<const TensorExpr>;
+
+/**
+ * @brief Tensor variable reference expression
+ *
+ * Represents a reference to a named tensor variable.
+ */
+class TensorVar : public TensorExpr {
+ public:
+  std::string name_;
+
+  /**
+   * @brief Create a tensor variable reference
+   *
+   * @param name Variable name
+   * @param dtype Element data type
+   * @param shape Shape dimensions
+   * @param span Source location
+   * @return Shared pointer to const TensorVar expression
+   */
+  TensorVar(std::string name, DataType dtype, std::vector<ScalarExprPtr> shape, Span span)
+      : TensorExpr(std::move(span), dtype, std::move(shape)), name_(std::move(name)) {}
+
+  [[nodiscard]] const char* type_name() const override { return "TensorVar"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(TensorExpr::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&TensorVar::name_, "name")));
+  }
+};
+
+using TensorVarPtr = std::shared_ptr<const TensorVar>;
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TENSOR_EXPR_H_

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -16,6 +16,7 @@
 
 #include "pypto/core/error.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tensor_expr.h"
 
 namespace pypto {
 namespace ir {
@@ -81,6 +82,9 @@ class ExprFunctor {
   virtual R VisitExpr_(const NegPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const NotPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const BitNotPtr& op, Args... args) = 0;
+
+  // Tensor expressions
+  virtual R VisitExpr_(const TensorVarPtr& op, Args... args) = 0;
 };
 
 // Macro to dispatch based on expression type
@@ -126,6 +130,9 @@ R ExprFunctor<R, Args...>::VisitExpr(const ExprPtr& expr, Args... args) {
   EXPR_FUNCTOR_DISPATCH(Neg);
   EXPR_FUNCTOR_DISPATCH(Not);
   EXPR_FUNCTOR_DISPATCH(BitNot);
+
+  // Tensor expressions
+  EXPR_FUNCTOR_DISPATCH(TensorVar);
 
   // Should never reach here if all types are handled
   throw pypto::TypeError("Unknown expression type in ExprFunctor::VisitExpr");

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -66,6 +66,9 @@ class ExprMutator : public ExprFunctor<ExprPtr> {
   ExprPtr VisitExpr_(const NegPtr& op) override;
   ExprPtr VisitExpr_(const NotPtr& op) override;
   ExprPtr VisitExpr_(const BitNotPtr& op) override;
+
+  // Tensor expressions - reconstruct with mutated children
+  ExprPtr VisitExpr_(const TensorVarPtr& op) override;
 };
 
 }  // namespace ir

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -66,6 +66,20 @@ class ExprVisitor : public ExprFunctor<void> {
   void VisitExpr_(const NegPtr& op) override;
   void VisitExpr_(const NotPtr& op) override;
   void VisitExpr_(const BitNotPtr& op) override;
+
+  // Tensor expressions - visit tensor nodes
+  void VisitExpr_(const TensorVarPtr& op) override;
+
+ private:
+  /**
+   * @brief Helper to visit both children of a binary expression
+   */
+  void VisitBinaryOp_(const BinaryExprPtr& op);
+
+  /**
+   * @brief Helper to visit the operand of a unary expression
+   */
+  void VisitUnaryOp_(const UnaryExprPtr& op);
 };
 
 }  // namespace ir

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -528,7 +528,7 @@ class BitNot(UnaryExpr):
             span: Source location
         """
 
-def structural_hash(expr: ScalarExpr, enable_auto_mapping: bool = False) -> int:
+def structural_hash(expr: Expr, enable_auto_mapping: bool = False) -> int:
     """Compute structural hash of an expression.
 
     Ignores source location (Span). Two expressions with identical structure hash to the same value.
@@ -543,7 +543,7 @@ def structural_hash(expr: ScalarExpr, enable_auto_mapping: bool = False) -> int:
         Hash value of the expression structure
     """
 
-def structural_equal(lhs: ScalarExpr, rhs: ScalarExpr, enable_auto_mapping: bool = False) -> bool:
+def structural_equal(lhs: Expr, rhs: Expr, enable_auto_mapping: bool = False) -> bool:
     """Check if two expressions are structurally equal.
 
     Ignores source location (Span). Returns True if expressions have identical structure.
@@ -558,3 +558,30 @@ def structural_equal(lhs: ScalarExpr, rhs: ScalarExpr, enable_auto_mapping: bool
     Returns:
         True if expressions are structurally equal, False otherwise
     """
+
+# ========== Tensor Expressions ==========
+
+class TensorExpr(Expr):
+    """Base class for all tensor expressions."""
+
+    dtype: Final[DataType]
+    """Element data type."""
+
+    shape: Final[List[ScalarExpr]]
+    """Shape dimensions (symbolic or constant)."""
+
+class TensorVar(TensorExpr):
+    """Tensor variable reference."""
+
+    name: Final[str]
+    """Variable name."""
+
+    def __init__(self, name: str, dtype: DataType, shape: List[ScalarExpr], span: Span) -> None:
+        """Create a tensor variable reference.
+
+        Args:
+            name: Variable name
+            dtype: Element data type
+            shape: Shape dimensions
+            span: Source location
+        """

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -19,6 +19,8 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tensor_expr.h"
+#include "pypto/ir/transform/base/functor.h"
 #include "pypto/ir/transform/transformers.h"
 
 namespace pypto {
@@ -159,7 +161,7 @@ int64_t StructuralHasher::HashExpr(const ExprPtr& expr) {
     return HashVar(var);
   }
 
-  // All other types use generic field-based hashing
+  // All other scalar expr types use generic field-based hashing
   HASH_DISPATCH(ConstInt)
   HASH_DISPATCH(Call)
 
@@ -171,6 +173,9 @@ int64_t StructuralHasher::HashExpr(const ExprPtr& expr) {
   if (auto unary = std::dynamic_pointer_cast<const UnaryExpr>(expr)) {
     return HashNode(unary);
   }
+
+  // Tensor expressions
+  HASH_DISPATCH(TensorVar)
 
   // Unknown type - return hash of type name
   throw pypto::TypeError("Unknown expression type in StructuralHasher::HashExpr");

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -13,6 +13,7 @@
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tensor_expr.h"
 
 namespace pypto {
 namespace ir {
@@ -86,6 +87,14 @@ DEFINE_UNARY_VISITOR(Not)
 DEFINE_UNARY_VISITOR(BitNot)
 
 #undef DEFINE_UNARY_VISITOR
+
+// Tensor expressions
+void ExprVisitor::VisitExpr_(const TensorVarPtr& op) {
+  // Leaf node, but need to visit shape expressions
+  for (const auto& dim : op->shape_) {
+    VisitExpr(dim);
+  }
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/tests/ut/ir/test_tensor_expr.py
+++ b/tests/ut/ir/test_tensor_expr.py
@@ -1,0 +1,204 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for TensorExpr IR nodes (TensorVar only)."""
+
+import pytest
+from pypto import DataType
+from pypto.pypto_core import ir
+
+
+class TestTensorVar:
+    """Test cases for TensorVar."""
+
+    def test_creation_with_constant_shape(self):
+        """Test TensorVar creation with constant dimensions."""
+        span = ir.Span.unknown()
+        shape = [
+            ir.ConstInt(2, DataType.INT32, span),
+            ir.ConstInt(3, DataType.INT32, span),
+            ir.ConstInt(4, DataType.INT32, span),
+        ]
+
+        tensor_var = ir.TensorVar("A", DataType.FP32, shape, span)
+
+        assert tensor_var.name == "A"
+        assert tensor_var.dtype == DataType.FP32
+        assert len(tensor_var.shape) == 3
+        assert isinstance(tensor_var, ir.TensorExpr)
+        assert isinstance(tensor_var, ir.Expr)
+
+    def test_creation_with_symbolic_shape(self):
+        """Test TensorVar with symbolic shape dimensions."""
+        span = ir.Span.unknown()
+        # Create symbolic shape with Var nodes
+        N = ir.Var("N", DataType.INT32, span)
+        M = ir.Var("M", DataType.INT32, span)
+        K = ir.Var("K", DataType.INT32, span)
+        shape = [N, M, K]
+
+        tensor_var = ir.TensorVar("B", DataType.FP16, shape, span)
+
+        assert tensor_var.name == "B"
+        assert tensor_var.dtype == DataType.FP16
+        assert len(tensor_var.shape) == 3
+        # Check that shape contains symbolic expressions
+        assert all(isinstance(dim, ir.ScalarExpr) for dim in tensor_var.shape)
+
+    def test_different_dtypes(self):
+        """Test TensorVar with different data types."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT32, span)]
+
+        for dtype in [DataType.FP32, DataType.FP16, DataType.INT32, DataType.BOOL]:
+            tensor = ir.TensorVar("T", dtype, shape, span)
+            assert tensor.dtype == dtype
+
+    def test_scalar_shape_dimensions(self):
+        """Test tensor with scalar (0-D) shape."""
+        span = ir.Span.unknown()
+        shape = []  # Scalar tensor
+
+        scalar_tensor = ir.TensorVar("scalar", DataType.FP32, shape, span)
+        assert len(scalar_tensor.shape) == 0
+
+    def test_high_dimensional_tensor(self):
+        """Test tensor with many dimensions."""
+        span = ir.Span.unknown()
+        # 5D tensor
+        shape = [ir.ConstInt(i + 1, DataType.INT32, span) for i in range(5)]
+
+        tensor = ir.TensorVar("T", DataType.FP32, shape, span)
+        assert len(tensor.shape) == 5
+
+    def test_mixed_symbolic_constant_shape(self):
+        """Test tensor with mixed symbolic and constant dimensions."""
+        span = ir.Span.unknown()
+        N = ir.Var("N", DataType.INT32, span)
+        shape = [
+            ir.ConstInt(2, DataType.INT32, span),  # Constant
+            N,  # Symbolic
+            ir.ConstInt(4, DataType.INT32, span),  # Constant
+        ]
+
+        tensor = ir.TensorVar("T", DataType.FP32, shape, span)
+        assert len(tensor.shape) == 3
+        assert isinstance(tensor.shape[0], ir.ConstInt)
+        assert isinstance(tensor.shape[1], ir.Var)
+        assert isinstance(tensor.shape[2], ir.ConstInt)
+
+
+class TestTensorVarStructuralEqual:
+    """Test cases for structural equality of TensorVar."""
+
+    def test_tensor_var_equality_same_instance(self):
+        """Test structural equality for same TensorVar instance."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span), ir.ConstInt(3, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape, span)
+
+        assert ir.structural_equal(A, A)
+
+    def test_tensor_var_equality_different_instances(self):
+        """Test structural equality for different TensorVar instances."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span), ir.ConstInt(3, DataType.INT32, span)]
+
+        A1 = ir.TensorVar("A", DataType.FP32, shape, span)
+        A2 = ir.TensorVar("A", DataType.FP32, shape, span)
+        B = ir.TensorVar("B", DataType.FP32, shape, span)
+
+        # Without auto-mapping, different instances are not equal
+        assert not ir.structural_equal(A1, A2, enable_auto_mapping=False)
+
+        # With auto-mapping, same structure should be equal
+        assert ir.structural_equal(A1, B, enable_auto_mapping=True)
+
+    def test_tensor_different_shapes_not_equal(self):
+        """Test that tensors with different shapes are not equal."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(2, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(3, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape1, span)
+        B = ir.TensorVar("A", DataType.FP32, shape2, span)
+
+        assert not ir.structural_equal(A, B)
+
+    def test_tensor_different_dtypes_not_equal(self):
+        """Test that tensors with different dtypes are not equal."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape, span)
+        B = ir.TensorVar("A", DataType.FP16, shape, span)
+
+        assert not ir.structural_equal(A, B)
+
+
+class TestTensorVarStructuralHash:
+    """Test cases for structural hashing of TensorVar."""
+
+    def test_tensor_var_hash_consistency(self):
+        """Test that same TensorVar instance has consistent hash."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span), ir.ConstInt(3, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape, span)
+
+        hash1 = ir.structural_hash(A)
+        hash2 = ir.structural_hash(A)
+        assert hash1 == hash2
+
+    def test_tensor_var_hash_different_names(self):
+        """Test that different TensorVar names produce different hashes."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape, span)
+        B = ir.TensorVar("B", DataType.FP32, shape, span)
+
+        hash_a = ir.structural_hash(A, enable_auto_mapping=False)
+        hash_b = ir.structural_hash(B, enable_auto_mapping=False)
+
+        # Different names should produce different hashes
+        assert hash_a != hash_b
+
+    def test_tensor_var_hash_same_content(self):
+        """Test that TensorVar with same content has same hash."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(2, DataType.INT32, span)]
+
+        A1 = ir.TensorVar("A", DataType.FP32, shape, span)
+        A2 = ir.TensorVar("A", DataType.FP32, shape, span)
+
+        hash_a1 = ir.structural_hash(A1, enable_auto_mapping=False)
+        hash_a2 = ir.structural_hash(A2, enable_auto_mapping=False)
+
+        # Same content should have same hash (content-based)
+        assert hash_a1 == hash_a2
+
+    def test_tensor_var_hash_different_shapes(self):
+        """Test that different shapes produce different hashes."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(2, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(3, DataType.INT32, span)]
+
+        A = ir.TensorVar("A", DataType.FP32, shape1, span)
+        B = ir.TensorVar("A", DataType.FP32, shape2, span)
+
+        hash_a = ir.structural_hash(A)
+        hash_b = ir.structural_hash(B)
+
+        # Different shapes should have different hashes
+        assert hash_a != hash_b
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add TensorExpr as a new expression type for tensor computations, initially implementing only TensorVar for tensor variable references.

Changes:
- Add TensorExpr base class with dtype and symbolic shape support
- Add TensorVar for tensor variable references with symbolic dimensions
- Integrate TensorExpr into IR transform infrastructure:
  * Update ExprFunctor dispatch for TensorVar
  * Implement ExprVisitor support for TensorVar traversal
  * Implement ExprMutator support for TensorVar transformation
  * Add structural equality and hashing for TensorVar
- Add Python bindings and type stubs for TensorExpr/TensorVar
- Add comprehensive unit tests (14 test cases)
- Fix missing <utility> include in expr.h for std::move