### PR TITLE
feat(ir): add automatic span capture for operations

### DIFF
--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -534,7 +534,7 @@ class IRBuilder:
             frame = frame.f_back.f_back
         if frame is not None:
             info = inspect.getframeinfo(frame)
-            return ir.Span(info.filename, info.lineno, 0)
+            return ir.Span(info.filename, info.lineno, -1)
         return ir.Span.unknown()
 
     def _combine_spans(self, begin: ir.Span, end: ir.Span) -> ir.Span:

--- a/python/pypto/ir/operators.py
+++ b/python/pypto/ir/operators.py
@@ -34,7 +34,7 @@ def _capture_call_span() -> _ir.Span:
 
     if frame is not None:
         info = inspect.getframeinfo(frame)
-        return _ir.Span(info.filename, info.lineno, 0)
+        return _ir.Span(info.filename, info.lineno, -1)
 
     return _ir.Span.unknown()
 

--- a/python/pypto/language/parser/span_tracker.py
+++ b/python/pypto/language/parser/span_tracker.py
@@ -50,6 +50,8 @@ class SpanTracker:
             self.source_file,
             getattr(ast_node, "lineno", 0) + self.line_offset,
             getattr(ast_node, "col_offset", 0) + self.col_offset,
+            getattr(ast_node, "end_lineno", 0) + self.line_offset,
+            getattr(ast_node, "end_col_offset", 0) + self.col_offset,
         )
 
     def get_multiline_span(self, start_node: ast.AST, end_node: ast.AST) -> ir.Span:
@@ -69,8 +71,8 @@ class SpanTracker:
             self.source_file,
             getattr(start_node, "lineno", 0) + self.line_offset,
             getattr(start_node, "col_offset", 0) + self.col_offset,
-            getattr(end_node, "lineno", 0) + self.line_offset,
-            getattr(end_node, "col_offset", 0) + self.col_offset,
+            getattr(end_node, "end_lineno", 0) + self.line_offset,
+            getattr(end_node, "end_col_offset", 0) + self.col_offset,
         )
 
 

--- a/src/ir/core.cpp
+++ b/src/ir/core.cpp
@@ -32,8 +32,19 @@ std::string Span::to_string() const {
 }
 
 bool Span::is_valid() const {
-  return begin_line_ > 0 && begin_column_ > 0 && end_line_ > 0 && end_column_ > 0 &&
-         end_line_ >= begin_line_ && (end_line_ > begin_line_ || end_column_ >= begin_column_);
+  if (begin_line_ <= 0 || (begin_column_ <= 0 && begin_column_ != -1)) {
+    return false;
+  }
+  if (end_line_ == -1 || end_column_ == -1) {
+    return true;
+  }
+  if (end_line_ <= 0 || (end_column_ <= 0 && end_column_ != -1)) {
+    return false;
+  }
+  if (begin_column_ == -1 || end_column_ == -1) {
+    return end_line_ >= begin_line_;
+  }
+  return end_line_ >= begin_line_ && (end_line_ > begin_line_ || end_column_ >= begin_column_);
 }
 
 Span Span::unknown() { return Span("", -1, -1, -1, -1); }

