### PR TITLE
feat(ir): Add return_values member to IfStmt and ForStmt

### DIFF
--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -109,13 +109,16 @@ class IfStmt : public Stmt {
    * @param condition Condition expression
    * @param then_body Then branch statements
    * @param else_body Else branch statements (can be empty)
+   * @param return_vars Return variables (can be empty)
    * @param span Source location
    */
-  IfStmt(ExprPtr condition, std::vector<StmtPtr> then_body, std::vector<StmtPtr> else_body, Span span)
+  IfStmt(ExprPtr condition, std::vector<StmtPtr> then_body, std::vector<StmtPtr> else_body,
+         std::vector<VarPtr> return_vars, Span span)
       : Stmt(std::move(span)),
         condition_(std::move(condition)),
         then_body_(std::move(then_body)),
-        else_body_(std::move(else_body)) {}
+        else_body_(std::move(else_body)),
+        return_vars_(std::move(return_vars)) {}
 
   [[nodiscard]] std::string TypeName() const override { return "IfStmt"; }
 
@@ -128,13 +131,15 @@ class IfStmt : public Stmt {
     return std::tuple_cat(Stmt::GetFieldDescriptors(),
                           std::make_tuple(reflection::UsualField(&IfStmt::condition_, "condition"),
                                           reflection::UsualField(&IfStmt::then_body_, "then_body"),
-                                          reflection::UsualField(&IfStmt::else_body_, "else_body")));
+                                          reflection::UsualField(&IfStmt::else_body_, "else_body"),
+                                          reflection::DefField(&IfStmt::return_vars_, "return_vars")));
   }
 
  public:
-  ExprPtr condition_;               // Condition expression
-  std::vector<StmtPtr> then_body_;  // Then branch statements
-  std::vector<StmtPtr> else_body_;  // Else branch statements (can be empty)
+  ExprPtr condition_;                // Condition expression
+  std::vector<StmtPtr> then_body_;   // Then branch statements
+  std::vector<StmtPtr> else_body_;   // Else branch statements (can be empty)
+  std::vector<VarPtr> return_vars_;  // Return variables (can be empty)
 };
 
 using IfStmtPtr = std::shared_ptr<const IfStmt>;
@@ -197,15 +202,18 @@ class ForStmt : public Stmt {
    * @param stop Stop value expression
    * @param step Step value expression
    * @param body Loop body statements
+   * @param return_vars Return variables (can be empty)
    * @param span Source location
    */
-  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<StmtPtr> body, Span span)
+  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<StmtPtr> body,
+          std::vector<VarPtr> return_vars, Span span)
       : Stmt(std::move(span)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
         stop_(std::move(stop)),
         step_(std::move(step)),
-        body_(std::move(body)) {}
+        body_(std::move(body)),
+        return_vars_(std::move(return_vars)) {}
 
   [[nodiscard]] std::string TypeName() const override { return "ForStmt"; }
 
@@ -220,15 +228,17 @@ class ForStmt : public Stmt {
                                           reflection::UsualField(&ForStmt::start_, "start"),
                                           reflection::UsualField(&ForStmt::stop_, "stop"),
                                           reflection::UsualField(&ForStmt::step_, "step"),
-                                          reflection::UsualField(&ForStmt::body_, "body")));
+                                          reflection::UsualField(&ForStmt::body_, "body"),
+                                          reflection::DefField(&ForStmt::return_vars_, "return_vars")));
   }
 
  public:
