### PR TITLE
feat(ir): add AddAllocPass for TileType MemRef allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(PYPTO_SOURCES
     src/ir/transform/init_memref.cpp
     src/ir/transform/basic_memory_reuse_pass.cpp
     src/ir/transform/insert_sync_pass.cpp
+    src/ir/transform/add_alloc_pass.cpp
     src/ir/serialization/serializer.cpp
     src/ir/serialization/deserializer.cpp
     src/ir/serialization/type_registry.cpp

--- a/examples/ir_builder/dynamic_softmax_codegen.py
+++ b/examples/ir_builder/dynamic_softmax_codegen.py
@@ -1,0 +1,470 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Dynamic Softmax Code Generation Example
+
+Demonstrates:
+1. Building dynamic softmax computation using IRBuilder and block operations
+2. Creating multiple helper functions (InCore) and orchestration function
+3. Using FOR loops and IF statements with function calls
+4. Generating PTO assembly (.pto format)
+
+Dynamic Softmax Algorithm:
+    1. rowmax: find max value in each row
+    2. rowexpandsub: subtract max from each element (for numerical stability)
+    3. elem_exp: apply exp to each element
+    4. rowsum: sum all elements in each row
+    5. rowexpanddiv: divide each element by row sum
+"""
+
+import os
+
+from pypto import DataType, ir
+from pypto.ir import IRBuilder
+
+
+def BuildRowMaxFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build rowmax InCore function.
+
+    Computes the maximum value along each row.
+    Input: tensor [8, 8], Output: tensor [8, 1]
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The rowmax function
+    """
+    with ib.function("rowmax") as f:
+        # Parameters
+        input_tensor = f.param("input", ir.TensorType([8, 8], dtype))
+        output_tensor = f.param("output", ir.TensorType([8, 1], dtype))
+        f.return_type(ir.TensorType([8, 1], dtype))
+
+        # Load tile from input (8x8)
+        x = ib.let("x", ir.op.block.load(input_tensor, 0, 0, 8, 8))
+
+        # Compute row max (8x8 -> 8x1)
+        result = ib.let("result", ir.op.block.row_max(x))
+
+        # Store result to output (8x1)
+        output_new = ib.let("output_new", ir.op.block.store(result, 0, 0, 8, 1, output_tensor))
+
+        # Return the updated output tensor
+        ib.return_stmt(output_new)
+
+    return f.get_result()
+
+
+def BuildRowExpandSubFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build rowexpandsub InCore function.
+
+    Performs row-wise broadcast subtraction: input_x[i,j] - input_row[i,0]
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The rowexpandsub function
+    """
+    with ib.function("rowexpandsub") as f:
+        # Parameters
+        input_x = f.param("input_x", ir.TensorType([8, 8], dtype))
+        input_row = f.param("input_row", ir.TensorType([8, 1], dtype))
+        output_tensor = f.param("output", ir.TensorType([8, 8], dtype))
+        f.return_type(ir.TensorType([8, 8], dtype))
+
+        # Load tiles
+        x = ib.let("x", ir.op.block.load(input_x, 0, 0, 8, 8))
+        row_vals = ib.let("row_vals", ir.op.block.load(input_row, 0, 0, 8, 1))
+
+        # Row expand subtract (8x8, 8x1 -> 8x8)
+        result = ib.let("result", ir.op.block.row_expand_sub(x, row_vals))
+
+        # Store result
+        output_new = ib.let("output_new", ir.op.block.store(result, 0, 0, 8, 8, output_tensor))
+
+        # Return the updated output tensor
+        ib.return_stmt(output_new)
+
+    return f.get_result()
+
+
+def BuildElemExpFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build elem_exp InCore function.
+
+    Applies element-wise exponential operation.
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The elem_exp function
+    """
+    with ib.function("elem_exp") as f:
+        # Parameters
+        input_tensor = f.param("input", ir.TensorType([8, 8], dtype))
+        output_tensor = f.param("output", ir.TensorType([8, 8], dtype))
+        f.return_type(ir.TensorType([8, 8], dtype))
+
+        # Load tile
+        x = ib.let("x", ir.op.block.load(input_tensor, 0, 0, 8, 8))
+
+        # Apply exp
+        result = ib.let("result", ir.op.block.exp(x))
+
+        # Store result
+        output_new = ib.let("output_new", ir.op.block.store(result, 0, 0, 8, 8, output_tensor))
+
+        # Return the updated output tensor
+        ib.return_stmt(output_new)
+
+    return f.get_result()
+
+
+def BuildRowSumFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build rowsum InCore function.
+
+    Computes the sum of values along each row.
+    Input: tensor [8, 8], Output: tensor [8, 1]
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The rowsum function
+    """
+    with ib.function("rowsum") as f:
+        # Parameters
+        input_tensor = f.param("input", ir.TensorType([8, 8], dtype))
+        output_tensor = f.param("output", ir.TensorType([8, 1], dtype))
+        f.return_type(ir.TensorType([8, 1], dtype))
+
+        # Load tile
+        x = ib.let("x", ir.op.block.load(input_tensor, 0, 0, 8, 8))
+
+        # Compute row sum (8x8 -> 8x1)
+        result = ib.let("result", ir.op.block.row_sum(x))
+
+        # Store result
+        output_new = ib.let("output_new", ir.op.block.store(result, 0, 0, 8, 1, output_tensor))
+
+        # Return the updated output tensor
+        ib.return_stmt(output_new)
+
+    return f.get_result()
+
+
+def BuildRowExpandDivFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build rowexpanddiv InCore function.
+
+    Performs row-wise broadcast division: input_x[i,j] / input_row[i,0]
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The rowexpanddiv function
+    """
+    with ib.function("rowexpanddiv") as f:
+        # Parameters
+        input_x = f.param("input_x", ir.TensorType([8, 8], dtype))
+        input_row = f.param("input_row", ir.TensorType([8, 1], dtype))
+        output_tensor = f.param("output", ir.TensorType([8, 8], dtype))
+        f.return_type(ir.TensorType([8, 8], dtype))
+
+        # Load tiles
+        x = ib.let("x", ir.op.block.load(input_x, 0, 0, 8, 8))
+        row_vals = ib.let("row_vals", ir.op.block.load(input_row, 0, 0, 8, 1))
+
+        # Row expand divide (8x8, 8x1 -> 8x8)
+        result = ib.let("result", ir.op.block.row_expand_div(x, row_vals))
+
+        # Store result
+        output_new = ib.let("output_new", ir.op.block.store(result, 0, 0, 8, 8, output_tensor))
+
+        # Return the updated output tensor
+        ib.return_stmt(output_new)
+
+    return f.get_result()
+
+
+def BuildDynamicSoftmaxFunction(ib: IRBuilder, dtype: DataType = DataType.FP32):
+    """Build dynamic_softmax Orchestration function.
+
+    Main function that orchestrates the softmax computation using helper functions.
+    Includes FOR loop for processing full tiles and IF statement for tail processing.
+
+    Args:
+        ib: IR Builder instance
+        dtype: Data type for computation
+
+    Returns:
+        ir.Function: The dynamic_softmax function
+    """
+    with ib.function("dynamic_softmax") as f:
+        # Parameters - 6 memref tensors
+        input_tensor = f.param("input", ir.TensorType([128, 128], dtype))
+        output_tensor = f.param("output", ir.TensorType([128, 128], dtype))
+        temp_rowmax = f.param("temp_rowmax", ir.TensorType([8, 1], dtype))
+        temp_shifted = f.param("temp_shifted", ir.TensorType([8, 8], dtype))
+        temp_exp = f.param("temp_exp", ir.TensorType([8, 8], dtype))
+        temp_rowsum = f.param("temp_rowsum", ir.TensorType([8, 1], dtype))
+        f.return_type(ir.TensorType([128, 128], dtype))
+
+        # Scalar declarations
+        num_full_tiles = ib.let("num_full_tiles", ir.ConstInt(4, DataType.INT32, ir.Span.unknown()))
+        tail_rows = ib.let("tail_rows", ir.ConstInt(0, DataType.INT32, ir.Span.unknown()))
+        zero = ib.let("zero", ir.ConstInt(0, DataType.INT32, ir.Span.unknown()))
+        has_tail = ib.let("has_tail", ir.ConstBool(False, ir.Span.unknown()))
+
+        # Create loop variable
+        tile_idx = ib.var("tile_idx", ir.ScalarType(DataType.INT32))
+
+        # FOR loop to process full tiles
+        with ib.for_loop(tile_idx, 0, num_full_tiles, 1) as loop:
+            # Iteration argument: output tensor is carried across iterations
+            output_iter = loop.iter_arg("output_iter", output_tensor)
+            loop.return_var("output_updated")
+
+            # Inside loop: call helper functions with return value capture for SSA
+            # 1. Call rowmax - returns updated temp_rowmax
+            rowmax_op = ir.GlobalVar("rowmax")
+            rowmax_call = ir.Call(rowmax_op, [input_tensor, temp_rowmax], ir.Span.unknown())
+            temp_rowmax_updated = ib.let("temp_rowmax_updated", rowmax_call)
+
+            # 2. Call rowexpandsub - returns updated temp_shifted
+            rowexpandsub_op = ir.GlobalVar("rowexpandsub")
+            rowexpandsub_call = ir.Call(
+                rowexpandsub_op, [input_tensor, temp_rowmax_updated, temp_shifted], ir.Span.unknown()
+            )
+            temp_shifted_updated = ib.let("temp_shifted_updated", rowexpandsub_call)
+
+            # 3. Call elem_exp - returns updated temp_exp
+            elem_exp_op = ir.GlobalVar("elem_exp")
+            elem_exp_call = ir.Call(elem_exp_op, [temp_shifted_updated, temp_exp], ir.Span.unknown())
+            temp_exp_updated = ib.let("temp_exp_updated", elem_exp_call)
+
+            # 4. Call rowsum - returns updated temp_rowsum
+            rowsum_op = ir.GlobalVar("rowsum")
+            rowsum_call = ir.Call(rowsum_op, [temp_exp_updated, temp_rowsum], ir.Span.unknown())
+            temp_rowsum_updated = ib.let("temp_rowsum_updated", rowsum_call)
+
+            # 5. Call rowexpanddiv - returns updated output
+            rowexpanddiv_op = ir.GlobalVar("rowexpanddiv")
+            rowexpanddiv_call = ir.Call(
+                rowexpanddiv_op, [temp_exp_updated, temp_rowsum_updated, output_iter], ir.Span.unknown()
+            )
+            output_from_call = ib.let("output_from_call", rowexpanddiv_call)
+
+            # Yield updated output tensor
+            ib.emit(ir.YieldStmt([output_from_call], ir.Span.unknown()))
+
+        # Get output after loop
+        output_after_loop = loop.output()
+
+        # Check if there's a tail to process
+        has_tail = ib.let("has_tail", tail_rows > zero)
+
+        # IF statement for tail processing
+        with ib.if_stmt(has_tail) as if_builder:
+            if_builder.return_var("output_final", ir.TensorType([128, 128], dtype))
+
+            # Then branch: process tail with SSA return values
+            # Call the same sequence of functions for tail
+            # 1. Call rowmax - returns updated temp_rowmax
+            tail_rowmax_op = ir.GlobalVar("rowmax")
+            tail_rowmax_call = ir.Call(tail_rowmax_op, [input_tensor, temp_rowmax], ir.Span.unknown())
+            tail_temp_rowmax_updated = ib.let("tail_temp_rowmax_updated", tail_rowmax_call)
+
+            # 2. Call rowexpandsub - returns updated temp_shifted
+            tail_rowexpandsub_op = ir.GlobalVar("rowexpandsub")
+            tail_rowexpandsub_call = ir.Call(
+                tail_rowexpandsub_op,
+                [input_tensor, tail_temp_rowmax_updated, temp_shifted],
+                ir.Span.unknown(),
+            )
+            tail_temp_shifted_updated = ib.let("tail_temp_shifted_updated", tail_rowexpandsub_call)
+
+            # 3. Call elem_exp - returns updated temp_exp
+            tail_elem_exp_op = ir.GlobalVar("elem_exp")
+            tail_elem_exp_call = ir.Call(
+                tail_elem_exp_op, [tail_temp_shifted_updated, temp_exp], ir.Span.unknown()
+            )
+            tail_temp_exp_updated = ib.let("tail_temp_exp_updated", tail_elem_exp_call)
+
+            # 4. Call rowsum - returns updated temp_rowsum
+            tail_rowsum_op = ir.GlobalVar("rowsum")
+            tail_rowsum_call = ir.Call(
+                tail_rowsum_op, [tail_temp_exp_updated, temp_rowsum], ir.Span.unknown()
+            )
+            tail_temp_rowsum_updated = ib.let("tail_temp_rowsum_updated", tail_rowsum_call)
+
+            # 5. Call rowexpanddiv - returns updated output
+            tail_rowexpanddiv_op = ir.GlobalVar("rowexpanddiv")
+            tail_rowexpanddiv_call = ir.Call(
+                tail_rowexpanddiv_op,
+                [tail_temp_exp_updated, tail_temp_rowsum_updated, output_after_loop],
+                ir.Span.unknown(),
+            )
+            output_with_tail = ib.let("output_with_tail", tail_rowexpanddiv_call)
+
+            # Yield updated tensor
+            ib.emit(ir.YieldStmt([output_with_tail], ir.Span.unknown()))
+
+            # Else branch: no tail processing
+            if_builder.else_()
+            ib.emit(ir.YieldStmt([output_after_loop], ir.Span.unknown()))
+
+        # Get final output from if statement
+        output_final = if_builder.output()
+
+        # Return final output
+        ib.return_stmt(output_final)
+
+    return f.get_result()
+
+
+def BuildDynamicSoftmaxIR(dtype: DataType = DataType.FP32):
+    """Build complete dynamic softmax IR with all functions.
+
+    Creates all InCore helper functions and the main Orchestration function.
+
+    Args:
+        dtype: Data type for computation
+
+    Returns:
+        ir.Program: The complete program with all functions
+    """
+    ib = IRBuilder()
+
+    # Build all InCore functions
+    print("Building InCore functions...")
+    rowmax_func = BuildRowMaxFunction(ib, dtype)
+    rowexpandsub_func = BuildRowExpandSubFunction(ib, dtype)
+    elem_exp_func = BuildElemExpFunction(ib, dtype)
+    rowsum_func = BuildRowSumFunction(ib, dtype)
+    rowexpanddiv_func = BuildRowExpandDivFunction(ib, dtype)
+    print("✓ InCore functions built")
+
+    # Build Orchestration function
+    print("Building Orchestration function...")
+    dynamic_softmax_func = BuildDynamicSoftmaxFunction(ib, dtype)
+    print("✓ Orchestration function built")
+
+    # Create program with all functions
+    functions = [
+        rowmax_func,
+        rowexpandsub_func,
+        elem_exp_func,
+        rowsum_func,
+        rowexpanddiv_func,
+        dynamic_softmax_func,
+    ]
+
+    program = ir.Program(functions, "dynamic_softmax_module", ir.Span.unknown())
+    return program
+
+
+def main():
+    """Main entry point for dynamic softmax code generation."""
+
+    print("=" * 70)
+    print("Dynamic Softmax Code Generation (PTO Assembly)")
+    print("=" * 70)
+
+    # Configuration
+    dtype = DataType.FP32
+
+    print(f"\nConfiguration: {dtype}")
+    print("Generating PTO assembly format (.pto files)")
+
+    # Step 1: Build IR
+    print("\n[1] Building IR using IRBuilder and block operations...")
+    program = BuildDynamicSoftmaxIR(dtype)
+    print("✓ IR construction complete")
+
+    # Step 2: Print original IR (preview)
+    print("\n[2] Original IR (Python syntax - preview):")
+    print("-" * 70)
+    ir_text = ir.python_print(program)
+    lines = ir_text.split("\n")
+    preview_lines = min(30, len(lines))
+    print("\n".join(lines[:preview_lines]))
+    if len(lines) > preview_lines:
+        print(f"\n... ({len(lines) - preview_lines} more lines)")
+    print("-" * 70)
+
+    # Step 3: Compile with passes and codegen
+    print("\n[3] Compiling with PassManager and PTOCodegen...")
+    print("    - Running optimization passes (XPlatform strategy)")
+    print("    - Dumping IR after each pass")
+    print("    - Generating PTO assembly")
+
+    output_dir = ir.compile(
+        program,
+        strategy=ir.OptimizationStrategy.XPlatform,
+        dump_passes=True,
+    )
+    print("✓ Compilation complete")
+    print(f"✓ All artifacts saved to: {output_dir}")
+
+    # Step 4: Read and preview the generated PTO assembly
+    pto_file = os.path.join(output_dir, "output.pto")
+    with open(pto_file, "r") as f:
+        pto_code = f.read()
+
+    print("\n[4] Generated PTO Assembly (preview):")
+    print("=" * 70)
+    # Print first 40 lines as preview
+    lines = pto_code.split("\n")
+    preview_lines = min(40, len(lines))
+    print("\n".join(lines[:preview_lines]))
+    if len(lines) > preview_lines:
+        print(f"\n... ({len(lines) - preview_lines} more lines)")
+    print("=" * 70)
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("Compilation complete!")
+    print("=" * 70)
+    print("\nSummary:")
+    print("  - Module name: dynamic_softmax_module")
+    print(f"  - Number of functions: {len(program.functions)}")
+    print(f"  - Output directory: {output_dir}")
+    print("  - Output format: PTO assembly (.pto)")
+    print(f"  - Data type: {dtype}")
+    print("  - Optimization strategy: XPlatform")
+    print("\nFunctions implemented:")
+    print("  - rowmax (InCore): row-wise maximum reduction")
+    print("  - rowexpandsub (InCore): row-wise broadcast subtraction")
+    print("  - elem_exp (InCore): element-wise exponential")
+    print("  - rowsum (InCore): row-wise sum reduction")
+    print("  - rowexpanddiv (InCore): row-wise broadcast division")
+    print("  - dynamic_softmax (Orchestration): main softmax orchestration")
+    print("\nGenerated artifacts:")
+    print(f"  - {os.path.join(output_dir, 'original.py')} - Original IR")
+    print(f"  - {os.path.join(output_dir, 'after_*.py')} - IR after each pass")
+    print(f"  - {os.path.join(output_dir, 'output.pto')} - Final PTO assembly")
+    print("\nThe generated PTO assembly:")
+    print("  - Uses SSA-style variable naming with % prefix")
+    print("  - Includes type annotations for all operations")
+    print("  - Compatible with PTO ISA specification")
+    print("  - Entry point: @dynamic_softmax")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/pypto/codegen/pto_codegen.h
+++ b/include/pypto/codegen/pto_codegen.h
@@ -165,6 +165,17 @@ class PTOCodegen : public IRMutator {
   std::string ExtractVarName(const ExprPtr& expr);
 
   /**
+   * @brief Resolve physical tile name for a logical variable
+   *
+   * Maps logical variable names to their physical tile names based on MemRef sharing.
+   * For variables sharing the same MemRef, returns the first variable's name.
+   *
+   * @param var_name Logical variable name
+   * @return Physical tile name (may be same as input if no mapping exists)
+   */
+  std::string ResolvePhysicalTile(const std::string& var_name);
+
+  /**
    * @brief Convert DataType to PTO type string
    *
    * Maps PyPTO DataType enum to PTO type notation.
@@ -218,6 +229,8 @@ class PTOCodegen : public IRMutator {
   std::vector<std::string> code_lines_;                         // Accumulated code lines
   std::map<std::string, TileInfo> tile_decls_;                  // Tile declarations (name -> info)
   std::vector<std::pair<std::string, DataType>> scalar_decls_;  // Scalar declarations (ordered)
+  std::map<std::string, std::string> var_to_physical_tile_;     // Logical var name -> physical tile name
+  std::map<uint64_t, std::string> memref_to_var_;               // MemRef ID -> variable name (for params)
   int indent_level_ = 0;                                        // Current indentation level
   std::string current_function_name_;                           // Current function being generated
 };

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -38,6 +38,7 @@ enum class ObjectKind {
   // Expression kinds
   Var,
   IterArg,
+  MemRef,
   Call,
   TupleGetItemExpr,
   ConstInt,
@@ -88,6 +89,7 @@ enum class ObjectKind {
 
   // Type kinds
   UnknownType,
+  MemRefType,
   ScalarType,
   ShapedType,
   TensorType,

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -312,6 +312,56 @@ class IterArg : public Var {
 using IterArgPtr = std::shared_ptr<const IterArg>;
 
 /**
+ * @brief Memory reference variable for shaped types (tensor and tile)
+ *
+ * Represents a memory allocation with metadata (space, address, size, id).
+ * Inherits from Var, making it a first-class IR expression that can be
+ * declared and referenced like other variables.
+ *
+ * Memory references have auto-generated names based on their ID (e.g., "mem_123")
+ * and MemRefType as their type.
+ */
+class MemRef : public Var {
+ public:
+  MemorySpace memory_space_;  ///< Memory space (DDR, UB, L1, etc.)
+  ExprPtr addr_;              ///< Starting address expression
+  uint64_t size_;             ///< Size in bytes (64-bit unsigned)
+  uint64_t id_;               ///< Unique identifier (used for name generation)
+
+  /**
+   * @brief Constructor with all parameters including explicit ID
+   *
+   * Generates a variable name from the ID (e.g., "mem_123") and creates
+   * a MemRefType for the type. Calls Var constructor with these values.
+   *
+   * @param memory_space Memory space (DDR, UB, L1, etc.)
+   * @param addr Starting address expression
+   * @param size Size in bytes
+   * @param id Unique identifier (used to generate variable name)
+   * @param span Source location (defaults to Span::unknown())
+   */
+  MemRef(MemorySpace memory_space, ExprPtr addr, uint64_t size, uint64_t id, Span span = Span::unknown());
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::MemRef; }
+  [[nodiscard]] std::string TypeName() const override { return "MemRef"; }
+
+  /**
+   * @brief Get field descriptors for reflection-based visitation
+   *
+   * @return Tuple of field descriptors
+   */
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Var::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&MemRef::memory_space_, "memory_space"),
+                                          reflection::UsualField(&MemRef::addr_, "addr"),
+                                          reflection::UsualField(&MemRef::size_, "size"),
+                                          reflection::UsualField(&MemRef::id_, "id")));
+  }
+};
+
+// MemRefPtr is already declared in memref.h, just reuse it here
+
+/**
  * @brief Function call expression
  *
  * Represents a function call with an operation and arguments.

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -38,6 +38,7 @@ namespace ir {
 // Expression types
 DEFINE_KIND_TRAIT(Var, ObjectKind::Var)
 DEFINE_KIND_TRAIT(IterArg, ObjectKind::IterArg)
+DEFINE_KIND_TRAIT(MemRef, ObjectKind::MemRef)
 DEFINE_KIND_TRAIT(Call, ObjectKind::Call)
 DEFINE_KIND_TRAIT(TupleGetItemExpr, ObjectKind::TupleGetItemExpr)
 DEFINE_KIND_TRAIT(ConstInt, ObjectKind::ConstInt)
@@ -93,6 +94,7 @@ DEFINE_KIND_TRAIT(ScalarType, ObjectKind::ScalarType)
 DEFINE_KIND_TRAIT(TensorType, ObjectKind::TensorType)
 DEFINE_KIND_TRAIT(TileType, ObjectKind::TileType)
 DEFINE_KIND_TRAIT(TupleType, ObjectKind::TupleType)
+DEFINE_KIND_TRAIT(MemRefType, ObjectKind::MemRefType)
 
 // Other IR node types
 DEFINE_KIND_TRAIT(Function, ObjectKind::Function)

--- a/include/pypto/ir/memref.h
+++ b/include/pypto/ir/memref.h
@@ -30,6 +30,9 @@ namespace ir {
 class Expr;
 using ExprPtr = std::shared_ptr<const Expr>;
 
+class MemRef;
+using MemRefPtr = std::shared_ptr<const MemRef>;
+
 /**
  * @brief Memory space enumeration
  *
@@ -49,47 +52,6 @@ enum class MemorySpace {
   L0B,  ///< L0B buffer
   L0C   ///< L0C buffer
 };
-
-/**
- * @brief Memory reference for shaped types (tensor and tile)
- *
- * Represents memory allocation information for ShapedType instances.
- * Tracks memory space, address, and size.
- * This is a plain struct (not an IRNode) that is embedded in ShapedType.
- */
-struct MemRef {
-  MemorySpace memory_space_;  ///< Memory space (DDR, UB, L1, etc.)
-  ExprPtr addr_;              ///< Starting address (expression)
-  uint64_t size_;             ///< Size in bytes (64-bit unsigned)
-
-  /**
-   * @brief Default constructor for aggregate initialization
-   */
-  MemRef() = default;
-
-  /**
-   * @brief Constructor with all parameters
-   *
-   * @param memory_space Memory space (DDR, UB, L1, etc.)
-   * @param addr Starting address expression
-   * @param size Size in bytes
-   */
-  MemRef(MemorySpace memory_space, ExprPtr addr, uint64_t size)
-      : memory_space_(memory_space), addr_(std::move(addr)), size_(size) {}
-
-  /**
-   * @brief Get field descriptors for reflection-based visitation
-   *
-   * @return Tuple of field descriptors
-   */
-  static constexpr auto GetFieldDescriptors() {
-    return std::make_tuple(reflection::UsualField(&MemRef::memory_space_, "memory_space"),
-                           reflection::UsualField(&MemRef::addr_, "addr"),
-                           reflection::UsualField(&MemRef::size_, "size"));
-  }
-};
-
-using MemRefPtr = std::shared_ptr<const MemRef>;
 
 /**
  * @brief Convert MemorySpace enum to string

--- a/include/pypto/ir/transform/add_alloc_pass.h
+++ b/include/pypto/ir/transform/add_alloc_pass.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORM_ADD_ALLOC_PASS_H_
+#define PYPTO_IR_TRANSFORM_ADD_ALLOC_PASS_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/ir/memref.h"
+#include "pypto/ir/transform/base/pass.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Pass to add alloc operations for all MemRef objects in TileType variables
+ *
+ * This pass traverses all TileType variables in a Function and creates alloc operations
+ * for each unique MemRef. The alloc operations are added at the beginning of the function.
+ *
+ * The pass:
+ * 1. Identifies all TileType variables in the function
+ * 2. Collects all unique MemRef objects from these TileType variables
+ * 3. Creates an alloc operation for each unique MemRef
+ * 4. Prepends these alloc operations to the function body
+ *
+ * Each alloc operation has no input/output arguments but is bound to a MemRef pointer
+ * to track memory allocation for that specific buffer.
+ */
+class AddAllocPass : public Pass {
+ public:
+  AddAllocPass() = default;
+
+  [[nodiscard]] std::string Name() const { return "AddAllocPass"; }
+
+  [[nodiscard]] FunctionPtr Run(const FunctionPtr& func) override;
+
+ private:
+  /**
+   * @brief Collect all unique MemRef objects from TileType variables in a statement
+   *
+   * @param stmt Statement to traverse
+   * @param memrefs Vector to accumulate unique MemRef objects
+   */
+  void CollectMemRefsFromStatement(const StmtPtr& stmt, std::vector<MemRefPtr>& memrefs);
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORM_ADD_ALLOC_PASS_H_

--- a/include/pypto/ir/transform/base/functor.h
+++ b/include/pypto/ir/transform/base/functor.h
@@ -51,6 +51,7 @@ class ExprFunctor {
   // Leaf nodes
   virtual R VisitExpr_(const VarPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const IterArgPtr& op, Args... args) = 0;
+  virtual R VisitExpr_(const MemRefPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const ConstIntPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const ConstFloatPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const ConstBoolPtr& op, Args... args) = 0;
@@ -99,8 +100,9 @@ class ExprFunctor {
 template <typename R, typename... Args>
 R ExprFunctor<R, Args...>::VisitExpr(const ExprPtr& expr, Args... args) {
   // Leaf nodes
-  // Note: IterArg must be checked before Var since IterArg inherits from Var
+  // Note: IterArg and MemRef must be checked before Var since they inherit from Var
   EXPR_FUNCTOR_DISPATCH(IterArg);
+  EXPR_FUNCTOR_DISPATCH(MemRef);
   EXPR_FUNCTOR_DISPATCH(Var);
   EXPR_FUNCTOR_DISPATCH(ConstInt);
   EXPR_FUNCTOR_DISPATCH(ConstFloat);

--- a/include/pypto/ir/transform/base/mutator.h
+++ b/include/pypto/ir/transform/base/mutator.h
@@ -37,6 +37,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   // Leaf nodes - return as-is by default
   ExprPtr VisitExpr_(const VarPtr& op) override;
   ExprPtr VisitExpr_(const IterArgPtr& op) override;
+  ExprPtr VisitExpr_(const MemRefPtr& op) override;
   ExprPtr VisitExpr_(const ConstIntPtr& op) override;
   ExprPtr VisitExpr_(const ConstFloatPtr& op) override;
   ExprPtr VisitExpr_(const ConstBoolPtr& op) override;

--- a/include/pypto/ir/transform/base/visitor.h
+++ b/include/pypto/ir/transform/base/visitor.h
@@ -36,6 +36,7 @@ class IRVisitor : public IRFunctor<void> {
   // Leaf nodes - no children to visit
   void VisitExpr_(const VarPtr& op) override;
   void VisitExpr_(const IterArgPtr& op) override;
+  void VisitExpr_(const MemRefPtr& op) override;
   void VisitExpr_(const ConstIntPtr& op) override;
   void VisitExpr_(const ConstFloatPtr& op) override;
   void VisitExpr_(const ConstBoolPtr& op) override;

--- a/include/pypto/ir/transform/init_memref.h
+++ b/include/pypto/ir/transform/init_memref.h
@@ -29,10 +29,16 @@ namespace ir {
  * 2. `memref.size` is calculated based on static shape and dtype.
  *    If shape is dynamic (contains non-ConstInt), size defaults to 0.
  * 3. `memref.memory_space` defaults to `UB`.
- *    If a variable is used as:
+ *    A variable's memory space is set to `DDR` if it is:
+ *    - A function parameter (all input/output parameters are in main memory)
  *    - Source (1st arg) of `block.load`
  *    - Destination (6th arg) of `block.store`
- *    Then its memory space is set to `DDR`.
+ *
+ * Special Handling:
+ * - IterArg inherits MemRef from its initValue to maintain consistency
+ *   (e.g., loop variables initialized with DDR parameters become DDR)
+ * - Variables assigned from block.store inherit the MemRef of the 6th argument
+ *   (the output tensor being stored to)
  */
 class InitMemRefPass : public Pass {
  public:

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -373,6 +373,37 @@ class TupleType : public Type {
 
 using TupleTypePtr = std::shared_ptr<const TupleType>;
 
+/**
+ * @brief Memory reference type representation
+ *
+ * Represents a memory reference type for shaped data (tensors and tiles).
+ * Used as the type for MemRef variables.
+ */
+class MemRefType : public Type {
+ public:
+  /**
+   * @brief Create a memory reference type
+   */
+  MemRefType() = default;
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::MemRefType; }
+  [[nodiscard]] std::string TypeName() const override { return "MemRefType"; }
+
+  static constexpr auto GetFieldDescriptors() { return Type::GetFieldDescriptors(); }
+};
+
+using MemRefTypePtr = std::shared_ptr<const MemRefType>;
+
+/**
+ * @brief Get a shared pointer to the singleton MemRefType instance
+ *
+ * @return Shared pointer to MemRefType
+ */
+inline MemRefTypePtr GetMemRefType() {
+  static const auto memref_type = std::make_shared<MemRefType>();
+  return memref_type;
+}
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -283,15 +283,6 @@ void BindIR(nb::module_& m) {
       .def_rw("stride", &TileView::stride, "Stride for each dimension")
       .def_rw("start_offset", &TileView::start_offset, "Starting offset");
 
-  // MemRef - struct (not IRNode)
-  nb::class_<MemRef>(ir, "MemRef", "Memory reference for shaped types (embedded in ShapedType)")
-      .def(nb::init<>(), "Create an empty memory reference (for aggregate initialization)")
-      .def(nb::init<MemorySpace, ExprPtr, uint64_t>(), nb::arg("memory_space"), nb::arg("addr"),
-           nb::arg("size"), "Create a memory reference with memory_space, addr, and size")
-      .def_rw("memory_space_", &MemRef::memory_space_, "Memory space (DDR, UB, L1, etc.)")
-      .def_rw("addr_", &MemRef::addr_, "Starting address expression")
-      .def_rw("size_", &MemRef::size_, "Size in bytes (64-bit unsigned)");
-
   // Dynamic dimension constant
   ir.attr("DYNAMIC_DIM") = kDynamicDim;
 
@@ -339,6 +330,18 @@ void BindIR(nb::module_& m) {
                     nb::arg("name"), nb::arg("type"), nb::arg("initValue"), nb::arg("span"),
                     "Create an iteration argument with initial value");
   BindFields<IterArg>(iterarg_class);
+
+  // MemRef - now inherits from Var (first-class expression)
+  auto memref_class =
+      nb::class_<MemRef, Var>(ir, "MemRef", "Memory reference variable for shaped types (inherits from Var)");
+  memref_class
+      .def(nb::init<MemorySpace, ExprPtr, uint64_t, uint64_t, Span>(), nb::arg("memory_space"),
+           nb::arg("addr"), nb::arg("size"), nb::arg("id"), nb::arg("span") = Span::unknown(),
+           "Create a memory reference with memory_space, addr, size, id, and span")
+      .def_rw("memory_space_", &MemRef::memory_space_, "Memory space (DDR, UB, L1, etc.)")
+      .def_rw("addr_", &MemRef::addr_, "Starting address expression")
+      .def_rw("size_", &MemRef::size_, "Size in bytes (64-bit unsigned)")
+      .def_rw("id_", &MemRef::id_, "Unique identifier for this MemRef instance");
 
   // ConstInt - const shared_ptr
   auto constint_class = nb::class_<ConstInt, Expr>(ir, "ConstInt", "Constant integer expression");

--- a/python/bindings/modules/pass.cpp
+++ b/python/bindings/modules/pass.cpp
@@ -15,6 +15,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
+#include "pypto/ir/transform/add_alloc_pass.h"
 #include "pypto/ir/transform/basic_memory_reuse_pass.h"
 #include "pypto/ir/transform/identity_pass.h"
 #include "pypto/ir/transform/init_memref.h"
@@ -52,9 +53,15 @@ void BindPass(nb::module_& m) {
                                          "A pass for basic memory reuse based on dependency graph")
       .def(nb::init<>(), "Create a BasicMemoryReuse pass");
 
-  // InsertSyncPass - automatically insert sync/bar operations
+  // AddAllocPass - a pass that adds alloc operations for MemRef objects
+  nb::class_<AddAllocPass, Pass>(
+      passes, "AddAllocPass",
+      "A pass that adds alloc operations for all MemRef objects in TileType variables")
+      .def(nb::init<>(), "Create an AddAlloc pass");
+
+  // InsertSyncPass - a pass that inserts sync operations
   nb::class_<InsertSyncPass, Pass>(passes, "InsertSyncPass",
-                                   "A pass that automatically inserts sync and bar operations")
+                                   "A pass that inserts sync operations for pipeline synchronization")
       .def(nb::init<>(), "Create an InsertSync pass");
 }
 

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -400,6 +400,7 @@ class IRBuilder:
         memory_space: ir.MemorySpace,
         addr: Union[int, ir.Expr],
         size: int,
+        id: int,
         span: Optional[ir.Span] = None,
     ) -> ir.MemRef:
         """Create a MemRef with normalized address expression.
@@ -408,6 +409,7 @@ class IRBuilder:
             memory_space: Memory space (DDR, UB, L1, L0A, L0B, L0C)
             addr: Address expression (int or Expr)
             size: Size in bytes
+            id: Unique identifier for this MemRef
             span: Optional explicit span. If None, captured from call site.
 
         Returns:
@@ -415,11 +417,11 @@ class IRBuilder:
 
         Example:
             >>> addr = ir.ConstInt(0x1000, DataType.INT64, ir.Span.unknown())
-            >>> memref = ib.memref(ir.MemorySpace.DDR, addr, 1024)
+            >>> memref = ib.memref(ir.MemorySpace.DDR, addr, 1024, 0)
         """
         actual_span = span if span is not None else self._capture_call_span()
         addr_expr = _normalize_expr(addr, actual_span)
-        return ir.MemRef(memory_space, addr_expr, size)
+        return ir.MemRef(memory_space, addr_expr, size, id, actual_span)
 
     def tile_view(
         self,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -72,6 +72,7 @@ class PassManager:
             OptimizationStrategy.XPlatform: [
                 ("InitMemRef", lambda: passes.InitMemRefPass()),
                 ("MemoryReuse", lambda: passes.BasicMemoryReusePass()),
+                ("AddAlloc", lambda: passes.AddAllocPass()),
             ],
         }
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -486,8 +486,8 @@ class MemorySpace(enum.Enum):
     L0C = ...
     """L0C buffer."""
 
-class MemRef:
-    """Memory reference for shaped types (embedded in ShapedType)."""
+class MemRef(Var):
+    """Memory reference variable for shaped types (inherits from Var)."""
 
     memory_space_: MemorySpace
     """Memory space (DDR, UB, L1, etc.)."""
@@ -498,18 +498,18 @@ class MemRef:
     size_: int
     """Size in bytes (64-bit unsigned)."""
 
-    @overload
-    def __init__(self) -> None:
-        """Create an empty memory reference (for aggregate initialization)."""
+    id_: int
+    """Unique identifier for this MemRef instance."""
 
-    @overload
-    def __init__(self, memory_space: MemorySpace, addr: Expr, size: int) -> None:
-        """Create a memory reference with memory_space, addr, and size.
+    def __init__(self, memory_space: MemorySpace, addr: Expr, size: int, id: int, span: Span = ...) -> None:
+        """Create a memory reference with memory_space, addr, size, id, and span.
 
         Args:
             memory_space: Memory space (DDR, UB, L1, etc.)
             addr: Starting address expression
             size: Size in bytes
+            id: Unique identifier for this MemRef instance
+            span: Source location (defaults to Span.unknown())
         """
 
 DYNAMIC_DIM: Final[int]

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -97,10 +97,28 @@ class InsertSyncPass(Pass):
     def __init__(self) -> None:
         """Create an InsertSync pass."""
 
+class AddAllocPass(Pass):
+    """A pass that adds alloc operations for all MemRef objects in TileType variables.
+
+    This pass traverses the function and creates alloc operations for each unique
+    MemRef object found in TileType variables. The alloc operations are prepended
+    to the function body to allocate memory for these MemRef objects.
+
+    The pass:
+    1. Identifies all TileType variables in the function
+    2. Collects all unique MemRef objects from these variables
+    3. Creates an alloc operation for each unique MemRef
+    4. Prepends these alloc operations to the function body
+    """
+
+    def __init__(self) -> None:
+        """Create an AddAlloc pass."""
+
 __all__ = [
     "Pass",
     "IdentityPass",
     "InitMemRefPass",
     "BasicMemoryReusePass",
     "InsertSyncPass",
+    "AddAllocPass",
 ]

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -11,7 +11,12 @@
 
 #include "pypto/ir/memref.h"
 
+#include <algorithm>
 #include <string>
+#include <utility>
+
+#include "pypto/ir/expr.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
@@ -34,6 +39,23 @@ std::string MemorySpaceToString(MemorySpace space) {
       return "Unknown";
   }
 }
+
+// Helper function to convert string to lowercase
+static std::string ToLowerCase(const std::string& str) {
+  std::string result = str;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return result;
+}
+
+// MemRef implementation
+MemRef::MemRef(MemorySpace memory_space, ExprPtr addr, uint64_t size, uint64_t id, Span span)
+    : Var("mem_" + ToLowerCase(MemorySpaceToString(memory_space)) + "_" + std::to_string(id), GetMemRefType(),
+          std::move(span)),
+      memory_space_(memory_space),
+      addr_(std::move(addr)),
+      size_(size),
+      id_(id) {}
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -216,6 +216,7 @@ class IRSerializer::Impl {
     memref_map["memory_space"] = msgpack::object(static_cast<uint8_t>(memref.memory_space_), zone);
     memref_map["addr"] = SerializeNode(memref.addr_, zone);
     memref_map["size"] = msgpack::object(memref.size_, zone);
+    memref_map["id"] = msgpack::object(memref.id_, zone);
     return msgpack::object(memref_map, zone);
   }
 

--- a/src/ir/transform/add_alloc_pass.cpp
+++ b/src/ir/transform/add_alloc_pass.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transform/add_alloc_pass.h"
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/memref.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transform/base/visitor.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+// Visitor to collect all MemRef objects from TileType variables
+class MemRefCollectorVisitor : public IRVisitor {
+ public:
+  MemRefCollectorVisitor() = default;
+
+  const std::vector<MemRefPtr>& GetMemRefs() const { return memrefs_; }
+
+  void VisitExpr_(const VarPtr& op) override {
+    // Check if this variable has a TileType with MemRef
+    auto tile_type = std::dynamic_pointer_cast<const TileType>(op->GetType());
+    if (tile_type && tile_type->memref_.has_value()) {
+      AddMemRefIfUnique(tile_type->memref_.value());
+    }
+  }
+
+  void VisitExpr_(const IterArgPtr& op) override {
+    // Check if this iteration argument has a TileType with MemRef
+    auto tile_type = std::dynamic_pointer_cast<const TileType>(op->GetType());
+    if (tile_type && tile_type->memref_.has_value()) {
+      AddMemRefIfUnique(tile_type->memref_.value());
+    }
+  }
+
+ private:
+  std::vector<MemRefPtr> memrefs_;
+  std::set<const MemRef*> seen_ptrs_;  // Track raw MemRef pointers to avoid duplicates
+
+  void AddMemRefIfUnique(const MemRefPtr& memref) {
+    // Use raw pointer address to check uniqueness (same shared_ptr)
+    const MemRef* raw_ptr = memref.get();
+    if (seen_ptrs_.find(raw_ptr) == seen_ptrs_.end()) {
+      memrefs_.push_back(memref);
+      seen_ptrs_.insert(raw_ptr);
+    }
+  }
+};
+
+}  // namespace
+
+void AddAllocPass::CollectMemRefsFromStatement(const StmtPtr& stmt, std::vector<MemRefPtr>& memrefs) {
+  // Create a visitor to traverse the statement
+  MemRefCollectorVisitor visitor;
+  visitor.VisitStmt(stmt);
+
+  // Add collected MemRefs to the vector (avoiding duplicates by comparing raw pointers)
+  std::set<const ir::MemRef*> existing_ptrs;
+  for (const auto& mr : memrefs) {
+    existing_ptrs.insert(mr.get());
+  }
+
+  for (const auto& mr : visitor.GetMemRefs()) {
+    if (existing_ptrs.find(mr.get()) == existing_ptrs.end()) {
+      memrefs.push_back(mr);
+      existing_ptrs.insert(mr.get());
+    }
+  }
+}
+
+FunctionPtr AddAllocPass::Run(const FunctionPtr& func) {
+  // Step 1: Collect all unique MemRef objects from TileType variables in the function
+  std::vector<MemRefPtr> memrefs;
+  CollectMemRefsFromStatement(func->body_, memrefs);
+
+  // Step 2: Create alloc operations for each MemRef
+  std::vector<StmtPtr> alloc_stmts;
+
+  for (const auto& memref : memrefs) {
+    // Create block.alloc operation with all MemRef fields as arguments
+    auto alloc_op = std::make_shared<Op>("block.alloc");
+
+    // Create expressions for each MemRef field:
+    // 1. memory_space - Convert enum to ConstInt
+    auto memspace_expr = std::make_shared<ConstInt>(static_cast<int64_t>(memref->memory_space_),
+                                                    DataType::INT64, Span::unknown());
+
+    // 2. addr - Already an ExprPtr
+    ExprPtr addr_expr = memref->addr_;
+
+    // 3. size - Convert uint64_t to ConstInt
+    auto size_expr =
+        std::make_shared<ConstInt>(static_cast<int64_t>(memref->size_), DataType::INT64, Span::unknown());
+
+    // 4. id - Convert uint64_t to ConstInt
+    auto id_expr =
+        std::make_shared<ConstInt>(static_cast<int64_t>(memref->id_), DataType::INT64, Span::unknown());
+
+    // Build argument vector: [memspace, addr, size, id]
+    std::vector<ExprPtr> alloc_args;
+    alloc_args.push_back(memspace_expr);
+    alloc_args.push_back(addr_expr);
+    alloc_args.push_back(size_expr);
+    alloc_args.push_back(id_expr);
+
+    // Create a Call expression for the alloc operation
+    // The alloc operation now returns MemRefType
+    auto alloc_call = std::make_shared<Call>(alloc_op, alloc_args, GetMemRefType(), Span::unknown());
+
+    // Create an assignment statement: mem_123: MemRefType = block.alloc(memspace, addr, size, id)
+    // where mem_123 is the MemRef variable itself (which is already a Var)
+    auto assign_stmt = std::make_shared<AssignStmt>(memref, alloc_call, Span::unknown());
+    alloc_stmts.push_back(assign_stmt);
+  }
+
+  // Step 3: Prepend alloc statements to function body
+  StmtPtr new_body = func->body_;
+
+  if (!alloc_stmts.empty()) {
+    // If there are alloc statements, create a sequence
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(func->body_)) {
+      // Append alloc statements before existing statements
+      std::vector<StmtPtr> all_stmts = alloc_stmts;
+      all_stmts.insert(all_stmts.end(), seq->stmts_.begin(), seq->stmts_.end());
+      new_body = std::make_shared<SeqStmts>(all_stmts, func->body_->span_);
+    } else {
+      // Wrap existing body in sequence with alloc statements
+      alloc_stmts.push_back(func->body_);
+      new_body = std::make_shared<SeqStmts>(alloc_stmts, func->body_->span_);
+    }
+  }
+
+  // Step 4: Return transformed function
+  return std::make_shared<Function>(func->name_, func->params_, func->return_types_, new_body, func->span_);
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transform/mutator.cpp
+++ b/src/ir/transform/mutator.cpp
@@ -53,6 +53,11 @@ ExprPtr IRMutator::VisitExpr_(const IterArgPtr& op) {
   }
 }
 
+ExprPtr IRMutator::VisitExpr_(const MemRefPtr& op) {
+  // MemRef is immutable, return original
+  return op;
+}
+
 ExprPtr IRMutator::VisitExpr_(const ConstIntPtr& op) {
   // ConstInt is immutable, return original
   return op;
@@ -86,7 +91,8 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
 
   // Copy-on-write: only create new node if arguments changed
   if (changed) {
-    return std::make_shared<const Call>(op->op_, std::move(new_args), op->span_);
+    // Preserve original type and kwargs when reconstructing the Call node
+    return std::make_shared<const Call>(op->op_, std::move(new_args), op->kwargs_, op->GetType(), op->span_);
   } else {
     return op;
   }

--- a/src/ir/transform/python_printer.cpp
+++ b/src/ir/transform/python_printer.cpp
@@ -16,6 +16,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>
@@ -23,6 +24,7 @@
 
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
@@ -134,6 +136,7 @@ class IRPythonPrinter : public IRVisitor {
   // Expression visitors
   void VisitExpr_(const VarPtr& op) override;
   void VisitExpr_(const IterArgPtr& op) override;
+  void VisitExpr_(const MemRefPtr& op) override;
   void VisitExpr_(const ConstIntPtr& op) override;
   void VisitExpr_(const ConstFloatPtr& op) override;
   void VisitExpr_(const ConstBoolPtr& op) override;
@@ -317,7 +320,7 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
 
     // Add optional memref parameter if present
     if (tile_type->memref_.has_value()) {
-      oss << ", memref=" << PrintMemRef(*tile_type->memref_.value());
+      oss << ", memref=" << tile_type->memref_.value()->name_;
     }
 
     // Add optional tile_view parameter if present
@@ -339,6 +342,10 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
     return oss.str();
   }
 
+  if (auto memref_type = As<MemRefType>(type)) {
+    return prefix_ + ".MemRefType";
+  }
+
   return prefix_ + ".UnknownType";
 }
 
@@ -358,6 +365,8 @@ void IRPythonPrinter::DecreaseIndent() {
 void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << op->name_; }
 
 void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << op->name_; }
+
+void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << op->name_; }
 
 void IRPythonPrinter::VisitExpr_(const ConstIntPtr& op) { stream_ << op->value_; }
 
@@ -410,7 +419,19 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   // Print positional arguments
   for (size_t i = 0; i < op->args_.size(); ++i) {
     if (i > 0) stream_ << ", ";
-    VisitExpr(op->args_[i]);
+
+    // Special handling for block.alloc's first argument (memory_space)
+    if (op->op_->name_ == "block.alloc" && i == 0) {
+      // Try to extract the integer value and convert it to MemorySpace enum
+      if (auto const_int = std::dynamic_pointer_cast<const ConstInt>(op->args_[i])) {
+        int space_value = static_cast<int>(const_int->value_);
+        stream_ << prefix_ << ".MemorySpace." << MemorySpaceToString(static_cast<MemorySpace>(space_value));
+      } else {
+        VisitExpr(op->args_[i]);
+      }
+    } else {
+      VisitExpr(op->args_[i]);
+    }
   }
 
   // Print kwargs as keyword arguments
@@ -1025,8 +1046,8 @@ std::string IRPythonPrinter::PrintMemRef(const MemRef& memref) {
   IRPythonPrinter temp_printer(prefix_);
   oss << temp_printer.Print(memref.addr_);
 
-  // Print size
-  oss << ", " << memref.size_ << ")";
+  // Print size and id
+  oss << ", " << memref.size_ << ", " << memref.id_ << ")";
   return oss.str();
 }
 

--- a/src/ir/transform/visitor.cpp
+++ b/src/ir/transform/visitor.cpp
@@ -46,6 +46,11 @@ void IRVisitor::VisitExpr_(const IterArgPtr& op) {
   }
 }
 
+void IRVisitor::VisitExpr_(const MemRefPtr& op) {
+  // MemRef is a Var with MemRefType, no additional children to visit
+  // The type is MemRefType which has no sub-expressions
+}
+
 void IRVisitor::VisitExpr_(const ConstIntPtr& op) {
   // Leaf node, no children to visit
 }

--- a/tests/ut/ir/transforms/test_add_alloc_pass.py
+++ b/tests/ut/ir/transforms/test_add_alloc_pass.py
@@ -1,0 +1,389 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from pypto import ir
+from pypto.ir import builder
+from pypto.ir.op import block
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import DataType, passes
+
+
+def count_alloc_operations(func):
+    """Count the number of block.alloc operations in a function.
+
+    Args:
+        func: Function to analyze
+
+    Returns:
+        Number of block.alloc operations found
+    """
+    if not isinstance(func.body, ir.SeqStmts):
+        return 0
+
+    count = 0
+    for stmt in func.body.stmts:
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            if stmt.value.op.name == "block.alloc":
+                count += 1
+    return count
+
+
+def get_alloc_statement_indices(func):
+    """Get the indices of all block.alloc statements in a function.
+
+    Args:
+        func: Function to analyze
+
+    Returns:
+        List of statement indices where block.alloc operations are found
+    """
+    if not isinstance(func.body, ir.SeqStmts):
+        return []
+
+    indices = []
+    for i, stmt in enumerate(func.body.stmts):
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            if stmt.value.op.name == "block.alloc":
+                indices.append(i)
+    return indices
+
+
+def test_add_alloc_pass_simple():
+    """Test AddAllocPass with a simple function containing TileType variables.
+
+    Verifies that:
+    1. Alloc operations are created for each unique MemRef
+    2. Alloc operations are placed at the beginning of the function
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_simple_alloc") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        tile_height = 64
+        tile_width = 64
+
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, tile_height, tile_width))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        result = ib.let("result", block.store(tile_b, 0, 0, tile_height, tile_width, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Run InitMemRefPass first to initialize MemRef for tiles
+    init_pass = passes.InitMemRefPass()
+    func_with_memref = init_pass.run(func)
+
+    # Run the AddAllocPass
+    add_alloc_pass = passes.AddAllocPass()
+    optimized_func = add_alloc_pass.run(func_with_memref)
+    print(f"optimized_func: {optimized_func}")
+
+    # Verify alloc operations were added
+    alloc_count = count_alloc_operations(optimized_func)
+    assert alloc_count > 0, "AddAllocPass should create at least one alloc operation"
+
+    # Verify alloc operations are at the beginning
+    alloc_indices = get_alloc_statement_indices(optimized_func)
+    assert len(alloc_indices) > 0, "Should have alloc operations"
+
+    # First statement should be an alloc
+    assert alloc_indices[0] == 0, "First alloc should be at index 0"
+
+    # All alloc operations should be consecutive at the beginning
+    for i, idx in enumerate(alloc_indices):
+        assert idx == i, f"Alloc operations should be at the beginning, but found at index {idx}"
+
+
+def test_add_alloc_pass_multiple_tiles():
+    """Test AddAllocPass with multiple TileType variables.
+
+    Verifies that:
+    1. Each unique MemRef gets its own alloc operation
+    2. Multiple alloc operations are created for multiple tiles
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_multiple_tiles") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        tile_height = 64
+        tile_width = 64
+
+        # Create 4 tiles to test multiple allocs
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, tile_height, tile_width))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
+        result = ib.let("result", block.store(tile_c, 0, 0, tile_height, tile_width, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Run InitMemRefPass first to initialize MemRef for tiles
+    init_pass = passes.InitMemRefPass()
+    func_with_memref = init_pass.run(func)
+
+    # Run the AddAllocPass
+    add_alloc_pass = passes.AddAllocPass()
+    optimized_func = add_alloc_pass.run(func_with_memref)
+
+    # Verify multiple alloc operations were created
+    alloc_count = count_alloc_operations(optimized_func)
+    # We expect 3 allocs for the 3 TileType variables (tile_a, tile_b, tile_c)
+    # The result variable is TensorType and reuses the output parameter's MemRef
+    assert alloc_count == 3, f"Expected 3 alloc operations for 3 tiles, but got {alloc_count}"
+
+    # Verify alloc operations are at the beginning
+    alloc_indices = get_alloc_statement_indices(optimized_func)
+    for i, idx in enumerate(alloc_indices):
+        assert idx == i, "All alloc operations should be at the beginning"
+
+
+def test_add_alloc_pass_with_xplatform_strategy():
+    """Test AddAllocPass as part of XPlatform optimization strategy.
+
+    Verifies that:
+    1. AddAllocPass runs after InitMemRefPass and BasicMemoryReusePass
+    2. All three passes work together correctly
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_xplatform") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        tile_height = 64
+        tile_width = 64
+
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, tile_height, tile_width))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        result = ib.let("result", block.store(tile_b, 0, 0, tile_height, tile_width, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Run XPlatform strategy (which includes AddAllocPass)
+    pm = PassManager.get_strategy(OptimizationStrategy.XPlatform)
+    optimized_result = pm.run_passes(func)
+    assert isinstance(optimized_result, ir.Function), "Result should be a Function"
+    optimized_func = optimized_result
+
+    # Verify alloc operations were added
+    alloc_count = count_alloc_operations(optimized_func)
+    assert alloc_count > 0, "XPlatform strategy should include AddAllocPass which creates alloc operations"
+
+    # Verify the function is still valid
+    assert optimized_func is not None
+    assert optimized_func.name == "test_xplatform"
+    assert isinstance(optimized_func.body, ir.SeqStmts)
+
+
+def test_add_alloc_pass_with_memory_reuse():
+    """Test AddAllocPass behavior when memory reuse happens.
+
+    Verifies that:
+    1. AddAllocPass runs after BasicMemoryReusePass
+    2. When variables share MemRef due to reuse, only one alloc is created for that MemRef
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_with_reuse") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        tile_height = 64
+        tile_width = 64
+
+        # Sequential operations allow memory reuse
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, tile_height, tile_width))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
+        result = ib.let("result", block.store(tile_c, 0, 0, tile_height, tile_width, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Run XPlatform strategy
+    pm = PassManager.get_strategy(OptimizationStrategy.XPlatform)
+    optimized_result = pm.run_passes(func)
+    assert isinstance(optimized_result, ir.Function), "Result should be a Function"
+    optimized_func = optimized_result
+
+    # Verify alloc operations were added
+    alloc_count = count_alloc_operations(optimized_func)
+    assert alloc_count > 0, "Should create alloc operations even with memory reuse"
+
+    # Verify the function structure
+    assert isinstance(optimized_func.body, ir.SeqStmts)
+    stmts = optimized_func.body.stmts
+
+    # Verify alloc operations come before other operations
+    alloc_indices = get_alloc_statement_indices(optimized_func)
+    if alloc_indices:
+        last_alloc_idx = max(alloc_indices)
+        first_non_alloc_idx = None
+        for i, stmt in enumerate(stmts):
+            if i > last_alloc_idx and isinstance(stmt, ir.AssignStmt):
+                if not (isinstance(stmt.value, ir.Call) and stmt.value.op.name == "block.alloc"):
+                    first_non_alloc_idx = i
+                    break
+
+        if first_non_alloc_idx is not None:
+            assert last_alloc_idx < first_non_alloc_idx, (
+                "All alloc operations should come before other operations"
+            )
+
+
+def test_add_alloc_pass_empty_function():
+    """Test AddAllocPass with a function that has no TileType variables.
+
+    Verifies that:
+    1. The pass handles functions with no tiles gracefully
+    2. No alloc operations are created for non-TileType variables
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_empty") as f:
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+        ib.return_stmt(output)
+
+    func = f.get_result()
+
+    # Run the AddAllocPass
+    add_alloc_pass = passes.AddAllocPass()
+    optimized_func = add_alloc_pass.run(func)
+
+    # Verify no alloc operations were created (since there are no TileType variables)
+    alloc_count = count_alloc_operations(optimized_func)
+    assert alloc_count == 0, "Should not create alloc operations for non-TileType variables"
+
+    # Verify the function is still valid
+    assert optimized_func is not None
+    assert optimized_func.name == "test_empty"
+
+
+def test_add_alloc_pass_alloc_placement():
+    """Test that AddAllocPass correctly places alloc operations at the function beginning.
+
+    Verifies that:
+    1. All alloc statements are placed at the very beginning
+    2. No alloc statements are intermixed with other operations
+    3. The order of operations after alloc is preserved
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_placement") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, 64, 64))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        result = ib.let("result", block.store(tile_b, 0, 0, 64, 64, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Run the AddAllocPass
+    add_alloc_pass = passes.AddAllocPass()
+    optimized_func = add_alloc_pass.run(func)
+
+    assert isinstance(optimized_func.body, ir.SeqStmts)
+    stmts = optimized_func.body.stmts
+
+    # Find first non-alloc statement index
+    first_non_alloc_idx = None
+    for i, stmt in enumerate(stmts):
+        if isinstance(stmt, ir.AssignStmt):
+            if not (isinstance(stmt.value, ir.Call) and stmt.value.op.name == "mem.alloc"):
+                first_non_alloc_idx = i
+                break
+
+    # All statements before first_non_alloc_idx should be alloc operations
+    if first_non_alloc_idx is not None:
+        for i in range(first_non_alloc_idx):
+            stmt = stmts[i]
+            assert isinstance(stmt, ir.AssignStmt), f"Statement {i} should be AssignStmt"
+            assert isinstance(stmt.value, ir.Call), f"Statement {i} should have a Call value"
+            assert stmt.value.op.name == "block.alloc", f"Statement {i} should be a block.alloc operation"
+
+    # Verify the original operation order is preserved
+    tile_a_found = False
+    tile_a_idx = None
+    tile_b_idx = None
+    for i, stmt in enumerate(stmts):
+        if isinstance(stmt, ir.AssignStmt):
+            if stmt.var.name == "tile_a":
+                tile_a_found = True
+                tile_a_idx = i
+            elif stmt.var.name == "tile_b":
+                assert tile_a_found, "tile_b should come after tile_a"
+                assert tile_a_idx is not None, "tile_a_idx should be set"
+                tile_b_idx = i
+                assert tile_a_idx < tile_b_idx, "Operations order should be preserved"
+
+
+def test_add_alloc_pass_raw_pointer_uniqueness():
+    """Test that AddAllocPass uses raw pointer comparison for MemRef uniqueness.
+
+    Verifies that:
+    1. Only one alloc is created for the same shared_ptr MemRef
+    2. Different shared_ptr objects result in different alloc operations
+    """
+    ib = builder.IRBuilder()
+
+    with ib.function("test_pointer_uniqueness") as f:
+        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
+        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
+        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+
+        # Create 4 tiles with different MemRef objects
+        tile_a = ib.let("tile_a", block.load(input_a, 0, 0, 64, 64))
+        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
+        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
+        result = ib.let("result", block.store(tile_c, 0, 0, 64, 64, output))
+
+        ib.return_stmt(result)
+
+    func = f.get_result()
+
+    # Before any pass, each tile should have a unique MemRef
+    # Run InitMemRefPass first to initialize MemRef
+    init_pass = passes.InitMemRefPass()
+    func_with_memref = init_pass.run(func)
+
+    # Now run AddAllocPass
+    add_alloc_pass = passes.AddAllocPass()
+    optimized_func = add_alloc_pass.run(func_with_memref)
+
+    # Count alloc operations
+    alloc_count = count_alloc_operations(optimized_func)
+
+    # We expect 3 allocs for the 3 TileType variables (tile_a, tile_b, tile_c)
+    # The result variable is TensorType and reuses the output parameter's MemRef
+    assert alloc_count == 3, f"Expected 3 unique MemRef objects, but got {alloc_count} allocs"
+
+    # Verify alloc operations are placed at the beginning
+    alloc_indices = get_alloc_statement_indices(optimized_func)
+    assert len(alloc_indices) == alloc_count, "All alloc operations should be identified"
+
+    for i, idx in enumerate(alloc_indices):
+        assert idx == i, "Alloc operations should be consecutive at the beginning"

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -111,9 +111,15 @@ def test_basic_memory_reuse_simple():
     assert len(stmts) >= 5
 
     # All intermediate tiles should have memrefs
-    for i in range(5):
-        stmt = stmts[i]
-        assert isinstance(stmt, ir.AssignStmt)
+    # Filter out alloc statements (which create MemRef variables) and only check tile variables
+    tile_stmts = [
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.var.type, core_ir.ShapedType)
+    ]
+    assert len(tile_stmts) >= 5, f"Expected at least 5 tile statements, got {len(tile_stmts)}"
+
+    for stmt in tile_stmts[:5]:
         var = stmt.var
         assert isinstance(var.type, core_ir.ShapedType)
         assert var.type.memref is not None

--- a/tests/ut/ir/transforms/test_insert_sync.py
+++ b/tests/ut/ir/transforms/test_insert_sync.py
@@ -66,9 +66,9 @@ def test_insert_sync_cross_pipe():
     dim64 = ir.ConstInt(64, DataType.INT64, span)
 
     # Create unique memrefs for each tile variable
-    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)  # 64*64*4
-    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
-    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384, 0)  # 64*64*4
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384, 1)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384, 2)
 
     # Create variables with memrefs
     input_a = ir.Var("input_a", ir.TensorType([64, 64], DataType.FP32), span)
@@ -130,10 +130,10 @@ def test_insert_sync_intra_pipe():
     dim64 = ir.ConstInt(64, DataType.INT64, span)
 
     # Create unique memrefs for each tile
-    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
-    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
-    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
-    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384, 3)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384, 4)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384, 5)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384, 6)
 
     # Create variables with memrefs (as function parameters and locals)
     t_a = ir.Var("t_a", ir.TileType([dim64, dim64], DataType.FP32, memref_a), span)
@@ -197,10 +197,10 @@ def test_insert_sync_ifstmt():
     dim64 = ir.ConstInt(64, DataType.INT64, span)
 
     # Create unique memrefs
-    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
-    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
-    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
-    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
+    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384, 7)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384, 8)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384, 9)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384, 10)
 
     # Create variables with memrefs
     input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32, memref_input), span)
@@ -298,11 +298,11 @@ def test_insert_sync_cross_ifstmt_dependency():
     dim64 = ir.ConstInt(64, DataType.INT64, span)
 
     # Create unique memrefs for each tile
-    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
-    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
-    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
-    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
-    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384)
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384, 11)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384, 12)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384, 13)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384, 14)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384, 15)
 
     # Create variables with memrefs
     input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32), span)
@@ -411,12 +411,12 @@ def test_insert_sync_nested_ifstmt():
     dim64 = ir.ConstInt(64, DataType.INT64, span)
 
     # Create unique memrefs
-    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384)
-    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384)
-    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384)
-    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384)
-    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384)
-    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(81920, DataType.INT64, span), 16384)
+    memref_input = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0, DataType.INT64, span), 16384, 16)
+    memref_a = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(16384, DataType.INT64, span), 16384, 17)
+    memref_d = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(32768, DataType.INT64, span), 16384, 18)
+    memref_b = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(49152, DataType.INT64, span), 16384, 19)
+    memref_c = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(65536, DataType.INT64, span), 16384, 20)
+    memref_output = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(81920, DataType.INT64, span), 16384, 21)
 
     # Create variables
     input_tensor = ir.Var("input", ir.TensorType([64, 64], DataType.FP32, memref_input), span)


### PR DESCRIPTION
**Summary**  
- Introduces `AddAllocPass` to insert `block.alloc` for unique `TileType` `MemRef`s.  
- Integrates `AddAllocPass` into the default XPlatform optimization pipeline.

**Details**  
- **IR & MemRef**: Extends `MemRef` / `TileType` and kind traits to support the new allocation semantics, and updates serialization/deserialization accordingly.  
- **Transform Pass**: Adds `AddAllocPass` plus supporting functor/mutator/visitor logic, and wires it together with `InitMemRefPass` and `BasicMemoryReusePass`.  
- **Python Bindings**: Updates the `ir` and `pass` Python bindings and `.pyi` stubs to expose the new MemRef capabilities and pass entry points.  
- **Examples**: Adds a `dynamic_softmax_codegen` IRBuilder example and updates the `sinh_taylor` codegen example to demonstrate the new allocation behavior.  
- **Tests**: Expands MemRef unit tests, adds `test_add_alloc_pass`, and adjusts `test_basic_memory_reuse` and `test_insert_sync` to cover the new MemRef shape and pass behavior.