--- a/tests/ut/ir/operators/test_operation_span_capture.py
+++ b/tests/ut/ir/operators/test_operation_span_capture.py
@@ -1,0 +1,253 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for automatic span capture in IR operations."""
+
+import inspect
+
+import pytest
+from pypto import DataType, ir
+from pypto.ir.op import block as block_ops
+from pypto.ir.op import tensor as tensor_ops
+from pypto.ir.utils import _get_span_or_capture
+
+
+def get_current_line():
+    """Get the current line number in the calling code."""
+    frame = inspect.currentframe()
+    if frame and frame.f_back:
+        return frame.f_back.f_lineno
+    return -1
+
+
+class TestTensorOperationSpanCapture:
+    """Test span capture for tensor operations."""
+
+    def test_tensor_add_captures_span(self):
+        """Tensor operations should capture caller span automatically."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+        y = ir.Var("y", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        # Call operation - span should be captured
+        line_before = get_current_line()
+        result = tensor_ops.add(x, y)
+
+        # Verify span points to this file and line
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+        assert result.span.begin_line == line_before + 1
+
+    def test_tensor_mul_captures_span(self):
+        """Test mul operation span capture."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        # Test with scalar
+        line_before = get_current_line()
+        result = tensor_ops.mul(x, 2.0)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+        assert result.span.begin_line == line_before + 1
+
+    def test_tensor_create_captures_span(self):
+        """Test create operation span capture."""
+        line_before = get_current_line()
+        result = tensor_ops.create([64, 32], DataType.FP32)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+        assert result.span.begin_line == line_before + 1
+
+    def test_tensor_matmul_captures_span(self):
+        """Test matmul operation span capture."""
+        lhs = ir.Var("lhs", ir.TensorType([64, 32], DataType.FP32), ir.Span.unknown())
+        rhs = ir.Var("rhs", ir.TensorType([32, 16], DataType.FP32), ir.Span.unknown())
+
+        result = tensor_ops.matmul(lhs, rhs)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_explicit_span_overrides_capture(self):
+        """Explicit span should override automatic capture."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+        y = ir.Var("y", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        explicit_span = ir.Span("custom.py", 100, 20)
+        result = tensor_ops.add(x, y, span=explicit_span)
+
+        # Should use explicit span, not captured span
+        assert result.span.filename == "custom.py"
+        assert result.span.begin_line == 100
+        assert result.span.begin_column == 20
+
+    def test_nested_operations_each_capture_own_span(self):
+        """Each nested operation should capture its own span."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+        y = ir.Var("y", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        line_before_add = get_current_line()
+        add_result = tensor_ops.add(x, y)
+        line_before_mul = get_current_line()
+        mul_result = tensor_ops.mul(add_result, 2.0)
+
+        # Each should have different line numbers
+        assert add_result.span.begin_line == line_before_add + 1
+        assert mul_result.span.begin_line == line_before_mul + 1
+        assert add_result.span.begin_line != mul_result.span.begin_line
+        assert add_result.span.is_valid()
+        assert mul_result.span.is_valid()
+
+    def test_tensor_view_captures_span(self):
+        """Test view operation span capture."""
+        tensor = ir.Var("tensor", ir.TensorType([64, 32], DataType.FP32), ir.Span.unknown())
+
+        result = tensor_ops.view(tensor, [32, 16], [0, 0])
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_tensor_cast_captures_span(self):
+        """Test cast operation span capture."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        result = tensor_ops.cast(x, DataType.FP16)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_tensor_exp_captures_span(self):
+        """Test exp operation span capture."""
+        x = ir.Var("x", ir.TensorType([64], DataType.FP32), ir.Span.unknown())
+
+        result = tensor_ops.exp(x)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_tensor_row_max_captures_span(self):
+        """Test row_max operation span capture."""
+        x = ir.Var("x", ir.TensorType([64, 32], DataType.FP32), ir.Span.unknown())
+
+        result = tensor_ops.row_max(x, axis=-1)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+
+class TestBlockOperationSpanCapture:
+    """Test span capture for block operations."""
+
+    def test_block_matmul_captures_span(self):
+        """Block operations should also capture span."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        a = ir.Var("a", tile_type, ir.Span.unknown())
+        b = ir.Var("b", tile_type, ir.Span.unknown())
+
+        result = block_ops.matmul(a, b)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_block_add_captures_span(self):
+        """Test block add operation span capture."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        a = ir.Var("a", tile_type, ir.Span.unknown())
+        b = ir.Var("b", tile_type, ir.Span.unknown())
+
+        result = block_ops.add(a, b)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_block_load_captures_span(self):
+        """Test block load operation span capture."""
+        tensor = ir.Var("tensor", ir.TensorType([64, 64], DataType.FP16), ir.Span.unknown())
+
+        result = block_ops.load(tensor, 0, 0, 16, 16)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_block_exp_captures_span(self):
+        """Test block exp operation span capture."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        tile = ir.Var("tile", tile_type, ir.Span.unknown())
+
+        result = block_ops.exp(tile)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_block_row_max_captures_span(self):
+        """Test block row_max operation span capture."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        tile = ir.Var("tile", tile_type, ir.Span.unknown())
+
+        result = block_ops.row_max(tile)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+
+    def test_block_explicit_span_override(self):
+        """Explicit span should override automatic capture for block ops."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        a = ir.Var("a", tile_type, ir.Span.unknown())
+        b = ir.Var("b", tile_type, ir.Span.unknown())
+
+        explicit_span = ir.Span("block_ops.py", 42, 5)
+        result = block_ops.add(a, b, span=explicit_span)
+
+        assert result.span.filename == "block_ops.py"
+        assert result.span.begin_line == 42
+        assert result.span.begin_column == 5
+
+
+class TestUtilityFunction:
+    """Test the _get_span_or_capture utility function."""
+
+    def test_get_span_or_capture_returns_explicit_span(self):
+        """When span provided, should return it unchanged."""
+
+        explicit = ir.Span("test.py", 42, 10)
+        result = _get_span_or_capture(span=explicit)
+
+        assert result.filename == "test.py"
+        assert result.begin_line == 42
+        assert result.begin_column == 10
+
+    def test_get_span_or_capture_auto_captures(self):
+        """When span not provided, should capture from caller."""
+
+        line_before = get_current_line()
+        result = _get_span_or_capture(frame_offset=0)
+
+        # Should capture this test file
+        assert result.filename.endswith("test_operation_span_capture.py")
+        assert result.is_valid()
+        assert result.begin_line == line_before + 1
+
+    def test_get_span_or_capture_with_frame_offset(self):
+        """Test frame offset parameter works correctly."""
+
+        def wrapper():
+            # With offset=1, should skip this wrapper and capture caller
+            return _get_span_or_capture(frame_offset=1)
+
+        line_before = get_current_line()
+        result = wrapper()
+
+        # Should capture the line where wrapper() is called, not inside wrapper
+        assert result.filename.endswith("test_operation_span_capture.py")
+        assert result.is_valid()
+        assert result.begin_line == line_before + 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_parser_span_passing.py
+++ b/tests/ut/language/parser/test_parser_span_passing.py
@@ -1,0 +1,276 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for parser passing span information to operations."""
+
+import inspect
+
+import pypto.language as pl
+import pytest
+from pypto.pypto_core import ir
+
+
+def get_current_line():
+    """Get the current line number in the calling code."""
+    frame = inspect.currentframe()
+    if frame and frame.f_back:
+        return frame.f_back.f_lineno
+    return -1
+
+
+class TestParserSpanPassing:
+    """Test that parser passes accurate span information to operations."""
+
+    def test_parser_passes_span_to_tensor_add(self):
+        """Parser should pass AST span to tensor.add operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_func(
+            x: pl.Tensor[[64], pl.FP32],
+            y: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            z: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, y)  # Line current_line + 7
+            return z
+
+        # Function should be created successfully
+        assert isinstance(test_func, ir.Function)
+        assert test_func.name == "test_func"
+
+        # Check that the function body contains statements with valid spans
+        body = test_func.body
+        assert isinstance(body, ir.SeqStmts)
+        assert len(body.stmts) > 0
+
+        # Find the assign statement containing the add operation
+        for stmt in body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.add":
+                    # Verify span is valid and not unknown
+                    assert value.span.is_valid()
+                    # Check line number points to the operation call (line current_line + 7)
+                    assert value.span.begin_line == current_line + 7
+                    # Check column points to the operation (after "= ")
+                    assert value.span.begin_column > 0
+                    # Verify end position is set (parser should provide range)
+                    # End line should be same line or later
+                    assert value.span.end_line >= value.span.begin_line
+                    # If same line, end column should be after begin
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+                    break
+
+    def test_parser_passes_span_to_tensor_mul(self):
+        """Parser should pass AST span to tensor.mul operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_mul(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            y: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)  # Line current_line + 4
+            return y
+
+        assert isinstance(test_mul, ir.Function)
+        assert isinstance(test_mul.body, ir.SeqStmts)
+
+        # Check that operations have valid spans
+        for stmt in test_mul.body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.mul_scalar":
+                    assert value.span.is_valid()
+                    assert value.span.begin_line == current_line + 4
+                    assert value.span.begin_column > 0
+                    assert value.span.end_line >= value.span.begin_line
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+
+    def test_parser_passes_span_to_tensor_create(self):
+        """Parser should pass AST span to tensor.create operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_create() -> pl.Tensor[[64, 32], pl.FP32]:
+            x: pl.Tensor[[64, 32], pl.FP32] = pl.op.tensor.create([64, 32], dtype=pl.FP32)  # current_line + 4
+            return x
+
+        assert isinstance(test_create, ir.Function)
+        assert isinstance(test_create.body, ir.SeqStmts)
+
+        for stmt in test_create.body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.create":
+                    assert value.span.is_valid()
+                    assert value.span.begin_line == current_line + 4
+                    assert value.span.begin_column == 46
+                    assert value.span.end_line >= value.span.begin_line
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+
+    def test_parser_span_accuracy_multiple_operations(self):
+        """Test that parser assigns different spans to different operations."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_multi(x: pl.Tensor[[32], pl.FP32]) -> pl.Tensor[[32], pl.FP32]:
+            y: pl.Tensor[[32], pl.FP32] = pl.op.tensor.mul(x, 2.0)  # current_line + 4
+            z: pl.Tensor[[32], pl.FP32] = pl.op.tensor.add(y, 1.0)  # current_line + 5
+            return z
+
+        assert isinstance(test_multi, ir.Function)
+        assert isinstance(test_multi.body, ir.SeqStmts)
+
+        # Collect all Call spans
+        call_spans = []
+        for stmt in test_multi.body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                call_spans.append((stmt.value.op.name, stmt.value.span))
+
+        # Should have at least 2 operations
+        assert len(call_spans) >= 2
+
+        # All spans should be valid with proper line/column info
+        for (op_name, span), offset in zip(call_spans, [4, 5]):
+            assert span.is_valid(), f"Invalid span for {op_name}"
+            assert span.begin_line == current_line + offset, f"Invalid line number for {op_name}"
+            assert span.begin_column == 42, f"Invalid column number for {op_name}"
+            assert span.end_line >= span.begin_line, f"Invalid end line for {op_name}"
+            if span.end_line == span.begin_line:
+                assert span.end_column >= span.begin_column, f"Invalid end column for {op_name}"
+
+    def test_parser_passes_span_to_matmul(self):
+        """Parser should pass AST span to tensor.matmul operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_matmul(
+            a: pl.Tensor[[64, 32], pl.FP32],
+            b: pl.Tensor[[32, 16], pl.FP32],
+        ) -> pl.Tensor[[64, 16], pl.FP32]:
+            c: pl.Tensor[[64, 16], pl.FP32] = pl.op.tensor.matmul(a, b)  # current_line + 7
+            return c
+
+        assert isinstance(test_matmul, ir.Function)
+        assert isinstance(test_matmul.body, ir.SeqStmts)
+
+        for stmt in test_matmul.body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.matmul":
+                    assert value.span.is_valid()
+                    assert value.span.begin_line == current_line + 7
+                    assert value.span.begin_column > 0
+                    assert value.span.end_line >= value.span.begin_line
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+
+    def test_parser_passes_span_to_cast(self):
+        """Parser should pass AST span to tensor.cast operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_cast(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP16]:
+            y: pl.Tensor[[64], pl.FP16] = pl.op.tensor.cast(x, target_type=pl.FP16)  # current_line + 4
+            return y
+
+        assert isinstance(test_cast, ir.Function)
+        assert isinstance(test_cast.body, ir.SeqStmts)
+
+        for stmt in test_cast.body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.cast":
+                    assert value.span.is_valid()
+                    assert value.span.begin_line == current_line + 4
+                    assert value.span.begin_column > 0
+                    assert value.span.end_line >= value.span.begin_line
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+
+    def test_parser_passes_span_to_exp(self):
+        """Parser should pass AST span to tensor.exp operation."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_exp(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            y: pl.Tensor[[64], pl.FP32] = pl.op.tensor.exp(x)  # current_line + 4
+            return y
+
+        assert isinstance(test_exp, ir.Function)
+        assert isinstance(test_exp.body, ir.SeqStmts)
+
+        for stmt in test_exp.body.stmts:
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+                if isinstance(value, ir.Call) and value.op.name == "tensor.exp":
+                    assert value.span.is_valid()
+                    assert value.span.begin_line == current_line + 4
+                    assert value.span.begin_column > 0
+                    assert value.span.end_line >= value.span.begin_line
+                    if value.span.end_line == value.span.begin_line:
+                        assert value.span.end_column >= value.span.begin_column
+
+    def test_all_operations_have_valid_spans(self):
+        """Comprehensive test that all operations get valid spans from parser."""
+
+        current_line = get_current_line()
+
+        @pl.function
+        def test_comprehensive(
+            x: pl.Tensor[[64], pl.FP32],
+            y: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            a: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, y)  # current_line + 7
+            b: pl.Tensor[[64], pl.FP32] = pl.op.tensor.sub(a, 1.0)  # current_line + 8
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(b, 2.0)  # current_line + 9
+            d: pl.Tensor[[64], pl.FP32] = pl.op.tensor.div(c, 3.0)  # current_line + 10
+            e: pl.Tensor[[64], pl.FP32] = pl.op.tensor.exp(d)  # current_line + 11
+            return e
+
+        assert isinstance(test_comprehensive, ir.Function)
+        assert isinstance(test_comprehensive.body, ir.SeqStmts)
+
+        # Collect all operations and verify spans
+        operations_checked = 0
+        expected_lines = [7, 8, 9, 10, 11]
+        for stmt in test_comprehensive.body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                span = stmt.value.span
+                op_name = stmt.value.op.name
+
+                # Verify span validity
+                assert span.is_valid(), f"Invalid span for {op_name}"
+
+                # Verify line number
+                assert span.begin_line == current_line + expected_lines[operations_checked]
+
+                # Verify column number
+                assert span.begin_column > 0, f"Invalid column for {op_name}"
+
+                # Verify end position
+                assert span.end_line >= span.begin_line, f"Invalid end line for {op_name}"
+                if span.end_line == span.begin_line:
+                    assert span.end_column >= span.begin_column, f"Invalid end column for {op_name}"
+
+                operations_checked += 1
+
+        # Should have checked exactly 5 operations
+        assert operations_checked == 5
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add span capture utility that records source locations when operations are created. Operations now accept optional span parameter - if not provided, the span is captured from the call site using frame inspection.

- Add _get_span_or_capture() utility for frame-based span capture
- Update all tensor and block operations with optional span parameter
- Update parser to pass AST spans to operations
- Enhance C++ Span::is_valid() to handle partial spans (column=-1)
- Add comprehensive tests for span capture and parser span passing