### PR TITLE
feat(ir): Add Python-based IR parser with decorator DSL support

### DIFF
--- a/docs/dev/00-ir_definition.md
+++ b/docs/dev/00-ir_definition.md
@@ -86,7 +86,7 @@ The PyPTO IR can be described using the following BNF grammar:
                  [ "return" <var_list> ]
 
 <for_stmt>   ::= "for" <var> [ "," "(" <iter_arg_list> ")" ] "in"
-                 ( "range" | "pi.range" ) "(" <expr> "," <expr> "," <expr>
+                 ( "range" | "pl.range" ) "(" <expr> "," <expr> "," <expr>
                  [ "," "init_values" "=" "[" <expr_list> "]" ] ")" ":" <stmt_list>
                  [ <return_assignments> ]
 
@@ -202,9 +202,9 @@ sum_iter = ir.IterArg(
 )
 
 # IterArg is used within ForStmt:
-# for i, (sum,) in pi.range(0, n, 1, init_values=[0]):
-#     sum = pi.yield(sum + i)
-# sum_final: pi.Int64 = sum  # Capture final value in return variable
+# for i, (sum,) in pl.range(0, n, 1, init_values=[0]):
+#     sum = pl.yield(sum + i)
+# sum_final: pl.Int64 = sum  # Capture final value in return variable
 ```
 
 **SSA Semantics:**
@@ -212,8 +212,8 @@ sum_iter = ir.IterArg(
 ```
 # Python syntax
 sum_init = 0
-for i, (sum,) in pi.range(0, 10, 1, init_values=[sum_init]):
-    sum = pi.yield(sum + i)
+for i, (sum,) in pl.range(0, 10, 1, init_values=[sum_init]):
+    sum = pl.yield(sum + i)
 sum_final = sum
 
 # Equivalent SSA IR
