### PR TITLE
feat(ir): Add IterArg class and iter_args field to ForStmt

### DIFF
--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -231,6 +231,47 @@ class Var : public Expr {
 using VarPtr = std::shared_ptr<const Var>;
 
 /**
+ * @brief Iteration argument variable
+ *
+ * Represents an iteration argument with initial value and current value.
+ * Used in for loops to track iteration variables.
+ */
+class IterArg : public Var {
+ public:
+  ExprPtr initValue_;  // Initial value expression
+  VarPtr value_;       // Current value variable
+
+  /**
+   * @brief Create an iteration argument
+   *
+   * @param name Variable name
+   * @param type Type of the variable (ScalarType or TensorType)
+   * @param initValue Initial value expression (can be any Expr)
+   * @param value Current value variable (must be a Var)
+   * @param span Source location
+   */
+  IterArg(std::string name, TypePtr type, ExprPtr initValue, VarPtr value, Span span)
+      : Var(std::move(name), std::move(type), std::move(span)),
+        initValue_(std::move(initValue)),
+        value_(std::move(value)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "IterArg"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (initValue_ and value_ as USUAL fields)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Var::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&IterArg::initValue_, "initValue"),
+                                          reflection::UsualField(&IterArg::value_, "value")));
+  }
+};
+
+using IterArgPtr = std::shared_ptr<const IterArg>;
+
+/**
  * @brief Function call expression
  *
  * Represents a function call with an operation and arguments.

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -204,15 +204,17 @@ class ForStmt : public Stmt {
    * @param step Step value expression
    * @param body Loop body statement
    * @param return_vars Return variables (can be empty)
+   * @param iter_args Iteration arguments (can be empty)
    * @param span Source location
    */
-  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, StmtPtr body,
-          std::vector<VarPtr> return_vars, Span span)
+  ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<IterArgPtr> iter_args,
+          StmtPtr body, std::vector<VarPtr> return_vars, Span span)
       : Stmt(std::move(span)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
         stop_(std::move(stop)),
         step_(std::move(step)),
+        iter_args_(std::move(iter_args)),
         body_(std::move(body)),
         return_vars_(std::move(return_vars)) {}
 
@@ -229,17 +231,19 @@ class ForStmt : public Stmt {
                                           reflection::UsualField(&ForStmt::start_, "start"),
                                           reflection::UsualField(&ForStmt::stop_, "stop"),
                                           reflection::UsualField(&ForStmt::step_, "step"),
+                                          reflection::DefField(&ForStmt::iter_args_, "iter_args"),
                                           reflection::UsualField(&ForStmt::body_, "body"),
                                           reflection::DefField(&ForStmt::return_vars_, "return_vars")));
   }
 
  public:
