### PR TITLE
refactor: update remaining pybind references to nanobind

### DIFF
--- a/include/pypto/core/common.h
+++ b/include/pypto/core/common.h
@@ -18,7 +18,7 @@
  * - Compiler hints and attributes
  * - Utility macros for code generation
  * - Build configuration constants
- * - PyBind11 module configuration
+ * - nanobind module configuration
  */
 
 #ifndef PYPTO_CORE_COMMON_H_
@@ -35,14 +35,11 @@ namespace pypto {
 #define PYPTO_VERSION_PATCH 0
 
 // ============================================================================
-// PyBind11 Module Configuration
+// nanobind Module Configuration
 // ============================================================================
 
-// Default name for the PyBind11 Python module
-constexpr auto pypto_pybind_module_name = "pypto_core";
-
-// Default docstring for the PyBind11 module
-#define PYPTO_PYBIND_MODULE_DOC "PyPTO core library"
+// Default docstring for the nanobind module
+#define PYPTO_NANOBIND_MODULE_DOC "PyPTO core library"
 
 // ============================================================================
 // Compiler Hints and Attributes

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -26,7 +26,7 @@
 namespace nb = nanobind;
 
 NB_MODULE(pypto_core, m) {
-  m.doc() = PYPTO_PYBIND_MODULE_DOC;
+  m.doc() = PYPTO_NANOBIND_MODULE_DOC;
 
   // Register error handling bindings
   pypto::python::BindErrors(m);

--- a/src/core/backtrace.cpp
+++ b/src/core/backtrace.cpp
@@ -82,7 +82,7 @@ void Backtrace::ErrorCallback(void* data, const char* msg, int errnum) {
 
 /// Clean up file paths from debug info that may contain temp build directory prefixes.
 /// When building via pip in a temp directory, paths may look like:
-///   /private/var/folders/.../build/./python/pybind/modules/logging.cpp
+///   /private/var/folders/.../build/./python/nanobind/modules/logging.cpp
 /// This function extracts just the relative path portion.
 std::string CleanupFilePath(const std::string& path) {
   if (path.empty()) {


### PR DESCRIPTION
Update documentation and comments to reflect the migration from pybind11 to nanobind, including:
- Module configuration constants and comments in common.h
- Example paths in backtrace.cpp comments