### PR TITLE
feat(ir): Add ForStmt statement

### DIFF
--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -180,6 +180,59 @@ class YieldStmt : public Stmt {
 
 using YieldStmtPtr = std::shared_ptr<const YieldStmt>;
 
+/**
+ * @brief For loop statement
+ *
+ * Represents a for loop: for loop_var in range(start, stop, step): body
+ * where loop_var is the loop variable, start/stop/step are expressions,
+ * and body is a list of statements.
+ */
+class ForStmt : public Stmt {
+ public:
+  /**
+   * @brief Create a for loop statement
+   *
+   * @param loop_var Loop variable
+   * @param start Start value expression
+   * @param stop Stop value expression
+   * @param step Step value expression
+   * @param body Loop body statements
+   * @param span Source location
+   */
+  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<StmtPtr> body, Span span)
+      : Stmt(std::move(span)),
+        loop_var_(std::move(loop_var)),
+        start_(std::move(start)),
+        stop_(std::move(stop)),
+        step_(std::move(step)),
+        body_(std::move(body)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "ForStmt"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (loop_var as DEF field, others as USUAL fields)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Stmt::GetFieldDescriptors(),
+                          std::make_tuple(reflection::DefField(&ForStmt::loop_var_, "loop_var"),
+                                          reflection::UsualField(&ForStmt::start_, "start"),
+                                          reflection::UsualField(&ForStmt::stop_, "stop"),
+                                          reflection::UsualField(&ForStmt::step_, "step"),
+                                          reflection::UsualField(&ForStmt::body_, "body")));
+  }
+
+ public:
+  VarPtr loop_var_;            // Loop variable
+  ExprPtr start_;              // Start value expression
+  ExprPtr stop_;               // Stop value expression
+  ExprPtr step_;               // Step value expression
+  std::vector<StmtPtr> body_;  // Loop body statements
+};
+
+using ForStmtPtr = std::shared_ptr<const ForStmt>;
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -164,6 +164,7 @@ class StmtFunctor {
   virtual R VisitStmt_(const AssignStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const IfStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const YieldStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const ForStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -179,6 +180,7 @@ R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   STMT_FUNCTOR_DISPATCH(AssignStmt);
   STMT_FUNCTOR_DISPATCH(IfStmt);
   STMT_FUNCTOR_DISPATCH(YieldStmt);
+  STMT_FUNCTOR_DISPATCH(ForStmt);
   STMT_FUNCTOR_DISPATCH(Stmt);
 
   // Should never reach here if all types are handled

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -74,6 +74,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override;
   StmtPtr VisitStmt_(const IfStmtPtr& op) override;
   StmtPtr VisitStmt_(const YieldStmtPtr& op) override;
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -73,6 +73,7 @@ class IRVisitor : public IRFunctor<void> {
   void VisitStmt_(const AssignStmtPtr& op) override;
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
+  void VisitStmt_(const ForStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -129,6 +129,7 @@ class IRPrinter : public IRVisitor {
   void VisitStmt_(const AssignStmtPtr& op) override;
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
+  void VisitStmt_(const ForStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -344,6 +344,30 @@ void BindIR(nb::module_& m) {
             return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
           },
           "Detailed representation of the yield statement");
+
+  // ForStmt - const shared_ptr
+  auto for_stmt_class = nb::class_<ForStmt, Stmt>(
+      ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
+  for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&,
+                              const std::vector<StmtPtr>&, const Span&>(),
+                     nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("body"),
+                     nb::arg("span"), "Create a for loop statement");
+  BindFields<ForStmt>(for_stmt_class);
+  for_stmt_class
+      .def(
+          "__str__",
+          [](const std::shared_ptr<const ForStmt>& self) {
+            IRPrinter printer;
+            return printer.Print(self);
+          },
+          "String representation of the for loop statement")
+      .def(
+          "__repr__",
+          [](const std::shared_ptr<const ForStmt>& self) {
+            IRPrinter printer;
+            return "<ir." + self->TypeName() + ": " + printer.Print(self) + ">";
+          },
+          "Detailed representation of the for loop statement");
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -667,6 +667,38 @@ class YieldStmt(Stmt):
         """
         ...
 
+class ForStmt(Stmt):
+    """For loop statement: for loop_var in range(start, stop, step): body."""
+
+    loop_var: Final[Var]
+    """Loop variable."""
+
+    start: Final[Expr]
+    """Start value expression."""
+
+    stop: Final[Expr]
+    """Stop value expression."""
+
+    step: Final[Expr]
+    """Step value expression."""
+
+    body: Final[list[Stmt]]
+    """Loop body statements."""
+
+    def __init__(
+        self, loop_var: Var, start: Expr, stop: Expr, step: Expr, body: list[Stmt], span: Span
+    ) -> None:
+        """Create a for loop statement.
+
+        Args:
+            loop_var: Loop variable
+            start: Start value expression
+            stop: Stop value expression
+            step: Step value expression
+            body: Loop body statements
+            span: Source location
+        """
+
 def structural_hash(node: IRNode, enable_auto_mapping: bool = False) -> int:
     """Compute structural hash of an IR node.
 

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -277,6 +277,26 @@ void IRPrinter::VisitStmt_(const YieldStmtPtr& op) {
   }
 }
 
+void IRPrinter::VisitStmt_(const ForStmtPtr& op) {
+  // Print for statement: for loop_var in range(start, stop, step):\n  body
+  stream_ << "for ";
+  VisitExpr(op->loop_var_);
+  stream_ << " in range(";
+  VisitExpr(op->start_);
+  stream_ << ", ";
+  VisitExpr(op->stop_);
+  stream_ << ", ";
+  VisitExpr(op->step_);
+  stream_ << "):\n";
+  for (size_t i = 0; i < op->body_.size(); ++i) {
+    stream_ << "  ";
+    VisitStmt(op->body_[i]);
+    if (i < op->body_.size() - 1) {
+      stream_ << "\n";
+    }
+  }
+}
+
 void IRPrinter::VisitStmt_(const StmtPtr& op) {
   // Base Stmt: just print the type name
   stream_ << op->TypeName();

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -173,6 +173,7 @@ bool StructuralEqual::Equal(const IRNodePtr& lhs, const IRNodePtr& rhs) {
   EQUAL_DISPATCH(AssignStmt)
   EQUAL_DISPATCH(IfStmt)
   EQUAL_DISPATCH(YieldStmt)
+  EQUAL_DISPATCH(ForStmt)
 
   // Unknown IR node type
   throw pypto::TypeError("Unknown IR node type in StructuralEqual::Equal");

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -197,6 +197,7 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(AssignStmt)
   HASH_DISPATCH(IfStmt)
   HASH_DISPATCH(YieldStmt)
+  HASH_DISPATCH(ForStmt)
 
   // Free Var types that may be mapped to other free vars
   if (auto var = std::dynamic_pointer_cast<const Var>(node)) {

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -124,6 +124,21 @@ void IRVisitor::VisitStmt_(const YieldStmtPtr& op) {
   }
 }
 
+void IRVisitor::VisitStmt_(const ForStmtPtr& op) {
+  INTERNAL_CHECK(op->loop_var_) << "ForStmt has null loop_var";
+  INTERNAL_CHECK(op->start_) << "ForStmt has null start";
+  INTERNAL_CHECK(op->stop_) << "ForStmt has null stop";
+  INTERNAL_CHECK(op->step_) << "ForStmt has null step";
+  VisitExpr(op->loop_var_);
+  VisitExpr(op->start_);
+  VisitExpr(op->stop_);
+  VisitExpr(op->step_);
+  for (size_t i = 0; i < op->body_.size(); ++i) {
+    INTERNAL_CHECK(op->body_[i]) << "ForStmt has null body statement at index " << i;
+    VisitStmt(op->body_[i]);
+  }
+}
+
 void IRVisitor::VisitStmt_(const StmtPtr& op) {
   // Base Stmt has no children to visit
 }

--- a/tests/ut/ir/test_hash_equal.py
+++ b/tests/ut/ir/test_hash_equal.py
@@ -377,6 +377,85 @@ class TestStructuralHash:
         hash2 = ir.structural_hash(yield_stmt2)
         assert hash1 != hash2
 
+    def test_for_stmt_same_structure_hash(self):
+        """Test ForStmt nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [assign1], span)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [assign2], span)
+
+        hash1 = ir.structural_hash(for_stmt1)
+        hash2 = ir.structural_hash(for_stmt2)
+        assert hash1 == hash2
+
+    def test_for_stmt_different_loop_var_hash(self):
+        """Test ForStmt nodes with different loop vars hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+
+        for_stmt1 = ir.ForStmt(i, start, stop, step, [assign], span)
+        for_stmt2 = ir.ForStmt(j, start, stop, step, [assign], span)
+
+        hash1 = ir.structural_hash(for_stmt1)
+        hash2 = ir.structural_hash(for_stmt2)
+        assert hash1 != hash2
+
+    def test_for_stmt_different_range_hash(self):
+        """Test ForStmt nodes with different range values hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(20, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start1, span)
+
+        for_stmt1 = ir.ForStmt(i, start1, stop1, step1, [assign], span)
+        for_stmt2 = ir.ForStmt(i, start2, stop2, step2, [assign], span)
+
+        hash1 = ir.structural_hash(for_stmt1)
+        hash2 = ir.structural_hash(for_stmt2)
+        assert hash1 != hash2
+
+    def test_for_stmt_different_body_hash(self):
+        """Test ForStmt nodes with different body statements hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i, start, span)
+        assign2 = ir.AssignStmt(i, x, span)
+
+        for_stmt1 = ir.ForStmt(i, start, stop, step, [assign1], span)
+        for_stmt2 = ir.ForStmt(i, start, stop, step, [assign2], span)
+
+        hash1 = ir.structural_hash(for_stmt1)
+        hash2 = ir.structural_hash(for_stmt2)
+        assert hash1 != hash2
+
 
 class TestStructuralEquality:
     """Tests for structural equality function."""
@@ -748,6 +827,106 @@ class TestStructuralEquality:
         yield_stmt2 = ir.YieldStmt([x], span)
 
         assert not ir.structural_equal(yield_stmt1, yield_stmt2)
+
+    def test_for_stmt_structural_equal(self):
+        """Test structural equality of ForStmt nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [assign1], span)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [assign2], span)
+
+        assert ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_for_stmt_different_loop_var_equal(self):
+        """Test ForStmt nodes with different loop vars are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+
+        for_stmt1 = ir.ForStmt(i, start, stop, step, [assign], span)
+        for_stmt2 = ir.ForStmt(j, start, stop, step, [assign], span)
+
+        assert ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_for_stmt_different_range_not_equal(self):
+        """Test ForStmt nodes with different range values are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(20, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start1, span)
+
+        for_stmt1 = ir.ForStmt(i, start1, stop1, step1, [assign], span)
+        for_stmt2 = ir.ForStmt(i, start2, stop2, step2, [assign], span)
+
+        assert not ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_for_stmt_different_body_not_equal(self):
+        """Test ForStmt nodes with different body statements are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i, start, span)
+        assign2 = ir.AssignStmt(i, x, span)
+
+        for_stmt1 = ir.ForStmt(i, start, stop, step, [assign1], span)
+        for_stmt2 = ir.ForStmt(i, start, stop, step, [assign2], span)
+
+        assert not ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_for_stmt_empty_vs_non_empty_body_not_equal(self):
+        """Test ForStmt nodes with empty and non-empty body lists are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+
+        for_stmt1 = ir.ForStmt(i, start, stop, step, [], span)
+        for_stmt2 = ir.ForStmt(i, start, stop, step, [assign], span)
+
+        assert not ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_for_stmt_different_from_base_stmt_not_equal(self):
+        """Test ForStmt and base Stmt nodes are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [assign], span)
+        base_stmt = ir.Stmt(span)
+
+        assert not ir.structural_equal(for_stmt, base_stmt)
 
     def test_yield_stmt_different_from_base_stmt_not_equal(self):
         """Test YieldStmt and base Stmt nodes are not equal."""
@@ -1355,6 +1534,56 @@ class TestAutoMapping:
 
         # Different lengths should not be equal
         assert not ir.structural_equal(yield_stmt1, yield_stmt2, enable_auto_mapping=True)
+
+    def test_auto_mapping_with_for_stmt(self):
+        """Test auto mapping with ForStmt."""
+        # Build: for i in range(0, 10, 1): i = 0
+        i1 = ir.Var("i", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        start1 = ir.ConstInt(0, DataType.INT64, ir.Span.unknown())
+        stop1 = ir.ConstInt(10, DataType.INT64, ir.Span.unknown())
+        step1 = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        assign1 = ir.AssignStmt(i1, start1, ir.Span.unknown())
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [assign1], ir.Span.unknown())
+
+        # Build: for j in range(0, 10, 1): j = 0
+        j = ir.Var("j", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        start2 = ir.ConstInt(0, DataType.INT64, ir.Span.unknown())
+        stop2 = ir.ConstInt(10, DataType.INT64, ir.Span.unknown())
+        step2 = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        assign2 = ir.AssignStmt(j, start2, ir.Span.unknown())
+        for_stmt2 = ir.ForStmt(j, start2, stop2, step2, [assign2], ir.Span.unknown())
+
+        assert ir.structural_equal(for_stmt1, for_stmt2, enable_auto_mapping=True)
+        assert ir.structural_equal(for_stmt1, for_stmt2, enable_auto_mapping=False)
+
+        hash_with_auto1 = ir.structural_hash(for_stmt1, enable_auto_mapping=True)
+        hash_with_auto2 = ir.structural_hash(for_stmt2, enable_auto_mapping=True)
+        assert hash_with_auto1 == hash_with_auto2
+
+        hash_without_auto1 = ir.structural_hash(for_stmt1, enable_auto_mapping=False)
+        hash_without_auto2 = ir.structural_hash(for_stmt2, enable_auto_mapping=False)
+        assert hash_without_auto1 == hash_without_auto2
+
+    def test_auto_mapping_for_stmt_different_structure(self):
+        """Test auto mapping with ForStmt where structures differ."""
+        # Build: for i in range(0, 10, 1): i = 0
+        i1 = ir.Var("i", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        start1 = ir.ConstInt(0, DataType.INT64, ir.Span.unknown())
+        stop1 = ir.ConstInt(10, DataType.INT64, ir.Span.unknown())
+        step1 = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        assign1 = ir.AssignStmt(i1, start1, ir.Span.unknown())
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [assign1], ir.Span.unknown())
+
+        # Build: for j in range(0, 20, 1): j = 0
+        j = ir.Var("j", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        start2 = ir.ConstInt(0, DataType.INT64, ir.Span.unknown())
+        stop2 = ir.ConstInt(20, DataType.INT64, ir.Span.unknown())
+        step2 = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        assign2 = ir.AssignStmt(j, start2, ir.Span.unknown())
+        for_stmt2 = ir.ForStmt(j, start2, stop2, step2, [assign2], ir.Span.unknown())
+
+        # Different stop values should not be equal
+        assert not ir.structural_equal(for_stmt1, for_stmt2, enable_auto_mapping=True)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_printer.py
+++ b/tests/ut/ir/test_printer.py
@@ -723,5 +723,46 @@ def test_yield_stmt_printing():
     assert str(yield_stmt4) == "yield x, y, z"
 
 
+def test_for_stmt_printing():
+    """Test printing of ForStmt statements."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    i = ir.Var("i", ir.ScalarType(dtype), span)
+    start = ir.ConstInt(0, dtype, span)
+    stop = ir.ConstInt(10, dtype, span)
+    step = ir.ConstInt(1, dtype, span)
+
+    # For loop with empty body
+    for_stmt = ir.ForStmt(i, start, stop, step, [], span)
+    assert str(for_stmt) == "for i in range(0, 10, 1):\n"
+
+    # For loop with single statement
+    assign = ir.AssignStmt(i, start, span)
+    for_stmt2 = ir.ForStmt(i, start, stop, step, [assign], span)
+    assert str(for_stmt2) == "for i in range(0, 10, 1):\n  i = 0"
+
+    # For loop with multiple statements
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    assign1 = ir.AssignStmt(i, x, span)
+    assign2 = ir.AssignStmt(x, y, span)
+    for_stmt3 = ir.ForStmt(i, start, stop, step, [assign1, assign2], span)
+    assert str(for_stmt3) == "for i in range(0, 10, 1):\n  i = x\n  x = y"
+
+    # For loop with variable expressions
+    n = ir.Var("n", ir.ScalarType(dtype), span)
+    m = ir.Var("m", ir.ScalarType(dtype), span)
+    k = ir.Var("k", ir.ScalarType(dtype), span)
+    for_stmt4 = ir.ForStmt(i, n, m, k, [assign], span)
+    assert str(for_stmt4) == "for i in range(n, m, k):\n  i = 0"
+
+    # For loop with arithmetic expressions
+    start_expr = ir.Add(n, ir.ConstInt(1, dtype, span), dtype, span)
+    stop_expr = ir.Mul(m, ir.ConstInt(2, dtype, span), dtype, span)
+    step_expr = ir.Sub(k, ir.ConstInt(1, dtype, span), dtype, span)
+    for_stmt5 = ir.ForStmt(i, start_expr, stop_expr, step_expr, [assign], span)
+    assert str(for_stmt5) == "for i in range(n + 1, m * 2, k - 1):\n  i = 0"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add ForStmt class in stmt.h with loop_var (VarPtr), start/stop/step (ExprPtr), and body (vector<StmtPtr>) fields
- Implement visitor support for ForStmt traversal
- Implement mutator support with copy-on-write semantics
- Implement printer support with format: "for loop_var in range(start, stop, step):\n  body"