### PR TITLE
refactor: unify IR visitor pattern to support both expressions and statements

### DIFF
--- a/include/pypto/ir/scalar_expr.h
+++ b/include/pypto/ir/scalar_expr.h
@@ -28,7 +28,7 @@ namespace ir {
 
 // Forward declaration for visitor pattern
 // Implementation in pypto/ir/transform/base/visitor.h
-class ScalarExprVisitor;
+class IRVisitor;
 
 /**
  * @brief Base class for operations/functions

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -18,17 +18,19 @@ namespace pypto {
 namespace ir {
 
 /**
- * @brief Expression mutator for immutable transformations
+ * @brief IR mutator for immutable transformations
  *
- * Provides default implementations that recursively transform the expression tree.
- * Returns new ExprPtr for transformed expressions, respecting immutability.
+ * Provides default implementations that recursively transform the IR tree.
+ * Returns new ExprPtr or StmtPtr for transformed IR nodes, respecting immutability.
  * Uses copy-on-write: if children are unchanged, returns the original shared_ptr.
  */
-class ExprMutator : public ExprFunctor<ExprPtr> {
+class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
  public:
-  ~ExprMutator() override = default;
+  ~IRMutator() override = default;
 
+  // Override base class methods
   ExprPtr VisitExpr(const ExprPtr& expr) override;
+  StmtPtr VisitStmt(const StmtPtr& stmt) override;
 
  protected:
   // Leaf nodes - return as-is by default
@@ -69,6 +71,9 @@ class ExprMutator : public ExprFunctor<ExprPtr> {
 
   // Tensor expressions - reconstruct with mutated children
   ExprPtr VisitExpr_(const TensorVarPtr& op) override;
+
+  // Statement types
+  StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 
 }  // namespace ir

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -18,17 +18,18 @@ namespace pypto {
 namespace ir {
 
 /**
- * @brief Read-only expression visitor
+ * @brief Read-only IR visitor for both expressions and statements
  *
- * Provides default implementations that recursively traverse the expression tree.
- * Subclasses can override specific VisitExpr_ methods to implement custom behavior.
- * All methods are const and do not modify the visited expressions.
+ * Provides default implementations that recursively traverse the IR tree.
+ * Subclasses can override specific VisitExpr_ or VisitStmt_ methods to implement custom behavior.
+ * All methods don't modify the visited IR nodes.
  */
-class ExprVisitor : public ExprFunctor<void> {
+class IRVisitor : public IRFunctor<void> {
  public:
-  ~ExprVisitor() override = default;
+  ~IRVisitor() override = default;
 
   void VisitExpr(const ExprPtr& expr) override;
+  void VisitStmt(const StmtPtr& stmt) override;
 
  protected:
   // Leaf nodes - no children to visit
@@ -69,6 +70,9 @@ class ExprVisitor : public ExprFunctor<void> {
 
   // Tensor expressions - visit tensor nodes
   void VisitExpr_(const TensorVarPtr& op) override;
+
+  // Statement types
+  void VisitStmt_(const StmtPtr& op) override;
 
  private:
   /**

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -61,15 +61,15 @@ Precedence GetPrecedence(const ExprPtr& expr);
 bool IsRightAssociative(const ExprPtr& expr);
 
 /**
- * @brief Expression pretty printer
+ * @brief IR pretty printer
  *
- * Prints expressions with minimal parentheses based on operator precedence.
- * Inherits from ExprVisitor to traverse the expression tree.
+ * Prints IR nodes (expressions and statements) with minimal parentheses based on operator precedence.
+ * Inherits from IRVisitor to traverse the IR tree.
  */
-class ExprPrinter : public ExprVisitor {
+class IRPrinter : public IRVisitor {
  public:
-  ExprPrinter() = default;
-  ~ExprPrinter() override = default;
+  IRPrinter() = default;
+  ~IRPrinter() override = default;
 
   /**
    * @brief Print an expression to a string
@@ -78,6 +78,14 @@ class ExprPrinter : public ExprVisitor {
    * @return String representation with minimal parentheses
    */
   std::string Print(const ExprPtr& expr);
+
+  /**
+   * @brief Print a statement to a string
+   *
+   * @param stmt Statement to print
+   * @return String representation
+   */
+  std::string Print(const StmtPtr& stmt);
 
  protected:
   // Leaf nodes
@@ -115,6 +123,9 @@ class ExprPrinter : public ExprVisitor {
   void VisitExpr_(const NegPtr& op) override;
   void VisitExpr_(const NotPtr& op) override;
   void VisitExpr_(const BitNotPtr& op) override;
+
+  // Statement types
+  void VisitStmt_(const StmtPtr& op) override;
 
  private:
   std::ostringstream stream_;

--- a/python/pybind/modules/ir.cpp
+++ b/python/pybind/modules/ir.cpp
@@ -98,14 +98,14 @@ void BindIR(py::module_& m) {
       .def(
           "__str__",
           [](const std::shared_ptr<const ScalarExpr>& self) {
-            ExprPrinter printer;
+            IRPrinter printer;
             return printer.Print(self);
           },
           "String representation of the expression")
       .def(
           "__repr__",
           [](const std::shared_ptr<const ScalarExpr>& self) {
-            ExprPrinter printer;
+            IRPrinter printer;
             return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
           },
           "Detailed representation of the expression");
@@ -224,14 +224,14 @@ void BindIR(py::module_& m) {
       .def(
           "__str__",
           [](const std::shared_ptr<const TensorExpr>& self) {
-            ExprPrinter printer;
+            IRPrinter printer;
             return printer.Print(self);
           },
           "String representation of the expression")
       .def(
           "__repr__",
           [](const std::shared_ptr<const TensorExpr>& self) {
-            ExprPrinter printer;
+            IRPrinter printer;
             return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
           },
           "Detailed representation of the expression");

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -71,19 +71,26 @@ bool IsRightAssociative(const ExprPtr& expr) {
   return std::dynamic_pointer_cast<const Pow>(expr) != nullptr;
 }
 
-std::string ExprPrinter::Print(const ExprPtr& expr) {
+std::string IRPrinter::Print(const ExprPtr& expr) {
   stream_.str("");  // Clear the stream
   stream_.clear();  // Clear any error flags
   VisitExpr(expr);
   return stream_.str();
 }
 
+std::string IRPrinter::Print(const StmtPtr& stmt) {
+  stream_.str("");  // Clear the stream
+  stream_.clear();  // Clear any error flags
+  VisitStmt(stmt);
+  return stream_.str();
+}
+
 // Leaf nodes
-void ExprPrinter::VisitExpr_(const VarPtr& op) { stream_ << op->name_; }
+void IRPrinter::VisitExpr_(const VarPtr& op) { stream_ << op->name_; }
 
-void ExprPrinter::VisitExpr_(const ConstIntPtr& op) { stream_ << op->value_; }
+void IRPrinter::VisitExpr_(const ConstIntPtr& op) { stream_ << op->value_; }
 
-void ExprPrinter::VisitExpr_(const CallPtr& op) {
+void IRPrinter::VisitExpr_(const CallPtr& op) {
   stream_ << op->op_->name_ << "(";
   for (size_t i = 0; i < op->args_.size(); ++i) {
     if (i > 0) stream_ << ", ";
@@ -93,7 +100,7 @@ void ExprPrinter::VisitExpr_(const CallPtr& op) {
 }
 
 // Helper methods
-bool ExprPrinter::NeedsParens(const ExprPtr& parent, const ExprPtr& child, bool is_left) {
+bool IRPrinter::NeedsParens(const ExprPtr& parent, const ExprPtr& child, bool is_left) {
   Precedence parent_prec = GetPrecedence(parent);
   Precedence child_prec = GetPrecedence(child);
 
@@ -118,7 +125,7 @@ bool ExprPrinter::NeedsParens(const ExprPtr& parent, const ExprPtr& child, bool 
   return false;
 }
 
-void ExprPrinter::PrintChild(const ExprPtr& parent, const ExprPtr& child, bool is_left) {
+void IRPrinter::PrintChild(const ExprPtr& parent, const ExprPtr& child, bool is_left) {
   bool needs_parens = NeedsParens(parent, child, is_left);
 
   if (needs_parens) {
@@ -132,13 +139,13 @@ void ExprPrinter::PrintChild(const ExprPtr& parent, const ExprPtr& child, bool i
   }
 }
 
-void ExprPrinter::PrintBinaryOp(const BinaryExprPtr& op, const char* op_symbol) {
+void IRPrinter::PrintBinaryOp(const BinaryExprPtr& op, const char* op_symbol) {
   PrintChild(op, op->left_, true);
   stream_ << " " << op_symbol << " ";
   PrintChild(op, op->right_, false);
 }
 
-void ExprPrinter::PrintFunctionBinaryOp(const BinaryExprPtr& op, const char* func_name) {
+void IRPrinter::PrintFunctionBinaryOp(const BinaryExprPtr& op, const char* func_name) {
   stream_ << func_name << "(";
   VisitExpr(op->left_);
   stream_ << ", ";
@@ -147,40 +154,40 @@ void ExprPrinter::PrintFunctionBinaryOp(const BinaryExprPtr& op, const char* fun
 }
 
 // Arithmetic binary operators
-void ExprPrinter::VisitExpr_(const AddPtr& op) { PrintBinaryOp(op, "+"); }
-void ExprPrinter::VisitExpr_(const SubPtr& op) { PrintBinaryOp(op, "-"); }
-void ExprPrinter::VisitExpr_(const MulPtr& op) { PrintBinaryOp(op, "*"); }
-void ExprPrinter::VisitExpr_(const FloorDivPtr& op) { PrintBinaryOp(op, "//"); }
-void ExprPrinter::VisitExpr_(const FloorModPtr& op) { PrintBinaryOp(op, "%"); }
-void ExprPrinter::VisitExpr_(const FloatDivPtr& op) { PrintBinaryOp(op, "/"); }
-void ExprPrinter::VisitExpr_(const PowPtr& op) { PrintBinaryOp(op, "**"); }
+void IRPrinter::VisitExpr_(const AddPtr& op) { PrintBinaryOp(op, "+"); }
+void IRPrinter::VisitExpr_(const SubPtr& op) { PrintBinaryOp(op, "-"); }
+void IRPrinter::VisitExpr_(const MulPtr& op) { PrintBinaryOp(op, "*"); }
+void IRPrinter::VisitExpr_(const FloorDivPtr& op) { PrintBinaryOp(op, "//"); }
+void IRPrinter::VisitExpr_(const FloorModPtr& op) { PrintBinaryOp(op, "%"); }
+void IRPrinter::VisitExpr_(const FloatDivPtr& op) { PrintBinaryOp(op, "/"); }
+void IRPrinter::VisitExpr_(const PowPtr& op) { PrintBinaryOp(op, "**"); }
 
 // Function-style binary operators
-void ExprPrinter::VisitExpr_(const MinPtr& op) { PrintFunctionBinaryOp(op, "min"); }
-void ExprPrinter::VisitExpr_(const MaxPtr& op) { PrintFunctionBinaryOp(op, "max"); }
+void IRPrinter::VisitExpr_(const MinPtr& op) { PrintFunctionBinaryOp(op, "min"); }
+void IRPrinter::VisitExpr_(const MaxPtr& op) { PrintFunctionBinaryOp(op, "max"); }
 
 // Comparison operators
-void ExprPrinter::VisitExpr_(const EqPtr& op) { PrintBinaryOp(op, "=="); }
-void ExprPrinter::VisitExpr_(const NePtr& op) { PrintBinaryOp(op, "!="); }
-void ExprPrinter::VisitExpr_(const LtPtr& op) { PrintBinaryOp(op, "<"); }
-void ExprPrinter::VisitExpr_(const LePtr& op) { PrintBinaryOp(op, "<="); }
-void ExprPrinter::VisitExpr_(const GtPtr& op) { PrintBinaryOp(op, ">"); }
-void ExprPrinter::VisitExpr_(const GePtr& op) { PrintBinaryOp(op, ">="); }
+void IRPrinter::VisitExpr_(const EqPtr& op) { PrintBinaryOp(op, "=="); }
+void IRPrinter::VisitExpr_(const NePtr& op) { PrintBinaryOp(op, "!="); }
+void IRPrinter::VisitExpr_(const LtPtr& op) { PrintBinaryOp(op, "<"); }
+void IRPrinter::VisitExpr_(const LePtr& op) { PrintBinaryOp(op, "<="); }
+void IRPrinter::VisitExpr_(const GtPtr& op) { PrintBinaryOp(op, ">"); }
+void IRPrinter::VisitExpr_(const GePtr& op) { PrintBinaryOp(op, ">="); }
 
 // Logical operators (Python keywords)
-void ExprPrinter::VisitExpr_(const AndPtr& op) { PrintBinaryOp(op, "and"); }
-void ExprPrinter::VisitExpr_(const OrPtr& op) { PrintBinaryOp(op, "or"); }
-void ExprPrinter::VisitExpr_(const XorPtr& op) { PrintBinaryOp(op, "xor"); }
+void IRPrinter::VisitExpr_(const AndPtr& op) { PrintBinaryOp(op, "and"); }
+void IRPrinter::VisitExpr_(const OrPtr& op) { PrintBinaryOp(op, "or"); }
+void IRPrinter::VisitExpr_(const XorPtr& op) { PrintBinaryOp(op, "xor"); }
 
 // Bitwise operators
-void ExprPrinter::VisitExpr_(const BitAndPtr& op) { PrintBinaryOp(op, "&"); }
-void ExprPrinter::VisitExpr_(const BitOrPtr& op) { PrintBinaryOp(op, "|"); }
-void ExprPrinter::VisitExpr_(const BitXorPtr& op) { PrintBinaryOp(op, "^"); }
-void ExprPrinter::VisitExpr_(const BitShiftLeftPtr& op) { PrintBinaryOp(op, "<<"); }
-void ExprPrinter::VisitExpr_(const BitShiftRightPtr& op) { PrintBinaryOp(op, ">>"); }
+void IRPrinter::VisitExpr_(const BitAndPtr& op) { PrintBinaryOp(op, "&"); }
+void IRPrinter::VisitExpr_(const BitOrPtr& op) { PrintBinaryOp(op, "|"); }
+void IRPrinter::VisitExpr_(const BitXorPtr& op) { PrintBinaryOp(op, "^"); }
+void IRPrinter::VisitExpr_(const BitShiftLeftPtr& op) { PrintBinaryOp(op, "<<"); }
+void IRPrinter::VisitExpr_(const BitShiftRightPtr& op) { PrintBinaryOp(op, ">>"); }
 
 // Unary operators
-void ExprPrinter::VisitExpr_(const NegPtr& op) {
+void IRPrinter::VisitExpr_(const NegPtr& op) {
   stream_ << "-";
   // Unary operators need parens for their operands if operand has lower precedence
   Precedence operand_prec = GetPrecedence(op->operand_);
@@ -193,13 +200,13 @@ void ExprPrinter::VisitExpr_(const NegPtr& op) {
   }
 }
 
-void ExprPrinter::VisitExpr_(const AbsPtr& op) {
+void IRPrinter::VisitExpr_(const AbsPtr& op) {
   stream_ << "abs(";
   VisitExpr(op->operand_);
   stream_ << ")";
 }
 
-void ExprPrinter::VisitExpr_(const NotPtr& op) {
+void IRPrinter::VisitExpr_(const NotPtr& op) {
   stream_ << "not ";
   // Not operator needs parens for operands with lower precedence
   Precedence operand_prec = GetPrecedence(op->operand_);
@@ -212,7 +219,7 @@ void ExprPrinter::VisitExpr_(const NotPtr& op) {
   }
 }
 
-void ExprPrinter::VisitExpr_(const BitNotPtr& op) {
+void IRPrinter::VisitExpr_(const BitNotPtr& op) {
   stream_ << "~";
   // Bitwise not needs parens for operands with lower precedence
   Precedence operand_prec = GetPrecedence(op->operand_);
@@ -223,6 +230,12 @@ void ExprPrinter::VisitExpr_(const BitNotPtr& op) {
   } else {
     VisitExpr(op->operand_);
   }
+}
+
+// Statement types
+void IRPrinter::VisitStmt_(const StmtPtr& op) {
+  // Base Stmt: just print the type name
+  stream_ << op->TypeName();
 }
 
 }  // namespace ir

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -18,18 +18,20 @@
 namespace pypto {
 namespace ir {
 
-void ExprVisitor::VisitExpr(const ExprPtr& expr) { ExprFunctor::VisitExpr(expr); }
+void IRVisitor::VisitExpr(const ExprPtr& expr) { ExprFunctor<void>::VisitExpr(expr); }
+
+void IRVisitor::VisitStmt(const StmtPtr& stmt) { StmtFunctor<void>::VisitStmt(stmt); }
 
 // Leaf nodes - no children to visit
-void ExprVisitor::VisitExpr_(const VarPtr& op) {
+void IRVisitor::VisitExpr_(const VarPtr& op) {
   // Leaf node, no children to visit
 }
 
-void ExprVisitor::VisitExpr_(const ConstIntPtr& op) {
+void IRVisitor::VisitExpr_(const ConstIntPtr& op) {
   // Leaf node, no children to visit
 }
 
-void ExprVisitor::VisitExpr_(const CallPtr& op) {
+void IRVisitor::VisitExpr_(const CallPtr& op) {
   // Visit all arguments
   for (size_t i = 0; i < op->args_.size(); ++i) {
     INTERNAL_CHECK(op->args_[i]) << "Call has null argument at index " << i;
@@ -39,7 +41,7 @@ void ExprVisitor::VisitExpr_(const CallPtr& op) {
 
 // Macro to generate binary visitor with null checks
 #define DEFINE_BINARY_VISITOR(OpType)                                \
-  void ExprVisitor::VisitExpr_(const OpType##Ptr& op) {              \
+  void IRVisitor::VisitExpr_(const OpType##Ptr& op) {                \
     INTERNAL_CHECK(op->left_) << #OpType " has null left operand";   \
     INTERNAL_CHECK(op->right_) << #OpType " has null right operand"; \
     VisitExpr(op->left_);                                            \
@@ -75,7 +77,7 @@ DEFINE_BINARY_VISITOR(BitShiftRight)
 
 // Macro to generate unary visitor with null checks
 #define DEFINE_UNARY_VISITOR(OpType)                             \
-  void ExprVisitor::VisitExpr_(const OpType##Ptr& op) {          \
+  void IRVisitor::VisitExpr_(const OpType##Ptr& op) {            \
     INTERNAL_CHECK(op->operand_) << #OpType " has null operand"; \
     VisitExpr(op->operand_);                                     \
   }
@@ -89,11 +91,16 @@ DEFINE_UNARY_VISITOR(BitNot)
 #undef DEFINE_UNARY_VISITOR
 
 // Tensor expressions
-void ExprVisitor::VisitExpr_(const TensorVarPtr& op) {
+void IRVisitor::VisitExpr_(const TensorVarPtr& op) {
   // Leaf node, but need to visit shape expressions
   for (const auto& dim : op->shape_) {
     VisitExpr(dim);
   }
+}
+
+// Statement types
+void IRVisitor::VisitStmt_(const StmtPtr& op) {
+  // Base Stmt has no children to visit
 }
 
 }  // namespace ir


### PR DESCRIPTION
- Rename ExprVisitor/ExprMutator/ExprPrinter to IRVisitor/IRMutator/IRPrinter
- Add StmtFunctor base class for statement visitor pattern
- Add IRFunctor to unify ExprFunctor and StmtFunctor
- Extend all visitor classes to support statements via VisitStmt methods