### PR TITLE
feat(ir): Refactor IfStmt and ForStmt to use single StmtPtr for body

### DIFF
--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_STMT_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -99,26 +100,37 @@ using AssignStmtPtr = std::shared_ptr<const AssignStmt>;
  * @brief Conditional statement
  *
  * Represents an if-else statement: if condition then then_body else else_body
- * where condition is an expression and then_body/else_body are statement lists.
+ * where condition is an expression and then_body/else_body is statement.
  */
 class IfStmt : public Stmt {
  public:
   /**
-   * @brief Create a conditional statement
+   * @brief Create a conditional statement with then and else branches
    *
    * @param condition Condition expression
-   * @param then_body Then branch statements
-   * @param else_body Else branch statements (can be empty)
+   * @param then_body Then branch statement
+   * @param else_body Else branch statement (can be optional)
    * @param return_vars Return variables (can be empty)
    * @param span Source location
    */
-  IfStmt(ExprPtr condition, std::vector<StmtPtr> then_body, std::vector<StmtPtr> else_body,
+  IfStmt(ExprPtr condition, StmtPtr then_body, std::optional<StmtPtr> else_body,
          std::vector<VarPtr> return_vars, Span span)
       : Stmt(std::move(span)),
         condition_(std::move(condition)),
         then_body_(std::move(then_body)),
         else_body_(std::move(else_body)),
         return_vars_(std::move(return_vars)) {}
+
+  /**
+   * @brief Create a conditional statement with only then branch
+   *
+   * @param condition Condition expression
+   * @param then_body Then branch statement
+   * @param return_vars Return variables (can be empty)
+   * @param span Source location
+   */
+  IfStmt(ExprPtr condition, StmtPtr then_body, std::vector<VarPtr> return_vars, Span span)
+      : IfStmt(condition, then_body, std::nullopt, return_vars, span) {}
 
   [[nodiscard]] std::string TypeName() const override { return "IfStmt"; }
 
@@ -136,10 +148,10 @@ class IfStmt : public Stmt {
   }
 
  public:
-  ExprPtr condition_;                // Condition expression
-  std::vector<StmtPtr> then_body_;   // Then branch statements
-  std::vector<StmtPtr> else_body_;   // Else branch statements (can be empty)
-  std::vector<VarPtr> return_vars_;  // Return variables (can be empty)
+  ExprPtr condition_;                 // Condition expression
+  StmtPtr then_body_;                 // Then branch statement
+  std::optional<StmtPtr> else_body_;  // Else branch statement (optional)
+  std::vector<VarPtr> return_vars_;   // Return variables (can be empty)
 };
 
 using IfStmtPtr = std::shared_ptr<const IfStmt>;
@@ -190,7 +202,7 @@ using YieldStmtPtr = std::shared_ptr<const YieldStmt>;
  *
  * Represents a for loop: for loop_var in range(start, stop, step): body
  * where loop_var is the loop variable, start/stop/step are expressions,
- * and body is a list of statements.
+ * and body is a statement.
  */
 class ForStmt : public Stmt {
  public:
@@ -201,11 +213,11 @@ class ForStmt : public Stmt {
    * @param start Start value expression
    * @param stop Stop value expression
    * @param step Step value expression
-   * @param body Loop body statements
+   * @param body Loop body statement
    * @param return_vars Return variables (can be empty)
    * @param span Source location
    */
-  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<StmtPtr> body,
+  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, StmtPtr body,
           std::vector<VarPtr> return_vars, Span span)
       : Stmt(std::move(span)),
         loop_var_(std::move(loop_var)),
@@ -237,7 +249,7 @@ class ForStmt : public Stmt {
   ExprPtr start_;                    // Start value expression
   ExprPtr stop_;                     // Stop value expression
   ExprPtr step_;                     // Step value expression
-  std::vector<StmtPtr> body_;        // Loop body statements
+  StmtPtr body_;                     // Loop body statement
   std::vector<VarPtr> return_vars_;  // Return variables (can be empty)
 };
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
@@ -17,6 +18,7 @@
 
 #include <any>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -372,10 +374,14 @@ void BindIR(nb::module_& m) {
   // IfStmt - const shared_ptr
   auto if_stmt_class = nb::class_<IfStmt, Stmt>(
       ir, "IfStmt", "Conditional statement: if condition then then_body else else_body");
-  if_stmt_class.def(nb::init<const ExprPtr&, const std::vector<StmtPtr>&, const std::vector<StmtPtr>&,
+  if_stmt_class.def(nb::init<const ExprPtr&, const StmtPtr&, const std::optional<StmtPtr>&,
                              const std::vector<VarPtr>&, const Span&>(),
-                    nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body"), nb::arg("return_vars"),
-                    nb::arg("span"), "Create a conditional statement");
+                    nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body").none(),
+                    nb::arg("return_vars"), nb::arg("span"),
+                    "Create a conditional statement with then and else branches (else_body can be None)");
+  if_stmt_class.def(nb::init<const ExprPtr&, const StmtPtr&, const std::vector<VarPtr>&, const Span&>(),
+                    nb::arg("condition"), nb::arg("then_body"), nb::arg("return_vars"), nb::arg("span"),
+                    "Create a conditional statement with only then branch");
   BindFields<IfStmt>(if_stmt_class);
   BindStrRepr<IfStmt>(if_stmt_class);
 
@@ -390,8 +396,8 @@ void BindIR(nb::module_& m) {
   // ForStmt - const shared_ptr
   auto for_stmt_class = nb::class_<ForStmt, Stmt>(
       ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
-  for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&,
-                              const std::vector<StmtPtr>&, const std::vector<VarPtr>&, const Span&>(),
+  for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&, const StmtPtr&,
+                              const std::vector<VarPtr>&, const Span&>(),
                      nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("body"),
                      nb::arg("return_vars"), nb::arg("span"), "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -710,32 +710,52 @@ class IfStmt(Stmt):
     condition: Final[Expr]
     """Condition expression."""
 
-    then_body: Final[list[Stmt]]
-    """Then branch statements."""
+    then_body: Final[Stmt]
+    """Then branch statement."""
 
-    else_body: Final[list[Stmt]]
-    """Else branch statements (can be empty)."""
+    else_body: Final[Stmt | None]
+    """Else branch statement (can be None)."""
 
     return_vars: Final[list[Var]]
     """Return variables (can be empty)."""
 
+    @overload
     def __init__(
         self,
         condition: Expr,
-        then_body: list[Stmt],
-        else_body: list[Stmt],
+        then_body: Stmt,
+        else_body: Stmt | None,
         return_vars: list[Var],
         span: Span,
     ) -> None:
-        """Create a conditional statement.
+        """Create a conditional statement with then and else branches.
 
         Args:
             condition: Condition expression
-            then_body: Then branch statements
-            else_body: Else branch statements (can be empty)
+            then_body: Then branch statement
+            else_body: Else branch statement (can be None)
             return_vars: Return variables (can be empty)
             span: Source location
         """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        condition: Expr,
+        then_body: Stmt,
+        return_vars: list[Var],
+        span: Span,
+    ) -> None:
+        """Create a conditional statement with only then branch.
+
+        Args:
+            condition: Condition expression
+            then_body: Then branch statement
+            return_vars: Return variables (can be empty)
+            span: Source location
+        """
+        ...
 
 class YieldStmt(Stmt):
     """Yield statement: yield value."""
@@ -777,8 +797,8 @@ class ForStmt(Stmt):
     step: Final[Expr]
     """Step value expression."""
 
-    body: Final[list[Stmt]]
-    """Loop body statements."""
+    body: Final[Stmt]
+    """Loop body statement."""
 
     return_vars: Final[list[Var]]
     """Return variables (can be empty)."""
@@ -789,7 +809,7 @@ class ForStmt(Stmt):
         start: Expr,
         stop: Expr,
         step: Expr,
-        body: list[Stmt],
+        body: Stmt,
         return_vars: list[Var],
         span: Span,
     ) -> None:

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -13,6 +13,7 @@
 
 #include <fstream>
 #include <map>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -53,6 +54,10 @@ class FieldSerializerVisitor {
   // Visit IRNode pointer fields
   template <typename IRNodePtrType>
   result_type VisitIRNodeField(const IRNodePtrType& field);
+
+  // Visit optional IRNode pointer fields
+  template <typename IRNodePtrType>
+  result_type VisitIRNodeField(const std::optional<IRNodePtrType>& field);
 
   // Visit vector of IRNode pointers
   template <typename IRNodePtrType>
@@ -247,6 +252,17 @@ msgpack::object FieldSerializerVisitor::InitResult() const { return msgpack::obj
 template <typename IRNodePtrType>
 msgpack::object FieldSerializerVisitor::VisitIRNodeField(const IRNodePtrType& field) {
   return ctx_.SerializeNode(field, zone_);
+}
+
+// Overload for std::optional<IRNodePtr>
+template <typename IRNodePtrType>
+msgpack::object FieldSerializerVisitor::VisitIRNodeField(const std::optional<IRNodePtrType>& field) {
+  if (field.has_value() && *field) {
+    return ctx_.SerializeNode(*field, zone_);
+  } else {
+    // Return null object for empty optional
+    return msgpack::object();
+  }
 }
 
 template <typename IRNodePtrType>

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -58,6 +59,28 @@ class StructuralEqual {
     INTERNAL_CHECK(lhs) << "structural_equal encountered null lhs IR node field";
     INTERNAL_CHECK(rhs) << "structural_equal encountered null rhs IR node field";
     return Equal(lhs, rhs);
+  }
+
+  // Specialization for std::optional<IRNodePtr>
+  template <typename IRNodePtrType>
+  result_type VisitIRNodeField(const std::optional<IRNodePtrType>& lhs,
+                               const std::optional<IRNodePtrType>& rhs) {
+    // Both are empty (nullopt)
+    if (!lhs.has_value() && !rhs.has_value()) {
+      return true;
+    }
+    // One is empty, the other is not
+    if (!lhs.has_value() || !rhs.has_value()) {
+      return false;
+    }
+    // Both have values, compare them
+    if (!*lhs && !*rhs) {
+      return true;  // Both are nullptr
+    }
+    if (!*lhs || !*rhs) {
+      return false;  // One is nullptr, the other is not
+    }
+    return Equal(*lhs, *rhs);
   }
 
   template <typename IRNodePtrType>

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -58,6 +59,17 @@ class StructuralHasher {
   result_type VisitIRNodeField(const IRNodePtrType& field) {
     INTERNAL_CHECK(field) << "structural_hash encountered null IR node field";
     return HashNode(field);
+  }
+
+  // Specialization for std::optional<IRNodePtr>
+  template <typename IRNodePtrType>
+  result_type VisitIRNodeField(const std::optional<IRNodePtrType>& field) {
+    if (field.has_value() && *field) {
+      return HashNode(*field);
+    } else {
+      // Hash empty optional as 0
+      return 0;
+    }
   }
 
   template <typename IRNodePtrType>

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -107,13 +107,11 @@ void IRVisitor::VisitStmt_(const AssignStmtPtr& op) {
 void IRVisitor::VisitStmt_(const IfStmtPtr& op) {
   INTERNAL_CHECK(op->condition_) << "IfStmt has null condition";
   VisitExpr(op->condition_);
-  for (size_t i = 0; i < op->then_body_.size(); ++i) {
-    INTERNAL_CHECK(op->then_body_[i]) << "IfStmt has null then_body statement at index " << i;
-    VisitStmt(op->then_body_[i]);
-  }
-  for (size_t i = 0; i < op->else_body_.size(); ++i) {
-    INTERNAL_CHECK(op->else_body_[i]) << "IfStmt has null else_body statement at index " << i;
-    VisitStmt(op->else_body_[i]);
+  INTERNAL_CHECK(op->then_body_) << "IfStmt has null then_body";
+  VisitStmt(op->then_body_);
+  if (op->else_body_.has_value()) {
+    INTERNAL_CHECK(*op->else_body_) << "IfStmt has null else_body";
+    VisitStmt(*op->else_body_);
   }
   for (size_t i = 0; i < op->return_vars_.size(); ++i) {
     INTERNAL_CHECK(op->return_vars_[i]) << "IfStmt has null return_vars at index " << i;
@@ -137,10 +135,8 @@ void IRVisitor::VisitStmt_(const ForStmtPtr& op) {
   VisitExpr(op->start_);
   VisitExpr(op->stop_);
   VisitExpr(op->step_);
-  for (size_t i = 0; i < op->body_.size(); ++i) {
-    INTERNAL_CHECK(op->body_[i]) << "ForStmt has null body statement at index " << i;
-    VisitStmt(op->body_[i]);
-  }
+  INTERNAL_CHECK(op->body_) << "ForStmt has null body";
+  VisitStmt(op->body_);
   for (size_t i = 0; i < op->return_vars_.size(); ++i) {
     INTERNAL_CHECK(op->return_vars_[i]) << "ForStmt has null return_vars at index " << i;
     VisitExpr(op->return_vars_[i]);

--- a/tests/ut/ir/test_if_stmt.py
+++ b/tests/ut/ir/test_if_stmt.py
@@ -24,13 +24,13 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt = ir.IfStmt(condition, assign, [], span)
 
         assert if_stmt is not None
         assert if_stmt.span.filename == "test.py"
         assert isinstance(if_stmt.condition, ir.Eq)
-        assert len(if_stmt.then_body) == 1
-        assert len(if_stmt.else_body) == 0
+        assert isinstance(if_stmt.then_body, ir.AssignStmt)
+        assert if_stmt.else_body is None
 
     def test_if_stmt_has_attributes(self):
         """Test that IfStmt has condition, then_body, and else_body attributes."""
@@ -41,13 +41,12 @@ class TestIfStmt:
         condition = ir.Lt(a, b, dtype, span)
         assign1 = ir.AssignStmt(a, b, span)
         assign2 = ir.AssignStmt(b, a, span)
-        if_stmt = ir.IfStmt(condition, [assign1], [assign2], [], span)
+        if_stmt = ir.IfStmt(condition, assign1, assign2, [], span)
 
         assert if_stmt.condition is not None
-        assert len(if_stmt.then_body) == 1
-        assert len(if_stmt.else_body) == 1
-        assert isinstance(if_stmt.then_body[0], ir.AssignStmt)
-        assert isinstance(if_stmt.else_body[0], ir.AssignStmt)
+        assert isinstance(if_stmt.then_body, ir.AssignStmt)
+        assert if_stmt.else_body is not None
+        assert isinstance(if_stmt.else_body, ir.AssignStmt)
         assert len(if_stmt.return_vars) == 0
 
     def test_if_stmt_is_stmt(self):
@@ -58,7 +57,7 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt = ir.IfStmt(condition, assign, [], span)
 
         assert isinstance(if_stmt, ir.Stmt)
         assert isinstance(if_stmt, ir.IRNode)
@@ -71,7 +70,7 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt = ir.IfStmt(condition, assign, [], span)
 
         # Attempting to modify should raise AttributeError
         with pytest.raises(AttributeError):
@@ -91,9 +90,9 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt = ir.IfStmt(condition, assign, [], span)
 
-        assert len(if_stmt.else_body) == 0
+        assert if_stmt.else_body is None
 
     def test_if_stmt_with_different_condition_types(self):
         """Test IfStmt with different condition expression types."""
@@ -105,17 +104,17 @@ class TestIfStmt:
 
         # Test with Eq condition
         condition1 = ir.Eq(x, y, dtype, span)
-        if_stmt1 = ir.IfStmt(condition1, [assign], [], [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
         assert isinstance(if_stmt1.condition, ir.Eq)
 
         # Test with Lt condition
         condition2 = ir.Lt(x, y, dtype, span)
-        if_stmt2 = ir.IfStmt(condition2, [assign], [], [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
         assert isinstance(if_stmt2.condition, ir.Lt)
 
         # Test with And condition
         condition3 = ir.And(x, y, dtype, span)
-        if_stmt3 = ir.IfStmt(condition3, [assign], [], [], span)
+        if_stmt3 = ir.IfStmt(condition3, assign, [], span)
         assert isinstance(if_stmt3.condition, ir.And)
 
     def test_if_stmt_with_multiple_statements(self):
@@ -129,10 +128,13 @@ class TestIfStmt:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, x, span)
-        if_stmt = ir.IfStmt(condition, [assign1, assign2], [assign3], [], span)
+        then_seq = ir.SeqStmts([assign1, assign2], span)
+        if_stmt = ir.IfStmt(condition, then_seq, assign3, [], span)
 
-        assert len(if_stmt.then_body) == 2
-        assert len(if_stmt.else_body) == 1
+        assert isinstance(if_stmt.then_body, ir.SeqStmts)
+        assert len(if_stmt.then_body.stmts) == 2
+        assert if_stmt.else_body is not None
+        assert isinstance(if_stmt.else_body, ir.AssignStmt)
 
     def test_if_stmt_with_return_vars(self):
         """Test IfStmt with return_vars."""
@@ -147,68 +149,20 @@ class TestIfStmt:
         assign = ir.AssignStmt(x, y, span)
 
         # IfStmt with empty return_vars
-        if_stmt1 = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt1 = ir.IfStmt(condition, assign, [], span)
         assert len(if_stmt1.return_vars) == 0
 
         # IfStmt with single return variable
-        if_stmt2 = ir.IfStmt(condition, [assign], [], [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
         assert len(if_stmt2.return_vars) == 1
         assert if_stmt2.return_vars[0].name == "a"
 
         # IfStmt with multiple return variables
-        if_stmt3 = ir.IfStmt(condition, [assign], [], [a, b, c], span)
+        if_stmt3 = ir.IfStmt(condition, assign, [a, b, c], span)
         assert len(if_stmt3.return_vars) == 3
         assert if_stmt3.return_vars[0].name == "a"
         assert if_stmt3.return_vars[1].name == "b"
         assert if_stmt3.return_vars[2].name == "c"
-
-
-class TestIfStmtPrinting:
-    """Test printing of IfStmt statements."""
-
-    def test_if_stmt_printing(self):
-        """Test printing of IfStmt statements."""
-        span = ir.Span.unknown()
-        dtype = DataType.INT64
-        x = ir.Var("x", ir.ScalarType(dtype), span)
-        y = ir.Var("y", ir.ScalarType(dtype), span)
-        z = ir.Var("z", ir.ScalarType(dtype), span)
-
-        # Basic if statement without else
-        condition = ir.Eq(x, y, dtype, span)
-        assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
-        assert str(if_stmt) == "if x == y:\n  x = y"
-
-        # If statement with else
-        assign1 = ir.AssignStmt(x, y, span)
-        assign2 = ir.AssignStmt(y, z, span)
-        if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], [], span)
-        assert str(if_stmt2) == "if x == y:\n  x = y\nelse:\n  y = z"
-
-        # If statement with multiple statements in then_body
-        assign3 = ir.AssignStmt(z, x, span)
-        if_stmt3 = ir.IfStmt(condition, [assign1, assign2], [], [], span)
-        assert str(if_stmt3) == "if x == y:\n  x = y\n  y = z"
-
-        # If statement with multiple statements in both branches
-        if_stmt4 = ir.IfStmt(condition, [assign1, assign2], [assign3], [], span)
-        assert str(if_stmt4) == "if x == y:\n  x = y\n  y = z\nelse:\n  z = x"
-
-        # If statement with complex condition
-        complex_condition = ir.And(ir.Lt(x, y, dtype, span), ir.Gt(z, x, dtype, span), dtype, span)
-        if_stmt5 = ir.IfStmt(complex_condition, [assign1], [], [], span)
-        assert str(if_stmt5) == "if x < y and z > x:\n  x = y"
-
-        # If statement with return variables
-        a = ir.Var("a", ir.ScalarType(dtype), span)
-        if_stmt6 = ir.IfStmt(condition, [assign1], [], [a], span)
-        assert str(if_stmt6) == "if x == y:\n  x = y\nreturn a"
-
-        # If statement with multiple return variables
-        b = ir.Var("b", ir.ScalarType(dtype), span)
-        if_stmt7 = ir.IfStmt(condition, [assign1], [assign2], [a, b], span)
-        assert str(if_stmt7) == "if x == y:\n  x = y\nelse:\n  y = z\nreturn a, b"
 
 
 class TestIfStmtHash:
@@ -227,8 +181,8 @@ class TestIfStmtHash:
         assign1 = ir.AssignStmt(x1, y1, span)
         assign2 = ir.AssignStmt(x2, y2, span)
 
-        if_stmt1 = ir.IfStmt(condition1, [assign1], [], [], span)
-        if_stmt2 = ir.IfStmt(condition2, [assign2], [], [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -246,8 +200,8 @@ class TestIfStmtHash:
         condition2 = ir.Lt(x, z, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition1, [assign], [], [], span)
-        if_stmt2 = ir.IfStmt(condition2, [assign], [], [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -264,8 +218,8 @@ class TestIfStmtHash:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign1], [], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign2], [], [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign2, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -282,8 +236,8 @@ class TestIfStmtHash:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign1], [assign1], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign1, assign2, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -300,9 +254,9 @@ class TestIfStmtHash:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign], [], [a], span)
-        if_stmt2 = ir.IfStmt(condition, [assign], [], [b], span)
-        if_stmt3 = ir.IfStmt(condition, [assign], [], [a, b], span)
+        if_stmt1 = ir.IfStmt(condition, assign, [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, [b], span)
+        if_stmt3 = ir.IfStmt(condition, assign, [a, b], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -321,12 +275,40 @@ class TestIfStmtHash:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign], [], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign], [], [a], span)
+        if_stmt1 = ir.IfStmt(condition, assign, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
         assert hash1 != hash2
+
+    def test_if_stmt_with_nullopt_else_body_hash(self):
+        """Test IfStmt nodes with nullopt else_body hash correctly."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x1, y1, dtype, span)
+        condition2 = ir.Eq(x2, y2, dtype, span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        # Both have nullopt else_body
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, None, [], span)
+
+        hash1 = ir.structural_hash(if_stmt1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(if_stmt2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+        # One with nullopt else_body, one with else_body
+        assign_else = ir.AssignStmt(y1, x1, span)
+        if_stmt3 = ir.IfStmt(condition1, assign1, assign_else, [], span)
+
+        hash3 = ir.structural_hash(if_stmt3, enable_auto_mapping=True)
+        assert hash1 != hash3
 
 
 class TestIfStmtEquality:
@@ -345,8 +327,8 @@ class TestIfStmtEquality:
         assign1 = ir.AssignStmt(x1, y1, span)
         assign2 = ir.AssignStmt(x2, y2, span)
 
-        if_stmt1 = ir.IfStmt(condition1, [assign1], [], [], span)
-        if_stmt2 = ir.IfStmt(condition2, [assign2], [], [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, [], span)
 
         # Different variable pointers, so not equal without auto_mapping
         assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
@@ -364,8 +346,8 @@ class TestIfStmtEquality:
         condition2 = ir.Lt(x, z, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition1, [assign], [], [], span)
-        if_stmt2 = ir.IfStmt(condition2, [assign], [], [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -380,8 +362,8 @@ class TestIfStmtEquality:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign1], [], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign2], [], [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign2, [], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -396,8 +378,8 @@ class TestIfStmtEquality:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign1], [assign1], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign1], [assign2], [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, assign1, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign1, assign2, [], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -410,7 +392,7 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt = ir.IfStmt(condition, [assign], [], [], span)
+        if_stmt = ir.IfStmt(condition, assign, [], span)
         stmt = ir.Stmt(span)
 
         assert not ir.structural_equal(if_stmt, stmt)
@@ -426,9 +408,9 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign], [], [a], span)
-        if_stmt2 = ir.IfStmt(condition, [assign], [], [b], span)
-        if_stmt3 = ir.IfStmt(condition, [assign], [], [a, b], span)
+        if_stmt1 = ir.IfStmt(condition, assign, [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, [b], span)
+        if_stmt3 = ir.IfStmt(condition, assign, [a, b], span)
 
         assert ir.structural_equal(if_stmt1, if_stmt2)
         assert not ir.structural_equal(if_stmt1, if_stmt3)
@@ -444,10 +426,32 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, [assign], [], [], span)
-        if_stmt2 = ir.IfStmt(condition, [assign], [], [a], span)
+        if_stmt1 = ir.IfStmt(condition, assign, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
+
+    def test_if_stmt_with_nullopt_else_body_equal(self):
+        """Test IfStmt nodes with nullopt else_body are equal when structurally same."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x1 = ir.Var("x", ir.ScalarType(dtype), span)
+        y1 = ir.Var("y", ir.ScalarType(dtype), span)
+        x2 = ir.Var("x", ir.ScalarType(dtype), span)
+        y2 = ir.Var("y", ir.ScalarType(dtype), span)
+        condition1 = ir.Eq(x1, y1, dtype, span)
+        condition2 = ir.Eq(x2, y2, dtype, span)
+        assign1 = ir.AssignStmt(x1, y1, span)
+        assign2 = ir.AssignStmt(x2, y2, span)
+
+        # Both have nullopt else_body
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, None, [], span)
+
+        # With auto_mapping, they should be equal
+        assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
+        # Without auto_mapping, they should not be equal (different variable pointers)
+        assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
 
 
 class TestIfStmtAutoMapping:
@@ -461,7 +465,7 @@ class TestIfStmtAutoMapping:
         condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
         assign1_then = ir.AssignStmt(x1, y1, ir.Span.unknown())
         assign1_else = ir.AssignStmt(y1, x1, ir.Span.unknown())
-        if_stmt1 = ir.IfStmt(condition1, [assign1_then], [assign1_else], [], ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, assign1_then, assign1_else, [], ir.Span.unknown())
 
         # Build: if a == b then a = b else b = a
         a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
@@ -469,7 +473,7 @@ class TestIfStmtAutoMapping:
         condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
         assign2_then = ir.AssignStmt(a, b, ir.Span.unknown())
         assign2_else = ir.AssignStmt(b, a, ir.Span.unknown())
-        if_stmt2 = ir.IfStmt(condition2, [assign2_then], [assign2_else], [], ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, assign2_then, assign2_else, [], ir.Span.unknown())
 
         assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
         assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
@@ -489,7 +493,7 @@ class TestIfStmtAutoMapping:
         y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
         assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
-        if_stmt1 = ir.IfStmt(condition1, [assign1], [], [], ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, assign1, [], ir.Span.unknown())
 
         # Build: if a == b then a = b else b = a
         a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
@@ -497,7 +501,7 @@ class TestIfStmtAutoMapping:
         condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
         assign2_then = ir.AssignStmt(a, b, ir.Span.unknown())
         assign2_else = ir.AssignStmt(b, a, ir.Span.unknown())
-        if_stmt2 = ir.IfStmt(condition2, [assign2_then], [assign2_else], [], ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, assign2_then, assign2_else, [], ir.Span.unknown())
 
         # Different structure (one has else, one doesn't)
         assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)
@@ -511,7 +515,7 @@ class TestIfStmtAutoMapping:
         r2 = ir.Var("r2", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
         assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
-        if_stmt1 = ir.IfStmt(condition1, [assign1], [], [r1, r2], ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, assign1, [r1, r2], ir.Span.unknown())
 
         # Build: if a == b then a = b return s1, s2
         a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
@@ -520,7 +524,7 @@ class TestIfStmtAutoMapping:
         s2 = ir.Var("s2", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
         assign2 = ir.AssignStmt(a, b, ir.Span.unknown())
-        if_stmt2 = ir.IfStmt(condition2, [assign2], [], [s1, s2], ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, assign2, [s1, s2], ir.Span.unknown())
 
         # With auto_mapping, they should be equal (return_vars are DefField)
         assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)

--- a/tests/ut/ir/test_serialization.py
+++ b/tests/ut/ir/test_serialization.py
@@ -212,8 +212,8 @@ class TestStatementSerialization:
         z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
 
         cond = ir.Gt(x, y, DataType.INT64, ir.Span.unknown())
-        then_body: list[ir.Stmt] = [ir.AssignStmt(z, x, ir.Span.unknown())]
-        else_body: list[ir.Stmt] = [ir.AssignStmt(z, y, ir.Span.unknown())]
+        then_body = ir.AssignStmt(z, x, ir.Span.unknown())
+        else_body = ir.AssignStmt(z, y, ir.Span.unknown())
 
         if_stmt = ir.IfStmt(cond, then_body, else_body, [], ir.Span.unknown())
 
@@ -221,6 +221,50 @@ class TestStatementSerialization:
         restored = ir.deserialize(data)
 
         assert ir.structural_equal(if_stmt, restored, enable_auto_mapping=True)
+
+    def test_serialize_if_stmt_with_nullopt_else_body(self):
+        """Test serialization of IfStmt with nullopt else_body."""
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+
+        cond = ir.Gt(x, y, DataType.INT64, ir.Span.unknown())
+        then_body = ir.AssignStmt(z, x, ir.Span.unknown())
+
+        # IfStmt with nullopt else_body (using constructor that only takes then_body)
+        if_stmt = ir.IfStmt(cond, then_body, [], ir.Span.unknown())
+
+        data = ir.serialize(if_stmt)
+        restored = ir.deserialize(data)
+        restored_if_stmt = cast(ir.IfStmt, restored)
+
+        # Check structural equality
+        assert ir.structural_equal(if_stmt, restored, enable_auto_mapping=True)
+
+        # Verify that else_body is None in the restored version
+        assert restored_if_stmt.else_body is None
+
+    def test_serialize_if_stmt_with_nullopt_else_body_explicit(self):
+        """Test serialization of IfStmt with explicitly None else_body."""
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+
+        cond = ir.Gt(x, y, DataType.INT64, ir.Span.unknown())
+        then_body = ir.AssignStmt(z, x, ir.Span.unknown())
+
+        # IfStmt with explicitly None else_body
+        if_stmt = ir.IfStmt(cond, then_body, None, [], ir.Span.unknown())
+
+        data = ir.serialize(if_stmt)
+        restored = ir.deserialize(data)
+        restored_if_stmt = cast(ir.IfStmt, restored)
+
+        # Check structural equality
+        assert ir.structural_equal(if_stmt, restored, enable_auto_mapping=True)
+
+        # Verify that else_body is None in the restored version
+        assert restored_if_stmt.else_body is None
 
     def test_serialize_for_stmt(self):
         """Test serialization of ForStmt."""
@@ -231,9 +275,7 @@ class TestStatementSerialization:
         stop = ir.ConstInt(10, DataType.INT64, ir.Span.unknown())
         step = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
 
-        body: list[ir.Stmt] = [
-            ir.AssignStmt(x, ir.Add(x, i, DataType.INT64, ir.Span.unknown()), ir.Span.unknown())
-        ]
+        body = ir.AssignStmt(x, ir.Add(x, i, DataType.INT64, ir.Span.unknown()), ir.Span.unknown())
 
         for_stmt = ir.ForStmt(i, start, stop, step, body, [], ir.Span.unknown())
 


### PR DESCRIPTION
    Change body fields from std::vector<StmtPtr> to StmtPtr to simplify
    the API. Multiple statements can be wrapped in SeqStmts when needed.
    Also change IfStmt::else_body_ to std::optional<StmtPtr> and add a
    constructor that only takes then_body.
    
    Updates:
    - IfStmt and ForStmt field types in stmt.h
    - Field visitor to handle std::optional<IRNodePtr>
    - Serialization/deserialization logic
    - Visitor, mutator, and printer implementations
    - Structural hash and equality comparisons
    - Python bindings
    - All test cases to use new API with SeqStmts