### PR TITLE
feat(ir): Add Python-style IR printer with pi module syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(PYPTO_SOURCES
     src/ir/transform/visitor.cpp
     src/ir/transform/mutator.cpp
     src/ir/transform/printer.cpp
+    src/ir/transform/python_printer.cpp
     src/ir/transform/structural_hash.cpp
     src/ir/transform/structural_equal.cpp
     src/ir/serialization/serializer.cpp

--- a/docs/dev/05-python_syntax.md
+++ b/docs/dev/05-python_syntax.md
@@ -1,0 +1,503 @@
+# Python IR Syntax Specification
+
+## Overview
+
+This document specifies the Python-style syntax for PyPTO's IR (Intermediate Representation). The syntax is designed to be:
+
+1. **Complete**: Includes all information needed to reconstruct the IR
+2. **Parseable**: Can be parsed back into the IR (parser to be implemented)
+3. **Pythonic**: Follows Python programming style and passes most Python linters
+4. **SSA-style**: Uses SSA (Static Single Assignment) style for control flow with `pi.yield()` and `pi.range()`
+
+## Module Structure
+
+Every IR module starts with a program header and import statement. The default uses `pi` as the module alias (recommended):
+
+```python
+# pypto.program: program_name
+import pypto.ir as pi
+```
+
+For unnamed programs:
+
+```python
+# pypto.program
+import pypto.ir as pi
+```
+
+**Note:** The module prefix is configurable. You can use `ir` for legacy code or any custom prefix.
+
+## Type System
+
+### Scalar Types
+
+Scalar types use the module prefix (default `pi`) followed by the type name:
+
+```python
+x: pi.Int64
+y: pi.FP32
+z: pi.Bool
+```
+
+Available scalar types:
+- **Integers**: `pi.Int4`, `pi.Int8`, `pi.Int16`, `pi.Int32`, `pi.Int64`
+- **Unsigned integers**: `pi.UInt4`, `pi.UInt8`, `pi.UInt16`, `pi.UInt32`, `pi.UInt64`
+- **Floating point**: `pi.FP4`, `pi.FP8`, `pi.FP16`, `pi.FP32`
+- **Brain float**: `pi.BFloat16`
+- **Hisilicon float**: `pi.HF4`, `pi.HF8`
+- **Boolean**: `pi.Bool`
+
+### Tensor Types
+
+Tensor types use PyTorch-style syntax with shape as a tuple:
+
+```python
+a: pi.Tensor((4, 8), pi.FP32)      # Fixed shape (4, 8)
+b: pi.Tensor((n, m), pi.Int64)     # Symbolic shape (n, m)
+```
+
+### Tile Types
+
+Tile types are 2D tensors (at most 2 dimensions), also using PyTorch-style syntax:
+
+```python
+t: pi.Tile((16, 16), pi.FP16)      # 2D tile (16, 16)
+```
+
+## Expressions
+
+### Variables
+
+Variables are referenced by name:
+
+```python
+x
+tensor_a
+```
+
+### Constants
+
+Integer and floating-point literals:
+
+```python
+42
+-5
+3.14
+```
+
+### Binary Operations
+
+Use Python operators naturally:
+
+```python
+a + b           # Add
+a - b           # Sub
+a * b           # Mul
+a // b          # FloorDiv
+a % b           # FloorMod
+a / b           # FloatDiv
+a ** b          # Pow
+a == b          # Eq
+a != b          # Ne
+a < b           # Lt
+a <= b          # Le
+a > b           # Gt
+a >= b          # Ge
+a and b         # And
+a or b          # Or
+a ^ b           # Xor (logical)
+a & b           # BitAnd
+a | b           # BitOr
+a << b          # BitShiftLeft
+a >> b          # BitShiftRight
+```
+
+### Unary Operations
+
+```python
+-x              # Neg
+~x              # BitNot
+not x           # Not
+abs(x)          # Abs
+```
+
+### Min/Max
+
+```python
+min(a, b)       # Min
+max(a, b)       # Max
+```
+
+### Function/Op Calls
+
+```python
+# Regular Op call
+op_name(arg1, arg2)
+
+# Op call with attributes (keyword arguments)
+tensor_add(a, b, broadcast=True, axis=0)
+
+# Function call (GlobalVar) - implicit from program context
+my_function(x, y)
+```
+
+## Statements
+
+### Assignment
+
+Assignments include type annotations:
+
+```python
+x: pi.Int64 = expr
+y: pi.Tensor((4,), pi.FP32) = tensor_op(a)
+```
+
+### If Statement (SSA-style)
+
+If statements with return variables use `pi.yield()` to return values from each branch:
+
+```python
+# If with both branches returning values
+if condition:
+    y1 = pi.yield(value1)
+else:
+    y1 = pi.yield(value2)
+
+# If without else
+if condition:
+    y1 = pi.yield(value)
+
+# Multiple return values (no inline type annotations - not valid Python)
+if condition:
+    y1, y2 = pi.yield(value1, value2)
+else:
+    y1, y2 = pi.yield(value3, value4)
+```
+
+**Key points:**
+- `pi.yield()` in each branch assigns to SSA phi nodes
+- Variables defined in yield become accessible after the if statement
+- Both branches must yield the same variables for SSA consistency
+- Type annotations cannot be used inline with tuple unpacking (Python limitation)
+
+### For Loop (SSA-style with iter_args)
+
+For loops with loop-carried values (iter_args) use `pi.range()` with tuple unpacking:
+
+```python
+# Simple loop without iter_args (no type annotation in loop header)
+for i in range(start, stop, step):
+    body_statements
+
+# Loop with iter_args (loop-carried values)
+# No inline type annotations - not valid Python syntax
+j_init: pi.Int64 = 0
+for i, (j,) in pi.range(0, n, 1, init_values=[j_init]):
+    j = pi.yield(j + 1)
+j_final = j
+
+# Multiple iter_args
+sum_init: pi.Int64 = 0
+prod_init: pi.Int64 = 1
+for i, (sum, prod) in pi.range(0, 10, 1, init_values=[sum_init, prod_init]):
+    sum, prod = pi.yield(sum + i, prod * i)
+sum_final, prod_final = sum, prod   # function return values
+```
+
+**Key points:**
+- Loop-carried values (iter_args) use `pi.range()` with `init_values`
+- Tuple unpacking `(j,)` declares the iter_args
+- `pi.yield()` updates values for the next iteration
+- After the loop, iter_args contain final values and can be assigned to output variables (e.g., `j_final = j`)
+- Type annotations cannot be used in for loop headers or tuple unpacking (Python limitation)
+
+### Yield Statement
+
+```python
+yield            # YieldStmt with no values
+yield x          # YieldStmt with single value
+yield x, y       # YieldStmt with multiple values
+```
+
+### Statement Sequences
+
+Statements are naturally sequenced in Python (maps to `SeqStmts`):
+
+```python
+stmt1
+stmt2
+stmt3
+```
+
+Multiple assignments in a row create `OpStmts`:
+
+```python
+x: pi.Int64 = expr1
+y: pi.Int64 = expr2
+z: pi.Int64 = expr3
+```
+
+## Functions
+
+Functions use Python's `def` syntax with type annotations:
+
+```python
+def function_name(param1: pi.Int64, param2: pi.FP32) -> pi.Int64:
+    x: pi.Int64 = param1 + 1
+    return x
+```
+
+Multiple return types use `tuple`:
+
+```python
+def function_name(x: pi.Int64) -> tuple[pi.Int64, pi.Int64]:
+    y: pi.Int64 = x + 1
+    z: pi.Int64 = x * 2
+    return y, z
+```
+
+No return types:
+
+```python
+def function_name(x: pi.Int64):
+    y: pi.Int64 = x + 1
+```
+
+## Complete Examples
+
+### Example 1: Simple Function
+
+```python
+def add_one(x: pi.Int64) -> pi.Int64:
+    y: pi.Int64 = x + 1
+    return y
+```
+
+### Example 2: Tensor Operation
+
+```python
+def tensor_add_wrapper(
+    a: pi.Tensor((4, 8), pi.FP32),
+    b: pi.Tensor((4, 8), pi.FP32)
+) -> pi.Tensor((4, 8), pi.FP32):
+    c: pi.Tensor((4, 8), pi.FP32) = tensor_add(a, b)
+    return c
+```
+
+### Example 3: Control Flow with If
+
+```python
+def conditional(x: pi.Int64) -> pi.Int64:
+    if x > 0:
+        y1: pi.Int64 = pi.yield(x * 2)
+    else:
+        y1: pi.Int64 = pi.yield(x * 3)
+    return y1
+```
+
+### Example 4: Loop with iter_args
+
+```python
+def loop_sum(n: pi.Int64) -> pi.Int64:
+    sum_init: pi.Int64 = 0
+    for i, (sum,) in pi.range(0, n, 1, init_values=[sum_init]):
+        sum = pi.yield(sum + i)
+    sum_final: pi.Int64 = sum
+    return sum_final
+```
+
+### Example 5: Full Program
+
+```python
+# pypto.program: my_program
+import pypto.ir as pi
+
+def add(x: pi.Int64, y: pi.Int64) -> pi.Int64:
+    z: pi.Int64 = x + y
+    return z
+
+def multiply(x: pi.Int64, y: pi.Int64) -> pi.Int64:
+    z: pi.Int64 = x * y
+    return z
+
+def compute(a: pi.Int64, b: pi.Int64) -> pi.Int64:
+    temp1: pi.Int64 = add(a, b)
+    temp2: pi.Int64 = multiply(temp1, 2)
+    return temp2
+```
+
+### Example 6: Complex Nested Control Flow
+
+```python
+def flash_attention_kernel(
+    q: pi.Tensor((64, 128), pi.FP16),
+    k: pi.Tensor((1024, 128), pi.FP16),
+    v: pi.Tensor((1024, 128), pi.FP16)
+) -> pi.Tensor((64, 128), pi.FP32):
+    attention_init: pi.Tensor((64, 128), pi.FP32) = tensor_create(shape=[64, 128], dtype=pi.FP32)
+    oi_init: pi.Tensor((64, 128), pi.FP32) = tensor_create(shape=[64, 128], dtype=pi.FP32)
+    li_init: pi.Tensor((64, 1), pi.FP32) = tensor_create(shape=[64, 1], dtype=pi.FP32)
+    mi_init: pi.Tensor((64, 1), pi.FP32) = tensor_create(shape=[64, 1], dtype=pi.FP32)
+
+    for loop_idx, (
+        mi,
+        li,
+        attention,
+        oi
+    ) in pi.range(0, 16, 1, init_values=[mi_init, li_init, attention_init, oi_init]):
+        kj: pi.Tensor((64, 128), pi.FP16) = tensor_view(k, shape=[64, 128], offset=[loop_idx * 64, 0])
+        vj: pi.Tensor((64, 128), pi.FP16) = tensor_view(v, shape=[64, 128], offset=[loop_idx * 64, 0])
+        sij: pi.Tensor((64, 128), pi.FP16) = tensor_matmul(q, kj, aTrans=False, bTrans=True)
+
+        # ... more computation ...
+
+        mi, li, attention, oi = pi.yield(
+            mi_updated, li_updated, attention_updated, oi_updated
+        )
+
+    attention_final: pi.Tensor((64, 128), pi.FP32) = attention
+    return attention_final
+```
+
+## SSA-Style Control Flow Semantics
+
+### If Statements
+
+The `pi.yield()` in if statements creates SSA phi nodes at the merge point:
+
+```python
+# Before if: x is defined
+if condition:
+    y1 = pi.yield(x + 1)
+else:
+    y1 = pi.yield(x + 2)
+# After if: y1 is defined (phi node merging the two branches)
+```
+
+This is equivalent to SSA IR:
+```
+y1 = phi(x + 1, x + 2)  // based on condition
+```
+
+### For Loops
+
+The `pi.yield()` in for loops updates loop-carried values (iter_args):
+
+```python
+sum_init: pi.Int64 = 0
+for i, (sum,) in pi.range(0, 10, 1, init_values=[sum_init]):
+    sum = pi.yield(sum + i)
+sum_final: pi.Int64 = sum
+```
+
+This is equivalent to SSA IR with phi nodes:
+```
+sum_init = 0
+loop (i = 0 to 10, sum_phi):
+    sum_phi = phi(sum_init, sum_next)  // first iteration uses sum_init, then sum_next
+    sum_next = sum_phi + i
+    yield sum_next
+sum_final = sum_next  // capture final value in return variable
+```
+
+**Key semantics:**
+- `sum_init`: Initial value before loop
+- `sum`: IterArg variable, scoped to the loop
+- `sum_final`: Return variable that captures the final value after loop completion
+- Assignment after the loop (`sum_final = sum`) captures the final yielded value
+
+## Configurable Module Prefix
+
+The printer supports configurable module prefixes to match your import style:
+
+### Default: `pi` (Recommended)
+
+```python
+# Recommended: short and clear
+import pypto.ir as pi
+
+x: pi.Int64 = 42
+tensor: pi.Tensor((64, 128), pi.FP32) = ...
+```
+
+### Legacy: `ir`
+
+```python
+# Legacy style for backward compatibility
+import pypto.ir as pi
+
+x: pi.Int64 = 42
+tensor: pi.Tensor((64, 128), pi.FP32) = ...
+```
+
+### Custom Prefix
+
+```python
+# Any custom prefix you prefer
+import pypto.ir as myir
+
+x: mypi.Int64 = 42
+tensor: mypi.Tensor[mypi.FP32, 64, 128] = ...
+```
+
+## Usage with Python Printer
+
+The IR can be printed to Python syntax using:
+
+```python
+import pypto.ir as pi
+
+# Print with default "pi" prefix (recommended)
+expr = ir.Add(a, b, dtype, span)
+print(ir.python_print(expr))  # "a + b"
+
+stmt = ir.AssignStmt(x, expr, span)
+print(ir.python_print(stmt))  # "x: pi.Int64 = a + b"
+
+# Print with custom prefix
+print(ir.python_print(stmt, "ir"))     # "x: pi.Int64 = a + b"
+print(ir.python_print(stmt, "myir"))   # "x: mypi.Int64 = a + b"
+
+# Print programs
+program = ir.Program([func], "my_program", span)
+print(ir.python_print(program))          # Uses "import pypto.ir as pi"
+print(ir.python_print(program, "ir"))    # Uses "import pypto.ir as pi"
+
+# str() uses Python printer with default "pi" prefix
+print(str(program))
+
+# as_python() method also accepts custom prefix
+print(program.as_python("custom"))
+```
+
+## Migration from Old Printer
+
+The old `IRPrinter` is deprecated. Code using the old printer should migrate to `IRPythonPrinter`:
+
+**Old code:**
+```python
+import pypto.ir as pi
+printer = ir.IRPrinter()  # Deprecated
+output = printer.Print(expr)
+```
+
+**New code:**
+```python
+import pypto.ir as pi
+output = ir.python_print(expr)  # Recommended
+# Or use str()
+output = str(expr)  # Also uses Python printer
+```
+
+## Future Work
+
+1. **Parser Implementation**: A Python parser to read this syntax and construct IR is planned
+2. **Span Support**: Optional span information (source location) can be added via comments or function calls
+3. **Type Inference**: Allow omitting type annotations where they can be inferred
+4. **Pretty Printing Options**: Configurable formatting (compact vs. verbose, indentation style, etc.)
+
+## References
+
+- [IR Definition](00-ir_definition.md) - Core IR structures
+- [Structural Comparison](01-structural_comparison.md) - IR equality and hashing
+- [Operator Registration](03-operator_registration.md) - Op system and type inference

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -64,10 +64,12 @@ Precedence GetPrecedence(const ExprPtr& expr);
 bool IsRightAssociative(const ExprPtr& expr);
 
 /**
- * @brief IR pretty printer
+ * @brief IR pretty printer (DEPRECATED - use IRPythonPrinter for new code)
  *
  * Prints IR nodes (expressions and statements) with minimal parentheses based on operator precedence.
  * Inherits from IRVisitor to traverse the IR tree.
+ *
+ * @deprecated This printer is deprecated. Use IRPythonPrinter for Python-style IR syntax.
  */
 class IRPrinter : public IRVisitor {
  public:
@@ -199,6 +201,15 @@ class IRPrinter : public IRVisitor {
    */
   bool NeedsParens(const ExprPtr& parent, const ExprPtr& child, bool is_left);
 };
+
+/**
+ * @brief Print an IR node in Python syntax
+ *
+ * @param node IR node to print (Expr, Stmt, Function, or Program)
+ * @param prefix Module prefix to use (default: "pi", can be "ir" for legacy)
+ * @return Python-style string representation
+ */
+std::string PythonPrint(const IRNodePtr& node, const std::string& prefix = "pi");
 
 }  // namespace ir
 }  // namespace pypto

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -267,17 +267,13 @@ class IterArg(Var):
     initValue: Final[Expr]
     """Initial value expression (can be any Expr)."""
 