-  VarPtr loop_var_;                  // Loop variable
-  ExprPtr start_;                    // Start value expression
-  ExprPtr stop_;                     // Stop value expression
-  ExprPtr step_;                     // Step value expression
-  StmtPtr body_;                     // Loop body statement
-  std::vector<VarPtr> return_vars_;  // Return variables (can be empty)
+  VarPtr loop_var_;                    // Loop variable
+  ExprPtr start_;                      // Start value expression
+  ExprPtr stop_;                       // Stop value expression
+  ExprPtr step_;                       // Step value expression
+  std::vector<IterArgPtr> iter_args_;  // Iteration arguments (can be empty)
+  StmtPtr body_;                       // Loop body statement
+  std::vector<VarPtr> return_vars_;    // Return variables (can be empty)
 };
 
 using ForStmtPtr = std::shared_ptr<const ForStmt>;

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -49,6 +49,7 @@ class ExprFunctor {
  protected:
   // Leaf nodes
   virtual R VisitExpr_(const VarPtr& op, Args... args) = 0;
+  virtual R VisitExpr_(const IterArgPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const ConstIntPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const CallPtr& op, Args... args) = 0;
 
@@ -93,6 +94,8 @@ class ExprFunctor {
 template <typename R, typename... Args>
 R ExprFunctor<R, Args...>::VisitExpr(const ExprPtr& expr, Args... args) {
   // Leaf nodes
+  // Note: IterArg must be checked before Var since IterArg inherits from Var
+  EXPR_FUNCTOR_DISPATCH(IterArg);
   EXPR_FUNCTOR_DISPATCH(Var);
   EXPR_FUNCTOR_DISPATCH(ConstInt);
   EXPR_FUNCTOR_DISPATCH(Call);

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -36,6 +36,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
  protected:
   // Leaf nodes - return as-is by default
   ExprPtr VisitExpr_(const VarPtr& op) override;
+  ExprPtr VisitExpr_(const IterArgPtr& op) override;
   ExprPtr VisitExpr_(const ConstIntPtr& op) override;
   ExprPtr VisitExpr_(const CallPtr& op) override;
 

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -35,6 +35,7 @@ class IRVisitor : public IRFunctor<void> {
  protected:
   // Leaf nodes - no children to visit
   void VisitExpr_(const VarPtr& op) override;
+  void VisitExpr_(const IterArgPtr& op) override;
   void VisitExpr_(const ConstIntPtr& op) override;
   void VisitExpr_(const CallPtr& op) override;
 

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -109,6 +109,7 @@ class IRPrinter : public IRVisitor {
  protected:
   // Leaf nodes
   void VisitExpr_(const VarPtr& op) override;
+  void VisitExpr_(const IterArgPtr& op) override;
   void VisitExpr_(const ConstIntPtr& op) override;
   void VisitExpr_(const CallPtr& op) override;
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -242,6 +242,15 @@ void BindIR(nb::module_& m) {
   BindStrRepr<Var>(var_class);
   BindFields<Var>(var_class);
 
+  // IterArg - const shared_ptr
+  auto iterarg_class = nb::class_<IterArg, Var>(ir, "IterArg", "Iteration argument variable");
+  iterarg_class.def(
+      nb::init<const std::string&, const TypePtr&, const ExprPtr&, const VarPtr&, const Span&>(),
+      nb::arg("name"), nb::arg("type"), nb::arg("initValue"), nb::arg("value"), nb::arg("span"),
+      "Create an iteration argument with initial value and current value");
+  BindStrRepr<IterArg>(iterarg_class);
+  BindFields<IterArg>(iterarg_class);
+
   // ConstInt - const shared_ptr
   auto constint_class = nb::class_<ConstInt, ScalarExpr>(ir, "ConstInt", "Constant integer expression");
   constint_class.def(nb::init<int, DataType, const Span&>(), nb::arg("value"), nb::arg("dtype"),
@@ -393,10 +402,11 @@ void BindIR(nb::module_& m) {
   // ForStmt - const shared_ptr
   auto for_stmt_class = nb::class_<ForStmt, Stmt>(
       ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
-  for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&, const StmtPtr&,
-                              const std::vector<VarPtr>&, const Span&>(),
-                     nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("body"),
-                     nb::arg("return_vars"), nb::arg("span"), "Create a for loop statement");
+  for_stmt_class.def(
+      nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&, const std::vector<IterArgPtr>&,
+               const StmtPtr&, const std::vector<VarPtr>&, const Span&>(),
+      nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("iter_args"),
+      nb::arg("body"), nb::arg("return_vars"), nb::arg("span"), "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);
   BindStrRepr<ForStmt>(for_stmt_class);
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -261,6 +261,32 @@ class Var(Expr):
     def __repr__(self) -> str:
         """Detailed representation of the variable."""
 
+class IterArg(Var):
+    """Iteration argument variable."""
+
+    initValue: Final[Expr]
+    """Initial value expression (can be any Expr)."""
+
+    value: Final[Var]
+    """Current value variable (must be a Var)."""
+
+    def __init__(self, name: str, type: Type, initValue: Expr, value: Var, span: Span) -> None:
+        """Create an iteration argument with initial value and current value.
+
+        Args:
+            name: Variable name
+            type: Type of the variable (ScalarType or TensorType)
+            initValue: Initial value expression (can be any Expr)
+            value: Current value variable (must be a Var)
+            span: Source location
+        """
+
+    def __str__(self) -> str:
+        """String representation of the iteration argument."""
+
+    def __repr__(self) -> str:
+        """Detailed representation of the iteration argument."""
+
 class ConstInt(ScalarExpr):
     """Constant integer expression."""
 
@@ -778,6 +804,9 @@ class ForStmt(Stmt):
     step: Final[Expr]
     """Step value expression."""
 
+    iter_args: Final[list[IterArg]]
+    """Iteration arguments (can be empty)."""
+
     body: Final[Stmt]
     """Loop body statement."""
 
@@ -790,6 +819,7 @@ class ForStmt(Stmt):
         start: Expr,
         stop: Expr,
         step: Expr,
+        iter_args: list[IterArg],
         body: Stmt,
         return_vars: list[Var],
         span: Span,

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -156,6 +156,7 @@ class IRSerializer::Impl {
     return SerializeFieldsGeneric(p, zone);                   \
   }
 
+    SERIALIZE_FIELDS(IterArg);
     SERIALIZE_FIELDS(Var);
     SERIALIZE_FIELDS(ConstInt);
     SERIALIZE_FIELDS(Call);

--- a/src/ir/transform/printer.cpp
+++ b/src/ir/transform/printer.cpp
@@ -105,6 +105,11 @@ std::string IRPrinter::Print(const ProgramPtr& program) {
 // Leaf nodes
 void IRPrinter::VisitExpr_(const VarPtr& op) { stream_ << op->name_; }
 
+void IRPrinter::VisitExpr_(const IterArgPtr& op) {
+  // Print IterArg similar to Var, but with additional info if needed
+  stream_ << op->name_;
+}
+
 void IRPrinter::VisitExpr_(const ConstIntPtr& op) { stream_ << op->value_; }
 
 void IRPrinter::VisitExpr_(const CallPtr& op) {
@@ -322,7 +327,17 @@ void IRPrinter::VisitStmt_(const ForStmtPtr& op) {
   VisitExpr(op->stop_);
   stream_ << ", ";
   VisitExpr(op->step_);
-  stream_ << "):\n";
+  stream_ << ")";
+  // Print iter_args if present
+  if (!op->iter_args_.empty()) {
+    stream_ << " with iter_args(";
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      VisitExpr(op->iter_args_[i]);
+    }
+    stream_ << ")";
+  }
+  stream_ << ":\n";
   // Check if body is SeqStmts to handle indentation and empty body
   if (auto seq_stmts = std::dynamic_pointer_cast<const SeqStmts>(op->body_)) {
     if (!seq_stmts->stmts_.empty()) {

--- a/tests/ut/ir/test_iter_arg.py
+++ b/tests/ut/ir/test_iter_arg.py
@@ -1,0 +1,231 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for IterArg class."""
+
+from typing import cast
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestIterArg:
+    """Test IterArg class."""
+
+    def test_iter_arg_creation(self):
+        """Test creating an IterArg instance."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        name = "iter_arg"
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, value, span)
+
+        assert iter_arg is not None
+        assert iter_arg.span.filename == "test.py"
+        assert iter_arg.name == name
+        assert iter_arg.initValue is not None
+        assert iter_arg.value is not None
+        assert isinstance(iter_arg.initValue, ir.ConstInt)
+        assert isinstance(iter_arg.value, ir.Var)
+
+    def test_iter_arg_has_attributes(self):
+        """Test that IterArg has name, initValue, and value attributes."""
+        span = ir.Span("test.py", 10, 5, 10, 15)
+        dtype = DataType.INT64
+        name = "iter_arg"
+        init_value = ir.ConstInt(5, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg = ir.IterArg(name, ir.ScalarType(dtype), init_value, value, span)
+
+        assert iter_arg.name == name
+        assert iter_arg.initValue is not None
+        assert iter_arg.value is not None
+        assert cast(ir.ConstInt, iter_arg.initValue).value == 5
+        assert cast(ir.Var, iter_arg.value).name == "v"
+
+    def test_iter_arg_is_var(self):
+        """Test that IterArg is an instance of Var."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+
+        assert isinstance(iter_arg, ir.Var)
+        assert isinstance(iter_arg, ir.Expr)
+        assert isinstance(iter_arg, ir.IRNode)
+
+    def test_iter_arg_immutability(self):
+        """Test that IterArg attributes are immutable."""
+        span = ir.Span("test.py", 1, 1, 1, 5)
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+
+        # Attempting to modify should raise AttributeError
+        with pytest.raises(AttributeError):
+            iter_arg.name = "new_name"  # type: ignore
+        with pytest.raises(AttributeError):
+            iter_arg.initValue = ir.ConstInt(1, dtype, span)  # type: ignore
+        with pytest.raises(AttributeError):
+            iter_arg.value = ir.Var("new_v", ir.ScalarType(dtype), span)  # type: ignore
+
+    def test_iter_arg_with_different_init_value_types(self):
+        """Test IterArg with different expression types for initValue."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        dtype = DataType.INT64
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+
+        # Test with ConstInt
+        init_value1 = ir.ConstInt(5, dtype, span)
+        iter_arg1 = ir.IterArg("arg1", ir.ScalarType(dtype), init_value1, value, span)
+        assert isinstance(iter_arg1.initValue, ir.ConstInt)
+
+        # Test with Var
+        init_value2 = ir.Var("x", ir.ScalarType(dtype), span)
+        iter_arg2 = ir.IterArg("arg2", ir.ScalarType(dtype), init_value2, value, span)
+        assert isinstance(iter_arg2.initValue, ir.Var)
+
+        # Test with binary expression
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        init_value3 = ir.Add(x, y, dtype, span)
+        iter_arg3 = ir.IterArg("arg3", ir.ScalarType(dtype), init_value3, value, span)
+        assert isinstance(iter_arg3.initValue, ir.Add)
+
+
+class TestIterArgHash:
+    """Tests for IterArg hash function."""
+
+    def test_iter_arg_same_structure_hash(self):
+        """Test IterArg nodes with same structure hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value1 = ir.ConstInt(0, dtype, span)
+        value1 = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value1, span)
+
+        init_value2 = ir.ConstInt(0, dtype, span)
+        value2 = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value2, span)
+
+        hash1 = ir.structural_hash(iter_arg1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(iter_arg2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+    def test_iter_arg_different_name_hash(self):
+        """Test IterArg nodes with different names hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, value, span)
+
+        hash1 = ir.structural_hash(iter_arg1)
+        hash2 = ir.structural_hash(iter_arg2)
+        assert hash1 != hash2
+
+    def test_iter_arg_different_init_value_hash(self):
+        """Test IterArg nodes with different initValue hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        init_value1 = ir.ConstInt(0, dtype, span)
+        init_value2 = ir.ConstInt(1, dtype, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value, span)
+
+        hash1 = ir.structural_hash(iter_arg1)
+        hash2 = ir.structural_hash(iter_arg2)
+        assert hash1 != hash2
+
+    def test_iter_arg_different_value_hash(self):
+        """Test IterArg nodes with different value hash differently."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value1 = ir.Var("v1", ir.ScalarType(dtype), span)
+        value2 = ir.Var("v2", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value1, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value2, span)
+
+        hash1 = ir.structural_hash(iter_arg1)
+        hash2 = ir.structural_hash(iter_arg2)
+        assert hash1 != hash2
+
+
+class TestIterArgEquality:
+    """Tests for IterArg structural equality function."""
+
+    def test_iter_arg_structural_equal(self):
+        """Test structural equality of IterArg nodes."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value1 = ir.ConstInt(0, dtype, span)
+        value1 = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value1, span)
+
+        init_value2 = ir.ConstInt(0, dtype, span)
+        value2 = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value2, span)
+
+        assert ir.structural_equal(iter_arg1, iter_arg2, enable_auto_mapping=True)
+
+    def test_iter_arg_different_name_not_equal(self):
+        """Test IterArg nodes with different names are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg1", ir.ScalarType(dtype), init_value, value, span)
+        iter_arg2 = ir.IterArg("iter_arg2", ir.ScalarType(dtype), init_value, value, span)
+
+        assert not ir.structural_equal(iter_arg1, iter_arg2)
+
+    def test_iter_arg_different_init_value_not_equal(self):
+        """Test IterArg nodes with different initValue are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        init_value1 = ir.ConstInt(0, dtype, span)
+        init_value2 = ir.ConstInt(1, dtype, span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value1, value, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value2, value, span)
+
+        assert not ir.structural_equal(iter_arg1, iter_arg2)
+
+    def test_iter_arg_different_value_not_equal(self):
+        """Test IterArg nodes with different value are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value1 = ir.Var("v1", ir.ScalarType(dtype), span)
+        value2 = ir.Var("v2", ir.ScalarType(dtype), span)
+        iter_arg1 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value1, span)
+        iter_arg2 = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value2, span)
+
+        assert not ir.structural_equal(iter_arg1, iter_arg2)
+
+    def test_iter_arg_different_from_base_var_not_equal(self):
+        """Test IterArg and base Var nodes are not equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        init_value = ir.ConstInt(0, dtype, span)
+        value = ir.Var("v", ir.ScalarType(dtype), span)
+        iter_arg = ir.IterArg("iter_arg", ir.ScalarType(dtype), init_value, value, span)
+        base_var = ir.Var("iter_arg", ir.ScalarType(dtype), span)
+
+        assert not ir.structural_equal(iter_arg, base_var)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This commit introduces the IterArg class and adds iter_args support to ForStmt:
    1. Created IterArg class (inherits from Var):
       - Contains initValue (ExprPtr) and value (VarPtr) fields
       - initValue can be any expression, value must be a Var
       - Added to expr.h with proper field descriptors
    
    2. Updated ForStmt class:
       - Added iter_args_ member (std::vector<IterArgPtr>)
       - Updated constructor to include iter_args parameter
       - Parameter order: loop_var, start, stop, step, iter_args, body, return_vars, span
       - Registered iter_args_ as DefField in GetFieldDescriptors()
    
    3. Updated IR transformation infrastructure:
       - Added VisitExpr_(const IterArgPtr&) to visitor and mutator
       - Updated VisitStmt_(const ForStmtPtr&) to handle iter_args
       - Added IterArg dispatch in functor.h (before Var due to inheritance)
       - Updated printer to handle IterArg and iter_args in ForStmt
    
    4. Updated Python bindings:
       - Added IterArg class binding in ir.cpp
       - Updated ForStmt constructor binding with iter_args parameter
       - Added IterArg type definition in ir.pyi
       - Updated ForStmt type definition with iter_args field
    
    5. Updated serialization:
       - Added DeserializeIterArg function
       - Updated DeserializeForStmt to handle iter_args
       - Added IterArg to serialization registry
       - Fixed serialization order (IterArg before Var)
    
    6. Added comprehensive tests:
       - Created test_iter_arg.py with IterArg tests
       - Updated test_for_stmt.py to use new constructor signature
       - Added iter_args test cases to test_for_stmt.py
       - Added serialization tests for IterArg and ForStmt with iter_args