### PR TITLE
feat(ir): Add Program class to represent top-level program containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PYPTO_SOURCES
     src/core/error.cpp
     src/ir/core.cpp
     src/ir/function.cpp
+    src/ir/program.cpp
     src/ir/transform/visitor.cpp
     src/ir/transform/mutator.cpp
     src/ir/transform/printer.cpp

--- a/include/pypto/ir/program.h
+++ b/include/pypto/ir/program.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_PROGRAM_H_
+#define PYPTO_IR_PROGRAM_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "pypto/ir/core.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/reflection/field_traits.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Program definition
+ *
+ * Represents a complete program with a list of functions and optional program name.
+ * Programs are immutable IR nodes.
+ */
+class Program : public IRNode {
+ public:
+  /**
+   * @brief Create a program
+   *
+   * @param functions List of functions
+   * @param name Program name
+   * @param span Source location
+   */
+  Program(std::vector<FunctionPtr> functions, std::string name, Span span)
+      : IRNode(std::move(span)), functions_(std::move(functions)), name_(std::move(name)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "Program"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (name as IGNORE field, functions as USUAL field)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(IRNode::GetFieldDescriptors(),
+                          std::make_tuple(reflection::IgnoreField(&Program::name_, "name"),
+                                          reflection::UsualField(&Program::functions_, "functions")));
+  }
+
+ public:
+  std::string name_;                    // Program name
+  std::vector<FunctionPtr> functions_;  // List of functions
+};
+
+using ProgramPtr = std::shared_ptr<const Program>;
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_PROGRAM_H_

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/visitor.h"
 
