### PR TITLE
feat(ir): implement IfStmt and YieldStmt statement types

### DIFF
--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -162,6 +162,8 @@ class StmtFunctor {
  protected:
   // Statement types
   virtual R VisitStmt_(const AssignStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const IfStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const YieldStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -175,6 +177,8 @@ template <typename R, typename... Args>
 R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   // Dispatch to concrete statement types
   STMT_FUNCTOR_DISPATCH(AssignStmt);
+  STMT_FUNCTOR_DISPATCH(IfStmt);
+  STMT_FUNCTOR_DISPATCH(YieldStmt);
   STMT_FUNCTOR_DISPATCH(Stmt);
 
   // Should never reach here if all types are handled

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -72,6 +72,8 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
 
   // Statement types
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override;
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override;
+  StmtPtr VisitStmt_(const YieldStmtPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -71,6 +71,8 @@ class IRVisitor : public IRFunctor<void> {
 
   // Statement types
   void VisitStmt_(const AssignStmtPtr& op) override;
+  void VisitStmt_(const IfStmtPtr& op) override;
+  void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -127,6 +127,8 @@ class IRPrinter : public IRVisitor {
 
   // Statement types
   void VisitStmt_(const AssignStmtPtr& op) override;
+  void VisitStmt_(const IfStmtPtr& op) override;
+  void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -298,6 +298,52 @@ void BindIR(nb::module_& m) {
             return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
           },
           "Detailed representation of the assignment statement");
+
+  // IfStmt - const shared_ptr
+  auto if_stmt_class = nb::class_<IfStmt, Stmt>(
+      ir, "IfStmt", "Conditional statement: if condition then then_body else else_body");
+  if_stmt_class.def(
+      nb::init<const ExprPtr&, const std::vector<StmtPtr>&, const std::vector<StmtPtr>&, const Span&>(),
+      nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body"), nb::arg("span"),
+      "Create a conditional statement");
+  BindFields<IfStmt>(if_stmt_class);
+  if_stmt_class
+      .def(
+          "__str__",
+          [](const std::shared_ptr<const IfStmt>& self) {
+            IRPrinter printer;
+            return printer.Print(self);
+          },
+          "String representation of the conditional statement")
+      .def(
+          "__repr__",
+          [](const std::shared_ptr<const IfStmt>& self) {
+            IRPrinter printer;
+            return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
+          },
+          "Detailed representation of the conditional statement");
+
+  // YieldStmt - const shared_ptr
+  auto yield_stmt_class = nb::class_<YieldStmt, Stmt>(ir, "YieldStmt", "Yield statement: yield value");
+  yield_stmt_class.def(nb::init<const std::vector<VarPtr>&, const Span&>(), nb::arg("value"), nb::arg("span"),
+                       "Create a yield statement with a list of variables");
+  yield_stmt_class.def(nb::init<const Span&>(), nb::arg("span"), "Create a yield statement without values");
+  BindFields<YieldStmt>(yield_stmt_class);
+  yield_stmt_class
+      .def(
+          "__str__",
+          [](const std::shared_ptr<const YieldStmt>& self) {
+            IRPrinter printer;
+            return printer.Print(self);
+          },
+          "String representation of the yield statement")
+      .def(
+          "__repr__",
+          [](const std::shared_ptr<const YieldStmt>& self) {
+            IRPrinter printer;
+            return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
+          },
+          "Detailed representation of the yield statement");
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """Type stubs for PyPTO IR (Intermediate Representation) module."""
 
-from typing import Final, Sequence
+from typing import Final, Sequence, overload
 
 from pypto import DataType
 
@@ -619,6 +619,53 @@ class AssignStmt(Stmt):
             value: Expression
             span: Source location
         """
+
+class IfStmt(Stmt):
+    """Conditional statement: if condition then then_body else else_body."""
+
+    condition: Final[Expr]
+    """Condition expression."""
+
+    then_body: Final[list[Stmt]]
+    """Then branch statements."""
+
+    else_body: Final[list[Stmt]]
+    """Else branch statements (can be empty)."""
+
+    def __init__(self, condition: Expr, then_body: list[Stmt], else_body: list[Stmt], span: Span) -> None:
+        """Create a conditional statement.
+
+        Args:
+            condition: Condition expression
+            then_body: Then branch statements
+            else_body: Else branch statements (can be empty)
+            span: Source location
+        """
+
+class YieldStmt(Stmt):
+    """Yield statement: yield value."""
+
+    value: Final[list[Var]]
+    """List of variables to yield (can be empty)."""
+
+    @overload
+    def __init__(self, value: list[Var], span: Span) -> None:
+        """Create a yield statement with a list of variables.
+
+        Args:
+            value: List of variables to yield
+            span: Source location
+        """
+        ...
+
+    @overload
+    def __init__(self, span: Span) -> None:
+        """Create a yield statement without values.
+
+        Args:
+            span: Source location
+        """
+        ...
 
 def structural_hash(node: IRNode, enable_auto_mapping: bool = False) -> int:
     """Compute structural hash of an IR node.

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -241,6 +241,42 @@ void IRPrinter::VisitStmt_(const AssignStmtPtr& op) {
   VisitExpr(op->value_);
 }
 
+void IRPrinter::VisitStmt_(const IfStmtPtr& op) {
+  // Print if statement: if condition:\n  then_body\nelse:\n  else_body
+  stream_ << "if ";
+  VisitExpr(op->condition_);
+  stream_ << ":\n";
+  for (size_t i = 0; i < op->then_body_.size(); ++i) {
+    stream_ << "  ";
+    VisitStmt(op->then_body_[i]);
+    if (i < op->then_body_.size() - 1 || !op->else_body_.empty()) {
+      stream_ << "\n";
+    }
+  }
+  if (!op->else_body_.empty()) {
+    stream_ << "else:\n";
+    for (size_t i = 0; i < op->else_body_.size(); ++i) {
+      stream_ << "  ";
+      VisitStmt(op->else_body_[i]);
+      if (i < op->else_body_.size() - 1) {
+        stream_ << "\n";
+      }
+    }
+  }
+}
+
+void IRPrinter::VisitStmt_(const YieldStmtPtr& op) {
+  // Print yield statement: yield value1, value2, ... or yield
+  stream_ << "yield";
+  if (!op->value_.empty()) {
+    stream_ << " ";
+    for (size_t i = 0; i < op->value_.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      VisitExpr(op->value_[i]);
+    }
+  }
+}
+
 void IRPrinter::VisitStmt_(const StmtPtr& op) {
   // Base Stmt: just print the type name
   stream_ << op->TypeName();

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -171,6 +171,8 @@ bool StructuralEqual::Equal(const IRNodePtr& lhs, const IRNodePtr& rhs) {
   EQUAL_DISPATCH(BinaryExpr)
   EQUAL_DISPATCH(UnaryExpr)
   EQUAL_DISPATCH(AssignStmt)
+  EQUAL_DISPATCH(IfStmt)
+  EQUAL_DISPATCH(YieldStmt)
 
   // Unknown IR node type
   throw pypto::TypeError("Unknown IR node type in StructuralEqual::Equal");

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -195,6 +195,8 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(BinaryExpr)
   HASH_DISPATCH(UnaryExpr)
   HASH_DISPATCH(AssignStmt)
+  HASH_DISPATCH(IfStmt)
+  HASH_DISPATCH(YieldStmt)
 
   // Free Var types that may be mapped to other free vars
   if (auto var = std::dynamic_pointer_cast<const Var>(node)) {

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -104,6 +104,26 @@ void IRVisitor::VisitStmt_(const AssignStmtPtr& op) {
   VisitExpr(op->value_);
 }
 
+void IRVisitor::VisitStmt_(const IfStmtPtr& op) {
+  INTERNAL_CHECK(op->condition_) << "IfStmt has null condition";
+  VisitExpr(op->condition_);
+  for (size_t i = 0; i < op->then_body_.size(); ++i) {
+    INTERNAL_CHECK(op->then_body_[i]) << "IfStmt has null then_body statement at index " << i;
+    VisitStmt(op->then_body_[i]);
+  }
+  for (size_t i = 0; i < op->else_body_.size(); ++i) {
+    INTERNAL_CHECK(op->else_body_[i]) << "IfStmt has null else_body statement at index " << i;
+    VisitStmt(op->else_body_[i]);
+  }
+}
+
+void IRVisitor::VisitStmt_(const YieldStmtPtr& op) {
+  for (size_t i = 0; i < op->value_.size(); ++i) {
+    INTERNAL_CHECK(op->value_[i]) << "YieldStmt has null value at index " << i;
+    VisitExpr(op->value_[i]);
+  }
+}
+
 void IRVisitor::VisitStmt_(const StmtPtr& op) {
   // Base Stmt has no children to visit
 }

--- a/tests/ut/ir/test_hash_equal.py
+++ b/tests/ut/ir/test_hash_equal.py
@@ -212,7 +212,8 @@ class TestStructuralHash:
 
         hash1 = ir.structural_hash(assign1)
         hash2 = ir.structural_hash(assign2)
-        print(f"hash1: {hash1}, hash2: {hash2}")
+        # Different variable pointers result in different hashes without auto_mapping
+        assert hash1 != hash2
 
     def test_assign_stmt_different_var_hash(self):
         """Test AssignStmt nodes with different var hash."""
@@ -227,7 +228,7 @@ class TestStructuralHash:
 
         hash1 = ir.structural_hash(assign1)
         hash2 = ir.structural_hash(assign2)
-        print(f"hash1: {hash1}, hash2: {hash2}")
+        assert hash1 == hash2
 
     def test_assign_stmt_different_value_hash(self):
         """Test AssignStmt nodes with different value hash."""
@@ -242,7 +243,7 @@ class TestStructuralHash:
 
         hash1 = ir.structural_hash(assign1)
         hash2 = ir.structural_hash(assign2)
-        print(f"hash1: {hash1}, hash2: {hash2}")
+        assert hash1 != hash2
 
     def test_assign_stmt_different_from_base_stmt_hash(self):
         """Test AssignStmt and base Stmt nodes hash differently."""
@@ -255,6 +256,126 @@ class TestStructuralHash:
 
         hash_assign = ir.structural_hash(assign)
         assert hash_assign != 0
+
+    def test_if_stmt_same_structure_hash(self):
+        """Test IfStmt nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x1, y1, dtype, span)
+        condition2 = ir.Eq(x2, y2, dtype, span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        if_stmt1 = ir.IfStmt(condition1, [assign1], [], span)
+        if_stmt2 = ir.IfStmt(condition2, [assign2], [], span)
+
+        hash1 = ir.structural_hash(if_stmt1)
+        hash2 = ir.structural_hash(if_stmt2)
+        # Different variable pointers result in different hashes without auto_mapping
+        assert hash1 != hash2
+
+    def test_if_stmt_different_condition_hash(self):
+        """Test IfStmt nodes with different condition hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x, y, dtype, span)
+        condition2 = ir.Lt(x, z, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+
+        if_stmt1 = ir.IfStmt(condition1, [assign], [], span)
+        if_stmt2 = ir.IfStmt(condition2, [assign], [], span)
+
+        hash1 = ir.structural_hash(if_stmt1)
+        hash2 = ir.structural_hash(if_stmt2)
+        assert hash1 != hash2
+
+    def test_if_stmt_different_then_body_hash(self):
+        """Test IfStmt nodes with different then_body hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+
+        if_stmt1 = ir.IfStmt(condition, [assign1], [], span)
+        if_stmt2 = ir.IfStmt(condition, [assign2], [], span)
+
+        hash1 = ir.structural_hash(if_stmt1)
+        hash2 = ir.structural_hash(if_stmt2)
+        assert hash1 != hash2
+
+    def test_if_stmt_different_else_body_hash(self):
+        """Test IfStmt nodes with different else_body hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+
+        if_stmt1 = ir.IfStmt(condition, [assign1], [assign1], span)
+        if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], span)
+
+        hash1 = ir.structural_hash(if_stmt1)
+        hash2 = ir.structural_hash(if_stmt2)
+        assert hash1 != hash2
+
+    def test_yield_stmt_same_structure_hash(self):
+        """Test YieldStmt nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([x1, y1], span)
+        yield_stmt2 = ir.YieldStmt([x2, y2], span)
+
+        hash1 = ir.structural_hash(yield_stmt1)
+        hash2 = ir.structural_hash(yield_stmt2)
+        # Different variable pointers result in different hashes without auto_mapping
+        assert hash1 != hash2
+
+    def test_yield_stmt_different_vars_hash(self):
+        """Test YieldStmt nodes with different vars hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([x, y], span)
+        yield_stmt2 = ir.YieldStmt([x, z], span)
+
+        hash1 = ir.structural_hash(yield_stmt1)
+        hash2 = ir.structural_hash(yield_stmt2)
+        assert hash1 != hash2
+
+    def test_yield_stmt_empty_vs_non_empty_hash(self):
+        """Test YieldStmt nodes with empty and non-empty value lists hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([], span)
+        yield_stmt2 = ir.YieldStmt([x], span)
+
+        hash1 = ir.structural_hash(yield_stmt1)
+        hash2 = ir.structural_hash(yield_stmt2)
+        assert hash1 != hash2
 
 
 class TestStructuralEquality:
@@ -457,8 +578,10 @@ class TestStructuralEquality:
         assign1 = ir.AssignStmt(x1, y1, span)
         assign2 = ir.AssignStmt(x2, y2, span)
 
-        equal = ir.structural_equal(assign1, assign2)
-        print(f"equal: {equal}")
+        # Different variable pointers, so not equal without auto_mapping
+        assert not ir.structural_equal(assign1, assign2, enable_auto_mapping=False)
+        # With auto_mapping, they should be equal
+        assert ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
 
     def test_assign_stmt_different_var_not_equal(self):
         """Test AssignStmt nodes with different var are not equal."""
@@ -471,8 +594,7 @@ class TestStructuralEquality:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(z, y, span)
 
-        equal = ir.structural_equal(assign1, assign2)
-        print(f"equal: {equal}")
+        assert ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
 
     def test_assign_stmt_different_value_not_equal(self):
         """Test AssignStmt nodes with different value are not equal."""
@@ -485,8 +607,10 @@ class TestStructuralEquality:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(x, z, span)
 
-        equal = ir.structural_equal(assign1, assign2)
-        print(f"equal: {equal}")
+        # Different value, so not equal
+        assert not ir.structural_equal(assign1, assign2, enable_auto_mapping=False)
+        # With auto_mapping, they should be equal (x maps to x, y maps to z)
+        assert ir.structural_equal(assign1, assign2, enable_auto_mapping=True)
 
     def test_assign_stmt_different_from_base_stmt_not_equal(self):
         """Test AssignStmt and base Stmt nodes are not equal."""
@@ -498,8 +622,143 @@ class TestStructuralEquality:
         assign = ir.AssignStmt(x, y, span)
         stmt = ir.Stmt(span)
 
-        equal = ir.structural_equal(assign, stmt)
-        print(f"equal: {equal}")
+        # Different types, so not equal
+        assert not ir.structural_equal(assign, stmt)
+
+    def test_if_stmt_structural_equal(self):
+        """Test structural equality of IfStmt nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x1, y1, dtype, span)
+        condition2 = ir.Eq(x2, y2, dtype, span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        if_stmt1 = ir.IfStmt(condition1, [assign1], [], span)
+        if_stmt2 = ir.IfStmt(condition2, [assign2], [], span)
+
+        # Different variable pointers, so not equal without auto_mapping
+        assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
+        # With auto_mapping, they should be equal
+        assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
+
+    def test_if_stmt_different_condition_not_equal(self):
+        """Test IfStmt nodes with different condition are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x, y, dtype, span)
+        condition2 = ir.Lt(x, z, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+
+        if_stmt1 = ir.IfStmt(condition1, [assign], [], span)
+        if_stmt2 = ir.IfStmt(condition2, [assign], [], span)
+
+        assert not ir.structural_equal(if_stmt1, if_stmt2)
+
+    def test_if_stmt_different_then_body_not_equal(self):
+        """Test IfStmt nodes with different then_body are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+
+        if_stmt1 = ir.IfStmt(condition, [assign1], [], span)
+        if_stmt2 = ir.IfStmt(condition, [assign2], [], span)
+
+        assert not ir.structural_equal(if_stmt1, if_stmt2)
+
+    def test_if_stmt_different_else_body_not_equal(self):
+        """Test IfStmt nodes with different else_body are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+
+        if_stmt1 = ir.IfStmt(condition, [assign1], [assign1], span)
+        if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], span)
+
+        assert not ir.structural_equal(if_stmt1, if_stmt2)
+
+    def test_if_stmt_different_from_base_stmt_not_equal(self):
+        """Test IfStmt and base Stmt nodes are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+        stmt = ir.Stmt(span)
+
+        assert not ir.structural_equal(if_stmt, stmt)
+
+    def test_yield_stmt_structural_equal(self):
+        """Test structural equality of YieldStmt nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([x1, y1], span)
+        yield_stmt2 = ir.YieldStmt([x2, y2], span)
+
+        # Different variable pointers, so not equal without auto_mapping
+        assert not ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=False)
+        # With auto_mapping, they should be equal
+        assert ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=True)
+
+    def test_yield_stmt_different_vars_not_equal(self):
+        """Test YieldStmt nodes with different vars are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([x, y], span)
+        yield_stmt2 = ir.YieldStmt([x, z], span)
+
+        assert not ir.structural_equal(yield_stmt1, yield_stmt2)
+
+    def test_yield_stmt_empty_vs_non_empty_not_equal(self):
+        """Test YieldStmt nodes with empty and non-empty value lists are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        yield_stmt1 = ir.YieldStmt([], span)
+        yield_stmt2 = ir.YieldStmt([x], span)
+
+        assert not ir.structural_equal(yield_stmt1, yield_stmt2)
+
+    def test_yield_stmt_different_from_base_stmt_not_equal(self):
+        """Test YieldStmt and base Stmt nodes are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        yield_stmt = ir.YieldStmt([x], span)
+        stmt = ir.Stmt(span)
+
+        assert not ir.structural_equal(yield_stmt, stmt)
 
 
 class TestHashEqualityConsistency:
@@ -1010,6 +1269,92 @@ class TestAutoMapping:
         hash_without_auto1 = ir.structural_hash(assign1, enable_auto_mapping=False)
         hash_without_auto2 = ir.structural_hash(assign2, enable_auto_mapping=False)
         assert hash_without_auto1 != hash_without_auto2
+
+    def test_auto_mapping_with_if_stmt(self):
+        """Test auto mapping with IfStmt."""
+        # Build: if x == y then x = y else y = x
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
+        assign1_then = ir.AssignStmt(x1, y1, ir.Span.unknown())
+        assign1_else = ir.AssignStmt(y1, x1, ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, [assign1_then], [assign1_else], ir.Span.unknown())
+
+        # Build: if a == b then a = b else b = a
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
+        assign2_then = ir.AssignStmt(a, b, ir.Span.unknown())
+        assign2_else = ir.AssignStmt(b, a, ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, [assign2_then], [assign2_else], ir.Span.unknown())
+
+        assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
+        assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
+
+        hash_with_auto1 = ir.structural_hash(if_stmt1, enable_auto_mapping=True)
+        hash_with_auto2 = ir.structural_hash(if_stmt2, enable_auto_mapping=True)
+        assert hash_with_auto1 == hash_with_auto2
+
+        hash_without_auto1 = ir.structural_hash(if_stmt1, enable_auto_mapping=False)
+        hash_without_auto2 = ir.structural_hash(if_stmt2, enable_auto_mapping=False)
+        assert hash_without_auto1 != hash_without_auto2
+
+    def test_auto_mapping_if_stmt_different_structure(self):
+        """Test auto mapping with IfStmt where structure differs."""
+        # Build: if x == y then x = y
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
+        assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, [assign1], [], ir.Span.unknown())
+
+        # Build: if a == b then a = b else b = a
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
+        assign2_then = ir.AssignStmt(a, b, ir.Span.unknown())
+        assign2_else = ir.AssignStmt(b, a, ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, [assign2_then], [assign2_else], ir.Span.unknown())
+
+        # Different structure (one has else, one doesn't)
+        assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
+
+    def test_auto_mapping_with_yield_stmt(self):
+        """Test auto mapping with YieldStmt."""
+        # Build: yield x, y
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        yield_stmt1 = ir.YieldStmt([x1, y1], ir.Span.unknown())
+
+        # Build: yield a, b
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        yield_stmt2 = ir.YieldStmt([a, b], ir.Span.unknown())
+
+        assert ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=True)
+        assert not ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=False)
+
+        hash_with_auto1 = ir.structural_hash(yield_stmt1, enable_auto_mapping=True)
+        hash_with_auto2 = ir.structural_hash(yield_stmt2, enable_auto_mapping=True)
+        assert hash_with_auto1 == hash_with_auto2
+
+        hash_without_auto1 = ir.structural_hash(yield_stmt1, enable_auto_mapping=False)
+        hash_without_auto2 = ir.structural_hash(yield_stmt2, enable_auto_mapping=False)
+        assert hash_without_auto1 != hash_without_auto2
+
+    def test_auto_mapping_yield_stmt_different_length(self):
+        """Test auto mapping with YieldStmt where list lengths differ."""
+        # Build: yield x
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        yield_stmt1 = ir.YieldStmt([x1], ir.Span.unknown())
+
+        # Build: yield a, b
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        b = ir.Var("b", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        yield_stmt2 = ir.YieldStmt([a, b], ir.Span.unknown())
+
+        # Different lengths should not be equal
+        assert not ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=True)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_printer.py
+++ b/tests/ut/ir/test_printer.py
@@ -663,5 +663,65 @@ def test_assign_stmt_with_division_types():
     assert str(assign) == "x = y % 2"
 
 
+def test_if_stmt_printing():
+    """Test printing of IfStmt statements."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # Basic if statement without else
+    condition = ir.Eq(x, y, dtype, span)
+    assign = ir.AssignStmt(x, y, span)
+    if_stmt = ir.IfStmt(condition, [assign], [], span)
+    assert str(if_stmt) == "if x == y:\n  x = y"
+
+    # If statement with else
+    assign1 = ir.AssignStmt(x, y, span)
+    assign2 = ir.AssignStmt(y, z, span)
+    if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], span)
+    assert str(if_stmt2) == "if x == y:\n  x = y\nelse:\n  y = z"
+
+    # If statement with multiple statements in then_body
+    assign3 = ir.AssignStmt(z, x, span)
+    if_stmt3 = ir.IfStmt(condition, [assign1, assign2], [], span)
+    assert str(if_stmt3) == "if x == y:\n  x = y\n  y = z"
+
+    # If statement with multiple statements in both branches
+    if_stmt4 = ir.IfStmt(condition, [assign1, assign2], [assign3], span)
+    assert str(if_stmt4) == "if x == y:\n  x = y\n  y = z\nelse:\n  z = x"
+
+    # If statement with complex condition
+    complex_condition = ir.And(ir.Lt(x, y, dtype, span), ir.Gt(z, x, dtype, span), dtype, span)
+    if_stmt5 = ir.IfStmt(complex_condition, [assign1], [], span)
+    assert str(if_stmt5) == "if x < y and z > x:\n  x = y"
+
+
+def test_yield_stmt_printing():
+    """Test printing of YieldStmt statements."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    # Yield without value
+    yield_stmt = ir.YieldStmt(span)
+    assert str(yield_stmt) == "yield"
+
+    # Yield with single variable
+    yield_stmt2 = ir.YieldStmt([x], span)
+    assert str(yield_stmt2) == "yield x"
+
+    # Yield with multiple variables
+    yield_stmt3 = ir.YieldStmt([x, y], span)
+    assert str(yield_stmt3) == "yield x, y"
+
+    # Yield with three variables
+    yield_stmt4 = ir.YieldStmt([x, y, z], span)
+    assert str(yield_stmt4) == "yield x, y, z"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_stmt.py
+++ b/tests/ut/ir/test_stmt.py
@@ -141,5 +141,207 @@ class TestAssignStmt:
         assert isinstance(assign4.value, ir.Add)
 
 
+class TestIfStmt:
+    """Test IfStmt class."""
+
+    def test_if_stmt_creation(self):
+        """Test creating an IfStmt instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+
+        assert if_stmt is not None
+        assert if_stmt.span.filename == "test.py"
+        assert isinstance(if_stmt.condition, ir.Eq)
+        assert len(if_stmt.then_body) == 1
+        assert len(if_stmt.else_body) == 0
+
+    def test_if_stmt_has_attributes(self):
+        """Test that IfStmt has condition, then_body, and else_body attributes."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        condition = ir.Lt(a, b, dtype, span)
+        assign1 = ir.AssignStmt(a, b, span)
+        assign2 = ir.AssignStmt(b, a, span)
+        if_stmt = ir.IfStmt(condition, [assign1], [assign2], span)
+
+        assert if_stmt.condition is not None
+        assert len(if_stmt.then_body) == 1
+        assert len(if_stmt.else_body) == 1
+        assert isinstance(if_stmt.then_body[0], ir.AssignStmt)
+        assert isinstance(if_stmt.else_body[0], ir.AssignStmt)
+
+    def test_if_stmt_is_stmt(self):
+        """Test that IfStmt is an instance of Stmt."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+
+        assert isinstance(if_stmt, ir.Stmt)
+        assert isinstance(if_stmt, ir.IRNode)
+
+    def test_if_stmt_immutability(self):
+        """Test that IfStmt attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            if_stmt.condition = ir.Eq(y, x, dtype, span)  # type: ignore
+        with pytest.raises(AttributeError):
+            if_stmt.then_body = []  # type: ignore
+        with pytest.raises(AttributeError):
+            if_stmt.else_body = []  # type: ignore
+
+    def test_if_stmt_with_empty_else_body(self):
+        """Test IfStmt with empty else_body."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign = ir.AssignStmt(x, y, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+
+        assert len(if_stmt.else_body) == 0
+
+    def test_if_stmt_with_different_condition_types(self):
+        """Test IfStmt with different condition expression types."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        # Test with Eq condition
+        condition1 = ir.Eq(x, y, dtype, span)
+        if_stmt1 = ir.IfStmt(condition1, [assign], [], span)
+        assert isinstance(if_stmt1.condition, ir.Eq)
+
+        # Test with Lt condition
+        condition2 = ir.Lt(x, y, dtype, span)
+        if_stmt2 = ir.IfStmt(condition2, [assign], [], span)
+        assert isinstance(if_stmt2.condition, ir.Lt)
+
+        # Test with And condition
+        condition3 = ir.And(x, y, dtype, span)
+        if_stmt3 = ir.IfStmt(condition3, [assign], [], span)
+        assert isinstance(if_stmt3.condition, ir.And)
+
+    def test_if_stmt_with_multiple_statements(self):
+        """Test IfStmt with multiple statements in then_body and else_body."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        condition = ir.Eq(x, y, dtype, span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+        assign3 = ir.AssignStmt(z, x, span)
+        if_stmt = ir.IfStmt(condition, [assign1, assign2], [assign3], span)
+
+        assert len(if_stmt.then_body) == 2
+        assert len(if_stmt.else_body) == 1
+
+
+class TestYieldStmt:
+    """Test YieldStmt class."""
+
+    def test_yield_stmt_creation_with_value(self):
+        """Test creating a YieldStmt instance with a value."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        yield_stmt = ir.YieldStmt([x], span)
+
+        assert yield_stmt is not None
+        assert yield_stmt.span.filename == "test.py"
+        assert len(yield_stmt.value) == 1
+        assert yield_stmt.value[0].name == "x"
+
+    def test_yield_stmt_creation_without_value(self):
+        """Test creating a YieldStmt instance without a value."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        yield_stmt = ir.YieldStmt(span)
+
+        assert yield_stmt is not None
+        assert yield_stmt.span.filename == "test.py"
+        assert len(yield_stmt.value) == 0
+
+    def test_yield_stmt_has_value_attribute(self):
+        """Test that YieldStmt has value attribute."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        yield_stmt = ir.YieldStmt([a], span)
+
+        assert len(yield_stmt.value) == 1
+        assert yield_stmt.value[0].name == "a"
+
+    def test_yield_stmt_is_stmt(self):
+        """Test that YieldStmt is an instance of Stmt."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        yield_stmt = ir.YieldStmt([x], span)
+
+        assert isinstance(yield_stmt, ir.Stmt)
+        assert isinstance(yield_stmt, ir.IRNode)
+
+    def test_yield_stmt_immutability(self):
+        """Test that YieldStmt attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        yield_stmt = ir.YieldStmt([x], span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            yield_stmt.value = [y]  # type: ignore
+
+    def test_yield_stmt_with_multiple_vars(self):
+        """Test YieldStmt with multiple variables."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        # Test with single Var
+        yield_stmt1 = ir.YieldStmt([x], span)
+        assert len(yield_stmt1.value) == 1
+        assert yield_stmt1.value[0].name == "x"
+
+        # Test with multiple Vars
+        yield_stmt2 = ir.YieldStmt([x, y], span)
+        assert len(yield_stmt2.value) == 2
+        assert yield_stmt2.value[0].name == "x"
+        assert yield_stmt2.value[1].name == "y"
+
+        # Test with three Vars
+        yield_stmt3 = ir.YieldStmt([x, y, z], span)
+        assert len(yield_stmt3.value) == 3
+        assert yield_stmt3.value[0].name == "x"
+        assert yield_stmt3.value[1].name == "y"
+        assert yield_stmt3.value[2].name == "z"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add two new statement types to the IR:
- IfStmt: Conditional statement with condition expression, then_body, and optional else_body (both are statement lists)
- YieldStmt: Yield statement with a list of variables to yield

Implementation includes:
- C++ class definitions with private members and friend declarations
- Visitor, mutator, and printer implementations
- Structural hash and equality support
- Python bindings with proper constructors
- Comprehensive test cases for both statement types

Notice:
- test_hash_equal cases are not implemented yet.
- IfStmt should have return fields, but not implemented yet.