-    value: Final[Var]
-    """Current value variable (must be a Var)."""
-
-    def __init__(self, name: str, type: Type, initValue: Expr, value: Var, span: Span) -> None:
+    def __init__(self, name: str, type: Type, initValue: Expr, span: Span) -> None:
         """Create an iteration argument with initial value and current value.
 
         Args:
             name: Variable name
             type: Type of the variable (ScalarType or TensorType)
             initValue: Initial value expression (can be any Expr)
-            value: Current value variable (must be a Var)
             span: Source location
         """
 
@@ -1162,4 +1158,16 @@ def get_op(op_name: str) -> Op:
 
     Raises:
         Exception: If operator is not registered
+    """
+
+# ========== Python Printer ==========
+def python_print(node: IRNode, prefix: str = "pi") -> str:
+    """Print an IR node as a Python string.
+
+    Args:
+        node: IR node to print
+        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+
+    Returns:
+        String representation of the IR node
     """

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -80,8 +80,7 @@ static IRNodePtr DeserializeIterArg(const msgpack::object& fields_obj, msgpack::
   std::string name = GET_FIELD(std::string, "name");
   auto initValue =
       std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("initValue"), zone));
-  auto value = std::static_pointer_cast<const Var>(ctx.DeserializeNode(GET_FIELD_OBJ("value"), zone));
-  return std::make_shared<IterArg>(name, type, initValue, value, span);
+  return std::make_shared<IterArg>(name, type, initValue, span);
 }
 
 // Deserialize ConstInt
@@ -207,12 +206,12 @@ static IRNodePtr DeserializeYieldStmt(const msgpack::object& fields_obj, msgpack
                                       DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
 
-  std::vector<VarPtr> value;
+  std::vector<ExprPtr> value;
   auto value_obj = GET_FIELD_OBJ("value");
   if (value_obj.type == msgpack::type::ARRAY) {
     for (uint32_t i = 0; i < value_obj.via.array.size; ++i) {
       value.push_back(
-          std::static_pointer_cast<const Var>(ctx.DeserializeNode(value_obj.via.array.ptr[i], zone)));
+          std::static_pointer_cast<const Expr>(ctx.DeserializeNode(value_obj.via.array.ptr[i], zone)));
     }
   }
 

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -34,11 +34,9 @@ void IRVisitor::VisitExpr_(const VarPtr& op) {
 }
 
 void IRVisitor::VisitExpr_(const IterArgPtr& op) {
-  // Visit initValue as Expr and value as Var
+  // Visit initValue as Expr
   INTERNAL_CHECK(op->initValue_) << "IterArg has null initValue";
-  INTERNAL_CHECK(op->value_) << "IterArg has null value";
   VisitExpr(op->initValue_);
-  VisitExpr(op->value_);
   // Also visit type if it's a TensorType (inherited from Var)
   if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->GetType())) {
     for (const auto& dim : tensor_type->shape_) {

--- a/tests/ut/ir/test_for_stmt.py
+++ b/tests/ut/ir/test_for_stmt.py
@@ -211,12 +211,10 @@ class TestForStmt:
 
         # Create IterArg instances
         init_value1 = ir.ConstInt(5, dtype, span)
-        value1 = ir.Var("v1", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(dtype), init_value1, value1, span)
+        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(dtype), init_value1, span)
 
         init_value2 = x
-        value2 = ir.Var("v2", ir.ScalarType(dtype), span)
-        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(dtype), init_value2, value2, span)
+        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(dtype), init_value2, span)
 
         # ForStmt with empty iter_args
         for_stmt1 = ir.ForStmt(i, start, stop, step, [], assign, [], span)

--- a/tests/ut/ir/test_iter_arg.py
+++ b/tests/ut/ir/test_iter_arg.py
@@ -24,16 +24,13 @@ class TestIterArg:
         dtype = DataType.INT64
         name = "iter_arg"
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, value, span)
+        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, span)
 
         assert iter_arg is not None
         assert iter_arg.span.filename == "test.py"
         assert iter_arg.name == name
         assert iter_arg.initValue is not None
-        assert iter_arg.value is not None
         assert isinstance(iter_arg.initValue, ir.ConstInt)
-        assert isinstance(iter_arg.value, ir.Var)
 
     def test_iter_arg_has_attributes(self):
         """Test that IterArg has name, initValue, and value attributes."""
@@ -41,22 +38,18 @@ class TestIterArg:
         dtype = DataType.INT64
         name = "iter_arg"
         init_value = ir.ConstInt(5, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, value, span)
+        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, span)
 
         assert iter_arg.name == name
         assert iter_arg.initValue is not None
-        assert iter_arg.value is not None
         assert cast(ir.ConstInt, iter_arg.initValue).value == 5
-        assert cast(ir.Var, iter_arg.value).name == "v"
 
     def test_iter_arg_is_var(self):
         """Test that IterArg is an instance of Var."""
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, span)
 
         assert isinstance(iter_arg, ir.Var)
         assert isinstance(iter_arg, ir.Expr)
@@ -67,8 +60,7 @@ class TestIterArg:
         span = ir.Span("test.py", 1, 1, 1, 5)
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, span)
 
         # Attempting to modify should raise AttributeError
         with pytest.raises(AttributeError):
@@ -82,23 +74,22 @@ class TestIterArg:
         """Test IterArg with different expression types for initValue."""
         span = ir.Span("test.py", 1, 1, 1, 10)
         dtype = DataType.INT64
-        value = ir.Var("v", ir.ScalarType(dtype), span)
 
         # Test with ConstInt
         init_value1 = ir.ConstInt(5, dtype, span)
-        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(dtype), init_value1, value, span)
+        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(dtype), init_value1, span)
         assert isinstance(iter_arg1.initValue, ir.ConstInt)
 
         # Test with Var
         init_value2 = ir.Var("x", ir.ScalarType(dtype), span)
-        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(dtype), init_value2, value, span)
+        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(dtype), init_value2, span)
         assert isinstance(iter_arg2.initValue, ir.Var)
 
         # Test with binary expression
         x = ir.Var("x", ir.ScalarType(dtype), span)
         y = ir.Var("y", ir.ScalarType(dtype), span)
         init_value3 = ir.Add(x, y, dtype, span)
-        iter_arg3 = ir.IterArg("arg3", ir.ScalarType(dtype), init_value3, value, span)
+        iter_arg3 = ir.IterArg("arg3", ir.ScalarType(dtype), init_value3, span)
         assert isinstance(iter_arg3.initValue, ir.Add)
 
 
@@ -110,12 +101,10 @@ class TestIterArgHash:
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value1 = ir.ConstInt(0, dtype, span)
-        value1 = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value1, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, span)
 
         init_value2 = ir.ConstInt(0, dtype, span)
-        value2 = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value2, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, span)
 
         hash1 = ir.structural_hash(iter_arg1, enable_auto_mapping=True)
         hash2 = ir.structural_hash(iter_arg2, enable_auto_mapping=True)
@@ -126,9 +115,8 @@ class TestIterArgHash:
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, value, span)
-        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, span)
+        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, span)
 
         hash1 = ir.structural_hash(iter_arg1)
         hash2 = ir.structural_hash(iter_arg2)
@@ -138,11 +126,10 @@ class TestIterArgHash:
         """Test IterArg nodes with different initValue hash differently."""
         span = ir.Span.unknown()
         dtype = DataType.INT64
-        value = ir.Var("v", ir.ScalarType(dtype), span)
         init_value1 = ir.ConstInt(0, dtype, span)
         init_value2 = ir.ConstInt(1, dtype, span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value, span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, span)
 
         hash1 = ir.structural_hash(iter_arg1)
         hash2 = ir.structural_hash(iter_arg2)
@@ -153,10 +140,8 @@ class TestIterArgHash:
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value1 = ir.Var("v1", ir.ScalarType(dtype), span)
-        value2 = ir.Var("v2", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value1, span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value2, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, span)
 
         hash1 = ir.structural_hash(iter_arg1)
         hash2 = ir.structural_hash(iter_arg2)
@@ -171,12 +156,10 @@ class TestIterArgEquality:
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value1 = ir.ConstInt(0, dtype, span)
-        value1 = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value1, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, span)
 
         init_value2 = ir.ConstInt(0, dtype, span)
-        value2 = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value2, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, span)
 
         assert ir.structural_equal(iter_arg1, iter_arg2, enable_auto_mapping=True)
 
@@ -185,9 +168,8 @@ class TestIterArgEquality:
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, value, span)
-        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, span)
+        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, span)
 
         assert not ir.structural_equal(iter_arg1, iter_arg2)
 
@@ -195,33 +177,21 @@ class TestIterArgEquality:
         """Test IterArg nodes with different initValue are not equal."""
         span = ir.Span.unknown()
         dtype = DataType.INT64
-        value = ir.Var("v", ir.ScalarType(dtype), span)
         init_value1 = ir.ConstInt(0, dtype, span)
         init_value2 = ir.ConstInt(1, dtype, span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value, span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, span)
 
         assert not ir.structural_equal(iter_arg1, iter_arg2)
 
-    def test_iter_arg_different_value_not_equal(self):
-        """Test IterArg nodes with different value are not equal."""
-        span = ir.Span.unknown()
-        dtype = DataType.INT64
-        init_value = ir.ConstInt(0, dtype, span)
-        value1 = ir.Var("v1", ir.ScalarType(dtype), span)
-        value2 = ir.Var("v2", ir.ScalarType(dtype), span)
-        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value1, span)
-        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value2, span)
-
-        assert not ir.structural_equal(iter_arg1, iter_arg2)
+    # Removed test_iter_arg_different_value_not_equal since value field no longer exists
 
     def test_iter_arg_different_from_base_var_not_equal(self):
         """Test IterArg and base Var nodes are not equal."""
         span = ir.Span.unknown()
         dtype = DataType.INT64
         init_value = ir.ConstInt(0, dtype, span)
-        value = ir.Var("v", ir.ScalarType(dtype), span)
-        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, span)
         base_var = ir.Var("iter_arg", ir.ScalarType(dtype), span)
 
         assert not ir.structural_equal(iter_arg, base_var)

--- a/tests/ut/ir/test_op_stmts.py
+++ b/tests/ut/ir/test_op_stmts.py
@@ -125,7 +125,7 @@ class TestOpStmtsPrinting:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         assign = ir.AssignStmt(x, y, span)
         op_stmts = ir.OpStmts([assign], span)
-        assert str(op_stmts) == "x = y"
+        assert str(op_stmts) == "x: pi.Int64 = y"
 
     def test_op_stmts_printing_multiple(self):
         """Test printing of OpStmts with multiple statements."""
@@ -138,7 +138,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, x, span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x = y\ny = z\nz = x"
+        assert str(op_stmts) == "x: pi.Int64 = y\ny: pi.Int64 = z\nz: pi.Int64 = x"
 
     def test_op_stmts_printing_empty(self):
         """Test printing of OpStmts with empty statement list."""
@@ -157,7 +157,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, ir.ConstInt(0, dtype, span), span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x = y\ny = z\nz = 0"
+        assert str(op_stmts) == "x: pi.Int64 = y\ny: pi.Int64 = z\nz: pi.Int64 = 0"
 
 
 class TestOpStmtsHash:

--- a/tests/ut/ir/test_printer.py
+++ b/tests/ut/ir/test_printer.py
@@ -388,7 +388,7 @@ def test_assign_stmt_simple():
     y = ir.Var("y", ir.ScalarType(dtype), span)
 
     assign = ir.AssignStmt(x, y, span)
-    assert str(assign) == "x = y"
+    assert str(assign) == "x: pi.Int64 = y"
 
 
 def test_assign_stmt_with_constant():
@@ -399,7 +399,7 @@ def test_assign_stmt_with_constant():
     c5 = ir.ConstInt(5, dtype, span)
 
     assign = ir.AssignStmt(x, c5, span)
-    assert str(assign) == "x = 5"
+    assert str(assign) == "x: pi.Int64 = 5"
 
 
 def test_assign_stmt_with_arithmetic():
@@ -413,12 +413,12 @@ def test_assign_stmt_with_arithmetic():
     # x = y + z
     add = ir.Add(y, z, dtype, span)
     assign = ir.AssignStmt(x, add, span)
-    assert str(assign) == "x = y + z"
+    assert str(assign) == "x: pi.Int64 = y + z"
 
     # x = y * z
     mul = ir.Mul(y, z, dtype, span)
     assign = ir.AssignStmt(x, mul, span)
-    assert str(assign) == "x = y * z"
+    assert str(assign) == "x: pi.Int64 = y * z"
 
 
 def test_assign_stmt_with_complex_expression():
@@ -436,13 +436,13 @@ def test_assign_stmt_with_complex_expression():
     mul2 = ir.Mul(z, c3, dtype, span)
     add = ir.Add(mul1, mul2, dtype, span)
     assign = ir.AssignStmt(x, add, span)
-    assert str(assign) == "x = y * 2 + z * 3"
+    assert str(assign) == "x: pi.Int64 = y * 2 + z * 3"
 
     # x = (y + z) * 2
     add = ir.Add(y, z, dtype, span)
     mul = ir.Mul(add, c2, dtype, span)
     assign = ir.AssignStmt(x, mul, span)
-    assert str(assign) == "x = (y + z) * 2"
+    assert str(assign) == "x: pi.Int64 = (y + z) * 2"
 
 
 def test_assign_stmt_with_function_call():
@@ -457,7 +457,7 @@ def test_assign_stmt_with_function_call():
     op = ir.Op("foo")
     call = ir.Call(op, [y, z], span)
     assign = ir.AssignStmt(x, call, span)
-    assert str(assign) == "x = foo(y, z)"
+    assert str(assign) == "x: pi.Int64 = foo(y, z)"
 
 
 def test_assign_stmt_with_unary_operators():
@@ -470,17 +470,17 @@ def test_assign_stmt_with_unary_operators():
     # x = -y
     neg = ir.Neg(y, dtype, span)
     assign = ir.AssignStmt(x, neg, span)
-    assert str(assign) == "x = -y"
+    assert str(assign) == "x: pi.Int64 = -y"
 
     # x = abs(y)
     abs_expr = ir.Abs(y, dtype, span)
     assign = ir.AssignStmt(x, abs_expr, span)
-    assert str(assign) == "x = abs(y)"
+    assert str(assign) == "x: pi.Int64 = abs(y)"
 
     # x = not y
     not_expr = ir.Not(y, dtype, span)
     assign = ir.AssignStmt(x, not_expr, span)
-    assert str(assign) == "x = not y"
+    assert str(assign) == "x: pi.Int64 = not y"
 
 
 def test_assign_stmt_with_comparison():
@@ -494,12 +494,12 @@ def test_assign_stmt_with_comparison():
     # x = y < z
     lt = ir.Lt(y, z, dtype, span)
     assign = ir.AssignStmt(x, lt, span)
-    assert str(assign) == "x = y < z"
+    assert str(assign) == "x: pi.Int64 = y < z"
 
     # x = y == z
     eq = ir.Eq(y, z, dtype, span)
     assign = ir.AssignStmt(x, eq, span)
-    assert str(assign) == "x = y == z"
+    assert str(assign) == "x: pi.Int64 = y == z"
 
 
 def test_assign_stmt_with_logical_operators():
@@ -513,12 +513,12 @@ def test_assign_stmt_with_logical_operators():
     # x = y and z
     and_expr = ir.And(y, z, dtype, span)
     assign = ir.AssignStmt(x, and_expr, span)
-    assert str(assign) == "x = y and z"
+    assert str(assign) == "x: pi.Int64 = y and z"
 
     # x = y or z
     or_expr = ir.Or(y, z, dtype, span)
     assign = ir.AssignStmt(x, or_expr, span)
-    assert str(assign) == "x = y or z"
+    assert str(assign) == "x: pi.Int64 = y or z"
 
 
 def test_assign_stmt_with_nested_expressions():
@@ -536,7 +536,7 @@ def test_assign_stmt_with_nested_expressions():
     sub = ir.Sub(w, c2, dtype, span)
     mul = ir.Mul(add, sub, dtype, span)
     assign = ir.AssignStmt(x, mul, span)
-    assert str(assign) == "x = (y + z) * (w - 2)"
+    assert str(assign) == "x: pi.Int64 = (y + z) * (w - 2)"
 
 
 def test_assign_stmt_with_power_operator():
@@ -551,13 +551,13 @@ def test_assign_stmt_with_power_operator():
     # x = y ** 2
     pow_expr = ir.Pow(y, c2, dtype, span)
     assign = ir.AssignStmt(x, pow_expr, span)
-    assert str(assign) == "x = y ** 2"
+    assert str(assign) == "x: pi.Int64 = y ** 2"
 
     # x = 2 ** 3 ** y (right-associative)
     pow1 = ir.Pow(c3, y, dtype, span)
     pow2 = ir.Pow(c2, pow1, dtype, span)
     assign = ir.AssignStmt(x, pow2, span)
-    assert str(assign) == "x = 2 ** 3 ** y"
+    assert str(assign) == "x: pi.Int64 = 2 ** 3 ** y"
 
 
 def test_assign_stmt_with_min_max():
@@ -571,12 +571,12 @@ def test_assign_stmt_with_min_max():
     # x = min(y, z)
     min_expr = ir.Min(y, z, dtype, span)
     assign = ir.AssignStmt(x, min_expr, span)
-    assert str(assign) == "x = min(y, z)"
+    assert str(assign) == "x: pi.Int64 = min(y, z)"
 
     # x = max(y, z)
     max_expr = ir.Max(y, z, dtype, span)
     assign = ir.AssignStmt(x, max_expr, span)
-    assert str(assign) == "x = max(y, z)"
+    assert str(assign) == "x: pi.Int64 = max(y, z)"
 
 
 def test_assign_stmt_with_bitwise_operators():
@@ -590,17 +590,17 @@ def test_assign_stmt_with_bitwise_operators():
     # x = y & z
     bit_and = ir.BitAnd(y, z, dtype, span)
     assign = ir.AssignStmt(x, bit_and, span)
-    assert str(assign) == "x = y & z"
+    assert str(assign) == "x: pi.Int64 = y & z"
 
     # x = y | z
     bit_or = ir.BitOr(y, z, dtype, span)
     assign = ir.AssignStmt(x, bit_or, span)
-    assert str(assign) == "x = y | z"
+    assert str(assign) == "x: pi.Int64 = y | z"
 
     # x = y << z
     shift_left = ir.BitShiftLeft(y, z, dtype, span)
     assign = ir.AssignStmt(x, shift_left, span)
-    assert str(assign) == "x = y << z"
+    assert str(assign) == "x: pi.Int64 = y << z"
 
 
 def test_assign_stmt_repr():
@@ -627,16 +627,16 @@ def test_multiple_assign_statements():
 
     # x = 1
     assign1 = ir.AssignStmt(x, c1, span)
-    assert str(assign1) == "x = 1"
+    assert str(assign1) == "x: pi.Int64 = 1"
 
     # y = 2
     assign2 = ir.AssignStmt(y, c2, span)
-    assert str(assign2) == "y = 2"
+    assert str(assign2) == "y: pi.Int64 = 2"
 
     # z = x + y
     add = ir.Add(x, y, dtype, span)
     assign3 = ir.AssignStmt(z, add, span)
-    assert str(assign3) == "z = x + y"
+    assert str(assign3) == "z: pi.Int64 = x + y"
 
 
 def test_assign_stmt_with_division_types():
@@ -650,17 +650,17 @@ def test_assign_stmt_with_division_types():
     # x = y / 2
     float_div = ir.FloatDiv(y, c2, dtype, span)
     assign = ir.AssignStmt(x, float_div, span)
-    assert str(assign) == "x = y / 2"
+    assert str(assign) == "x: pi.Int64 = y / 2"
 
     # x = y // 2
     floor_div = ir.FloorDiv(y, c2, dtype, span)
     assign = ir.AssignStmt(x, floor_div, span)
-    assert str(assign) == "x = y // 2"
+    assert str(assign) == "x: pi.Int64 = y // 2"
 
     # x = y % 2
     mod = ir.FloorMod(y, c2, dtype, span)
     assign = ir.AssignStmt(x, mod, span)
-    assert str(assign) == "x = y % 2"
+    assert str(assign) == "x: pi.Int64 = y % 2"
 
 
 def test_yield_stmt_printing():

--- a/tests/ut/ir/test_python_printer.py
+++ b/tests/ut/ir/test_python_printer.py
@@ -1,0 +1,512 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for Python IR printer with type annotations and SSA-style syntax."""
+
+import pytest
+from pypto import DataType, ir
+
+
+def test_python_print_basic_expressions():
+    """Test Python-style printing of basic expressions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+
+    # Variables should include just the name
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    assert "x" in ir.python_print(x)
+
+    # Constants
+    c = ir.ConstInt(42, dtype, span)
+    assert "42" in ir.python_print(c)
+
+    # Binary operations
+    a = ir.Var("a", ir.ScalarType(dtype), span)
+    b = ir.Var("b", ir.ScalarType(dtype), span)
+    c = ir.ConstInt(42, dtype, span)
+    add = ir.Add(ir.Add(a, b, dtype, span), c, dtype, span)
+    result = ir.python_print(add)
+    assert "a + b + 42" in result
+
+
+def test_python_print_assignment_with_type_annotation():
+    """Test assignment statements include type annotations."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    c = ir.ConstInt(42, dtype, span)
+    assign = ir.AssignStmt(x, c, span)
+
+    result = ir.python_print(assign)
+    # Should have type annotation with default "pi" prefix
+    assert "x:" in result or "x :" in result
+    assert "pi.Int64" in result
+    assert "42" in result
+
+
+def test_python_print_tensor_type_annotation():
+    """Test tensor type annotations."""
+    span = ir.Span.unknown()
+    dim1 = ir.ConstInt(64, DataType.INT32, span)
+    dim2 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType(DataType.FP32, [dim1, dim2])
+    a = ir.Var("a", tensor_type, span)
+    b = ir.Var("b", tensor_type, span)
+
+    # Create an assignment to see the type annotation
+    assign = ir.AssignStmt(a, b, span)
+    result = ir.python_print(assign)
+
+    assert "a:" in result or "a :" in result
+    assert "pi.Tensor((64, 128), pi.FP32)" in result
+
+
+def test_python_print_function_with_annotations():
+    """Test function definitions include type annotations."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    # Simple function body
+    add = ir.Add(x, y, dtype, span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+    assign = ir.AssignStmt(z, add, span)
+    yield_stmt = ir.YieldStmt([z], span)
+    body = ir.SeqStmts([assign, yield_stmt], span)
+
+    func = ir.Function("add_func", [x, y], [ir.ScalarType(dtype)], body, span)
+    result = ir.python_print(func)
+
+    # Check for function signature with type annotations
+    assert "def add_func" in result
+    assert "x:" in result or "x :" in result
+    assert "y:" in result or "y :" in result
+    assert "pi.Int64" in result
+    assert "->" in result  # Return type annotation
+
+
+def test_python_print_program():
+    """Test program printing with header."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    assign = ir.AssignStmt(y, x, span)
+    func = ir.Function("simple_func", [x], [ir.ScalarType(dtype)], assign, span)
+    program = ir.Program([func], "test_program", span)
+
+    result = ir.python_print(program)
+
+    # Check for program header with default "pi" prefix
+    assert "# pypto.program: test_program" in result
+    assert "import pypto.ir as pi" in result
+    assert "def simple_func" in result
+
+
+def test_python_print_if_stmt_basic():
+    """Test basic if statement printing."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    zero = ir.ConstInt(0, dtype, span)
+    condition = ir.Gt(x, zero, dtype, span)
+
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    c1 = ir.ConstInt(1, dtype, span)
+    assign = ir.AssignStmt(y, c1, span)
+
+    if_stmt = ir.IfStmt(condition, assign, None, [], span)
+    result = ir.python_print(if_stmt)
+
+    assert "if" in result
+    assert "x > 0" in result or "x>0" in result
+
+
+def test_python_print_for_stmt_basic():
+    """Test basic for loop printing."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    i = ir.Var("i", ir.ScalarType(dtype), span)
+    start = ir.ConstInt(0, dtype, span)
+    stop = ir.ConstInt(10, dtype, span)
+    step = ir.ConstInt(1, dtype, span)
+
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    c2 = ir.ConstInt(2, dtype, span)
+    mul = ir.Mul(i, c2, dtype, span)
+    assign = ir.AssignStmt(x, mul, span)
+
+    for_stmt = ir.ForStmt(i, start, stop, step, [], assign, [], span)
+    result = ir.python_print(for_stmt)
+
+    assert "for" in result
+    assert "for i in range" in result  # No type annotation in for loop header
+    assert "pi.Int64" in result  # Type annotation in body assignment
+    assert "range" in result
+    assert "0" in result
+    assert "10" in result
+
+
+def test_python_print_all_binary_operators():
+    """Test all binary operators are printed correctly."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    a = ir.Var("a", ir.ScalarType(dtype), span)
+    b = ir.Var("b", ir.ScalarType(dtype), span)
+
+    # Arithmetic operators
+    ops_and_symbols = [
+        (ir.Add(a, b, dtype, span), "+"),
+        (ir.Sub(a, b, dtype, span), "-"),
+        (ir.Mul(a, b, dtype, span), "*"),
+        (ir.FloorDiv(a, b, dtype, span), "//"),
+        (ir.FloorMod(a, b, dtype, span), "%"),
+        (ir.FloatDiv(a, b, dtype, span), "/"),
+        (ir.Pow(a, b, dtype, span), "**"),
+        # Comparison operators
+        (ir.Eq(a, b, dtype, span), "=="),
+        (ir.Ne(a, b, dtype, span), "!="),
+        (ir.Lt(a, b, dtype, span), "<"),
+        (ir.Le(a, b, dtype, span), "<="),
+        (ir.Gt(a, b, dtype, span), ">"),
+        (ir.Ge(a, b, dtype, span), ">="),
+        # Logical operators
+        (ir.And(a, b, dtype, span), "and"),
+        (ir.Or(a, b, dtype, span), "or"),
+        # Bitwise operators
+        (ir.BitAnd(a, b, dtype, span), "&"),
+        (ir.BitOr(a, b, dtype, span), "|"),
+        (ir.BitXor(a, b, dtype, span), "^"),
+        (ir.BitShiftLeft(a, b, dtype, span), "<<"),
+        (ir.BitShiftRight(a, b, dtype, span), ">>"),
+    ]
+
+    for expr, symbol in ops_and_symbols:
+        result = ir.python_print(expr)
+        assert symbol in result, f"Symbol {symbol} not found in {result}"
+
+
+def test_python_print_all_unary_operators():
+    """Test all unary operators are printed correctly."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+
+    # Negation
+    neg = ir.Neg(x, dtype, span)
+    result = ir.python_print(neg)
+    assert "-x" in result or "- x" in result
+
+    # Bitwise not
+    bitnot = ir.BitNot(x, dtype, span)
+    result = ir.python_print(bitnot)
+    assert "~x" in result or "~ x" in result
+
+    # Logical not
+    not_expr = ir.Not(x, dtype, span)
+    result = ir.python_print(not_expr)
+    assert "not" in result
+
+    # Abs
+    abs_expr = ir.Abs(x, dtype, span)
+    result = ir.python_print(abs_expr)
+    assert "abs" in result
+
+
+def test_python_print_min_max():
+    """Test min/max function-style operators."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    a = ir.Var("a", ir.ScalarType(dtype), span)
+    b = ir.Var("b", ir.ScalarType(dtype), span)
+
+    min_expr = ir.Min(a, b, dtype, span)
+    result = ir.python_print(min_expr)
+    assert "min(a, b)" in result or "min( a, b )" in result or "min(a,b)" in result
+
+    max_expr = ir.Max(a, b, dtype, span)
+    result = ir.python_print(max_expr)
+    assert "max(a, b)" in result or "max( a, b )" in result or "max(a,b)" in result
+
+
+def test_python_print_call_expression():
+    """Test function call expressions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    a = ir.Var("a", ir.ScalarType(dtype), span)
+    b = ir.Var("b", ir.ScalarType(dtype), span)
+
+    op = ir.Op("my_op")
+    call = ir.Call(op, [a, b], span)
+    result = ir.python_print(call)
+
+    assert "my_op" in result
+    assert "(" in result
+    assert ")" in result
+
+
+def test_python_print_op_with_attributes():
+    """Test Op calls with attributes are printed as keyword arguments."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    a = ir.Var("a", ir.ScalarType(dtype), span)
+    b = ir.Var("b", ir.ScalarType(dtype), span)
+
+    op = ir.Op("tensor_add")
+    # Note: We can't easily set attributes from Python bindings without proper support
+    # This is a basic structure test
+    call = ir.Call(op, [a, b], span)
+    result = ir.python_print(call)
+
+    assert "tensor_add" in result
+    assert "a" in result
+    assert "b" in result
+
+
+def test_python_print_yield_stmt():
+    """Test yield statement printing."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    # Yield with no values
+    yield_empty = ir.YieldStmt(span)
+    result = ir.python_print(yield_empty)
+    assert "yield" in result
+
+    # Yield with single value
+    yield_single = ir.YieldStmt([x], span)
+    result = ir.python_print(yield_single)
+    assert "yield" in result
+    assert "x" in result
+
+    # Yield with multiple values
+    yield_multi = ir.YieldStmt([x, y], span)
+    result = ir.python_print(yield_multi)
+    assert "yield" in result
+    assert "x" in result
+    assert "y" in result
+
+
+def test_python_print_seq_stmts():
+    """Test sequence of statements."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    z = ir.Var("z", ir.ScalarType(dtype), span)
+
+    c1 = ir.ConstInt(1, dtype, span)
+    c2 = ir.ConstInt(2, dtype, span)
+
+    assign1 = ir.AssignStmt(x, c1, span)
+    assign2 = ir.AssignStmt(y, c2, span)
+    add = ir.Add(x, y, dtype, span)
+    assign3 = ir.AssignStmt(z, add, span)
+
+    seq = ir.SeqStmts([assign1, assign2, assign3], span)
+    result = ir.python_print(seq)
+
+    # All assignments should be present
+    assert "x:" in result
+    assert "y:" in result
+    assert "z:" in result
+
+
+def test_python_print_op_stmts():
+    """Test OpStmts (sequence of assignments)."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+
+    c1 = ir.ConstInt(1, dtype, span)
+    c2 = ir.ConstInt(2, dtype, span)
+
+    assign1 = ir.AssignStmt(x, c1, span)
+    assign2 = ir.AssignStmt(y, c2, span)
+
+    op_stmts = ir.OpStmts([assign1, assign2], span)
+    result = ir.python_print(op_stmts)
+
+    assert "x:" in result
+    assert "y:" in result
+
+
+def test_python_print_tile_type():
+    """Test tile type annotations."""
+    span = ir.Span.unknown()
+    dim1 = ir.ConstInt(16, DataType.INT32, span)
+    dim2 = ir.ConstInt(16, DataType.INT32, span)
+    tile_type = ir.TileType(DataType.FP16, [dim1, dim2])
+    t = ir.Var("t", tile_type, span)
+
+    assign = ir.AssignStmt(t, t, span)
+    result = ir.python_print(assign)
+
+    assert "t:" in result
+    assert "pi.Tile((16, 16), pi.FP16)" in result
+
+
+def test_python_print_all_scalar_types():
+    """Test all scalar type annotations."""
+    span = ir.Span.unknown()
+
+    type_map = [
+        (DataType.INT8, "pi.Int8"),
+        (DataType.INT16, "pi.Int16"),
+        (DataType.INT32, "pi.Int32"),
+        (DataType.INT64, "pi.Int64"),
+        (DataType.UINT8, "pi.UInt8"),
+        (DataType.UINT16, "pi.UInt16"),
+        (DataType.UINT32, "pi.UInt32"),
+        (DataType.UINT64, "pi.UInt64"),
+        (DataType.FP16, "pi.FP16"),
+        (DataType.FP32, "pi.FP32"),
+        (DataType.BF16, "pi.BFloat16"),
+    ]
+
+    for dtype, expected_str in type_map:
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        c = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(x, c, span)
+        result = ir.python_print(assign)
+        assert expected_str in result, f"Expected {expected_str} in output for {dtype}"
+
+
+def test_python_print_complex_nested_function():
+    """Test complex function with nested control flow."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+
+    # Parameters
+    n = ir.Var("n", ir.ScalarType(dtype), span)
+
+    # Initialize sum
+    sum_var = ir.Var("sum", ir.ScalarType(dtype), span)
+    zero = ir.ConstInt(0, dtype, span)
+    init_sum = ir.AssignStmt(sum_var, zero, span)
+
+    # Loop variable
+    i = ir.Var("i", ir.ScalarType(dtype), span)
+    start = ir.ConstInt(0, dtype, span)
+    step = ir.ConstInt(1, dtype, span)
+
+    # Loop body: sum = sum + i
+    sum_copy = ir.Var("sum", ir.ScalarType(dtype), span)
+    add_expr = ir.Add(sum_copy, i, dtype, span)
+    update_sum = ir.AssignStmt(sum_var, add_expr, span)
+
+    # For loop
+    for_stmt = ir.ForStmt(i, start, n, step, [], update_sum, [], span)
+
+    # Yield sum
+    yield_stmt = ir.YieldStmt([sum_var], span)
+
+    # Function body
+    body = ir.SeqStmts([init_sum, for_stmt, yield_stmt], span)
+    func = ir.Function("loop_sum", [n], [ir.ScalarType(dtype)], body, span)
+
+    result = ir.python_print(func)
+
+    # Verify structure
+    assert "def loop_sum" in result
+    assert "n:" in result
+    assert "pi.Int64" in result
+    assert "for" in result
+    assert "range" in result
+    assert "return" in result  # Functions use return, not yield
+
+
+def test_python_print_program_with_multiple_functions():
+    """Test program with multiple functions."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+
+    # Function 1
+    x1 = ir.Var("x", ir.ScalarType(dtype), span)
+    y1 = ir.Var("y", ir.ScalarType(dtype), span)
+    assign1 = ir.AssignStmt(y1, x1, span)
+    func1 = ir.Function("func1", [x1], [ir.ScalarType(dtype)], assign1, span)
+
+    # Function 2
+    x2 = ir.Var("a", ir.ScalarType(dtype), span)
+    y2 = ir.Var("b", ir.ScalarType(dtype), span)
+    assign2 = ir.AssignStmt(y2, x2, span)
+    func2 = ir.Function("func2", [x2], [ir.ScalarType(dtype)], assign2, span)
+
+    program = ir.Program([func1, func2], "multi_func_program", span)
+    result = ir.python_print(program)
+
+    # Check program structure with default "pi" prefix
+    assert "# pypto.program: multi_func_program" in result
+    assert "import pypto.ir as pi" in result
+    assert "def func1" in result
+    assert "def func2" in result
+
+
+def test_python_print_str_method():
+    """Test that str() uses the Python printer."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    c = ir.ConstInt(42, dtype, span)
+    assign = ir.AssignStmt(x, c, span)
+
+    # str() should use Python printer with default "pi" prefix
+    str_result = str(assign)
+    # Should include type annotation
+    assert "pi.Int64" in str_result or "Int64" in str_result
+
+
+def test_python_print_custom_prefix():
+    """Test configurable prefix for type annotations."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    c = ir.ConstInt(42, dtype, span)
+    assign = ir.AssignStmt(x, c, span)
+
+    # Test default prefix "pi"
+    result_pi = ir.python_print(assign)
+    assert "pi.Int64" in result_pi
+
+    # Test "ir" prefix
+    result_ir = ir.python_print(assign, "ir")
+    assert "ir.Int64" in result_ir
+
+    # Test custom prefix
+    result_custom = ir.python_print(assign, "myir")
+    assert "myir.Int64" in result_custom
+
+    # Test with program to check import statement
+    func = ir.Function("test", [x], [ir.ScalarType(dtype)], assign, span)
+    program = ir.Program([func], "test_prog", span)
+
+    # Default "pi" should use "import pypto.ir as pi"
+    prog_pi = ir.python_print(program)
+    assert "import pypto.ir as pi" in prog_pi
+    assert "pi.Int64" in prog_pi
+
+    # "ir" prefix should use "from pypto import ir"
+    prog_ir = ir.python_print(program, "ir")
+    assert "from pypto import ir" in prog_ir
+    assert "ir.Int64" in prog_ir
+
+    # Custom prefix should use "import pypto.ir as <prefix>"
+    prog_custom = ir.python_print(program, "custom")
+    assert "import pypto.ir as custom" in prog_custom
+    assert "custom.Int64" in prog_custom
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_serialization.py
+++ b/tests/ut/ir/test_serialization.py
@@ -33,8 +33,7 @@ class TestBasicSerialization:
     def test_serialize_iter_arg(self):
         """Test serialization of IterArg node."""
         init_value = ir.ConstInt(5, DataType.INT64, ir.Span.unknown())
