### PR TITLE
feat(ir): add AssignStmt for assignment statements

### DIFF
--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -33,9 +33,10 @@ namespace ir {
  * All expressions are immutable.
  */
 class Expr : public IRNode {
- public:
+ protected:
   TypePtr type_;  // Type of the expression result
 
+ public:
   /**
    * @brief Create an expression
    *
@@ -51,6 +52,13 @@ class Expr : public IRNode {
    * @return Human-readable type name (e.g., "ScalarExpr", "Var", "Call")
    */
   [[nodiscard]] std::string TypeName() const override { return "Expr"; }
+
+  /**
+   * @brief Get the type of this expression
+   *
+   * @return Type pointer of the expression result
+   */
+  [[nodiscard]] const TypePtr& GetType() const { return type_; }
 
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(IRNode::GetFieldDescriptors(),

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -14,9 +14,12 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "pypto/ir/core.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/reflection/field_traits.h"
 
 namespace pypto {
 namespace ir {
@@ -48,6 +51,43 @@ class Stmt : public IRNode {
 };
 
 using StmtPtr = std::shared_ptr<const Stmt>;
+
+/**
+ * @brief Assignment statement
+ *
+ * Represents an assignment operation: var = value
+ * where var is a variable and value is an expression.
+ */
+class AssignStmt : public Stmt {
+ public:
+  VarPtr var_;     // Variable
+  ExprPtr value_;  // Expression
+
+  /**
+   * @brief Create an assignment statement
+   *
+   * @param var Variable
+   * @param value Expression
+   * @param span Source location
+   */
+  AssignStmt(VarPtr var, ExprPtr value, Span span)
+      : Stmt(std::move(span)), var_(std::move(var)), value_(std::move(value)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "AssignStmt"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (var and value as DEF and USUAL fields)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Stmt::GetFieldDescriptors(),
+                          std::make_tuple(reflection::DefField(&AssignStmt::var_, "var"),
+                                          reflection::UsualField(&AssignStmt::value_, "value")));
+  }
+};
+
+using AssignStmtPtr = std::shared_ptr<const AssignStmt>;
 
 }  // namespace ir
 }  // namespace pypto

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -160,7 +160,8 @@ class StmtFunctor {
   virtual R VisitStmt(const StmtPtr& stmt, Args... args);
 
  protected:
-  // Base statement type
+  // Statement types
+  virtual R VisitStmt_(const AssignStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -172,7 +173,8 @@ class StmtFunctor {
 
 template <typename R, typename... Args>
 R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
-  // Currently only base Stmt class exists
+  // Dispatch to concrete statement types
+  STMT_FUNCTOR_DISPATCH(AssignStmt);
   STMT_FUNCTOR_DISPATCH(Stmt);
 
   // Should never reach here if all types are handled

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_IR_TRANSFORM_BASE_MUTATOR_H_
 #define PYPTO_IR_TRANSFORM_BASE_MUTATOR_H_
 
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/functor.h"
 
 namespace pypto {
@@ -70,6 +71,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   ExprPtr VisitExpr_(const BitNotPtr& op) override;
 
   // Statement types
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_IR_TRANSFORM_BASE_VISITOR_H_
 #define PYPTO_IR_TRANSFORM_BASE_VISITOR_H_
 
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/functor.h"
 
 namespace pypto {
@@ -69,6 +70,7 @@ class IRVisitor : public IRFunctor<void> {
   void VisitExpr_(const BitNotPtr& op) override;
 
   // Statement types
+  void VisitStmt_(const AssignStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <string>
 
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/visitor.h"
 
 namespace pypto {
@@ -125,6 +126,7 @@ class IRPrinter : public IRVisitor {
   void VisitExpr_(const BitNotPtr& op) override;
 
   // Statement types
+  void VisitStmt_(const AssignStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -261,6 +261,43 @@ void BindIR(nb::module_& m) {
   auto stmt_class = nb::class_<Stmt, IRNode>(ir, "Stmt", "Base class for all statements");
   stmt_class.def(nb::init<const Span&>(), nb::arg("span"), "Create a statement");
   BindFields<Stmt>(stmt_class);
+  stmt_class
+      .def(
+          "__str__",
+          [](const std::shared_ptr<const Stmt>& self) {
+            IRPrinter printer;
+            return printer.Print(self);
+          },
+          "String representation of the statement")
+      .def(
+          "__repr__",
+          [](const std::shared_ptr<const Stmt>& self) {
+            IRPrinter printer;
+            return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
+          },
+          "Detailed representation of the statement");
+
+  // AssignStmt - const shared_ptr
+  auto assign_stmt_class =
+      nb::class_<AssignStmt, Stmt>(ir, "AssignStmt", "Assignment statement: var = value");
+  assign_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const Span&>(), nb::arg("var"),
+                        nb::arg("value"), nb::arg("span"), "Create an assignment statement");
+  BindFields<AssignStmt>(assign_stmt_class);
+  assign_stmt_class
+      .def(
+          "__str__",
+          [](const std::shared_ptr<const AssignStmt>& self) {
+            IRPrinter printer;
+            return printer.Print(self);
+          },
+          "String representation of the assignment statement")
+      .def(
+          "__repr__",
+          [](const std::shared_ptr<const AssignStmt>& self) {
+            IRPrinter printer;
+            return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
+          },
+          "Detailed representation of the assignment statement");
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -92,16 +92,6 @@ class IRNode:
     span: Final[Span]
     """Source location of this IR node."""
 
-class Stmt(IRNode):
-    """Base class for all statements."""
-
-    def __init__(self, span: Span) -> None:
-        """Create a statement.
-
-        Args:
-            span: Source location
-        """
-
 class Expr(IRNode):
     """Base class for all expressions."""
 
@@ -599,6 +589,34 @@ class BitNot(UnaryExpr):
         Args:
             operand: Operand expression
             dtype: Data type
+            span: Source location
+        """
+
+class Stmt(IRNode):
+    """Base class for all statements."""
+
+    def __init__(self, span: Span) -> None:
+        """Create a statement.
+
+        Args:
+            span: Source location
+        """
+
+class AssignStmt(Stmt):
+    """Assignment statement: var = value."""
+
+    var: Final[Var]
+    """Variable."""
+
+    value: Final[Expr]
+    """Expression."""
+
+    def __init__(self, var: Var, value: Expr, span: Span) -> None:
+        """Create an assignment statement.
+
+        Args:
+            var: Variable
+            value: Expression
             span: Source location
         """
 

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
 
 namespace pypto {
 namespace ir {
@@ -233,6 +234,13 @@ void IRPrinter::VisitExpr_(const BitNotPtr& op) {
 }
 
 // Statement types
+void IRPrinter::VisitStmt_(const AssignStmtPtr& op) {
+  // Print assignment: var = value
+  VisitExpr(op->var_);
+  stream_ << " = ";
+  VisitExpr(op->value_);
+}
+
 void IRPrinter::VisitStmt_(const StmtPtr& op) {
   // Base Stmt: just print the type name
   stream_ << op->TypeName();

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -173,6 +173,7 @@ bool StructuralEqual::Equal(const IRNodePtr& lhs, const IRNodePtr& rhs) {
   EQUAL_DISPATCH(Call)
   EQUAL_DISPATCH(BinaryExpr)
   EQUAL_DISPATCH(UnaryExpr)
+  EQUAL_DISPATCH(AssignStmt)
   EQUAL_DISPATCH(Stmt)
 
   // Unknown IR node type
@@ -213,7 +214,7 @@ bool StructuralEqual::EqualVar(const VarPtr& lhs, const VarPtr& rhs) {
   }
 
   // Check type equality first - only add to mapping if types match
-  if (!EqualType(lhs->type_, rhs->type_)) {
+  if (!EqualType(lhs->GetType(), rhs->GetType())) {
     return false;
   }
 

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -173,6 +173,7 @@ int64_t StructuralHasher::HashNode(const IRNodePtr& node) {
   HASH_DISPATCH(Call)
   HASH_DISPATCH(BinaryExpr)
   HASH_DISPATCH(UnaryExpr)
+  HASH_DISPATCH(AssignStmt)
   HASH_DISPATCH(Stmt)
 
   // Free Var types that may be mapped to other free vars

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -13,6 +13,7 @@
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -25,7 +26,7 @@ void IRVisitor::VisitStmt(const StmtPtr& stmt) { StmtFunctor<void>::VisitStmt(st
 // Leaf nodes - no children to visit
 void IRVisitor::VisitExpr_(const VarPtr& op) {
   // Visit type if it's a TensorType (to visit shape expressions)
-  if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->type_)) {
+  if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->GetType())) {
     for (const auto& dim : tensor_type->shape_) {
       VisitExpr(dim);
     }
@@ -96,6 +97,13 @@ DEFINE_UNARY_VISITOR(BitNot)
 #undef DEFINE_UNARY_VISITOR
 
 // Statement types
+void IRVisitor::VisitStmt_(const AssignStmtPtr& op) {
+  INTERNAL_CHECK(op->var_) << "AssignStmt has null var";
+  INTERNAL_CHECK(op->value_) << "AssignStmt has null value";
+  VisitExpr(op->var_);
+  VisitExpr(op->value_);
+}
+
 void IRVisitor::VisitStmt_(const StmtPtr& op) {
   // Base Stmt has no children to visit
 }

--- a/tests/ut/ir/test_hash_equal.py
+++ b/tests/ut/ir/test_hash_equal.py
@@ -225,6 +225,66 @@ class TestStructuralHash:
         # Different IR node types should hash differently
         assert hash_stmt != hash_expr
 
+    def test_assign_stmt_same_structure_hash(self):
+        """Test AssignStmt nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        hash1 = ir.structural_hash(assign1)
+        hash2 = ir.structural_hash(assign2)
+        print(f"hash1: {hash1}, hash2: {hash2}")
+
+    def test_assign_stmt_different_var_hash(self):
+        """Test AssignStmt nodes with different var hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(z, y, span)
+
+        hash1 = ir.structural_hash(assign1)
+        hash2 = ir.structural_hash(assign2)
+        print(f"hash1: {hash1}, hash2: {hash2}")
+
+    def test_assign_stmt_different_value_hash(self):
+        """Test AssignStmt nodes with different value hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+
+        hash1 = ir.structural_hash(assign1)
+        hash2 = ir.structural_hash(assign2)
+        print(f"hash1: {hash1}, hash2: {hash2}")
+
+    def test_assign_stmt_different_from_base_stmt_hash(self):
+        """Test AssignStmt and base Stmt nodes hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+
+        assign = ir.AssignStmt(x, y, span)
+        stmt = ir.Stmt(span)
+
+        hash_assign = ir.structural_hash(assign)
+        hash_stmt = ir.structural_hash(stmt)
+        print(f"hash_assign: {hash_assign}, hash_stmt: {hash_stmt}")
+
 
 class TestStructuralEquality:
     """Tests for structural equality function."""
@@ -432,6 +492,62 @@ class TestStructuralEquality:
         # Different IR node types should not be equal
         assert not ir.structural_equal(stmt, expr)
 
+    def test_assign_stmt_structural_equal(self):
+        """Test structural equality of AssignStmt nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        equal = ir.structural_equal(assign1, assign2)
+        print(f"equal: {equal}")
+
+    def test_assign_stmt_different_var_not_equal(self):
+        """Test AssignStmt nodes with different var are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(z, y, span)
+
+        equal = ir.structural_equal(assign1, assign2)
+        print(f"equal: {equal}")
+
+    def test_assign_stmt_different_value_not_equal(self):
+        """Test AssignStmt nodes with different value are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+
+        equal = ir.structural_equal(assign1, assign2)
+        print(f"equal: {equal}")
+
+    def test_assign_stmt_different_from_base_stmt_not_equal(self):
+        """Test AssignStmt and base Stmt nodes are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+
+        assign = ir.AssignStmt(x, y, span)
+        stmt = ir.Stmt(span)
+
+        equal = ir.structural_equal(assign, stmt)
+        print(f"equal: {equal}")
+
 
 class TestHashEqualityConsistency:
     """Test that hash and equality are consistent."""
@@ -477,6 +593,18 @@ class TestHashEqualityConsistency:
             (
                 ir.Stmt(ir.Span.unknown()),
                 ir.Stmt(ir.Span.unknown()),
+            ),
+            (
+                ir.AssignStmt(
+                    ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown()),
+                    ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown()),
+                    ir.Span.unknown(),
+                ),
+                ir.AssignStmt(
+                    ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown()),
+                    ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown()),
+                    ir.Span.unknown(),
+                ),
             ),
         ]
 
@@ -831,6 +959,84 @@ class TestAutoMapping:
         assert ir.structural_hash(call1, enable_auto_mapping=True) == ir.structural_hash(
             call2, enable_auto_mapping=True
         )
+
+    def test_auto_mapping_with_assign_stmt(self):
+        """Test auto mapping with AssignStmt."""
+        # Build: x = y
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
+
+        # Build: a = b
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign2 = ir.AssignStmt(a, b, ir.Span.unknown())
+
+        equal_with_auto = ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
+        equal_without_auto = ir.structural_equal(assign1, assign2, enable_auto_mapping=False)
+
+        hash_with_auto1 = ir.structural_hash(assign1, enable_auto_mapping=True)
+        hash_with_auto2 = ir.structural_hash(assign2, enable_auto_mapping=True)
+
+        hash_without_auto1 = ir.structural_hash(assign1, enable_auto_mapping=False)
+        hash_without_auto2 = ir.structural_hash(assign2, enable_auto_mapping=False)
+
+        print(f"equal_with_auto: {equal_with_auto}, equal_without_auto: {equal_without_auto}")
+        print(f"hash_with_auto1: {hash_with_auto1}, hash_with_auto2: {hash_with_auto2}")
+        print(f"hash_without_auto1: {hash_without_auto1}, hash_without_auto2: {hash_without_auto2}")
+
+    def test_auto_mapping_assign_stmt_different_var_same_value(self):
+        """Test auto mapping with AssignStmt where var differs but value is same."""
+        # Build: x = y
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign1 = ir.AssignStmt(x, y, ir.Span.unknown())
+
+        # Build: z = y
+        z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign2 = ir.AssignStmt(z, y, ir.Span.unknown())
+
+        equal_with_auto = ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
+        hash1 = ir.structural_hash(assign1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(assign2, enable_auto_mapping=True)
+        print(f"equal_with_auto: {equal_with_auto}, hash1: {hash1}, hash2: {hash2}")
+
+    def test_auto_mapping_assign_stmt_same_var_different_value(self):
+        """Test auto mapping with AssignStmt where var is same but value differs."""
+        # Build: x = y
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign1 = ir.AssignStmt(x, y, ir.Span.unknown())
+
+        # Build: x = z
+        z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        assign2 = ir.AssignStmt(x, z, ir.Span.unknown())
+
+        equal_with_auto = ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
+        hash1 = ir.structural_hash(assign1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(assign2, enable_auto_mapping=True)
+        print(f"equal_with_auto: {equal_with_auto}, hash1: {hash1}, hash2: {hash2}")
+
+    def test_auto_mapping_assign_stmt_with_expression(self):
+        """Test auto mapping with AssignStmt containing complex expressions."""
+        # Build: x = y + z
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        z1 = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        add1 = ir.Add(y1, z1, DataType.INT64, ir.Span.unknown())
+        assign1 = ir.AssignStmt(x1, add1, ir.Span.unknown())
+
+        # Build: a = b + c
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        c = ir.Var("c", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        add2 = ir.Add(b, c, DataType.INT64, ir.Span.unknown())
+        assign2 = ir.AssignStmt(a, add2, ir.Span.unknown())
+
+        equal_with_auto = ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
+        hash1 = ir.structural_hash(assign1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(assign2, enable_auto_mapping=True)
+        print(f"equal_with_auto: {equal_with_auto}, hash1: {hash1}, hash2: {hash2}")
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_printer.py
+++ b/tests/ut/ir/test_printer.py
@@ -370,5 +370,298 @@ def test_repr_method():
     assert repr_str == "<ir.Add: a + b>"
 
 
+# ========== Statement Printing Tests ==========
+
+
+def test_base_stmt_printing():
+    """Test printing of base Stmt."""
+    span = ir.Span.unknown()
+    stmt = ir.Stmt(span)
+    assert str(stmt) == "Stmt"
+
+
+def test_assign_stmt_simple():
+    """Test simple assignment statement."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    assign = ir.AssignStmt(x, y, span)
+    assert str(assign) == "x = y"
+
+
+def test_assign_stmt_with_constant():
+    """Test assignment with constant value."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    c5 = ir.ConstInt(5, dtype, span)
+
+    assign = ir.AssignStmt(x, c5, span)
+    assert str(assign) == "x = 5"
+
+
+def test_assign_stmt_with_arithmetic():
+    """Test assignment with arithmetic expression."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = y + z
+    add = ir.Add(y, z, dtype, span)
+    assign = ir.AssignStmt(x, add, span)
+    assert str(assign) == "x = y + z"
+
+    # x = y * z
+    mul = ir.Mul(y, z, dtype, span)
+    assign = ir.AssignStmt(x, mul, span)
+    assert str(assign) == "x = y * z"
+
+
+def test_assign_stmt_with_complex_expression():
+    """Test assignment with complex nested expressions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+    c2 = ir.ConstInt(2, dtype, span)
+    c3 = ir.ConstInt(3, dtype, span)
+
+    # x = y * 2 + z * 3
+    mul1 = ir.Mul(y, c2, dtype, span)
+    mul2 = ir.Mul(z, c3, dtype, span)
+    add = ir.Add(mul1, mul2, dtype, span)
+    assign = ir.AssignStmt(x, add, span)
+    assert str(assign) == "x = y * 2 + z * 3"
+
+    # x = (y + z) * 2
+    add = ir.Add(y, z, dtype, span)
+    mul = ir.Mul(add, c2, dtype, span)
+    assign = ir.AssignStmt(x, mul, span)
+    assert str(assign) == "x = (y + z) * 2"
+
+
+def test_assign_stmt_with_function_call():
+    """Test assignment with function call."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = foo(y, z)
+    op = ir.Op("foo")
+    call = ir.Call(op, [y, z], span)
+    assign = ir.AssignStmt(x, call, span)
+    assert str(assign) == "x = foo(y, z)"
+
+
+def test_assign_stmt_with_unary_operators():
+    """Test assignment with unary operators."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    # x = -y
+    neg = ir.Neg(y, dtype, span)
+    assign = ir.AssignStmt(x, neg, span)
+    assert str(assign) == "x = -y"
+
+    # x = abs(y)
+    abs_expr = ir.Abs(y, dtype, span)
+    assign = ir.AssignStmt(x, abs_expr, span)
+    assert str(assign) == "x = abs(y)"
+
+    # x = not y
+    not_expr = ir.Not(y, dtype, span)
+    assign = ir.AssignStmt(x, not_expr, span)
+    assert str(assign) == "x = not y"
+
+
+def test_assign_stmt_with_comparison():
+    """Test assignment with comparison expression."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = y < z
+    lt = ir.Lt(y, z, dtype, span)
+    assign = ir.AssignStmt(x, lt, span)
+    assert str(assign) == "x = y < z"
+
+    # x = y == z
+    eq = ir.Eq(y, z, dtype, span)
+    assign = ir.AssignStmt(x, eq, span)
+    assert str(assign) == "x = y == z"
+
+
+def test_assign_stmt_with_logical_operators():
+    """Test assignment with logical operators."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = y and z
+    and_expr = ir.And(y, z, dtype, span)
+    assign = ir.AssignStmt(x, and_expr, span)
+    assert str(assign) == "x = y and z"
+
+    # x = y or z
+    or_expr = ir.Or(y, z, dtype, span)
+    assign = ir.AssignStmt(x, or_expr, span)
+    assert str(assign) == "x = y or z"
+
+
+def test_assign_stmt_with_nested_expressions():
+    """Test assignment with deeply nested expressions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+    w = ir.Var("w", ir.ScalarType(dtype), span)
+    c2 = ir.ConstInt(2, dtype, span)
+
+    # x = (y + z) * (w - 2)
+    add = ir.Add(y, z, dtype, span)
+    sub = ir.Sub(w, c2, dtype, span)
+    mul = ir.Mul(add, sub, dtype, span)
+    assign = ir.AssignStmt(x, mul, span)
+    assert str(assign) == "x = (y + z) * (w - 2)"
+
+
+def test_assign_stmt_with_power_operator():
+    """Test assignment with power operator."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    c2 = ir.ConstInt(2, dtype, span)
+    c3 = ir.ConstInt(3, dtype, span)
+
+    # x = y ** 2
+    pow_expr = ir.Pow(y, c2, dtype, span)
+    assign = ir.AssignStmt(x, pow_expr, span)
+    assert str(assign) == "x = y ** 2"
+
+    # x = 2 ** 3 ** y (right-associative)
+    pow1 = ir.Pow(c3, y, dtype, span)
+    pow2 = ir.Pow(c2, pow1, dtype, span)
+    assign = ir.AssignStmt(x, pow2, span)
+    assert str(assign) == "x = 2 ** 3 ** y"
+
+
+def test_assign_stmt_with_min_max():
+    """Test assignment with min/max functions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = min(y, z)
+    min_expr = ir.Min(y, z, dtype, span)
+    assign = ir.AssignStmt(x, min_expr, span)
+    assert str(assign) == "x = min(y, z)"
+
+    # x = max(y, z)
+    max_expr = ir.Max(y, z, dtype, span)
+    assign = ir.AssignStmt(x, max_expr, span)
+    assert str(assign) == "x = max(y, z)"
+
+
+def test_assign_stmt_with_bitwise_operators():
+    """Test assignment with bitwise operators."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # x = y & z
+    bit_and = ir.BitAnd(y, z, dtype, span)
+    assign = ir.AssignStmt(x, bit_and, span)
+    assert str(assign) == "x = y & z"
+
+    # x = y | z
+    bit_or = ir.BitOr(y, z, dtype, span)
+    assign = ir.AssignStmt(x, bit_or, span)
+    assert str(assign) == "x = y | z"
+
+    # x = y << z
+    shift_left = ir.BitShiftLeft(y, z, dtype, span)
+    assign = ir.AssignStmt(x, shift_left, span)
+    assert str(assign) == "x = y << z"
+
+
+def test_assign_stmt_repr():
+    """Test __repr__ for AssignStmt."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    assign = ir.AssignStmt(x, y, span)
+    repr_str = repr(assign)
+    assert repr_str == "<ir.AssignStmt: x = y>"
+
+
+def test_multiple_assign_statements():
+    """Test printing multiple assignment statements."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+    c1 = ir.ConstInt(1, dtype, span)
+    c2 = ir.ConstInt(2, dtype, span)
+
+    # x = 1
+    assign1 = ir.AssignStmt(x, c1, span)
+    assert str(assign1) == "x = 1"
+
+    # y = 2
+    assign2 = ir.AssignStmt(y, c2, span)
+    assert str(assign2) == "y = 2"
+
+    # z = x + y
+    add = ir.Add(x, y, dtype, span)
+    assign3 = ir.AssignStmt(z, add, span)
+    assert str(assign3) == "z = x + y"
+
+
+def test_assign_stmt_with_division_types():
+    """Test assignment with different division types."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    c2 = ir.ConstInt(2, dtype, span)
+
+    # x = y / 2
+    float_div = ir.FloatDiv(y, c2, dtype, span)
+    assign = ir.AssignStmt(x, float_div, span)
+    assert str(assign) == "x = y / 2"
+
+    # x = y // 2
+    floor_div = ir.FloorDiv(y, c2, dtype, span)
+    assign = ir.AssignStmt(x, floor_div, span)
+    assert str(assign) == "x = y // 2"
+
+    # x = y % 2
+    mod = ir.FloorMod(y, c2, dtype, span)
+    assign = ir.AssignStmt(x, mod, span)
+    assert str(assign) == "x = y % 2"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add AssignStmt class to represent assignment operations (var = value) in the IR.

- Add AssignStmt class in stmt.h with var_ and value_ fields
- Add reflection support via GetFieldDescriptors()
- Update transform classes (mutator, visitor, printer) to handle AssignStmt
- Add Python bindings with __str__ and __repr__ methods
- Add comprehensive unit tests for AssignStmt

Notice: hash_equal test cases of AssignStmt are implemented without assertion.