### PR TITLE
feat(ir): Add MemRef and memory space support for shaped types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(PYPTO_SOURCES
     src/ir/function.cpp
     src/ir/program.cpp
     src/ir/builder.cpp
+    src/ir/memref.cpp
     src/ir/op_registry.cpp
     src/ir/op/type_inference.cpp
     src/ir/op/tensor_ops/elementwise.cpp

--- a/docs/dev/05-python_syntax.md
+++ b/docs/dev/05-python_syntax.md
@@ -64,6 +64,63 @@ Tile types are 2D tensors (at most 2 dimensions), also using PyTorch-style synta
 t: pi.Tile((16, 16), pi.FP16)      # 2D tile (16, 16)
 ```
 
+### Memory References (MemRef)
+
+`MemRef` describes memory allocation information for tensors and tiles. It can be created using constructor syntax:
+
+```python
+# Create a MemRef with constructor
+addr_expr = pi.ConstInt(0x1000, pi.Int64, span)
+memref = pi.MemRef(pi.MemorySpace.DDR, addr_expr, 1024)
+
+# Available memory spaces:
+# - pi.MemorySpace.DDR   (off-chip main memory)
+# - pi.MemorySpace.UB    (on-chip Unified Buffer)
+# - pi.MemorySpace.L1    (L1 cache)
+# - pi.MemorySpace.L0A   (L0A buffer for matrix A)
+# - pi.MemorySpace.L0B   (L0B buffer for matrix B)
+# - pi.MemorySpace.L0C   (L0C buffer for matrix C/result)
+```
+
+Tensors and tiles can include optional `memref` parameter:
+
+```python
+# Tensor with memory reference
+tensor: pi.Tensor((64, 128), pi.FP32, memref=pi.MemRef(pi.MemorySpace.DDR, addr, 8192))
+
+# Tile with memory reference
+tile: pi.Tile((16, 16), pi.FP16, memref=pi.MemRef(pi.MemorySpace.L0A, addr, 512))
+```
+
+### Tile Views (TileView)
+
+`TileView` describes the layout and access pattern for a tile, including valid shape, stride, and start offset:
+
+```python
+# Create a TileView with constructor
+valid_shape = [pi.ConstInt(16, pi.Int64, span), pi.ConstInt(16, pi.Int64, span)]
+stride = [pi.ConstInt(1, pi.Int64, span), pi.ConstInt(16, pi.Int64, span)]
+start_offset = pi.ConstInt(0, pi.Int64, span)
+
+tile_view = pi.TileView(valid_shape=valid_shape, stride=stride, start_offset=start_offset)
+```
+
+Tile types can include both `memref` and `tile_view`:
+
+```python
+# Complete tile type with memory reference and view
+tile: pi.Tile(
+    (16, 16),
+    pi.FP16,
+    memref=pi.MemRef(pi.MemorySpace.L0A, addr, 512),
+    tile_view=pi.TileView(
+        valid_shape=[pi.ConstInt(16, pi.Int64, span), pi.ConstInt(16, pi.Int64, span)],
+        stride=[pi.ConstInt(1, pi.Int64, span), pi.ConstInt(16, pi.Int64, span)],
+        start_offset=pi.ConstInt(0, pi.Int64, span)
+    )
+)
+```
+
 ## Expressions
 
 ### Variables

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -26,6 +26,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/ir/core.h"
+#include "pypto/ir/memref.h"
 #include "pypto/ir/reflection/field_traits.h"
 #include "pypto/ir/type.h"
 
@@ -200,7 +201,8 @@ class Var : public Expr {
    * @brief Create a variable reference
    *
    * @param name Variable name
-   * @param type Type of the variable (ScalarType or TensorType)
+   * @param type Type of the variable (ScalarType, TensorType, or TileType)
+   *             Memory reference information is stored in ShapedType for Tensor/Tile types
    * @param span Source location
    * @return Shared pointer to const Var expression
    */
@@ -212,7 +214,7 @@ class Var : public Expr {
   /**
    * @brief Get field descriptors for reflection-based visitation
    *
-   * @return Tuple of field descriptors (name_ as USUAL field, type_ is in Expr)
+   * @return Tuple of field descriptors (name_ as IGNORE field)
    */
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(Expr::GetFieldDescriptors(),
@@ -262,7 +264,8 @@ class IterArg : public Var {
    * @brief Create an iteration argument
    *
    * @param name Variable name (scoped to loop body)
-   * @param type Type of the variable (ScalarType or TensorType)
+   * @param type Type of the variable (ScalarType, TensorType, or TileType)
+   *             Memory reference information is stored in ShapedType for Tensor/Tile types
    * @param initValue Initial value expression for first iteration
    * @param span Source location
    */
@@ -274,7 +277,7 @@ class IterArg : public Var {
   /**
    * @brief Get field descriptors for reflection-based visitation
    *
-   * @return Tuple of field descriptors (initValue_ and value_ as USUAL fields)
+   * @return Tuple of field descriptors (initValue_ as USUAL field)
    */
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(Var::GetFieldDescriptors(),

--- a/include/pypto/ir/memref.h
+++ b/include/pypto/ir/memref.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_MEMREF_H_
+#define PYPTO_IR_MEMREF_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/ir/reflection/field_traits.h"
+
+namespace pypto {
+namespace ir {
+
+// Forward declarations
+class Expr;
+using ExprPtr = std::shared_ptr<const Expr>;
+
+/**
+ * @brief Memory space enumeration
+ *
+ * Defines the available memory spaces in the hardware hierarchy:
+ * - DDR: Double Data Rate memory (off-chip)
+ * - UB: Unified Buffer (on-chip shared memory)
+ * - L1: L1 cache
+ * - L0A: L0A buffer (matrix A operand)
+ * - L0B: L0B buffer (matrix B operand)
+ * - L0C: L0C buffer (matrix C/result)
+ */
+enum class MemorySpace {
+  DDR,  ///< DDR memory (off-chip)
+  UB,   ///< Unified Buffer (on-chip)
+  L1,   ///< L1 cache
+  L0A,  ///< L0A buffer
+  L0B,  ///< L0B buffer
+  L0C   ///< L0C buffer
+};
+
+/**
+ * @brief Memory reference for shaped types (tensor and tile)
+ *
+ * Represents memory allocation information for ShapedType instances.
+ * Tracks memory space, address, and size.
+ * This is a plain struct (not an IRNode) that is embedded in ShapedType.
+ */
+struct MemRef {
+  MemorySpace memory_space_;  ///< Memory space (DDR, UB, L1, etc.)
+  ExprPtr addr_;              ///< Starting address (expression)
+  uint64_t size_;             ///< Size in bytes (64-bit unsigned)
+
+  /**
+   * @brief Default constructor for aggregate initialization
+   */
+  MemRef() = default;
+
+  /**
+   * @brief Constructor with all parameters
+   *
+   * @param memory_space Memory space (DDR, UB, L1, etc.)
+   * @param addr Starting address expression
+   * @param size Size in bytes
+   */
+  MemRef(MemorySpace memory_space, ExprPtr addr, uint64_t size)
+      : memory_space_(memory_space), addr_(std::move(addr)), size_(size) {}
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::make_tuple(reflection::UsualField(&MemRef::memory_space_, "memory_space"),
+                           reflection::UsualField(&MemRef::addr_, "addr"),
+                           reflection::UsualField(&MemRef::size_, "size"));
+  }
+};
+
+/**
+ * @brief Convert MemorySpace enum to string
+ *
+ * @param space Memory space enum value
+ * @return String representation
+ */
+std::string MemorySpaceToString(MemorySpace space);
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_MEMREF_H_

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_TYPE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -20,6 +21,7 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/memref.h"
 #include "pypto/ir/reflection/field_traits.h"
 
 namespace pypto {
@@ -108,30 +110,117 @@ class ScalarType : public Type {
 using ScalarTypePtr = std::shared_ptr<const ScalarType>;
 
 /**
+ * @brief Tile view representation
+ *
+ * Represents the view information for a tile, including valid shape,
+ * stride, and start offset. This is used by TileType to track how
+ * a tile views its underlying memory.
+ */
+struct TileView {
+  std::vector<ExprPtr> valid_shape;  ///< Valid shape dimensions
+  std::vector<ExprPtr> stride;       ///< Stride for each dimension
+  ExprPtr start_offset;              ///< Starting offset
+
+  /**
+   * @brief Default constructor for aggregate initialization
+   */
+  TileView() = default;
+
+  /**
+   * @brief Constructor with all parameters
+   *
+   * @param valid_shape Valid shape dimensions
+   * @param stride Stride for each dimension
+   * @param start_offset Starting offset
+   */
+  TileView(std::vector<ExprPtr> valid_shape, std::vector<ExprPtr> stride, ExprPtr start_offset)
+      : valid_shape(std::move(valid_shape)),
+        stride(std::move(stride)),
+        start_offset(std::move(start_offset)) {}
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::make_tuple(reflection::UsualField(&TileView::valid_shape, "valid_shape"),
+                           reflection::UsualField(&TileView::stride, "stride"),
+                           reflection::UsualField(&TileView::start_offset, "start_offset"));
+  }
+};
+
+/**
+ * @brief Base class for shaped types (tensors and tiles)
+ *
+ * Represents types that have shape dimensions and optional memory references.
+ * Both TensorType and TileType inherit from this class.
+ */
+class ShapedType : public Type {
+ public:
+  DataType dtype_;                ///< Element data type
+  std::vector<ExprPtr> shape_;    ///< Shape dimensions (symbolic or constant)
+  std::optional<MemRef> memref_;  ///< Optional memory reference
+
+  /**
+   * @brief Create a shaped type without memory reference
+   *
+   * @param dtype Element data type
+   * @param shape Shape dimensions
+   */
+  ShapedType(DataType dtype, std::vector<ExprPtr> shape)
+      : dtype_(dtype), shape_(std::move(shape)), memref_(std::nullopt) {}
+
+  /**
+   * @brief Create a shaped type with memory reference
+   *
+   * @param dtype Element data type
+   * @param shape Shape dimensions
+   * @param memref Memory reference
+   */
+  ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRef> memref)
+      : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "ShapedType"; }
+
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Type::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&ShapedType::dtype_, "dtype"),
+                                          reflection::UsualField(&ShapedType::shape_, "shape"),
+                                          reflection::UsualField(&ShapedType::memref_, "memref")));
+  }
+};
+
+using ShapedTypePtr = std::shared_ptr<const ShapedType>;
+
+/**
  * @brief Tensor type representation
  *
  * Represents a tensor type with a data type and shape dimensions.
  */
-class TensorType : public Type {
+class TensorType : public ShapedType {
  public:
-  DataType dtype_;              // Element data type
-  std::vector<ExprPtr> shape_;  // Shape dimensions (symbolic or constant)
-
   /**
-   * @brief Create a tensor type
+   * @brief Create a tensor type without memory reference
    *
    * @param shape Shape dimensions
    * @param dtype Element data type
    */
-  TensorType(std::vector<ExprPtr> shape, DataType dtype) : dtype_(dtype), shape_(std::move(shape)) {}
+  TensorType(std::vector<ExprPtr> shape, DataType dtype) : ShapedType(dtype, std::move(shape)) {}
+
+  /**
+   * @brief Create a tensor type with memory reference
+   *
+   * @param shape Shape dimensions
+   * @param dtype Element data type
+   * @param memref Memory reference
+   */
+  TensorType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRef> memref)
+      : ShapedType(dtype, std::move(shape), std::move(memref)) {}
 
   [[nodiscard]] std::string TypeName() const override { return "TensorType"; }
 
-  static constexpr auto GetFieldDescriptors() {
-    return std::tuple_cat(Type::GetFieldDescriptors(),
-                          std::make_tuple(reflection::UsualField(&TensorType::dtype_, "dtype"),
-                                          reflection::UsualField(&TensorType::shape_, "shape")));
-  }
+  static constexpr auto GetFieldDescriptors() { return ShapedType::GetFieldDescriptors(); }
 };
 
 using TensorTypePtr = std::shared_ptr<const TensorType>;
@@ -142,28 +231,55 @@ using TensorTypePtr = std::shared_ptr<const TensorType>;
  * Represents a tile type (2D tensor with at most 2 dimensions).
  * Tiles are used for hardware-optimized operations on 2D data structures.
  */
-class TileType : public Type {
+class TileType : public ShapedType {
  public:
-  DataType dtype_;              // Element data type
-  std::vector<ExprPtr> shape_;  // Shape dimensions (at most 2 dimensions)
+  std::optional<TileView> tile_view_;  ///< Optional tile view information
 
   /**
-   * @brief Create a tile type
+   * @brief Create a tile type without memory reference or tile view
    *
    * @param shape Shape dimensions (must have at most 2 dimensions)
    * @param dtype Element data type
    * @throws std::invalid_argument if shape has more than 2 dimensions
    */
-  TileType(std::vector<ExprPtr> shape, DataType dtype) : dtype_(dtype), shape_(std::move(shape)) {
+  TileType(std::vector<ExprPtr> shape, DataType dtype)
+      : ShapedType(dtype, std::move(shape)), tile_view_(std::nullopt) {
+    CHECK(shape_.size() <= 2) << "TileType can have at most 2 dimensions, got " << shape_.size();
+  }
+
+  /**
+   * @brief Create a tile type with memory reference
+   *
+   * @param shape Shape dimensions (must have at most 2 dimensions)
+   * @param dtype Element data type
+   * @param memref Memory reference
+   * @throws std::invalid_argument if shape has more than 2 dimensions
+   */
+  TileType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRef> memref)
+      : ShapedType(dtype, std::move(shape), std::move(memref)), tile_view_(std::nullopt) {
+    CHECK(shape_.size() <= 2) << "TileType can have at most 2 dimensions, got " << shape_.size();
+  }
+
+  /**
+   * @brief Create a tile type with memory reference and tile view
+   *
+   * @param shape Shape dimensions (must have at most 2 dimensions)
+   * @param dtype Element data type
+   * @param memref Memory reference
+   * @param tile_view Tile view information
+   * @throws std::invalid_argument if shape has more than 2 dimensions
+   */
+  TileType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRef> memref,
+           std::optional<TileView> tile_view)
+      : ShapedType(dtype, std::move(shape), std::move(memref)), tile_view_(std::move(tile_view)) {
     CHECK(shape_.size() <= 2) << "TileType can have at most 2 dimensions, got " << shape_.size();
   }
 
   [[nodiscard]] std::string TypeName() const override { return "TileType"; }
 
   static constexpr auto GetFieldDescriptors() {
-    return std::tuple_cat(Type::GetFieldDescriptors(),
-                          std::make_tuple(reflection::UsualField(&TileType::dtype_, "dtype"),
-                                          reflection::UsualField(&TileType::shape_, "shape")));
+    return std::tuple_cat(ShapedType::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&TileType::tile_view_, "tile_view")));
   }
 };
 

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -36,4 +36,30 @@ from .builder import IRBuilder  # noqa: F401
 # This patches the native TensorType and TileType classes to accept integer shapes
 from .type import TensorType, TileType  # noqa: F401
 
-__all__ = ["op", "IRBuilder", "TensorType", "TileType"]
+
+def python_print(node, prefix="pi"):  # type: ignore[misc]
+    """
+    Print IR node or Type object in Python IR syntax.
+
+    This is a unified wrapper that dispatches to the appropriate C++ function
+    based on the type of the input object.
+
+    Args:
+        node: IR node (Expr, Stmt, Function, Program) or Type object to print
+        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+
+    Returns:
+        str: Python-style string representation
+    """
+    from pypto.pypto_core import ir as _ir_core  # noqa: PLC0415
+
+    # Check if node is a Type object
+    if isinstance(node, _ir_core.Type):
+        # Use the separate function for Type objects
+        return _ir_core.python_print_type(node, prefix)
+    else:
+        # Use the standard function for IRNode objects
+        return _ir_core.python_print(node, prefix)
+
+
+__all__ = ["op", "IRBuilder", "TensorType", "TileType", "python_print"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -8,7 +8,8 @@
 # -----------------------------------------------------------------------------------------------------------
 """Type stubs for PyPTO IR (Intermediate Representation) module."""
 
-from typing import Final, Mapping, Sequence, Union, overload
+import enum
+from typing import Final, Mapping, Optional, Sequence, Union, overload
 
 from pypto import DataType
 
@@ -281,8 +282,8 @@ class ScalarType(Type):
             dtype: Data type
         """
 
-class TensorType(Type):
-    """Tensor type representation."""
+class ShapedType(Type):
+    """Base class for shaped types (tensors and tiles)."""
 
     dtype: Final[DataType]
     """Element data type."""
@@ -290,9 +291,15 @@ class TensorType(Type):
     shape: Final[Sequence[Expr]]
     """Shape dimensions."""
 
+    memref: Final[Optional[MemRef]]
+    """Optional memory reference."""
+
+class TensorType(ShapedType):
+    """Tensor type representation."""
+
     @overload
     def __init__(self, shape: Sequence[Expr], dtype: DataType) -> None:
-        """Create a tensor type.
+        """Create a tensor type without memory reference.
 
         Args:
             shape: Shape dimensions as Expr nodes
@@ -300,26 +307,59 @@ class TensorType(Type):
         """
 
     @overload
+    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef]) -> None:
+        """Create a tensor type with memory reference.
+
+        Args:
+            shape: Shape dimensions as Expr nodes
+            dtype: Element data type
+            memref: Optional memory reference
+        """
+
+    @overload
     def __init__(self, shape: Sequence[int], dtype: DataType) -> None:
-        """Create a tensor type.
+        """Create a tensor type without memory reference.
 
         Args:
             shape: Shape dimensions as integers (automatically converted to ConstInt)
             dtype: Element data type
         """
 
-class TileType(Type):
+class TileView:
+    """Tile view representation with valid shape, stride, and start offset."""
+
+    valid_shape: Sequence[Expr]
+    """Valid shape dimensions."""
+
+    stride: Sequence[Expr]
+    """Stride for each dimension."""
+
+    start_offset: Expr
+    """Starting offset."""
+
+    @overload
+    def __init__(self) -> None:
+        """Create an empty tile view."""
+
+    @overload
+    def __init__(self, valid_shape: Sequence[Expr], stride: Sequence[Expr], start_offset: Expr) -> None:
+        """Create a tile view with valid_shape, stride, and start_offset.
+
+        Args:
+            valid_shape: Valid shape dimensions
+            stride: Stride for each dimension
+            start_offset: Starting offset
+        """
+
+class TileType(ShapedType):
     """Tile type representation (2D tensor with at most 2 dimensions)."""
 
-    dtype: Final[DataType]
-    """Element data type."""
-
-    shape: Final[Sequence[Expr]]
-    """Shape dimensions (at most 2 dimensions)."""
+    tile_view: Final[Optional[TileView]]
+    """Optional tile view information."""
 
     @overload
     def __init__(self, shape: Sequence[Expr], dtype: DataType) -> None:
-        """Create a tile type (validates shape has at most 2 dimensions).
+        """Create a tile type without memory reference (validates shape has at most 2 dimensions).
 
         Args:
             shape: Shape dimensions as Expr nodes
@@ -330,8 +370,37 @@ class TileType(Type):
         """
 
     @overload
+    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef]) -> None:
+        """Create a tile type with memory reference (validates shape has at most 2 dimensions).
+
+        Args:
+            shape: Shape dimensions as Expr nodes
+            dtype: Element data type
+            memref: Optional memory reference
+
+        Raises:
+            Exception: If shape has more than 2 dimensions
+        """
+
+    @overload
+    def __init__(
+        self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef], tile_view: Optional[TileView]
+    ) -> None:
+        """Create a tile type with memory reference and tile view.
+
+        Args:
+            shape: Shape dimensions as Expr nodes
+            dtype: Element data type
+            memref: Optional memory reference
+            tile_view: Optional tile view information
+
+        Raises:
+            Exception: If shape has more than 2 dimensions
+        """
+
+    @overload
     def __init__(self, shape: Sequence[int], dtype: DataType) -> None:
-        """Create a tile type (validates shape has at most 2 dimensions).
+        """Create a tile type without memory reference (validates shape has at most 2 dimensions).
 
         Args:
             shape: Shape dimensions as integers (automatically converted to ConstInt)
@@ -354,6 +423,53 @@ class TupleType(Type):
             types: List of types in the tuple
         """
 
+class MemorySpace(enum.Enum):
+    """Memory space enumeration."""
+
+    DDR = ...
+    """DDR memory (off-chip)."""
+
+    UB = ...
+    """Unified Buffer (on-chip)."""
+
+    L1 = ...
+    """L1 cache."""
+
+    L0A = ...
+    """L0A buffer."""
+
+    L0B = ...
+    """L0B buffer."""
+
+    L0C = ...
+    """L0C buffer."""
+
+class MemRef:
+    """Memory reference for shaped types (embedded in ShapedType)."""
+
+    memory_space_: MemorySpace
+    """Memory space (DDR, UB, L1, etc.)."""
+
+    addr_: Expr
+    """Starting address expression."""
+
+    size_: int
+    """Size in bytes (64-bit unsigned)."""
+
+    @overload
+    def __init__(self) -> None:
+        """Create an empty memory reference (for aggregate initialization)."""
+
+    @overload
+    def __init__(self, memory_space: MemorySpace, addr: Expr, size: int) -> None:
+        """Create a memory reference with memory_space, addr, and size.
+
+        Args:
+            memory_space: Memory space (DDR, UB, L1, etc.)
+            addr: Starting address expression
+            size: Size in bytes
+        """
+
 DYNAMIC_DIM: Final[int]
 """Constant representing a dynamic dimension (value: -1).
 
@@ -369,11 +485,12 @@ class Var(Expr):
     """Variable name."""
 
     def __init__(self, name: str, type: Type, span: Span) -> None:
-        """Create a variable reference expression.
+        """Create a variable reference.
 
         Args:
             name: Variable name
-            type: Type of the variable (ScalarType or TensorType)
+            type: Type of the variable (ScalarType, TensorType, or TileType)
+                  Memory reference information is stored in ShapedType for Tensor/Tile types
             span: Source location
         """
 
@@ -390,11 +507,12 @@ class IterArg(Var):
     """Initial value expression (can be any Expr)."""
 
     def __init__(self, name: str, type: Type, initValue: Expr, span: Span) -> None:
-        """Create an iteration argument with initial value and current value.
+        """Create an iteration argument.
 
         Args:
             name: Variable name
-            type: Type of the variable (ScalarType or TensorType)
+            type: Type of the variable (ScalarType, TensorType, or TileType)
+                  Memory reference information is stored in ShapedType for Tensor/Tile types
             initValue: Initial value expression (can be any Expr)
             span: Source location
         """
@@ -484,6 +602,24 @@ class Call(Expr):
             op: Operation/function to call
             args: List of argument expressions
             kwargs: Keyword arguments (metadata)
+            span: Source location
+        """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        op: Op,
+        args: Sequence[Expr],
+        type: Type,
+        span: Span,
+    ) -> None:
+        """Create a function call expression with explicit type.
+
+        Args:
+            op: Operation/function to call
+            args: List of argument expressions
+            type: Explicit result type
             span: Source location
         """
         ...
@@ -1311,6 +1447,31 @@ def assert_structural_equal(
         ValueError: If objects are not structurally equal, with detailed diagnostic message
     """
 
+@overload
+def memref_init(func: Function) -> Function: ...
+@overload
+def memref_init(program: Program) -> Program: ...
+def memref_init(func_or_program: Function | Program) -> Function | Program:
+    """Initialize MemRef for all Tile/Tensor variables.
+
+    Creates default MemRef objects for variables with TileType or TensorType
+    that don't already have a MemRef attached.
+
+    Default memory space allocation strategy:
+    - TileType → MemorySpace.UB (Unified Buffer)
+    - TensorType → MemorySpace.DDR (DDR memory)
+
+    Args:
+        func_or_program: Function or Program to transform
+
+    Returns:
+        Transformed Function or Program with MemRef initialized
+
+    Example:
+        >>> func = ... # Create function with Tile/Tensor variables
+        >>> func_with_memref = ir.memref_init(func)
+    """
+
 def serialize(node: IRNode) -> bytes:
     """Serialize an IR node to MessagePack bytes.
 
@@ -1660,6 +1821,17 @@ def python_print(node: IRNode, prefix: str = "pi") -> str:
 
     Returns:
         String representation of the IR node
+    """
+
+def python_print_type(type: Type, prefix: str = "pi") -> str:
+    """Print a Type object as a Python string.
+
+    Args:
+        type: Type object to print
+        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+
+    Returns:
+        String representation of the Type
     """
 
 def add(lhs: Expr, rhs: Expr, span: Span) -> Expr:

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/memref.h"
+
+#include <string>
+
+namespace pypto {
+namespace ir {
+
+std::string MemorySpaceToString(MemorySpace space) {
+  switch (space) {
+    case MemorySpace::DDR:
+      return "DDR";
+    case MemorySpace::UB:
+      return "UB";
+    case MemorySpace::L1:
+      return "L1";
+    case MemorySpace::L0A:
+      return "L0A";
+    case MemorySpace::L0B:
+      return "L0B";
+    case MemorySpace::L0C:
+      return "L0C";
+    default:
+      return "Unknown";
+  }
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/test_memref.py
+++ b/tests/ut/ir/test_memref.py
@@ -1,0 +1,849 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Comprehensive tests for MemRef, MemorySpace, and TileView."""
+
+import pytest
+from pypto import DataType, ir
+from pypto.ir import IRBuilder
+
+
+class TestMemorySpace:
+    """Tests for MemorySpace enum."""
+
+    def test_memory_space_values(self):
+        """Test all MemorySpace enum values."""
+        assert ir.MemorySpace.DDR is not None
+        assert ir.MemorySpace.UB is not None
+        assert ir.MemorySpace.L1 is not None
+        assert ir.MemorySpace.L0A is not None
+        assert ir.MemorySpace.L0B is not None
+        assert ir.MemorySpace.L0C is not None
+
+    def test_memory_space_equality(self):
+        """Test MemorySpace enum equality."""
+        assert ir.MemorySpace.DDR == ir.MemorySpace.DDR
+        assert ir.MemorySpace.UB == ir.MemorySpace.UB
+        assert ir.MemorySpace.DDR != ir.MemorySpace.UB
+
+    def test_memory_space_in_dict(self):
+        """Test using MemorySpace as dictionary keys."""
+        memory_map = {
+            ir.MemorySpace.DDR: "off-chip",
+            ir.MemorySpace.UB: "on-chip",
+            ir.MemorySpace.L1: "L1 cache",
+        }
+        assert memory_map[ir.MemorySpace.DDR] == "off-chip"
+        assert memory_map[ir.MemorySpace.UB] == "on-chip"
+        assert memory_map[ir.MemorySpace.L1] == "L1 cache"
+
+
+class TestMemRef:
+    """Tests for MemRef struct."""
+
+    def test_memref_creation_empty(self):
+        """Test creating an empty MemRef."""
+        memref = ir.MemRef()
+        assert memref is not None
+
+    def test_memref_set_attributes(self):
+        """Test setting MemRef attributes."""
+        span = ir.Span.unknown()
+        addr = ir.ConstInt(0, DataType.INT64, span)
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.DDR
+        memref.addr_ = addr
+        memref.size_ = 1024
+
+        assert memref.memory_space_ == ir.MemorySpace.DDR
+        assert memref.addr_.same_as(addr)
+        assert memref.size_ == 1024
+
+    def test_memref_different_memory_spaces(self):
+        """Test MemRef with different memory spaces."""
+        span = ir.Span.unknown()
+        addr = ir.ConstInt(0, DataType.INT64, span)
+
+        # Test each memory space
+        for mem_space in [
+            ir.MemorySpace.DDR,
+            ir.MemorySpace.UB,
+            ir.MemorySpace.L1,
+            ir.MemorySpace.L0A,
+            ir.MemorySpace.L0B,
+            ir.MemorySpace.L0C,
+        ]:
+            memref = ir.MemRef()
+            memref.memory_space_ = mem_space
+            memref.addr_ = addr
+            memref.size_ = 2048
+            assert memref.memory_space_ == mem_space
+
+    def test_memref_with_symbolic_address(self):
+        """Test MemRef with symbolic address expression."""
+        span = ir.Span.unknown()
+        base_addr = ir.Var("base_addr", ir.ScalarType(DataType.INT64), span)
+        offset = ir.ConstInt(128, DataType.INT64, span)
+        addr_expr = ir.Add(base_addr, offset, DataType.INT64, span)
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = addr_expr
+        memref.size_ = 4096
+
+        assert isinstance(memref.addr_, ir.Add)
+        assert memref.size_ == 4096
+
+    def test_memref_large_size(self):
+        """Test MemRef with large size values (uint64)."""
+        span = ir.Span.unknown()
+        addr = ir.ConstInt(0, DataType.INT64, span)
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.DDR
+        memref.addr_ = addr
+        memref.size_ = 2**32  # 4GB
+
+        assert memref.size_ == 2**32
+
+    def test_memref_zero_address(self):
+        """Test MemRef with zero address."""
+        span = ir.Span.unknown()
+        addr = ir.ConstInt(0, DataType.INT64, span)
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.L1
+        memref.addr_ = addr
+        memref.size_ = 512
+
+        assert isinstance(memref.addr_, ir.ConstInt)
+        assert memref.addr_.value == 0
+
+
+class TestTileView:
+    """Tests for TileView struct."""
+
+    def test_tileview_creation_empty(self):
+        """Test creating an empty TileView."""
+        tile_view = ir.TileView()
+        assert tile_view is not None
+
+    def test_tileview_set_attributes(self):
+        """Test setting TileView attributes."""
+        span = ir.Span.unknown()
+        valid_shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        tile_view = ir.TileView()
+        tile_view.valid_shape = valid_shape
+        tile_view.stride = stride
+        tile_view.start_offset = start_offset
+
+        assert len(tile_view.valid_shape) == 2
+        assert len(tile_view.stride) == 2
+        assert isinstance(tile_view.start_offset, ir.Expr)
+
+    def test_tileview_symbolic_dimensions(self):
+        """Test TileView with symbolic dimensions."""
+        span = ir.Span.unknown()
+        M = ir.Var("M", ir.ScalarType(DataType.INT64), span)
+        N = ir.Var("N", ir.ScalarType(DataType.INT64), span)
+
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [M, N]
+        tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), M]
+        tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        assert isinstance(tile_view.valid_shape[0], ir.Var)
+        assert isinstance(tile_view.valid_shape[1], ir.Var)
+
+    def test_tileview_non_contiguous_stride(self):
+        """Test TileView with non-contiguous stride."""
+        span = ir.Span.unknown()
+
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(8, DataType.INT64, span), ir.ConstInt(8, DataType.INT64, span)]
+        tile_view.stride = [ir.ConstInt(2, DataType.INT64, span), ir.ConstInt(32, DataType.INT64, span)]
+        tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        # Verify non-unit stride in first dimension
+        assert isinstance(tile_view.stride[0], ir.ConstInt)
+        assert tile_view.stride[0].value == 2
+
+
+class TestTensorTypeWithMemRef:
+    """Tests for TensorType with MemRef."""
+
+    def test_tensor_type_without_memref(self):
+        """Test TensorType creation without MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span), ir.ConstInt(20, DataType.INT64, span)]
+
+        tensor_type = ir.TensorType(shape, DataType.FP32)
+        assert tensor_type.dtype == DataType.FP32
+        assert len(tensor_type.shape) == 2
+        assert tensor_type.memref is None
+
+    def test_tensor_type_with_memref(self):
+        """Test TensorType creation with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span), ir.ConstInt(20, DataType.INT64, span)]
+
+        # Create MemRef
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.DDR
+        memref.addr_ = ir.ConstInt(0x1000, DataType.INT64, span)
+        memref.size_ = 10 * 20 * 4  # 10x20 FP32 elements
+
+        tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+        assert tensor_type.memref is not None
+        assert tensor_type.memref.memory_space_ == ir.MemorySpace.DDR
+        assert tensor_type.memref.size_ == 800
+
+    def test_tensor_type_memref_different_spaces(self):
+        """Test TensorType with MemRef in different memory spaces."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(32, DataType.INT64, span)]
+
+        for mem_space in [ir.MemorySpace.DDR, ir.MemorySpace.UB, ir.MemorySpace.L1]:
+            memref = ir.MemRef()
+            memref.memory_space_ = mem_space
+            memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+            memref.size_ = 128
+
+            tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+            assert tensor_type.memref is not None
+            assert tensor_type.memref.memory_space_ == mem_space
+
+    def test_tensor_var_with_memref(self):
+        """Test Var with TensorType containing MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(64, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0x2000, DataType.INT64, span)
+        memref.size_ = 256
+
+        tensor_type = ir.TensorType(shape, DataType.FP16, memref)
+        tensor_var = ir.Var("tensor_ub", tensor_type, span)
+
+        assert isinstance(tensor_var.type, ir.TensorType)
+        assert tensor_var.type.memref is not None
+        assert tensor_var.type.memref.memory_space_ == ir.MemorySpace.UB
+
+
+class TestTileTypeWithMemRef:
+    """Tests for TileType with MemRef and TileView."""
+
+    def test_tile_type_without_memref(self):
+        """Test TileType creation without MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        tile_type = ir.TileType(shape, DataType.FP32)
+        assert tile_type.dtype == DataType.FP32
+        assert len(tile_type.shape) == 2
+        assert tile_type.memref is None
+        assert tile_type.tile_view is None
+
+    def test_tile_type_with_memref(self):
+        """Test TileType creation with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 16 * 16 * 4
+
+        tile_type = ir.TileType(shape, DataType.FP32, memref)
+        assert tile_type.memref is not None
+        assert tile_type.memref.memory_space_ == ir.MemorySpace.UB
+
+    def test_tile_type_with_memref_and_tileview(self):
+        """Test TileType with both MemRef and TileView."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        # Create MemRef
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 16 * 16 * 2
+
+        # Create TileView
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view)
+        assert tile_type.memref is not None
+        assert tile_type.tile_view is not None
+        assert len(tile_type.tile_view.valid_shape) == 2
+
+    def test_tile_type_1d_with_memref(self):
+        """Test 1D TileType with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(32, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.L0A
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 128
+
+        tile_type = ir.TileType(shape, DataType.FP32, memref)
+        assert len(tile_type.shape) == 1
+        assert tile_type.memref is not None
+        assert tile_type.memref.memory_space_ == ir.MemorySpace.L0A
+
+    def test_tile_type_validation_3d_fails(self):
+        """Test that TileType rejects 3D shapes."""
+        span = ir.Span.unknown()
+        shape = [
+            ir.ConstInt(8, DataType.INT64, span),
+            ir.ConstInt(8, DataType.INT64, span),
+            ir.ConstInt(8, DataType.INT64, span),
+        ]
+
+        with pytest.raises(Exception):
+            ir.TileType(shape, DataType.FP32)
+
+    def test_tile_var_with_memref_l0c(self):
+        """Test Var with TileType containing MemRef in L0C."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.L0C
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 512
+
+        tile_type = ir.TileType(shape, DataType.FP16, memref)
+        tile_var = ir.Var("output_tile", tile_type, span)
+
+        assert isinstance(tile_var.type, ir.TileType)
+        assert tile_var.type.memref is not None
+        assert tile_var.type.memref.memory_space_ == ir.MemorySpace.L0C
+
+
+class TestMemRefSerialization:
+    """Tests for MemRef serialization and deserialization."""
+
+    def test_serialize_tensor_with_memref(self):
+        """Test serializing TensorType with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.DDR
+        memref.addr_ = ir.ConstInt(0x1000, DataType.INT64, span)
+        memref.size_ = 40
+
+        tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+        tensor_var = ir.Var("tensor", tensor_type, span)
+
+        # Serialize
+        data = ir.serialize(tensor_var)
+        assert data is not None
+
+        # Deserialize
+        restored = ir.deserialize(data)
+        assert isinstance(restored, ir.Var)
+        assert isinstance(restored.type, ir.TensorType)
+        assert restored.type.memref is not None
+        assert restored.type.memref.memory_space_ == ir.MemorySpace.DDR
+
+    def test_serialize_tile_with_memref_and_view(self):
+        """Test serializing TileType with MemRef and TileView."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 512
+
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view)
+        tile_var = ir.Var("tile", tile_type, span)
+
+        # Serialize
+        data = ir.serialize(tile_var)
+        assert data is not None
+
+        # Deserialize
+        restored = ir.deserialize(data)
+        assert isinstance(restored, ir.Var)
+        assert isinstance(restored.type, ir.TileType)
+        assert restored.type.memref is not None
+        assert restored.type.tile_view is not None
+        assert len(restored.type.tile_view.valid_shape) == 2
+
+    def test_serialize_assign_with_memref(self):
+        """Test serializing AssignStmt with MemRef-enabled types."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(32, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0x4000, DataType.INT64, span)
+        memref.size_ = 128
+
+        tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+        lhs = ir.Var("result", tensor_type, span)
+        rhs = ir.Var("input", tensor_type, span)
+
+        stmt = ir.AssignStmt(lhs, rhs, span)
+
+        # Serialize
+        data = ir.serialize(stmt)
+        assert data is not None
+
+        # Deserialize
+        restored = ir.deserialize(data)
+        assert isinstance(restored, ir.AssignStmt)
+        assert isinstance(restored.var.type, ir.ShapedType)
+        assert restored.var.type.memref is not None
+
+
+class TestMemRefStructuralComparison:
+    """Tests for structural comparison with MemRef."""
+
+    def test_tensor_with_same_memref_structural_equal(self):
+        """Test structural equality of tensors with identical MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span)]
+
+        memref1 = ir.MemRef()
+        memref1.memory_space_ = ir.MemorySpace.DDR
+        memref1.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref1.size_ = 40
+
+        memref2 = ir.MemRef()
+        memref2.memory_space_ = ir.MemorySpace.DDR
+        memref2.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref2.size_ = 40
+
+        tensor_type1 = ir.TensorType(shape, DataType.FP32, memref1)
+        tensor_type2 = ir.TensorType(shape, DataType.FP32, memref2)
+
+        var1 = ir.Var("t1", tensor_type1, span)
+        var2 = ir.Var("t2", tensor_type2, span)
+
+        assert ir.structural_equal(var1, var2, enable_auto_mapping=True)
+
+    def test_tensor_with_different_memref_not_equal(self):
+        """Test that tensors with different MemRef are not structurally equal."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span)]
+
+        memref1 = ir.MemRef()
+        memref1.memory_space_ = ir.MemorySpace.DDR
+        memref1.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref1.size_ = 40
+
+        memref2 = ir.MemRef()
+        memref2.memory_space_ = ir.MemorySpace.UB
+        memref2.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref2.size_ = 40
+
+        tensor_type1 = ir.TensorType(shape, DataType.FP32, memref1)
+        tensor_type2 = ir.TensorType(shape, DataType.FP32, memref2)
+
+        var1 = ir.Var("t1", tensor_type1, span)
+        var2 = ir.Var("t2", tensor_type2, span)
+
+        # Different memory spaces should make them not equal
+        assert not ir.structural_equal(var1, var2)
+
+    def test_tile_with_memref_structural_hash(self):
+        """Test structural hash consistency for tiles with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        memref1 = ir.MemRef()
+        memref1.memory_space_ = ir.MemorySpace.UB
+        memref1.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref1.size_ = 512
+
+        memref2 = ir.MemRef()
+        memref2.memory_space_ = ir.MemorySpace.UB
+        memref2.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref2.size_ = 512
+
+        tile_type1 = ir.TileType(shape, DataType.FP16, memref1)
+        tile_type2 = ir.TileType(shape, DataType.FP16, memref2)
+
+        var1 = ir.Var("tile1", tile_type1, span)
+        var2 = ir.Var("tile2", tile_type2, span)
+
+        hash1 = ir.structural_hash(var1, enable_auto_mapping=True)
+        hash2 = ir.structural_hash(var2, enable_auto_mapping=True)
+        assert hash1 == hash2
+
+
+class TestMemRefPythonPrinter:
+    """Tests for Python printing with MemRef."""
+
+    def test_print_tensor_with_memref(self):
+        """Test Python printing of TensorType with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.DDR
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 40
+
+        tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+        tensor_var = ir.Var("tensor", tensor_type, span)
+        stmt = ir.AssignStmt(tensor_var, ir.ConstInt(0, DataType.INT64, span), span)
+
+        result = ir.python_print(stmt)
+        # Just verify it doesn't crash and produces output
+        assert result is not None
+        assert len(result) > 0
+
+    def test_print_tile_with_memref(self):
+        """Test Python printing of TileType with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        memref = ir.MemRef()
+        memref.memory_space_ = ir.MemorySpace.UB
+        memref.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref.size_ = 512
+
+        tile_type = ir.TileType(shape, DataType.FP16, memref)
+        tile_var = ir.Var("tile", tile_type, span)
+        stmt = ir.AssignStmt(tile_var, ir.ConstInt(0, DataType.INT64, span), span)
+
+        result = ir.python_print(stmt)
+        assert result is not None
+        assert len(result) > 0
+
+
+class TestMemRefIntegration:
+    """Integration tests combining MemRef with other IR features."""
+
+    def test_memref_in_function(self):
+        """Test using MemRef in a function."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(10, DataType.INT64, span)]
+
+        # Input tensor with DDR MemRef
+        memref_in = ir.MemRef()
+        memref_in.memory_space_ = ir.MemorySpace.DDR
+        memref_in.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref_in.size_ = 40
+
+        input_type = ir.TensorType(shape, DataType.FP32, memref_in)
+        input_var = ir.Var("input", input_type, span)
+
+        # Output tensor with UB MemRef
+        memref_out = ir.MemRef()
+        memref_out.memory_space_ = ir.MemorySpace.UB
+        memref_out.addr_ = ir.ConstInt(0x1000, DataType.INT64, span)
+        memref_out.size_ = 40
+
+        output_type = ir.TensorType(shape, DataType.FP32, memref_out)
+        output_var = ir.Var("output", output_type, span)
+
+        # Create function body
+        body = ir.AssignStmt(output_var, input_var, span)
+
+        # Create function
+        func = ir.Function("copy_ddr_to_ub", [input_var], [output_type], body, span)
+
+        assert func is not None
+        assert len(func.params) == 1
+        assert isinstance(func.params[0].type, ir.ShapedType)
+        assert func.params[0].type.memref is not None
+        assert func.params[0].type.memref.memory_space_ == ir.MemorySpace.DDR
+
+    def test_memref_with_ops(self):
+        """Test MemRef with operator calls."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        # Create tile with L0A MemRef
+        memref_a = ir.MemRef()
+        memref_a.memory_space_ = ir.MemorySpace.L0A
+        memref_a.addr_ = ir.ConstInt(0, DataType.INT64, span)
+        memref_a.size_ = 512
+
+        tile_type_a = ir.TileType(shape, DataType.FP16, memref_a)
+        tile_a = ir.Var("tile_a", tile_type_a, span)
+
+        # Create tile with L0B MemRef
+        memref_b = ir.MemRef()
+        memref_b.memory_space_ = ir.MemorySpace.L0B
+        memref_b.addr_ = ir.ConstInt(0x200, DataType.INT64, span)
+        memref_b.size_ = 512
+
+        tile_type_b = ir.TileType(shape, DataType.FP16, memref_b)
+        tile_b = ir.Var("tile_b", tile_type_b, span)
+
+        # Create tile with L0C MemRef for output
+        memref_c = ir.MemRef()
+        memref_c.memory_space_ = ir.MemorySpace.L0C
+        memref_c.addr_ = ir.ConstInt(0x400, DataType.INT64, span)
+        memref_c.size_ = 512
+
+        tile_type_c = ir.TileType(shape, DataType.FP32, memref_c)
+
+        # Create matmul op
+        op = ir.Op("matmul")
+        call = ir.Call(op, [tile_a, tile_b], tile_type_c, span)
+
+        assert call is not None
+        assert isinstance(call.type, ir.ShapedType)
+        assert call.type.memref is not None
+        assert call.type.memref.memory_space_ == ir.MemorySpace.L0C
+
+
+class TestMemRefConstructor:
+    """Tests for MemRef constructor syntax."""
+
+    def test_memref_constructor(self):
+        """Test creating MemRef with constructor."""
+        span = ir.Span.unknown()
+        addr = ir.ConstInt(0x1000, DataType.INT64, span)
+
+        # Create MemRef with constructor
+        memref = ir.MemRef(ir.MemorySpace.DDR, addr, 1024)
+
+        assert memref.memory_space_ == ir.MemorySpace.DDR
+        assert memref.addr_.same_as(addr)
+        assert memref.size_ == 1024
+
+    def test_memref_constructor_different_spaces(self):
+        """Test MemRef constructor with different memory spaces."""
+        span = ir.Span.unknown()
+
+        for mem_space in [
+            ir.MemorySpace.DDR,
+            ir.MemorySpace.UB,
+            ir.MemorySpace.L1,
+            ir.MemorySpace.L0A,
+            ir.MemorySpace.L0B,
+            ir.MemorySpace.L0C,
+        ]:
+            addr = ir.ConstInt(0, DataType.INT64, span)
+            memref = ir.MemRef(mem_space, addr, 2048)
+            assert memref.memory_space_ == mem_space
+            assert memref.size_ == 2048
+
+
+class TestTileViewConstructor:
+    """Tests for TileView constructor syntax."""
+
+    def test_tileview_constructor(self):
+        """Test creating TileView with constructor."""
+        span = ir.Span.unknown()
+        valid_shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        # Create TileView with constructor
+        tv = ir.TileView(valid_shape, stride, start_offset)
+
+        assert len(tv.valid_shape) == 2
+        assert len(tv.stride) == 2
+        assert tv.start_offset.same_as(start_offset)
+
+    def test_tileview_constructor_with_vars(self):
+        """Test TileView constructor with symbolic expressions."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+        m = ir.Var("m", ir.ScalarType(DataType.INT64), span)
+
+        valid_shape = [n, m]
+        stride = [ir.ConstInt(1, DataType.INT64, span), n]
+        start_offset = ir.ConstInt(0, DataType.INT64, span)
+
+        tv = ir.TileView(valid_shape, stride, start_offset)
+
+        assert len(tv.valid_shape) == 2
+        assert tv.valid_shape[0].same_as(n)
+        assert tv.valid_shape[1].same_as(m)
+
+
+class TestPythonSyntaxPrinting:
+    """Tests for Python syntax printing with MemRef and TileView."""
+
+    def test_tensor_type_with_memref_print(self):
+        """Test printing TensorType with MemRef."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(64, DataType.INT64, span), ir.ConstInt(128, DataType.INT64, span)]
+        addr = ir.ConstInt(0x1000, DataType.INT64, span)
+        memref = ir.MemRef(ir.MemorySpace.DDR, addr, 1024)
+
+        tensor_type = ir.TensorType(shape, DataType.FP32, memref)
+        printed = ir.python_print(tensor_type)
+
+        assert "pi.Tensor" in printed
+        assert "pi.FP32" in printed
+        assert "memref=" in printed
+        assert "pi.MemRef" in printed
+        assert "pi.MemorySpace.DDR" in printed
+
+    def test_tile_type_with_memref_and_tileview_print(self):
+        """Test printing TileType with MemRef and TileView."""
+        span = ir.Span.unknown()
+        shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+
+        addr = ir.ConstInt(0, DataType.INT64, span)
+        memref = ir.MemRef(ir.MemorySpace.L0A, addr, 512)
+
+        valid_shape = [ir.ConstInt(16, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+        start_offset = ir.ConstInt(0, DataType.INT64, span)
+        tv = ir.TileView(valid_shape, stride, start_offset)
+
+        tile_type = ir.TileType(shape, DataType.FP16, memref, tv)
+        printed = ir.python_print(tile_type)
+
+        assert "pi.Tile" in printed
+        assert "pi.FP16" in printed
+        assert "memref=" in printed
+        assert "pi.MemRef" in printed
+        assert "pi.MemorySpace.L0A" in printed
+        assert "tile_view=" in printed
+        assert "pi.TileView" in printed
+        assert "valid_shape=" in printed
+        assert "stride=" in printed
+        assert "start_offset=" in printed
+
+    def test_memref_print_with_symbolic_addr(self):
+        """Test printing MemRef with symbolic address."""
+        span = ir.Span.unknown()
+        base = ir.Var("base_addr", ir.ScalarType(DataType.INT64), span)
+        offset = ir.ConstInt(128, DataType.INT64, span)
+        addr = ir.Add(base, offset, DataType.INT64, span)
+
+        memref = ir.MemRef(ir.MemorySpace.UB, addr, 2048)
+
+        shape = [ir.ConstInt(32, DataType.INT64, span)]
+        tensor_type = ir.TensorType(shape, DataType.INT32, memref)
+        printed = ir.python_print(tensor_type)
+
+        assert "base_addr" in printed
+        assert "128" in printed
+        assert "pi.MemorySpace.UB" in printed
+
+
+class TestIRBuilderHelpers:
+    """Tests for IR Builder helper methods."""
+
+    def test_builder_memref(self):
+        """Test IRBuilder.memref() helper."""
+        ib = IRBuilder()
+
+        # Create memref with int address
+        memref = ib.memref(ir.MemorySpace.DDR, 0x1000, 1024)
+
+        assert isinstance(memref, ir.MemRef)
+        assert memref.memory_space_ == ir.MemorySpace.DDR
+        assert memref.size_ == 1024
+
+    def test_builder_tile_view(self):
+        """Test IRBuilder.tile_view() helper."""
+        ib = IRBuilder()
+
+        # Create tile view with integer dimensions
+        tv = ib.tile_view([16, 16], [1, 16], 0)
+
+        assert isinstance(tv, ir.TileView)
+        assert len(tv.valid_shape) == 2
+        assert len(tv.stride) == 2
+
+    def test_builder_tensor_type(self):
+        """Test IRBuilder.tensor_type() helper."""
+        ib = IRBuilder()
+
+        # Simple tensor type
+        tensor_t = ib.tensor_type([64, 128], DataType.FP32)
+
+        assert isinstance(tensor_t, ir.TensorType)
+        assert len(tensor_t.shape) == 2
+        assert tensor_t.dtype == DataType.FP32
+        assert tensor_t.memref is None
+
+    def test_builder_tensor_type_with_memref(self):
+        """Test IRBuilder.tensor_type() with memref."""
+        ib = IRBuilder()
+
+        # Create memref
+        memref = ib.memref(ir.MemorySpace.DDR, 0x1000, 1024)
+
+        # Tensor type with memref
+        tensor_t = ib.tensor_type([64, 128], DataType.FP32, memref=memref)
+
+        assert isinstance(tensor_t, ir.TensorType)
+        assert tensor_t.memref is not None
+        assert tensor_t.memref.memory_space_ == ir.MemorySpace.DDR
+
+    def test_builder_tile_type(self):
+        """Test IRBuilder.tile_type() helper."""
+        ib = IRBuilder()
+
+        # Simple tile type
+        tile_t = ib.tile_type([16, 16], DataType.FP16)
+
+        assert isinstance(tile_t, ir.TileType)
+        assert len(tile_t.shape) == 2
+        assert tile_t.dtype == DataType.FP16
+
+    def test_builder_tile_type_with_memref_and_tileview(self):
+        """Test IRBuilder.tile_type() with memref and tile_view."""
+        ib = IRBuilder()
+
+        # Create memref and tile view
+        memref = ib.memref(ir.MemorySpace.L0A, 0, 512)
+        tv = ib.tile_view([16, 16], [1, 16], 0)
+
+        # Tile type with memref and tile_view
+        tile_t = ib.tile_type([16, 16], DataType.FP16, memref=memref, tile_view=tv)
+
+        assert isinstance(tile_t, ir.TileType)
+        assert tile_t.memref is not None
+        assert tile_t.tile_view is not None
+        assert tile_t.memref.memory_space_ == ir.MemorySpace.L0A
+
+    def test_builder_round_trip(self):
+        """Test round-trip: create with builder, print to Python syntax."""
+        ib = IRBuilder()
+
+        # Create complex tile type with builder
+        memref = ib.memref(ir.MemorySpace.L0B, 0x200, 1024)
+        tv = ib.tile_view([32, 32], [1, 32], 0)
+        tile_t = ib.tile_type([32, 32], DataType.FP32, memref=memref, tile_view=tv)
+
+        # Print to Python syntax
+        printed = ir.python_print(tile_t)
+
+        # Verify output contains all expected elements
+        assert "pi.Tile" in printed
+        assert "(32, 32)" in printed
+        assert "pi.FP32" in printed
+        assert "memref=pi.MemRef" in printed
+        assert "pi.MemorySpace.L0B" in printed
+        assert "tile_view=pi.TileView" in printed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add MemRef struct to represent memory references with space, address, and size
- Add MemorySpace enum (DDR, UB, L1, L0A, L0B, L0C) for hardware memory hierarchy
- Refactor type system: introduce ShapedType base class for TensorType and TileType
- Add optional memref field to TensorType and TileType for memory allocation tracking
- Add TileView struct for tile view information (valid_shape, stride, start_offset)
- Implement serialization/deserialization for MemRef and MemorySpace
- Add structural equality and hash support for MemRef
- Add Python bindings for MemRef and MemorySpace
- Add comprehensive tests for memref functionality (609 lines)
- Update documentation for memref and serialization