### PR TITLE
refactor(ir): replace dynamic_pointer_cast with As/IsA for leaf types

### DIFF
--- a/src/ir/expr.cpp
+++ b/src/ir/expr.cpp
@@ -8,12 +8,12 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-
 #include "pypto/ir/expr.h"
 
 #include <utility>
 
 #include "pypto/core/error.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -22,7 +22,7 @@ namespace ir {
 TupleGetItemExpr::TupleGetItemExpr(ExprPtr tuple, int index, Span span)
     : Expr(std::move(span)), tuple_(std::move(tuple)), index_(index) {
   // Type checking: tuple must have TupleType
-  auto tuple_type = std::dynamic_pointer_cast<const TupleType>(tuple_->GetType());
+  auto tuple_type = As<TupleType>(tuple_->GetType());
   CHECK(tuple_type) << "TupleGetItemExpr requires tuple to have TupleType, got "
                     << tuple_->GetType()->TypeName();
 

--- a/src/ir/op/block_ops/broadcast.cpp
+++ b/src/ir/op/block_ops/broadcast.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
@@ -38,12 +39,12 @@ TypePtr DeduceBlockRowExpandType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TileType (the main tile)
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
   // Second argument must be TileType (the row vector)
-  auto row_type = std::dynamic_pointer_cast<const TileType>(args[1]->GetType());
+  auto row_type = As<TileType>(args[1]->GetType());
   CHECK(row_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
                   << args[1]->GetType()->TypeName();
 
@@ -58,14 +59,14 @@ TypePtr DeduceBlockRowExpandType(const std::vector<ExprPtr>& args,
                                << row_shape.size() << " dimensions";
 
   // Second dimension of row vector must be 1
-  auto row_col_const = std::dynamic_pointer_cast<const ConstInt>(row_shape[1]);
+  auto row_col_const = As<ConstInt>(row_shape[1]);
   CHECK(row_col_const && row_col_const->value_ == 1)
       << "The operator " << op_name << " requires second argument to have shape [M, 1], but got shape [?, "
       << (row_col_const ? std::to_string(row_col_const->value_) : "?") << "]";
 
   // First dimension (rows) must match
-  auto tile_rows_const = std::dynamic_pointer_cast<const ConstInt>(tile_shape[0]);
-  auto row_rows_const = std::dynamic_pointer_cast<const ConstInt>(row_shape[0]);
+  auto tile_rows_const = As<ConstInt>(tile_shape[0]);
+  auto row_rows_const = As<ConstInt>(row_shape[0]);
 
   if (tile_rows_const && row_rows_const) {
     CHECK(tile_rows_const->value_ == row_rows_const->value_)

--- a/src/ir/op/block_ops/elementwise.cpp
+++ b/src/ir/op/block_ops/elementwise.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
@@ -41,8 +42,8 @@ TypePtr DeduceBlockOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // Both arguments must be TileType
-  auto tile_type1 = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
-  auto tile_type2 = std::dynamic_pointer_cast<const TileType>(args[1]->GetType());
+  auto tile_type1 = As<TileType>(args[0]->GetType());
+  auto tile_type2 = As<TileType>(args[1]->GetType());
 
   CHECK(tile_type1) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                     << args[0]->GetType()->TypeName();
@@ -68,12 +69,12 @@ TypePtr DeduceBlockOpScalarBinaryType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
   // Second argument MUST be ScalarType
-  auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(args[1]->GetType());
+  auto scalar_type = As<ScalarType>(args[1]->GetType());
   CHECK(scalar_type) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
                      << args[1]->GetType()->TypeName();
 

--- a/src/ir/op/block_ops/matmul.cpp
+++ b/src/ir/op/block_ops/matmul.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
@@ -38,8 +39,8 @@ TypePtr DeduceBlockMatMulType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // Both arguments must be TileType
-  auto lhs_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
-  auto rhs_type = std::dynamic_pointer_cast<const TileType>(args[1]->GetType());
+  auto lhs_type = As<TileType>(args[0]->GetType());
+  auto rhs_type = As<TileType>(args[1]->GetType());
 
   CHECK(lhs_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                   << args[0]->GetType()->TypeName();
@@ -66,8 +67,8 @@ TypePtr DeduceBlockMatMulType(const std::vector<ExprPtr>& args,
   ExprPtr n_dim = rhs_shape[1];
 
   // Try to verify K dimensions match if they are constant
-  auto k_lhs_const = std::dynamic_pointer_cast<const ConstInt>(k_dim_lhs);
-  auto k_rhs_const = std::dynamic_pointer_cast<const ConstInt>(k_dim_rhs);
+  auto k_lhs_const = As<ConstInt>(k_dim_lhs);
+  auto k_rhs_const = As<ConstInt>(k_dim_rhs);
 
   if (k_lhs_const && k_rhs_const) {
     CHECK(k_lhs_const->value_ == k_rhs_const->value_)

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -28,6 +28,7 @@
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
@@ -70,7 +71,7 @@ TypePtr DeduceBlockLoadType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TensorType
-  auto tensor_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -108,12 +109,12 @@ TypePtr DeduceBlockStoreType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
   // Last argument should be the output tensor
-  auto output_tensor_type = std::dynamic_pointer_cast<const TensorType>(args.back()->GetType());
+  auto output_tensor_type = As<TensorType>(args.back()->GetType());
   CHECK(output_tensor_type) << "The operator " << op_name
                             << " requires last argument to be a TensorType, but got "
                             << args.back()->GetType()->TypeName();
@@ -129,7 +130,7 @@ TypePtr DeduceBlockMoveType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "The operator " << op_name << " requires 1 argument, but got " << args.size();
 
   // 2. Validate first argument is TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/block_ops/reduction.cpp
+++ b/src/ir/op/block_ops/reduction.cpp
@@ -26,6 +26,7 @@
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
@@ -56,7 +57,7 @@ TypePtr DeduceBlockReductionType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "The operator " << op_name << " requires 1 argument, but got " << args.size();
 
   // First argument must be TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
@@ -125,7 +126,7 @@ TypePtr DeduceBlockRowReductionType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "The operator " << op_name << " requires 1 argument, but got " << args.size();
 
   // First argument must be TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/block_ops/unary.cpp
+++ b/src/ir/op/block_ops/unary.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/type.h"
@@ -37,7 +38,7 @@ TypePtr DeduceBlockUnaryType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // Argument must be TileType
-  auto tile_type = std::dynamic_pointer_cast<const TileType>(args[0]->GetType());
+  auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
@@ -37,8 +38,8 @@ TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // Try TensorType first
-  auto tensor_type1 = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
-  auto tensor_type2 = std::dynamic_pointer_cast<const TensorType>(args[1]->GetType());
+  auto tensor_type1 = As<TensorType>(args[0]->GetType());
+  auto tensor_type2 = As<TensorType>(args[1]->GetType());
 
   CHECK(tensor_type1) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                       << args[0]->GetType()->TypeName();
@@ -63,8 +64,8 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
-  auto tensor_type1 = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
-  auto scalar_type2 = std::dynamic_pointer_cast<const ScalarType>(args[1]->GetType());
+  auto tensor_type1 = As<TensorType>(args[0]->GetType());
+  auto scalar_type2 = As<ScalarType>(args[1]->GetType());
 
   CHECK(tensor_type1) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                       << args[0]->GetType()->TypeName();

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -26,6 +26,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
@@ -54,8 +55,8 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 2) << "tensor.matmul requires exactly 2 arguments (lhs, rhs), but got " << args.size();
 
   // First two arguments must be TensorType
-  auto lhs_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
-  auto rhs_type = std::dynamic_pointer_cast<const TensorType>(args[1]->GetType());
+  auto lhs_type = As<TensorType>(args[0]->GetType());
+  auto rhs_type = As<TensorType>(args[1]->GetType());
 
   CHECK(lhs_type) << "tensor.matmul requires first argument to be a TensorType, but got "
                   << args[0]->GetType()->TypeName();

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -24,6 +24,7 @@
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
@@ -67,12 +68,12 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TensorType
-  auto tensor_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "tensor.view requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   // Second argument is the number of shape dimensions (ConstInt)
-  auto shape_ndim_const = std::dynamic_pointer_cast<const ConstInt>(args[1]);
+  auto shape_ndim_const = As<ConstInt>(args[1]);
   CHECK(shape_ndim_const)
       << "tensor.view requires second argument to be a ConstInt indicating number of shape "
          "dimensions";
@@ -104,12 +105,12 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
   CHECK(args.size() >= 2) << "tensor.assemble requires at least 2 arguments, but got " << args.size();
 
   // First argument (target) must be TensorType
-  auto target_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto target_type = As<TensorType>(args[0]->GetType());
   CHECK(target_type) << "tensor.assemble requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   // Second argument (source) must be TensorType
-  auto source_type = std::dynamic_pointer_cast<const TensorType>(args[1]->GetType());
+  auto source_type = As<TensorType>(args[1]->GetType());
   CHECK(source_type) << "tensor.assemble requires second argument to be a TensorType, but got "
                      << args[1]->GetType()->TypeName();
 

--- a/src/ir/op/tensor_ops/reduction.cpp
+++ b/src/ir/op/tensor_ops/reduction.cpp
@@ -23,6 +23,7 @@
 
 #include "pypto/core/any_cast.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
@@ -51,7 +52,7 @@ TypePtr DeduceTensorReductionType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   // First argument must be TensorType
-  auto tensor_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -22,6 +22,7 @@
 
 #include "pypto/core/any_cast.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
 namespace pypto {
@@ -31,7 +32,7 @@ TypePtr DeduceTensorExpType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.exp requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "tensor.exp requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -50,7 +51,7 @@ TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.cast requires exactly 1 argument (input), but got " << args.size();
 
-  auto tensor_type = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
+  auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "tensor.cast requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
 
@@ -133,22 +134,22 @@ bool ValidateTileShape(const std::vector<ExprPtr>& shape) { return shape.size() 
 
 bool CheckTypeCompatibility(const TypePtr& type1, const TypePtr& type2) {
   // Check if both are scalar types
-  auto scalar1 = std::dynamic_pointer_cast<const ScalarType>(type1);
-  auto scalar2 = std::dynamic_pointer_cast<const ScalarType>(type2);
+  auto scalar1 = As<ScalarType>(type1);
+  auto scalar2 = As<ScalarType>(type2);
   if (scalar1 && scalar2) {
     return true;
   }
 
   // Check if both are tensor types
-  auto tensor1 = std::dynamic_pointer_cast<const TensorType>(type1);
-  auto tensor2 = std::dynamic_pointer_cast<const TensorType>(type2);
+  auto tensor1 = As<TensorType>(type1);
+  auto tensor2 = As<TensorType>(type2);
   if (tensor1 && tensor2) {
     return true;
   }
 
   // Check if both are tile types
-  auto tile1 = std::dynamic_pointer_cast<const TileType>(type1);
-  auto tile2 = std::dynamic_pointer_cast<const TileType>(type2);
+  auto tile1 = As<TileType>(type1);
+  auto tile2 = As<TileType>(type2);
   if (tile1 && tile2) {
     return true;
   }
@@ -159,17 +160,17 @@ bool CheckTypeCompatibility(const TypePtr& type1, const TypePtr& type2) {
 
 std::optional<DataType> ExtractDataType(const TypePtr& type) {
   // Try ScalarType
-  if (auto scalar = std::dynamic_pointer_cast<const ScalarType>(type)) {
+  if (auto scalar = As<ScalarType>(type)) {
     return scalar->dtype_;
   }
 
   // Try TensorType
-  if (auto tensor = std::dynamic_pointer_cast<const TensorType>(type)) {
+  if (auto tensor = As<TensorType>(type)) {
     return tensor->dtype_;
   }
 
   // Try TileType
-  if (auto tile = std::dynamic_pointer_cast<const TileType>(type)) {
+  if (auto tile = As<TileType>(type)) {
     return tile->dtype_;
   }
 
@@ -178,12 +179,12 @@ std::optional<DataType> ExtractDataType(const TypePtr& type) {
 
 std::vector<ExprPtr> ExtractShape(const TypePtr& type) {
   // Try TensorType
-  if (auto tensor = std::dynamic_pointer_cast<const TensorType>(type)) {
+  if (auto tensor = As<TensorType>(type)) {
     return tensor->shape_;
   }
 
   // Try TileType
-  if (auto tile = std::dynamic_pointer_cast<const TileType>(type)) {
+  if (auto tile = As<TileType>(type)) {
     return tile->shape_;
   }
 
@@ -193,7 +194,7 @@ std::vector<ExprPtr> ExtractShape(const TypePtr& type) {
 
 std::optional<int64_t> GetConstantDimension(const ExprPtr& dim) {
   // Try to cast to ConstInt
-  if (auto const_int = std::dynamic_pointer_cast<const ConstInt>(dim)) {
+  if (auto const_int = As<ConstInt>(dim)) {
     return const_int->value_;
   }
 

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -29,6 +29,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
 #include "pypto/ir/scalar_expr.h"
@@ -242,9 +243,9 @@ class IRSerializer::Impl {
     std::map<std::string, msgpack::object> type_map;
     type_map["type_kind"] = msgpack::object(type->TypeName(), zone);
 
-    if (auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(type)) {
+    if (auto scalar_type = As<ScalarType>(type)) {
       type_map["dtype"] = msgpack::object(scalar_type->dtype_.Code(), zone);
-    } else if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
+    } else if (auto tensor_type = As<TensorType>(type)) {
       type_map["dtype"] = msgpack::object(tensor_type->dtype_.Code(), zone);
 
       std::vector<msgpack::object> shape_vec;
@@ -257,7 +258,7 @@ class IRSerializer::Impl {
       if (tensor_type->memref_.has_value()) {
         type_map["memref"] = SerializeMemRef(tensor_type->memref_, zone);
       }
-    } else if (auto tile_type = std::dynamic_pointer_cast<const TileType>(type)) {
+    } else if (auto tile_type = As<TileType>(type)) {
       type_map["dtype"] = msgpack::object(tile_type->dtype_.Code(), zone);
 
       std::vector<msgpack::object> shape_vec;
@@ -275,13 +276,13 @@ class IRSerializer::Impl {
       if (tile_type->tile_view_.has_value()) {
         type_map["tile_view"] = SerializeTileView(tile_type->tile_view_, zone);
       }
-    } else if (auto tuple_type = std::dynamic_pointer_cast<const TupleType>(type)) {
+    } else if (auto tuple_type = As<TupleType>(type)) {
       std::vector<msgpack::object> types_vec;
       for (const auto& t : tuple_type->types_) {
         types_vec.push_back(SerializeType(t, zone));
       }
       type_map["types"] = msgpack::object(types_vec, zone);
-    } else if (std::dynamic_pointer_cast<const UnknownType>(type)) {
+    } else if (IsA<UnknownType>(type)) {
       // UnknownType has no additional fields
     } else {
       INTERNAL_UNREACHABLE << "Unknown Type subclass: " << type->TypeName();

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -22,6 +22,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/serialization/type_registry.h"
@@ -176,7 +177,7 @@ static IRNodePtr DeserializeConstInt(const msgpack::object& fields_obj, msgpack:
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
   auto type = ctx.DeserializeType(GET_FIELD_OBJ("type"), zone);
   int value = GET_FIELD(int, "value");
-  auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(type);
+  auto scalar_type = As<ScalarType>(type);
   INTERNAL_CHECK(scalar_type) << "ConstInt is expected to have ScalarType type, but got " + type->TypeName();
   return std::make_shared<ConstInt>(value, scalar_type->dtype_, span);
 }
@@ -187,7 +188,7 @@ static IRNodePtr DeserializeConstFloat(const msgpack::object& fields_obj, msgpac
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
   auto type = ctx.DeserializeType(GET_FIELD_OBJ("type"), zone);
   double value = GET_FIELD(double, "value");
-  auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(type);
+  auto scalar_type = As<ScalarType>(type);
   INTERNAL_CHECK(scalar_type) << "ConstFloat is expected to have ScalarType type, but got " +
                                      type->TypeName();
   return std::make_shared<ConstFloat>(value, scalar_type->dtype_, span);
@@ -230,7 +231,7 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
                                           DeserializerContext& ctx) {                                     \
     auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));                                               \
     auto type = ctx.DeserializeType(GET_FIELD_OBJ("type"), zone);                                         \
-    auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(type);                                 \
+    auto scalar_type = As<ScalarType>(type);                                                              \
     INTERNAL_CHECK(scalar_type) << #ClassName " is expected to have ScalarType type, but got " +          \
                                        type->TypeName();                                                  \
     auto left = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("left"), zone));   \
@@ -268,7 +269,7 @@ DESERIALIZE_BINARY_EXPR(BitShiftRight)
                                           DeserializerContext& ctx) {                              \
     auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));                                        \
     auto type = ctx.DeserializeType(GET_FIELD_OBJ("type"), zone);                                  \
-    auto scalar_type = std::dynamic_pointer_cast<const ScalarType>(type);                          \
+    auto scalar_type = As<ScalarType>(type);                                                       \
     INTERNAL_CHECK(scalar_type) << #ClassName " is expected to have ScalarType type, but got " +   \
                                        type->TypeName();                                           \
     auto operand =                                                                                 \

--- a/src/ir/transform/insert_sync_pass.cpp
+++ b/src/ir/transform/insert_sync_pass.cpp
@@ -22,6 +22,7 @@
 
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -60,12 +61,12 @@ bool IsSameMem(const MemRefPtr& a, const MemRefPtr& b) { return a.get() == b.get
  * @brief Extract pipe type from a statement
  */
 PipeType GetStmtPipe(const StmtPtr& stmt) {
-  if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
-    if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+  if (auto assign = As<AssignStmt>(stmt)) {
+    if (auto call = As<Call>(assign->value_)) {
       return call->op_->GetPipe().value_or(PipeType::S);
     }
-  } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
-    if (auto call = std::dynamic_pointer_cast<const Call>(eval->expr_)) {
+  } else if (auto eval = As<EvalStmt>(stmt)) {
+    if (auto call = As<Call>(eval->expr_)) {
       return call->op_->GetPipe().value_or(PipeType::S);
     }
   }
@@ -151,10 +152,10 @@ class SyncInserter : public IRMutator {
       std::set<MemRefPtr> reads;
       std::set<MemRefPtr> writes;
 
-      if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (auto assign = As<AssignStmt>(stmt)) {
         writes = get_memrefs(assign->var_);
         reads = get_memrefs(assign->value_);
-      } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      } else if (auto eval = As<EvalStmt>(stmt)) {
         reads = get_memrefs(eval->expr_);
       }
 

--- a/src/ir/transform/structural_equal.cpp
+++ b/src/ir/transform/structural_equal.cpp
@@ -23,6 +23,7 @@
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/reflection/field_visitor.h"
@@ -549,8 +550,8 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
     return false;
   }
 
-  if (auto lhs_scalar = std::dynamic_pointer_cast<const ScalarType>(lhs)) {
-    auto rhs_scalar = std::dynamic_pointer_cast<const ScalarType>(rhs);
+  if (auto lhs_scalar = As<ScalarType>(lhs)) {
+    auto rhs_scalar = As<ScalarType>(rhs);
     if (!rhs_scalar) {
       if constexpr (AssertMode) {
         ThrowMismatch("Type cast failed for ScalarType", IRNodePtr(), IRNodePtr(), "", "");
@@ -567,8 +568,8 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       return false;
     }
     return true;
-  } else if (auto lhs_tensor = std::dynamic_pointer_cast<const TensorType>(lhs)) {
-    auto rhs_tensor = std::dynamic_pointer_cast<const TensorType>(rhs);
+  } else if (auto lhs_tensor = As<TensorType>(lhs)) {
+    auto rhs_tensor = As<TensorType>(rhs);
     if (!rhs_tensor) {
       if constexpr (AssertMode) {
         ThrowMismatch("Type cast failed for TensorType", IRNodePtr(), IRNodePtr(), "", "");
@@ -597,8 +598,8 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       if (!Equal(lhs_tensor->shape_[i], rhs_tensor->shape_[i])) return false;
     }
     return true;
-  } else if (auto lhs_tile = std::dynamic_pointer_cast<const TileType>(lhs)) {
-    auto rhs_tile = std::dynamic_pointer_cast<const TileType>(rhs);
+  } else if (auto lhs_tile = As<TileType>(lhs)) {
+    auto rhs_tile = As<TileType>(rhs);
     if (!rhs_tile) {
       if constexpr (AssertMode) {
         ThrowMismatch("Type cast failed for TileType", IRNodePtr(), IRNodePtr(), "", "");
@@ -668,8 +669,8 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       if (!Equal(lhs_tv.start_offset, rhs_tv.start_offset)) return false;
     }
     return true;
-  } else if (auto lhs_tuple = std::dynamic_pointer_cast<const TupleType>(lhs)) {
-    auto rhs_tuple = std::dynamic_pointer_cast<const TupleType>(rhs);
+  } else if (auto lhs_tuple = As<TupleType>(lhs)) {
+    auto rhs_tuple = As<TupleType>(rhs);
     if (!rhs_tuple) {
       if constexpr (AssertMode) {
         ThrowMismatch("Type cast failed for TupleType", IRNodePtr(), IRNodePtr(), "", "");
@@ -689,7 +690,7 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       if (!EqualType(lhs_tuple->types_[i], rhs_tuple->types_[i])) return false;
     }
     return true;
-  } else if (std::dynamic_pointer_cast<const UnknownType>(lhs)) {
+  } else if (IsA<UnknownType>(lhs)) {
     return true;
   }
 

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/transform/base/visitor.h"
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/type.h"
@@ -26,7 +27,7 @@ void IRVisitor::VisitStmt(const StmtPtr& stmt) { StmtFunctor<void>::VisitStmt(st
 // Leaf nodes - no children to visit
 void IRVisitor::VisitExpr_(const VarPtr& op) {
   // Visit type if it's a TensorType (to visit shape expressions)
-  if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->GetType())) {
+  if (auto tensor_type = As<TensorType>(op->GetType())) {
     for (const auto& dim : tensor_type->shape_) {
       VisitExpr(dim);
     }
@@ -38,7 +39,7 @@ void IRVisitor::VisitExpr_(const IterArgPtr& op) {
   INTERNAL_CHECK(op->initValue_) << "IterArg has null initValue";
   VisitExpr(op->initValue_);
   // Also visit type if it's a TensorType (inherited from Var)
-  if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->GetType())) {
+  if (auto tensor_type = As<TensorType>(op->GetType())) {
     for (const auto& dim : tensor_type->shape_) {
       VisitExpr(dim);
     }


### PR DESCRIPTION
Replace std::dynamic_pointer_cast with the Kind-based As<T> and IsA<T> interfaces for all concrete/leaf IR node types to improve type casting performance and consistency.

Changes:
- Replace dynamic_pointer_cast with As<T> for 121+ occurrences across leaf types (ScalarType, TensorType, TileType, TupleType, ConstInt, AssignStmt, EvalStmt, Call, IterArg, Program, Function, etc.)
- Preserve dynamic_pointer_cast for base class types (Expr, Stmt, Var, Type, ShapedType) to maintain polymorphic flexibility