### PR TITLE
feat(ir): Add Function class to IR system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(PYPTO_SOURCES
     src/core/backtrace.cpp
     src/core/error.cpp
     src/ir/core.cpp
+    src/ir/function.cpp
     src/ir/transform/visitor.cpp
     src/ir/transform/mutator.cpp
     src/ir/transform/printer.cpp

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_FUNCTION_H_
+#define PYPTO_IR_FUNCTION_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "pypto/ir/core.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/reflection/field_traits.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Function definition
+ *
+ * Represents a complete function definition with name, parameters, return types, and body.
+ * Functions are immutable IR nodes.
+ */
+class Function : public IRNode {
+ public:
+  /**
+   * @brief Create a function definition
+   *
+   * @param name Function name
+   * @param params Parameter variables
+   * @param return_types Return types
+   * @param body Function body statement (use SeqStmts for multiple statements)
+   * @param span Source location
+   */
+  Function(std::string name, std::vector<VarPtr> params, std::vector<TypePtr> return_types, StmtPtr body,
+           Span span)
+      : IRNode(std::move(span)),
+        name_(std::move(name)),
+        params_(std::move(params)),
+        return_types_(std::move(return_types)),
+        body_(std::move(body)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "Function"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (params as DEF field, return_types and body as USUAL fields, name as
+   * IGNORE field)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(IRNode::GetFieldDescriptors(),
+                          std::make_tuple(reflection::IgnoreField(&Function::name_, "name"),
+                                          reflection::DefField(&Function::params_, "params"),
+                                          reflection::UsualField(&Function::return_types_, "return_types"),
+                                          reflection::UsualField(&Function::body_, "body")));
+  }
+
+ public:
+  std::string name_;                   // Function name
+  std::vector<VarPtr> params_;         // Parameter variables
+  std::vector<TypePtr> return_types_;  // Return types
+  StmtPtr body_;                       // Function body statement
+};
+
+using FunctionPtr = std::shared_ptr<const Function>;
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_FUNCTION_H_

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -244,20 +244,54 @@ class ForStmt : public Stmt {
 using ForStmtPtr = std::shared_ptr<const ForStmt>;
 
 /**
- * @brief Operation statements
+ * @brief Sequence of statements
  *
  * Represents a sequence of statements: stmt1; stmt2; ... stmtN
  * where stmts is a list of statements.
+ */
+class SeqStmts : public Stmt {
+ public:
+  /**
+   * @brief Create a sequence of statements
+   *
+   * @param stmts List of statements
+   * @param span Source location
+   */
+  SeqStmts(std::vector<StmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "SeqStmts"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (stmts as USUAL field)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Stmt::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&SeqStmts::stmts_, "stmts")));
+  }
+
+ public:
+  std::vector<StmtPtr> stmts_;  // List of statements
+};
+
+using SeqStmtsPtr = std::shared_ptr<const SeqStmts>;
+
+/**
+ * @brief Operation statements
+ *
+ * Represents a sequence of assignment statements: assign1; assign2; ... assignN
+ * where stmts is a list of assignment statements.
  */
 class OpStmts : public Stmt {
  public:
   /**
    * @brief Create an operation statements
    *
-   * @param stmts List of statements
+   * @param stmts List of assignment statements
    * @param span Source location
    */
-  OpStmts(std::vector<StmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
+  OpStmts(std::vector<AssignStmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
 
   [[nodiscard]] std::string TypeName() const override { return "OpStmts"; }
 
@@ -272,7 +306,7 @@ class OpStmts : public Stmt {
   }
 
  public:
-  std::vector<StmtPtr> stmts_;  // List of statements
+  std::vector<AssignStmtPtr> stmts_;  // List of assignment statements
 };
 
 using OpStmtsPtr = std::shared_ptr<const OpStmts>;

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -165,6 +165,7 @@ class StmtFunctor {
   virtual R VisitStmt_(const IfStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const YieldStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const ForStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const SeqStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const OpStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
@@ -182,6 +183,7 @@ R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   STMT_FUNCTOR_DISPATCH(IfStmt);
   STMT_FUNCTOR_DISPATCH(YieldStmt);
   STMT_FUNCTOR_DISPATCH(ForStmt);
+  STMT_FUNCTOR_DISPATCH(SeqStmts);
   STMT_FUNCTOR_DISPATCH(OpStmts);
   STMT_FUNCTOR_DISPATCH(Stmt);
 

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -75,6 +75,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   StmtPtr VisitStmt_(const IfStmtPtr& op) override;
   StmtPtr VisitStmt_(const YieldStmtPtr& op) override;
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
+  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override;
   StmtPtr VisitStmt_(const OpStmtsPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -74,6 +74,7 @@ class IRVisitor : public IRFunctor<void> {
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const ForStmtPtr& op) override;
+  void VisitStmt_(const SeqStmtsPtr& op) override;
   void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <string>
 
+#include "pypto/ir/function.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/visitor.h"
 
@@ -88,6 +89,14 @@ class IRPrinter : public IRVisitor {
    */
   std::string Print(const StmtPtr& stmt);
 
+  /**
+   * @brief Print a function to a string
+   *
+   * @param func Function to print
+   * @return String representation
+   */
+  std::string Print(const FunctionPtr& func);
+
  protected:
   // Leaf nodes
   void VisitExpr_(const VarPtr& op) override;
@@ -130,8 +139,12 @@ class IRPrinter : public IRVisitor {
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const YieldStmtPtr& op) override;
   void VisitStmt_(const ForStmtPtr& op) override;
+  void VisitStmt_(const SeqStmtsPtr& op) override;
   void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
+
+  // Function type
+  void VisitFunction(const FunctionPtr& func);
 
  private:
   std::ostringstream stream_;

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -721,18 +721,104 @@ class ForStmt(Stmt):
             span: Source location
         """
 
-class OpStmts(Stmt):
-    """Operation statements: a sequence of statements."""
+class SeqStmts(Stmt):
+    """Sequence of statements: a sequence of statements."""
 
     stmts: Final[list[Stmt]]
     """List of statements."""
 
     def __init__(self, stmts: list[Stmt], span: Span) -> None:
-        """Create an operation statements.
+        """Create a sequence of statements.
 
         Args:
             stmts: List of statements
             span: Source location
+        """
+
+    def __str__(self) -> str:
+        """String representation of the sequence of statements.
+
+        Returns:
+            Sequence of statements as a string
+        """
+
+    def __repr__(self) -> str:
+        """Detailed representation of the sequence of statements.
+
+        Returns:
+            Sequence of statements with type information
+        """
+
+class OpStmts(Stmt):
+    """Operation statements: a sequence of assignment statements."""
+
+    stmts: Final[list[AssignStmt]]
+    """List of assignment statements."""
+
+    def __init__(self, stmts: list[AssignStmt], span: Span) -> None:
+        """Create an operation statements.
+
+        Args:
+            stmts: List of assignment statements
+            span: Source location
+        """
+
+    def __str__(self) -> str:
+        """String representation of the operation statements.
+
+        Returns:
+            Operation statements as a string
+        """
+
+    def __repr__(self) -> str:
+        """Detailed representation of the operation statements.
+
+        Returns:
+            Operation statements with type information
+        """
+
+class Function(IRNode):
+    """Function definition with name, parameters, return types, and body."""
+
+    params: Final[list[Var]]
+    """Parameter variables."""
+
+    return_types: Final[list[Type]]
+    """Return types."""
+
+    body: Final[Stmt]
+    """Function body statement (use SeqStmts for multiple statements)."""
+
+    def __init__(
+        self,
+        name: str,
+        params: list[Var],
+        return_types: list[Type],
+        body: Stmt,
+        span: Span,
+    ) -> None:
+        """Create a function definition.
+
+        Args:
+            name: Function name
+            params: Parameter variables
+            return_types: Return types
+            body: Function body statement (use SeqStmts for multiple statements)
+            span: Source location
+        """
+
+    def __str__(self) -> str:
+        """String representation of the function.
+
+        Returns:
+            Function as a string
+        """
+
+    def __repr__(self) -> str:
+        """Detailed representation of the function.
+
+        Returns:
+            Function with type information
         """
 
 def structural_hash(node: IRNode, enable_auto_mapping: bool = False) -> int:

--- a/src/ir/function.cpp
+++ b/src/ir/function.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/function.h"
+
+namespace pypto {
+namespace ir {
+
+// Function constructor is implemented inline in the header file
+// No additional implementation needed here
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -147,9 +147,16 @@ void IRVisitor::VisitStmt_(const ForStmtPtr& op) {
   }
 }
 
+void IRVisitor::VisitStmt_(const SeqStmtsPtr& op) {
+  for (size_t i = 0; i < op->stmts_.size(); ++i) {
+    INTERNAL_CHECK(op->stmts_[i]) << "SeqStmts has null statement at index " << i;
+    VisitStmt(op->stmts_[i]);
+  }
+}
+
 void IRVisitor::VisitStmt_(const OpStmtsPtr& op) {
   for (size_t i = 0; i < op->stmts_.size(); ++i) {
-    INTERNAL_CHECK(op->stmts_[i]) << "OpStmts has null statement at index " << i;
+    INTERNAL_CHECK(op->stmts_[i]) << "OpStmts has null assignment statement at index " << i;
     VisitStmt(op->stmts_[i]);
   }
 }

--- a/tests/ut/ir/test_function.py
+++ b/tests/ut/ir/test_function.py
@@ -1,0 +1,426 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for Function class."""
+
+from typing import cast
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestFunction:
+    """Test Function class."""
+
+    def test_function_creation(self):
+        """Test creating a Function instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        assert func is not None
+        assert func.span.filename == "test.py"
+        assert len(func.params) == 1
+        assert len(func.return_types) == 1
+        assert func.body is not None
+
+    def test_function_has_attributes(self):
+        """Test that Function has params, return_types, and body attributes."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(a, b, span)
+        assign2 = ir.AssignStmt(b, ir.ConstInt(0, dtype, span), span)
+        body = ir.SeqStmts([assign1, assign2], span)
+        func = ir.Function("my_func", [a, b], [ir.ScalarType(dtype)], body, span)
+
+        assert len(func.params) == 2
+        assert len(func.return_types) == 1
+        assert func.body is not None
+        assert cast(ir.Var, func.params[0]).name == "a"
+        assert cast(ir.Var, func.params[1]).name == "b"
+        assert isinstance(func.return_types[0], ir.ScalarType)
+        assert isinstance(func.body, ir.SeqStmts)
+
+    def test_function_is_irnode(self):
+        """Test that Function is an instance of IRNode."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        assert isinstance(func, ir.IRNode)
+
+    def test_function_immutability(self):
+        """Test that Function attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            func.params = []  # type: ignore
+        with pytest.raises(AttributeError):
+            func.return_types = []  # type: ignore
+        with pytest.raises(AttributeError):
+            func.body = assign  # type: ignore
+
+    def test_function_with_empty_params(self):
+        """Test Function with empty parameter list."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+        func = ir.Function("no_params", [], [ir.ScalarType(dtype)], assign, span)
+
+        assert len(func.params) == 0
+        assert len(func.return_types) == 1
+        assert func.body is not None
+
+    def test_function_with_empty_return_types(self):
+        """Test Function with empty return types list."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+        func = ir.Function("no_return", [x], [], assign, span)
+
+        assert len(func.params) == 1
+        assert len(func.return_types) == 0
+        assert func.body is not None
+
+    def test_function_with_seqstmts_body(self):
+        """Test Function with SeqStmts body containing multiple statements."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        body = ir.SeqStmts([assign1, assign2], span)
+        func = ir.Function("multi_stmt", [x], [ir.ScalarType(dtype)], body, span)
+
+        assert len(func.params) == 1
+        assert len(func.return_types) == 1
+        assert isinstance(func.body, ir.SeqStmts)
+        assert len(cast(ir.SeqStmts, func.body).stmts) == 2
+
+    def test_function_with_multiple_params(self):
+        """Test Function with multiple parameters."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        c = ir.Var("c", ir.ScalarType(dtype), span)
+        add_expr = ir.Add(a, b, dtype, span)
+        assign = ir.AssignStmt(c, add_expr, span)
+        func = ir.Function("add_func", [a, b], [ir.ScalarType(dtype)], assign, span)
+
+        assert len(func.params) == 2
+        assert cast(ir.Var, func.params[0]).name == "a"
+        assert cast(ir.Var, func.params[1]).name == "b"
+
+    def test_function_with_multiple_return_types(self):
+        """Test Function with multiple return types."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(2, dtype, span), span)
+        body = ir.SeqStmts([assign1, assign2], span)
+        func = ir.Function("multi_return", [z], [ir.ScalarType(dtype), ir.ScalarType(dtype)], body, span)
+
+        assert len(func.return_types) == 2
+        assert isinstance(func.return_types[0], ir.ScalarType)
+        assert isinstance(func.return_types[1], ir.ScalarType)
+
+    def test_function_string_representation(self):
+        """Test Function string representation."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        # Function with single param and single return
+        func1 = ir.Function("simple_func", [x], [ir.ScalarType(dtype)], assign, span)
+        str_repr = str(func1)
+        assert isinstance(str_repr, str)
+
+        # Function with multiple statements using SeqStmts
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        body = ir.SeqStmts([assign, assign2], span)
+        func2 = ir.Function("multi_stmt", [x], [ir.ScalarType(dtype)], body, span)
+        str_repr2 = str(func2)
+        assert isinstance(str_repr2, str)
+
+
+class TestFunctionHash:
+    """Tests for Function hash function."""
+
+    def test_function_same_structure_hash(self):
+        """Test Function nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        func1 = ir.Function("test_func", [x1], [ir.ScalarType(dtype)], assign1, span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        func2 = ir.Function("test_func", [x2], [ir.ScalarType(dtype)], assign2, span)
+
+        hash1 = ir.structural_hash(func1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(func2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+    def test_function_different_name_hash(self):
+        """Test Function nodes with different names hash the same (name is IgnoreField)."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("func1", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("func2", [x], [ir.ScalarType(dtype)], assign, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 == hash2  # name is IgnoreField, so should hash the same
+
+    def test_function_different_params_hash(self):
+        """Test Function nodes with different parameters hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x, z], [ir.ScalarType(dtype)], assign, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+    def test_function_different_return_types_hash(self):
+        """Test Function nodes with different return types hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(DataType.INT32)], assign, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+    def test_function_different_body_hash(self):
+        """Test Function nodes with different body hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign2, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+    def test_function_empty_vs_non_empty_params_hash(self):
+        """Test Function nodes with empty vs non-empty params hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+    def test_function_empty_vs_non_empty_return_types_hash(self):
+        """Test Function nodes with empty vs non-empty return_types hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [x], [], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+    def test_function_different_body_types_hash(self):
+        """Test Function nodes with different body types hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        body2 = ir.SeqStmts([assign1, assign2], span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], body2, span)
+
+        hash1 = ir.structural_hash(func1)
+        hash2 = ir.structural_hash(func2)
+        assert hash1 != hash2
+
+
+class TestFunctionStructuralEqual:
+    """Tests for Function structural equality function."""
+
+    def test_function_structural_equal(self):
+        """Test Function nodes with same structure are equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        func1 = ir.Function("test_func", [x1], [ir.ScalarType(dtype)], assign1, span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        func2 = ir.Function("test_func", [x2], [ir.ScalarType(dtype)], assign2, span)
+
+        assert ir.structural_equal(func1, func2, enable_auto_mapping=True)
+
+    def test_function_different_name_equal(self):
+        """Test Function nodes with different names are equal (name is IgnoreField)."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("func1", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("func2", [x], [ir.ScalarType(dtype)], assign, span)
+
+        assert ir.structural_equal(func1, func2)  # name is IgnoreField
+
+    def test_function_different_params_not_equal(self):
+        """Test Function nodes with different parameters are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x, z], [ir.ScalarType(dtype)], assign, span)
+
+        assert not ir.structural_equal(func1, func2)
+
+    def test_function_different_return_types_not_equal(self):
+        """Test Function nodes with different return types are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(DataType.INT32)], assign, span)
+
+        assert not ir.structural_equal(func1, func2)
+
+    def test_function_different_body_not_equal(self):
+        """Test Function nodes with different body are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign2, span)
+
+        assert not ir.structural_equal(func1, func2)
+
+    def test_function_different_from_base_irnode_not_equal(self):
+        """Test Function is not equal to a different IRNode type."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        # Compare with a Var (different IRNode type)
+        assert not ir.structural_equal(func, x)
+
+    def test_function_empty_vs_non_empty_params_not_equal(self):
+        """Test Function nodes with empty vs non-empty params are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [], [ir.ScalarType(dtype)], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        assert not ir.structural_equal(func1, func2)
+
+    def test_function_empty_vs_non_empty_return_types_not_equal(self):
+        """Test Function nodes with empty vs non-empty return_types are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+
+        func1 = ir.Function("test_func", [x], [], assign, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        assert not ir.structural_equal(func1, func2)
+
+    def test_function_different_body_types_not_equal(self):
+        """Test Function nodes with different body types are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        body2 = ir.SeqStmts([assign1, assign2], span)
+
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], body2, span)
+
+        assert not ir.structural_equal(func1, func2)

--- a/tests/ut/ir/test_seq_stmts.py
+++ b/tests/ut/ir/test_seq_stmts.py
@@ -1,0 +1,273 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for SeqStmts class."""
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestSeqStmts:
+    """Test SeqStmts class."""
+
+    def test_seq_stmts_creation(self):
+        """Test creating a SeqStmts instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        seq_stmts = ir.SeqStmts([assign1, assign2], span)
+
+        assert seq_stmts is not None
+        assert seq_stmts.span.filename == "test.py"
+        assert len(seq_stmts.stmts) == 2
+
+    def test_seq_stmts_has_attributes(self):
+        """Test that SeqStmts has stmts attribute."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(a, b, span)
+        assign2 = ir.AssignStmt(b, a, span)
+        seq_stmts = ir.SeqStmts([assign1, assign2], span)
+
+        assert seq_stmts.stmts is not None
+        assert len(seq_stmts.stmts) == 2
+        assert isinstance(seq_stmts.stmts[0], ir.AssignStmt)
+        assert isinstance(seq_stmts.stmts[1], ir.AssignStmt)
+
+    def test_seq_stmts_is_stmt(self):
+        """Test that SeqStmts is an instance of Stmt."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        seq_stmts = ir.SeqStmts([assign], span)
+
+        assert isinstance(seq_stmts, ir.Stmt)
+        assert isinstance(seq_stmts, ir.IRNode)
+
+    def test_seq_stmts_immutability(self):
+        """Test that SeqStmts attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        seq_stmts = ir.SeqStmts([assign], span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            seq_stmts.stmts = []  # type: ignore
+
+    def test_seq_stmts_with_empty_list(self):
+        """Test SeqStmts with empty statement list."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        seq_stmts = ir.SeqStmts([], span)
+
+        assert len(seq_stmts.stmts) == 0
+
+    def test_seq_stmts_with_single_stmt(self):
+        """Test SeqStmts with single statement."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+        seq_stmts = ir.SeqStmts([assign], span)
+
+        assert len(seq_stmts.stmts) == 1
+        assert isinstance(seq_stmts.stmts[0], ir.AssignStmt)
+
+    def test_seq_stmts_with_multiple_stmts(self):
+        """Test SeqStmts with multiple statements."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+        assign3 = ir.AssignStmt(z, ir.ConstInt(0, dtype, span), span)
+        seq_stmts = ir.SeqStmts([assign1, assign2, assign3], span)
+
+        assert len(seq_stmts.stmts) == 3
+        assert isinstance(seq_stmts.stmts[0], ir.AssignStmt)
+        assert isinstance(seq_stmts.stmts[1], ir.AssignStmt)
+        assert isinstance(seq_stmts.stmts[2], ir.AssignStmt)
+
+    def test_seq_stmts_string_representation(self):
+        """Test SeqStmts string representation."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+
+        # Single statement
+        seq_stmts1 = ir.SeqStmts([assign1], span)
+        str_repr1 = str(seq_stmts1)
+        assert isinstance(str_repr1, str)
+
+        # Multiple statements
+        seq_stmts2 = ir.SeqStmts([assign1, assign2], span)
+        str_repr2 = str(seq_stmts2)
+        assert isinstance(str_repr2, str)
+
+
+class TestSeqStmtsHash:
+    """Tests for SeqStmts hash function."""
+
+    def test_seq_stmts_same_structure_hash(self):
+        """Test SeqStmts nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1_1 = ir.AssignStmt(x1, y1, span)
+        assign1_2 = ir.AssignStmt(y1, ir.ConstInt(0, dtype, span), span)
+        seq_stmts1 = ir.SeqStmts([assign1_1, assign1_2], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2_1 = ir.AssignStmt(x2, y2, span)
+        assign2_2 = ir.AssignStmt(y2, ir.ConstInt(0, dtype, span), span)
+        seq_stmts2 = ir.SeqStmts([assign2_1, assign2_2], span)
+
+        hash1 = ir.structural_hash(seq_stmts1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(seq_stmts2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+    def test_seq_stmts_different_statements_hash(self):
+        """Test SeqStmts nodes with different statements hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        assign3 = ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)
+
+        seq_stmts1 = ir.SeqStmts([assign1, assign2], span)
+        seq_stmts2 = ir.SeqStmts([assign1, assign3], span)
+
+        hash1 = ir.structural_hash(seq_stmts1)
+        hash2 = ir.structural_hash(seq_stmts2)
+        assert hash1 != hash2
+
+    def test_seq_stmts_different_length_hash(self):
+        """Test SeqStmts nodes with different lengths hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+
+        seq_stmts1 = ir.SeqStmts([assign1], span)
+        seq_stmts2 = ir.SeqStmts([assign1, assign2], span)
+
+        hash1 = ir.structural_hash(seq_stmts1)
+        hash2 = ir.structural_hash(seq_stmts2)
+        assert hash1 != hash2
+
+    def test_seq_stmts_empty_hash(self):
+        """Test empty SeqStmts hash."""
+        span = ir.Span.unknown()
+        seq_stmts1 = ir.SeqStmts([], span)
+        seq_stmts2 = ir.SeqStmts([], span)
+
+        hash1 = ir.structural_hash(seq_stmts1)
+        hash2 = ir.structural_hash(seq_stmts2)
+        assert hash1 == hash2
+
+
+class TestSeqStmtsStructuralEqual:
+    """Tests for SeqStmts structural equality function."""
+
+    def test_seq_stmts_structural_equal(self):
+        """Test SeqStmts nodes with same structure are equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1_1 = ir.AssignStmt(x1, y1, span)
+        assign1_2 = ir.AssignStmt(y1, ir.ConstInt(0, dtype, span), span)
+        seq_stmts1 = ir.SeqStmts([assign1_1, assign1_2], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2_1 = ir.AssignStmt(x2, y2, span)
+        assign2_2 = ir.AssignStmt(y2, ir.ConstInt(0, dtype, span), span)
+        seq_stmts2 = ir.SeqStmts([assign2_1, assign2_2], span)
+
+        assert ir.structural_equal(seq_stmts1, seq_stmts2, enable_auto_mapping=True)
+
+    def test_seq_stmts_structural_equal_different_statements(self):
+        """Test SeqStmts nodes with different statements are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+        assign3 = ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)
+
+        seq_stmts1 = ir.SeqStmts([assign1, assign2], span)
+        seq_stmts2 = ir.SeqStmts([assign1, assign3], span)
+
+        assert not ir.structural_equal(seq_stmts1, seq_stmts2)
+
+    def test_seq_stmts_structural_equal_different_length(self):
+        """Test SeqStmts nodes with different lengths are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, ir.ConstInt(0, dtype, span), span)
+
+        seq_stmts1 = ir.SeqStmts([assign1], span)
+        seq_stmts2 = ir.SeqStmts([assign1, assign2], span)
+
+        assert not ir.structural_equal(seq_stmts1, seq_stmts2)
+
+    def test_seq_stmts_structural_equal_empty(self):
+        """Test empty SeqStmts are equal."""
+        span = ir.Span.unknown()
+        seq_stmts1 = ir.SeqStmts([], span)
+        seq_stmts2 = ir.SeqStmts([], span)
+
+        assert ir.structural_equal(seq_stmts1, seq_stmts2)
+
+    def test_seq_stmts_structural_equal_multiple_statements(self):
+        """Test SeqStmts with multiple statements."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        z1 = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1_1 = ir.AssignStmt(x1, y1, span)
+        assign1_2 = ir.AssignStmt(y1, z1, span)
+        assign1_3 = ir.AssignStmt(z1, ir.ConstInt(0, dtype, span), span)
+        seq_stmts1 = ir.SeqStmts([assign1_1, assign1_2, assign1_3], span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        z2 = ir.Var("z", ir.ScalarType(dtype), span)
+        assign2_1 = ir.AssignStmt(x2, y2, span)
+        assign2_2 = ir.AssignStmt(y2, z2, span)
+        assign2_3 = ir.AssignStmt(z2, ir.ConstInt(0, dtype, span), span)
+        seq_stmts2 = ir.SeqStmts([assign2_1, assign2_2, assign2_3], span)
+
+        assert ir.structural_equal(seq_stmts1, seq_stmts2, enable_auto_mapping=True)


### PR DESCRIPTION
Add Function class to represent complete function definitions in the IR. Function inherits from IRNode and contains:
- name: Function name
- params: Parameter variables (DefField)
- return_vars: Return variables (UsualField)
- body: Function body statements (UsualField)