### PR TITLE
feat(ir): Add keepdim parameter to block.sum and fix test_rms_norm_block_function

### DIFF
--- a/docs/dev/03-operator_registration.md
+++ b/docs/dev/03-operator_registration.md
@@ -4,10 +4,11 @@ This document describes the operator registration system for PyPTO IR, which pro
 
 ## Overview
 
-The operator registration system supports three kinds of operations:
+The operator registration system supports four kinds of operations:
 - **ScalarOp**: Operations on scalar values (existing system, unchanged)
 - **TensorOp**: Operations on N-dimensional tensors with broadcasting
 - **TileOp**: Operations on 2D tiles (at most 2 dimensions) for hardware optimization
+- **BlockOp**: Block-level operations for hardware-optimized programming with tiles and scalar broadcasting
 
 ## Key Features
 
@@ -26,11 +27,20 @@ OpRegistry (Singleton)
     │   ├── TensorSub
     │   ├── TensorMul
     │   └── TensorDiv
-    └── TileOp
-        ├── TileAdd
-        ├── TileSub
-        ├── TileMul
-        └── TileDiv
+    ├── TileOp
+    │   ├── TileAdd
+    │   ├── TileSub
+    │   ├── TileMul
+    │   └── TileDiv
+    └── BlockOp
+        ├── BlockGetBlockIdx
+        ├── BlockUbCopyIn
+        ├── BlockUbCopyOut
+        ├── BlockAdd
+        ├── BlockMul
+        ├── BlockDiv
+        ├── BlockSum
+        └── BlockSqrt
 ```
 
 ## Type System
@@ -299,10 +309,12 @@ except Exception as e:
 
 To add a new operator (e.g., `TensorMatMul`):
 
-1. Choose or create appropriate category file under `src/ir/op/tensor_ops/` or `src/ir/op/tile_ops/`
+1. Choose or create appropriate category file under `src/ir/op/tensor_ops/`, `src/ir/op/tile_ops/`, or `src/ir/op/block_ops/`
    - Element-wise ops: `elementwise.cpp`
    - Matrix ops: `matmul.cpp` (create if needed)
    - Reduction ops: `reduction.cpp` (create if needed)
+   - Memory ops: `memory.cpp` (block_ops only)
+   - Unary ops: `unary.cpp` (block_ops only)
 2. Add `REGISTER_OP()` call with complete configuration:
    ```cpp
    REGISTER_OP("tensor.matmul")
@@ -327,3 +339,5 @@ To add a new operator (e.g., `TensorMatMul`):
 - Operator registry implementation: `src/ir/op_registry.cpp`
 - Tensor operator implementations: `src/ir/op/tensor_ops/`
 - Tile operator implementations: `src/ir/op/tile_ops/`
+- Block operator implementations: `src/ir/op/block_ops/`
+- [Block Operations Documentation](06-block_operations.md) - Detailed guide for block operations

--- a/docs/dev/04-operator_organization.md
+++ b/docs/dev/04-operator_organization.md
@@ -14,8 +14,13 @@ src/ir/op/
 ├── type_inference.cpp           # Type inference utilities implementation
 ├── tensor_ops/                  # Tensor operator implementations
 │   └── elementwise.cpp          # Element-wise operations
-└── tile_ops/                    # Tile operator implementations
-    └── elementwise.cpp          # Element-wise operations
+├── tile_ops/                    # Tile operator implementations
+│   └── elementwise.cpp          # Element-wise operations
+└── block_ops/                   # Block operator implementations
+    ├── memory.cpp               # Memory operations
+    ├── elementwise.cpp          # Element-wise operations
+    ├── reduction.cpp            # Reduction operations
+    └── unary.cpp                # Unary operations
 ```
 
 ## Why This Organization?
@@ -37,7 +42,12 @@ src/ir/op_registry.cpp           # Registry + all operator implementations
 src/ir/op/
 ├── type_inference.cpp           # Shared type inference utilities
 ├── tensor_ops/elementwise.cpp   # Tensor elementwise ops
-└── tile_ops/elementwise.cpp     # Tile elementwise ops
+├── tile_ops/elementwise.cpp     # Tile elementwise ops
+└── block_ops/                   # Block operations
+    ├── memory.cpp               # Memory operations
+    ├── elementwise.cpp          # Element-wise ops
+    ├── reduction.cpp            # Reduction ops
+    └── unary.cpp                # Unary ops
 ```
 
 **Benefits:**
@@ -131,10 +141,15 @@ src/ir/op/
 │   ├── reduction.cpp           # TODO: Sum, Max, Min, etc.
 │   ├── matmul.cpp              # TODO: Matrix multiplication
 │   └── transform.cpp           # TODO: Reshape, Transpose, etc.
-└── tile_ops/
-    ├── elementwise.cpp         # ✓ Exists
-    ├── matmul.cpp              # TODO: Tile matmul for hardware
-    └── load_store.cpp          # TODO: Tile load/store operations
+├── tile_ops/
+│   ├── elementwise.cpp         # ✓ Exists
+│   ├── matmul.cpp              # TODO: Tile matmul for hardware
+│   └── load_store.cpp          # TODO: Tile load/store operations
+└── block_ops/
+    ├── memory.cpp              # ✓ Exists (get_block_idx, ub_copy_in, ub_copy_out)
+    ├── elementwise.cpp         # ✓ Exists (add, mul, div)
+    ├── reduction.cpp           # ✓ Exists (sum with keepdim)
+    └── unary.cpp               # ✓ Exists (sqrt)
 ```
 
 ## Adding New Operators
@@ -152,6 +167,10 @@ set(PYPTO_SOURCES
     src/ir/op/type_inference.cpp
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tile_ops/elementwise.cpp
+    src/ir/op/block_ops/memory.cpp
+    src/ir/op/block_ops/elementwise.cpp
+    src/ir/op/block_ops/reduction.cpp
+    src/ir/op/block_ops/unary.cpp
     # Add new category files here
 )
 ```

--- a/examples/block-level/rmsnorm.py
+++ b/examples/block-level/rmsnorm.py
@@ -47,7 +47,7 @@ def rms_norm_block(
         x, row * tile[0] + block_idx, col * tile[1], tile[0], tile[1]
     )
     x_sq = pypto.block.mul(x_tmp, x_tmp)
-    sum_x_sq = pypto.block.sum(x_sq)
+    sum_x_sq = pypto.block.sum(x_sq, -1, True)
     mean_x_sq = pypto.block.div(sum_x_sq, x_tmp.size)
     mean_x_sq_eps = pypto.block.add(mean_x_sq, epsilon)
     sqrt_mean = pypto.block.sqrt(mean_x_sq_eps)


### PR DESCRIPTION
- Add keepdim parameter support to block.sum operation. When keepdim=True, the reduced axis is kept as dimension 1 instead of being removed, which enables proper broadcasting in operations like RMS normalization.
- Update documents of block operation