### PR TITLE
Add Program IR support with multi-function capabilities

### DIFF
--- a/docs/dev/00-ir_definition.md
+++ b/docs/dev/00-ir_definition.md
@@ -330,7 +330,7 @@ sum_iter = ir.IterArg(
 # IterArg is used within ForStmt:
 # for i, (sum,) in pl.range(0, n, 1, init_values=[0]):
 #     sum = pl.yield(sum + i)
-# sum_final: pl.Int64 = sum  # Capture final value in return variable
+# sum_final: pl.INT64 = sum  # Capture final value in return variable
 ```
 
 **SSA Semantics:**

--- a/examples/ir_builder/program_builder_example.py
+++ b/examples/ir_builder/program_builder_example.py
@@ -1,0 +1,131 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Example demonstrating manual Program construction with IRBuilder.
+
+This example shows how to:
+- Build programs with multiple functions using IRBuilder
+- Use declare_function() to enable cross-function calls
+- Create GlobalVar references for calling functions within a program
+- Print the resulting program as Python code
+"""
+
+from typing import cast
+
+import pypto
+from pypto import DataType
+from pypto.ir import IRBuilder
+from pypto.pypto_core import ir
+
+
+def build_math_library():
+    """Build a program with functions that call each other.
+
+    Returns:
+        IR Program with square, cube, and sum_of_squares functions
+    """
+    ib = IRBuilder()
+
+    with ib.program("MathLib") as prog:
+        # Declare functions up front to enable cross-function calls
+        square_gvar = prog.declare_function("square")
+        prog.declare_function("cube")
+        prog.declare_function("sum_of_squares")
+
+        # Build function 1: square(x) = x * x
+        print("Building square function...")
+        with ib.function("square") as f:
+            x = f.param("x", ir.ScalarType(DataType.INT64))
+            f.return_type(ir.ScalarType(DataType.INT64))
+
+            result = ib.let("result", x * x)
+            ib.return_stmt(result)
+
+        square_func = f.get_result()
+        prog.add_function(square_func)
+
+        # Build function 2: cube(x) = x * square(x)
+        print("Building cube function (calls square)...")
+        with ib.function("cube") as f:
+            x = f.param("x", ir.ScalarType(DataType.INT64))
+            f.return_type(ir.ScalarType(DataType.INT64))
+
+            # Call square function using its GlobalVar
+            x_squared = ib.let("x_squared", ir.Call(square_gvar, [x], ir.Span.unknown()))
+            result = ib.let("result", x * x_squared)
+            ib.return_stmt(result)
+
+        cube_func = f.get_result()
+        prog.add_function(cube_func)
+
+        # Build function 3: sum_of_squares(a, b) = square(a) + square(b)
+        print("Building sum_of_squares function (calls square twice)...")
+        with ib.function("sum_of_squares") as f:
+            a = f.param("a", ir.ScalarType(DataType.INT64))
+            b = f.param("b", ir.ScalarType(DataType.INT64))
+            f.return_type(ir.ScalarType(DataType.INT64))
+
+            # Call square twice using GlobalVar
+            a_sq = ib.let("a_sq", ir.Call(square_gvar, [a], ir.Span.unknown()))
+            b_sq = ib.let("b_sq", ir.Call(square_gvar, [b], ir.Span.unknown()))
+            result = ib.let("result", a_sq + b_sq)
+            ib.return_stmt(result)
+
+        sum_func = f.get_result()
+        prog.add_function(sum_func)
+
+    program = prog.get_result()
+    return program
+
+
+def main():
+    """Build and demonstrate the program."""
+    print("=" * 70)
+    print("Building MathLib Program")
+    print("=" * 70)
+
+    math_lib = build_math_library()
+
+    print("\n" + "=" * 70)
+    print("Program Information")
+    print("=" * 70)
+    print(f"Program name: {math_lib.name}")
+    print(f"Number of functions: {len(math_lib.functions)}")
+    print(f"Functions: {[f.name for f in math_lib.functions.values()]}")
+
+    # Verify cross-function calls
+    print("\n" + "=" * 70)
+    print("Cross-Function Call Verification")
+    print("=" * 70)
+    sum_func = cast(ir.Function, math_lib.get_function("sum_of_squares"))
+    print(f"sum_of_squares has {len(sum_func.params)} parameters: {[p.name for p in sum_func.params]}")
+    print("It calls the 'square' function internally via GlobalVar references")
+
+    cube_func = cast(ir.Function, math_lib.get_function("cube"))
+    print(f"cube has {len(cube_func.params)} parameters: {[p.name for p in cube_func.params]}")
+    print("It also calls 'square' via GlobalVar")
+
+    # Print as Python code
+    print("\n" + "=" * 70)
+    print("Generated Python Code (@pl.program format)")
+    print("=" * 70)
+    code = pypto.ir.python_print(math_lib)
+    print(code)
+
+    print("\n" + "=" * 70)
+    print("Note: The printed code includes:")
+    print("  - @pl.program decorator on the class")
+    print("  - 'self' parameter added to all methods")
+    print("  - Cross-function calls printed as self.square(...)")
+    print("  - Valid Python that can be parsed back")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ir_parser/program_example.py
+++ b/examples/ir_parser/program_example.py
@@ -1,0 +1,97 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Example demonstrating @pl.program decorator with cross-function calls.
+
+Key points:
+- Methods in @pl.program class must have 'self' as first parameter (valid Python syntax)
+- Cross-function calls use self.method_name() syntax
+- The parser automatically strips 'self' from IR - it won't appear in generated IR functions
+- Cross-function calls are resolved to GlobalVar references automatically
+"""
+
+import pypto
+import pypto.language as pl
+
+# Define a program where functions call each other
+# NOTE: For now, test with pl.parse_program to avoid decorator nesting issues
+program_code = """
+@pl.program
+class MathOps:
+    @pl.function
+    def square(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+        result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, x)
+        return result
+
+    @pl.function
+    def sum_of_squares(
+        self,
+        a: pl.Tensor[[1], pl.INT32],
+        b: pl.Tensor[[1], pl.INT32],
+    ) -> pl.Tensor[[1], pl.INT32]:
+        # Call the square method using self.square()
+        a_squared: pl.Tensor[[1], pl.INT32] = self.square(a)
+        b_squared: pl.Tensor[[1], pl.INT32] = self.square(b)
+        result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(a_squared, b_squared)
+        return result
+
+    @pl.function
+    def pythagorean(
+        self,
+        a: pl.Tensor[[1], pl.INT32],
+        b: pl.Tensor[[1], pl.INT32],
+    ) -> pl.Tensor[[1], pl.INT32]:
+        # Call another function in the program using self
+        result: pl.Tensor[[1], pl.INT32] = self.sum_of_squares(a, b)
+        return result
+"""
+
+# Parse the program from the string
+MathOps = pl.parse_program(program_code)
+
+
+def main():
+    """Demonstrate program usage and introspection."""
+    # MathOps is now an ir.Program object
+    print("=" * 70)
+    print("Program Information")
+    print("=" * 70)
+    print(f"Program name: {MathOps.name}")
+    print(f"Number of functions: {len(MathOps.functions)}")
+    print(f"Function names: {[f.name for f in MathOps.functions.values()]}")
+
+    # Verify cross-function calls
+    print("\n" + "=" * 70)
+    print("Function Details")
+    print("=" * 70)
+    sum_func = MathOps.get_function("sum_of_squares")
+    assert sum_func is not None
+    print(f"Function 'sum_of_squares' has {len(sum_func.params)} parameters (self was stripped)")
+    print(f"Parameters: {[p.name for p in sum_func.params]}")
+    print("It calls 'square' internally via GlobalVar references")
+
+    # Print the program back as Python code
+    print("\n" + "=" * 70)
+    print("Program as Python Code")
+    print("=" * 70)
+    code = pypto.ir.python_print(MathOps)
+    print(code)
+
+    print("\n" + "=" * 70)
+    print("Round-Trip Test")
+    print("=" * 70)
+    # Parse the printed code back
+    reparsed = pl.parse_program(code)
+    print(f"Reparsed program name: {reparsed.name}")
+    print(f"Reparsed function count: {len(reparsed.functions)}")
+    print("Round-trip successful!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ typeCheckingMode = "basic"
 pythonVersion = "3.9"
 reportMissingTypeStubs = false
 reportMissingModuleSource = false
+reportCallIssue = false
 
 [tool.pylint]
 # Pylint is not used in this project, but as it is a widely used linter,

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -45,16 +45,16 @@ void BindIRBuilder(nb::module_& m) {
       .def(nb::init<>(), "Create a new IR builder")
 
       // Function building
-      .def("BeginFunction", &IRBuilder::BeginFunction, nb::arg("name"), nb::arg("span"),
+      .def("begin_function", &IRBuilder::BeginFunction, nb::arg("name"), nb::arg("span"),
            "Begin building a function.\n\n"
-           "Creates a new function context. Must be closed with EndFunction().\n\n"
+           "Creates a new function context. Must be closed with end_function().\n\n"
            "Args:\n"
            "    name: Function name\n"
            "    span: Source location for function definition\n\n"
            "Raises:\n"
            "    RuntimeError: If already inside a function (nested functions not allowed)")
 
-      .def("FuncArg", &IRBuilder::FuncArg, nb::arg("name"), nb::arg("type"), nb::arg("span"),
+      .def("func_arg", &IRBuilder::FuncArg, nb::arg("name"), nb::arg("type"), nb::arg("span"),
            "Add a function parameter.\n\n"
            "Must be called within a function context.\n\n"
            "Args:\n"
@@ -66,7 +66,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a function context")
 
-      .def("ReturnType", &IRBuilder::ReturnType, nb::arg("type"),
+      .def("return_type", &IRBuilder::ReturnType, nb::arg("type"),
            "Add a return type to the current function.\n\n"
            "Can be called multiple times for multiple return types.\n\n"
            "Args:\n"
@@ -74,7 +74,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a function context")
 
-      .def("EndFunction", &IRBuilder::EndFunction, nb::arg("end_span"),
+      .def("end_function", &IRBuilder::EndFunction, nb::arg("end_span"),
            "End building a function.\n\n"
            "Finalizes the function and returns it.\n\n"
            "Args:\n"
@@ -85,10 +85,10 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If not inside a function context")
 
       // For loop building
-      .def("BeginForLoop", &IRBuilder::BeginForLoop, nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"),
+      .def("begin_for_loop", &IRBuilder::BeginForLoop, nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"),
            nb::arg("step"), nb::arg("span"),
            "Begin building a for loop.\n\n"
-           "Creates a new for loop context. Must be closed with EndForLoop().\n\n"
+           "Creates a new for loop context. Must be closed with end_for_loop().\n\n"
            "Args:\n"
            "    loop_var: Loop variable\n"
            "    start: Start value expression\n"
@@ -98,7 +98,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("AddIterArg", &IRBuilder::AddIterArg, nb::arg("iter_arg"),
+      .def("add_iter_arg", &IRBuilder::AddIterArg, nb::arg("iter_arg"),
            "Add an iteration argument to the current for loop.\n\n"
            "Iteration arguments are loop-carried values (SSA-style).\n\n"
            "Args:\n"
@@ -106,7 +106,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a for loop context")
 
-      .def("AddReturnVar", &IRBuilder::AddReturnVar, nb::arg("var"),
+      .def("add_return_var", &IRBuilder::AddReturnVar, nb::arg("var"),
            "Add a return variable to the current for loop.\n\n"
            "Return variables capture the final values of iteration arguments.\n"
            "Must match the number of iteration arguments.\n\n"
@@ -115,7 +115,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a for loop context")
 
-      .def("EndForLoop", &IRBuilder::EndForLoop, nb::arg("end_span"),
+      .def("end_for_loop", &IRBuilder::EndForLoop, nb::arg("end_span"),
            "End building a for loop.\n\n"
            "Finalizes the loop and returns it.\n\n"
            "Args:\n"
@@ -127,16 +127,16 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If number of return variables doesn't match iteration arguments")
 
       // If statement building
-      .def("BeginIf", &IRBuilder::BeginIf, nb::arg("condition"), nb::arg("span"),
+      .def("begin_if", &IRBuilder::BeginIf, nb::arg("condition"), nb::arg("span"),
            "Begin building an if statement.\n\n"
-           "Creates a new if context. Must be closed with EndIf().\n\n"
+           "Creates a new if context. Must be closed with end_if().\n\n"
            "Args:\n"
            "    condition: Condition expression\n"
            "    span: Source location for if statement\n\n"
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("BeginElse", &IRBuilder::BeginElse, nb::arg("span"),
+      .def("begin_else", &IRBuilder::BeginElse, nb::arg("span"),
            "Begin the else branch of the current if statement.\n\n"
            "Must be called after building the then branch.\n\n"
            "Args:\n"
@@ -145,7 +145,7 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If not inside an if context\n"
            "    RuntimeError: If else branch already begun")
 
-      .def("AddIfReturnVar", &IRBuilder::AddIfReturnVar, nb::arg("var"),
+      .def("add_if_return_var", &IRBuilder::AddIfReturnVar, nb::arg("var"),
            "Add a return variable to the current if statement.\n\n"
            "Return variables are used for SSA phi nodes.\n\n"
            "Args:\n"
@@ -153,7 +153,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside an if context")
 
-      .def("EndIf", &IRBuilder::EndIf, nb::arg("end_span"),
+      .def("end_if", &IRBuilder::EndIf, nb::arg("end_span"),
            "End building an if statement.\n\n"
            "Finalizes the if statement and returns it.\n\n"
            "Args:\n"
@@ -164,7 +164,7 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If not inside an if context")
 
       // Statement recording
-      .def("Emit", &IRBuilder::Emit, nb::arg("stmt"),
+      .def("emit", &IRBuilder::Emit, nb::arg("stmt"),
            "Emit a statement in the current context.\n\n"
            "Adds a statement to the current context's statement list.\n\n"
            "Args:\n"
@@ -172,7 +172,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("Assign", &IRBuilder::Assign, nb::arg("var"), nb::arg("value"), nb::arg("span"),
+      .def("assign", &IRBuilder::Assign, nb::arg("var"), nb::arg("value"), nb::arg("span"),
            "Create an assignment statement and emit it.\n\n"
            "Convenience method that creates and emits an assignment.\n\n"
            "Args:\n"
@@ -184,7 +184,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("Var", &IRBuilder::Var, nb::arg("name"), nb::arg("type"), nb::arg("span"),
+      .def("var", &IRBuilder::Var, nb::arg("name"), nb::arg("type"), nb::arg("span"),
            "Create a variable (does not emit).\n\n"
            "Helper to create a variable. User must create assignment separately.\n\n"
            "Args:\n"
@@ -194,7 +194,7 @@ void BindIRBuilder(nb::module_& m) {
            "Returns:\n"
            "    Var: The created variable")
 
-      .def("Return", nb::overload_cast<const std::vector<ExprPtr>&, const Span&>(&IRBuilder::Return),
+      .def("return_", nb::overload_cast<const std::vector<ExprPtr>&, const Span&>(&IRBuilder::Return),
            nb::arg("values"), nb::arg("span"),
            "Create a return statement and emit it.\n\n"
            "Convenience method that creates and emits a return statement.\n\n"
@@ -206,7 +206,7 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("Return", nb::overload_cast<const Span&>(&IRBuilder::Return), nb::arg("span"),
+      .def("return_", nb::overload_cast<const Span&>(&IRBuilder::Return), nb::arg("span"),
            "Create an empty return statement and emit it.\n\n"
            "Convenience method that creates and emits an empty return statement.\n\n"
            "Args:\n"
@@ -217,20 +217,83 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If not inside a valid context")
 
       // Context state queries
-      .def("InFunction", &IRBuilder::InFunction,
+      .def("in_function", &IRBuilder::InFunction,
            "Check if currently inside a function.\n\n"
            "Returns:\n"
            "    bool: True if inside a function context")
 
-      .def("InLoop", &IRBuilder::InLoop,
+      .def("in_loop", &IRBuilder::InLoop,
            "Check if currently inside a for loop.\n\n"
            "Returns:\n"
            "    bool: True if inside a for loop context")
 
-      .def("InIf", &IRBuilder::InIf,
+      .def("in_if", &IRBuilder::InIf,
            "Check if currently inside an if statement.\n\n"
            "Returns:\n"
-           "    bool: True if inside an if statement context");
+           "    bool: True if inside an if statement context")
+
+      .def("in_program", &IRBuilder::InProgram,
+           "Check if currently inside a program.\n\n"
+           "Returns:\n"
+           "    bool: True if inside a program context")
+
+      // Program building
+      .def("begin_program", &IRBuilder::BeginProgram, nb::arg("name"), nb::arg("span"),
+           "Begin building a program.\n\n"
+           "Creates a new program context. Must be closed with end_program().\n\n"
+           "Args:\n"
+           "    name: Program name\n"
+           "    span: Source location for program definition\n\n"
+           "Raises:\n"
+           "    RuntimeError: If already inside another program")
+
+      .def("declare_function", &IRBuilder::DeclareFunction, nb::arg("func_name"),
+           "Declare a function in the current program.\n\n"
+           "Creates a GlobalVar for the function that can be used in Call expressions\n"
+           "before the function is fully built. This enables cross-function calls.\n\n"
+           "Args:\n"
+           "    func_name: Function name to declare\n\n"
+           "Returns:\n"
+           "    GlobalVar: GlobalVar that can be used in Call expressions\n\n"
+           "Raises:\n"
+           "    RuntimeError: If not inside a program context")
+
+      .def("get_global_var", &IRBuilder::GetGlobalVar, nb::arg("func_name"),
+           "Get a GlobalVar for a declared function.\n\n"
+           "Retrieves a GlobalVar that was previously declared with declare_function.\n\n"
+           "Args:\n"
+           "    func_name: Function name\n\n"
+           "Returns:\n"
+           "    GlobalVar: GlobalVar for the function\n\n"
+           "Raises:\n"
+           "    RuntimeError: If not inside a program context or function not declared")
+
+      .def("add_function", &IRBuilder::AddFunction, nb::arg("func"),
+           "Add a completed function to the current program.\n\n"
+           "The function must have been previously declared with declare_function.\n\n"
+           "Args:\n"
+           "    func: Completed function to add\n\n"
+           "Raises:\n"
+           "    RuntimeError: If not inside a program context")
+
+      .def("end_program", &IRBuilder::EndProgram, nb::arg("end_span"),
+           "End building a program.\n\n"
+           "Finalizes the program and returns it.\n\n"
+           "Args:\n"
+           "    end_span: Source location for end of program\n\n"
+           "Returns:\n"
+           "    Program: The built program\n\n"
+           "Raises:\n"
+           "    RuntimeError: If not inside a program context")
+
+      .def("get_function_return_types", &IRBuilder::GetFunctionReturnTypes, nb::arg("gvar"),
+           "Get return types for a function by its GlobalVar.\n\n"
+           "Returns the return types for a function if it has been added to the program.\n"
+           "Returns empty list if not inside a program or function not yet added.\n\n"
+           "Args:\n"
+           "    gvar: GlobalVar for the function\n\n"
+           "Returns:\n"
+           "    List[Type]: Vector of return types");
 }
 
 }  // namespace python

--- a/python/pypto/ir/parser/decorator.py
+++ b/python/pypto/ir/parser/decorator.py
@@ -12,12 +12,168 @@
 import ast
 import inspect
 import textwrap
-from typing import Callable
+from typing import Callable, TypeVar, Union
 
 from pypto.pypto_core import ir
 
 from .ast_parser import ASTParser
 from .diagnostics import ParserError, ParserSyntaxError
+
+
+def _calculate_col_offset(source_lines: list[str]) -> int:
+    """Calculate the column offset (indentation) of the first non-empty line.
+
+    This is needed because ast.parse() requires code starting at column 0,
+    but we need to report errors at the correct column in the original file.
+
+    Args:
+        source_lines: List of source code lines
+
+    Returns:
+        Column offset (number of leading spaces/tabs in first non-empty line)
+    """
+    for line in source_lines:
+        if line.strip():  # Skip empty lines
+            return len(line) - len(line.lstrip())
+    return 0
+
+
+def _parse_ast_tree(source_code: str, entity_type: str) -> ast.AST:
+    """Parse source code into an AST tree with proper error handling.
+
+    Args:
+        source_code: Python source code to parse
+        entity_type: Type of entity being parsed ("function" or "class") for error messages
+
+    Returns:
+        Parsed AST tree
+
+    Raises:
+        ParserSyntaxError: If the source code has syntax errors
+    """
+    try:
+        return ast.parse(source_code)
+    except SyntaxError as e:
+        raise ParserSyntaxError(
+            f"Failed to parse {entity_type} source: {e.msg}",
+            hint=f"Check for Python syntax errors in your {entity_type}",
+        )
+
+
+TypeASTNode = TypeVar("TypeASTNode", bound=Union[ast.FunctionDef, ast.ClassDef])
+
+
+def _find_ast_node(tree: ast.AST, node_type: type[TypeASTNode], name: str, entity_type: str) -> TypeASTNode:
+    """Find a specific AST node by type and name.
+
+    Args:
+        tree: AST tree to search
+        node_type: Type of AST node to find (ast.FunctionDef or ast.ClassDef)
+        name: Name of the node to find
+        entity_type: Type of entity for error messages ("function" or "class")
+
+    Returns:
+        Found AST node
+
+    Raises:
+        ParserSyntaxError: If the node cannot be found
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, node_type) and node.name == name:
+            return node
+
+    raise ParserSyntaxError(
+        f"Could not find {entity_type} definition for {name}",
+        hint=f"Ensure the {entity_type} is properly defined",
+    )
+
+
+def _attach_source_lines_to_error(error: ParserError, source_file: str, source_lines_raw: list[str]) -> None:
+    """Attach source lines to a ParserError if not already present.
+
+    Args:
+        error: ParserError to attach source lines to
+        source_file: Path to the source file
+        source_lines_raw: Raw source lines as fallback
+    """
+    if error.source_lines is None:
+        try:
+            with open(source_file, encoding="utf-8") as f:
+                error.source_lines = f.read().split("\n")
+        except Exception:
+            # Fallback to the raw source lines if we can't read the file
+            error.source_lines = source_lines_raw
+
+
+def _has_pl_function_decorator(node: ast.FunctionDef) -> bool:
+    """Check if a function node has @pl.function decorator.
+
+    Args:
+        node: AST FunctionDef node to check
+
+    Returns:
+        True if the node has @pl.function decorator
+    """
+    for decorator in node.decorator_list:
+        # Check various decorator patterns
+        # ast.Attribute: pl.function
+        if isinstance(decorator, ast.Attribute):
+            if decorator.attr == "function":
+                return True
+        # ast.Name: function (if imported directly)
+        elif isinstance(decorator, ast.Name):
+            if decorator.id == "function":
+                return True
+        # ast.Call: @pl.function() with parentheses
+        elif isinstance(decorator, ast.Call):
+            if isinstance(decorator.func, ast.Attribute) and decorator.func.attr == "function":
+                return True
+            elif isinstance(decorator.func, ast.Name) and decorator.func.id == "function":
+                return True
+    return False
+
+
+def _is_class_method(func: Callable) -> bool:
+    """Check if a function is a method inside a class (not a standalone function).
+
+    This performs strict validation to determine if a function with 'self' as the first
+    parameter is actually defined inside a class, rather than a standalone function that
+    just happens to have 'self' as a parameter name.
+
+    Args:
+        func: Function to check
+
+    Returns:
+        True if the function is a method inside a class
+    """
+    # Check if first parameter is 'self'
+    try:
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        if not (params and params[0] == "self"):
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # Check if __qualname__ indicates this is a method (contains a dot)
+    qualname = func.__qualname__
+    if "." not in qualname:
+        # No dot in qualname means it's a standalone function, not a method
+        return False
+
+    # Verify it has indentation (defined inside a class, not at module level)
+    try:
+        source_lines_raw, _ = inspect.getsourcelines(func)
+        col_offset = _calculate_col_offset(source_lines_raw)
+        if col_offset > 0:
+            # This is an indented method inside a class
+            return True
+    except (OSError, TypeError):
+        # If we can't get source lines, assume it's a method based on qualname
+        # (This can happen with dynamically generated code)
+        return True
+
+    return False
 
 
 def function(func: Callable) -> ir.Function:
@@ -40,6 +196,12 @@ def function(func: Callable) -> ir.Function:
         ...     return result
     """
 
+    # Check if this is a method inside a class decorated with @pl.program
+    # If so, return the original function - it will be parsed by @pl.program decorator
+    if _is_class_method(func):
+        # Don't parse now - let @pl.program handle it with proper global_vars context
+        return func  # type: ignore[return-value]
+
     # Get source code and file information
     source_file = inspect.getfile(func)
 
@@ -49,13 +211,7 @@ def function(func: Callable) -> ir.Function:
     source_code = "".join(source_lines_raw)
 
     # Calculate indentation offset before dedenting
-    # This is needed because ast.parse() requires code starting at column 0,
-    # but we need to report errors at the correct column in the original file
-    col_offset = 0
-    for line in source_lines_raw:
-        if line.strip():  # Skip empty lines
-            col_offset = len(line) - len(line.lstrip())
-            break
+    col_offset = _calculate_col_offset(source_lines_raw)
 
     # Remove leading indentation so ast.parse() can parse it
     source_code = textwrap.dedent(source_code)
@@ -67,27 +223,8 @@ def function(func: Callable) -> ir.Function:
     line_offset = starting_line - 1
 
     try:
-        try:
-            tree = ast.parse(source_code)
-        except SyntaxError as e:
-            # Convert Python syntax error to ParserSyntaxError
-            raise ParserSyntaxError(
-                f"Failed to parse function source: {e.msg}",
-                hint="Check for Python syntax errors in your function",
-            )
-
-        # Find the function definition in the AST
-        func_def = None
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
-                func_def = node
-                break
-
-        if func_def is None:
-            raise ParserSyntaxError(
-                f"Could not find function definition for {func.__name__}",
-                hint="Ensure the function is properly defined",
-            )
+        tree = _parse_ast_tree(source_code, "function")
+        func_def = _find_ast_node(tree, ast.FunctionDef, func.__name__, "function")
 
         # Create parser and parse the function
         parser = ASTParser(source_file, source_lines, line_offset, col_offset)
@@ -108,17 +245,151 @@ def function(func: Callable) -> ir.Function:
 
     except ParserError as e:
         # Attach source lines if not already present
-        # Use the full file content for proper line number display
-        if e.source_lines is None:
-            try:
-                with open(source_file, encoding="utf-8") as f:
-                    e.source_lines = f.read().split("\n")
-            except Exception:
-                # Fallback to the function source lines if we can't read the file
-                e.source_lines = source_lines_raw
-
+        _attach_source_lines_to_error(e, source_file, source_lines_raw)
         # Always raise the exception - let the excepthook handle uncaught cases
         raise
 
 
-__all__ = ["function"]
+def program(cls: type) -> ir.Program:
+    """Decorator that parses a class with @pl.function methods into a Program.
+
+    The class should contain one or more methods decorated with @pl.function.
+    Each method is parsed as a separate function and added to the program.
+    Methods must have 'self' as the first parameter (standard Python syntax),
+    which is automatically stripped from the IR.
+
+    Args:
+        cls: Class with @pl.function decorated methods
+
+    Returns:
+        IR Program object
+
+    Example:
+        >>> @pl.program
+        ... class MyProgram:
+        ...     @pl.function
+        ...     def add(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        ...         result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+        ...         return result
+        ...
+        ...     @pl.function
+        ...     def mul(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        ...         result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+        ...         return result
+        >>> # MyProgram is now an ir.Program object
+    """
+    # Get source code and file information
+    source_file = inspect.getfile(cls)
+    source_lines_raw, starting_line = inspect.getsourcelines(cls)
+    source_code = "".join(source_lines_raw)
+
+    # Calculate indentation offset before dedenting
+    col_offset = _calculate_col_offset(source_lines_raw)
+
+    # Remove leading indentation so ast.parse() can parse it
+    source_code = textwrap.dedent(source_code)
+
+    # Use dedented source lines so column offsets align with AST
+    source_lines = source_code.split("\n")
+
+    # Calculate line offset (AST line numbers are 1-based, but we want to map to original file)
+    line_offset = starting_line - 1
+
+    try:
+        tree = _parse_ast_tree(source_code, "class")
+        class_def = _find_ast_node(tree, ast.ClassDef, cls.__name__, "class")
+
+        # Pass 1: Collect all @pl.function methods and create GlobalVars
+        global_vars = {}
+        func_defs = []
+
+        for node in class_def.body:
+            if isinstance(node, ast.FunctionDef):
+                if _has_pl_function_decorator(node):
+                    # Create GlobalVar for this function
+                    gvar = ir.GlobalVar(node.name)
+                    global_vars[node.name] = gvar
+                    func_defs.append(node)
+
+        if not func_defs:
+            raise ParserSyntaxError(
+                f"Class '{cls.__name__}' contains no @pl.function decorated methods",
+                hint="Add at least one method decorated with @pl.function",
+            )
+
+        # Pass 2: Parse each function body with GlobalVar map for cross-function calls
+        # Build a map from GlobalVar to parsed functions as we go, so later functions
+        # can use return type information from earlier functions
+        functions = []
+        gvar_to_func = {}
+
+        for func_def in func_defs:
+            # Strip 'self' parameter if present (must be done before parsing)
+            func_def_to_parse = func_def
+            if func_def.args.args and func_def.args.args[0].arg == "self":
+                # Create a new arguments object with self removed
+                new_args = ast.arguments(
+                    posonlyargs=func_def.args.posonlyargs,
+                    args=func_def.args.args[1:],  # Skip 'self'
+                    vararg=func_def.args.vararg,
+                    kwonlyargs=func_def.args.kwonlyargs,
+                    kw_defaults=func_def.args.kw_defaults,
+                    kwarg=func_def.args.kwarg,
+                    defaults=func_def.args.defaults,
+                )
+
+                # Create a new function def node with self removed
+                func_def_to_parse = ast.FunctionDef(
+                    name=func_def.name,
+                    args=new_args,
+                    body=func_def.body,
+                    decorator_list=func_def.decorator_list,
+                    returns=func_def.returns,
+                    type_comment=func_def.type_comment,
+                    lineno=func_def.lineno,
+                    col_offset=func_def.col_offset,
+                )
+                # Copy end line numbers if they exist
+                if hasattr(func_def, "end_lineno"):
+                    func_def_to_parse.end_lineno = func_def.end_lineno
+                if hasattr(func_def, "end_col_offset"):
+                    func_def_to_parse.end_col_offset = func_def.end_col_offset
+
+            # Create parser with global_vars and gvar_to_func map for cross-function call resolution
+            parser = ASTParser(
+                source_file,
+                source_lines,
+                line_offset,
+                col_offset,
+                global_vars=global_vars,
+                gvar_to_func=gvar_to_func,
+            )
+
+            try:
+                ir_func = parser.parse_function(func_def_to_parse)
+            except ParserError:
+                raise
+            except SyntaxError as e:
+                raise ParserSyntaxError(
+                    f"Failed to parse function '{func_def_to_parse.name}': {e.msg}",
+                    hint="Check for Python syntax errors in your function definition",
+                ) from e
+
+            functions.append(ir_func)
+            # Update gvar_to_func map so subsequent functions can use this function's return type
+            gvar = global_vars[ir_func.name]
+            gvar_to_func[gvar] = ir_func
+
+        # Create Program with class name and span
+        program_span = ir.Span(source_file, starting_line, col_offset)
+        program = ir.Program(functions, cls.__name__, program_span)
+
+        return program
+
+    except ParserError as e:
+        # Attach source lines if not already present
+        _attach_source_lines_to_error(e, source_file, source_lines_raw)
+        raise
+
+
+__all__ = ["function", "program"]

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -26,9 +26,9 @@ Typical usage:
         return result
 """
 
-# Import function decorator from pypto.ir.parser
-from pypto.ir.parser.decorator import function
-from pypto.ir.parser.text_parser import load, parse
+# Import decorators and parsing functions from pypto.ir.parser
+from pypto.ir.parser.decorator import function, program
+from pypto.ir.parser.text_parser import load, load_program, parse, parse_program
 from pypto.pypto_core import DataType
 
 from . import op
@@ -57,8 +57,11 @@ BOOL = DataType.BOOL
 
 __all__ = [
     "function",
+    "program",
     "parse",
     "load",
+    "parse_program",
+    "load_program",
     "Tensor",
     "range",
     "yield_",

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1696,7 +1696,7 @@ class IRBuilder:
         """Create an IR builder."""
 
     # Function building
-    def BeginFunction(self, name: str, span: Span) -> None:
+    def begin_function(self, name: str, span: Span) -> None:
         """Begin building a function.
 
         Args:
@@ -1704,7 +1704,7 @@ class IRBuilder:
             span: Source location for function definition
         """
 
-    def FuncArg(self, name: str, type: Type, span: Span) -> Var:
+    def func_arg(self, name: str, type: Type, span: Span) -> Var:
         """Add a function parameter.
 
         Args:
@@ -1716,14 +1716,14 @@ class IRBuilder:
             Variable representing the parameter
         """
 
-    def ReturnType(self, type: Type) -> None:
+    def return_type(self, type: Type) -> None:
         """Add a return type to the current function.
 
         Args:
             type: Return type
         """
 
-    def EndFunction(self, end_span: Span) -> Function:
+    def end_function(self, end_span: Span) -> Function:
         """End building a function.
 
         Args:
@@ -1734,7 +1734,7 @@ class IRBuilder:
         """
 
     # For loop building
-    def BeginForLoop(self, loop_var: Var, start: Expr, stop: Expr, step: Expr, span: Span) -> None:
+    def begin_for_loop(self, loop_var: Var, start: Expr, stop: Expr, step: Expr, span: Span) -> None:
         """Begin building a for loop.
 
         Args:
@@ -1745,21 +1745,21 @@ class IRBuilder:
             span: Source location for loop definition
         """
 
-    def AddIterArg(self, iter_arg: IterArg) -> None:
+    def add_iter_arg(self, iter_arg: IterArg) -> None:
         """Add an iteration argument to the current for loop.
 
         Args:
             iter_arg: Iteration argument with initial value
         """
 
-    def AddReturnVar(self, var: Var) -> None:
+    def add_return_var(self, var: Var) -> None:
         """Add a return variable to the current for loop.
 
         Args:
             var: Return variable
         """
 
-    def EndForLoop(self, end_span: Span) -> ForStmt:
+    def end_for_loop(self, end_span: Span) -> ForStmt:
         """End building a for loop.
 
         Args:
@@ -1770,7 +1770,7 @@ class IRBuilder:
         """
 
     # If statement building
-    def BeginIf(self, condition: Expr, span: Span) -> None:
+    def begin_if(self, condition: Expr, span: Span) -> None:
         """Begin building an if statement.
 
         Args:
@@ -1778,21 +1778,21 @@ class IRBuilder:
             span: Source location for if statement
         """
 
-    def BeginElse(self, span: Span) -> None:
+    def begin_else(self, span: Span) -> None:
         """Begin the else branch of the current if statement.
 
         Args:
             span: Source location for else keyword
         """
 
-    def AddIfReturnVar(self, var: Var) -> None:
+    def add_if_return_var(self, var: Var) -> None:
         """Add a return variable to the current if statement.
 
         Args:
             var: Return variable
         """
 
-    def EndIf(self, end_span: Span) -> IfStmt:
+    def end_if(self, end_span: Span) -> IfStmt:
         """End building an if statement.
 
         Args:
@@ -1802,15 +1802,74 @@ class IRBuilder:
             The built if statement
         """
 
+    # Program building
+    def begin_program(self, name: str, span: Span) -> None:
+        """Begin building a program.
+
+        Args:
+            name: Program name
+            span: Source location for program definition
+        """
+
+    def declare_function(self, func_name: str) -> GlobalVar:
+        """Declare a function and get its GlobalVar for cross-function calls.
+
+        Args:
+            func_name: Function name to declare
+
+        Returns:
+            GlobalVar that can be used in Call expressions
+        """
+
+    def get_global_var(self, func_name: str) -> GlobalVar:
+        """Get GlobalVar for a declared function.
+
+        Args:
+            func_name: Function name
+
+        Returns:
+            GlobalVar for the function
+        """
+
+    def add_function(self, func: Function) -> None:
+        """Add a completed function to the current program.
+
+        Args:
+            func: Function to add
+        """
+
+    def end_program(self, end_span: Span) -> Program:
+        """End building a program.
+
+        Args:
+            end_span: Source location for end of program
+
+        Returns:
+            The built program
+        """
+
+    def get_function_return_types(self, gvar: GlobalVar) -> list[Type]:
+        """Get return types for a function by its GlobalVar.
+
+        Returns the return types for a function if it has been added to the program.
+        Returns empty list if not inside a program or function not yet added.
+
+        Args:
+            gvar: GlobalVar for the function
+
+        Returns:
+            Vector of return types
+        """
+
     # Statement recording
-    def Emit(self, stmt: Stmt) -> None:
+    def emit(self, stmt: Stmt) -> None:
         """Emit a statement in the current context.
 
         Args:
             stmt: Statement to emit
         """
 
-    def Assign(self, var: Var, value: Expr, span: Span) -> AssignStmt:
+    def assign(self, var: Var, value: Expr, span: Span) -> AssignStmt:
         """Create an assignment statement and emit it.
 
         Args:
@@ -1822,7 +1881,7 @@ class IRBuilder:
             The created assignment statement
         """
 
-    def Var(self, name: str, type: Type, span: Span) -> Var:
+    def var(self, name: str, type: Type, span: Span) -> Var:
         """Create a variable (does not emit).
 
         Args:
@@ -1834,11 +1893,23 @@ class IRBuilder:
             The created variable
         """
 
-    def Return(self, values: list[Expr], span: Span) -> ReturnStmt:
+    @overload
+    def return_(self, values: list[Expr], span: Span) -> ReturnStmt:
         """Create a return statement and emit it.
 
         Args:
-            values: List of expressions to return (can be empty)
+            values: List of expressions to return
+            span: Source location for return statement
+
+        Returns:
+            The created return statement
+        """
+
+    @overload
+    def return_(self, span: Span) -> ReturnStmt:
+        """Create an empty return statement and emit it.
+
+        Args:
             span: Source location for return statement
 
         Returns:
@@ -1846,25 +1917,85 @@ class IRBuilder:
         """
 
     # Context state queries
-    def InFunction(self) -> bool:
+    def in_function(self) -> bool:
         """Check if currently inside a function.
 
         Returns:
             True if inside a function context
         """
 
-    def InLoop(self) -> bool:
+    def in_loop(self) -> bool:
         """Check if currently inside a for loop.
 
         Returns:
             True if inside a for loop context
         """
 
-    def InIf(self) -> bool:
+    def in_if(self) -> bool:
         """Check if currently inside an if statement.
 
         Returns:
             True if inside an if statement context
+        """
+
+    def in_program(self) -> bool:
+        """Check if currently inside a program.
+
+        Returns:
+            True if inside a program context
+        """
+
+class ProgramBuilder:
+    """Helper for building programs within a program context.
+
+    This class is used as a context manager helper for IRBuilder.program().
+    It provides methods for declaring functions, managing GlobalVars, and
+    constructing the final Program.
+    """
+
+    def declare_function(self, name: str) -> GlobalVar:
+        """Declare a function and get its GlobalVar for cross-function calls.
+
+        This should be called before building the function to enable other
+        functions to reference it via Call expressions.
+
+        Args:
+            name: Function name to declare
+
+        Returns:
+            GlobalVar that can be used in Call expressions
+        """
+
+    def get_global_var(self, name: str) -> GlobalVar:
+        """Get GlobalVar for a declared function.
+
+        Args:
+            name: Function name
+
+        Returns:
+            GlobalVar for the function
+
+        Raises:
+            RuntimeError: If function not declared
+        """
+
+    def add_function(self, func: Function) -> None:
+        """Add a function to the program.
+
+        The function name must match a previously declared function name.
+
+        Args:
+            func: Function to add
+        """
+
+    def get_result(self) -> Program:
+        """Get the built Program.
+
+        Returns:
+            The completed program IR node
+
+        Raises:
+            AssertionError: If called before program is complete
         """
 
 # ========== Python Printer ==========

--- a/tests/ut/ir/core/test_tuple_type.py
+++ b/tests/ut/ir/core/test_tuple_type.py
@@ -417,7 +417,7 @@ class TestTuplePythonPrinter:
 
         result = ir.python_print(assign)
         assert "pl.Tuple([" in result
-        assert "pl.Int64" in result
+        assert "pl.INT64" in result
         assert "pl.FP32" in result
 
     def test_python_print_tuple_get_item(self):

--- a/tests/ut/ir/parser/test_program_decorator.py
+++ b/tests/ut/ir/parser/test_program_decorator.py
@@ -1,0 +1,279 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for @pl.program decorator."""
+
+import pypto
+import pypto.language as pl
+import pytest
+from pypto.ir.parser.diagnostics.exceptions import ParserSyntaxError, UndefinedVariableError
+from pypto.pypto_core import ir
+
+
+class TestProgramDecorator:
+    """Tests for @pl.program decorator."""
+
+    def test_single_function_program(self):
+        """Test @pl.program with a single function."""
+
+        @pl.program
+        class SimpleProgram:
+            @pl.function
+            def add_one(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+                return result
+
+        assert isinstance(SimpleProgram, ir.Program)
+        assert SimpleProgram.name == "SimpleProgram"
+        assert len(SimpleProgram.functions) == 1
+
+        # Verify the function is accessible
+        add_func = SimpleProgram.get_function("add_one")
+        assert add_func is not None
+        assert add_func.name == "add_one"
+        # self parameter should be stripped
+        assert len(add_func.params) == 1
+        assert add_func.params[0].name == "x"
+
+    def test_multiple_functions_program(self):
+        """Test @pl.program with multiple functions."""
+
+        @pl.program
+        class MathOps:
+            @pl.function
+            def square(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, x)
+                return result
+
+            @pl.function
+            def double(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                two: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, two)
+                return result
+
+        assert isinstance(MathOps, ir.Program)
+        assert MathOps.name == "MathOps"
+        assert len(MathOps.functions) == 2
+
+        # Verify both functions exist
+        square_func = MathOps.get_function("square")
+        double_func = MathOps.get_function("double")
+        assert square_func is not None
+        assert double_func is not None
+
+    def test_cross_function_calls(self):
+        """Test cross-function calls using self.method() syntax."""
+
+        @pl.program
+        class CallTest:
+            @pl.function
+            def square(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, x)
+                return result
+
+            @pl.function
+            def sum_of_squares(
+                self, a: pl.Tensor[[1], pl.INT32], b: pl.Tensor[[1], pl.INT32]
+            ) -> pl.Tensor[[1], pl.INT32]:
+                # Call square method using self
+                a_squared: pl.Tensor[[1], pl.INT32] = self.square(a)
+                b_squared: pl.Tensor[[1], pl.INT32] = self.square(b)
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(a_squared, b_squared)
+                return result
+
+        assert isinstance(CallTest, ir.Program)
+        assert len(CallTest.functions) == 2
+
+        # Verify sum_of_squares function exists and has proper parameters
+        sum_func = CallTest.get_function("sum_of_squares")
+        assert sum_func is not None
+        # Should have 2 params (a, b) - self is stripped
+        assert len(sum_func.params) == 2
+
+    def test_forward_reference(self):
+        """Test calling a function defined later in the class."""
+
+        @pl.program
+        class ForwardRef:
+            @pl.function
+            def caller(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                # Call helper which is defined below
+                result: pl.Tensor[[1], pl.INT32] = self.helper(x)
+                return result
+
+            @pl.function
+            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, 2)
+                return result
+
+        assert isinstance(ForwardRef, ir.Program)
+        assert len(ForwardRef.functions) == 2
+
+    def test_recursive_call(self):
+        """Test function calling itself recursively via self.method_name()."""
+
+        @pl.program
+        class RecursiveTest:
+            @pl.function
+            def factorial(self, n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                _zero: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+                one: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+                # Note: This is just for testing IR structure, not a real factorial implementation
+                # In real DSL, we'd need if statements for base case
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(n, one)
+                return result
+
+        assert isinstance(RecursiveTest, ir.Program)
+
+    def test_transitive_calls(self):
+        """Test transitive calls where A calls B calls C."""
+
+        @pl.program
+        class TransitiveCalls:
+            @pl.function
+            def a(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = self.b(x)
+                return result
+
+            @pl.function
+            def b(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = self.c(x)
+                return result
+
+            @pl.function
+            def c(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, 3)
+                return result
+
+        assert isinstance(TransitiveCalls, ir.Program)
+        assert len(TransitiveCalls.functions) == 3
+
+    def test_self_parameter_stripped(self):
+        """Test that self parameter is properly stripped from IR."""
+
+        @pl.program
+        class SelfTest:
+            @pl.function
+            def test_func(
+                self, x: pl.Tensor[[1], pl.INT32], y: pl.Tensor[[1], pl.INT32]
+            ) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(x, y)
+                return result
+
+        func = SelfTest.get_function("test_func")
+        assert func is not None
+        # Should only have x and y parameters (self stripped)
+        assert len(func.params) == 2
+        assert func.params[0].name == "x"
+        assert func.params[1].name == "y"
+
+    def test_program_name_from_class(self):
+        """Test that program name is extracted from class name."""
+
+        @pl.program
+        class MyCustomProgram:
+            @pl.function
+            def dummy(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                return x
+
+        assert MyCustomProgram.name == "MyCustomProgram"
+
+    def test_empty_class_error(self):
+        """Test that empty class raises error."""
+        with pytest.raises(ParserSyntaxError):  # Should raise ParserSyntaxError
+
+            @pl.program
+            class EmptyProgram:
+                pass
+
+    def test_undefined_method_call_error(self):
+        """Test that calling undefined method raises error."""
+        with pytest.raises(UndefinedVariableError):  # Should raise UndefinedVariableError
+
+            @pl.program
+            class UndefinedCall:
+                @pl.function
+                def caller(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                    # Try to call a method that doesn't exist
+                    result: pl.Tensor[[1], pl.INT32] = self.nonexistent(x)  # type: ignore
+                    return result
+
+
+class TestProgramRoundTrip:
+    """Test round-trip: parse → print → parse."""
+
+    def test_roundtrip_simple_program(self):
+        """Test that printing and re-parsing produces equivalent IR."""
+
+        @pl.program
+        class Original:
+            @pl.function
+            def add(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+                return result
+
+        # Print to code
+        code = pypto.ir.python_print(Original)
+
+        # Verify code contains expected elements
+        assert "@pl.program" in code
+        assert "class Original:" in code
+        assert "def add(self," in code  # Should have self parameter
+
+        # Re-parse the code
+        reparsed = pl.parse_program(code)
+
+        # Verify structural equivalence
+        assert isinstance(reparsed, ir.Program)
+        assert reparsed.name == "Original"
+        assert len(reparsed.functions) == 1
+
+        # Verify function structure matches
+        reparsed_func = reparsed.get_function("add")
+        original_func = Original.get_function("add")
+        assert reparsed_func is not None
+        assert original_func is not None
+        assert len(reparsed_func.params) == len(original_func.params)
+
+        # Verify structural equivalence
+        pypto.ir.assert_structural_equal(reparsed, Original)
+
+    def test_roundtrip_with_cross_function_calls(self):
+        """Test round-trip with cross-function calls."""
+
+        @pl.program
+        class WithCalls:
+            @pl.function
+            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, 2)
+                return result
+
+            @pl.function
+            def caller(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = self.helper(x)
+                return result
+
+        # Print to code
+        code = pypto.ir.python_print(WithCalls)
+
+        # Verify cross-function calls are printed with self
+        assert "self.helper(" in code
+
+        # Re-parse
+        reparsed = pl.parse_program(code)
+
+        assert isinstance(reparsed, ir.Program)
+        assert len(reparsed.functions) == 2
+
+        # Verify structural equivalence
+        pypto.ir.assert_structural_equal(reparsed, WithCalls)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -52,7 +52,7 @@ def test_python_print_assignment_with_type_annotation():
     result = ir.python_print(assign)
     # Should have type annotation with default "pl" prefix
     assert "x:" in result or "x :" in result
-    assert "pl.Int64" in result
+    assert "pl.INT64" in result
     assert "42" in result
 
 
@@ -94,7 +94,7 @@ def test_python_print_function_with_annotations():
     assert "def add_func" in result
     assert "x:" in result or "x :" in result
     assert "y:" in result or "y :" in result
-    assert "pl.Int64" in result
+    assert "pl.INT64" in result
     assert "->" in result  # Return type annotation
 
 
@@ -155,7 +155,7 @@ def test_python_print_for_stmt_basic():
 
     assert "for" in result
     assert "for i in range" in result  # No type annotation in for loop header
-    assert "pl.Int64" in result  # Type annotation in body assignment
+    assert "pl.INT64" in result  # Type annotation in body assignment
     assert "range" in result
     assert "0" in result
     assert "10" in result
@@ -368,17 +368,17 @@ def test_python_print_all_scalar_types():
     span = ir.Span.unknown()
 
     type_map = [
-        (DataType.INT8, "pl.Int8"),
-        (DataType.INT16, "pl.Int16"),
-        (DataType.INT32, "pl.Int32"),
-        (DataType.INT64, "pl.Int64"),
-        (DataType.UINT8, "pl.UInt8"),
-        (DataType.UINT16, "pl.UInt16"),
-        (DataType.UINT32, "pl.UInt32"),
-        (DataType.UINT64, "pl.UInt64"),
+        (DataType.INT8, "pl.INT8"),
+        (DataType.INT16, "pl.INT16"),
+        (DataType.INT32, "pl.INT32"),
+        (DataType.INT64, "pl.INT64"),
+        (DataType.UINT8, "pl.UINT8"),
+        (DataType.UINT16, "pl.UINT16"),
+        (DataType.UINT32, "pl.UINT32"),
+        (DataType.UINT64, "pl.UINT64"),
         (DataType.FP16, "pl.FP16"),
         (DataType.FP32, "pl.FP32"),
-        (DataType.BF16, "pl.BFloat16"),
+        (DataType.BF16, "pl.BFLOAT16"),
     ]
 
     for dtype, expected_str in type_map:
@@ -427,7 +427,7 @@ def test_python_print_complex_nested_function():
     # Verify structure
     assert "def loop_sum" in result
     assert "n:" in result
-    assert "pl.Int64" in result
+    assert "pl.INT64" in result
     assert "for" in result
     assert "range" in result
     assert "return" in result  # Functions use return, not yield
@@ -471,7 +471,7 @@ def test_python_print_str_method():
     # str() should use Python printer with default "pl" prefix
     str_result = str(assign)
     # Should include type annotation
-    assert "pl.Int64" in str_result or "Int64" in str_result
+    assert "pl.INT64" in str_result
 
 
 def test_python_print_custom_prefix():
@@ -484,15 +484,15 @@ def test_python_print_custom_prefix():
 
     # Test default prefix "pl"
     result_pi = ir.python_print(assign)
-    assert "pl.Int64" in result_pi
+    assert "pl.INT64" in result_pi
 
     # Test "ir" prefix
     result_ir = ir.python_print(assign, "ir")
-    assert "ir.Int64" in result_ir
+    assert "ir.INT64" in result_ir
 
     # Test custom prefix
     result_custom = ir.python_print(assign, "myir")
-    assert "myir.Int64" in result_custom
+    assert "myir.INT64" in result_custom
 
     # Test with program to check import statement
     func = ir.Function("test", [x], [ir.ScalarType(dtype)], assign, span)
@@ -501,17 +501,17 @@ def test_python_print_custom_prefix():
     # Default "pl" should use "import pypto.language as pl"
     prog_pi = ir.python_print(program)
     assert "import pypto.language as pl" in prog_pi
-    assert "pl.Int64" in prog_pi
+    assert "pl.INT64" in prog_pi
 
     # "ir" prefix should use "from pypto import ir"
     prog_ir = ir.python_print(program, "language")
     assert "from pypto import language" in prog_ir
-    assert "language.Int64" in prog_ir
+    assert "language.INT64" in prog_ir
 
     # Custom prefix should use "import pypto.ir as <prefix>"
     prog_custom = ir.python_print(program, "custom")
-    assert "import pypto.language as custom" in prog_custom
-    assert "custom.Int64" in prog_custom
+    assert "from pypto import language as custom" in prog_custom
+    assert "custom.INT64" in prog_custom
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/statements/test_op_stmts.py
+++ b/tests/ut/ir/statements/test_op_stmts.py
@@ -125,7 +125,7 @@ class TestOpStmtsPrinting:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         assign = ir.AssignStmt(x, y, span)
         op_stmts = ir.OpStmts([assign], span)
-        assert str(op_stmts) == "x: pl.Int64 = y"
+        assert str(op_stmts) == "x: pl.INT64 = y"
 
     def test_op_stmts_printing_multiple(self):
         """Test printing of OpStmts with multiple statements."""
@@ -138,7 +138,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, x, span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pl.Int64 = y\ny: pl.Int64 = z\nz: pl.Int64 = x"
+        assert str(op_stmts) == "x: pl.INT64 = y\ny: pl.INT64 = z\nz: pl.INT64 = x"
 
     def test_op_stmts_printing_empty(self):
         """Test printing of OpStmts with empty statement list."""
@@ -157,7 +157,7 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, ir.ConstInt(0, dtype, span), span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pl.Int64 = y\ny: pl.Int64 = z\nz: pl.Int64 = 0"
+        assert str(op_stmts) == "x: pl.INT64 = y\ny: pl.INT64 = z\nz: pl.INT64 = 0"
 
 
 class TestOpStmtsHash:

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -1,0 +1,201 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for Python IR printer."""
+
+import pypto
+import pypto.language as pl
+import pytest
+from pypto import DataType, ir
+
+
+class TestPythonPrinterProgram:
+    """Tests for Python printer with Program nodes."""
+
+    def test_print_empty_program(self):
+        """Test printing an empty program."""
+        span = ir.Span.unknown()
+        program = ir.Program([], "EmptyProgram", span)
+
+        code = pypto.ir.python_print(program)
+
+        assert "@pl.program" in code
+        assert "class EmptyProgram:" in code
+
+    def test_print_program_with_single_function(self):
+        """Test printing a program with a single function."""
+        span = ir.Span.unknown()
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+        add_expr = ir.Add(x, y, DataType.INT64, span)
+        assign = ir.AssignStmt(x, add_expr, span)
+        func = ir.Function("add", [x, y], [ir.ScalarType(DataType.INT64)], assign, span)
+        program = ir.Program([func], "SingleFunc", span)
+
+        code = pypto.ir.python_print(program)
+
+        assert "@pl.program" in code
+        assert "class SingleFunc:" in code
+        assert "@pl.function" in code
+        assert "def add(self," in code  # Should have self parameter
+        assert "x: pl.INT64" in code or "x: pl.INT64" in code
+
+    def test_print_program_with_multiple_functions(self):
+        """Test printing a program with multiple functions."""
+        span = ir.Span.unknown()
+
+        # Create first function
+        x1 = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        body1 = ir.AssignStmt(x1, x1, span)
+        func1 = ir.Function("func1", [x1], [ir.ScalarType(DataType.INT64)], body1, span)
+
+        # Create second function
+        x2 = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        body2 = ir.AssignStmt(x2, x2, span)
+        func2 = ir.Function("func2", [x2], [ir.ScalarType(DataType.INT64)], body2, span)
+
+        program = ir.Program([func1, func2], "MultiFunc", span)
+
+        code = pypto.ir.python_print(program)
+
+        assert "@pl.program" in code
+        assert "class MultiFunc:" in code
+        assert code.count("@pl.function") == 2
+        assert "def func1(self," in code
+        assert "def func2(self," in code
+
+    def test_print_program_methods_have_self(self):
+        """Test that printed methods include self parameter."""
+        span = ir.Span.unknown()
+        x = ir.Var("x", ir.ScalarType(DataType.INT32), span)
+        y = ir.Var("y", ir.ScalarType(DataType.INT32), span)
+        z = ir.Var("z", ir.ScalarType(DataType.INT32), span)
+        add_expr = ir.Add(x, y, DataType.INT32, span)
+        assign = ir.AssignStmt(z, add_expr, span)
+        func = ir.Function("my_func", [x, y], [ir.ScalarType(DataType.INT32)], assign, span)
+        program = ir.Program([func], "TestProgram", span)
+
+        code = pypto.ir.python_print(program)
+
+        # Verify self is the first parameter
+        assert "def my_func(self, x:" in code
+
+    def test_print_program_with_cross_function_calls(self):
+        """Test that cross-function calls print as self.method_name()."""
+        span = ir.Span.unknown()
+
+        # Create helper function
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        helper_body = ir.AssignStmt(x, x, span)
+        helper = ir.Function("helper", [x], [ir.ScalarType(DataType.INT64)], helper_body, span)
+
+        # Create program to get GlobalVar
+        temp_program = ir.Program([helper], "TempProgram", span)
+        helper_gvar = temp_program.get_global_var("helper")
+        assert helper_gvar is not None
+
+        # Create main function that calls helper
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+        call = ir.Call(helper_gvar, [y], span)
+        main_body = ir.AssignStmt(y, call, span)
+        main = ir.Function("main", [y], [ir.ScalarType(DataType.INT64)], main_body, span)
+
+        # Create final program with both functions
+        program = ir.Program([helper, main], "WithCalls", span)
+
+        code = pypto.ir.python_print(program)
+
+        # Verify cross-function call is printed with self
+        assert "self.helper(" in code
+
+    def test_standalone_function_no_self(self):
+        """Test that standalone Function printing doesn't add self."""
+        span = ir.Span.unknown()
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        body = ir.AssignStmt(x, x, span)
+        func = ir.Function("standalone", [x], [ir.ScalarType(DataType.INT64)], body, span)
+
+        code = pypto.ir.python_print(func)
+
+        # Standalone functions should NOT have self
+        assert "def standalone(x:" in code or "def standalone(x :" in code
+        assert "def standalone(self," not in code
+
+    def test_roundtrip_program_parse_print_parse(self):
+        """Test that parse → print → parse produces equivalent IR."""
+
+        @pl.program
+        class Original:
+            @pl.function
+            def add(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, 1.0)
+                return result
+
+        # Print to code
+        code = pypto.ir.python_print(Original)
+
+        # Re-parse
+        reparsed = pl.parse_program(code)
+
+        # Verify structural properties match
+        assert isinstance(reparsed, ir.Program)
+        assert reparsed.name == Original.name
+        assert len(reparsed.functions) == len(Original.functions)
+
+    def test_roundtrip_with_cross_function_calls(self):
+        """Test round-trip preserves cross-function calls."""
+
+        @pl.program
+        class WithCalls:
+            @pl.function
+            def square(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.mul(x, x)
+                return result
+
+            @pl.function
+            def sum_of_squares(
+                self, a: pl.Tensor[[1], pl.INT32], b: pl.Tensor[[1], pl.INT32]
+            ) -> pl.Tensor[[1], pl.INT32]:
+                a_sq: pl.Tensor[[1], pl.INT32] = self.square(a)
+                b_sq: pl.Tensor[[1], pl.INT32] = self.square(b)
+                result: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(a_sq, b_sq)
+                return result
+
+        # Print
+        code = pypto.ir.python_print(WithCalls)
+
+        # Verify printed code has self.square() calls
+        assert "self.square(a)" in code
+        assert "self.square(b)" in code
+
+        # Re-parse
+        reparsed = pl.parse_program(code)
+
+        assert isinstance(reparsed, ir.Program)
+        assert len(reparsed.functions) == 2
+
+    def test_printed_program_is_valid_python(self):
+        """Test that printed program code is syntactically valid Python."""
+        span = ir.Span.unknown()
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        body = ir.AssignStmt(x, x, span)
+        func = ir.Function("test", [x], [ir.ScalarType(DataType.INT64)], body, span)
+        program = ir.Program([func], "ValidSyntax", span)
+
+        code = pypto.ir.python_print(program)
+
+        # Try to compile it as Python code (will raise SyntaxError if invalid)
+        try:
+            compile(code, "<string>", "exec")
+        except SyntaxError as e:
+            pytest.fail(f"Printed code has invalid Python syntax: {e}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements Program-level IR to enable multi-function programs with cross-function calls. Programs can contain multiple functions that can call each other, with automatic resolution of forward references through a two-pass parsing strategy.

Key changes:
- Add Program and GlobalVar IR nodes for function references
- Extend IRBuilder with ProgramContext for program construction
- Implement @pl.program decorator for class-based program definitions
- Add two-pass parsing to resolve cross-function call dependencies
- Support automatic type inference for function call return values
- Update python_printer to round-trip Programs back to source
- Add comprehensive tests for program parsing and printing

Cross-layer updates:
- C++ headers: ProgramContext, BeginProgram/EndProgram, GlobalVar support
- Python bindings: All new methods with complete docstrings
- Type stubs: Full type definitions for Program and ProgramBuilder

Documentation includes detailed examples of @pl.program usage with cross-function calls and forward references.