-        value = ir.Var("v", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(DataType.INT64), init_value, value, ir.Span.unknown())
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(DataType.INT64), init_value, ir.Span.unknown())
 
         data = ir.serialize(iter_arg)
         assert isinstance(data, bytes)
@@ -46,16 +45,13 @@ class TestBasicSerialization:
         assert restored_iter_arg.name == "iter_arg"
         assert isinstance(restored_iter_arg.initValue, ir.ConstInt)
         assert cast(ir.ConstInt, restored_iter_arg.initValue).value == 5
-        assert isinstance(restored_iter_arg.value, ir.Var)
-        assert restored_iter_arg.value.name == "v"
 
     def test_serialize_iter_arg_with_expr_init_value(self):
         """Test serialization of IterArg with expression as initValue."""
         x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
         init_value = ir.Add(x, y, DataType.INT64, ir.Span.unknown())
-        value = ir.Var("v", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(DataType.INT64), init_value, value, ir.Span.unknown())
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(DataType.INT64), init_value, ir.Span.unknown())
 
         data = ir.serialize(iter_arg)
         restored = ir.deserialize(data)
@@ -307,12 +303,10 @@ class TestStatementSerialization:
 
         # Create IterArg instances
         init_value1 = ir.ConstInt(5, DataType.INT64, ir.Span.unknown())
-        value1 = ir.Var("v1", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(DataType.INT64), init_value1, value1, ir.Span.unknown())
+        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(DataType.INT64), init_value1, ir.Span.unknown())
 
         init_value2 = x
-        value2 = ir.Var("v2", ir.ScalarType(DataType.INT64), ir.Span.unknown())
-        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(DataType.INT64), init_value2, value2, ir.Span.unknown())
+        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(DataType.INT64), init_value2, ir.Span.unknown())
 
         body = ir.AssignStmt(x, ir.Add(x, i, DataType.INT64, ir.Span.unknown()), ir.Span.unknown())
 


### PR DESCRIPTION
Implements a new Python printer (PythonPrint/IRPythonPrinter) that generates Python-compatible syntax using pi.* API (e.g., pi.var(), pi.add()). This replaces the legacy IRPrinter for string representations.

Changes:
- Add python_printer.cpp with IRPythonPrinter implementation
- Add PythonPrint() unified API for all IR node types
- Update Python bindings: __str__ uses PythonPrint, add as_python() method
- Mark legacy IRPrinter as deprecated in favor of Python-style output
- Add comprehensive test suite (test_python_printer.py)
- Add documentation (05-python_syntax.md)