### PR TITLE
refactor(ir): add Program interface to Pass and integrate dump into PassManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(PYPTO_SOURCES
     src/ir/transform/structural_hash.cpp
     src/ir/transform/structural_equal.cpp
     src/ir/transform/dependency_analyzer.cpp
+    src/ir/transform/pass.cpp
     src/ir/transform/identity_pass.cpp
     src/ir/transform/init_memref.cpp
     src/ir/transform/basic_memory_reuse_pass.cpp

--- a/include/pypto/ir/transform/base/pass.h
+++ b/include/pypto/ir/transform/base/pass.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/transform/base/mutator.h"
 
 namespace pypto {
@@ -24,9 +25,10 @@ namespace ir {
 /**
  * @brief Base class for IR transformation passes
  *
- * Pass is an abstract base class that extends IRMutator to provide function-level transformations.
- * Each pass operates on a Function and returns a transformed Function.
- * Passes maintain immutability - they return new FunctionPtr instances rather than modifying in place.
+ * Pass is an abstract base class that extends IRMutator to provide transformations
+ * on both Function and Program levels. Each pass can operate on individual Functions
+ * or entire Programs, returning transformed IR nodes.
+ * Passes maintain immutability - they return new IR instances rather than modifying in place.
  */
 class Pass : public IRMutator {
  public:
@@ -35,13 +37,26 @@ class Pass : public IRMutator {
   /**
    * @brief Execute the pass on a function
    *
-   * This is the main entry point for pass execution. Subclasses must implement this method
-   * to define their transformation logic.
+   * This is the main entry point for function-level pass execution.
+   * Subclasses must implement this method to define their transformation logic.
    *
    * @param func Input function to transform
    * @return Transformed function (may be the same pointer if no changes were made)
    */
   virtual FunctionPtr Run(const FunctionPtr& func) = 0;
+
+  /**
+   * @brief Execute the pass on a program
+   *
+   * This method provides program-level transformation capability.
+   * The default implementation applies the pass to each function in the program
+   * independently. Subclasses can override this method to implement program-wide
+   * transformations (e.g., inter-procedural optimizations).
+   *
+   * @param program Input program to transform
+   * @return Transformed program with all functions processed
+   */
+  virtual ProgramPtr Run(const ProgramPtr& program);
 };
 
 }  // namespace ir

--- a/python/bindings/modules/pass.cpp
+++ b/python/bindings/modules/pass.cpp
@@ -32,7 +32,10 @@ void BindPass(nb::module_& m) {
 
   // Pass base class for IR transformations
   nb::class_<Pass>(passes, "Pass", "Base class for IR transformation passes")
-      .def("run", &Pass::Run, nb::arg("func"), "Execute the pass on a function");
+      .def("run", nb::overload_cast<const FunctionPtr&>(&Pass::Run), nb::arg("func"),
+           "Execute the pass on a function")
+      .def("run", nb::overload_cast<const ProgramPtr&>(&Pass::Run), nb::arg("program"),
+           "Execute the pass on a program");
 
   // IdentityPass - a pass that appends a suffix to function name
   nb::class_<IdentityPass, Pass>(passes, "IdentityPass",

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -66,6 +66,9 @@ from .parser import Tensor, function, range, yield_  # noqa: F401, E402
 # Import PassManager and OptimizationStrategy
 from .pass_manager import OptimizationStrategy, PassManager  # noqa: F401, E402
 
+# Import python_print utility
+from .printer import python_print  # noqa: F401, E402
+
 # Import TensorType and TileType with enhanced __init__ that supports integer shapes
 # This patches the native TensorType and TileType classes to accept integer shapes
 from .type import TensorType, TileType  # noqa: F401, E402
@@ -80,15 +83,14 @@ def compile(
     """Compile a Program through passes and codegen.
 
     This function provides a complete compilation pipeline that:
-    1. Dumps the original IR
-    2. Runs optimization passes via PassManager
-    3. Dumps IR after each pass (if dump_passes=True)
-    4. Generates PTO assembly code via PTOCodegen
-    5. Saves all artifacts to a unified output directory
+    1. Runs optimization passes via PassManager
+    2. Optionally dumps IR before and after each pass (if dump_passes=True)
+    3. Generates PTO assembly code via PTOCodegen
+    4. Saves all artifacts to a unified output directory
 
     Args:
         program: Input Program to compile
-        output_dir: Output directory (default: build_output/<program_name>)
+        output_dir: Output directory (default: build_output/<program_name>_<timestamp>)
         strategy: Optimization strategy to use (default: Default)
         dump_passes: Whether to dump IR after each pass (default: True)
 
@@ -116,76 +118,20 @@ def compile(
     # Create output directory
     os.makedirs(output_dir, exist_ok=True)
 
-    # Step 1: Dump frontend IR (original IR before any passes)
-    frontend_path = os.path.join(output_dir, "00_frontend.py")
-    with open(frontend_path, "w") as f:
-        f.write(python_print(program, prefix="pl"))
-
-    # Step 2: Run passes with PassManager
+    # Run passes with PassManager
     pm = PassManager.get_strategy(strategy)
+    transformed_program = pm.run_passes(program, dump_ir=dump_passes, output_dir=output_dir)
 
-    if dump_passes and len(pm.passes) > 0:
-        # Run passes one by one and dump Program state after each pass
-        current_program = program
-        pass_names = pm.get_pass_names()
-
-        for i, (pass_instance, pass_name) in enumerate(zip(pm.passes, pass_names), start=1):
-            # Apply this pass to all functions in the program
-            transformed_functions = []
-            for global_var, func in current_program.functions.items():
-                transformed_func = pass_instance.run(func)
-                transformed_functions.append(transformed_func)
-
-            # Create new program with transformed functions
-            current_program = _ir_core.Program(
-                transformed_functions, current_program.name, current_program.span
-            )
-
-            # Dump IR after this pass with sequential numbering (01, 02, ...)
-            pass_dump_path = os.path.join(output_dir, f"{i:02d}_after_{pass_name}.py")
-            with open(pass_dump_path, "w") as f:
-                f.write(python_print(current_program, prefix="pl"))
-
-        transformed_program = current_program
-    else:
-        # Run all passes at once without dumping
-        result = pm.run_passes(program)
-        # Since input is a Program, output must be a Program
-        transformed_program = result  # type: ignore[assignment]
-
-    # Step 3: Generate PTO assembly code
+    # Generate PTO assembly code
     codegen = _ir_core.PTOCodegen()
     pto_code = codegen.generate(transformed_program)  # type: ignore[arg-type]
 
-    # Step 4: Save PTO assembly
+    # Save PTO assembly
     pto_path = os.path.join(output_dir, "output.pto")
     with open(pto_path, "w") as f:
         f.write(pto_code)
 
     return output_dir
-
-
-def python_print(node, prefix="pl"):  # type: ignore[misc]
-    """
-    Print IR node or Type object in Python IR syntax.
-
-    This is a unified wrapper that dispatches to the appropriate C++ function
-    based on the type of the input object.
-
-    Args:
-        node: IR node (Expr, Stmt, Function, Program) or Type object to print
-        prefix: Module prefix (default 'pl' for 'import pypto.language as pl')
-
-    Returns:
-        str: Python-style string representation
-    """
-    # Check if node is a Type object
-    if isinstance(node, _ir_core.Type):
-        # Use the separate function for Type objects
-        return _ir_core.python_print_type(node, prefix)
-    else:
-        # Use the standard function for IRNode objects
-        return _ir_core.python_print(node, prefix)
 
 
 __all__ = [

--- a/python/pypto/ir/printer.py
+++ b/python/pypto/ir/printer.py
@@ -1,0 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Utilities for printing IR nodes in Python syntax."""
+
+from pypto.pypto_core import ir as _ir_core
+
+
+def python_print(node, prefix="pl"):  # type: ignore[misc]
+    """
+    Print IR node or Type object in Python IR syntax.
+
+    This is a unified wrapper that dispatches to the appropriate C++ function
+    based on the type of the input object.
+
+    Args:
+        node: IR node (Expr, Stmt, Function, Program) or Type object to print
+        prefix: Module prefix (default 'pl' for 'import pypto.language as pl')
+
+    Returns:
+        str: Python-style string representation
+    """
+    # Check if node is a Type object
+    if isinstance(node, _ir_core.Type):
+        # Use the separate function for Type objects
+        return _ir_core.python_print_type(node, prefix)
+    else:
+        # Use the standard function for IRNode objects
+        return _ir_core.python_print(node, prefix)

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -8,16 +8,19 @@
 # -----------------------------------------------------------------------------------------------------------
 """Type stubs for PyPTO IR Pass transformations."""
 
-from pypto.pypto_core.ir import Function
+from typing import Union, overload
+
+from pypto.pypto_core.ir import Function, Program
 
 class Pass:
     """Base class for IR transformation passes.
 
-    A Pass represents a transformation that can be applied to a Function.
+    A Pass represents a transformation that can be applied to a Function or Program.
     Concrete pass implementations should inherit from this class and
     implement the run() method.
     """
 
+    @overload
     def run(self, func: Function) -> Function:
         """Execute the pass on a function.
 
@@ -26,6 +29,27 @@ class Pass:
 
         Returns:
             Transformed Function after the pass has been applied
+        """
+
+    @overload
+    def run(self, program: Program) -> Program:
+        """Execute the pass on a program.
+
+        Args:
+            program: Input Program to transform
+
+        Returns:
+            Transformed Program after the pass has been applied
+        """
+
+    def run(self, input_ir: Union[Function, Program]) -> Union[Function, Program]:
+        """Execute the pass on a function or program.
+
+        Args:
+            input_ir: Input Function or Program to transform
+
+        Returns:
+            Transformed Function or Program after the pass has been applied
         """
 
 class IdentityPass(Pass):

--- a/src/ir/transform/pass.cpp
+++ b/src/ir/transform/pass.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transform/base/pass.h"
+
+#include <memory>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/program.h"
+
+namespace pypto {
+namespace ir {
+
+ProgramPtr Pass::Run(const ProgramPtr& program) {
+  INTERNAL_CHECK(program) << "Pass cannot run on null program";
+
+  // Apply the pass to each function in the program independently
+  std::vector<FunctionPtr> transformed_functions;
+  transformed_functions.reserve(program->functions_.size());
+
+  for (const auto& [global_var, func] : program->functions_) {
+    FunctionPtr transformed_func = Run(func);
+    transformed_functions.push_back(transformed_func);
+  }
+
+  // Create a new program with the transformed functions
+  // The Program constructor will create new GlobalVars and maintain the sorted map
+  return std::make_shared<const Program>(transformed_functions, program->name_, program->span_);
+}
+
+}  // namespace ir
+}  // namespace pypto


### PR DESCRIPTION
Major refactoring to improve Pass and PassManager architecture:

1. Pass class enhancements:
   - Add Run(ProgramPtr) virtual method for program-level transformations
   - Provide default implementation that applies pass to each function
   - Enable future inter-procedural optimizations

2. PassManager improvements:
   - Add dump_ir parameter to run_passes() method
   - Integrate IR dumping logic (00_frontend.py and pass outputs)
   - Simplify API: unified handling of Function and Program inputs

3. ir.compile() simplification:
   - Reduce code from ~90 lines to ~25 lines (70% reduction)
   - Delegate all IR dumping to PassManager
   - Clarify responsibility: compile() manages output_dir, PassManager handles passes

4. Circular import resolution:
   - Extract python_print to new printer.py module
   - Avoid circular dependency between __init__.py and pass_manager.py

5. API behavior changes:
   - When dump_passes=False: no IR files are saved (only output.pto)
   - When dump_passes=True: PassManager saves 00_frontend.py and all pass outputs
   - compile() always determines output_dir, passes it to PassManager

6. Test updates:
   - Update test cases to match new dump behavior
   - All tests maintain correctness with new architecture

Files changed:
- C++: pass.h, pass.cpp (new), pass bindings
- Python: pass_manager.py, __init__.py, printer.py (new), passes.pyi
- Build: CMakeLists.txt
- Tests: test_compile.py