@@ -97,6 +98,14 @@ class IRPrinter : public IRVisitor {
    */
   std::string Print(const FunctionPtr& func);
 
+  /**
+   * @brief Print a program to a string
+   *
+   * @param program Program to print
+   * @return String representation
+   */
+  std::string Print(const ProgramPtr& program);
+
  protected:
   // Leaf nodes
   void VisitExpr_(const VarPtr& op) override;
@@ -145,6 +154,9 @@ class IRPrinter : public IRVisitor {
 
   // Function type
   void VisitFunction(const FunctionPtr& func);
+
+  // Program type
+  void VisitProgram(const ProgramPtr& program);
 
  private:
   std::ostringstream stream_;

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -70,6 +71,8 @@ void BindStrRepr(PyClassType& nb_class) {
             IRPrinter printer;
             if constexpr (std::is_same_v<T, Function>) {
               return printer.Print(std::static_pointer_cast<const Function>(self));
+            } else if constexpr (std::is_same_v<T, Program>) {
+              return printer.Print(std::static_pointer_cast<const Program>(self));
             } else if constexpr (std::is_base_of_v<Expr, T>) {
               return printer.Print(std::static_pointer_cast<const Expr>(self));
             } else if constexpr (std::is_base_of_v<Stmt, T>) {
@@ -86,6 +89,8 @@ void BindStrRepr(PyClassType& nb_class) {
             std::string printed;
             if constexpr (std::is_same_v<T, Function>) {
               printed = printer.Print(std::static_pointer_cast<const Function>(self));
+            } else if constexpr (std::is_same_v<T, Program>) {
+              printed = printer.Print(std::static_pointer_cast<const Program>(self));
             } else if constexpr (std::is_base_of_v<Expr, T>) {
               printed = printer.Print(std::static_pointer_cast<const Expr>(self));
             } else if constexpr (std::is_base_of_v<Stmt, T>) {
@@ -322,6 +327,14 @@ void BindIR(nb::module_& m) {
                      nb::arg("span"), "Create a function definition");
   BindFields<Function>(function_class);
   BindStrRepr<Function>(function_class);
+
+  // Program - const shared_ptr
+  auto program_class = nb::class_<Program, IRNode>(
+      ir, "Program", "Program definition with a list of functions and program name");
+  program_class.def(nb::init<const std::vector<FunctionPtr>&, const std::string&, const Span&>(),
+                    nb::arg("functions"), nb::arg("name"), nb::arg("span"), "Create a program definition");
+  BindFields<Program>(program_class);
+  BindStrRepr<Program>(program_class);
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -780,6 +780,9 @@ class OpStmts(Stmt):
 class Function(IRNode):
     """Function definition with name, parameters, return types, and body."""
 
+    name: Final[str]
+    """Function name."""
+
     params: Final[list[Var]]
     """Parameter variables."""
 
@@ -819,6 +822,43 @@ class Function(IRNode):
 
         Returns:
             Function with type information
+        """
+
+class Program(IRNode):
+    """Program definition with a list of functions and optional program name."""
+
+    name: Final[str]
+    """Program name."""
+
+    functions: Final[list[Function]]
+    """List of functions."""
+
+    def __init__(
+        self,
+        functions: list[Function],
+        name: str,
+        span: Span,
+    ) -> None:
+        """Create a program definition.
+
+        Args:
+            functions: List of functions
+            name: Program name
+            span: Source location
+        """
+
+    def __str__(self) -> str:
+        """String representation of the program.
+
+        Returns:
+            Program as a string
+        """
+
+    def __repr__(self) -> str:
+        """Detailed representation of the program.
+
+        Returns:
+            Program with type information
         """
 
 def structural_hash(node: IRNode, enable_auto_mapping: bool = False) -> int:

--- a/src/ir/program.cpp
+++ b/src/ir/program.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/program.h"
+
+namespace pypto {
+namespace ir {
+
+// Program constructor is implemented inline in the header file
+// No additional implementation needed here
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 
@@ -91,6 +92,13 @@ std::string IRPrinter::Print(const FunctionPtr& func) {
   stream_.str("");  // Clear the stream
   stream_.clear();  // Clear any error flags
   VisitFunction(func);
+  return stream_.str();
+}
+
+std::string IRPrinter::Print(const ProgramPtr& program) {
+  stream_.str("");  // Clear the stream
+  stream_.clear();  // Clear any error flags
+  VisitProgram(program);
   return stream_.str();
 }
 
@@ -377,6 +385,20 @@ void IRPrinter::VisitFunction(const FunctionPtr& func) {
       if (i > 0) stream_ << ", ";
       // return_types is TypePtr list, print type name
       stream_ << func->return_types_[i]->TypeName();
+    }
+  }
+}
+
+void IRPrinter::VisitProgram(const ProgramPtr& program) {
+  // Print program name if not empty
+  if (!program->name_.empty()) {
+    stream_ << "# Program: " << program->name_ << "\n\n";
+  }
+  // Print all functions, separated by double newlines
+  for (size_t i = 0; i < program->functions_.size(); ++i) {
+    VisitFunction(program->functions_[i]);
+    if (i < program->functions_.size() - 1) {
+      stream_ << "\n\n";
     }
   }
 }

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -20,6 +20,7 @@
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -188,6 +189,7 @@ bool StructuralEqual::Equal(const IRNodePtr& lhs, const IRNodePtr& rhs) {
   EQUAL_DISPATCH(SeqStmts)
   EQUAL_DISPATCH(OpStmts)
   EQUAL_DISPATCH(Function)
+  EQUAL_DISPATCH(Program)
 
   // Unknown IR node type
   throw pypto::TypeError("Unknown IR node type in StructuralEqual::Equal");

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -20,6 +20,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -217,6 +218,7 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(SeqStmts)
   HASH_DISPATCH(OpStmts)
   HASH_DISPATCH(Function)
+  HASH_DISPATCH(Program)
 
   // Free Var types that may be mapped to other free vars
   if (auto var = std::dynamic_pointer_cast<const Var>(node)) {

--- a/tests/ut/ir/test_program.py
+++ b/tests/ut/ir/test_program.py
@@ -1,0 +1,266 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for Program class."""
+
+from typing import cast
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestProgram:
+    """Test Program class."""
+
+    def test_program_creation(self):
+        """Test creating a Program instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        program = ir.Program([func], "", span)
+
+        assert program is not None
+        assert program.span.filename == "test.py"
+        assert len(program.functions) == 1
+        assert program.name == ""
+
+    def test_program_has_attributes(self):
+        """Test that Program has name and functions attributes."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        a = ir.Var("a", ir.ScalarType(dtype), span)
+        b = ir.Var("b", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(a, b, span)
+        body = ir.SeqStmts([assign1], span)
+        func1 = ir.Function("func1", [a], [ir.ScalarType(dtype)], body, span)
+        func2 = ir.Function("func2", [b], [ir.ScalarType(dtype)], body, span)
+        program = ir.Program([func1, func2], "my_program", span)
+
+        assert program.name == "my_program"
+        assert len(program.functions) == 2
+        assert cast(ir.Function, program.functions[0]).name == "func1"
+        assert cast(ir.Function, program.functions[1]).name == "func2"
+
+    def test_program_is_irnode(self):
+        """Test that Program is an instance of IRNode."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        program = ir.Program([func], "", span)
+
+        assert isinstance(program, ir.IRNode)
+
+    def test_program_immutability(self):
+        """Test that Program attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        program = ir.Program([func], "test_program", span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            program.name = "new_name"  # type: ignore
+        with pytest.raises(AttributeError):
+            program.functions = []  # type: ignore
+
+    def test_program_with_empty_functions(self):
+        """Test Program with empty function list."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        program = ir.Program([], "", span)
+
+        assert len(program.functions) == 0
+        assert program.name == ""
+
+    def test_program_with_multiple_functions(self):
+        """Test Program with multiple functions."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(y, z, span)
+        func1 = ir.Function("func1", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("func2", [y], [ir.ScalarType(dtype)], assign2, span)
+        func3 = ir.Function("func3", [z], [ir.ScalarType(dtype)], assign1, span)
+        program = ir.Program([func1, func2, func3], "", span)
+
+        assert len(program.functions) == 3
+        assert cast(ir.Function, program.functions[0]).name == "func1"
+        assert cast(ir.Function, program.functions[1]).name == "func2"
+        assert cast(ir.Function, program.functions[2]).name == "func3"
+
+    def test_program_string_representation(self):
+        """Test Program string representation."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("simple_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        # Program with single function
+        program1 = ir.Program([func], "", span)
+        str_repr = str(program1)
+        assert "simple_func" in str_repr or isinstance(str_repr, str)
+
+        # Program with name
+        program2 = ir.Program([func], "my_program", span)
+        str_repr2 = str(program2)
+        assert "my_program" in str_repr2 or isinstance(str_repr2, str)
+
+
+class TestProgramHash:
+    """Tests for Program hash function."""
+
+    def test_program_same_structure_hash(self):
+        """Test Program nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        func1 = ir.Function("test_func", [x1], [ir.ScalarType(dtype)], assign1, span)
+        program1 = ir.Program([func1], "", span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        func2 = ir.Function("test_func", [x2], [ir.ScalarType(dtype)], assign2, span)
+        program2 = ir.Program([func2], "", span)
+
+        hash1 = ir.structural_hash(program1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(program2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+    def test_program_different_name_hash(self):
+        """Test Program nodes with different names hash the same (name is IgnoreField)."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        program1 = ir.Program([func], "program1", span)
+        program2 = ir.Program([func], "program2", span)
+
+        hash1 = ir.structural_hash(program1)
+        hash2 = ir.structural_hash(program2)
+        assert hash1 == hash2  # name is IgnoreField, so should hash the same
+
+    def test_program_different_functions_hash(self):
+        """Test Program nodes with different functions hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign2, span)
+
+        program1 = ir.Program([func1], "", span)
+        program2 = ir.Program([func2], "", span)
+
+        hash1 = ir.structural_hash(program1)
+        hash2 = ir.structural_hash(program2)
+        assert hash1 != hash2
+
+    def test_program_empty_vs_non_empty_functions_hash(self):
+        """Test Program nodes with empty vs non-empty functions hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        program1 = ir.Program([], "", span)
+        program2 = ir.Program([func], "", span)
+
+        hash1 = ir.structural_hash(program1)
+        hash2 = ir.structural_hash(program2)
+        assert hash1 != hash2
+
+
+class TestProgramStructuralEqual:
+    """Tests for Program structural equality function."""
+
+    def test_program_structural_equal(self):
+        """Test Program nodes with same structure are equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        func1 = ir.Function("test_func", [x1], [ir.ScalarType(dtype)], assign1, span)
+        program1 = ir.Program([func1], "", span)
+
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+        func2 = ir.Function("test_func", [x2], [ir.ScalarType(dtype)], assign2, span)
+        program2 = ir.Program([func2], "", span)
+
+        assert ir.structural_equal(program1, program2, enable_auto_mapping=True)
+
+    def test_program_different_name_not_equal(self):
+        """Test Program nodes with different names are equal (name is IgnoreField)."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+
+        program1 = ir.Program([func], "program1", span)
+        program2 = ir.Program([func], "program2", span)
+
+        assert ir.structural_equal(program1, program2)  # name is IgnoreField, so should be equal
+
+    def test_program_different_functions_not_equal(self):
+        """Test Program nodes with different functions are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        z = ir.Var("z", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, y, span)
+        assign2 = ir.AssignStmt(x, z, span)
+        func1 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign1, span)
+        func2 = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign2, span)
+
+        program1 = ir.Program([func1], "", span)
+        program2 = ir.Program([func2], "", span)
+
+        assert not ir.structural_equal(program1, program2)
+
+    def test_program_different_from_base_irnode_not_equal(self):
+        """Test Program is not equal to a different IRNode type."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, y, span)
+        func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+        program = ir.Program([func], "", span)
+
+        # Compare with a Var (different IRNode type)
+        assert not ir.structural_equal(program, x)


### PR DESCRIPTION
Implement Program class that inherits from IRNode and contains a list of functions with an optional program name. This provides a way to represent complete programs as immutable IR nodes.

Changes include:
- Add Program class with functions list and name field
- Update IRPrinter to support printing Program nodes
- Add Program dispatch logic to structural_hash and structural_equal
- Add Python bindings with proper field reflection
- Update Python type stubs (ir.pyi)
- Add comprehensive test suite covering creation, immutability, hash, and structural equality