### PR TITLE
refactor(ir): remove IfStmt delegate constructor

### DIFF
--- a/docs/dev/00-ir_definition.md
+++ b/docs/dev/00-ir_definition.md
@@ -437,7 +437,7 @@ then_assign = ir.AssignStmt(result, x, span)
 neg_x = ir.Neg(x, dtype, span)
 else_assign = ir.AssignStmt(result, neg_x, span)
 
-abs_stmt = ir.IfStmt(condition, [then_assign], [else_assign], [result], span)
+abs_stmt = ir.IfStmt(condition, then_assign, else_assign, [result], span)
 ```
 
 ### Example 3: Loop with Accumulation

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -121,17 +121,6 @@ class IfStmt : public Stmt {
         else_body_(std::move(else_body)),
         return_vars_(std::move(return_vars)) {}
 
-  /**
-   * @brief Create a conditional statement with only then branch
-   *
-   * @param condition Condition expression
-   * @param then_body Then branch statement
-   * @param return_vars Return variables (can be empty)
-   * @param span Source location
-   */
-  IfStmt(ExprPtr condition, StmtPtr then_body, std::vector<VarPtr> return_vars, Span span)
-      : IfStmt(condition, then_body, std::nullopt, return_vars, span) {}
-
   [[nodiscard]] std::string TypeName() const override { return "IfStmt"; }
 
   /**

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -379,9 +379,6 @@ void BindIR(nb::module_& m) {
                     nb::arg("condition"), nb::arg("then_body"), nb::arg("else_body").none(),
                     nb::arg("return_vars"), nb::arg("span"),
                     "Create a conditional statement with then and else branches (else_body can be None)");
-  if_stmt_class.def(nb::init<const ExprPtr&, const StmtPtr&, const std::vector<VarPtr>&, const Span&>(),
-                    nb::arg("condition"), nb::arg("then_body"), nb::arg("return_vars"), nb::arg("span"),
-                    "Create a conditional statement with only then branch");
   BindFields<IfStmt>(if_stmt_class);
   BindStrRepr<IfStmt>(if_stmt_class);
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -719,7 +719,6 @@ class IfStmt(Stmt):
     return_vars: Final[list[Var]]
     """Return variables (can be empty)."""
 
-    @overload
     def __init__(
         self,
         condition: Expr,
@@ -734,24 +733,6 @@ class IfStmt(Stmt):
             condition: Condition expression
             then_body: Then branch statement
             else_body: Else branch statement (can be None)
-            return_vars: Return variables (can be empty)
-            span: Source location
-        """
-        ...
-
-    @overload
-    def __init__(
-        self,
-        condition: Expr,
-        then_body: Stmt,
-        return_vars: list[Var],
-        span: Span,
-    ) -> None:
-        """Create a conditional statement with only then branch.
-
-        Args:
-            condition: Condition expression
-            then_body: Then branch statement
             return_vars: Return variables (can be empty)
             span: Source location
         """

--- a/src/ir/transform/mutator.cpp
+++ b/src/ir/transform/mutator.cpp
@@ -194,7 +194,7 @@ StmtPtr IRMutator::VisitStmt_(const IfStmtPtr& op) {
       return std::make_shared<const IfStmt>(std::move(new_condition), std::move(new_then_body),
                                             *new_else_body, std::move(new_return_vars), op->span_);
     } else {
-      return std::make_shared<const IfStmt>(std::move(new_condition), std::move(new_then_body),
+      return std::make_shared<const IfStmt>(std::move(new_condition), std::move(new_then_body), std::nullopt,
                                             std::move(new_return_vars), op->span_);
     }
   } else {

--- a/tests/ut/ir/test_if_stmt.py
+++ b/tests/ut/ir/test_if_stmt.py
@@ -24,7 +24,7 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, assign, [], span)
+        if_stmt = ir.IfStmt(condition, assign, None, [], span)
 
         assert if_stmt is not None
         assert if_stmt.span.filename == "test.py"
@@ -57,7 +57,7 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, assign, [], span)
+        if_stmt = ir.IfStmt(condition, assign, None, [], span)
 
         assert isinstance(if_stmt, ir.Stmt)
         assert isinstance(if_stmt, ir.IRNode)
@@ -70,8 +70,9 @@ class TestIfStmt:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, assign, [], span)
+        if_stmt = ir.IfStmt(condition, assign, None, [], span)
 
+        assert if_stmt.else_body is None
         # Attempting to modify should raise AttributeError
         with pytest.raises(AttributeError):
             if_stmt.condition = ir.Eq(y, x, dtype, span)  # type: ignore
@@ -81,18 +82,6 @@ class TestIfStmt:
             if_stmt.else_body = []  # type: ignore
         with pytest.raises(AttributeError):
             if_stmt.return_vars = []  # type: ignore
-
-    def test_if_stmt_with_empty_else_body(self):
-        """Test IfStmt with empty else_body."""
-        span = ir.Span("test.py", 1, 1, 1, 10)
-        dtype = DataType.INT64
-        x = ir.Var("x", ir.ScalarType(dtype), span)
-        y = ir.Var("y", ir.ScalarType(dtype), span)
-        condition = ir.Eq(x, y, dtype, span)
-        assign = ir.AssignStmt(x, y, span)
-        if_stmt = ir.IfStmt(condition, assign, [], span)
-
-        assert if_stmt.else_body is None
 
     def test_if_stmt_with_different_condition_types(self):
         """Test IfStmt with different condition expression types."""
@@ -104,17 +93,17 @@ class TestIfStmt:
 
         # Test with Eq condition
         condition1 = ir.Eq(x, y, dtype, span)
-        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, None, [], span)
         assert isinstance(if_stmt1.condition, ir.Eq)
 
         # Test with Lt condition
         condition2 = ir.Lt(x, y, dtype, span)
-        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, None, [], span)
         assert isinstance(if_stmt2.condition, ir.Lt)
 
         # Test with And condition
         condition3 = ir.And(x, y, dtype, span)
-        if_stmt3 = ir.IfStmt(condition3, assign, [], span)
+        if_stmt3 = ir.IfStmt(condition3, assign, None, [], span)
         assert isinstance(if_stmt3.condition, ir.And)
 
     def test_if_stmt_with_multiple_statements(self):
@@ -149,16 +138,16 @@ class TestIfStmt:
         assign = ir.AssignStmt(x, y, span)
 
         # IfStmt with empty return_vars
-        if_stmt1 = ir.IfStmt(condition, assign, [], span)
+        if_stmt1 = ir.IfStmt(condition, assign, None, [], span)
         assert len(if_stmt1.return_vars) == 0
 
         # IfStmt with single return variable
-        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, None, [a], span)
         assert len(if_stmt2.return_vars) == 1
         assert if_stmt2.return_vars[0].name == "a"
 
         # IfStmt with multiple return variables
-        if_stmt3 = ir.IfStmt(condition, assign, [a, b, c], span)
+        if_stmt3 = ir.IfStmt(condition, assign, None, [a, b, c], span)
         assert len(if_stmt3.return_vars) == 3
         assert if_stmt3.return_vars[0].name == "a"
         assert if_stmt3.return_vars[1].name == "b"
@@ -181,8 +170,8 @@ class TestIfStmtHash:
         assign1 = ir.AssignStmt(x1, y1, span)
         assign2 = ir.AssignStmt(x2, y2, span)
 
-        if_stmt1 = ir.IfStmt(condition1, assign1, [], span)
-        if_stmt2 = ir.IfStmt(condition2, assign2, [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, None, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -200,8 +189,8 @@ class TestIfStmtHash:
         condition2 = ir.Lt(x, z, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
-        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, None, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -218,8 +207,8 @@ class TestIfStmtHash:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign1, [], span)
-        if_stmt2 = ir.IfStmt(condition, assign2, [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign2, None, [], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -254,9 +243,9 @@ class TestIfStmtHash:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign, [a], span)
-        if_stmt2 = ir.IfStmt(condition, assign, [b], span)
-        if_stmt3 = ir.IfStmt(condition, assign, [a, b], span)
+        if_stmt1 = ir.IfStmt(condition, assign, None, [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, None, [b], span)
+        if_stmt3 = ir.IfStmt(condition, assign, None, [a, b], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -275,8 +264,8 @@ class TestIfStmtHash:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign, [], span)
-        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
+        if_stmt1 = ir.IfStmt(condition, assign, None, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign, None, [a], span)
 
         hash1 = ir.structural_hash(if_stmt1)
         hash2 = ir.structural_hash(if_stmt2)
@@ -327,8 +316,8 @@ class TestIfStmtEquality:
         assign1 = ir.AssignStmt(x1, y1, span)
         assign2 = ir.AssignStmt(x2, y2, span)
 
-        if_stmt1 = ir.IfStmt(condition1, assign1, [], span)
-        if_stmt2 = ir.IfStmt(condition2, assign2, [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign2, None, [], span)
 
         # Different variable pointers, so not equal without auto_mapping
         assert not ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=False)
@@ -346,8 +335,8 @@ class TestIfStmtEquality:
         condition2 = ir.Lt(x, z, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition1, assign, [], span)
-        if_stmt2 = ir.IfStmt(condition2, assign, [], span)
+        if_stmt1 = ir.IfStmt(condition1, assign, None, [], span)
+        if_stmt2 = ir.IfStmt(condition2, assign, None, [], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -362,8 +351,8 @@ class TestIfStmtEquality:
         assign1 = ir.AssignStmt(x, y, span)
         assign2 = ir.AssignStmt(y, z, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign1, [], span)
-        if_stmt2 = ir.IfStmt(condition, assign2, [], span)
+        if_stmt1 = ir.IfStmt(condition, assign1, None, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign2, None, [], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -392,7 +381,7 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt = ir.IfStmt(condition, assign, [], span)
+        if_stmt = ir.IfStmt(condition, assign, None, [], span)
         stmt = ir.Stmt(span)
 
         assert not ir.structural_equal(if_stmt, stmt)
@@ -408,9 +397,9 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign, [a], span)
-        if_stmt2 = ir.IfStmt(condition, assign, [b], span)
-        if_stmt3 = ir.IfStmt(condition, assign, [a, b], span)
+        if_stmt1 = ir.IfStmt(condition, assign, None, [a], span)
+        if_stmt2 = ir.IfStmt(condition, assign, None, [b], span)
+        if_stmt3 = ir.IfStmt(condition, assign, None, [a, b], span)
 
         assert ir.structural_equal(if_stmt1, if_stmt2)
         assert not ir.structural_equal(if_stmt1, if_stmt3)
@@ -426,8 +415,8 @@ class TestIfStmtEquality:
         condition = ir.Eq(x, y, dtype, span)
         assign = ir.AssignStmt(x, y, span)
 
-        if_stmt1 = ir.IfStmt(condition, assign, [], span)
-        if_stmt2 = ir.IfStmt(condition, assign, [a], span)
+        if_stmt1 = ir.IfStmt(condition, assign, None, [], span)
+        if_stmt2 = ir.IfStmt(condition, assign, None, [a], span)
 
         assert not ir.structural_equal(if_stmt1, if_stmt2)
 
@@ -493,7 +482,7 @@ class TestIfStmtAutoMapping:
         y1 = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
         assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
-        if_stmt1 = ir.IfStmt(condition1, assign1, [], ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [], ir.Span.unknown())
 
         # Build: if a == b then a = b else b = a
         a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
@@ -515,7 +504,7 @@ class TestIfStmtAutoMapping:
         r2 = ir.Var("r2", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition1 = ir.Eq(x1, y1, DataType.INT64, ir.Span.unknown())
         assign1 = ir.AssignStmt(x1, y1, ir.Span.unknown())
-        if_stmt1 = ir.IfStmt(condition1, assign1, [r1, r2], ir.Span.unknown())
+        if_stmt1 = ir.IfStmt(condition1, assign1, None, [r1, r2], ir.Span.unknown())
 
         # Build: if a == b then a = b return s1, s2
         a = ir.Var("a", ir.ScalarType(DataType.INT64), ir.Span.unknown())
@@ -524,7 +513,7 @@ class TestIfStmtAutoMapping:
         s2 = ir.Var("s2", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         condition2 = ir.Eq(a, b, DataType.INT64, ir.Span.unknown())
         assign2 = ir.AssignStmt(a, b, ir.Span.unknown())
-        if_stmt2 = ir.IfStmt(condition2, assign2, [s1, s2], ir.Span.unknown())
+        if_stmt2 = ir.IfStmt(condition2, assign2, None, [s1, s2], ir.Span.unknown())
 
         # With auto_mapping, they should be equal (return_vars are DefField)
         assert ir.structural_equal(if_stmt1, if_stmt2, enable_auto_mapping=True)

--- a/tests/ut/ir/test_serialization.py
+++ b/tests/ut/ir/test_serialization.py
@@ -232,28 +232,6 @@ class TestStatementSerialization:
         then_body = ir.AssignStmt(z, x, ir.Span.unknown())
 
         # IfStmt with nullopt else_body (using constructor that only takes then_body)
-        if_stmt = ir.IfStmt(cond, then_body, [], ir.Span.unknown())
-
-        data = ir.serialize(if_stmt)
-        restored = ir.deserialize(data)
-        restored_if_stmt = cast(ir.IfStmt, restored)
-
-        # Check structural equality
-        assert ir.structural_equal(if_stmt, restored, enable_auto_mapping=True)
-
-        # Verify that else_body is None in the restored version
-        assert restored_if_stmt.else_body is None
-
-    def test_serialize_if_stmt_with_nullopt_else_body_explicit(self):
-        """Test serialization of IfStmt with explicitly None else_body."""
-        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        z = ir.Var("z", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-
-        cond = ir.Gt(x, y, DataType.INT64, ir.Span.unknown())
-        then_body = ir.AssignStmt(z, x, ir.Span.unknown())
-
-        # IfStmt with explicitly None else_body
         if_stmt = ir.IfStmt(cond, then_body, None, [], ir.Span.unknown())
 
         data = ir.serialize(if_stmt)


### PR DESCRIPTION
Remove the IfStmt delegate constructor that accepts 4 parameters (condition, then_body, return_vars, span). All usages are updated to use the main constructor with explicit None/std::nullopt for else_body parameter.