### PR TITLE
feat(pass): Add InsertSyncPass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(PYPTO_SOURCES
     src/ir/transform/identity_pass.cpp
     src/ir/transform/init_memref.cpp
     src/ir/transform/basic_memory_reuse_pass.cpp
+    src/ir/transform/insert_sync_pass.cpp
     src/ir/serialization/serializer.cpp
     src/ir/serialization/deserializer.cpp
     src/ir/serialization/type_registry.cpp

--- a/include/pypto/ir/transform/insert_sync_pass.h
+++ b/include/pypto/ir/transform/insert_sync_pass.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORM_INSERT_SYNC_PASS_H_
+#define PYPTO_IR_TRANSFORM_INSERT_SYNC_PASS_H_
+
+#include <memory>
+
+#include "pypto/ir/function.h"
+#include "pypto/ir/transform/base/pass.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Pass for inserting synchronization operations (sync_src, sync_dst, bars)
+ *
+ * This pass analyzes data dependencies between operations based on MemRef.
+ * It inserts:
+ * - sync_src/sync_dst pairs for cross-pipe dependencies
+ * - bar_v/bar_m for intra-pipe dependencies in Vector/Cube units
+ */
+class InsertSyncPass : public Pass {
+ public:
+  InsertSyncPass() = default;
+  ~InsertSyncPass() override = default;
+
+  /**
+   * @brief Execute the insert sync pass
+   *
+   * @param func Input function
+   * @return Function with synchronization operations inserted
+   */
+  FunctionPtr Run(const FunctionPtr& func) override;
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORM_INSERT_SYNC_PASS_H_

--- a/python/bindings/modules/pass.cpp
+++ b/python/bindings/modules/pass.cpp
@@ -18,6 +18,7 @@
 #include "pypto/ir/transform/basic_memory_reuse_pass.h"
 #include "pypto/ir/transform/identity_pass.h"
 #include "pypto/ir/transform/init_memref.h"
+#include "pypto/ir/transform/insert_sync_pass.h"
 
 namespace nb = nanobind;
 
@@ -47,6 +48,11 @@ void BindPass(nb::module_& m) {
   nb::class_<BasicMemoryReusePass, Pass>(passes, "BasicMemoryReusePass",
                                          "A pass for basic memory reuse based on dependency graph")
       .def(nb::init<>(), "Create a BasicMemoryReuse pass");
+
+  // InsertSyncPass - automatically insert sync/bar operations
+  nb::class_<InsertSyncPass, Pass>(passes, "InsertSyncPass",
+                                   "A pass that automatically inserts sync and bar operations")
+      .def(nb::init<>(), "Create an InsertSync pass");
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -62,4 +62,21 @@ class BasicMemoryReusePass(Pass):
     def __init__(self) -> None:
         """Create a BasicMemoryReuse pass."""
 
-__all__ = ["Pass", "IdentityPass", "InitMemRefPass", "BasicMemoryReusePass"]
+class InsertSyncPass(Pass):
+    """A pass that automatically inserts sync and bar operations.
+
+    This pass analyzes data dependencies between operations based on MemRef
+    and inserts synchronization instructions (sync_src, sync_dst, bar_v, bar_m)
+    to ensure correct execution order across different hardware pipes.
+    """
+
+    def __init__(self) -> None:
+        """Create an InsertSync pass."""
+
+__all__ = [
+    "Pass",
+    "IdentityPass",
+    "InitMemRefPass",
+    "BasicMemoryReusePass",
+    "InsertSyncPass",
+]

--- a/src/ir/transform/insert_sync_pass.cpp
+++ b/src/ir/transform/insert_sync_pass.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transform/insert_sync_pass.h"
+
+#include <algorithm>
+#include <any>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transform/base/mutator.h"
+#include "pypto/ir/transform/base/visitor.h"
+#include "pypto/ir/transform/transformers.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+/**
+ * @brief Collector for all MemRefs in an expression
+ */
+class MemRefCollector : public IRVisitor {
+ public:
+  std::set<MemRefPtr> memrefs;
+
+  void VisitExpr_(const VarPtr& var) override {
+    if (auto shaped_type = std::dynamic_pointer_cast<const ShapedType>(var->GetType())) {
+      if (shaped_type->memref_.has_value()) {
+        memrefs.insert(*shaped_type->memref_);
+      }
+    }
+    IRVisitor::VisitExpr_(var);
+  }
+};
+
+/**
+ * @brief Helper to check if two MemRefs refer to the same memory
+ */
+bool IsSameMem(const MemRefPtr& a, const MemRefPtr& b) { return a.get() == b.get(); }
+
+/**
+ * @brief Extract pipe type from a statement
+ */
+PipeType GetStmtPipe(const StmtPtr& stmt) {
+  if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+    if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+      return call->op_->GetPipe().value_or(PipeType::S);
+    }
+  } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+    if (auto call = std::dynamic_pointer_cast<const Call>(eval->expr_)) {
+      return call->op_->GetPipe().value_or(PipeType::S);
+    }
+  }
+  return PipeType::S;
+}
+
+/**
+ * @brief Structure to represent a dependency edge
+ */
+struct DepEdge {
+  int producer_idx;
+  int consumer_idx;
+  PipeType producer_pipe;
+  PipeType consumer_pipe;
+  int event_id = -1;  // Assigned later
+};
+
+/**
+ * @brief Manager for hardware event IDs (0-7)
+ */
+class EventIdManager {
+ public:
+  static constexpr int kMaxEvents = 8;
+  std::vector<bool> busy_;
+
+  EventIdManager() : busy_(kMaxEvents, false) {}
+
+  int Allocate() {
+    for (int i = 0; i < kMaxEvents; ++i) {
+      if (!busy_[i]) {
+        busy_[i] = true;
+        return i;
+      }
+    }
+    throw ValueError("Out of hardware event IDs (max 8). Deadlock or resource exhaustion.");
+  }
+
+  void Release(int id) {
+    if (id < 0 || id >= kMaxEvents) return;
+    busy_[id] = false;
+  }
+};
+
+/**
+ * @brief Mutator that inserts sync operations into SeqStmts
+ */
+class SyncInserter : public IRMutator {
+ public:
+  FunctionPtr Run(const FunctionPtr& func) {
+    auto new_body = VisitStmt(func->body_);
+    return std::make_shared<Function>(func->name_, func->params_, func->return_types_, new_body, func->span_);
+  }
+
+  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
+    std::vector<StmtPtr> original_stmts;
+    for (const auto& s : op->stmts_) {
+      original_stmts.push_back(VisitStmt(s));
+    }
+
+    // 1. Analyze dependencies in this sequence
+    std::vector<std::shared_ptr<DepEdge>> deps;
+    std::set<std::pair<int, int>> existing_deps;  // Keep track of existing edges to avoid duplicates
+    std::map<MemRefPtr, int> last_writer;
+    std::map<MemRefPtr, std::vector<int>> last_readers;
+
+    auto get_memrefs = [](const ExprPtr& expr) {
+      MemRefCollector collector;
+      collector.VisitExpr(expr);
+      return collector.memrefs;
+    };
+
+    auto add_dep = [&](int prod, int cons, const std::vector<StmtPtr>& stmts) {
+      if (prod < 0) return;
+      if (existing_deps.count({prod, cons})) return;  // Skip if edge already exists
+
+      existing_deps.insert({prod, cons});
+      deps.push_back(
+          std::make_shared<DepEdge>(DepEdge{prod, cons, GetStmtPipe(stmts[prod]), GetStmtPipe(stmts[cons])}));
+    };
+
+    for (int i = 0; i < static_cast<int>(original_stmts.size()); ++i) {
+      const auto& stmt = original_stmts[i];
+      std::set<MemRefPtr> reads;
+      std::set<MemRefPtr> writes;
+
+      if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+        writes = get_memrefs(assign->var_);
+        reads = get_memrefs(assign->value_);
+      } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+        reads = get_memrefs(eval->expr_);
+      }
+
+      // Check RAW
+      for (const auto& r : reads) {
+        for (auto const& [m, idx] : last_writer) {
+          if (IsSameMem(r, m)) {
+            add_dep(idx, i, original_stmts);
+          }
+        }
+      }
+
+      // Check WAW and WAR
+      for (const auto& w : writes) {
+        // WAW
+        for (auto const& [m, idx] : last_writer) {
+          if (IsSameMem(w, m)) {
+            add_dep(idx, i, original_stmts);
+          }
+        }
+        // WAR
+        for (auto const& [m, indices] : last_readers) {
+          if (IsSameMem(w, m)) {
+            for (int r_idx : indices) {
+              add_dep(r_idx, i, original_stmts);
+            }
+          }
+        }
+      }
+
+      // Update last write/read
+      for (const auto& w : writes) {
+        last_writer[w] = i;
+        last_readers[w].clear();  // Reset readers on write
+      }
+      for (const auto& r : reads) {
+        last_readers[r].push_back(i);
+      }
+    }
+
+    // 2. Assign Event IDs (Simulation)
+    EventIdManager event_manager;
+    // Organize edges by producer and consumer for sequential processing
+    std::map<int, std::vector<std::shared_ptr<DepEdge>>> prod_edges;  // Outgoing (Set)
+    std::map<int, std::vector<std::shared_ptr<DepEdge>>> cons_edges;  // Incoming (Wait)
+
+    for (const auto& edge : deps) {
+      if (edge->producer_pipe != edge->consumer_pipe) {
+        prod_edges[edge->producer_idx].push_back(edge);
+        cons_edges[edge->consumer_idx].push_back(edge);
+      }
+    }
+
+    // Simulate execution to assign IDs
+    for (int i = 0; i < static_cast<int>(original_stmts.size()); ++i) {
+      // Process Waits (release IDs) BEFORE instruction execution
+      // NOTE: Wait instruction is inserted BEFORE consumer instruction.
+      if (cons_edges.count(i)) {
+        for (const auto& edge : cons_edges[i]) {
+          // Release ID
+          if (edge->event_id != -1) {
+            event_manager.Release(edge->event_id);
+          }
+        }
+      }
+
+      // Process Sets (allocate IDs) AFTER instruction execution
+      // NOTE: Set instruction is inserted AFTER producer instruction.
+      if (prod_edges.count(i)) {
+        for (const auto& edge : prod_edges[i]) {
+          // Allocate ID
+          edge->event_id = event_manager.Allocate();
+        }
+      }
+    }
+
+    // 3. Generate Insertions
+    std::map<int, std::vector<StmtPtr>> insert_before;
+    std::map<int, std::vector<StmtPtr>> insert_after;
+
+    auto create_sync_call = [](const std::string& op_name, PipeType p, PipeType tp, int event_id) {
+      auto& registry = OpRegistry::GetInstance();
+      std::vector<std::pair<std::string, std::any>> kwargs;
+      kwargs.push_back({"set_pipe", static_cast<int>(p)});
+      kwargs.push_back({"wait_pipe", static_cast<int>(tp)});
+      kwargs.push_back({"event_id", event_id});
+      auto call = registry.Create(op_name, {}, kwargs, Span::unknown());
+      return std::make_shared<const EvalStmt>(call, Span::unknown());
+    };
+
+    auto create_bar_call = [](const std::string& op_name) {
+      auto& registry = OpRegistry::GetInstance();
+      auto call = registry.Create(op_name, {}, {}, Span::unknown());
+      return std::make_shared<const EvalStmt>(call, Span::unknown());
+    };
+
+    for (const auto& edge : deps) {
+      if (edge->producer_pipe != edge->consumer_pipe) {
+        // Cross-pipe
+        if (edge->event_id == -1) continue;  // Should have been assigned
+        insert_after[edge->producer_idx].push_back(
+            create_sync_call("system.sync_src", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
+        insert_before[edge->consumer_idx].push_back(
+            create_sync_call("system.sync_dst", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
+      } else {
+        // Same pipe
+        if (edge->producer_pipe == PipeType::V) {
+          insert_before[edge->consumer_idx].push_back(create_bar_call("system.bar_v"));
+        } else if (edge->producer_pipe == PipeType::M) {
+          insert_before[edge->consumer_idx].push_back(create_bar_call("system.bar_m"));
+        }
+      }
+    }
+
+    // 4. Build new statement list
+    std::vector<StmtPtr> final_stmts;
+    for (int i = 0; i < static_cast<int>(original_stmts.size()); ++i) {
+      if (insert_before.count(i)) {
+        for (const auto& s : insert_before[i]) final_stmts.push_back(s);
+      }
+      final_stmts.push_back(original_stmts[i]);
+      if (insert_after.count(i)) {
+        for (const auto& s : insert_after[i]) final_stmts.push_back(s);
+      }
+    }
+
+    return std::make_shared<const SeqStmts>(final_stmts, op->span_);
+  }
+};
+
+}  // namespace
+
+FunctionPtr InsertSyncPass::Run(const FunctionPtr& func) {
+  INTERNAL_CHECK(func) << "InsertSyncPass cannot run on null function";
+  SyncInserter inserter;
+  return inserter.Run(func);
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/transforms/test_insert_sync.py
+++ b/tests/ut/ir/transforms/test_insert_sync.py
@@ -1,0 +1,117 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+from pypto import ir
+from pypto.ir import builder
+from pypto.ir.op import block
+from pypto.pypto_core import DataType, passes
+
+
+def test_insert_sync_cross_pipe():
+    """Test InsertSyncPass for cross-pipe dependencies (MTE2 -> V -> MTE3)."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_sync") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        input_b = f.param("input_b", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+
+        # MTE2
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, 64, 64))
+        tile_b = ib.let("tile_b", block.load(input_b, 0, 0, 64, 64))
+
+        # VECTOR (Depends on MTE2)
+        tile_c = ib.let("tile_c", block.add(tile_a, tile_b))
+
+        # MTE3 (Depends on VECTOR)
+        res = ib.let("res", block.store(tile_c, 0, 0, 64, 64, output))
+        ib.return_stmt(res)
+
+    func = f.get_result()
+
+    # Run passes
+    # 1. InitMemRefPass (required for InsertSyncPass to see memrefs)
+    init_memref = passes.InitMemRefPass()
+    func = init_memref.run(func)
+
+    # 2. InsertSyncPass
+    insert_sync = passes.InsertSyncPass()
+    synced_func = insert_sync.run(func)
+
+    # Verify sync ops are inserted
+    assert isinstance(synced_func.body, ir.SeqStmts)
+    stmts = synced_func.body.stmts
+
+    # Expected sequence roughly:
+    # load a
+    # load b
+    # sync_src (MTE2 -> V)
+    # sync_dst (MTE2 -> V)
+    # add
+    # sync_src (V -> MTE3)
+    # sync_dst (V -> MTE3)
+    # store
+
+    sync_src_count = 0
+    sync_dst_count = 0
+    for stmt in stmts:
+        if isinstance(stmt, ir.EvalStmt):
+            call = stmt.expr
+            if isinstance(call, ir.Call):
+                if call.op.name == "system.sync_src":
+                    sync_src_count += 1
+                elif call.op.name == "system.sync_dst":
+                    sync_dst_count += 1
+
+    # Two sync pairs for MTE2->V and one for V->MTE3 are expected.
+    assert sync_src_count == 3
+    assert sync_dst_count == 3
+
+
+def test_insert_sync_intra_pipe():
+    """Test InsertSyncPass for intra-pipe dependencies (V -> V)."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_sync_intra") as f:
+        t_a = f.param("t_a", ir.TileType([64, 64], DataType.FP32))
+        t_b = f.param("t_b", ir.TileType([64, 64], DataType.FP32))
+
+        # V
+        t_c = ib.let("t_c", block.add(t_a, t_b))
+        # V (Depends on previous V)
+        t_d = ib.let("t_d", block.add(t_c, t_a))
+
+        ib.return_stmt(t_d)
+
+    func = f.get_result()
+
+    # Run InitMemRefPass
+    init_memref = passes.InitMemRefPass()
+    func = init_memref.run(func)
+
+    # Run InsertSyncPass
+    insert_sync = passes.InsertSyncPass()
+    synced_func = insert_sync.run(func)
+
+    # Verify bar_v is inserted
+    assert isinstance(synced_func.body, ir.SeqStmts)
+    stmts = synced_func.body.stmts
+    bar_v_count = 0
+    for stmt in stmts:
+        if isinstance(stmt, ir.EvalStmt):
+            call = stmt.expr
+            if isinstance(call, ir.Call) and call.op.name == "system.bar_v":
+                bar_v_count += 1
+
+    assert bar_v_count == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Changes:
- Add InsertSyncPass to analyze dependencies and insert synchronization instructions
- Implement MemRef-based dependency analysis (RAW, WAR, WAW)
- Support cross-pipe sync (sync_src/sync_dst) with event ID management (0-7)
- Support intra-pipe sync (bar_v/bar_m)
- Register pass in Python bindings, type stubs, and CMakeLists.txt
- Add unit tests for cross-pipe and intra-pipe synchronization
- Ensure all pre-commit hooks (clang-format, ruff, pyright) pass