### PR TITLE
feat(ir): Add OpStmts class for statement sequences

### DIFF
--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -233,6 +233,40 @@ class ForStmt : public Stmt {
 
 using ForStmtPtr = std::shared_ptr<const ForStmt>;
 
+/**
+ * @brief Operation statements
+ *
+ * Represents a sequence of statements: stmt1; stmt2; ... stmtN
+ * where stmts is a list of statements.
+ */
+class OpStmts : public Stmt {
+ public:
+  /**
+   * @brief Create an operation statements
+   *
+   * @param stmts List of statements
+   * @param span Source location
+   */
+  OpStmts(std::vector<StmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "OpStmts"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (stmts as USUAL field)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Stmt::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&OpStmts::stmts_, "stmts")));
+  }
+
+ public:
+  std::vector<StmtPtr> stmts_;  // List of statements
+};
+
+using OpStmtsPtr = std::shared_ptr<const OpStmts>;
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -165,6 +165,7 @@ class StmtFunctor {
   virtual R VisitStmt_(const IfStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const YieldStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const ForStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const OpStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -181,6 +182,7 @@ R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   STMT_FUNCTOR_DISPATCH(IfStmt);
   STMT_FUNCTOR_DISPATCH(YieldStmt);
   STMT_FUNCTOR_DISPATCH(ForStmt);
+  STMT_FUNCTOR_DISPATCH(OpStmts);
   STMT_FUNCTOR_DISPATCH(Stmt);
 
   // Should never reach here if all types are handled

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -75,6 +75,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   StmtPtr VisitStmt_(const IfStmtPtr& op) override;
   StmtPtr VisitStmt_(const YieldStmtPtr& op) override;
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
+  StmtPtr VisitStmt_(const OpStmtsPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -74,6 +74,7 @@ class IRVisitor : public IRFunctor<void> {
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const ForStmtPtr& op) override;
+  void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -130,6 +130,7 @@ class IRPrinter : public IRVisitor {
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const ForStmtPtr& op) override;
+  void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -699,6 +699,20 @@ class ForStmt(Stmt):
             span: Source location
         """
 
+class OpStmts(Stmt):
+    """Operation statements: a sequence of statements."""
+
+    stmts: Final[list[Stmt]]
+    """List of statements."""
+
+    def __init__(self, stmts: list[Stmt], span: Span) -> None:
+        """Create an operation statements.
+
+        Args:
+            stmts: List of statements
+            span: Source location
+        """
+
 def structural_hash(node: IRNode, enable_auto_mapping: bool = False) -> int:
     """Compute structural hash of an IR node.
 

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -297,6 +297,16 @@ void IRPrinter::VisitStmt_(const ForStmtPtr& op) {
   }
 }
 
+void IRPrinter::VisitStmt_(const OpStmtsPtr& op) {
+  // Print statements sequentially, one per line
+  for (size_t i = 0; i < op->stmts_.size(); ++i) {
+    VisitStmt(op->stmts_[i]);
+    if (i < op->stmts_.size() - 1) {
+      stream_ << "\n";
+    }
+  }
+}
+
 void IRPrinter::VisitStmt_(const StmtPtr& op) {
   // Base Stmt: just print the type name
   stream_ << op->TypeName();

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -174,6 +174,7 @@ bool StructuralEqual::Equal(const IRNodePtr& lhs, const IRNodePtr& rhs) {
   EQUAL_DISPATCH(IfStmt)
   EQUAL_DISPATCH(YieldStmt)
   EQUAL_DISPATCH(ForStmt)
+  EQUAL_DISPATCH(OpStmts)
 
   // Unknown IR node type
   throw pypto::TypeError("Unknown IR node type in StructuralEqual::Equal");

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -198,6 +198,7 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(IfStmt)
   HASH_DISPATCH(YieldStmt)
   HASH_DISPATCH(ForStmt)
+  HASH_DISPATCH(OpStmts)
 
   // Free Var types that may be mapped to other free vars
   if (auto var = std::dynamic_pointer_cast<const Var>(node)) {

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -139,6 +139,13 @@ void IRVisitor::VisitStmt_(const ForStmtPtr& op) {
   }
 }
 
+void IRVisitor::VisitStmt_(const OpStmtsPtr& op) {
+  for (size_t i = 0; i < op->stmts_.size(); ++i) {
+    INTERNAL_CHECK(op->stmts_[i]) << "OpStmts has null statement at index " << i;
+    VisitStmt(op->stmts_[i]);
+  }
+}
+
 void IRVisitor::VisitStmt_(const StmtPtr& op) {
   // Base Stmt has no children to visit
 }

--- a/tests/ut/ir/test_op_stmts.py
+++ b/tests/ut/ir/test_op_stmts.py
@@ -1,0 +1,331 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for OpStmts class."""
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestOpStmts:
+    """Test OpStmts class."""
+
+    def test_op_stmts_creation(self):
+        """Test creating an OpStmts instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        op_stmts = ir.OpStmts([assign], span)
+
+        assert op_stmts is not None
+        assert op_stmts.span.filename == "test.py"
+        assert len(op_stmts.stmts) == 1
+        assert isinstance(op_stmts.stmts[0], ir.AssignStmt)
+
+    def test_op_stmts_has_attributes(self):
+        """Test that OpStmts has stmts attribute."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(a, b, span)
+        assign2 = ir.AssignStmt(b, a, span)
+        op_stmts = ir.OpStmts([assign1, assign2], span)
+
+        assert op_stmts.stmts is not None
+        assert len(op_stmts.stmts) == 2
+        assert isinstance(op_stmts.stmts[0], ir.AssignStmt)
+        assert isinstance(op_stmts.stmts[1], ir.AssignStmt)
+
+    def test_op_stmts_is_stmt(self):
+        """Test that OpStmts is an instance of Stmt."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        op_stmts = ir.OpStmts([assign], span)
+
+        assert isinstance(op_stmts, ir.Stmt)
+        assert isinstance(op_stmts, ir.IRNode)
+
+    def test_op_stmts_immutability(self):
+        """Test that OpStmts attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        op_stmts = ir.OpStmts([assign], span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            op_stmts.stmts = []  # type: ignore
+
+    def test_op_stmts_with_empty_list(self):
+        """Test OpStmts with empty statement list."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        op_stmts = ir.OpStmts([], span)
+
+        assert len(op_stmts.stmts) == 0
+
+    def test_op_stmts_with_multiple_statements(self):
+        """Test OpStmts with multiple statements."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+        assign3 = ir.AssignStmt(z, x, span)
+        op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
+
+        assert len(op_stmts.stmts) == 3
+        assert isinstance(op_stmts.stmts[0], ir.AssignStmt)
+        assert isinstance(op_stmts.stmts[1], ir.AssignStmt)
+        assert isinstance(op_stmts.stmts[2], ir.AssignStmt)
+
+    def test_op_stmts_with_different_statement_types(self):
+        """Test OpStmts with different statement types."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+
+        # Test with AssignStmt
+        assign = ir.AssignStmt(x, y, span)
+        op_stmts1 = ir.OpStmts([assign], span)
+        assert isinstance(op_stmts1.stmts[0], ir.AssignStmt)
+
+        # Test with IfStmt
+        condition = ir.Eq(x, y, dtype, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+        op_stmts2 = ir.OpStmts([if_stmt], span)
+        assert isinstance(op_stmts2.stmts[0], ir.IfStmt)
+
+        # Test with YieldStmt
+        yield_stmt = ir.YieldStmt([z], span)
+        op_stmts3 = ir.OpStmts([yield_stmt], span)
+        assert isinstance(op_stmts3.stmts[0], ir.YieldStmt)
+
+        # Test with mixed statement types
+        op_stmts4 = ir.OpStmts([assign, if_stmt, yield_stmt], span)
+        assert len(op_stmts4.stmts) == 3
+        assert isinstance(op_stmts4.stmts[0], ir.AssignStmt)
+        assert isinstance(op_stmts4.stmts[1], ir.IfStmt)
+        assert isinstance(op_stmts4.stmts[2], ir.YieldStmt)
+
+
+class TestOpStmtsPrinting:
+    """Test printing of OpStmts statements."""
+
+    def test_op_stmts_printing_single(self):
+        """Test printing of OpStmts with single statement."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        op_stmts = ir.OpStmts([assign], span)
+        assert str(op_stmts) == "x = y"
+
+    def test_op_stmts_printing_multiple(self):
+        """Test printing of OpStmts with multiple statements."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+        assign3 = ir.AssignStmt(z, x, span)
+        op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
+        assert str(op_stmts) == "x = y\ny = z\nz = x"
+
+    def test_op_stmts_printing_empty(self):
+        """Test printing of OpStmts with empty statement list."""
+        span = ir.Span.unknown()
+        op_stmts = ir.OpStmts([], span)
+        assert str(op_stmts) == ""
+
+    def test_op_stmts_printing_mixed_types(self):
+        """Test printing of OpStmts with mixed statement types."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        condition = ir.Eq(x, y, dtype, span)
+        if_stmt = ir.IfStmt(condition, [assign], [], span)
+        yield_stmt = ir.YieldStmt([z], span)
+        op_stmts = ir.OpStmts([assign, if_stmt, yield_stmt], span)
+        assert str(op_stmts) == "x = y\nif x == y:\n  x = y\nyield z"
+
+
+class TestOpStmtsHash:
+    """Tests for OpStmts hash function."""
+
+    def test_op_stmts_same_structure_hash(self):
+        """Test OpStmts nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        op_stmts1 = ir.OpStmts([assign1], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        op_stmts2 = ir.OpStmts([assign2], span)
+
+        hash1 = ir.structural_hash(op_stmts1)
+        hash2 = ir.structural_hash(op_stmts2)
+        # Different variable pointers result in different hashes without auto_mapping
+        assert hash1 != hash2
+
+    def test_op_stmts_different_statements_hash(self):
+        """Test OpStmts nodes with different statements hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+
+        op_stmts1 = ir.OpStmts([assign1], span)
+        op_stmts2 = ir.OpStmts([assign2], span)
+
+        hash1 = ir.structural_hash(op_stmts1)
+        hash2 = ir.structural_hash(op_stmts2)
+        assert hash1 != hash2
+
+    def test_op_stmts_different_length_hash(self):
+        """Test OpStmts nodes with different lengths hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, x, span)
+
+        op_stmts1 = ir.OpStmts([assign1], span)
+        op_stmts2 = ir.OpStmts([assign1, assign2], span)
+
+        hash1 = ir.structural_hash(op_stmts1)
+        hash2 = ir.structural_hash(op_stmts2)
+        assert hash1 != hash2
+
+    def test_op_stmts_empty_hash(self):
+        """Test OpStmts nodes with empty list hash."""
+        span = ir.Span.unknown()
+        op_stmts1 = ir.OpStmts([], span)
+        op_stmts2 = ir.OpStmts([], span)
+
+        hash1 = ir.structural_hash(op_stmts1)
+        hash2 = ir.structural_hash(op_stmts2)
+        assert hash1 == hash2
+
+
+class TestOpStmtsEquality:
+    """Tests for OpStmts structural equality function."""
+
+    def test_op_stmts_structural_equal(self):
+        """Test structural equality of OpStmts nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        op_stmts1 = ir.OpStmts([assign1], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        op_stmts2 = ir.OpStmts([assign2], span)
+
+        # Without auto_mapping, different variable objects are not equal
+        assert not ir.structural_equal(op_stmts1, op_stmts2)
+
+        # With auto_mapping, same structure should be equal
+        assert ir.structural_equal(op_stmts1, op_stmts2, enable_auto_mapping=True)
+
+    def test_op_stmts_structural_equal_different_statements(self):
+        """Test structural equality of OpStmts with different statements."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+
+        op_stmts1 = ir.OpStmts([assign1], span)
+        op_stmts2 = ir.OpStmts([assign2], span)
+
+        assert not ir.structural_equal(op_stmts1, op_stmts2)
+        assert ir.structural_equal(op_stmts1, op_stmts2, enable_auto_mapping=True)
+
+    def test_op_stmts_structural_equal_different_length(self):
+        """Test structural equality of OpStmts with different lengths."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, x, span)
+
+        op_stmts1 = ir.OpStmts([assign1], span)
+        op_stmts2 = ir.OpStmts([assign1, assign2], span)
+
+        assert not ir.structural_equal(op_stmts1, op_stmts2)
+        assert not ir.structural_equal(op_stmts1, op_stmts2, enable_auto_mapping=True)
+
+    def test_op_stmts_structural_equal_empty(self):
+        """Test structural equality of OpStmts with empty lists."""
+        span = ir.Span.unknown()
+        op_stmts1 = ir.OpStmts([], span)
+        op_stmts2 = ir.OpStmts([], span)
+
+        assert ir.structural_equal(op_stmts1, op_stmts2)
+        assert ir.structural_equal(op_stmts1, op_stmts2, enable_auto_mapping=True)
+
+    def test_op_stmts_structural_equal_multiple_statements(self):
+        """Test structural equality of OpStmts with multiple statements."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        z1 = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1_1 = ir.AssignStmt(x1, y1, span)
+        assign2_1 = ir.AssignStmt(y1, z1, span)
+        op_stmts1 = ir.OpStmts([assign1_1, assign2_1], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        z2 = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1_2 = ir.AssignStmt(x2, y2, span)
+        assign2_2 = ir.AssignStmt(y2, z2, span)
+        op_stmts2 = ir.OpStmts([assign1_2, assign2_2], span)
+
+        # Without auto_mapping, different variable objects are not equal
+        assert not ir.structural_equal(op_stmts1, op_stmts2)
+
+        # With auto_mapping, same structure should be equal
+        assert ir.structural_equal(op_stmts1, op_stmts2, enable_auto_mapping=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add a new OpStmts class that inherits from Stmt and contains a list of statements. This allows representing sequences of statements as a single statement node in the IR.

- Add OpStmts class in include/pypto/ir/stmt.h with stmts_ member
- Update StmtFunctor dispatcher to handle OpStmts
- Implement VisitStmt_ for OpStmts in visitor, mutator, and printer
- Add Python bindings for OpStmts class
- Add comprehensive test suite in tests/ut/ir/test_op_stmts.py