-  VarPtr loop_var_;            // Loop variable
-  ExprPtr start_;              // Start value expression
-  ExprPtr stop_;               // Stop value expression
-  ExprPtr step_;               // Step value expression
-  std::vector<StmtPtr> body_;  // Loop body statements
+  VarPtr loop_var_;                  // Loop variable
+  ExprPtr start_;                    // Start value expression
+  ExprPtr stop_;                     // Stop value expression
+  ExprPtr step_;                     // Step value expression
+  std::vector<StmtPtr> body_;        // Loop body statements
+  std::vector<VarPtr> return_vars_;  // Return variables (can be empty)
 };
 
 using ForStmtPtr = std::shared_ptr<const ForStmt>;

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -252,10 +252,10 @@ void BindIR(nb::module_& m) {
   // IfStmt - const shared_ptr
   auto if_stmt_class = nb::class_<IfStmt, Stmt>(
       ir, "IfStmt", "Conditional statement: if condition then then_body else else_body");
-  if_stmt_class.def(
-      nb::init<const ExprPtr&, const std::vector<StmtPtr>&, const std::vector<StmtPtr>&, const Span&>(),
-      nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body"), nb::arg("span"),
-      "Create a conditional statement");
+  if_stmt_class.def(nb::init<const ExprPtr&, const std::vector<StmtPtr>&, const std::vector<StmtPtr>&,
+                             const std::vector<VarPtr>&, const Span&>(),
+                    nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body"), nb::arg("return_vars"),
+                    nb::arg("span"), "Create a conditional statement");
   BindFields<IfStmt>(if_stmt_class);
   BindStrRepr<IfStmt>(if_stmt_class);
 
@@ -271,9 +271,9 @@ void BindIR(nb::module_& m) {
   auto for_stmt_class = nb::class_<ForStmt, Stmt>(
       ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
   for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&,
-                              const std::vector<StmtPtr>&, const Span&>(),
+                              const std::vector<StmtPtr>&, const std::vector<VarPtr>&, const Span&>(),
                      nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("body"),
-                     nb::arg("span"), "Create a for loop statement");
+                     nb::arg("return_vars"), nb::arg("span"), "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);
   BindStrRepr<ForStmt>(for_stmt_class);
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -632,13 +632,24 @@ class IfStmt(Stmt):
     else_body: Final[list[Stmt]]
     """Else branch statements (can be empty)."""
 
-    def __init__(self, condition: Expr, then_body: list[Stmt], else_body: list[Stmt], span: Span) -> None:
+    return_vars: Final[list[Var]]
+    """Return variables (can be empty)."""
+
+    def __init__(
+        self,
+        condition: Expr,
+        then_body: list[Stmt],
+        else_body: list[Stmt],
+        return_vars: list[Var],
+        span: Span,
+    ) -> None:
         """Create a conditional statement.
 
         Args:
             condition: Condition expression
             then_body: Then branch statements
             else_body: Else branch statements (can be empty)
+            return_vars: Return variables (can be empty)
             span: Source location
         """
 
@@ -685,8 +696,18 @@ class ForStmt(Stmt):
     body: Final[list[Stmt]]
     """Loop body statements."""
 
+    return_vars: Final[list[Var]]
+    """Return variables (can be empty)."""
+
     def __init__(
-        self, loop_var: Var, start: Expr, stop: Expr, step: Expr, body: list[Stmt], span: Span
+        self,
+        loop_var: Var,
+        start: Expr,
+        stop: Expr,
+        step: Expr,
+        body: list[Stmt],
+        return_vars: list[Var],
+        span: Span,
     ) -> None:
         """Create a for loop statement.
 
@@ -696,6 +717,7 @@ class ForStmt(Stmt):
             stop: Stop value expression
             step: Step value expression
             body: Loop body statements
+            return_vars: Return variables (can be empty)
             span: Source location
         """
 

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -263,6 +263,13 @@ void IRPrinter::VisitStmt_(const IfStmtPtr& op) {
       }
     }
   }
+  if (!op->return_vars_.empty()) {
+    stream_ << "\nreturn ";
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      VisitExpr(op->return_vars_[i]);
+    }
+  }
 }
 
 void IRPrinter::VisitStmt_(const YieldStmtPtr& op) {
@@ -293,6 +300,13 @@ void IRPrinter::VisitStmt_(const ForStmtPtr& op) {
     VisitStmt(op->body_[i]);
     if (i < op->body_.size() - 1) {
       stream_ << "\n";
+    }
+  }
+  if (!op->return_vars_.empty()) {
+    stream_ << "\nreturn ";
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      VisitExpr(op->return_vars_[i]);
     }
   }
 }

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -115,6 +115,10 @@ void IRVisitor::VisitStmt_(const IfStmtPtr& op) {
     INTERNAL_CHECK(op->else_body_[i]) << "IfStmt has null else_body statement at index " << i;
     VisitStmt(op->else_body_[i]);
   }
+  for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+    INTERNAL_CHECK(op->return_vars_[i]) << "IfStmt has null return_vars at index " << i;
+    VisitExpr(op->return_vars_[i]);
+  }
 }
 
 void IRVisitor::VisitStmt_(const YieldStmtPtr& op) {
@@ -136,6 +140,10 @@ void IRVisitor::VisitStmt_(const ForStmtPtr& op) {
   for (size_t i = 0; i < op->body_.size(); ++i) {
     INTERNAL_CHECK(op->body_[i]) << "ForStmt has null body statement at index " << i;
     VisitStmt(op->body_[i]);
+  }
+  for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+    INTERNAL_CHECK(op->return_vars_[i]) << "ForStmt has null return_vars at index " << i;
+    VisitExpr(op->return_vars_[i]);
   }
 }
 

--- a/tests/ut/ir/test_op_stmts.py
+++ b/tests/ut/ir/test_op_stmts.py
@@ -109,7 +109,7 @@ class TestOpStmts:
 
         # Test with IfStmt
         condition = ir.Eq(x, y, dtype, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], span)
+        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
         op_stmts2 = ir.OpStmts([if_stmt], span)
         assert isinstance(op_stmts2.stmts[0], ir.IfStmt)
 
@@ -167,7 +167,7 @@ class TestOpStmtsPrinting:
         z = ir.Var("z", ir.ScalarType(dtype), span)
         assign = ir.AssignStmt(x, y, span)
         condition = ir.Eq(x, y, dtype, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], span)
+        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
         yield_stmt = ir.YieldStmt([z], span)
         op_stmts = ir.OpStmts([assign, if_stmt, yield_stmt], span)
         assert str(op_stmts) == "x = y\nif x == y:\n  x = y\nyield z"


### PR DESCRIPTION
This commit adds a `return_values_` member (std::vector<VarPtr>) to both IfStmt and ForStmt classes. The member is optional and defaults to an empty list.