@@ -479,8 +479,8 @@ for_stmt = ir.ForStmt(
 **Loop with iteration arguments (loop-carried values):**
 
 ```python
-# for i, (sum,) in pi.range(0, 10, 1, init_values=[sum_init]):
-#     sum = pi.yield(sum + i)
+# for i, (sum,) in pl.range(0, 10, 1, init_values=[sum_init]):
+#     sum = pl.yield(sum + i)
 # sum_final = sum
 
 i = ir.Var("i", ir.ScalarType(DataType.INT64), ir.Span.unknown())

--- a/docs/dev/07-ir_parser.md
+++ b/docs/dev/07-ir_parser.md
@@ -1,0 +1,412 @@
+# IR Parser for DSL Functions
+
+## Overview
+
+The IR parser provides a decorator-based system for converting high-level Python DSL code into PyPTO IR structures. It allows developers to write IR-generating functions in a more natural Python syntax and have them automatically converted to IR.
+
+## Architecture
+
+The parser consists of several cooperating components:
+
+```
+@pl.function decorator
+       ↓
+   AST Parser ──→ Span Tracker
+       ↓              ↓
+  IR Builder ←── Type Resolver
+       ↓
+ Scope Manager (SSA Verification)
+       ↓
+   ir.Function
+```
+
+### Components
+
+1. **Decorator (`decorator.py`)**: Entry point that extracts AST and orchestrates parsing
+2. **AST Parser (`ast_parser.py`)**: Converts Python AST nodes to IR builder calls
+3. **Span Tracker (`span_tracker.py`)**: Preserves source location information
+4. **Scope Manager (`scope_manager.py`)**: Enforces SSA properties and scope isolation
+5. **Type Resolver (`type_resolver.py`)**: Converts type annotations to IR types
+6. **DSL APIs (`dsl_api.py`)**: Helper functions (`range`, `yeild`, `Tensor`)
+
+## Usage
+
+### Basic Function
+
+```python
+import pypto
+import pypto.language as pl
+
+@pl.function
+def simple_add(
+    x: pl.Tensor[[64, 128], pl.FP16],
+    y: pl.Tensor[[64, 128], pl.FP16],
+) -> pl.Tensor[[64, 128], pl.FP16]:
+    result: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.add(x, y)
+    return result
+
+# simple_add is now an ir.Function object
+assert isinstance(simple_add, pypto.ir.Function)
+```
+
+### Type Annotations
+
+All function parameters and local variables must have type annotations:
+
+```python
+@pl.function
+def typed_example(
+    scalar: pl.Tensor[[1], pl.INT32],
+    tensor: pl.Tensor[[64, 128], pl.FP32],
+) -> pl.Tensor[[64, 128], pl.FP32]:
+    # Local variables need type annotations
+    result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.mul(tensor, 2.0)
+    return result
+```
+
+**Type syntax**: Two syntaxes are supported:
+
+**Recommended (subscript notation):**
+```python
+x: pl.Tensor[[64, 128], pl.FP16]
+```
+
+**Legacy (call notation):**
+```python
+x: pl.Tensor((64, 128), pl.FP16)  # Also supported but not recommended
+```
+
+Both syntaxes work identically. The parser accepts both, but the printer always outputs the recommended subscript notation.
+
+**Type components:**
+- Shape: List `[64, 128]` or tuple `(64, 128)`
+- DType: `pl.FP16`, `pl.FP32`, `pl.INT32`, etc.
+
+### For Loops with Iteration Arguments
+
+For loops use `pl.range()` with tuple unpacking to support loop-carried values (iter_args):
+
+```python
+@pl.function
+def sum_loop(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+    sum_init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+    # Loop variable and iter_args are unpacked
+    for i, (sum_val,) in pl.range(10, init_values=[sum_init]):
+        new_sum: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(sum_val, i)
+        # Yield the value for next iteration
+        sum_out = pl.yeild(new_sum)
+
+    return sum_out
+```
+
+**Syntax**: `for loop_var, (iter_arg1, iter_arg2, ...) in pl.range(stop, init_values=[...])`
+- `loop_var`: Loop index variable (e.g., `i`)
+- `(iter_arg1, ...)`: Tuple of iteration arguments (loop-carried values)
+- `init_values`: List of initial values for iter_args
+
+**Important**: The number of iter_args must match the number of init_values.
+
+### Yielding Values from Scopes
+
+Use `pl.yeild()` to explicitly return values from nested scopes (for loops, if statements):
+
+```python
+# Single value yield
+result = pl.yeild(expr)
+
+# Multiple value yield (tuple unpacking)
+v1, v2, v3 = pl.yeild(expr1, expr2, expr3)
+
+# Annotated yield
+output: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(value)
+```
+
+**Note**: The spelling is `yeild` (not `yield`) to avoid conflicts with Python's keyword.
+
+### If Statements with Phi Nodes
+
+If statements create SSA phi nodes for values that differ between branches:
+
+```python
+@pl.function
+def conditional(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    if x > 0:
+        positive: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+        result = pl.yeild(positive)
+    else:
+        negative: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, -1.0)
+        result = pl.yeild(negative)
+
+    return result
+```
+
+The `result` variable captures the phi node output from the if statement.
+
+## SSA (Static Single Assignment) Properties
+
+The parser enforces SSA properties to ensure valid IR:
+
+### Single Assignment Rule
+
+Each variable can only be assigned once within a scope:
+
+```python
+# ✓ Valid - single assignment per scope
+@pl.function
+def valid_ssa(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    y: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+    return y
+
+# ✗ Invalid - double assignment
+@pl.function
+def invalid_ssa(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    y: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+    y = pl.op.tensor.mul(x, 2.0)  # Error: SSA violation
+    return y
+```
+
+### Scope Isolation
+
+Variables defined in inner scopes are not accessible in outer scopes unless explicitly yielded:
+
+```python
+# ✗ Invalid - variable leaks from scope
+@pl.function
+def invalid_scope(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    for i, (sum_val,) in pl.range(10, init_values=[x]):
+        temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(sum_val, i)
+        # temp is not yielded
+
+    return temp  # Error: temp not defined in outer scope
+
+# ✓ Valid - explicit yield
+@pl.function
+def valid_scope(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    for i, (sum_val,) in pl.range(10, init_values=[x]):
+        temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(sum_val, i)
+        result = pl.yeild(temp)  # Explicitly yield
+
+    return result  # OK: result is output of loop
+```
+
+### Iteration Arguments
+
+Loop-carried values (iter_args) create new SSA values on each iteration:
+
+```python
+@pl.function
+def iter_args_example(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+    init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+    for i, (accumulator,) in pl.range(10, init_values=[init]):
+        # accumulator is a phi node - different value each iteration
+        # On iteration 0: accumulator = init
+        # On iteration 1+: accumulator = previous yield value
+
+        next_val: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(accumulator, i)
+        result = pl.yeild(next_val)  # Becomes accumulator in next iteration
+
+    return result
+```
+
+## Span Tracking
+
+The parser preserves source location information from the original Python code:
+
+```python
+@pl.function
+def example(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    # Each statement gets a span pointing to the source line
+    y: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)  # Span: line 3
+    return y  # Span: line 4
+```
+
+Every IR node created by the parser includes a `Span` object with:
+- `filename`: Source file path
+- `begin_line`: Starting line number
+- `begin_column`: Starting column offset
+- `end_line`: Ending line number (for multi-line constructs)
+- `end_column`: Ending column offset
+
+This enables:
+- Better error messages pointing to source code
+- Debugging and code visualization tools
+- Source-to-IR mapping for analysis
+
+## Supported Operations
+
+### Tensor Operations
+
+All `pl.op.tensor.*` operations are supported:
+
+```python
+# Creation
+t = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+
+# Binary operations
+result = pl.op.tensor.add(a, b)
+result = pl.op.tensor.mul(a, b)
+result = pl.op.tensor.sub(a, b)
+result = pl.op.tensor.div(a, b)
+
+# Matrix operations
+result = pl.op.tensor.matmul(a, b, out_dtype=pl.FP32, b_trans=True)
+
+# Reductions
+max_val = pl.op.tensor.row_max(tensor, axis=-1, keep_dim=1)
+sum_val = pl.op.tensor.row_sum(tensor, axis=-1, keep_dim=1)
+
+# Transforms
+casted = pl.op.tensor.cast(tensor, target_type=pl.FP32, mode="round")
+viewed = pl.op.tensor.view(tensor, [32, 256], [offset_h, offset_w])
+
+# Element-wise
+result = pl.op.tensor.exp(tensor)
+result = pl.op.tensor.maximum(a, b)
+```
+
+### Binary Expressions
+
+Python operators are automatically converted to IR expressions:
+
+```python
+# Arithmetic
+result = a + b  # ir.add(a, b, span)
+result = a - b  # ir.sub(a, b, span)
+result = a * b  # ir.mul(a, b, span)
+result = a / b  # ir.truediv(a, b, span)
+
+# Comparisons
+cond = i == 0    # ir.eq(i, 0, span)
+cond = x < 10    # ir.lt(x, 10, span)
+cond = y >= 5    # ir.ge(y, 5, span)
+```
+
+### Literals
+
+Python literals are automatically converted:
+
+```python
+# Integer literals → ConstInt
+i = 42  # ir.ConstInt(42, DataType.INT64, span)
+
+# Float literals → ConstFloat
+f = 3.14  # ir.ConstFloat(3.14, DataType.FP32, span)
+
+# List literals → Python list (for operation arguments)
+shape = [64, 128]
+tensor = pl.op.tensor.create(shape, dtype=pl.FP32)
+```
+
+## Complex Example
+
+Here's a complete example showing nested control flow:
+
+```python
+@pl.function
+def flash_attn_simplified(
+    q: pl.Tensor[[64, 128], pl.FP16],
+    k: pl.Tensor[[1024, 128], pl.FP16],
+) -> pl.Tensor[[64, 128], pl.FP32]:
+    # Initialize accumulator
+    attn_init: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create(
+        [64, 128], dtype=pl.FP32
+    )
+
+    # Loop over blocks
+    for i, (attn,) in pl.range(16, init_values=[attn_init]):
+        # Get block
+        k_block: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.view(
+            k, [64, 128], [i * 64, 0]
+        )
+
+        # Compute attention for this block
+        scores: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+            q, k_block, b_trans=True
+        )
+
+        # Conditional update
+        if i == 0:
+            new_attn: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.cast(
+                scores, target_type=pl.FP32
+            )
+            result = pl.yeild(new_attn)
+        else:
+            updated: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.add(attn, scores)
+            result = pl.yeild(updated)
+
+        final = pl.yeild(result)
+
+    return final
+```
+
+## Implementation Details
+
+### Parser Pipeline
+
+1. **Decorator invocation**: `@pl.function` captures the function
+2. **AST extraction**: `inspect.getsource()` gets source code, `ast.parse()` creates AST
+3. **Function parsing**:
+   - Parse function signature (parameters, return type)
+   - Create IRBuilder and function context
+   - Parse function body statements
+4. **Statement parsing**:
+   - Annotated assignments → `ib.let()`
+   - For loops → `ib.for_loop()` with iter_args
+   - If statements → `ib.if_stmt()` with return_vars
+   - Returns → `ib.return_stmt()`
+5. **Expression parsing**: Convert Python expressions to IR expressions
+6. **Type resolution**: Convert type annotations to IR types
+7. **Scope management**: Track variables and enforce SSA
+8. **Span tracking**: Preserve source locations
+9. **IR generation**: Build and return `ir.Function`
+
+### Error Handling
+
+The parser provides detailed error messages:
+
+```python
+# SSA violation
+ValueError: SSA violation: Variable 'x' is already defined in current scope.
+Each variable can only be assigned once per scope.
+
+# Undefined variable
+ValueError: Undefined variable: result
+
+# Type mismatch
+ValueError: Type mismatch in let statement for variable 'x':
+  Inferred type: TensorType([64, 128], FP32)
+  Provided type: TensorType([64, 64], FP32)
+
+# Missing type annotation
+ValueError: Parameter 'x' missing type annotation
+```
+
+## Limitations
+
+Current limitations of the parser:
+
+1. **Scalar comparisons only**: If conditions must use scalar values, not tensors
+2. **No nested functions**: Cannot define functions inside `@pl.function`
+3. **Limited Python features**: Only supports subset of Python (no classes, decorators within functions, etc.)
+4. **Explicit yields required**: All scope outputs must be explicitly yielded
+5. **Type annotations required**: All variables must have type annotations
+
+## Testing
+
+Comprehensive tests are available in `tests/ut/ir/parser/`:
+
+```bash
+# Run parser tests
+pytest tests/ut/ir/parser/
+
+# Run with coverage
+pytest tests/ut/ir/parser/ --cov=pypto.ir.parser
+```
+
+## See Also
+
+- [Python IR Syntax](05-python_syntax.md) - Full syntax specification
+- [IR Builder](06-ir_builder.md) - Manual IR construction API
+- [IR Definition](00-ir_definition.md) - Core IR concepts

--- a/examples/ir_parser/flash_attention_parsing.py
+++ b/examples/ir_parser/flash_attention_parsing.py
@@ -1,0 +1,123 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pypto.language as pl
+
+
+@pl.function
+def flash_attn(
+    q_13: pl.Tensor[[64, 128], pl.FP16],
+    k_16: pl.Tensor[[1024, 128], pl.FP16],
+    v_19: pl.Tensor[[1024, 128], pl.FP16],
+) -> pl.Tensor[[64, 128], pl.FP32]:
+    attn_initial: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+    oi_update_initial: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+    li_update_initial: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create([64, 1], dtype=pl.FP32)
+    mi_update_initial: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create([64, 1], dtype=pl.FP32)
+
+    # statement.for with iter_args → pl.range with tuple unpacking
+    for i, (mi_update, li_update, attn_update, oi_update) in pl.range(
+        16,
+        init_values=[
+            mi_update_initial,
+            li_update_initial,
+            attn_initial,
+            oi_update_initial,
+        ],
+    ):
+        # Inner statement.block
+        kj: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.view(k_16, [64, 128], [i * 64, 0])
+        vj: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.view(v_19, [64, 128], [i * 64, 0])
+        sij: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+            q_13, kj, out_dtype=pl.FP16, a_trans=False, b_trans=True, c_matrix_nz=False
+        )
+        sij_1: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.mul(sij, 0.0883883)
+        row_max: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.row_max(sij_1, axis=-1, keep_dim=1)
+        sub: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.sub(sij_1, row_max)
+        p_ij: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.exp(sub)
+        l_ij: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.row_sum(p_ij, axis=-1, keep_dim=1)
+        tildaPij_83: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.cast(
+            p_ij, target_type=pl.FP16, mode="round"
+        )
+
+        # Nested if with yield (SSA phi node)
+        if i == 0:
+            # Inner statement.block
+            oiUpdate_87: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+                tildaPij_83, vj, out_dtype=pl.FP16
+            )
+            oiUpdate_90: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.assemble(
+                oi_update, oiUpdate_87, offset=[0, 0]
+            )
+
+            # Nested if inside first branch
+            if i == 15:
+                attn_94: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.div(oiUpdate_90, l_ij)
+                attn_95: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_94)
+            else:
+                attn_95: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_update)
+
+            # More statements in first branch
+            liUpdate_98: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(li_update, l_ij, offset=[0, 0])
+            miUpdate_101: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(
+                mi_update, row_max, offset=[0, 0]
+            )
+
+            # statement.yield → pl.yeild with assignment
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129 = pl.yeild(
+                miUpdate_101, liUpdate_98, attn_95, oiUpdate_90
+            )
+        else:
+            # Else branch
+            mi_102: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create(shape=[64, 1], dtype=pl.FP32)
+            miUpdate_103: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.maximum(mi_102, row_max)
+            t1_104: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.sub(mi_102, miUpdate_103)
+            t2_105: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.exp(t1_104)
+            t3_106: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.sub(row_max, miUpdate_103)
+            t4_107: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.exp(t3_106)
+            t5_108: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.mul(t4_107, l_ij)
+            t6_109: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.mul(t2_105, li_update)
+            liUpdate_110: pl.Tensor[pl.FP32, 64, 1] = pl.op.tensor.add(t6_109, t5_108)
+            liUpdate_113: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(
+                li_update, liUpdate_110, offset=[0, 0]
+            )
+            q3_114: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.mul(oi_update, t2_105)
+            q1_115: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+                tildaPij_83,
+                vj,
+                out_dtype=pl.FP16,
+                a_trans=False,
+                b_trans=False,
+                c_matrix_nz=False,
+            )
+            q2_116: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.mul(q1_115, t4_107)
+            oiUpdate_117: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.add(q3_114, q2_116)
+            oiUpdate_120: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.assemble(
+                oi_update, oiUpdate_117, offset=[0, 0]
+            )
+
+            # Nested if in else branch
+            if i == 15:
+                attn_124: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.div(oiUpdate_120, liUpdate_113)
+                attn_125: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_124)
+            else:
+                attn_125: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_update)
+
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129 = pl.yeild(
+                miUpdate_103, liUpdate_113, attn_125, oiUpdate_120
+            )
+
+        # For loop yield (updates iter_args for next iteration)
+        mi_final, li_final, attn_final, oi_final = pl.yeild(
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129
+        )
+    return attn_final
+
+
+print(flash_attn)

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -243,8 +243,8 @@ using VarPtr = std::shared_ptr<const Var>;
  * 4. Capture final value in ForStmt's return_vars
  *
  * @example
- * // for i, (sum,) in pi.range(0, n, 1, init_values=[0]):
- * //     sum = pi.yield(sum + i)
+ * // for i, (sum,) in pl.range(0, n, 1, init_values=[0]):
+ * //     sum = pl.yield(sum + i)
  * // sum_final = sum
  * auto sum_iter = std::make_shared<IterArg>("sum", type, init_val, span);
  * auto sum_final = std::make_shared<Var>("sum_final", type, span);

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -235,8 +235,8 @@ using ReturnStmtPtr = std::shared_ptr<const ReturnStmt>;
  * **Basic loop:** for loop_var in range(start, stop, step): body
  *
  * **Loop with iteration arguments:**
- * for loop_var, (iter_arg1, iter_arg2) in pi.range(start, stop, step, init_values=[...]):
- *     iter_arg1, iter_arg2 = pi.yield(new_val1, new_val2)
+ * for loop_var, (iter_arg1, iter_arg2) in pl.range(start, stop, step, init_values=[...]):
+ *     iter_arg1, iter_arg2 = pl.yield(new_val1, new_val2)
  * return_var1 = iter_arg1
  * return_var2 = iter_arg2
  *

--- a/include/pypto/ir/transform/printer.h
+++ b/include/pypto/ir/transform/printer.h
@@ -212,19 +212,19 @@ class IRPrinter : public IRVisitor {
  * @brief Print an IR node in Python syntax
  *
  * @param node IR node to print (Expr, Stmt, Function, or Program)
- * @param prefix Module prefix to use (default: "pi", can be "ir" for legacy)
+ * @param prefix Module prefix to use (default: "pl", can be "ir" for legacy)
  * @return Python-style string representation
  */
-std::string PythonPrint(const IRNodePtr& node, const std::string& prefix = "pi");
+std::string PythonPrint(const IRNodePtr& node, const std::string& prefix = "pl");
 
 /**
  * @brief Print a type in Python syntax
  *
  * @param type Type to print (ScalarType, TensorType, TupleType, etc.)
- * @param prefix Module prefix to use (default: "pi", can be "ir" for legacy)
+ * @param prefix Module prefix to use (default: "pl", can be "ir" for legacy)
  * @return Python-style string representation
  */
-std::string PythonPrint(const TypePtr& type, const std::string& prefix = "pi");
+std::string PythonPrint(const TypePtr& type, const std::string& prefix = "pl");
 
 }  // namespace ir
 }  // namespace pypto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,14 @@ select = [
 ignore = [
   "ANN401",  # flake8-annotations: any-type
   "PLR2004", # pylint: magic-value-comparison
+  "PLR0911", # too many return statements
 ]
 fixable = ["ALL"]
 
 [tool.ruff.lint.pylint]
 max-statements = 100
 max-args = 10
+max-branches = 15
 
 [tool.ruff.format]
 quote-style = "double"

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -153,7 +153,7 @@ void BindIR(nb::module_& m) {
   auto type_class = nb::class_<Type>(ir, "Type", "Base class for type representations");
   BindFields<Type>(type_class);
   type_class.def(
-      "__str__", [](const TypePtr& self) { return PythonPrint(self, "pi"); },
+      "__str__", [](const TypePtr& self) { return PythonPrint(self, "pl"); },
       "Python-style string representation");
   type_class.def(
       "__eq__", [](const TypePtr& self, const TypePtr& other) { return structural_equal(self, other); },
@@ -182,17 +182,17 @@ void BindIR(nb::module_& m) {
       .def(
           "__str__",
           [](const IRNodePtr& self) {
-            // Use unified PythonPrint API with default "pi" prefix
-            return PythonPrint(self, "pi");
+            // Use unified PythonPrint API with default "pl" prefix
+            return PythonPrint(self, "pl");
           },
           "Python-style string representation")
       .def(
           "as_python",
           [](const IRNodePtr& self, const std::string& prefix) { return PythonPrint(self, prefix); },
-          nb::arg("prefix") = "pi",
+          nb::arg("prefix") = "pl",
           "Convert to Python-style string representation.\n\n"
           "Args:\n"
-          "    prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')");
+          "    prefix: Module prefix (default 'pl' for 'import pypto.language as pl')");
 
   // Expr - abstract base, const shared_ptr
   auto expr_class = nb::class_<Expr, IRNode>(ir, "Expr", "Base class for all expressions");
@@ -620,21 +620,21 @@ void BindIR(nb::module_& m) {
   ir.def(
       "python_print",
       [](const IRNodePtr& node, const std::string& prefix) { return PythonPrint(node, prefix); },
-      nb::arg("node"), nb::arg("prefix") = "pi",
+      nb::arg("node"), nb::arg("prefix") = "pl",
       "Print IR node (Expr, Stmt, Function, or Program) in Python IR syntax.\n\n"
       "Args:\n"
       "    node: IR node to print\n"
-      "    prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')");
+      "    prefix: Module prefix (default 'pl' for 'import pypto.language as pl')");
 
   // Python-style printer function for Type objects - use separate name to avoid overload ambiguity
   ir.def(
       "python_print_type",
       [](const TypePtr& type, const std::string& prefix) { return PythonPrint(type, prefix); },
-      nb::arg("type"), nb::arg("prefix") = "pi",
+      nb::arg("type"), nb::arg("prefix") = "pl",
       "Print Type object in Python IR syntax.\n\n"
       "Args:\n"
       "    type: Type to print\n"
-      "    prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')");
+      "    prefix: Module prefix (default 'pl' for 'import pypto.language as pl')");
 
   // operator functions for Var (wrapped in Python for span capture and normalization)
   // Using standalone C++ API functions from scalar_expr.h

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -19,6 +19,8 @@ This module provides:
 """
 
 # Re-export all core IR types and functions from native module
+# Re-export DataType for convenience
+from pypto.pypto_core import DataType  # noqa: F401
 from pypto.pypto_core.ir import *  # noqa: F401, F403
 
 # Import operation modules
@@ -29,18 +31,41 @@ from . import (
     operators,  # noqa: F401
 )
 
+# Export common DataType values for convenience
+FP4 = DataType.FP4
+FP8 = DataType.FP8
+FP16 = DataType.FP16
+FP32 = DataType.FP32
+BF16 = DataType.BF16
+HF4 = DataType.HF4
+HF8 = DataType.HF8
+INT4 = DataType.INT4
+INT8 = DataType.INT8
+INT16 = DataType.INT16
+INT32 = DataType.INT32
+INT64 = DataType.INT64
+UINT4 = DataType.UINT4
+UINT8 = DataType.UINT8
+UINT16 = DataType.UINT16
+UINT32 = DataType.UINT32
+UINT64 = DataType.UINT64
+BOOL = DataType.BOOL
+
 # Import IR Builder
-from .builder import IRBuilder  # noqa: F401
+from .builder import IRBuilder  # noqa: F401, E402
+
+# Import parser DSL APIs
+from .parser import Tensor, function, range, yeild  # noqa: F401, E402
 
 # Import PassManager and OptimizationStrategy
 from .pass_manager import OptimizationStrategy, PassManager  # noqa: F401
 
 # Import TensorType and TileType with enhanced __init__ that supports integer shapes
 # This patches the native TensorType and TileType classes to accept integer shapes
-from .type import TensorType, TileType  # noqa: F401
+from .type import TensorType, TileType  # noqa: F401, E402
 
 
-def python_print(node, prefix="pi"):  # type: ignore[misc]
+def python_print(node, prefix="pl"):  # type: ignore[misc]
     """
     Print IR node or Type object in Python IR syntax.
 
@@ -49,7 +74,7 @@ def python_print(node, prefix="pi"):  # type: ignore[misc]
 
     Args:
         node: IR node (Expr, Stmt, Function, Program) or Type object to print
-        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+        prefix: Module prefix (default 'pl' for 'import pypto.language as pl')
 
     Returns:
         str: Python-style string representation
@@ -65,4 +90,16 @@ def python_print(node, prefix="pi"):  # type: ignore[misc]
         return _ir_core.python_print(node, prefix)
 
 
-__all__ = ["op", "IRBuilder", "TensorType", "TileType", "python_print", "PassManager", "OptimizationStrategy"]
+__all__ = [
+    "op",
+    "IRBuilder",
+    "TensorType",
+    "TileType",
+    "python_print",
+    "PassManager",
+    "OptimizationStrategy",
+    "function",
+    "range",
+    "yeild",
+    "Tensor",
+]  # fmt: skip

--- a/python/pypto/ir/parser/__init__.py
+++ b/python/pypto/ir/parser/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+IR Parser module for converting high-level DSL code to IR builder programs.
+
+This module provides a decorator-based system for parsing Python functions
+with DSL annotations and converting them to IR structures.
+"""
+
+from .decorator import function
+from .dsl_api import Tensor, range, yeild
+
+__all__ = ["function", "range", "yeild", "Tensor"]

--- a/python/pypto/ir/parser/ast_parser.py
+++ b/python/pypto/ir/parser/ast_parser.py
@@ -1,0 +1,855 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""AST parsing for converting Python DSL to IR builder calls."""
+
+import ast
+from typing import Any
+
+from pypto.ir import IRBuilder
+from pypto.ir import op as ir_op
+from pypto.pypto_core import DataType, ir
+
+from .scope_manager import ScopeManager
+from .span_tracker import SpanTracker
+from .type_resolver import TypeResolver
+
+# TODO(syfeng): Enhance type checking and fix all type issues.
+# pyright: reportMissingImports=false, reportMissingTypeStubs=false, reportGeneralTypeIssues=false, reportAttributeAccessIssue=false, reportReturnType=false
+# pyright: reportOptionalOperand=false, reportOperatorIssue=false
+
+
+class ASTParser:
+    """Parses Python AST and builds IR using IRBuilder."""
+
+    def __init__(self, source_file: str, source_lines: list[str]):
+        """Initialize AST parser.
+
+        Args:
+            source_file: Path to source file
+            source_lines: Lines of source code
+        """
+        self.span_tracker = SpanTracker(source_file, source_lines)
+        self.scope_manager = ScopeManager()
+        self.type_resolver = TypeResolver()
+        self.builder = IRBuilder()
+
+        # Track context for handling yields and returns
+        self.in_for_loop = False
+        self.in_if_stmt = False
+        self.current_if_builder = None
+        self.current_loop_builder = None
+
+    def parse_function(self, func_def: ast.FunctionDef) -> ir.Function:
+        """Parse function definition and build IR.
+
+        Args:
+            func_def: AST FunctionDef node
+
+        Returns:
+            IR Function object
+        """
+        func_name = func_def.name
+        func_span = self.span_tracker.get_span(func_def)
+
+        # Enter function scope
+        self.scope_manager.enter_scope("function")
+
+        # Begin building function
+        with self.builder.function(func_name, func_span) as f:
+            # Parse parameters
+            for arg in func_def.args.args:
+                param_name = arg.arg
+                if arg.annotation is None:
+                    raise ValueError(f"Parameter '{param_name}' missing type annotation")
+
+                param_type = self.type_resolver.resolve_type(arg.annotation)
+                param_span = self.span_tracker.get_span(arg)
+
+                # Add parameter to function
+                param_var = f.param(param_name, param_type, param_span)
+
+                # Register in scope
+                self.scope_manager.define_var(param_name, param_var, allow_redef=True)
+
+            # Parse return type
+            if func_def.returns:
+                return_type = self.type_resolver.resolve_type(func_def.returns)
+                f.return_type(return_type)
+
+            # Parse function body
+            for stmt in func_def.body:
+                self.parse_statement(stmt)
+
+        # Exit function scope
+        self.scope_manager.exit_scope()
+
+        return f.get_result()
+
+    def parse_statement(self, stmt: ast.stmt) -> None:
+        """Parse a statement node.
+
+        Args:
+            stmt: AST statement node
+        """
+        if isinstance(stmt, ast.AnnAssign):
+            self.parse_annotated_assignment(stmt)
+        elif isinstance(stmt, ast.Assign):
+            self.parse_assignment(stmt)
+        elif isinstance(stmt, ast.For):
+            self.parse_for_loop(stmt)
+        elif isinstance(stmt, ast.If):
+            self.parse_if_statement(stmt)
+        elif isinstance(stmt, ast.Return):
+            self.parse_return(stmt)
+        elif isinstance(stmt, ast.Expr):
+            # Expression statement (e.g., standalone function call)
+            self.parse_expression(stmt.value)
+        else:
+            raise ValueError(f"Unsupported statement type: {type(stmt).__name__}")
+
+    def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:
+        """Parse annotated assignment: var: type = value.
+
+        Args:
+            stmt: AnnAssign AST node
+        """
+        if not isinstance(stmt.target, ast.Name):
+            raise ValueError("Only simple variable assignments supported")
+
+        var_name = stmt.target.id
+        span = self.span_tracker.get_span(stmt)
+
+        # Check if this is a yield assignment: var: type = pl.yeild(...)
+        if isinstance(stmt.value, ast.Call):
+            func = stmt.value.func
+            if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                # Handle yield assignment
+                yield_exprs = []
+                for arg in stmt.value.args:
+                    expr = self.parse_expression(arg)
+                    yield_exprs.append(expr)
+
+                # Emit yield statement
+                yield_span = self.span_tracker.get_span(stmt.value)
+                self.builder.emit(ir.YieldStmt(yield_exprs, yield_span))
+
+                # Track variable name for if statement output registration
+                if hasattr(self, "_current_yield_vars") and self._current_yield_vars is not None:
+                    self._current_yield_vars.append(var_name)
+
+                # Don't register in scope yet - will be done when if statement completes
+                return
+
+        # Parse value expression
+        if stmt.value is None:
+            raise NotImplementedError("Yield assignment with no value is not supported")
+        value_expr = self.parse_expression(stmt.value)
+
+        # Create variable with let
+        var = self.builder.let(var_name, value_expr, span=span)
+
+        # Register in scope
+        self.scope_manager.define_var(var_name, var)
+
+    def parse_assignment(self, stmt: ast.Assign) -> None:
+        """Parse regular assignment: var = value or tuple unpacking.
+
+        Args:
+            stmt: Assign AST node
+        """
+        # Handle tuple unpacking for yields
+        if len(stmt.targets) == 1:
+            target = stmt.targets[0]
+
+            # Handle tuple unpacking: (a, b, c) = pl.yeild(...)
+            if isinstance(target, ast.Tuple):
+                # Check if value is a pl.yeild() call
+                if isinstance(stmt.value, ast.Call):
+                    func = stmt.value.func
+                    if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                        # This is handled in yield parsing
+                        self.parse_yield_assignment(target, stmt.value)
+                        return
+
+                raise ValueError("Tuple unpacking only supported for pl.yeild()")
+
+            # Handle simple assignment
+            if isinstance(target, ast.Name):
+                var_name = target.id
+                span = self.span_tracker.get_span(stmt)
+
+                # Check if this is a yield assignment: var = pl.yeild(...)
+                if isinstance(stmt.value, ast.Call):
+                    func = stmt.value.func
+                    if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                        # Handle yield assignment
+                        yield_exprs = []
+                        for arg in stmt.value.args:
+                            expr = self.parse_expression(arg)
+                            if not isinstance(expr, ir.Expr):
+                                raise ValueError(f"Yield argument must be an IR expression, got {type(expr)}")
+                            yield_exprs.append(expr)
+
+                        # Emit yield statement
+                        yield_span = self.span_tracker.get_span(stmt.value)
+                        self.builder.emit(ir.YieldStmt(yield_exprs, yield_span))
+
+                        # Track variable name for loop/if output registration
+                        if hasattr(self, "_current_yield_vars") and self._current_yield_vars is not None:
+                            self._current_yield_vars.append(var_name)
+
+                        # Don't register in scope yet - will be done when loop/if completes
+                        return
+
+                value_expr = self.parse_expression(stmt.value)
+                var = self.builder.let(var_name, value_expr, span=span)
+                self.scope_manager.define_var(var_name, var)
+                return
+
+        raise ValueError(f"Unsupported assignment: {ast.unparse(stmt)}")
+
+    def parse_yield_assignment(self, target: ast.Tuple, value: ast.Call) -> None:
+        """Parse yield assignment: (a, b) = pl.yeild(x, y).
+
+        Args:
+            target: Tuple of target variable names
+            value: Call to pl.yeild()
+        """
+        # Parse yield expressions
+        yield_exprs = []
+        for arg in value.args:
+            expr = self.parse_expression(arg)
+            # Ensure it's an IR Expr
+            if not isinstance(expr, ir.Expr):
+                raise ValueError(f"Yield argument must be an IR expression, got {type(expr)}")
+            yield_exprs.append(expr)
+
+        # Emit yield statement
+        span = self.span_tracker.get_span(value)
+        self.builder.emit(ir.YieldStmt(yield_exprs, span))
+
+        # Track yielded variable names for if/for statement processing
+        if hasattr(self, "_current_yield_vars") and self._current_yield_vars is not None:
+            for elt in target.elts:
+                if isinstance(elt, ast.Name):
+                    self._current_yield_vars.append(elt.id)
+
+        # For tuple yields at the for loop level, register the variables
+        # (they'll be available as loop.get_result().return_vars)
+        if self.in_for_loop and not self.in_if_stmt:
+            # Register yielded variable names in scope
+            for i, elt in enumerate(target.elts):
+                if isinstance(elt, ast.Name):
+                    var_name = elt.id
+                    # Will be resolved from loop outputs
+                    self.scope_manager.define_var(var_name, f"loop_yield_{i}")
+
+    def parse_for_loop(self, stmt: ast.For) -> None:
+        """Parse for loop with pl.range().
+
+        Args:
+            stmt: For AST node
+        """
+        # Check if iterator is pl.range()
+        if not isinstance(stmt.iter, ast.Call):
+            raise ValueError("For loop must use pl.range()")
+
+        iter_call = stmt.iter
+        func = iter_call.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "range"):
+            raise ValueError("For loop must use pl.range()")
+
+        # Parse target: should be tuple like (i, (var1, var2, ...))
+        if not isinstance(stmt.target, ast.Tuple) or len(stmt.target.elts) != 2:
+            raise ValueError("For loop target must be: (loop_var, (iter_args...))")
+
+        loop_var_node = stmt.target.elts[0]
+        iter_args_node = stmt.target.elts[1]
+
+        if not isinstance(loop_var_node, ast.Name):
+            raise ValueError("Loop variable must be a simple name")
+
+        loop_var_name = loop_var_node.id
+
+        # Parse pl.range() arguments
+        range_args = self._parse_range_call(iter_call)
+
+        # Create loop variable
+        loop_var = self.builder.var(loop_var_name, ir.ScalarType(DataType.INT64))
+
+        # Begin for loop
+        span = self.span_tracker.get_span(stmt)
+
+        # Track loop output variable names
+        loop_output_vars = []
+
+        with self.builder.for_loop(
+            loop_var, range_args["start"], range_args["stop"], range_args["step"], span
+        ) as loop:
+            self.current_loop_builder = loop
+            self.in_for_loop = True
+            self.scope_manager.enter_scope("for")
+
+            # Register loop variable
+            self.scope_manager.define_var(loop_var_name, loop_var, allow_redef=True)
+
+            # Parse iter_args
+            if not isinstance(iter_args_node, ast.Tuple):
+                raise ValueError("Iter args must be a tuple")
+
+            init_values = range_args["init_values"]
+            if len(iter_args_node.elts) != len(init_values):
+                raise ValueError(
+                    f"Mismatch: {len(iter_args_node.elts)} iter_args but {len(init_values)} init_values"
+                )
+
+            # Add iter_args to loop
+            for i, iter_arg_node in enumerate(iter_args_node.elts):
+                if not isinstance(iter_arg_node, ast.Name):
+                    raise ValueError("Iter arg must be a simple name")
+
+                iter_arg_name = iter_arg_node.id
+                init_value = init_values[i]
+
+                # Add iter_arg
+                iter_arg_var = loop.iter_arg(iter_arg_name, init_value)
+                self.scope_manager.define_var(iter_arg_name, iter_arg_var, allow_redef=True)
+
+            # Add return variables (same count as iter_args)
+            for iter_arg_node in iter_args_node.elts:
+                iter_arg_name = iter_arg_node.id
+                return_var_name = f"{iter_arg_name}_out"
+                loop.return_var(return_var_name)
+
+            # Track yield outputs from loop
+            prev_yield_tracker = getattr(self, "_current_yield_vars", None)
+            self._current_yield_vars = []
+
+            # Parse loop body
+            for body_stmt in stmt.body:
+                self.parse_statement(body_stmt)
+
+            # Get the yielded variable names from the last yield
+            loop_output_vars = self._current_yield_vars[:]
+
+            # Restore yield tracker
+            self._current_yield_vars = prev_yield_tracker
+
+            # Exit for scope
+            self.scope_manager.exit_scope()
+            self.in_for_loop = False
+            self.current_loop_builder = None
+
+        # After for loop completes, register the output variables in the outer scope
+        loop_result = loop.get_result()
+        if hasattr(loop_result, "return_vars") and loop_result.return_vars and loop_output_vars:
+            # Register each output variable with its name
+            for i, var_name in enumerate(loop_output_vars):
+                if i < len(loop_result.return_vars):
+                    output_var = loop_result.return_vars[i]
+                    self.scope_manager.define_var(var_name, output_var)
+
+    def _parse_range_call(self, call: ast.Call) -> dict[str, Any]:
+        """Parse pl.range() call arguments.
+
+        Args:
+            call: AST Call node for pl.range()
+
+        Returns:
+            Dictionary with start, stop, step, init_values
+        """
+        # Parse positional arguments
+        if len(call.args) < 1:
+            raise ValueError("pl.range() requires at least 1 argument (stop)")
+
+        # Default values
+        start = 0
+        step = 1
+
+        if len(call.args) == 1:
+            # range(stop)
+            stop = self.parse_expression(call.args[0])
+        elif len(call.args) == 2:
+            # range(start, stop)
+            start = self.parse_expression(call.args[0])
+            stop = self.parse_expression(call.args[1])
+        elif len(call.args) >= 3:
+            # range(start, stop, step)
+            start = self.parse_expression(call.args[0])
+            stop = self.parse_expression(call.args[1])
+            step = self.parse_expression(call.args[2])
+
+        # Parse keyword arguments
+        init_values = []
+        for keyword in call.keywords:
+            if keyword.arg == "init_values":
+                # Parse list of init values
+                if isinstance(keyword.value, ast.List):
+                    for elt in keyword.value.elts:
+                        init_values.append(self.parse_expression(elt))
+                else:
+                    raise ValueError("init_values must be a list")
+
+        return {"start": start, "stop": stop, "step": step, "init_values": init_values}
+
+    def parse_if_statement(self, stmt: ast.If) -> None:
+        """Parse if statement with phi nodes.
+
+        Args:
+            stmt: If AST node
+        """
+        # Parse condition
+        condition = self.parse_expression(stmt.test)
+        span = self.span_tracker.get_span(stmt)
+
+        # Track yield output variable names from both branches
+        then_yield_vars = []
+
+        # Begin if statement
+        with self.builder.if_stmt(condition, span) as if_builder:
+            self.current_if_builder = if_builder
+            self.in_if_stmt = True
+
+            # Parse then branch to collect yield variable names first
+            # We need to know what variables will be yielded to declare return_vars
+            prev_yield_tracker = getattr(self, "_current_yield_vars", None)
+            self._current_yield_vars = []
+
+            # Scan then branch for yields (without executing)
+            then_yield_vars = self._scan_for_yields(stmt.body)
+
+            # Declare return vars based on yields
+            for var_name in then_yield_vars:
+                # Get type from annotation if available
+                # For now, use a generic tensor type - ideally we'd infer from yield expr
+                if_builder.return_var(var_name, ir.TensorType([1], DataType.INT32))
+
+            # Now parse then branch
+            self.scope_manager.enter_scope("if")
+            for then_stmt in stmt.body:
+                self.parse_statement(then_stmt)
+            self.scope_manager.exit_scope()
+
+            # Parse else branch if present
+            if stmt.orelse:
+                if_builder.else_()
+                self.scope_manager.enter_scope("else")
+                for else_stmt in stmt.orelse:
+                    self.parse_statement(else_stmt)
+                self.scope_manager.exit_scope()
+
+            # Restore previous yield tracker
+            self._current_yield_vars = prev_yield_tracker
+
+        # After if statement completes, register the output variables in the outer scope
+        if then_yield_vars:
+            # Get the output variables from the if statement
+            if_result = if_builder.get_result()
+            if hasattr(if_result, "return_vars") and if_result.return_vars:
+                # Register each output variable with its name
+                for i, var_name in enumerate(then_yield_vars):
+                    if i < len(if_result.return_vars):
+                        output_var = if_result.return_vars[i]
+                        self.scope_manager.define_var(var_name, output_var)
+
+        self.in_if_stmt = False
+        self.current_if_builder = None
+
+    def parse_return(self, stmt: ast.Return) -> None:
+        """Parse return statement.
+
+        Args:
+            stmt: Return AST node
+        """
+        span = self.span_tracker.get_span(stmt)
+
+        if stmt.value is None:
+            self.builder.return_stmt(None, span)
+            return
+
+        # Handle tuple return
+        if isinstance(stmt.value, ast.Tuple):
+            return_exprs = []
+            for elt in stmt.value.elts:
+                return_exprs.append(self.parse_expression(elt))
+            self.builder.return_stmt(return_exprs, span)
+        else:
+            # Single return value
+            return_expr = self.parse_expression(stmt.value)
+            self.builder.return_stmt([return_expr], span)
+
+    def parse_expression(self, expr: ast.expr) -> ir.Expr:
+        """Parse expression and return IR Expr.
+
+        Args:
+            expr: AST expression node
+
+        Returns:
+            IR expression or Python value for list literals
+        """
+        if isinstance(expr, ast.Name):
+            return self.parse_name(expr)
+        elif isinstance(expr, ast.Constant):
+            return self.parse_constant(expr)
+        elif isinstance(expr, ast.BinOp):
+            return self.parse_binop(expr)
+        elif isinstance(expr, ast.Compare):
+            return self.parse_compare(expr)
+        elif isinstance(expr, ast.Call):
+            return self.parse_call(expr)
+        elif isinstance(expr, ast.Attribute):
+            return self.parse_attribute(expr)
+        elif isinstance(expr, ast.UnaryOp):
+            return self.parse_unaryop(expr)
+        elif isinstance(expr, ast.List):
+            return self.parse_list(expr)
+        else:
+            raise ValueError(f"Unsupported expression type: {type(expr).__name__}")
+
+    def parse_name(self, name: ast.Name) -> ir.Var:
+        """Parse variable name reference.
+
+        Args:
+            name: Name AST node
+
+        Returns:
+            IR Var
+        """
+        var_name = name.id
+        var = self.scope_manager.lookup_var(var_name)
+
+        if var is None:
+            raise ValueError(f"Undefined variable: {var_name}")
+
+        # Return the IR Var
+        return var
+
+    def parse_constant(self, const: ast.Constant) -> ir.Expr:
+        """Parse constant value.
+
+        Args:
+            const: Constant AST node
+
+        Returns:
+            IR constant expression
+        """
+        span = self.span_tracker.get_span(const)
+        value = const.value
+
+        if isinstance(value, int):
+            return ir.ConstInt(value, DataType.INT64, span)
+        elif isinstance(value, float):
+            return ir.ConstFloat(value, DataType.FP32, span)
+        elif isinstance(value, bool):
+            return ir.ConstBool(value, span)
+        else:
+            raise ValueError(f"Unsupported constant type: {type(value)}")
+
+    def parse_binop(self, binop: ast.BinOp) -> ir.Expr:
+        """Parse binary operation.
+
+        Args:
+            binop: BinOp AST node
+
+        Returns:
+            IR binary expression
+        """
+        span = self.span_tracker.get_span(binop)
+        left = self.parse_expression(binop.left)
+        right = self.parse_expression(binop.right)
+
+        # Map operator to IR function
+        op_map = {
+            ast.Add: lambda lhs, rhs, span: ir.add(lhs, rhs, span),
+            ast.Sub: lambda lhs, rhs, span: ir.sub(lhs, rhs, span),
+            ast.Mult: lambda lhs, rhs, span: ir.mul(lhs, rhs, span),
+            ast.Div: lambda lhs, rhs, span: ir.truediv(lhs, rhs, span),
+            ast.FloorDiv: lambda lhs, rhs, span: ir.floordiv(lhs, rhs, span),
+            ast.Mod: lambda lhs, rhs, span: ir.mod(lhs, rhs, span),
+        }
+
+        op_type = type(binop.op)
+        if op_type not in op_map:
+            raise ValueError(f"Unsupported binary operator: {op_type.__name__}")
+
+        return op_map[op_type](left, right, span)
+
+    def parse_compare(self, compare: ast.Compare) -> ir.Expr:
+        """Parse comparison operation.
+
+        Args:
+            compare: Compare AST node
+
+        Returns:
+            IR comparison expression
+        """
+        if len(compare.ops) != 1 or len(compare.comparators) != 1:
+            raise ValueError("Only simple comparisons supported")
+
+        span = self.span_tracker.get_span(compare)
+        left = self.parse_expression(compare.left)
+        right = self.parse_expression(compare.comparators[0])
+
+        # Map comparison to IR function
+        op_map = {
+            ast.Eq: lambda lhs, rhs, span: ir.eq(lhs, rhs, span),
+            ast.NotEq: lambda lhs, rhs, span: ir.ne(lhs, rhs, span),
+            ast.Lt: lambda lhs, rhs, span: ir.lt(lhs, rhs, span),
+            ast.LtE: lambda lhs, rhs, span: ir.le(lhs, rhs, span),
+            ast.Gt: lambda lhs, rhs, span: ir.gt(lhs, rhs, span),
+            ast.GtE: lambda lhs, rhs, span: ir.ge(lhs, rhs, span),
+        }
+
+        op_type = type(compare.ops[0])
+        if op_type not in op_map:
+            raise ValueError(f"Unsupported comparison: {op_type.__name__}")
+
+        return op_map[op_type](left, right, span)
+
+    def parse_unaryop(self, unary: ast.UnaryOp) -> ir.Expr:
+        """Parse unary operation.
+
+        Args:
+            unary: UnaryOp AST node
+
+        Returns:
+            IR unary expression
+        """
+        span = self.span_tracker.get_span(unary)
+        operand = self.parse_expression(unary.operand)
+
+        op_map = {
+            ast.USub: lambda o, s: ir.neg(o, s),
+            ast.Not: lambda o, s: ir.bit_not(o, s),
+        }
+
+        op_type = type(unary.op)
+        if op_type not in op_map:
+            raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+
+        return op_map[op_type](operand, span)
+
+    def parse_call(self, call: ast.Call) -> ir.Expr:
+        """Parse function call.
+
+        Args:
+            call: Call AST node
+
+        Returns:
+            IR expression from call
+        """
+        func = call.func
+
+        # Handle pl.yeild() specially
+        if isinstance(func, ast.Attribute) and func.attr == "yeild":
+            return self.parse_yeild_call(call)
+
+        # Handle pl.op.tensor.* calls
+        if isinstance(func, ast.Attribute):
+            return self.parse_op_call(call)
+
+        raise ValueError(f"Unsupported function call: {ast.unparse(call)}")
+
+    def parse_yeild_call(self, call: ast.Call) -> ir.Expr:
+        """Parse pl.yeild() call.
+
+        Args:
+            call: Call to pl.yeild() or pl.yeild()
+
+        Returns:
+            IR expression (first yielded value for single yield)
+        """
+        span = self.span_tracker.get_span(call)
+        yield_exprs = []
+
+        for arg in call.args:
+            expr = self.parse_expression(arg)
+            yield_exprs.append(expr)
+
+        # Emit yield statement
+        self.builder.emit(ir.YieldStmt(yield_exprs, span))
+
+        # Track yielded variables for if statement processing
+        # This is for single assignment like: var = pl.yeild(expr)
+        # We'll return a placeholder that gets resolved when if statement completes
+
+        # Return first expression as the "value" of the yield
+        # This handles: var = pl.yeild(expr)
+        if len(yield_exprs) == 1:
+            return yield_exprs[0]
+
+        # For multiple yields, this should be handled as tuple assignment
+        raise ValueError("Multiple yields should use tuple unpacking assignment")
+
+    def parse_op_call(self, call: ast.Call) -> ir.Expr:
+        """Parse operation call like pl.op.tensor.create().
+
+        Args:
+            call: Call AST node
+
+        Returns:
+            IR expression from operation
+        """
+        func = call.func
+
+        # Navigate through attribute chain to find operation
+        # e.g., pl.op.tensor.create -> ["pl", "op", "tensor", "create"]
+        attrs = []
+        node = func
+        while isinstance(node, ast.Attribute):
+            attrs.insert(0, node.attr)
+            node = node.value
+
+        if isinstance(node, ast.Name):
+            attrs.insert(0, node.id)
+
+        # We expect: pl.op.tensor.{operation} or pl.op.tensor.{operation}
+        if len(attrs) >= 4 and attrs[1] == "op" and attrs[2] == "tensor":
+            op_name = attrs[3]
+            return self._parse_tensor_op(op_name, call)
+
+        raise ValueError(f"Unsupported operation call: {ast.unparse(call)}")
+
+    def _parse_tensor_op(self, op_name: str, call: ast.Call) -> ir.Expr:
+        """Parse tensor operation.
+
+        Args:
+            op_name: Name of tensor operation
+            call: Call AST node
+
+        Returns:
+            IR expression from tensor operation
+        """
+        # Parse arguments
+        args = [self.parse_expression(arg) for arg in call.args]
+
+        # Parse keyword arguments
+        kwargs = {}
+        for keyword in call.keywords:
+            key = keyword.arg
+            value = keyword.value
+
+            # Handle dtype specially
+            if key == "dtype":
+                kwargs[key] = self.type_resolver.resolve_dtype(value)
+            elif isinstance(value, ast.Constant):
+                kwargs[key] = value.value
+            elif isinstance(value, ast.UnaryOp) and isinstance(value.op, ast.USub):
+                # Handle negative numbers like -1
+                if isinstance(value.operand, ast.Constant):
+                    kwargs[key] = -value.operand.value
+                else:
+                    # Complex unary expression
+                    kwargs[key] = self.parse_expression(value)
+            elif isinstance(value, ast.Name):
+                if value.id in ["True", "False"]:
+                    kwargs[key] = value.id == "True"
+                else:
+                    # It's a variable reference
+                    kwargs[key] = self.parse_expression(value)
+            elif isinstance(value, ast.Attribute):
+                # Handle DataType.FP16 etc
+                kwargs[key] = self.type_resolver.resolve_dtype(value)
+            elif isinstance(value, ast.List):
+                # Handle list literals
+                kwargs[key] = self.parse_list(value)
+            else:
+                # Try to parse as expression
+                kwargs[key] = self.parse_expression(value)
+
+        # Call the appropriate tensor operation
+        if hasattr(ir_op.tensor, op_name):
+            op_func = getattr(ir_op.tensor, op_name)
+            return op_func(*args, **kwargs)
+
+        raise ValueError(f"Unknown tensor operation: {op_name}")
+
+    def parse_attribute(self, attr: ast.Attribute) -> ir.Expr:
+        """Parse attribute access.
+
+        Args:
+            attr: Attribute AST node
+
+        Returns:
+            IR expression
+        """
+        # This might be accessing a DataType enum or similar
+        # For now, this is primarily used in calls, not standalone
+        raise ValueError(f"Standalone attribute access not supported: {ast.unparse(attr)}")
+
+    def parse_list(self, list_node: ast.List):
+        """Parse list literal.
+
+        Args:
+            list_node: List AST node
+
+        Returns:
+            Python list of parsed elements (not IR Expr)
+        """
+        # For list literals like [64, 128], return a Python list
+        # These are used as arguments to operations
+        result = []
+        for elt in list_node.elts:
+            if isinstance(elt, ast.Constant):
+                result.append(elt.value)
+            else:
+                # Try to parse as expression
+                parsed = self.parse_expression(elt)
+                result.append(parsed)
+        return result
+
+    def _scan_for_yields(self, stmts: list[ast.stmt]) -> list[str]:
+        """Scan statements for yield assignments to determine output variable names.
+
+        Args:
+            stmts: List of statements to scan
+
+        Returns:
+            List of variable names that are yielded
+        """
+        yield_vars = []
+
+        for stmt in stmts:
+            # Check for annotated assignment with yeild: var: type = pl.yeild(...)
+            if isinstance(stmt, ast.AnnAssign):
+                if isinstance(stmt.target, ast.Name) and isinstance(stmt.value, ast.Call):
+                    func = stmt.value.func
+                    if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                        yield_vars.append(stmt.target.id)
+
+            # Check for regular assignment with yeild: var = pl.yeild(...)
+            elif isinstance(stmt, ast.Assign):
+                if len(stmt.targets) == 1:
+                    target = stmt.targets[0]
+                    # Single variable assignment
+                    if isinstance(target, ast.Name) and isinstance(stmt.value, ast.Call):
+                        func = stmt.value.func
+                        if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                            yield_vars.append(target.id)
+                    # Tuple unpacking: (a, b) = pl.yeild(...)
+                    elif isinstance(target, ast.Tuple) and isinstance(stmt.value, ast.Call):
+                        func = stmt.value.func
+                        if isinstance(func, ast.Attribute) and func.attr == "yeild":
+                            for elt in target.elts:
+                                if isinstance(elt, ast.Name):
+                                    yield_vars.append(elt.id)
+
+            # Recursively scan nested if statements
+            elif isinstance(stmt, ast.If):
+                yield_vars.extend(self._scan_for_yields(stmt.body))
+                if stmt.orelse:
+                    # Only take yields from else if they match then branch
+                    # For simplicity, just take from then branch
+                    pass
+
+        return yield_vars
+
+
+__all__ = ["ASTParser"]

--- a/python/pypto/ir/parser/decorator.py
+++ b/python/pypto/ir/parser/decorator.py
@@ -1,0 +1,78 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Decorator for parsing DSL functions to IR."""
+
+import ast
+import inspect
+from typing import Callable
+
+from pypto.pypto_core import ir
+
+from .ast_parser import ASTParser
+
+
+def function(func: Callable) -> ir.Function:
+    """Decorator that parses a DSL function and returns IR Function.
+
+    This decorator analyzes the decorated function's AST, parses the DSL
+    constructs (type annotations, pl.range, pl.yeild, etc.), and builds
+    an IR Function object.
+
+    Args:
+        func: Python function decorated with @pl.function
+
+    Returns:
+        IR Function object
+
+    Example:
+        >>> @pl.function
+        ... def my_func(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+        ...     result = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+        ...     return result
+    """
+    # Get source code and file information
+    source_lines = inspect.getsource(func).split("\n")
+    source_file = inspect.getfile(func)
+
+    # Parse source to AST
+    source_code = inspect.getsource(func)
+
+    # Remove any leading indentation to make it parseable
+    import textwrap  # noqa: PLC0415
+
+    source_code = textwrap.dedent(source_code)
+
+    try:
+        tree = ast.parse(source_code)
+    except SyntaxError as e:
+        raise ValueError(f"Failed to parse function source: {e}")
+
+    # Find the function definition in the AST
+    func_def = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
+            func_def = node
+            break
+
+    if func_def is None:
+        raise ValueError(f"Could not find function definition for {func.__name__}")
+
+    # Create parser and parse the function
+    parser = ASTParser(source_file, source_lines)
+
+    try:
+        ir_func = parser.parse_function(func_def)
+    except Exception as e:
+        raise ValueError(f"Failed to parse function '{func.__name__}': {e}") from e
+
+    return ir_func
+
+
+__all__ = ["function"]

--- a/python/pypto/ir/parser/dsl_api.py
+++ b/python/pypto/ir/parser/dsl_api.py
@@ -1,0 +1,98 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""DSL API helpers for writing IR functions.
+
+NOTE: This module re-exports from pypto.language for backwards compatibility.
+New code should use pypto.language directly.
+"""
+
+from typing import Any, Sequence, Tuple
+
+from pypto.ir import DataType
+
+# Import and re-export from pypto.language for backwards compatibility
+from pypto.language.dsl_api import RangeIterator, range, yeild
+
+
+# Keep the old Tensor class for backwards compatibility
+# This is now just a type annotation helper, the actual runtime wrapper is in pypto.language.Tensor
+class TensorMeta(type):
+    """Metaclass for Tensor to enable subscript notation."""
+
+    def __getitem__(cls, item: Tuple[Sequence[int], DataType]) -> "Tensor":
+        """Enable Tensor[[shape], dtype] syntax (recommended).
+
+        Args:
+            item: Tuple of (shape, dtype)
+
+        Returns:
+            Tensor instance with shape and dtype
+        """
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError("Tensor requires [shape, dtype] notation")
+
+        shape, dtype = item
+        return cls(shape, dtype)
+
+    def __call__(cls, shape: Sequence[int], dtype: Any) -> "Tensor":
+        """Enable Tensor((shape), dtype) syntax (legacy).
+
+        Args:
+            shape: Shape tuple or list
+            dtype: Data type (e.g., pl.FP16)
+
+        Returns:
+            Tensor instance with shape and dtype
+        """
+        # Support both call and metaclass instantiation
+        if isinstance(shape, tuple) and len(shape) == 2 and not isinstance(shape[0], int):
+            # This might be __call__ from metaclass with (shape, dtype) already unpacked
+            # In that case, shape is actually (real_shape, real_dtype)
+            return type.__call__(cls, shape, dtype)
+        return type.__call__(cls, shape, dtype)
+
+
+class Tensor(metaclass=TensorMeta):
+    """Type annotation helper for tensor types.
+
+    This is used in function signatures to specify tensor parameter types.
+
+    Supports two syntaxes:
+    - Recommended: pl.Tensor[[64, 128], pl.FP16]
+    - Legacy: pl.Tensor((64, 128), pl.FP16)
+
+    Examples:
+        >>> @pl.function
+        ... def my_func(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+        ...     pass
+        >>>
+        >>> # Legacy syntax also supported
+        >>> @pl.function
+        ... def legacy(x: pl.Tensor((64, 128), pl.FP16)) -> pl.Tensor((64, 128), pl.FP32):
+        ...     pass
+    """
+
+    def __init__(self, shape: Sequence[int], dtype: DataType):
+        """Initialize tensor type annotation.
+
+        Args:
+            shape: Shape (list or tuple)
+            dtype: Data type (e.g., pl.FP16)
+        """
+        self.shape = shape
+        self.dtype = dtype
+
+    @classmethod
+    def __class_getitem__(cls, item: Tuple[Sequence[int], DataType]) -> "Tensor":
+        """Support static type checkers for Tensor[[shape], dtype] syntax."""
+        return cls.__getitem__(item)
+
+
+__all__ = ["range", "yeild", "Tensor", "RangeIterator"]

--- a/python/pypto/ir/parser/scope_manager.py
+++ b/python/pypto/ir/parser/scope_manager.py
@@ -1,0 +1,164 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Scope management and SSA verification for IR parsing."""
+
+from typing import Any, Optional
+
+
+class SSAViolationError(Exception):
+    """Raised when SSA property is violated."""
+
+    pass
+
+
+class ScopeIsolationError(Exception):
+    """Raised when scope isolation is violated."""
+
+    pass
+
+
+class ScopeManager:
+    """Manages variable scopes and enforces SSA properties."""
+
+    def __init__(self):
+        """Initialize scope manager."""
+        self.scopes: list[dict[str, Any]] = [{}]  # Stack of scope dictionaries
+        self.assignments: dict[str, int] = {}  # Track assignment count per variable
+        self.scope_types: list[str] = ["global"]  # Track type of each scope
+        self.yielded_vars: dict[int, set[str]] = {}  # Track yielded variables per scope
+
+    def enter_scope(self, scope_type: str) -> None:
+        """Enter a new scope.
+
+        Args:
+            scope_type: Type of scope ('function', 'for', 'if')
+        """
+        self.scopes.append({})
+        self.scope_types.append(scope_type)
+        scope_id = len(self.scopes) - 1
+        self.yielded_vars[scope_id] = set()
+
+    def exit_scope(self) -> dict[str, Any]:
+        """Exit current scope and return defined variables.
+
+        Returns:
+            Dictionary of variables defined in the exited scope
+        """
+        if len(self.scopes) <= 1:
+            raise RuntimeError("Cannot exit global scope")
+
+        scope_vars = self.scopes.pop()
+        self.scope_types.pop()
+        scope_id = len(self.scopes)
+
+        # Clean up yielded vars tracking
+        if scope_id in self.yielded_vars:
+            del self.yielded_vars[scope_id]
+
+        return scope_vars
+
+    def define_var(self, name: str, value: Any, allow_redef: bool = False) -> None:
+        """Define a variable in the current scope.
+
+        Args:
+            name: Variable name
+            value: Variable value/node
+            allow_redef: If True, allow redefinition (for iter_args and parameters)
+
+        Raises:
+            SSAViolationError: If variable is already defined in current scope
+        """
+        current_scope = self.scopes[-1]
+
+        # Check SSA: variable should not already be defined in current scope
+        if name in current_scope and not allow_redef:
+            raise SSAViolationError(
+                f"SSA violation: Variable '{name}' is already defined in current scope. "
+                f"Each variable can only be assigned once per scope."
+            )
+
+        current_scope[name] = value
+
+        # Track assignment count globally
+        if name not in self.assignments:
+            self.assignments[name] = 0
+        self.assignments[name] += 1
+
+    def lookup_var(self, name: str) -> Optional[Any]:
+        """Lookup variable in scope chain.
+
+        Args:
+            name: Variable name to look up
+
+        Returns:
+            Variable value/node if found, None otherwise
+        """
+        # Search from innermost to outermost scope
+        for scope in reversed(self.scopes):
+            if name in scope:
+                return scope[name]
+        return None
+
+    def is_defined(self, name: str) -> bool:
+        """Check if variable is defined in any accessible scope.
+
+        Args:
+            name: Variable name
+
+        Returns:
+            True if variable is defined, False otherwise
+        """
+        return self.lookup_var(name) is not None
+
+    def mark_yielded(self, var_name: str) -> None:
+        """Mark a variable as yielded from current scope.
+
+        Args:
+            var_name: Variable name that is yielded
+        """
+        scope_id = len(self.scopes) - 1
+        if scope_id not in self.yielded_vars:
+            self.yielded_vars[scope_id] = set()
+        self.yielded_vars[scope_id].add(var_name)
+
+    def get_yielded_vars(self, scope_id: Optional[int] = None) -> set[str]:
+        """Get variables yielded from a specific scope.
+
+        Args:
+            scope_id: Scope ID (defaults to current scope)
+
+        Returns:
+            Set of yielded variable names
+        """
+        if scope_id is None:
+            scope_id = len(self.scopes) - 1
+        return self.yielded_vars.get(scope_id, set())
+
+    def current_scope_type(self) -> str:
+        """Get the type of the current scope.
+
+        Returns:
+            Scope type string ('global', 'function', 'for', 'if')
+        """
+        return self.scope_types[-1]
+
+    def in_scope_type(self, scope_type: str) -> bool:
+        """Check if currently in a specific scope type.
+
+        Args:
+            scope_type: Type to check for
+
+        Returns:
+            True if in the specified scope type
+        """
+        return scope_type in self.scope_types
+
+
+__all__ = ["ScopeManager", "SSAViolationError", "ScopeIsolationError"]

--- a/python/pypto/ir/parser/span_tracker.py
+++ b/python/pypto/ir/parser/span_tracker.py
@@ -1,0 +1,71 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Span tracking for preserving source location information during parsing."""
+
+import ast
+from typing import Optional, Sequence
+
+from pypto.pypto_core import ir
+
+
+class SpanTracker:
+    """Tracks source locations from AST nodes to IR spans."""
+
+    def __init__(self, source_file: str, source_lines: Sequence[str]):
+        """Initialize span tracker.
+
+        Args:
+            source_file: Path to the source file
+            source_lines: List of source code lines
+        """
+        self.source_file = source_file
+        self.source_lines = source_lines
+
+    def get_span(self, ast_node: Optional[ast.AST]) -> ir.Span:
+        """Extract span from AST node.
+
+        Args:
+            ast_node: AST node with line/column information
+
+        Returns:
+            IR span corresponding to the AST node location
+        """
+        if ast_node is None or not hasattr(ast_node, "lineno"):
+            return ir.Span.unknown()
+
+        return ir.Span(
+            self.source_file,
+            getattr(ast_node, "lineno", 0),
+            getattr(ast_node, "col_offset", 0),
+        )
+
+    def get_multiline_span(self, start_node: ast.AST, end_node: ast.AST) -> ir.Span:
+        """Get span covering multiple lines.
+
+        Args:
+            start_node: AST node at the start
+            end_node: AST node at the end
+
+        Returns:
+            IR span covering the range from start to end
+        """
+        if not hasattr(start_node, "lineno") or not hasattr(end_node, "lineno"):
+            return ir.Span.unknown()
+
+        return ir.Span(
+            self.source_file,
+            getattr(start_node, "lineno", 0),
+            getattr(start_node, "col_offset", 0),
+            getattr(end_node, "lineno", 0),
+            getattr(end_node, "col_offset", 0),
+        )
+
+
+__all__ = ["SpanTracker"]

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -1,0 +1,81 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+PyPTO Language module - Type-safe DSL API for writing IR functions.
+
+This module provides:
+- function decorator for parsing DSL functions to IR
+- Tensor type for type annotations and runtime wrapping
+- Type-safe operation wrappers (op.tensor.*)
+- DSL helpers (range, yeild)
+- DataType constants
+
+Typical usage:
+    import pypto.language as pl
+
+    @pl.function
+    def my_func(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+        result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+        return result
+"""
+
+# Import function decorator from pypto.ir.parser
+from pypto.ir.parser.decorator import function
+from pypto.pypto_core import DataType
+
+from . import op
+from .dsl_api import range, yeild
+from .tensor import Tensor
+
+# Re-export DataType constants for convenience
+FP4 = DataType.FP4
+FP8 = DataType.FP8
+FP16 = DataType.FP16
+FP32 = DataType.FP32
+BF16 = DataType.BF16
+HF4 = DataType.HF4
+HF8 = DataType.HF8
+INT4 = DataType.INT4
+INT8 = DataType.INT8
+INT16 = DataType.INT16
+INT32 = DataType.INT32
+INT64 = DataType.INT64
+UINT4 = DataType.UINT4
+UINT8 = DataType.UINT8
+UINT16 = DataType.UINT16
+UINT32 = DataType.UINT32
+UINT64 = DataType.UINT64
+BOOL = DataType.BOOL
+
+__all__ = [
+    "function",
+    "Tensor",
+    "range",
+    "yeild",
+    "op",
+    "FP4",
+    "FP8",
+    "FP16",
+    "FP32",
+    "BF16",
+    "HF4",
+    "HF8",
+    "INT4",
+    "INT8",
+    "INT16",
+    "INT32",
+    "INT64",
+    "UINT4",
+    "UINT8",
+    "UINT16",
+    "UINT32",
+    "UINT64",
+    "BOOL",
+]

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -1,0 +1,112 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""DSL API helpers for writing IR functions."""
+
+from typing import Any, List, Optional, Tuple
+
+
+class RangeIterator:
+    """Iterator for pl.range() that supports tuple unpacking."""
+
+    def __init__(
+        self,
+        stop: int,
+        start: int = 0,
+        step: int = 1,
+        init_values: Optional[List[Any]] = None,
+    ):
+        """Initialize range iterator.
+
+        Args:
+            stop: Stop value
+            start: Start value (default 0)
+            step: Step value (default 1)
+            init_values: Initial values for iter_args
+        """
+        self.start = start
+        self.stop = stop
+        self.step = step
+        self.init_values = init_values or []
+        self.current = start
+
+    def __iter__(self):
+        """Return iterator."""
+        return self
+
+    def __next__(self) -> Tuple[int, Tuple[Any, ...]]:
+        """Get next iteration value.
+
+        Returns:
+            Tuple of (loop_var, (iter_arg_values...))
+        """
+        if self.current >= self.stop:
+            raise StopIteration
+
+        value = self.current
+        self.current += self.step
+
+        # Return (loop_var, iter_args_tuple)
+        return (value, tuple(self.init_values))
+
+
+def range(*args: int, init_values: Optional[List[Any]] = None) -> RangeIterator:
+    """Create a range iterator for for loops with iter_args.
+
+    This function is used in DSL code like:
+        for i, (var1, var2) in pl.range(16, init_values=[init1, init2]):
+
+    Args:
+        *args: Positional arguments (stop) or (start, stop) or (start, stop, step)
+        init_values: Initial values for iteration arguments
+
+    Returns:
+        RangeIterator that yields (loop_var, (iter_args...))
+
+    Examples:
+        >>> for i, (sum,) in pl.range(10, init_values=[0]):
+        ...     sum = sum + i
+        ...     sum_out = pl.yeild(sum)
+    """
+    if len(args) == 1:
+        return RangeIterator(args[0], init_values=init_values)
+    elif len(args) == 2:
+        return RangeIterator(args[1], args[0], init_values=init_values)
+    elif len(args) == 3:
+        return RangeIterator(args[1], args[0], args[2], init_values=init_values)
+    else:
+        raise ValueError("range() takes 1 to 3 positional arguments")
+
+
+def yeild(*values: Any) -> Any:
+    """Yield values from a scope (for, if).
+
+    This function is used to explicitly return values from nested scopes
+    and create SSA phi nodes.
+
+    Args:
+        *values: Values to yield
+
+    Returns:
+        The yielded value(s). For single value, returns the value.
+        For multiple values, returns tuple.
+
+    Examples:
+        >>> # Single value yield
+        >>> result = pl.yeild(x + 1)
+        >>>
+        >>> # Multiple value yield
+        >>> a, b = pl.yeild(x, y)
+    """
+    if len(values) == 1:
+        return values[0]
+    return tuple(values)
+
+
+__all__ = ["range", "yeild", "RangeIterator"]

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+PyPTO Language operations module.
+
+This module organizes language-level operations by category (e.g., tensor operations).
+Operations accept and return Tensor types for type-safe DSL code.
+"""
+
+from . import tensor_ops as tensor
+
+__all__ = [
+    "tensor",
+]

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1,0 +1,326 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tensor operations for PyPTO Language DSL.
+
+This module provides type-safe wrappers around pypto.ir.op.tensor operations
+that accept and return Tensor types instead of raw Expr/Call objects.
+"""
+
+from typing import List, Literal, Optional, Union
+
+from pypto.ir.op import tensor_ops as _ir_ops
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import Expr
+
+from ..tensor import Tensor
+
+
+def create(shape: List[int], dtype: DataType) -> Tensor:
+    """Create a new tensor with specified shape and dtype.
+
+    Args:
+        shape: List of dimension sizes
+        dtype: Data type of tensor elements
+
+    Returns:
+        Tensor wrapping the create operation
+    """
+    call_expr = _ir_ops.create(shape, dtype)
+    return Tensor(expr=call_expr)
+
+
+def view(tensor: Tensor, shape: List[Union[int, Expr]], offset: List[Union[int, Expr]]) -> Tensor:
+    """Create a view/slice of a tensor with new shape and offset.
+
+    Args:
+        tensor: Input tensor
+        shape: New shape dimensions
+        offset: Offset dimensions for the view
+
+    Returns:
+        Tensor wrapping the view operation
+    """
+    tensor_expr = tensor.unwrap()
+    call_expr = _ir_ops.view(tensor_expr, shape, offset)
+    return Tensor(expr=call_expr)
+
+
+def matmul(
+    lhs: Tensor,
+    rhs: Tensor,
+    out_dtype: Optional[Union[int, DataType]] = None,
+    a_trans: bool = False,
+    b_trans: bool = False,
+    c_matrix_nz: bool = False,
+) -> Tensor:
+    """Matrix multiplication with optional transpose.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor
+        out_dtype: Output data type (optional, inferred if not provided)
+        a_trans: Whether to transpose lhs
+        b_trans: Whether to transpose rhs
+        c_matrix_nz: C matrix non-zero flag
+
+    Returns:
+        Tensor wrapping the matmul operation
+    """
+    lhs_expr = lhs.unwrap()
+    rhs_expr = rhs.unwrap()
+    call_expr = _ir_ops.matmul(lhs_expr, rhs_expr, out_dtype, a_trans, b_trans, c_matrix_nz)
+    return Tensor(expr=call_expr)
+
+
+def mul(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+    """Element-wise multiplication of tensor and tensor or scalar.
+
+    Automatically selects between tensor.mul (tensor x tensor) and
+    tensor.mul_scalar (tensor x scalar) based on the rhs type.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+
+    Returns:
+        Tensor wrapping the mul operation
+    """
+    lhs_expr = lhs.unwrap()
+    if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    else:
+        rhs_expr = rhs
+    call_expr = _ir_ops.mul(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def mul_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+    """Element-wise multiplication of tensor and scalar.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
+
+    Returns:
+        Tensor wrapping the mul_scalar operation
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.mul_scalar(lhs_expr, rhs)
+    return Tensor(expr=call_expr)
+
+
+def add(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+    """Element-wise addition of tensor and tensor or scalar.
+
+    Automatically selects between tensor.add (tensor + tensor) and
+    tensor.add_scalar (tensor + scalar) based on the rhs type.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+
+    Returns:
+        Tensor wrapping the add operation
+    """
+    lhs_expr = lhs.unwrap()
+    if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    else:
+        rhs_expr = rhs
+    call_expr = _ir_ops.add(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def add_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+    """Element-wise addition of tensor and scalar.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
+
+    Returns:
+        Tensor wrapping the add_scalar operation
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.add_scalar(lhs_expr, rhs)
+    return Tensor(expr=call_expr)
+
+
+def sub(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+    """Element-wise subtraction of tensor and tensor or scalar.
+
+    Automatically selects between tensor.sub (tensor - tensor) and
+    tensor.sub_scalar (tensor - scalar) based on the rhs type.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+
+    Returns:
+        Tensor wrapping the sub operation
+    """
+    lhs_expr = lhs.unwrap()
+    if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    else:
+        rhs_expr = rhs
+    call_expr = _ir_ops.sub(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def sub_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+    """Element-wise subtraction of tensor and scalar.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
+
+    Returns:
+        Tensor wrapping the sub_scalar operation
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.sub_scalar(lhs_expr, rhs)
+    return Tensor(expr=call_expr)
+
+
+def div(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+    """Element-wise division of tensor and tensor or scalar.
+
+    Automatically selects between tensor.div (tensor / tensor) and
+    tensor.div_scalar (tensor / scalar) based on the rhs type.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+
+    Returns:
+        Tensor wrapping the div operation
+    """
+    lhs_expr = lhs.unwrap()
+    if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    else:
+        rhs_expr = rhs
+    call_expr = _ir_ops.div(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def div_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+    """Element-wise division of tensor and scalar.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
+
+    Returns:
+        Tensor wrapping the div_scalar operation
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.div_scalar(lhs_expr, rhs)
+    return Tensor(expr=call_expr)
+
+
+def maximum(lhs: Tensor, rhs: Tensor) -> Tensor:
+    """Element-wise maximum of two tensors.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor
+
+    Returns:
+        Tensor wrapping the maximum operation
+    """
+    lhs_expr = lhs.unwrap()
+    rhs_expr = rhs.unwrap()
+    call_expr = _ir_ops.maximum(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def row_max(input: Tensor, axis: int = -1, keep_dim: Union[int, bool] = 1) -> Tensor:
+    """Row-wise maximum reduction along specified axis.
+
+    Args:
+        input: Input tensor
+        axis: Reduction axis (default: -1, last axis)
+        keep_dim: Keep reduced dimension as 1
+
+    Returns:
+        Tensor wrapping the row_max operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.row_max(input_expr, axis, keep_dim)
+    return Tensor(expr=call_expr)
+
+
+def row_sum(input: Tensor, axis: int = -1, keep_dim: Union[int, bool] = 1) -> Tensor:
+    """Row-wise sum reduction along specified axis.
+
+    Args:
+        input: Input tensor
+        axis: Reduction axis (default: -1, last axis)
+        keep_dim: Keep reduced dimension as 1
+
+    Returns:
+        Tensor wrapping the row_sum operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.row_sum(input_expr, axis, keep_dim)
+    return Tensor(expr=call_expr)
+
+
+def exp(input: Tensor) -> Tensor:
+    """Element-wise exponential operation.
+
+    Args:
+        input: Input tensor
+
+    Returns:
+        Tensor wrapping the exp operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.exp(input_expr)
+    return Tensor(expr=call_expr)
+
+
+def cast(
+    input: Tensor,
+    target_type: Union[int, DataType],
+    mode: Literal["round", "floor", "ceil"] = "round",
+) -> Tensor:
+    """Type casting operation.
+
+    Args:
+        input: Input tensor
+        target_type: Target data type
+        mode: Rounding mode
+
+    Returns:
+        Tensor wrapping the cast operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.cast(input_expr, target_type, mode)
+    return Tensor(expr=call_expr)
+
+
+def assemble(target: Tensor, source: Tensor, offset: List[Union[int, Expr]]) -> Tensor:
+    """Write/update tensor values at specified offset.
+
+    Args:
+        target: Target tensor to update
+        source: Source tensor to write
+        offset: Offset dimensions for where to write
+
+    Returns:
+        Tensor wrapping the assemble operation
+    """
+    target_expr = target.unwrap()
+    source_expr = source.unwrap()
+    call_expr = _ir_ops.assemble(target_expr, source_expr, offset)
+    return Tensor(expr=call_expr)

--- a/python/pypto/language/tensor.py
+++ b/python/pypto/language/tensor.py
@@ -1,0 +1,145 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tensor wrapper type for PyPTO Language DSL."""
+
+from typing import Any, Optional, Sequence, Tuple
+
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import Expr
+
+
+class TensorMeta(type):
+    """Metaclass for Tensor to enable subscript notation."""
+
+    def __getitem__(cls, item: Tuple[Sequence[int], DataType]) -> "Tensor":
+        """Enable Tensor[[shape], dtype] syntax (recommended).
+
+        Args:
+            item: Tuple of (shape, dtype)
+
+        Returns:
+            Tensor instance with shape and dtype (annotation-only mode)
+        """
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError("Tensor requires [shape, dtype] notation")
+
+        shape, dtype = item
+        return cls(shape, dtype, _annotation_only=True)
+
+    def __call__(
+        cls, shape: Any = None, dtype: Any = None, expr: Optional[Expr] = None, _annotation_only: bool = False
+    ) -> "Tensor":  # type: ignore[misc]
+        """Enable both Tensor((shape), dtype) syntax and runtime wrapping.
+
+        Args:
+            shape: Shape tuple or list (for annotation mode)
+            dtype: Data type (for annotation mode)
+            expr: IR expression to wrap (for runtime mode)
+            _annotation_only: Internal flag for annotation-only mode
+
+        Returns:
+            Tensor instance
+        """
+        # Support metaclass instantiation for annotations
+        if (
+            isinstance(shape, tuple)
+            and len(shape) == 2
+            and not isinstance(shape[0], int)
+            and dtype is None
+            and expr is None
+        ):
+            # This is __getitem__ passing (shape, dtype) as first arg
+            # Unpack it properly
+            real_shape, real_dtype = shape
+            return type.__call__(cls, real_shape, real_dtype, None, _annotation_only)
+        return type.__call__(cls, shape, dtype, expr, _annotation_only)
+
+
+class Tensor(metaclass=TensorMeta):
+    """Tensor type for PyPTO Language DSL.
+
+    This class serves dual purposes:
+    1. Type annotation helper for function signatures
+    2. Runtime wrapper around IR Expr/Call objects
+
+    Annotation mode (used in type hints):
+        x: pl.Tensor[[64, 128], pl.FP16]
+
+    Runtime mode (wraps IR expressions):
+        tensor = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+        # Returns Tensor wrapping the Call expression
+
+    Examples:
+        >>> import pypto.language as pl
+        >>>
+        >>> @pl.function
+        ... def my_func(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+        ...     result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+        ...     return result
+    """
+
+    def __init__(
+        self,
+        shape: Optional[Sequence[int]] = None,
+        dtype: Optional[DataType] = None,
+        expr: Optional[Expr] = None,
+        _annotation_only: bool = False,
+    ):
+        """Initialize Tensor.
+
+        Args:
+            shape: Shape (for annotation mode)
+            dtype: Data type (for annotation mode)
+            expr: IR expression to wrap (for runtime mode)
+            _annotation_only: Whether this is annotation-only mode
+        """
+        if _annotation_only:
+            # Used for type annotations only
+            self.shape = shape
+            self.dtype = dtype
+            self._expr = None
+        elif expr is not None:
+            # Runtime wrapper around Expr
+            self._expr = expr
+            self.shape = None
+            self.dtype = None
+        else:
+            raise ValueError(
+                "Tensor must be initialized with either (shape, dtype) for "
+                "annotations or expr for runtime wrapping"
+            )
+
+    def unwrap(self) -> Expr:
+        """Get underlying IR expression.
+
+        Returns:
+            The wrapped Expr/Call object
+
+        Raises:
+            ValueError: If called on an annotation-only Tensor
+        """
+        if self._expr is None:
+            raise ValueError("Cannot unwrap annotation-only Tensor (used in type hints)")
+        return self._expr
+
+    @classmethod
+    def __class_getitem__(cls, item: Tuple[Sequence[int], DataType]) -> "Tensor":
+        """Support static type checkers for Tensor[[shape], dtype] syntax."""
+        return cls.__getitem__(item)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        if self._expr is not None:
+            return f"Tensor(expr={self._expr})"
+        else:
+            return f"Tensor[[{self.shape}], {self.dtype}]"
+
+
+__all__ = ["Tensor"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1812,23 +1812,23 @@ class IRBuilder:
         """
 
 # ========== Python Printer ==========
-def python_print(node: IRNode, prefix: str = "pi") -> str:
+def python_print(node: IRNode, prefix: str = "pl") -> str:
     """Print an IR node as a Python string.
 
     Args:
         node: IR node to print
-        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+        prefix: Module prefix (default 'pl' for 'import pypto.language as pl')
 
     Returns:
         String representation of the IR node
     """
 
-def python_print_type(type: Type, prefix: str = "pi") -> str:
+def python_print_type(type: Type, prefix: str = "pl") -> str:
     """Print a Type object as a Python string.
 
     Args:
         type: Type object to print
-        prefix: Module prefix (default 'pi' for 'import pypto.ir as pi')
+        prefix: Module prefix (default 'pl' for 'import pypto.language as pl')
 
     Returns:
         String representation of the Type

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -442,7 +442,7 @@ class StructuralEqualImpl {
       if (lhs || rhs) {
         msg << "Left-hand side:\n";
         if (lhs) {
-          std::string lhs_str = PythonPrint(lhs, "pi");
+          std::string lhs_str = PythonPrint(lhs, "pl");
           std::istringstream iss(lhs_str);
           std::string line;
           while (std::getline(iss, line)) {
@@ -454,7 +454,7 @@ class StructuralEqualImpl {
 
         msg << "\nRight-hand side:\n";
         if (rhs) {
-          std::string rhs_str = PythonPrint(rhs, "pi");
+          std::string rhs_str = PythonPrint(rhs, "pl");
           std::istringstream iss(rhs_str);
           std::string line;
           while (std::getline(iss, line)) {

--- a/tests/ut/ir/core/test_tuple_type.py
+++ b/tests/ut/ir/core/test_tuple_type.py
@@ -416,9 +416,9 @@ class TestTuplePythonPrinter:
         assign = ir.AssignStmt(var, ir.ConstInt(0, DataType.INT64, span), span)
 
         result = ir.python_print(assign)
-        assert "pi.Tuple([" in result
-        assert "pi.Int64" in result
-        assert "pi.FP32" in result
+        assert "pl.Tuple([" in result
+        assert "pl.Int64" in result
+        assert "pl.FP32" in result
 
     def test_python_print_tuple_get_item(self):
         """Test Python printing of TupleGetItemExpr."""

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -612,11 +612,11 @@ class TestPythonSyntaxPrinting:
         tensor_type = ir.TensorType(shape, DataType.FP32, memref)
         printed = ir.python_print(tensor_type)
 
-        assert "pi.Tensor" in printed
-        assert "pi.FP32" in printed
+        assert "pl.Tensor" in printed
+        assert "pl.FP32" in printed
         assert "memref=" in printed
-        assert "pi.MemRef" in printed
-        assert "pi.MemorySpace.DDR" in printed
+        assert "pl.MemRef" in printed
+        assert "pl.MemorySpace.DDR" in printed
 
     def test_tile_type_with_memref_and_tileview_print(self):
         """Test printing TileType with MemRef and TileView."""
@@ -634,13 +634,13 @@ class TestPythonSyntaxPrinting:
         tile_type = ir.TileType(shape, DataType.FP16, memref, tv)
         printed = ir.python_print(tile_type)
 
-        assert "pi.Tile" in printed
-        assert "pi.FP16" in printed
+        assert "pl.Tile" in printed
+        assert "pl.FP16" in printed
         assert "memref=" in printed
-        assert "pi.MemRef" in printed
-        assert "pi.MemorySpace.L0A" in printed
+        assert "pl.MemRef" in printed
+        assert "pl.MemorySpace.L0A" in printed
         assert "tile_view=" in printed
-        assert "pi.TileView" in printed
+        assert "pl.TileView" in printed
         assert "valid_shape=" in printed
         assert "stride=" in printed
         assert "start_offset=" in printed
@@ -660,7 +660,7 @@ class TestPythonSyntaxPrinting:
 
         assert "base_addr" in printed
         assert "128" in printed
-        assert "pi.MemorySpace.UB" in printed
+        assert "pl.MemorySpace.UB" in printed
 
 
 class TestIRBuilderHelpers:
@@ -754,12 +754,12 @@ class TestIRBuilderHelpers:
         printed = ir.python_print(tile_t)
 
         # Verify output contains all expected elements
-        assert "pi.Tile" in printed
-        assert "(32, 32)" in printed
-        assert "pi.FP32" in printed
-        assert "memref=pi.MemRef" in printed
-        assert "pi.MemorySpace.L0B" in printed
-        assert "tile_view=pi.TileView" in printed
+        assert "pl.Tile" in printed
+        assert "pl.Tile[[32, 32], pl.FP32," in printed
+        assert "pl.FP32" in printed
+        assert "memref=pl.MemRef" in printed
+        assert "pl.MemorySpace.L0B" in printed
+        assert "tile_view=pl.TileView" in printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/parser/__init__.py
+++ b/tests/ut/ir/parser/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for IR parser."""

--- a/tests/ut/ir/parser/test_control_flow.py
+++ b/tests/ut/ir/parser/test_control_flow.py
@@ -1,0 +1,173 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for control flow parsing (for loops, if statements)."""
+
+import pypto.language as pl
+from pypto.pypto_core import ir
+
+
+class TestForLoops:
+    """Tests for for loop parsing."""
+
+    def test_simple_for_loop(self):
+        """Test simple for loop with one iter_arg."""
+
+        @pl.function
+        def sum_loop(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (sum_val,) in pl.range(10, init_values=[init]):
+                new_sum: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(sum_val, i)
+                result = pl.yeild(new_sum)
+
+            return result
+
+        assert isinstance(sum_loop, ir.Function)
+        assert sum_loop.name == "sum_loop"
+
+    def test_for_loop_multiple_iter_args(self):
+        """Test for loop with multiple iteration arguments."""
+
+        @pl.function
+        def multi_iter(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init1: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+            init2: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (val1, val2) in pl.range(5, init_values=[init1, init2]):
+                new1: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(val1, i)
+                new2: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(val2, 2)
+                out1, out2 = pl.yeild(new1, new2)
+
+            return out1
+
+        assert isinstance(multi_iter, ir.Function)
+
+    def test_for_loop_with_range_params(self):
+        """Test for loop with start, stop, step parameters."""
+
+        @pl.function
+        def range_params(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (acc,) in pl.range(0, 10, 2, init_values=[init]):
+                new_acc: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(acc, i)
+                result = pl.yeild(new_acc)
+
+            return result
+
+        assert isinstance(range_params, ir.Function)
+
+    def test_nested_for_loops(self):
+        """Test nested for loops."""
+
+        @pl.function
+        def nested_loops(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (outer,) in pl.range(3, init_values=[init]):
+                for j, (inner,) in pl.range(2, init_values=[outer]):
+                    new_inner: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(inner, 1)
+                    inner_out = pl.yeild(new_inner)
+
+                outer_out = pl.yeild(inner_out)
+
+            return outer_out
+
+        assert isinstance(nested_loops, ir.Function)
+
+    def test_for_loop_with_operations(self):
+        """Test for loop with tensor operations."""
+
+        @pl.function
+        def loop_ops(x: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 128], pl.FP32]:
+            init: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+
+            for i, (acc,) in pl.range(4, init_values=[init]):
+                temp: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.add(acc, x)
+                result = pl.yeild(temp)
+
+            return result
+
+        assert isinstance(loop_ops, ir.Function)
+
+
+class TestIfStatements:
+    """Tests for if statement parsing.
+
+    Note: If conditions currently require scalar types, not tensors.
+    Tests use scalar loop variables for conditions.
+    """
+
+    def test_if_in_loop(self):
+        """Test if statement inside for loop."""
+
+        @pl.function
+        def if_in_loop(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+
+            for i, (acc,) in pl.range(5, init_values=[init]):
+                if i == 0:
+                    new_val: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(acc, 2.0)
+                    val: pl.Tensor[[64], pl.FP32] = pl.yeild(new_val)
+                else:
+                    val: pl.Tensor[[64], pl.FP32] = pl.yeild(acc)
+
+                result = pl.yeild(val)
+
+            return result
+
+        assert isinstance(if_in_loop, ir.Function)
+
+
+class TestComplexControlFlow:
+    """Tests for complex control flow combinations."""
+
+    def test_loop_with_if_and_multiple_iter_args(self):
+        """Test loop with if statement and multiple iter_args."""
+
+        @pl.function
+        def complex_flow(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64], pl.FP32]:
+            acc1: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+            acc2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+
+            for i, (a1, a2) in pl.range(10, init_values=[acc1, acc2]):
+                if i == 0:
+                    new1: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(a1, 2.0)
+                    new2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(a2, 3.0)
+                    val1, val2 = pl.yeild(new1, new2)
+                else:
+                    val1, val2 = pl.yeild(a1, a2)
+
+                out1, out2 = pl.yeild(val1, val2)
+
+            return out1
+
+        assert isinstance(complex_flow, ir.Function)
+
+    def test_sequential_loops(self):
+        """Test sequential (not nested) for loops."""
+
+        @pl.function
+        def sequential_loops(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+
+            # First loop
+            for i, (acc,) in pl.range(5, init_values=[init]):
+                new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, 1.0)
+                result1 = pl.yeild(new_acc)
+
+            # Second loop uses output of first
+            for j, (acc2,) in pl.range(3, init_values=[result1]):
+                new_acc2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(acc2, 2.0)
+                result2 = pl.yeild(new_acc2)
+
+            return result2
+
+        assert isinstance(sequential_loops, ir.Function)

--- a/tests/ut/ir/parser/test_decorator.py
+++ b/tests/ut/ir/parser/test_decorator.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for @pl.function decorator."""
+
+import pypto
+import pypto.language as pl
+import pytest
+from pypto.pypto_core import ir
+
+
+class TestDecorator:
+    """Tests for @pl.function decorator."""
+
+    def test_simple_function(self):
+        """Test parsing simple function with no control flow."""
+
+        @pl.function
+        def add_tensors(
+            x: pl.Tensor[[64, 128], pl.FP16],
+            y: pl.Tensor[[64, 128], pl.FP16],
+        ) -> pl.Tensor[[64, 128], pl.FP16]:
+            result: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.add(x, y)
+            return result
+
+        assert isinstance(add_tensors, ir.Function)
+        assert add_tensors.name == "add_tensors"
+        assert len(add_tensors.params) == 2
+        assert len(add_tensors.return_types) == 1
+
+    def test_function_with_multiple_statements(self):
+        """Test function with multiple statements."""
+
+        @pl.function
+        def multi_op(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            a: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            b: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(a, 1.0)
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.sub(b, 0.5)
+            return c
+
+        assert isinstance(multi_op, ir.Function)
+        assert multi_op.name == "multi_op"
+
+    def test_function_with_multiple_params(self):
+        """Test function with multiple parameters."""
+
+        @pl.function
+        def three_param(
+            x: pl.Tensor[[64], pl.FP32],
+            y: pl.Tensor[[64], pl.FP32],
+            z: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, y)
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(temp, z)
+            return result
+
+        assert len(three_param.params) == 3
+
+    def test_function_with_tensor_create(self):
+        """Test function that creates tensors."""
+
+        @pl.function
+        def create_tensor(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64, 128], pl.FP32]:
+            result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+            return result
+
+        assert isinstance(create_tensor, ir.Function)
+
+    def test_function_with_binary_ops(self):
+        """Test function with binary operations."""
+
+        @pl.function
+        def binary_ops(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            # Using operator overloading
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(
+                pl.op.tensor.mul(x, 2.0), pl.op.tensor.create([64], dtype=pl.FP32)
+            )
+            return result
+
+        assert isinstance(binary_ops, ir.Function)
+
+    def test_function_with_list_arguments(self):
+        """Test function that uses list arguments."""
+
+        @pl.function
+        def with_lists(x: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[32, 64], pl.FP32]:
+            # view takes list arguments
+            result: pl.Tensor[[32, 64], pl.FP32] = pl.op.tensor.view(x, [32, 64], [0, 0])
+            return result
+
+        assert isinstance(with_lists, ir.Function)
+
+    def test_function_serialization(self):
+        """Test that parsed functions can be serialized."""
+
+        @pl.function
+        def simple(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        # Should be able to serialize
+        data = pypto.ir.serialize(simple)
+        assert len(data) > 0
+
+        # Should be able to deserialize
+        restored = pypto.ir.deserialize(data)
+        assert isinstance(restored, ir.Function)
+        assert restored.name == "simple"
+
+    def test_function_with_different_dtypes(self):
+        """Test function with various data types."""
+
+        @pl.function
+        def dtypes(
+            fp16: pl.Tensor[[64], pl.FP16],
+            fp32: pl.Tensor[[64], pl.FP32],
+            int32: pl.Tensor[[64], pl.INT32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(
+                pl.op.tensor.cast(fp16, target_type=pl.FP32), fp32
+            )
+            return result
+
+        assert len(dtypes.params) == 3
+
+    def test_invalid_function_no_annotations(self):
+        """Test that function without annotations raises error."""
+
+        with pytest.raises(ValueError, match="missing type annotation"):
+
+            @pl.function
+            def no_annotations(x):
+                return x
+
+    def test_function_preserves_name(self):
+        """Test that function name is preserved."""
+
+        @pl.function
+        def my_custom_function_name(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        assert my_custom_function_name.name == "my_custom_function_name"
+
+    def test_function_with_negative_numbers(self):
+        """Test function with negative number literals."""
+
+        @pl.function
+        def with_negatives(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, -1.5)
+            return result
+
+        assert isinstance(with_negatives, ir.Function)

--- a/tests/ut/ir/parser/test_error_cases.py
+++ b/tests/ut/ir/parser/test_error_cases.py
@@ -1,0 +1,254 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for parser error handling."""
+
+import pypto
+import pypto.language as pl
+import pytest
+
+
+class TestErrorCases:
+    """Tests for parser error handling and validation."""
+
+    def test_missing_parameter_annotation(self):
+        """Test error when parameter lacks type annotation."""
+
+        with pytest.raises(ValueError, match="missing type annotation"):
+
+            @pl.function
+            def no_annotation(x):
+                return x
+
+    def test_missing_return_annotation(self):
+        """Test function without return annotation still works."""
+
+        @pl.function
+        def no_return_type(x: pl.Tensor[[64], pl.FP32]):
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            return result
+
+        # Should still parse successfully
+        assert isinstance(no_return_type, pypto.ir.Function)
+
+    def test_undefined_variable_reference(self):
+        """Test error when referencing undefined variable."""
+
+        with pytest.raises(ValueError, match="Undefined variable"):
+
+            @pl.function
+            def undefined_var(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, undefined)  # noqa: F821 # type: ignore
+                return result
+
+    def test_invalid_tensor_type_syntax(self):
+        """Test error on invalid tensor type syntax."""
+
+        with pytest.raises((ValueError, TypeError)):
+
+            @pl.function
+            def invalid_type(x: pl.Tensor) -> pl.Tensor[[64], pl.FP32]:  # type: ignore
+                return x
+
+    def test_iter_arg_init_values_mismatch(self):
+        """Test error when iter_args don't match init_values count."""
+
+        with pytest.raises(ValueError, match="Mismatch"):
+
+            @pl.function
+            def mismatch(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                init1: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+                init2: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+                # 3 iter_args but only 2 init_values
+                for i, (v1, v2, v3) in pl.range(5, init_values=[init1, init2]):
+                    out1, out2, out3 = pl.yeild(v1, v2, v3)
+
+                return out1
+
+    def test_unsupported_statement_type(self):
+        """Test error on unsupported Python statement."""
+
+        with pytest.raises(ValueError, match="Unsupported statement"):
+
+            @pl.function
+            def unsupported(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # Try/except is not supported
+                try:
+                    result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+                except:  # noqa: E722
+                    result: pl.Tensor[[64], pl.FP32] = x
+                return result
+
+    def test_invalid_range_usage(self):
+        """Test error when for loop doesn't use pl.range()."""
+
+        with pytest.raises(ValueError, match=r"must use pl\.range\(\)"):
+
+            @pl.function
+            def invalid_loop(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = n
+                # Using Python range() instead of pl.range()
+                for i in range(10):
+                    result = pl.op.tensor.add(result, 1)
+                return result
+
+    def test_invalid_loop_target_format(self):
+        """Test error on invalid for loop target format."""
+
+        with pytest.raises(ValueError, match="target must be"):
+
+            @pl.function
+            def bad_target(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+                # Missing iter_args tuple
+                for i in pl.range(5, init_values=[init]):
+                    result = pl.yeild(i)
+
+                return result
+
+    def test_unknown_tensor_operation(self):
+        """Test error on unknown tensor operation."""
+
+        with pytest.raises(ValueError, match="Unknown tensor operation"):
+
+            @pl.function
+            def unknown_op(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # nonexistent_op doesn't exist
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.nonexistent_op(x)  # type: ignore
+                return result
+
+
+class TestSSAValidation:
+    """Tests for SSA validation."""
+
+    def test_ssa_violation_double_assignment(self):
+        """Test that double assignment in same scope is caught."""
+
+        with pytest.raises(Exception):  # Will raise either SSAViolationError or ValueError
+
+            @pl.function
+            def double_assign(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # First assignment
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+                # Second assignment (SSA violation)
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+                return result
+
+    def test_variable_from_inner_scope_not_accessible(self):
+        """Test that variables from inner scopes aren't accessible without yield."""
+
+        # Note: This test demonstrates the expected behavior
+        # The current implementation tracks yields, so this should work correctly
+        @pl.function
+        def scope_test(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+
+            for i, (acc,) in pl.range(5, init_values=[init]):
+                temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, 1.0)
+                # temp is yielded, so it's accessible as 'result'
+                result = pl.yeild(temp)
+
+            # Can return result because it was yielded from loop
+            return result
+
+        assert isinstance(scope_test, pypto.ir.Function)
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_empty_function_body(self):
+        """Test function with minimal body (just return)."""
+
+        @pl.function
+        def minimal(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        assert isinstance(minimal, pypto.ir.Function)
+
+    def test_single_dimension_tensor(self):
+        """Test tensor with single dimension."""
+
+        @pl.function
+        def single_dim(x: pl.Tensor[[128], pl.FP32]) -> pl.Tensor[[128], pl.FP32]:
+            result: pl.Tensor[[128], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            return result
+
+        assert isinstance(single_dim, pypto.ir.Function)
+
+    def test_three_dimension_tensor(self):
+        """Test tensor with three dimensions."""
+
+        @pl.function
+        def three_dim(
+            x: pl.Tensor[[64, 128, 256], pl.FP32],
+        ) -> pl.Tensor[[64, 128, 256], pl.FP32]:
+            return x
+
+        assert isinstance(three_dim, pypto.ir.Function)
+
+    def test_loop_with_range_one(self):
+        """Test loop that executes only once."""
+
+        @pl.function
+        def one_iteration(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            for i, (acc,) in pl.range(1, init_values=[x]):
+                result = pl.yeild(acc)
+
+            return result
+
+        assert isinstance(one_iteration, pypto.ir.Function)
+
+    def test_loop_with_start_stop_step(self):
+        """Test loop with start, stop, and step parameters."""
+
+        @pl.function
+        def custom_range(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            for i, (acc,) in pl.range(2, 10, 2, init_values=[x]):
+                new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, 1.0)
+                result = pl.yeild(new_acc)
+
+            return result
+
+        assert isinstance(custom_range, pypto.ir.Function)
+
+    def test_function_with_many_variables(self):
+        """Test function with many local variables."""
+
+        @pl.function
+        def many_vars(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            v1: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+            v2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v1, 2.0)
+            v3: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v2, 3.0)
+            v4: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v3, 4.0)
+            v5: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v4, 5.0)
+            v6: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v5, 6.0)
+            v7: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v6, 7.0)
+            v8: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v7, 8.0)
+            v9: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v8, 9.0)
+            v10: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v9, 10.0)
+            return v10
+
+        assert isinstance(many_vars, pypto.ir.Function)
+
+    def test_different_shape_tensors(self):
+        """Test function with tensors of different shapes."""
+
+        @pl.function
+        def diff_shapes(
+            a: pl.Tensor[[64], pl.FP32],
+            b: pl.Tensor[[128], pl.FP32],
+            c: pl.Tensor[[256], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            return a
+
+        assert isinstance(diff_shapes, pypto.ir.Function)
+        assert len(diff_shapes.params) == 3

--- a/tests/ut/ir/parser/test_flash_attention.py
+++ b/tests/ut/ir/parser/test_flash_attention.py
@@ -1,0 +1,313 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Integration test for flash_attention.py parsing."""
+
+import pypto
+import pypto.language as pl
+import pytest
+from pypto.pypto_core import ir
+
+
+@pl.function
+def flash_attn(
+    q_13: pl.Tensor[[64, 128], pl.FP16],
+    k_16: pl.Tensor[[1024, 128], pl.FP16],
+    v_19: pl.Tensor[[1024, 128], pl.FP16],
+) -> pl.Tensor[[64, 128], pl.FP32]:
+    attn_initial: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+    oi_update_initial: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+    li_update_initial: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create([64, 1], dtype=pl.FP32)
+    mi_update_initial: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create([64, 1], dtype=pl.FP32)
+
+    # statement.for with iter_args → pl.range with tuple unpacking
+    for i, (mi_update, li_update, attn_update, oi_update) in pl.range(
+        16,
+        init_values=[
+            mi_update_initial,
+            li_update_initial,
+            attn_initial,
+            oi_update_initial,
+        ],
+    ):
+        # Inner statement.block
+        kj: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.view(k_16, [64, 128], [i * 64, 0])
+        vj: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.view(v_19, [64, 128], [i * 64, 0])
+        sij: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+            q_13, kj, out_dtype=pl.FP16, a_trans=False, b_trans=True, c_matrix_nz=False
+        )
+        sij_1: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.mul(sij, 0.0883883)
+        row_max: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.row_max(sij_1, axis=-1, keep_dim=1)
+        sub: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.sub(sij_1, row_max)
+        p_ij: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.exp(sub)
+        l_ij: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.row_sum(p_ij, axis=-1, keep_dim=1)
+        tildaPij_83: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.cast(
+            p_ij, target_type=pl.FP16, mode="round"
+        )
+
+        # Nested if with yield (SSA phi node)
+        if i == 0:
+            # Inner statement.block
+            oiUpdate_87: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+                tildaPij_83, vj, out_dtype=pl.FP16
+            )
+            oiUpdate_90: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.assemble(
+                oi_update, oiUpdate_87, offset=[0, 0]
+            )
+
+            # Nested if inside first branch
+            if i == 15:
+                attn_94: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.div(oiUpdate_90, l_ij)
+                attn_95: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_94)
+            else:
+                attn_95: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_update)
+
+            # More statements in first branch
+            liUpdate_98: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(li_update, l_ij, offset=[0, 0])
+            miUpdate_101: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(
+                mi_update, row_max, offset=[0, 0]
+            )
+
+            # statement.yield → pl.yeild with assignment
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129 = pl.yeild(
+                miUpdate_101, liUpdate_98, attn_95, oiUpdate_90
+            )
+        else:
+            # Else branch
+            mi_102: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create(shape=[64, 1], dtype=pl.FP32)
+            miUpdate_103: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.maximum(mi_102, row_max)
+            t1_104: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.sub(mi_102, miUpdate_103)
+            t2_105: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.exp(t1_104)
+            t3_106: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.sub(row_max, miUpdate_103)
+            t4_107: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.exp(t3_106)
+            t5_108: pl.Tensor[[64, 1], pl.FP16] = pl.op.tensor.mul(t4_107, l_ij)
+            t6_109: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.mul(t2_105, li_update)
+            liUpdate_110: pl.Tensor[pl.FP32, 64, 1] = pl.op.tensor.add(t6_109, t5_108)
+            liUpdate_113: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.assemble(
+                li_update, liUpdate_110, offset=[0, 0]
+            )
+            q3_114: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.mul(oi_update, t2_105)
+            q1_115: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.matmul(
+                tildaPij_83,
+                vj,
+                out_dtype=pl.FP16,
+                a_trans=False,
+                b_trans=False,
+                c_matrix_nz=False,
+            )
+            q2_116: pl.Tensor[[64, 128], pl.FP16] = pl.op.tensor.mul(q1_115, t4_107)
+            oiUpdate_117: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.add(q3_114, q2_116)
+            oiUpdate_120: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.assemble(
+                oi_update, oiUpdate_117, offset=[0, 0]
+            )
+
+            # Nested if in else branch
+            if i == 15:
+                attn_124: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.div(oiUpdate_120, liUpdate_113)
+                attn_125: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_124)
+            else:
+                attn_125: pl.Tensor[[64, 128], pl.FP32] = pl.yeild(attn_update)
+
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129 = pl.yeild(
+                miUpdate_103, liUpdate_113, attn_125, oiUpdate_120
+            )
+
+        # For loop yield (updates iter_args for next iteration)
+        mi_final, li_final, attn_final, oi_final = pl.yeild(
+            miUpdate_126, liUpdate_127, attn_128, oiUpdate_129
+        )
+    return attn_final
+
+
+class TestFlashAttention:
+    """Integration tests using flash_attention.py as example."""
+
+    def test_flash_attention_parses(self):
+        """Test that flash_attention.py parses successfully."""
+        # Import the flash_attention module which has @pl.function decorator
+        assert isinstance(flash_attn, ir.Function)
+        assert flash_attn.name == "flash_attn"
+
+    def test_flash_attention_has_correct_params(self):
+        """Test flash_attention has correct parameters."""
+
+        assert len(flash_attn.params) == 3
+        # Should have q, k, v parameters
+
+    def test_flash_attention_has_return_type(self):
+        """Test flash_attention has return type."""
+
+        assert len(flash_attn.return_types) == 1
+
+    def test_flash_attention_serializes(self):
+        """Test flash_attention can be serialized."""
+
+        # Should be able to serialize
+        data = pypto.ir.serialize(flash_attn)
+        assert len(data) > 0
+
+        # Should be able to deserialize
+        restored = pypto.ir.deserialize(data)
+        assert isinstance(restored, ir.Function)
+        assert restored.name == "flash_attn"
+        assert len(restored.params) == 3
+
+    def test_flash_attention_round_trip(self):
+        """Test flash_attention serialization round-trip."""
+
+        # Serialize, deserialize, serialize again
+        data1 = pypto.ir.serialize(flash_attn)
+        restored = pypto.ir.deserialize(data1)
+        data2 = pypto.ir.serialize(restored)
+
+        # Second restoration
+        restored2 = pypto.ir.deserialize(data2)
+
+        assert isinstance(restored2, ir.Function)
+
+        # Should have same structure
+        assert restored2.name == flash_attn.name
+        assert len(restored2.params) == len(flash_attn.params)
+
+    def test_flash_attention_with_multiple_iter_args(self):
+        """Test flash attention pattern with multiple iteration arguments."""
+
+        @pl.function
+        def multi_iter_attn(
+            q: pl.Tensor[[64, 128], pl.FP16],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            attn: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.create([64, 128], dtype=pl.FP32)
+            scale: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.create([64, 1], dtype=pl.FP32)
+
+            for i, (attn_val, scale_val) in pl.range(4, init_values=[attn, scale]):
+                # Update both
+                new_attn: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.mul(attn_val, 1.1)
+                new_scale: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.add(scale_val, 0.1)
+
+                attn_out, scale_out = pl.yeild(new_attn, new_scale)
+
+            return attn_out
+
+        assert isinstance(multi_iter_attn, ir.Function)
+
+    def test_flash_attention_ops(self):
+        """Test individual operations used in flash attention."""
+
+        @pl.function
+        def test_ops(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+            # Test operations used in flash attention
+
+            # Cast
+            fp32: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.cast(x, target_type=pl.FP32, mode="round")
+
+            # Mul
+            scaled: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.mul(fp32, 0.5)
+
+            # Row max
+            row_max_val: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.row_max(scaled, axis=-1, keep_dim=1)
+
+            # Sub
+            normalized: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.sub(scaled, row_max_val)
+
+            # Exp
+            exped: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.exp(normalized)
+
+            # Row sum
+            row_sum_val: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.row_sum(exped, axis=-1, keep_dim=1)
+
+            # Div
+            result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.div(exped, row_sum_val)
+
+            return result
+
+        assert isinstance(test_ops, ir.Function)
+
+
+class TestParserRobustness:
+    """Tests for parser robustness and edge cases."""
+
+    def test_large_tensor_shapes(self):
+        """Test parsing with large tensor shapes."""
+
+        @pl.function
+        def large_shapes(
+            x: pl.Tensor[[1024, 2048, 512], pl.FP32],
+        ) -> pl.Tensor[[1024, 2048, 512], pl.FP32]:
+            return x
+
+        assert isinstance(large_shapes, ir.Function)
+
+    def test_many_parameters(self):
+        """Test function with many parameters."""
+
+        @pl.function
+        def many_params(
+            a: pl.Tensor[[64], pl.FP32],
+            b: pl.Tensor[[64], pl.FP32],
+            c: pl.Tensor[[64], pl.FP32],
+            d: pl.Tensor[[64], pl.FP32],
+            e: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            temp1: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(a, b)
+            temp2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(c, d)
+            temp3: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(temp1, temp2)
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(temp3, e)
+            return result
+
+        assert len(many_params.params) == 5
+
+    def test_deep_nesting(self):
+        """Test deeply nested control flow."""
+
+        @pl.function
+        def deep_nesting(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+
+            for i, (v1,) in pl.range(2, init_values=[init]):
+                for j, (v2,) in pl.range(2, init_values=[v1]):
+                    if i == 0:
+                        if j == 0:
+                            inner: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(v2, 2.0)
+                            ir: pl.Tensor[[64], pl.FP32] = pl.yeild(inner)
+                        else:
+                            ir: pl.Tensor[[64], pl.FP32] = pl.yeild(v2)
+                        or_: pl.Tensor[[64], pl.FP32] = pl.yeild(ir)
+                    else:
+                        or_: pl.Tensor[[64], pl.FP32] = pl.yeild(v2)
+
+                    jr = pl.yeild(or_)
+
+                ir_out = pl.yeild(jr)
+
+            return ir_out
+
+        assert isinstance(deep_nesting, ir.Function)
+
+    def test_long_function(self):
+        """Test function with many statements."""
+
+        @pl.function
+        def long_function(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            v1: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+            v2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v1, 1.0)
+            v3: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v2, 1.0)
+            v4: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v3, 1.0)
+            v5: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v4, 1.0)
+            v6: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v5, 1.0)
+            v7: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v6, 1.0)
+            v8: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v7, 1.0)
+            v9: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v8, 1.0)
+            v10: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(v9, 1.0)
+            return v10
+
+        assert isinstance(long_function, ir.Function)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_printer_integration.py
+++ b/tests/ut/ir/parser/test_printer_integration.py
@@ -1,0 +1,77 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Integration tests for parser and printer round-trip."""
+
+import pypto
+import pypto.language as pl
+from pypto.pypto_core import DataType, ir
+
+
+class TestPrinterIntegration:
+    """Tests for printer integration with new subscript syntax."""
+
+    def test_tensor_type_printed_with_subscript(self):
+        """Test that TensorType is printed with subscript notation."""
+        tensor_type = ir.TensorType([64, 128], DataType.FP16)
+
+        result = pypto.ir.python_print(tensor_type)
+
+        # Should use subscript notation
+        assert "pl.Tensor[[64, 128], pl.FP16]" in result
+        # Should NOT use call notation
+        assert "pl.Tensor((" not in result
+
+    def test_tile_type_printed_with_subscript(self):
+        """Test that TileType is printed with subscript notation."""
+        tile_type = ir.TileType([16, 16], DataType.FP32)
+
+        result = pypto.ir.python_print(tile_type)
+
+        # Should use subscript notation
+        assert "pl.Tile[[16, 16], pl.FP32]" in result
+        # Should NOT use call notation
+        assert "pl.Tile((" not in result
+
+    def test_function_printed_with_subscript_types(self):
+        """Test that function parameters use subscript notation."""
+
+        @pl.function
+        def test_func(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[64, 128], pl.FP32]:
+            result: pl.Tensor[[64, 128], pl.FP32] = pl.op.tensor.cast(x, target_type=pl.FP32)
+            return result
+
+        # Print the function
+        printed = pypto.ir.python_print(test_func)
+
+        # Check subscript notation is used
+        assert "pl.Tensor[[64, 128], pl.FP16]" in printed
+        assert "pl.Tensor[[64, 128], pl.FP32]" in printed
+        # Check old notation is NOT used
+        assert "pl.Tensor((" not in printed
+
+    def test_parsed_function_printer_round_trip(self):
+        """Test that parsed functions can be printed correctly."""
+
+        @pl.function
+        def round_trip(
+            x: pl.Tensor[[64], pl.FP32],
+            y: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            sum_val: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, y)
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(sum_val, 2.0)
+            return result
+
+        # Print and check syntax
+        printed = pypto.ir.python_print(round_trip)
+
+        assert "def round_trip" in printed
+        assert "pl.Tensor[[64], pl.FP32]" in printed
+        # Printer uses simplified tensor operation notation
+        assert "tensor.add" in printed or "pl.op.tensor.add" in printed

--- a/tests/ut/ir/parser/test_scope_manager.py
+++ b/tests/ut/ir/parser/test_scope_manager.py
@@ -1,0 +1,162 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ScopeManager."""
+
+import pytest
+from pypto.ir.parser.scope_manager import ScopeManager, SSAViolationError
+
+
+class TestScopeManager:
+    """Tests for ScopeManager class."""
+
+    def test_initialization(self):
+        """Test ScopeManager initializes correctly."""
+        sm = ScopeManager()
+
+        assert len(sm.scopes) == 1  # Global scope
+        assert sm.current_scope_type() == "global"
+
+    def test_enter_exit_scope(self):
+        """Test entering and exiting scopes."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        assert len(sm.scopes) == 2
+        assert sm.current_scope_type() == "function"
+
+        sm.exit_scope()
+        assert len(sm.scopes) == 1
+        assert sm.current_scope_type() == "global"
+
+    def test_nested_scopes(self):
+        """Test nested scope management."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.enter_scope("for")
+        sm.enter_scope("if")
+
+        assert len(sm.scopes) == 4  # global + function + for + if
+        assert sm.current_scope_type() == "if"
+
+        sm.exit_scope()
+        assert sm.current_scope_type() == "for"
+
+        sm.exit_scope()
+        assert sm.current_scope_type() == "function"
+
+    def test_define_var(self):
+        """Test defining variables in scope."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.define_var("x", "value_x")
+
+        assert sm.is_defined("x")
+        assert sm.lookup_var("x") == "value_x"
+
+    def test_ssa_violation(self):
+        """Test SSA violation detection."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.define_var("x", "value1")
+
+        # Trying to redefine should raise SSAViolationError
+        with pytest.raises(SSAViolationError, match="already defined"):
+            sm.define_var("x", "value2")
+
+    def test_allow_redef(self):
+        """Test allowing redefinition for special cases."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.define_var("x", "value1", allow_redef=True)
+        sm.define_var("x", "value2", allow_redef=True)  # Should not raise
+
+        assert sm.lookup_var("x") == "value2"
+
+    def test_variable_shadowing(self):
+        """Test that variables in inner scopes shadow outer scopes."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.define_var("x", "outer")
+
+        sm.enter_scope("for")
+        sm.define_var("x", "inner")
+
+        # Inner scope should see inner value
+        assert sm.lookup_var("x") == "inner"
+
+        sm.exit_scope()
+        # Outer scope should see outer value
+        assert sm.lookup_var("x") == "outer"
+
+    def test_lookup_undefined_var(self):
+        """Test looking up undefined variable returns None."""
+        sm = ScopeManager()
+
+        assert sm.lookup_var("undefined") is None
+        assert not sm.is_defined("undefined")
+
+    def test_mark_yielded(self):
+        """Test marking variables as yielded."""
+        sm = ScopeManager()
+
+        sm.enter_scope("for")
+        sm.mark_yielded("result")
+
+        yielded = sm.get_yielded_vars()
+        assert "result" in yielded
+
+    def test_in_scope_type(self):
+        """Test checking if in specific scope type."""
+        sm = ScopeManager()
+
+        assert sm.in_scope_type("global")
+        assert not sm.in_scope_type("function")
+
+        sm.enter_scope("function")
+        assert sm.in_scope_type("function")
+        assert sm.in_scope_type("global")  # Still in global too
+
+        sm.enter_scope("for")
+        assert sm.in_scope_type("for")
+        assert sm.in_scope_type("function")
+
+    def test_exit_global_scope_error(self):
+        """Test that exiting global scope raises error."""
+        sm = ScopeManager()
+
+        with pytest.raises(RuntimeError, match="Cannot exit global scope"):
+            sm.exit_scope()
+
+    def test_scope_isolation(self):
+        """Test that scope variables are properly isolated."""
+        sm = ScopeManager()
+
+        sm.enter_scope("function")
+        sm.define_var("x", "func_var")
+
+        sm.enter_scope("for")
+        sm.define_var("y", "loop_var")
+
+        # Both variables should be accessible in inner scope
+        assert sm.is_defined("x")
+        assert sm.is_defined("y")
+
+        scope_vars = sm.exit_scope()
+
+        # After exiting, loop variable should not be in function scope
+        assert "y" in scope_vars
+        assert sm.is_defined("x")
+        # y is no longer accessible after exiting its scope
+        assert not sm.is_defined("y")

--- a/tests/ut/ir/parser/test_span_tracker.py
+++ b/tests/ut/ir/parser/test_span_tracker.py
@@ -1,0 +1,104 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for SpanTracker."""
+
+import ast
+
+from pypto.ir.parser.span_tracker import SpanTracker
+from pypto.pypto_core import ir
+
+
+class TestSpanTracker:
+    """Tests for SpanTracker class."""
+
+    def test_initialization(self):
+        """Test SpanTracker initializes correctly."""
+        source_file = "test.py"
+        source_lines = ["line1", "line2"]
+
+        tracker = SpanTracker(source_file, source_lines)
+
+        assert tracker.source_file == source_file
+        assert tracker.source_lines == source_lines
+
+    def test_get_span_from_node(self):
+        """Test getting span from AST node."""
+        source_file = "test.py"
+        source = "x = 42"
+        source_lines = source.split("\n")
+
+        tracker = SpanTracker(source_file, source_lines)
+
+        # Parse and get AST node
+        tree = ast.parse(source)
+        assign_node = tree.body[0]
+
+        span = tracker.get_span(assign_node)
+
+        assert isinstance(span, ir.Span)
+        assert span.filename == source_file
+        assert span.begin_line == 1
+        assert span.begin_column == 0
+
+    def test_get_span_none_node(self):
+        """Test getting span from None node returns unknown span."""
+        tracker = SpanTracker("test.py", [])
+
+        span = tracker.get_span(None)
+
+        # Should return unknown span
+        assert isinstance(span, ir.Span)
+
+    def test_get_multiline_span(self):
+        """Test getting span covering multiple lines."""
+        source_file = "test.py"
+        source = """def func():
+    x = 1
+    y = 2"""
+        source_lines = source.split("\n")
+
+        tracker = SpanTracker(source_file, source_lines)
+
+        tree = ast.parse(source)
+        func_node = tree.body[0]
+        assert isinstance(func_node, ast.FunctionDef)
+        first_stmt = func_node.body[0]
+        last_stmt = func_node.body[-1]
+
+        span = tracker.get_multiline_span(first_stmt, last_stmt)
+
+        assert isinstance(span, ir.Span)
+        assert span.filename == source_file
+        assert span.begin_line == 2  # First statement line
+        assert span.end_line == 3  # Last statement line
+
+    def test_get_multiline_span_same_line(self):
+        """Test multiline span on same line."""
+        tracker = SpanTracker("test.py", ["x = y + z"])
+
+        source = "x = y + z"
+        tree = ast.parse(source)
+        node = tree.body[0]
+
+        span = tracker.get_multiline_span(node, node)
+
+        assert span.begin_line == span.end_line
+
+    def test_span_preserves_filename(self):
+        """Test that span preserves the source filename."""
+        source_file = "/path/to/my_module.py"
+        tracker = SpanTracker(source_file, ["code"])
+
+        tree = ast.parse("x = 1")
+        node = tree.body[0]
+
+        span = tracker.get_span(node)
+
+        assert span.filename == source_file

--- a/tests/ut/ir/parser/test_type_resolver.py
+++ b/tests/ut/ir/parser/test_type_resolver.py
@@ -1,0 +1,134 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for TypeResolver."""
+
+import ast
+
+import pytest
+from pypto.ir.parser.type_resolver import TypeResolver
+from pypto.pypto_core import DataType, ir
+
+
+class TestTypeResolver:
+    """Tests for TypeResolver class."""
+
+    def test_resolve_tensor_type_subscript(self):
+        """Test resolving tensor type with subscript notation."""
+        resolver = TypeResolver()
+
+        # Parse: pl.Tensor[[64, 128], pl.FP16]
+        code = "pl.Tensor[[64, 128], pl.FP16]"
+        node = ast.parse(code, mode="eval").body
+
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.TensorType)
+        assert len(result.shape) == 2
+        # Shape elements are ConstInt expressions
+        assert result.dtype == DataType.FP16
+
+    def test_resolve_tensor_type_different_dtypes(self):
+        """Test resolving tensor types with different data types."""
+        resolver = TypeResolver()
+
+        test_cases = [
+            ("pl.Tensor[[64], pl.FP32]", DataType.FP32),
+            ("pl.Tensor[[32, 64], pl.INT32]", DataType.INT32),
+            ("pl.Tensor[[1, 2, 3], pl.FP16]", DataType.FP16),
+        ]
+
+        for code, expected_dtype in test_cases:
+            node = ast.parse(code, mode="eval").body
+            result = resolver.resolve_type(node)
+
+            assert isinstance(result, ir.TensorType)
+            assert result.dtype == expected_dtype
+
+    def test_resolve_dtype_attribute(self):
+        """Test resolving dtype from attribute access."""
+        resolver = TypeResolver()
+
+        # Parse: pl.FP16
+        code = "pl.FP16"
+        node = ast.parse(code, mode="eval").body
+
+        result = resolver.resolve_dtype(node)
+        assert result == DataType.FP16
+
+    def test_resolve_dtype_all_types(self):
+        """Test all supported dtype values."""
+        resolver = TypeResolver()
+
+        dtypes = [
+            ("pl.FP16", DataType.FP16),
+            ("pl.FP32", DataType.FP32),
+            ("pl.INT32", DataType.INT32),
+            ("pl.INT64", DataType.INT64),
+            ("pl.BOOL", DataType.BOOL),
+        ]
+
+        for code, expected in dtypes:
+            node = ast.parse(code, mode="eval").body
+            result = resolver.resolve_dtype(node)
+            assert result == expected
+
+    def test_resolve_invalid_dtype(self):
+        """Test error on invalid dtype."""
+        resolver = TypeResolver()
+
+        code = "pl.INVALID_TYPE"
+        node = ast.parse(code, mode="eval").body
+
+        with pytest.raises(ValueError, match="Unknown dtype"):
+            resolver.resolve_dtype(node)
+
+    def test_resolve_invalid_tensor_syntax(self):
+        """Test error on invalid tensor syntax."""
+        resolver = TypeResolver()
+
+        # Missing dtype
+        code = "pl.Tensor[[64, 128]]"
+        node = ast.parse(code, mode="eval").body
+
+        with pytest.raises(ValueError, match="requires"):
+            resolver.resolve_type(node)
+
+    def test_parse_shape_list(self):
+        """Test parsing shape from list literal."""
+        resolver = TypeResolver()
+
+        code = "[64, 128, 256]"
+        node = ast.parse(code, mode="eval").body
+
+        shape = resolver._parse_shape(node)
+        assert len(shape) == 3
+        assert shape == [64, 128, 256]
+
+    def test_parse_shape_tuple(self):
+        """Test parsing shape from tuple literal."""
+        resolver = TypeResolver()
+
+        code = "(32, 64)"
+        node = ast.parse(code, mode="eval").body
+
+        shape = resolver._parse_shape(node)
+        assert len(shape) == 2
+        assert shape == [32, 64]
+
+    def test_parse_shape_invalid(self):
+        """Test error on invalid shape."""
+        resolver = TypeResolver()
+
+        # Non-constant shape dimension
+        code = "x"
+        node = ast.parse(code, mode="eval").body
+
+        with pytest.raises(ValueError, match="must be tuple or list"):
+            resolver._parse_shape(node)

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -50,9 +50,9 @@ def test_python_print_assignment_with_type_annotation():
     assign = ir.AssignStmt(x, c, span)
 
     result = ir.python_print(assign)
-    # Should have type annotation with default "pi" prefix
+    # Should have type annotation with default "pl" prefix
     assert "x:" in result or "x :" in result
-    assert "pi.Int64" in result
+    assert "pl.Int64" in result
     assert "42" in result
 
 
@@ -70,7 +70,7 @@ def test_python_print_tensor_type_annotation():
     result = ir.python_print(assign)
 
     assert "a:" in result or "a :" in result
-    assert "pi.Tensor((64, 128), pi.FP32)" in result
+    assert "pl.Tensor[[64, 128], pl.FP32]" in result
 
 
 def test_python_print_function_with_annotations():
@@ -94,7 +94,7 @@ def test_python_print_function_with_annotations():
     assert "def add_func" in result
     assert "x:" in result or "x :" in result
     assert "y:" in result or "y :" in result
-    assert "pi.Int64" in result
+    assert "pl.Int64" in result
     assert "->" in result  # Return type annotation
 
 
@@ -111,9 +111,9 @@ def test_python_print_program():
 
     result = ir.python_print(program)
 
-    # Check for program header with default "pi" prefix
+    # Check for program header with default "pl" prefix
     assert "# pypto.program: test_program" in result
-    assert "import pypto.ir as pi" in result
+    assert "import pypto.language as pl" in result
     assert "def simple_func" in result
 
 
@@ -155,7 +155,7 @@ def test_python_print_for_stmt_basic():
 
     assert "for" in result
     assert "for i in range" in result  # No type annotation in for loop header
-    assert "pi.Int64" in result  # Type annotation in body assignment
+    assert "pl.Int64" in result  # Type annotation in body assignment
     assert "range" in result
     assert "0" in result
     assert "10" in result
@@ -360,7 +360,7 @@ def test_python_print_tile_type():
     result = ir.python_print(assign)
 
     assert "t:" in result
-    assert "pi.Tile((16, 16), pi.FP16)" in result
+    assert "pl.Tile[[16, 16], pl.FP16]" in result
 
 
 def test_python_print_all_scalar_types():
@@ -368,17 +368,17 @@ def test_python_print_all_scalar_types():
     span = ir.Span.unknown()
 
     type_map = [
-        (DataType.INT8, "pi.Int8"),
-        (DataType.INT16, "pi.Int16"),
-        (DataType.INT32, "pi.Int32"),
-        (DataType.INT64, "pi.Int64"),
-        (DataType.UINT8, "pi.UInt8"),
-        (DataType.UINT16, "pi.UInt16"),
-        (DataType.UINT32, "pi.UInt32"),
-        (DataType.UINT64, "pi.UInt64"),
-        (DataType.FP16, "pi.FP16"),
-        (DataType.FP32, "pi.FP32"),
-        (DataType.BF16, "pi.BFloat16"),
+        (DataType.INT8, "pl.Int8"),
+        (DataType.INT16, "pl.Int16"),
+        (DataType.INT32, "pl.Int32"),
+        (DataType.INT64, "pl.Int64"),
+        (DataType.UINT8, "pl.UInt8"),
+        (DataType.UINT16, "pl.UInt16"),
+        (DataType.UINT32, "pl.UInt32"),
+        (DataType.UINT64, "pl.UInt64"),
+        (DataType.FP16, "pl.FP16"),
+        (DataType.FP32, "pl.FP32"),
+        (DataType.BF16, "pl.BFloat16"),
     ]
 
     for dtype, expected_str in type_map:
@@ -427,7 +427,7 @@ def test_python_print_complex_nested_function():
     # Verify structure
     assert "def loop_sum" in result
     assert "n:" in result
-    assert "pi.Int64" in result
+    assert "pl.Int64" in result
     assert "for" in result
     assert "range" in result
     assert "return" in result  # Functions use return, not yield
@@ -453,9 +453,9 @@ def test_python_print_program_with_multiple_functions():
     program = ir.Program([func1, func2], "multi_func_program", span)
     result = ir.python_print(program)
 
-    # Check program structure with default "pi" prefix
+    # Check program structure with default "pl" prefix
     assert "# pypto.program: multi_func_program" in result
-    assert "import pypto.ir as pi" in result
+    assert "import pypto.language as pl" in result
     assert "def func1" in result
     assert "def func2" in result
 
@@ -468,10 +468,10 @@ def test_python_print_str_method():
     c = ir.ConstInt(42, dtype, span)
     assign = ir.AssignStmt(x, c, span)
 
-    # str() should use Python printer with default "pi" prefix
+    # str() should use Python printer with default "pl" prefix
     str_result = str(assign)
     # Should include type annotation
-    assert "pi.Int64" in str_result or "Int64" in str_result
+    assert "pl.Int64" in str_result or "Int64" in str_result
 
 
 def test_python_print_custom_prefix():
@@ -482,9 +482,9 @@ def test_python_print_custom_prefix():
     c = ir.ConstInt(42, dtype, span)
     assign = ir.AssignStmt(x, c, span)
 
-    # Test default prefix "pi"
+    # Test default prefix "pl"
     result_pi = ir.python_print(assign)
-    assert "pi.Int64" in result_pi
+    assert "pl.Int64" in result_pi
 
     # Test "ir" prefix
     result_ir = ir.python_print(assign, "ir")
@@ -498,19 +498,19 @@ def test_python_print_custom_prefix():
     func = ir.Function("test", [x], [ir.ScalarType(dtype)], assign, span)
     program = ir.Program([func], "test_prog", span)
 
-    # Default "pi" should use "import pypto.ir as pi"
+    # Default "pl" should use "import pypto.language as pl"
     prog_pi = ir.python_print(program)
-    assert "import pypto.ir as pi" in prog_pi
-    assert "pi.Int64" in prog_pi
+    assert "import pypto.language as pl" in prog_pi
+    assert "pl.Int64" in prog_pi
 
     # "ir" prefix should use "from pypto import ir"
-    prog_ir = ir.python_print(program, "ir")
-    assert "from pypto import ir" in prog_ir
-    assert "ir.Int64" in prog_ir
+    prog_ir = ir.python_print(program, "language")
+    assert "from pypto import language" in prog_ir
+    assert "language.Int64" in prog_ir
 
     # Custom prefix should use "import pypto.ir as <prefix>"
     prog_custom = ir.python_print(program, "custom")
-    assert "import pypto.ir as custom" in prog_custom
+    assert "import pypto.language as custom" in prog_custom
     assert "custom.Int64" in prog_custom
 
 

--- a/tests/ut/ir/statements/test_op_stmts.py
+++ b/tests/ut/ir/statements/test_op_stmts.py
@@ -125,7 +125,7 @@ class TestOpStmtsPrinting:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         assign = ir.AssignStmt(x, y, span)
         op_stmts = ir.OpStmts([assign], span)
-        assert str(op_stmts) == "x: pi.Int64 = y"
+        assert str(op_stmts) == "x: pl.Int64 = y"
 
     def test_op_stmts_printing_multiple(self):
         """Test printing of OpStmts with multiple statements."""
@@ -138,7 +138,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, x, span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pi.Int64 = y\ny: pi.Int64 = z\nz: pi.Int64 = x"
+        assert str(op_stmts) == "x: pl.Int64 = y\ny: pl.Int64 = z\nz: pl.Int64 = x"
 
     def test_op_stmts_printing_empty(self):
         """Test printing of OpStmts with empty statement list."""
@@ -157,7 +157,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, ir.ConstInt(0, dtype, span), span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pi.Int64 = y\ny: pi.Int64 = z\nz: pi.Int64 = 0"
+        assert str(op_stmts) == "x: pl.Int64 = y\ny: pl.Int64 = z\nz: pl.Int64 = 0"
 
 
 class TestOpStmtsHash:


### PR DESCRIPTION
This commit introduces a comprehensive IR parser that converts Python functions into PyPTO IR using decorators. The parser includes scope management, type resolution, span tracking, and full support for control flow, tensor operations, and operator expressions. Comprehensive test coverage and documentation included.