### PR TITLE
feat(pass): implement InsertSyncPass for IfStmt

### DIFF
--- a/src/ir/transform/insert_sync_pass.cpp
+++ b/src/ir/transform/insert_sync_pass.cpp
@@ -11,13 +11,13 @@
 
 #include "pypto/ir/transform/insert_sync_pass.h"
 
-#include <algorithm>
 #include <any>
 #include <map>
 #include <memory>
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -25,11 +25,9 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
-#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transform/base/mutator.h"
 #include "pypto/ir/transform/base/visitor.h"
-#include "pypto/ir/transform/transformers.h"
 
 namespace pypto {
 namespace ir {
@@ -59,6 +57,15 @@ class MemRefCollector : public IRVisitor {
 bool IsSameMem(const MemRefPtr& a, const MemRefPtr& b) { return a.get() == b.get(); }
 
 /**
+ * @brief Extract MemRefs from an expression
+ */
+std::set<MemRefPtr> GetExprMemRefs(const ExprPtr& expr) {
+  MemRefCollector collector;
+  collector.VisitExpr(expr);
+  return collector.memrefs;
+}
+
+/**
  * @brief Extract pipe type from a statement
  */
 PipeType GetStmtPipe(const StmtPtr& stmt) {
@@ -72,6 +79,54 @@ PipeType GetStmtPipe(const StmtPtr& stmt) {
     }
   }
   return PipeType::S;
+}
+
+/**
+ * @brief Extract pipe types from operations within a statement that access given memrefs
+ */
+std::set<PipeType> ExtractPipesForMemRefs(const StmtPtr& stmt, const std::set<MemRefPtr>& target_memrefs,
+                                          bool for_reads) {
+  std::set<PipeType> pipes;
+
+  if (!stmt || target_memrefs.empty()) return pipes;
+
+  auto has_target = [&](const std::set<MemRefPtr>& memrefs) {
+    for (const auto& m : memrefs) {
+      for (const auto& t : target_memrefs) {
+        if (IsSameMem(m, t)) return true;
+      }
+    }
+    return false;
+  };
+
+  if (auto assign = As<AssignStmt>(stmt)) {
+    PipeType pipe = GetStmtPipe(stmt);
+    if (for_reads && has_target(GetExprMemRefs(assign->value_))) {
+      pipes.insert(pipe);
+    }
+    if (!for_reads && has_target(GetExprMemRefs(assign->var_))) {
+      pipes.insert(pipe);
+    }
+  } else if (auto eval = As<EvalStmt>(stmt)) {
+    if (for_reads && has_target(GetExprMemRefs(eval->expr_))) {
+      PipeType pipe = GetStmtPipe(stmt);
+      pipes.insert(pipe);
+    }
+  } else if (auto seq = As<SeqStmts>(stmt)) {
+    for (const auto& s : seq->stmts_) {
+      auto sub_pipes = ExtractPipesForMemRefs(s, target_memrefs, for_reads);
+      pipes.insert(sub_pipes.begin(), sub_pipes.end());
+    }
+  } else if (auto if_stmt = As<IfStmt>(stmt)) {
+    auto then_pipes = ExtractPipesForMemRefs(if_stmt->then_body_, target_memrefs, for_reads);
+    pipes.insert(then_pipes.begin(), then_pipes.end());
+    if (if_stmt->else_body_) {
+      auto else_pipes = ExtractPipesForMemRefs(*if_stmt->else_body_, target_memrefs, for_reads);
+      pipes.insert(else_pipes.begin(), else_pipes.end());
+    }
+  }
+
+  return pipes;
 }
 
 /**
@@ -136,50 +191,133 @@ class SyncInserter : public IRMutator {
     return std::make_shared<Function>(func->name_, func->params_, func->return_types_, new_body, func->span_);
   }
 
-  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
-    std::vector<StmtPtr> original_stmts;
-    for (const auto& s : op->stmts_) {
-      original_stmts.push_back(VisitStmt(s));
-    }
+ private:
+  /**
+   * @brief Helper struct to summarize memrefs in a statement
+   */
+  struct MemRefSummary {
+    std::set<MemRefPtr> reads;
+    std::set<MemRefPtr> writes;
+  };
 
-    // 1. Analyze dependencies in this sequence
+  /**
+   * @brief Extract read and write memrefs from a statement
+   * Recursively traverses the statement tree to collect all memrefs
+   */
+  MemRefSummary ExtractMemRefs(const StmtPtr& stmt) {
+    MemRefSummary summary;
+
+    if (!stmt) return summary;
+
+    if (auto assign = As<AssignStmt>(stmt)) {
+      // AssignStmt: var_ is written, value_ is read
+      summary.writes = GetExprMemRefs(assign->var_);
+      summary.reads = GetExprMemRefs(assign->value_);
+    } else if (auto eval = As<EvalStmt>(stmt)) {
+      // EvalStmt: expr_ is read
+      summary.reads = GetExprMemRefs(eval->expr_);
+    } else if (auto seq = As<SeqStmts>(stmt)) {
+      // SeqStmts: merge all reads and writes from sub-statements
+      for (const auto& s : seq->stmts_) {
+        auto sub_summary = ExtractMemRefs(s);
+        summary.reads.insert(sub_summary.reads.begin(), sub_summary.reads.end());
+        summary.writes.insert(sub_summary.writes.begin(), sub_summary.writes.end());
+      }
+    } else if (auto if_stmt = As<IfStmt>(stmt)) {
+      // IfStmt: merge then and else branches
+      auto then_summary = ExtractMemRefs(if_stmt->then_body_);
+      summary.reads.insert(then_summary.reads.begin(), then_summary.reads.end());
+      summary.writes.insert(then_summary.writes.begin(), then_summary.writes.end());
+
+      if (if_stmt->else_body_) {
+        auto else_summary = ExtractMemRefs(*if_stmt->else_body_);
+        summary.reads.insert(else_summary.reads.begin(), else_summary.reads.end());
+        summary.writes.insert(else_summary.writes.begin(), else_summary.writes.end());
+      }
+    }
+    // For other statement types (YieldStmt, ReturnStmt, etc.), no memrefs
+
+    return summary;
+  }
+
+  /**
+   * @brief Extract memrefs from a list of variables
+   */
+  std::set<MemRefPtr> ExtractMemRefsFromVars(const std::vector<VarPtr>& vars) {
+    std::set<MemRefPtr> memrefs;
+    for (const auto& var : vars) {
+      if (auto shaped_type = std::dynamic_pointer_cast<const ShapedType>(var->GetType())) {
+        if (shaped_type->memref_.has_value()) {
+          memrefs.insert(*shaped_type->memref_);
+        }
+      }
+    }
+    return memrefs;
+  }
+
+  /**
+   * @brief Analyze dependencies between statements
+   */
+  std::vector<std::shared_ptr<DepEdge>> AnalyzeDependencies(const std::vector<StmtPtr>& stmts) {
     std::vector<std::shared_ptr<DepEdge>> deps;
-    std::set<std::pair<int, int>> existing_deps;  // Keep track of existing edges to avoid duplicates
     std::map<MemRefPtr, int> last_writer;
     std::map<MemRefPtr, std::vector<int>> last_readers;
 
-    auto get_memrefs = [](const ExprPtr& expr) {
-      MemRefCollector collector;
-      collector.VisitExpr(expr);
-      return collector.memrefs;
-    };
-
-    auto add_dep = [&](int prod, int cons, const std::vector<StmtPtr>& stmts) {
+    auto add_dep = [&](int prod, int cons, const MemRefPtr& memref, bool consumer_reads) {
       if (prod < 0) return;
-      if (existing_deps.count({prod, cons})) return;  // Skip if edge already exists
 
-      existing_deps.insert({prod, cons});
-      deps.push_back(
-          std::make_shared<DepEdge>(DepEdge{prod, cons, GetStmtPipe(stmts[prod]), GetStmtPipe(stmts[cons])}));
+      // Extract actual pipe types for IfStmt
+      auto get_pipes_for_stmt = [&](int idx, bool for_reads) -> std::set<PipeType> {
+        if (auto if_stmt = As<IfStmt>(stmts[idx])) {
+          return ExtractPipesForMemRefs(if_stmt, {memref}, for_reads);
+        } else {
+          return {GetStmtPipe(stmts[idx])};
+        }
+      };
+
+      // For RAW: producer writes, consumer reads
+      // For WAW: producer writes, consumer writes
+      // For WAR: producer reads, consumer writes
+      auto producer_pipes =
+          get_pipes_for_stmt(prod, !consumer_reads);  // Producer: writes if consumer reads, reads otherwise
+      auto consumer_pipes = get_pipes_for_stmt(cons, consumer_reads);
+
+      // Create edges for all pipe combinations
+      for (auto p_pipe : producer_pipes) {
+        for (auto c_pipe : consumer_pipes) {
+          // Skip S pipe edges
+          if (p_pipe == PipeType::S || c_pipe == PipeType::S) continue;
+
+          deps.push_back(std::make_shared<DepEdge>(DepEdge{prod, cons, p_pipe, c_pipe}));
+        }
+      }
     };
 
-    for (int i = 0; i < static_cast<int>(original_stmts.size()); ++i) {
-      const auto& stmt = original_stmts[i];
+    for (int i = 0; i < static_cast<int>(stmts.size()); ++i) {
+      const auto& stmt = stmts[i];
       std::set<MemRefPtr> reads;
       std::set<MemRefPtr> writes;
 
       if (auto assign = As<AssignStmt>(stmt)) {
-        writes = get_memrefs(assign->var_);
-        reads = get_memrefs(assign->value_);
+        writes = GetExprMemRefs(assign->var_);
+        reads = GetExprMemRefs(assign->value_);
       } else if (auto eval = As<EvalStmt>(stmt)) {
-        reads = get_memrefs(eval->expr_);
+        reads = GetExprMemRefs(eval->expr_);
+      } else if (auto if_stmt = As<IfStmt>(stmt)) {
+        // Extract reads from then/else branches for dependencies before IfStmt
+        auto memref_summary = ExtractMemRefs(if_stmt);
+        reads = memref_summary.reads;
+
+        // Extract writes from return_vars only (IfStmt's external output)
+        // Only return_vars' memrefs are visible to subsequent statements
+        writes = ExtractMemRefsFromVars(if_stmt->return_vars_);
       }
 
       // Check RAW
       for (const auto& r : reads) {
         for (auto const& [m, idx] : last_writer) {
           if (IsSameMem(r, m)) {
-            add_dep(idx, i, original_stmts);
+            add_dep(idx, i, r, true);  // Consumer reads
           }
         }
       }
@@ -189,14 +327,14 @@ class SyncInserter : public IRMutator {
         // WAW
         for (auto const& [m, idx] : last_writer) {
           if (IsSameMem(w, m)) {
-            add_dep(idx, i, original_stmts);
+            add_dep(idx, i, w, false);  // Consumer writes
           }
         }
         // WAR
         for (auto const& [m, indices] : last_readers) {
           if (IsSameMem(w, m)) {
             for (int r_idx : indices) {
-              add_dep(r_idx, i, original_stmts);
+              add_dep(r_idx, i, w, false);  // Consumer writes
             }
           }
         }
@@ -211,8 +349,13 @@ class SyncInserter : public IRMutator {
         last_readers[r].push_back(i);
       }
     }
+    return deps;
+  }
 
-    // 2. Assign Event IDs (Simulation)
+  /**
+   * @brief Simulate execution to assign hardware event IDs
+   */
+  void AssignEventIds(size_t stmt_count, const std::vector<std::shared_ptr<DepEdge>>& deps) {
     EventIdManager event_manager;
     // Organize edges by producer and consumer for sequential processing
     std::map<int, std::vector<std::shared_ptr<DepEdge>>> prod_edges;  // Outgoing (Set)
@@ -225,8 +368,12 @@ class SyncInserter : public IRMutator {
       }
     }
 
+    // Track allocated event IDs for each (producer_idx, src_pipe, dst_pipe) to enable sharing
+    using PipePairKey = std::tuple<int, PipeType, PipeType>;
+    std::map<PipePairKey, int> allocated_event_ids;
+
     // Simulate execution to assign IDs
-    for (int i = 0; i < static_cast<int>(original_stmts.size()); ++i) {
+    for (int i = 0; i < static_cast<int>(stmt_count); ++i) {
       // Process Waits (release IDs) BEFORE instruction execution
       // NOTE: Wait instruction is inserted BEFORE consumer instruction.
       if (cons_edges.count(i)) {
@@ -242,15 +389,34 @@ class SyncInserter : public IRMutator {
       // NOTE: Set instruction is inserted AFTER producer instruction.
       if (prod_edges.count(i)) {
         for (const auto& edge : prod_edges[i]) {
-          // Allocate ID
-          edge->event_id = event_manager.Allocate(edge->producer_pipe, edge->consumer_pipe);
+          // Check if we already allocated an event ID for this pipe pair
+          PipePairKey key = std::make_tuple(edge->producer_idx, edge->producer_pipe, edge->consumer_pipe);
+          auto it = allocated_event_ids.find(key);
+          if (it != allocated_event_ids.end()) {
+            // Reuse existing event ID
+            edge->event_id = it->second;
+          } else {
+            // Allocate new ID and store it
+            int new_id = event_manager.Allocate(edge->producer_pipe, edge->consumer_pipe);
+            edge->event_id = new_id;
+            allocated_event_ids[key] = new_id;
+          }
         }
       }
     }
+  }
 
-    // 3. Generate Insertions
-    std::map<int, std::vector<StmtPtr>> insert_before;
-    std::map<int, std::vector<StmtPtr>> insert_after;
+  /**
+   * @brief Generate synchronization instructions
+   */
+  void GenerateInsertions(const std::vector<std::shared_ptr<DepEdge>>& deps,
+                          std::map<int, std::vector<StmtPtr>>& insert_before,
+                          std::map<int, std::vector<StmtPtr>>& insert_after) {
+    std::set<std::pair<int, PipeType>> inserted_bars;  // Track inserted barriers (position, pipe)
+    // Track inserted sync instructions by (src_pipe, dst_pipe, event_id) only
+    // This ensures each event ID is only set/waited once
+    std::set<std::tuple<PipeType, PipeType, int>> inserted_sync_src;
+    std::set<std::tuple<PipeType, PipeType, int>> inserted_sync_dst;
 
     auto create_sync_call = [](const std::string& op_name, PipeType p, PipeType tp, int event_id) {
       auto& registry = OpRegistry::GetInstance();
@@ -271,13 +437,35 @@ class SyncInserter : public IRMutator {
     for (const auto& edge : deps) {
       if (edge->producer_pipe != edge->consumer_pipe) {
         // Cross-pipe
+        // Skip syncs involving S pipe (scalar pipe doesn't need sync)
+        if (edge->producer_pipe == PipeType::S || edge->consumer_pipe == PipeType::S) {
+          continue;
+        }
         if (edge->event_id == -1) continue;  // Should have been assigned
-        insert_after[edge->producer_idx].push_back(
-            create_sync_call("system.sync_src", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
-        insert_before[edge->consumer_idx].push_back(
-            create_sync_call("system.sync_dst", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
+
+        // Insert sync_src only if not already inserted for this (pipe_pair, event_id)
+        auto src_key = std::make_tuple(edge->producer_pipe, edge->consumer_pipe, edge->event_id);
+        if (!inserted_sync_src.count(src_key)) {
+          insert_after[edge->producer_idx].push_back(
+              create_sync_call("system.sync_src", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
+          inserted_sync_src.insert(src_key);
+        }
+
+        // Insert sync_dst only if not already inserted for this (pipe_pair, event_id)
+        auto dst_key = std::make_tuple(edge->producer_pipe, edge->consumer_pipe, edge->event_id);
+        if (!inserted_sync_dst.count(dst_key)) {
+          insert_before[edge->consumer_idx].push_back(
+              create_sync_call("system.sync_dst", edge->producer_pipe, edge->consumer_pipe, edge->event_id));
+          inserted_sync_dst.insert(dst_key);
+        }
       } else {
-        // Same pipe
+        // Same pipe - only insert one barrier per position and pipe type
+        auto bar_key = std::make_pair(edge->consumer_idx, edge->producer_pipe);
+        if (inserted_bars.count(bar_key)) {
+          continue;  // Already inserted a barrier at this position for this pipe
+        }
+        inserted_bars.insert(bar_key);
+
         if (edge->producer_pipe == PipeType::V) {
           insert_before[edge->consumer_idx].push_back(create_bar_call("system.bar_v"));
         } else if (edge->producer_pipe == PipeType::M) {
@@ -285,6 +473,25 @@ class SyncInserter : public IRMutator {
         }
       }
     }
+  }
+
+ public:
+  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
+    std::vector<StmtPtr> original_stmts;
+    for (const auto& s : op->stmts_) {
+      original_stmts.push_back(VisitStmt(s));
+    }
+
+    // 1. Analyze dependencies in this sequence
+    auto deps = AnalyzeDependencies(original_stmts);
+
+    // 2. Assign Event IDs (Simulation)
+    AssignEventIds(original_stmts.size(), deps);
+
+    // 3. Generate Insertions
+    std::map<int, std::vector<StmtPtr>> insert_before;
+    std::map<int, std::vector<StmtPtr>> insert_after;
+    GenerateInsertions(deps, insert_before, insert_after);
 
     // 4. Build new statement list
     std::vector<StmtPtr> final_stmts;
@@ -299,6 +506,17 @@ class SyncInserter : public IRMutator {
     }
 
     return std::make_shared<const SeqStmts>(final_stmts, op->span_);
+  }
+
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
+    // Recursively process then_body and else_body
+    // Internal dependencies are handled automatically through recursive calls
+    auto new_then_body = VisitStmt(op->then_body_);
+    auto new_else_body = op->else_body_ ? VisitStmt(*op->else_body_) : nullptr;
+
+    return std::make_shared<const IfStmt>(op->condition_, new_then_body, new_else_body,
+                                          op->return_vars_,  // Keep return_vars unchanged
+                                          op->span_);
   }
 };
 

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -7,6 +7,8 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+"""Tests for InitMemRefPass."""
+
 from pypto import ir
 from pypto.ir import builder
 from pypto.ir.op import block

--- a/tests/ut/ir/transforms/test_insert_sync.py
+++ b/tests/ut/ir/transforms/test_insert_sync.py
@@ -7,57 +7,101 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-import pytest
+"""Tests for InsertSyncPass."""
+
 from pypto import ir
-from pypto.ir import builder
 from pypto.ir.op import block
 from pypto.pypto_core import DataType, passes
 
 
+def count_syncs(stmt):
+    """Recursively count sync operations in a statement."""
+    counts = {"sync_src": 0, "sync_dst": 0, "bar_v": 0, "bar_m": 0}
+
+    if isinstance(stmt, ir.EvalStmt):
+        call = stmt.expr
+        if isinstance(call, ir.Call):
+            if call.op.name == "system.sync_src":
+                counts["sync_src"] += 1
+            elif call.op.name == "system.sync_dst":
+                counts["sync_dst"] += 1
+            elif call.op.name == "system.bar_v":
+                counts["bar_v"] += 1
+            elif call.op.name == "system.bar_m":
+                counts["bar_m"] += 1
+    elif isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            sub_counts = count_syncs(s)
+            for key in counts:
+                counts[key] += sub_counts[key]
+    elif isinstance(stmt, ir.IfStmt):
+        # Count syncs in then and else branches
+        then_counts = count_syncs(stmt.then_body)
+        for key in counts:
+            counts[key] += then_counts[key]
+        if stmt.else_body is not None:
+            else_counts = count_syncs(stmt.else_body)
+            for key in counts:
+                counts[key] += else_counts[key]
+
+    return counts
+
+
 def test_insert_sync_cross_pipe():
     """Test InsertSyncPass for cross-pipe dependencies (MTE2 -> V -> MTE3)."""
-    ib = builder.IRBuilder()
+    # Test structure:
+    #   tile_a = load(input_a)        # MTE2
+    #   tile_b = load(input_b)        # MTE2
+    #   sync_src (MTE2 -> V)          # Inserted
+    #   sync_dst (MTE2 -> V)          # Inserted
+    #   tile_c = add(tile_a, tile_b)  # V
+    #   sync_src (V -> MTE3)          # Inserted
+    #   sync_dst (V -> MTE3)          # Inserted
+    #   store(tile_c, output)         # MTE3
+    #
+    # Expected: 2 sync pairs (MTE2->V) + 1 sync pair (V->MTE3)
+    span = ir.Span.unknown()
 
-    with ib.function("test_sync") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        input_b = f.param("input_b", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+    # Create shape expressions
+    dim64 = ir.ConstInt(64, DataType.INT64, span)
 
-        # MTE2
-        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, 64, 64))
-        tile_b = ib.let("tile_b", block.load(input_b, 0, 0, 64, 64))
+    # Create unique memrefs for each tile variable
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)  # 64*64*4
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
 
-        # VECTOR (Depends on MTE2)
-        tile_c = ib.let("tile_c", block.add(tile_a, tile_b))
+    # Create variables with memrefs
+    input_a = ir.Var("input_a", ir.TensorType([64, 64], DataType.FP32), span)
+    input_b = ir.Var("input_b", ir.TensorType([64, 64], DataType.FP32), span)
+    output = ir.Var("output", ir.TensorType([64, 64], DataType.FP32), span)
 
-        # MTE3 (Depends on VECTOR)
-        res = ib.let("res", block.store(tile_c, 0, 0, 64, 64, output))
-        ib.return_stmt(res)
+    tile_a = ir.Var("tile_a", ir.TileType([dim64, dim64], DataType.FP32, memref_a), span)
+    tile_b = ir.Var("tile_b", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    tile_c = ir.Var("tile_c", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
 
-    func = f.get_result()
+    # Create operations
+    load_a = block.load(input_a, 0, 0, 64, 64)
+    load_b = block.load(input_b, 0, 0, 64, 64)
+    add_op = block.add(tile_a, tile_b)
+    store_op = block.store(tile_c, 0, 0, 64, 64, output)
 
-    # Run passes
-    # 1. InitMemRefPass (required for InsertSyncPass to see memrefs)
-    init_memref = passes.InitMemRefPass()
-    func = init_memref.run(func)
+    # Build statements
+    stmt_load_a = ir.AssignStmt(tile_a, load_a, span)
+    stmt_load_b = ir.AssignStmt(tile_b, load_b, span)
+    stmt_add = ir.AssignStmt(tile_c, add_op, span)
+    stmt_store = ir.EvalStmt(store_op, span)
+    stmt_return = ir.ReturnStmt(span)
 
-    # 2. InsertSyncPass
+    body = ir.SeqStmts([stmt_load_a, stmt_load_b, stmt_add, stmt_store, stmt_return], span)
+    func = ir.Function("test_sync", [input_a, input_b, output], [], body, span)
+
+    # Run InsertSyncPass directly without InitMemRefPass
     insert_sync = passes.InsertSyncPass()
     synced_func = insert_sync.run(func)
 
     # Verify sync ops are inserted
     assert isinstance(synced_func.body, ir.SeqStmts)
     stmts = synced_func.body.stmts
-
-    # Expected sequence roughly:
-    # load a
-    # load b
-    # sync_src (MTE2 -> V)
-    # sync_dst (MTE2 -> V)
-    # add
-    # sync_src (V -> MTE3)
-    # sync_dst (V -> MTE3)
-    # store
 
     sync_src_count = 0
     sync_dst_count = 0
@@ -70,33 +114,46 @@ def test_insert_sync_cross_pipe():
                 elif call.op.name == "system.sync_dst":
                     sync_dst_count += 1
 
-    # Two sync pairs for MTE2->V and one for V->MTE3 are expected.
     assert sync_src_count == 3
     assert sync_dst_count == 3
 
 
 def test_insert_sync_intra_pipe():
     """Test InsertSyncPass for intra-pipe dependencies (V -> V)."""
-    ib = builder.IRBuilder()
+    # Test structure:
+    #   t_c = add(t_a, t_b)  # V
+    #   bar_v                # Inserted
+    #   t_d = add(t_c, t_a)  # V (depends on t_c)
+    #
+    # Expected: 1 intra-pipe barrier (bar_v)
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT64, span)
 
-    with ib.function("test_sync_intra") as f:
-        t_a = f.param("t_a", ir.TileType([64, 64], DataType.FP32))
-        t_b = f.param("t_b", ir.TileType([64, 64], DataType.FP32))
+    # Create unique memrefs for each tile
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
 
-        # V
-        t_c = ib.let("t_c", block.add(t_a, t_b))
-        # V (Depends on previous V)
-        t_d = ib.let("t_d", block.add(t_c, t_a))
+    # Create variables with memrefs (as function parameters and locals)
+    t_a = ir.Var("t_a", ir.TileType([dim64, dim64], DataType.FP32, memref_a), span)
+    t_b = ir.Var("t_b", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    t_c = ir.Var("t_c", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    t_d = ir.Var("t_d", ir.TileType([dim64, dim64], DataType.FP32, memref_d), span)
 
-        ib.return_stmt(t_d)
+    # V pipe operations
+    add_c = block.add(t_a, t_b)
+    add_d = block.add(t_c, t_a)
 
-    func = f.get_result()
+    # Build statements
+    stmt_add_c = ir.AssignStmt(t_c, add_c, span)
+    stmt_add_d = ir.AssignStmt(t_d, add_d, span)
+    stmt_return = ir.ReturnStmt([t_d], span)
 
-    # Run InitMemRefPass
-    init_memref = passes.InitMemRefPass()
-    func = init_memref.run(func)
+    body = ir.SeqStmts([stmt_add_c, stmt_add_d, stmt_return], span)
+    func = ir.Function("test_sync_intra", [t_a, t_b], [], body, span)
 
-    # Run InsertSyncPass
+    # Run InsertSyncPass directly without InitMemRefPass
     insert_sync = passes.InsertSyncPass()
     synced_func = insert_sync.run(func)
 
@@ -113,5 +170,355 @@ def test_insert_sync_intra_pipe():
     assert bar_v_count == 1
 
 
-if __name__ == "__main__":
-    pytest.main([__file__])
+def test_insert_sync_ifstmt():
+    """Test InsertSyncPass for IfStmt with cross-pipe dependencies."""
+    # Test structure:
+    #   tile_a = load(input)          # MTE2
+    #   sync_src (MTE2 -> V)          # Inserted
+    #   sync_dst (MTE2 -> V)          # Inserted
+    #   if (condition):
+    #     then:
+    #       tile_b = add(tile_a, tile_a)   # V
+    #       bar_v                          # Inserted
+    #       tile_c = add(tile_b, tile_a)   # V
+    #       yield [tile_c]
+    #     else:
+    #       tile_b = mul(tile_a, tile_a)   # V
+    #       bar_v                          # Inserted
+    #       tile_c = add(tile_b, tile_a)   # V
+    #       yield [tile_c]
+    #   # tile_c from return_vars
+    #   sync_src (V -> MTE3)          # Inserted
+    #   sync_dst (V -> MTE3)          # Inserted
+    #   store(tile_c, output)         # MTE3
+    #
+    # Expected: 2 cross-pipe sync pairs (MTE2→V + V→MTE3) + 2 intra-pipe barriers (bar_v in then/else)
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT64, span)
+
+    # Create unique memrefs
+    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
+
+    # Create variables with memrefs
+    input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32, memref_input), span)
+    output_tensor = ir.Var("output", ir.TensorType([64, 64], DataType.FP32, memref_output), span)
+    tile_a = ir.Var("tile_a", ir.TileType([dim64, dim64], DataType.FP32, memref_input), span)
+
+    # Load from MTE2 pipe
+    load_op = block.load(input_tensor, 0, 0, 64, 64)
+    stmt_load = ir.AssignStmt(tile_a, load_op, span)
+
+    # Create condition
+    condition = ir.ConstBool(True, span)
+
+    # Build then branch with V pipe operations
+    add_op_then = block.add(tile_a, tile_a)
+    tile_b_then = ir.Var("tile_b_then", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    stmt_add_then = ir.AssignStmt(tile_b_then, add_op_then, span)
+
+    add_op2_then = block.add(tile_b_then, tile_a)
+    tile_c_then = ir.Var("tile_c_then", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    stmt_add2_then = ir.AssignStmt(tile_c_then, add_op2_then, span)
+
+    yield_then = ir.YieldStmt([tile_c_then], span)
+    then_body = ir.SeqStmts([stmt_add_then, stmt_add2_then, yield_then], span)
+
+    # Build else branch with V pipe operations
+    mul_op_else = block.mul(tile_a, tile_a)
+    tile_b_else = ir.Var("tile_b_else", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    stmt_mul_else = ir.AssignStmt(tile_b_else, mul_op_else, span)
+
+    add_op_else = block.add(tile_b_else, tile_a)
+    tile_c_else = ir.Var("tile_c_else", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    stmt_add_else = ir.AssignStmt(tile_c_else, add_op_else, span)
+
+    yield_else = ir.YieldStmt([tile_c_else], span)
+    else_body = ir.SeqStmts([stmt_mul_else, stmt_add_else, yield_else], span)
+
+    # Create IfStmt with return_vars
+    if_return_var = ir.Var("tile_c", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    if_stmt = ir.IfStmt(condition, then_body, else_body, [if_return_var], span)
+
+    # Store to MTE3 pipe (depends on IfStmt output)
+    store_op = block.store(if_return_var, 0, 0, 64, 64, output_tensor)
+    stmt_store = ir.EvalStmt(store_op, span)
+    stmt_return = ir.ReturnStmt(span)
+
+    # Build function body with the load, if statement, and store
+    body = ir.SeqStmts([stmt_load, if_stmt, stmt_store, stmt_return], span)
+    func = ir.Function("test_ifstmt_sync", [input_tensor, output_tensor], [], body, span)
+
+    # Run InsertSyncPass directly without InitMemRefPass
+    insert_sync = passes.InsertSyncPass()
+    synced_func = insert_sync.run(func)
+
+    # Verify the structure
+    assert isinstance(synced_func.body, ir.SeqStmts)
+
+    total_counts = count_syncs(synced_func.body)
+    sync_src_count = total_counts["sync_src"]
+    sync_dst_count = total_counts["sync_dst"]
+    bar_v_count = total_counts["bar_v"]
+
+    assert sync_src_count == 2, f"Expected exactly 2 sync_src, got {sync_src_count}"
+    assert sync_dst_count == 2, f"Expected exactly 2 sync_dst, got {sync_dst_count}"
+    assert bar_v_count == 2, f"Expected exactly 2 bar_v, got {bar_v_count}"
+
+
+def test_insert_sync_cross_ifstmt_dependency():
+    """Test InsertSyncPass for cross-IfStmt dependencies.
+
+    This test verifies that the pass can identify dependencies spanning across
+    if statements, where a V-pipe operation after the if depends on both a V-pipe
+    operation computed before the if and a result from inside the if.
+    """
+    # Test structure:
+    #   tile_a = load(input)          # MTE2 pipe
+    #   sync_src (MTE2 -> V)          # Inserted (for all tile_a users)
+    #   sync_dst (MTE2 -> V)          # Inserted
+    #   tile_b = add(tile_a, tile_a)  # V pipe (depends on tile_a)
+    #   if (condition):
+    #     then:
+    #       tile_c = add(tile_a, tile_a)   # V pipe (uses same sync pair)
+    #       yield [tile_c]
+    #     else:
+    #       tile_c = mul(tile_a, tile_a)   # V pipe (uses same sync pair)
+    #       yield [tile_c]
+    #   bar_v                         # Inserted (cross-if dependency: tile_b -> tile_d)
+    #   tile_d = add(tile_b, tile_c)  # V pipe (depends on tile_b and tile_c from if)
+    #   sync_src (V -> MTE3)          # Inserted
+    #   sync_dst (V -> MTE3)          # Inserted
+    #   store(tile_d, output)         # MTE3 pipe
+    #
+    # Expected: 2 sync_src, 2 sync_dst + 1 bar_v (same pipe pair shares one sync)
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT64, span)
+
+    # Create unique memrefs for each tile
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384)
+
+    # Create variables with memrefs
+    input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32), span)
+    output_tensor = ir.Var("output", ir.TensorType([64, 64], DataType.FP32, memref_output), span)
+
+    tile_a = ir.Var("tile_a", ir.TileType([dim64, dim64], DataType.FP32, memref_a), span)
+    tile_b = ir.Var("tile_b", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    tile_d = ir.Var("tile_d", ir.TileType([dim64, dim64], DataType.FP32, memref_d), span)
+
+    # Load from MTE2 pipe
+    load_op = block.load(input_tensor, 0, 0, 64, 64)
+    stmt_load = ir.AssignStmt(tile_a, load_op, span)
+
+    # V pipe operation before if: tile_b = add(tile_a, tile_a)
+    # This depends on tile_a which comes from MTE2
+    add_b_op = block.add(tile_a, tile_a)
+    stmt_add_b = ir.AssignStmt(tile_b, add_b_op, span)
+
+    # Create condition for if statement
+    condition = ir.ConstBool(True, span)
+
+    # Build then branch: tile_c = add(tile_a, tile_a) (V pipe, depends on tile_a)
+    add_c_then_op = block.add(tile_a, tile_a)
+    tile_c_then = ir.Var("tile_c_then", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    stmt_add_c_then = ir.AssignStmt(tile_c_then, add_c_then_op, span)
+    yield_then = ir.YieldStmt([tile_c_then], span)
+    then_body = ir.SeqStmts([stmt_add_c_then, yield_then], span)
+
+    # Build else branch: tile_c = mul(tile_a, tile_a) (V pipe, depends on tile_a)
+    mul_c_else_op = block.mul(tile_a, tile_a)
+    tile_c_else = ir.Var("tile_c_else", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    stmt_mul_c_else = ir.AssignStmt(tile_c_else, mul_c_else_op, span)
+    yield_else = ir.YieldStmt([tile_c_else], span)
+    else_body = ir.SeqStmts([stmt_mul_c_else, yield_else], span)
+
+    # Create IfStmt with return_vars for tile_c
+    if_return_var = ir.Var("tile_c", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    if_stmt = ir.IfStmt(condition, then_body, else_body, [if_return_var], span)
+
+    # V pipe operation after if: tile_d = add(tile_b, tile_c)
+    # This depends on both tile_b (computed before if) and tile_c (from if return_vars)
+    add_d_op = block.add(tile_b, if_return_var)
+    stmt_add_d = ir.AssignStmt(tile_d, add_d_op, span)
+
+    # Store to MTE3 pipe (depends on tile_d)
+    store_op = block.store(tile_d, 0, 0, 64, 64, output_tensor)
+    stmt_store = ir.EvalStmt(store_op, span)
+    stmt_return = ir.ReturnStmt(span)
+
+    # Build function body with load, tile_b, if, tile_d, store
+    body = ir.SeqStmts([stmt_load, stmt_add_b, if_stmt, stmt_add_d, stmt_store, stmt_return], span)
+    func = ir.Function("test_cross_ifstmt_sync", [input_tensor, output_tensor], [], body, span)
+
+    # Run InsertSyncPass
+    insert_sync = passes.InsertSyncPass()
+    synced_func = insert_sync.run(func)
+
+    # Verify the structure
+    assert isinstance(synced_func.body, ir.SeqStmts)
+
+    total_counts = count_syncs(synced_func.body)
+    sync_src_count = total_counts["sync_src"]
+    sync_dst_count = total_counts["sync_dst"]
+    bar_v_count = total_counts["bar_v"]
+
+    assert sync_src_count == 2, f"Expected exactly 2 sync_src, got {sync_src_count}"
+    assert sync_dst_count == 2, f"Expected exactly 2 sync_dst, got {sync_dst_count}"
+    assert bar_v_count == 1, f"Expected exactly 1 bar_v, got {bar_v_count}"
+
+
+def test_insert_sync_nested_ifstmt():
+    """Test InsertSyncPass for nested IfStmt."""
+    # Test structure:
+    #   tile_input = load(input)               # MTE2
+    #   sync_src (MTE2 -> V)                   # Inserted
+    #   sync_dst (MTE2 -> V)                   # Inserted
+    #   outer_if:
+    #     then:
+    #       tile_a = add(tile_input, tile_input)  # V
+    #       bar_v                                  # Inserted
+    #       inner_if:
+    #         then:
+    #           tile_d = mul(tile_a, tile_a)       # V
+    #           bar_v                              # Inserted
+    #           tile_b = add(tile_d, tile_a)       # V
+    #           yield [tile_b]
+    #         else:
+    #           tile_d = sub(tile_a, tile_a)       # V
+    #           bar_v                              # Inserted
+    #       tile_b = add(tile_d, tile_a)       # V
+    #       yield [tile_b]
+    #     # tile_b from inner_if return_vars
+    #     bar_v                                  # Inserted
+    #     tile_c = add(tile_b, tile_a)          # V
+    #     yield [tile_c]
+    #   else:
+    #     tile_c = sub(tile_input, tile_input)  # V
+    #     yield [tile_c]
+    # # tile_c from outer_if return_vars
+    # sync_src (V -> MTE3)                   # Inserted
+    # sync_dst (V -> MTE3)                   # Inserted
+    # store(tile_result, output)             # MTE3
+    #
+    # Expected: 2 cross-pipe sync pairs (MTE2→V + V→MTE3) + 4 intra-pipe barriers (bar_v)
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT64, span)
+
+    # Create unique memrefs
+    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(81920, DataType.INT64, span), 16384)
+
+    # Create variables
+    input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32, memref_input), span)
+    output_tensor = ir.Var("output", ir.TensorType([64, 64], DataType.FP32, memref_output), span)
+    tile_input = ir.Var("tile_input", ir.TileType([dim64, dim64], DataType.FP32, memref_input), span)
+
+    # Load from MTE2 pipe
+    load_op = block.load(input_tensor, 0, 0, 64, 64)
+    stmt_load = ir.AssignStmt(tile_input, load_op, span)
+
+    # Outer if condition
+    outer_condition = ir.ConstBool(True, span)
+
+    # --- Build outer then branch with nested if ---
+    # V pipe operation before nested if
+    tile_a = ir.Var("tile_a", ir.TileType([dim64, dim64], DataType.FP32, memref_a), span)
+    add_a = block.add(tile_input, tile_input)
+    stmt_add_a = ir.AssignStmt(tile_a, add_a, span)
+
+    # Inner if condition
+    inner_condition = ir.ConstBool(False, span)
+
+    # Inner then branch with extra instruction for internal dependency
+    tile_d_inner_then = ir.Var(
+        "tile_d_inner_then", ir.TileType([dim64, dim64], DataType.FP32, memref_d), span
+    )
+    mul_d_inner_then = block.mul(tile_a, tile_a)
+    stmt_mul_d_inner_then = ir.AssignStmt(tile_d_inner_then, mul_d_inner_then, span)
+
+    tile_b_inner_then = ir.Var(
+        "tile_b_inner_then", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span
+    )
+    add_b_inner_then = block.add(tile_d_inner_then, tile_a)
+    stmt_add_b_inner_then = ir.AssignStmt(tile_b_inner_then, add_b_inner_then, span)
+
+    yield_inner_then = ir.YieldStmt([tile_b_inner_then], span)
+    inner_then_body = ir.SeqStmts([stmt_mul_d_inner_then, stmt_add_b_inner_then, yield_inner_then], span)
+
+    # Inner else branch with extra instruction for internal dependency
+    tile_d_inner_else = ir.Var(
+        "tile_d_inner_else", ir.TileType([dim64, dim64], DataType.FP32, memref_d), span
+    )
+    sub_d_inner_else = block.sub(tile_a, tile_a)
+    stmt_sub_d_inner_else = ir.AssignStmt(tile_d_inner_else, sub_d_inner_else, span)
+
+    tile_b_inner_else = ir.Var(
+        "tile_b_inner_else", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span
+    )
+    add_b_inner_else = block.add(tile_d_inner_else, tile_a)
+    stmt_add_b_inner_else = ir.AssignStmt(tile_b_inner_else, add_b_inner_else, span)
+
+    yield_inner_else = ir.YieldStmt([tile_b_inner_else], span)
+    inner_else_body = ir.SeqStmts([stmt_sub_d_inner_else, stmt_add_b_inner_else, yield_inner_else], span)
+
+    # Inner IfStmt with return var
+    inner_return_var = ir.Var("tile_b", ir.TileType([dim64, dim64], DataType.FP32, memref_b), span)
+    inner_if_stmt = ir.IfStmt(inner_condition, inner_then_body, inner_else_body, [inner_return_var], span)
+
+    # Use the result from inner if
+    tile_c_outer_then = ir.Var(
+        "tile_c_outer_then", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span
+    )
+    add_c = block.add(inner_return_var, tile_a)
+    stmt_add_c = ir.AssignStmt(tile_c_outer_then, add_c, span)
+    yield_outer_then = ir.YieldStmt([tile_c_outer_then], span)
+
+    outer_then_body = ir.SeqStmts([stmt_add_a, inner_if_stmt, stmt_add_c, yield_outer_then], span)
+
+    # --- Build outer else branch (simple V pipe operation) ---
+    tile_c_outer_else = ir.Var(
+        "tile_c_outer_else", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span
+    )
+    sub_c = block.sub(tile_input, tile_input)
+    stmt_sub_c = ir.AssignStmt(tile_c_outer_else, sub_c, span)
+    yield_outer_else = ir.YieldStmt([tile_c_outer_else], span)
+    outer_else_body = ir.SeqStmts([stmt_sub_c, yield_outer_else], span)
+
+    # Outer IfStmt with return var
+    outer_return_var = ir.Var("tile_result", ir.TileType([dim64, dim64], DataType.FP32, memref_c), span)
+    outer_if_stmt = ir.IfStmt(outer_condition, outer_then_body, outer_else_body, [outer_return_var], span)
+
+    # Store result to MTE3 pipe
+    store_op = block.store(outer_return_var, 0, 0, 64, 64, output_tensor)
+    stmt_store = ir.EvalStmt(store_op, span)
+    stmt_return = ir.ReturnStmt(span)
+
+    # Build function body
+    body = ir.SeqStmts([stmt_load, outer_if_stmt, stmt_store, stmt_return], span)
+    func = ir.Function("test_nested_ifstmt_sync", [input_tensor, output_tensor], [], body, span)
+
+    # Run InsertSyncPass directly without InitMemRefPass
+    insert_sync = passes.InsertSyncPass()
+    synced_func = insert_sync.run(func)
+
+    # Verify the structure
+    assert isinstance(synced_func.body, ir.SeqStmts)
+
+    total_counts = count_syncs(synced_func.body)
+    sync_src_count = total_counts["sync_src"]
+    sync_dst_count = total_counts["sync_dst"]
+    bar_v_count = total_counts["bar_v"]
+
+    assert sync_src_count == 2, f"Expected exactly 2 sync_src, got {sync_src_count}"
+    assert sync_dst_count == 2, f"Expected exactly 2 sync_dst, got {sync_dst_count}"
+    assert bar_v_count == 4, f"Expected exactly 4 bar_v, got {bar_v_count}"


### PR DESCRIPTION
Changes:
- Implement recursive InsertSyncPass with support for IfStmt dependencies.
- Refactor SyncInserter logic into AnalyzeDependencies, AssignEventIds, and GenerateInsertions phases.
- Extract GetExprMemRefs to eliminate redundant MemRef collection logic.
- Simplify cross-pipe and intra-pipe synchronization insertion.
- Add comprehensive unit tests for nested IfStmt and cross-pipe scenarios.