### PR TITLE
feat(ir): Add infrastructure for synchronization pass (EvalStmt, Sync Ops, PipeType)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(PYPTO_SOURCES
     src/ir/op/block_ops/reduction.cpp
     src/ir/op/block_ops/unary.cpp
     src/ir/op/block_ops/memory.cpp
+    src/ir/op/sync_ops/sync.cpp
     src/ir/op/testing.cpp
     src/ir/transform/visitor.cpp
     src/ir/transform/mutator.cpp

--- a/docs/dev/00-ir_definition.md
+++ b/docs/dev/00-ir_definition.md
@@ -76,6 +76,7 @@ The PyPTO IR can be described using the following BNF grammar:
                | <if_stmt>
                | <for_stmt>
                | <yield_stmt>
+               | <eval_stmt>
                | <seq_stmts>
                | <op_stmts>
 
@@ -97,6 +98,8 @@ The PyPTO IR can be described using the following BNF grammar:
 <expr_list>  ::= <expr> { "," <expr> }
 
 <yield_stmt> ::= "yield" [ <var_list> ]
+
+<eval_stmt>  ::= <expr>
 
 <seq_stmts>  ::= <stmt> { ";" <stmt> }
 
@@ -133,6 +136,7 @@ The PyPTO IR can be described using the following BNF grammar:
                 | <tensor_type>
                 | <tile_type>
                 | <tuple_type>
+                | <pipe_type>
                 | <unknown_type>
 
 <scalar_type> ::= "ScalarType" "(" <data_type> ")"
@@ -142,6 +146,10 @@ The PyPTO IR can be described using the following BNF grammar:
 <tile_type>   ::= "TileType" "(" <data_type> "," <shape> ")"
 
 <tuple_type>  ::= "TupleType" "(" "[" <type_list> "]" ")"
+
+<pipe_type>   ::= "PipeType" "(" <pipe_kind> ")"
+
+<pipe_kind>   ::= "S" | "V" | "M" | "MTE1" | "MTE2" | "MTE3" | "ALL" | ...
 
 <shape>       ::= "[" <expr_list> "]"
 
@@ -518,6 +526,17 @@ for_stmt = ir.ForStmt(
 yield_stmt = ir.YieldStmt([x, y], ir.Span.unknown())
 ```
 
+#### EvalStmt - Evaluation Statement
+
+`EvalStmt` wraps an expression as a statement. It is primarily used for operations that have side effects but no return value, such as synchronization barriers or print statements.
+
+```python
+# Evaluate an expression for its side effects
+sync_op = ir.Op("system.bar_all")
+call_expr = ir.Call(sync_op, [], ir.Span.unknown())
+eval_stmt = ir.EvalStmt(call_expr, ir.Span.unknown())
+```
+
 #### SeqStmts - Statement Sequence
 
 ```python
@@ -640,6 +659,19 @@ tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
 
 ```python
 unknown = ir.UnknownType()
+```
+
+### PipeType
+
+`PipeType` represents hardware execution pipelines or synchronization barriers.
+
+- **pipe_kind**: The type of pipe (e.g., Scalar, Vector, Matrix, Memory Transfer)
+
+```python
+# Create PipeTypes
+pipe_s = ir.PipeType(ir.PipeType.S)      # Scalar pipe
+pipe_v = ir.PipeType(ir.PipeType.V)      # Vector pipe
+pipe_m = ir.PipeType(ir.PipeType.M)      # Matrix pipe
 ```
 
 ### TupleType

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -14,9 +14,11 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/reflection/field_traits.h"
 
 namespace pypto {

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -14,6 +14,7 @@
 
 #include <any>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -27,6 +28,7 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/reflection/field_traits.h"
 #include "pypto/ir/type.h"
 
@@ -156,8 +158,23 @@ class Op {
    */
   [[nodiscard]] const std::unordered_map<std::string, std::type_index>& GetAttrs() const { return attrs_; }
 
+  /**
+   * @brief Set the pipeline type for this operator
+   *
+   * @param pipe Pipeline type (e.g., MTE2, V)
+   */
+  void SetPipe(PipeType pipe) const { pipe_ = pipe; }
+
+  /**
+   * @brief Get the pipeline type for this operator
+   *
+   * @return Optional pipeline type (nullopt if not set)
+   */
+  [[nodiscard]] std::optional<PipeType> GetPipe() const { return pipe_; }
+
  private:
   mutable std::unordered_map<std::string, std::type_index> attrs_;  ///< Kwarg schema (key -> type)
+  mutable std::optional<PipeType> pipe_;                            ///< Pipeline type
 };
 
 using OpPtr = std::shared_ptr<const Op>;

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -30,6 +30,7 @@
 #include "pypto/core/common.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -267,6 +268,18 @@ class OpRegistryEntry {
   inline OpRegistryEntry& set_attr(const std::string& key) {
     CHECK(op_) << "Operator '" + name_ + "' has no operator instance";
     op_->SetAttrType<T>(key);  // Delegate to Op::SetAttrType (compile-time check happens there)
+    return *this;
+  }
+
+  /**
+   * @brief Set the pipeline type for the operator
+   *
+   * @param pipe Pipeline type (e.g., MTE2, V)
+   * @return Reference to this entry for method chaining
+   */
+  inline OpRegistryEntry& set_pipe(PipeType pipe) {
+    CHECK(op_) << "Operator '" + name_ + "' has no operator instance";
+    op_->SetPipe(pipe);
     return *this;
   }
 

--- a/include/pypto/ir/pipe.h
+++ b/include/pypto/ir/pipe.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_PIPE_H_
+#define PYPTO_IR_PIPE_H_
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Pipeline type enumeration for hardware execution units
+ */
+enum PipeType : int {
+  MTE1,  ///< Memory Transfer Engine 1 (L1 -> L0A/L0B)
+  MTE2,  ///< Memory Transfer Engine 2 (DDR -> UB)
+  MTE3,  ///< Memory Transfer Engine 3 (UB -> DDR)
+  M,     ///< Matrix Unit
+  V,     ///< Vector Unit
+  S,     ///< Scalar Unit
+  FIX,   ///< Fix Pipe (L0C -> UB)
+  ALL    ///< All Pipes
+};
+
+/**
+ * @brief Core type enumeration
+ */
+enum CoreType : int {
+  VECTOR,  ///< Vector Core (Alias for AIV)
+  CUBE     ///< Cube Core (Alias for AIC)
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_PIPE_H_

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -370,6 +370,42 @@ class OpStmts : public Stmt {
 
 using OpStmtsPtr = std::shared_ptr<const OpStmts>;
 
+/**
+ * @brief Evaluation statement
+ *
+ * Represents an expression executed as a statement: expr
+ * where expr is an expression (typically a Call).
+ * This is used for expressions that have side effects but no return value
+ * (or return value is ignored).
+ */
+class EvalStmt : public Stmt {
+ public:
+  /**
+   * @brief Create an evaluation statement
+   *
+   * @param expr Expression to execute
+   * @param span Source location
+   */
+  EvalStmt(ExprPtr expr, Span span) : Stmt(std::move(span)), expr_(std::move(expr)) {}
+
+  [[nodiscard]] std::string TypeName() const override { return "EvalStmt"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors (expr as USUAL field)
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Stmt::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&EvalStmt::expr_, "expr")));
+  }
+
+ public:
+  ExprPtr expr_;  // Expression
+};
+
+using EvalStmtPtr = std::shared_ptr<const EvalStmt>;
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -179,6 +179,7 @@ class StmtFunctor {
   virtual R VisitStmt_(const ForStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const SeqStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const OpStmtsPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const EvalStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -198,6 +199,7 @@ R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   STMT_FUNCTOR_DISPATCH(ForStmt);
   STMT_FUNCTOR_DISPATCH(SeqStmts);
   STMT_FUNCTOR_DISPATCH(OpStmts);
+  STMT_FUNCTOR_DISPATCH(EvalStmt);
   STMT_FUNCTOR_DISPATCH(Stmt);
 
   // Should never reach here if all types are handled

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -83,6 +83,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override;
   StmtPtr VisitStmt_(const OpStmtsPtr& op) override;
+  StmtPtr VisitStmt_(const EvalStmtPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -32,6 +32,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
@@ -106,6 +107,12 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       kwargs.emplace_back(key, nb::cast<std::string>(item.second));
     } else if (nb::isinstance<nb::float_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<double>(item.second));
+    } else if (nb::isinstance<PipeType>(item.second)) {
+      // Cast enum to int for storage
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<PipeType>(item.second)));
+    } else if (nb::isinstance<CoreType>(item.second)) {
+      // Cast enum to int for storage
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<CoreType>(item.second)));
     } else {
       throw pypto::TypeError("Unsupported kwarg type for key: " + key);
     }
