### PR TITLE
refactor(ir): enhance FieldIterator for pairwise visitation and fix AssignStmt checks

### DIFF
--- a/include/pypto/ir/transform/transformers.h
+++ b/include/pypto/ir/transform/transformers.h
@@ -39,7 +39,7 @@ namespace ir {
  *                            If false, variable names matter (default).
  * @return Structural hash value
  */
-int64_t structural_hash(const IRNodePtr& node, bool enable_auto_mapping = false);
+uint64_t structural_hash(const IRNodePtr& node, bool enable_auto_mapping = false);
 
 /**
  * @brief Check if two IR nodes are structurally equal


### PR DESCRIPTION
Refactor FieldIterator to support both single-node and pairwise visitation patterns, enabling more efficient structural equality comparisons. Add UNREACHABLE macros to logging system for better error handling.

- Extend FieldIterator::Visit() with overload for pairwise field comparison
- Add visitor callback wrappers (VisitIgnoreField, VisitDefField, VisitUsualField)
- Implement UNREACHABLE and INTERNAL_UNREACHABLE macros with [[noreturn]]
- Remove HASH_DISPATCH(Stmt) since Stmt is now abstract base class
- Fix test cases to use AssignStmt instead of bare Stmt instances
- Remove debug print statements and add proper assertions in tests