@@ -140,7 +147,10 @@ void BindIR(nb::module_& m) {
       .def(nb::init<std::string>(), nb::arg("name"), "Create an operation with the given name")
       .def_ro("name", &Op::name_, "Operation name")
       .def("has_attr", &Op::HasAttr, nb::arg("key"), "Check if a kwarg is registered in the schema")
-      .def("get_attr_keys", &Op::GetAttrKeys, "Get all registered kwarg keys from the schema");
+      .def("get_attr_keys", &Op::GetAttrKeys, "Get all registered kwarg keys from the schema")
+      .def_prop_ro(
+          "pipe", [](const Op& self) -> std::optional<PipeType> { return self.GetPipe(); },
+          "Pipeline type (optional)");
 
   // GlobalVar - global function reference
   nb::class_<GlobalVar, Op>(ir, "GlobalVar",
@@ -233,6 +243,24 @@ void BindIR(nb::module_& m) {
       .value("L0A", MemorySpace::L0A, "L0A buffer")
       .value("L0B", MemorySpace::L0B, "L0B buffer")
       .value("L0C", MemorySpace::L0C, "L0C buffer")
+      .export_values();
+
+  // PipeType enum
+  nb::enum_<PipeType>(ir, "PipeType", nb::is_arithmetic(), "Pipeline type enumeration")
+      .value("MTE1", PipeType::MTE1, "Memory Transfer Engine 1")
+      .value("MTE2", PipeType::MTE2, "Memory Transfer Engine 2")
+      .value("MTE3", PipeType::MTE3, "Memory Transfer Engine 3")
+      .value("M", PipeType::M, "Matrix Unit")
+      .value("V", PipeType::V, "Vector Unit")
+      .value("S", PipeType::S, "Scalar Unit")
+      .value("FIX", PipeType::FIX, "Fix Pipe")
+      .value("ALL", PipeType::ALL, "All Pipes")
+      .export_values();
+
+  // CoreType enum
+  nb::enum_<CoreType>(ir, "CoreType", nb::is_arithmetic(), "Core type enumeration")
+      .value("VECTOR", CoreType::VECTOR, "Vector Core")
+      .value("CUBE", CoreType::CUBE, "Cube Core")
       .export_values();
 
   // TileView - struct for tile view information
@@ -579,6 +607,12 @@ void BindIR(nb::module_& m) {
   op_stmts_class.def(nb::init<const std::vector<AssignStmtPtr>&, const Span&>(), nb::arg("stmts"),
                      nb::arg("span"), "Create an operation statements");
   BindFields<OpStmts>(op_stmts_class);
+
+  // EvalStmt - const shared_ptr
+  auto eval_stmt_class = nb::class_<EvalStmt, Stmt>(ir, "EvalStmt", "Evaluation statement: expr");
+  eval_stmt_class.def(nb::init<const ExprPtr&, const Span&>(), nb::arg("expr"), nb::arg("span"),
+                      "Create an evaluation statement");
+  BindFields<EvalStmt>(eval_stmt_class);
 
   // Function - const shared_ptr
   auto function_class = nb::class_<Function, IRNode>(

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -80,6 +80,9 @@ class Op:
     name: Final[str]
     """Operation name."""
 
+    pipe: Final[Optional[PipeType]]
+    """Pipeline type associated with this operation."""
+
     def __init__(self, name: str) -> None:
         """Create an operation with the given name.
 
@@ -422,6 +425,24 @@ class TupleType(Type):
         Args:
             types: List of types in the tuple
         """
+
+class PipeType(enum.IntEnum):
+    """Pipeline type enumeration for hardware execution units."""
+
+    MTE1 = ...
+    MTE2 = ...
+    MTE3 = ...
+    M = ...
+    V = ...
+    S = ...
+    FIX = ...
+    ALL = ...
+
+class CoreType(enum.IntEnum):
+    """Core type enumeration."""
+
+    VECTOR = ...
+    CUBE = ...
 
 class MemorySpace(enum.Enum):
     """Memory space enumeration."""
@@ -1271,6 +1292,20 @@ class OpStmts(Stmt):
 
         Returns:
             Operation statements with type information
+        """
+
+class EvalStmt(Stmt):
+    """Evaluation statement: expr."""
+
+    expr: Final[Expr]
+    """Expression."""
+
+    def __init__(self, expr: Expr, span: Span) -> None:
+        """Create an evaluation statement.
+
+        Args:
+            expr: Expression to execute
+            span: Source location
         """
 
 class Function(IRNode):

--- a/src/ir/op/block_ops/elementwise.cpp
+++ b/src/ir/op/block_ops/elementwise.cpp
@@ -26,6 +26,7 @@
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
@@ -91,6 +92,7 @@ TypePtr DeduceBlockOpScalarBinaryType(const std::vector<ExprPtr>& args,
 REGISTER_OP("block.mul")
     .set_op_category("BlockOp")
     .set_description("Element-wise multiplication of two tiles with broadcasting")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -101,6 +103,7 @@ REGISTER_OP("block.mul")
 REGISTER_OP("block.add")
     .set_op_category("BlockOp")
     .set_description("Element-wise addition of two tiles with broadcasting")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -111,6 +114,7 @@ REGISTER_OP("block.add")
 REGISTER_OP("block.div")
     .set_op_category("BlockOp")
     .set_description("Element-wise division of two tiles with broadcasting")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -121,6 +125,7 @@ REGISTER_OP("block.div")
 REGISTER_OP("block.sub")
     .set_op_category("BlockOp")
     .set_description("Element-wise subtraction of two tiles with broadcasting")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -131,6 +136,7 @@ REGISTER_OP("block.sub")
 REGISTER_OP("block.muls")
     .set_op_category("BlockOp")
     .set_description("Element-wise multiplication of tile and scalar")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Tile (TileType)")
     .add_argument("rhs", "Scalar (ScalarType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -141,6 +147,7 @@ REGISTER_OP("block.muls")
 REGISTER_OP("block.adds")
     .set_op_category("BlockOp")
     .set_description("Element-wise addition of tile and scalar")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Tile (TileType)")
     .add_argument("rhs", "Scalar (ScalarType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -151,6 +158,7 @@ REGISTER_OP("block.adds")
 REGISTER_OP("block.divs")
     .set_op_category("BlockOp")
     .set_description("Element-wise division of tile and scalar")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Tile (TileType)")
     .add_argument("rhs", "Scalar (ScalarType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
@@ -161,6 +169,7 @@ REGISTER_OP("block.divs")
 REGISTER_OP("block.subs")
     .set_op_category("BlockOp")
     .set_description("Element-wise subtraction of tile and scalar")
+    .set_pipe(PipeType::V)
     .add_argument("lhs", "Tile (TileType)")
     .add_argument("rhs", "Scalar (ScalarType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -26,6 +26,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
@@ -110,6 +111,7 @@ TypePtr DeduceBlockStoreType(const std::vector<ExprPtr>& args,
 REGISTER_OP("block.get_block_idx")
     .set_op_category("BlockOp")
     .set_description("Get the current block index")
+    .set_pipe(PipeType::S)
     .no_argument()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -119,6 +121,7 @@ REGISTER_OP("block.get_block_idx")
 REGISTER_OP("block.load")
     .set_op_category("BlockOp")
     .set_description("Copy data from tensor to unified buffer (tile)")
+    .set_pipe(PipeType::MTE2)
     .add_argument("tensor", "Source tensor (TensorType)")
     .add_argument("row_offset", "Row offset (scalar)")
     .add_argument("col_offset", "Column offset (scalar)")
@@ -132,6 +135,7 @@ REGISTER_OP("block.load")
 REGISTER_OP("block.store")
     .set_op_category("BlockOp")
     .set_description("Copy data from unified buffer (tile) to tensor")
+    .set_pipe(PipeType::MTE3)
     .add_argument("tile", "Source tile (TileType)")
     .add_argument("row_offset", "Row offset (scalar)")
     .add_argument("col_offset", "Column offset (scalar)")

--- a/src/ir/op/block_ops/reduction.cpp
+++ b/src/ir/op/block_ops/reduction.cpp
@@ -27,6 +27,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
 
@@ -124,6 +125,7 @@ TypePtr DeduceBlockSumType(const std::vector<ExprPtr>& args,
 REGISTER_OP("block.sum")
     .set_op_category("BlockOp")
     .set_description("Sum reduction of a tile along specified axis")
+    .set_pipe(PipeType::V)
     .add_argument("tile", "Input tile (TileType)")
     .set_attr<int>("axis")
     .set_attr<bool>("keepdim")

--- a/src/ir/op/block_ops/unary.cpp
+++ b/src/ir/op/block_ops/unary.cpp
@@ -23,6 +23,7 @@
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -51,6 +52,7 @@ TypePtr DeduceBlockUnaryType(const std::vector<ExprPtr>& args,
 REGISTER_OP("block.sqrt")
     .set_op_category("BlockOp")
     .set_description("Square root of a tile (element-wise)")
+    .set_pipe(PipeType::V)
     .add_argument("tile", "Input tile (TileType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <string>
+#include <vector>
+
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+// Helper to deduce UnknownType (for ops with no return value)
+TypePtr DeduceUnknownType(const std::vector<ExprPtr>& args,
+                          const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  return GetUnknownType();
+}
+
+}  // namespace
+
+// Register system.sync_src (Set Flag)
+// Attributes: set_pipe, wait_pipe, event_id
+REGISTER_OP("system.sync_src")
+    .set_description("Send a synchronization signal (Set Flag)")
+    .set_op_category("SyncOp")
+    .set_pipe(PipeType::S)
+    .no_argument()
+    .set_attr<int>("set_pipe")
+    .set_attr<int>("wait_pipe")
+    .set_attr<int>("event_id")
+    .f_deduce_type(DeduceUnknownType);
+
+// Register system.sync_dst (Wait Flag)
+// Attributes: set_pipe, wait_pipe, event_id
+REGISTER_OP("system.sync_dst")
+    .set_description("Wait for a synchronization signal (Wait Flag)")
+    .set_op_category("SyncOp")
+    .set_pipe(PipeType::S)
+    .no_argument()
+    .set_attr<int>("set_pipe")
+    .set_attr<int>("wait_pipe")
+    .set_attr<int>("event_id")
+    .f_deduce_type(DeduceUnknownType);
+
+// Register system.bar_v (Vector Barrier)
+// Attributes: None
+REGISTER_OP("system.bar_v")
+    .set_description("Vector unit barrier")
+    .set_op_category("SyncOp")
+    .set_pipe(PipeType::S)
+    .no_argument()
+    .f_deduce_type(DeduceUnknownType);
+
+// Register system.bar_m (Matrix Barrier)
+// Attributes: None
+REGISTER_OP("system.bar_m")
+    .set_description("Matrix unit barrier")
+    .set_op_category("SyncOp")
+    .set_pipe(PipeType::S)
+    .no_argument()
+    .f_deduce_type(DeduceUnknownType);
+
+// Register system.bar_all (Global Barrier)
+// Attributes: None
+REGISTER_OP("system.bar_all")
+    .set_description("Global barrier synchronization")
+    .set_op_category("SyncOp")
+    .set_pipe(PipeType::S)
+    .no_argument()
+    .f_deduce_type(DeduceUnknownType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -177,6 +177,7 @@ class IRSerializer::Impl {
     SERIALIZE_FIELDS(ForStmt);
     SERIALIZE_FIELDS(SeqStmts);
     SERIALIZE_FIELDS(OpStmts);
+    SERIALIZE_FIELDS(EvalStmt);
     SERIALIZE_FIELDS(Function);
     SERIALIZE_FIELDS(Program);
 

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -422,6 +422,14 @@ static IRNodePtr DeserializeOpStmts(const msgpack::object& fields_obj, msgpack::
   return std::make_shared<OpStmts>(stmts, span);
 }
 
+// Deserialize EvalStmt
+static IRNodePtr DeserializeEvalStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
+                                     DeserializerContext& ctx) {
+  auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
+  auto expr = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("expr"), zone));
+  return std::make_shared<EvalStmt>(expr, span);
+}
+
 // Deserialize Function
 static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack::zone& zone,
                                      DeserializerContext& ctx) {
@@ -545,6 +553,7 @@ static TypeRegistrar _return_stmt_registrar("ReturnStmt", DeserializeReturnStmt)
 static TypeRegistrar _for_stmt_registrar("ForStmt", DeserializeForStmt);
 static TypeRegistrar _seq_stmts_registrar("SeqStmts", DeserializeSeqStmts);
 static TypeRegistrar _op_stmts_registrar("OpStmts", DeserializeOpStmts);
+static TypeRegistrar _eval_stmt_registrar("EvalStmt", DeserializeEvalStmt);
 
 static TypeRegistrar _function_registrar("Function", DeserializeFunction);
 static TypeRegistrar _program_registrar("Program", DeserializeProgram);

--- a/src/ir/transform/mutator.cpp
+++ b/src/ir/transform/mutator.cpp
@@ -400,6 +400,18 @@ StmtPtr IRMutator::VisitStmt_(const OpStmtsPtr& op) {
   }
 }
 
+StmtPtr IRMutator::VisitStmt_(const EvalStmtPtr& op) {
+  INTERNAL_CHECK(op->expr_) << "EvalStmt has null expr";
+  auto new_expr = ExprFunctor<ExprPtr>::VisitExpr(op->expr_);
+  INTERNAL_CHECK(new_expr) << "EvalStmt expr mutated to null";
+
+  if (new_expr.get() != op->expr_.get()) {
+    return std::make_shared<const EvalStmt>(std::move(new_expr), op->span_);
+  } else {
+    return op;
+  }
+}
+
 StmtPtr IRMutator::VisitStmt_(const StmtPtr& op) {
   // Base Stmt is immutable, return original
   return op;

--- a/src/ir/transform/python_printer.cpp
+++ b/src/ir/transform/python_printer.cpp
@@ -104,6 +104,7 @@ class IRPythonPrinter : public IRVisitor {
   void VisitStmt_(const ForStmtPtr& op) override;
   void VisitStmt_(const SeqStmtsPtr& op) override;
   void VisitStmt_(const OpStmtsPtr& op) override;
+  void VisitStmt_(const EvalStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
   // Function and program visitors
@@ -548,6 +549,11 @@ void IRPythonPrinter::VisitStmt_(const OpStmtsPtr& op) {
       stream_ << "\n";
     }
   }
+}
+
+void IRPythonPrinter::VisitStmt_(const EvalStmtPtr& op) {
+  // Print expression statement: expr
+  VisitExpr(op->expr_);
 }
 
 void IRPythonPrinter::VisitStmt_(const StmtPtr& op) { stream_ << op->TypeName(); }

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -529,6 +529,7 @@ bool StructuralEqualImpl<AssertMode>::Equal(const IRNodePtr& lhs, const IRNodePt
   EQUAL_DISPATCH(ForStmt)
   EQUAL_DISPATCH(SeqStmts)
   EQUAL_DISPATCH(OpStmts)
+  EQUAL_DISPATCH(EvalStmt)
   EQUAL_DISPATCH(Function)
   EQUAL_DISPATCH(Program)
 

--- a/src/ir/transform/structural_hash.cpp
+++ b/src/ir/transform/structural_hash.cpp
@@ -331,6 +331,7 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(ForStmt)
   HASH_DISPATCH(SeqStmts)
   HASH_DISPATCH(OpStmts)
+  HASH_DISPATCH(EvalStmt)
   HASH_DISPATCH(Function)
   HASH_DISPATCH(Program)
 

--- a/tests/ut/ir/operators/test_block_ops.py
+++ b/tests/ut/ir/operators/test_block_ops.py
@@ -373,5 +373,27 @@ class TestBlockOpsIntegration:
         print(f"\n{func}")
 
 
+def test_block_ops_pipe():
+    """Test that block operators have the correct pipe property."""
+
+    # MTE2 ops
+    op = ir.get_op("block.load")
+    assert op.pipe == ir.PipeType.MTE2
+
+    # MTE3 ops
+    op = ir.get_op("block.store")
+    assert op.pipe == ir.PipeType.MTE3
+
+    # Vector ops
+    vector_ops = ["block.mul", "block.add", "block.div", "block.sum", "block.sqrt"]
+    for op_name in vector_ops:
+        op = ir.get_op(op_name)
+        assert op.pipe == ir.PipeType.V
+
+    # Scalar ops
+    op = ir.get_op("block.get_block_idx")
+    assert op.pipe == ir.PipeType.S
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_eval_stmt.py
+++ b/tests/ut/ir/statements/test_eval_stmt.py
@@ -1,0 +1,81 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from pypto import ir
+
+
+def test_eval_stmt_creation():
+    """Test creating an EvalStmt using a registered system op."""
+    span = ir.Span("test.py", 1, 1)
+
+    # Create system.bar_all() which takes no arguments but has an optional pipe attribute
+    # Here we create it without attributes first
+    call = ir.create_op_call("system.bar_all", [], span)
+
+    stmt = ir.EvalStmt(call, span)
+
+    assert stmt.expr.same_as(call)
+    assert stmt.span.filename == "test.py"
+
+
+def test_eval_stmt_python_print():
+    """Test printing an EvalStmt as Python code using system.sync_src."""
+    span = ir.Span("test.py", 1, 1)
+
+    # Create system.sync_src(set_pipe=MTE2, wait_pipe=V, event_id=1)
+    sync_call = ir.create_op_call(
+        "system.sync_src", [], {"set_pipe": ir.PipeType.MTE2, "wait_pipe": ir.PipeType.V, "event_id": 1}, span
+    )
+
+    stmt = ir.EvalStmt(sync_call, span)
+
+    # Print
+    code = ir.python_print(stmt)
+    # The output should look like: system.sync_src(set_pipe=1, wait_pipe=4, event_id=1)
+    # Note: Enums are currently printed as their integer values in kwargs because they are stored as ints
+    assert "system.sync_src(" in code
+    assert "set_pipe=" in code
+    assert "wait_pipe=" in code
+    assert "event_id=1" in code
+
+
+def test_eval_stmt_serialization():
+    """Test serializing and deserializing an EvalStmt."""
+    span = ir.Span("test.py", 1, 1)
+
+    # Create system.bar_v()
+    call = ir.create_op_call("system.bar_v", [], {}, span)
+
+    stmt = ir.EvalStmt(call, span)
+
+    # Serialize
+    data = ir.serialize(stmt)
+
+    # Deserialize
+    restored_stmt = ir.deserialize(data)
+
+    assert isinstance(restored_stmt, ir.EvalStmt)
+    assert ir.structural_equal(stmt, restored_stmt)
+
+
+def test_sync_ops_enum_usage():
+    """Test that PipeType and CoreType enums can be used correctly."""
+    # This test verifies the binding of enums
+    assert ir.PipeType.MTE2 is not None
+    assert ir.PipeType.V is not None
+    assert ir.CoreType.VECTOR is not None
+    assert ir.CoreType.CUBE is not None
+
+    # Verify we can pass them to create_op_call
+    span = ir.Span("test.py", 1, 1)
+    # system.bar_all has no attributes now, so we pass empty dict.
+    # But to test enum passing, let's use system.sync_src
+    ir.create_op_call(
+        "system.sync_src", [], {"set_pipe": ir.PipeType.MTE2, "wait_pipe": ir.PipeType.V, "event_id": 0}, span
+    )


### PR DESCRIPTION
This PR introduces the foundational infrastructure required to implement synchronization insertion passes in PyPTO. It enhances the IR with expression statements (`EvalStmt`), defines hardware architecture enumerations (`PipeType`, `CoreType`), and registers synchronization operations.

Changes:
- **IR Core**:
  - Add `EvalStmt` to allow expressions (e.g., function calls) to exist as standalone statements without assignment
  - Update `IRMutator`, `IRVisitor`, `PythonPrinter`, and serialization logic to support `EvalStmt`
  - Expose `EvalStmt` to Python bindings

- **Architecture**:
  - Introduce `include/pypto/ir/pipe.h` defining `PipeType` (MTE1, MTE2, V, etc.) and `CoreType` (VECTOR, CUBE)
  - Expose these enums to Python as `ir.PipeType` and `ir.CoreType`

- **Operators**:
  - Register system synchronization operations (`sync_src`, `sync_dst`, `bar_v`, `bar_m`, `bar_all`) in `src/ir/op/sync_ops/sync.cpp`
  - Extend `Op` and `OpRegistry` to support `PipeType` attribute
  - Annotate existing block operations with their corresponding pipeline types:
    * Memory Ops (`ub_copy_in`, `ub_copy_out`) -> MTE2, MTE3
    * Compute Ops (`mul`, `add`, `sum`, etc.) -> Vector (V)
    * Scalar Ops (`get_block_idx`) -> Scalar (S)

- **Testing**:
  - Add `tests/ut/ir/statements/test_eval_stmt.py` to verify `EvalStmt` creation, printing, and serialization
  - Update `tests/ut/ir/operators/test_block_ops.py` to verify the `pipe` attribute of block operations