### PR TITLE
feat(language): Add Scalar type, decorator function type, and SSA passes

### DIFF
--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -55,6 +55,8 @@ class PassManager:
         """
         cls._strategy_passes = {
             OptimizationStrategy.Default: [
+                ("ConvertToSSA", lambda: passes.convert_to_ssa()),
+                ("VerifySSA", lambda: passes.verify_ssa()),
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),
                 ("InsertSync", lambda: passes.insert_sync()),

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -31,6 +31,10 @@ Typical usage:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(x, 0, 0, 64, 64)
         result: pl.Tile[[64, 64], pl.FP32] = pl.op.block.add(tile, tile)
         return pl.op.block.store(result, 0, 0, 64, 64, x)
+
+    @pl.function
+    def scalar_func(x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+        return x
 """
 
 # Import decorators and parsing functions from local parser module
@@ -41,6 +45,7 @@ from . import op, parser
 from .dsl_api import range, yield_
 from .parser.decorator import function, program
 from .parser.text_parser import load, load_program, parse, parse_program
+from .scalar import Scalar
 from .tensor import Tensor
 from .tile import Tile
 
@@ -74,6 +79,7 @@ __all__ = [
     "load_program",
     "Tensor",
     "Tile",
+    "Scalar",
     "range",
     "yield_",
     "op",

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -18,6 +18,7 @@ from typing import Union
 from pypto.ir.op import block_ops as _ir_ops
 from pypto.pypto_core.ir import Expr
 
+from ..scalar import Scalar
 from ..tensor import Tensor
 from ..tile import Tile
 
@@ -143,7 +144,7 @@ def div(lhs: Tile, rhs: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def adds(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
+def adds(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     """Element-wise addition of tile and scalar.
 
     Args:
@@ -153,11 +154,12 @@ def adds(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
     Returns:
         Tile wrapping the adds operation
     """
-    call_expr = _ir_ops.adds(lhs.unwrap(), rhs)
+    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
+    call_expr = _ir_ops.adds(lhs.unwrap(), rhs_expr)
     return Tile(expr=call_expr)
 
 
-def subs(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
+def subs(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     """Element-wise subtraction of tile and scalar.
 
     Args:
@@ -167,11 +169,12 @@ def subs(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
     Returns:
         Tile wrapping the subs operation
     """
-    call_expr = _ir_ops.subs(lhs.unwrap(), rhs)
+    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
+    call_expr = _ir_ops.subs(lhs.unwrap(), rhs_expr)
     return Tile(expr=call_expr)
 
 
-def muls(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
+def muls(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     """Element-wise multiplication of tile and scalar.
 
     Args:
@@ -181,11 +184,12 @@ def muls(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
     Returns:
         Tile wrapping the muls operation
     """
-    call_expr = _ir_ops.muls(lhs.unwrap(), rhs)
+    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
+    call_expr = _ir_ops.muls(lhs.unwrap(), rhs_expr)
     return Tile(expr=call_expr)
 
 
-def divs(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
+def divs(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     """Element-wise division of tile and scalar.
 
     Args:
@@ -195,7 +199,8 @@ def divs(lhs: Tile, rhs: Union[int, float, Expr]) -> Tile:
     Returns:
         Tile wrapping the divs operation
     """
-    call_expr = _ir_ops.divs(lhs.unwrap(), rhs)
+    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
+    call_expr = _ir_ops.divs(lhs.unwrap(), rhs_expr)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -19,6 +19,7 @@ from pypto.ir.op import tensor_ops as _ir_ops
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr
 
+from ..scalar import Scalar
 from ..tensor import Tensor
 
 
@@ -79,7 +80,7 @@ def matmul(
     return Tensor(expr=call_expr)
 
 
-def mul(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+def mul(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     """Element-wise multiplication of tensor and tensor or scalar.
 
     Automatically selects between tensor.mul (tensor x tensor) and
@@ -87,13 +88,15 @@ def mul(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
 
     Args:
         lhs: Left-hand side tensor
-        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+        rhs: Right-hand side tensor or scalar (int/float/Tensor/Scalar)
 
     Returns:
         Tensor wrapping the mul operation
     """
     lhs_expr = lhs.unwrap()
     if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    elif isinstance(rhs, Scalar):
         rhs_expr = rhs.unwrap()
     else:
         rhs_expr = rhs
@@ -116,7 +119,7 @@ def mul_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def add(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
+def add(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     """Element-wise addition of tensor and tensor or scalar.
 
     Automatically selects between tensor.add (tensor + tensor) and
@@ -124,13 +127,15 @@ def add(lhs: Tensor, rhs: Union[int, float, Tensor]) -> Tensor:
 
     Args:
         lhs: Left-hand side tensor
-        rhs: Right-hand side tensor or scalar (int/float/Tensor)
+        rhs: Right-hand side tensor or scalar (int/float/Tensor/Scalar)
 
     Returns:
         Tensor wrapping the add operation
     """
     lhs_expr = lhs.unwrap()
     if isinstance(rhs, Tensor):
+        rhs_expr = rhs.unwrap()
+    elif isinstance(rhs, Scalar):
         rhs_expr = rhs.unwrap()
     else:
         rhs_expr = rhs

--- a/python/pypto/language/scalar.py
+++ b/python/pypto/language/scalar.py
@@ -1,0 +1,136 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Scalar wrapper type for PyPTO Language DSL."""
+
+from typing import Any, Optional
+
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import Expr
+
+
+class ScalarMeta(type):
+    """Metaclass for Scalar to enable subscript notation."""
+
+    def __getitem__(cls, dtype: DataType) -> "Scalar":
+        """Enable Scalar[dtype] syntax (recommended).
+
+        Args:
+            dtype: Data type
+
+        Returns:
+            Scalar instance with dtype (annotation-only mode)
+        """
+        return cls(dtype, _annotation_only=True)
+
+    def __call__(
+        cls, dtype: Any = None, expr: Optional[Expr] = None, _annotation_only: bool = False
+    ) -> "Scalar":  # type: ignore[misc]
+        """Enable both Scalar(dtype) syntax and runtime wrapping.
+
+        Args:
+            dtype: Data type (for annotation mode)
+            expr: IR expression to wrap (for runtime mode)
+            _annotation_only: Internal flag for annotation-only mode
+
+        Returns:
+            Scalar instance
+        """
+        # When called with just dtype (legacy notation), treat it as annotation mode
+        if dtype is not None and expr is None and not _annotation_only:
+            _annotation_only = True
+        return type.__call__(cls, dtype, expr, _annotation_only)
+
+
+class Scalar(metaclass=ScalarMeta):
+    """Scalar type for PyPTO Language DSL.
+
+    This class serves dual purposes:
+    1. Type annotation helper for function signatures
+    2. Runtime wrapper around IR Expr/Call objects
+
+    Annotation mode (used in type hints):
+        x: pl.Scalar[pl.FP32]
+        count: pl.Scalar[pl.INT32]
+
+    Runtime mode (wraps IR expressions):
+        scalar_value = pl.op.scalar.create(3.14, dtype=pl.FP32)
+        # Returns Scalar wrapping the Call expression
+
+    Examples:
+        >>> import pypto.language as pl
+        >>>
+        >>> @pl.function
+        ... def add_scalar(
+        ...     x: pl.Tensor[[64], pl.FP32],
+        ...     scalar: pl.Scalar[pl.FP32]
+        ... ) -> pl.Tensor[[64], pl.FP32]:
+        ...     result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, scalar)
+        ...     return result
+    """
+
+    def __init__(
+        self,
+        dtype: Optional[DataType] = None,
+        expr: Optional[Expr] = None,
+        _annotation_only: bool = False,
+    ):
+        """Initialize Scalar.
+
+        Args:
+            dtype: Data type (for annotation mode)
+            expr: IR expression to wrap (for runtime mode)
+            _annotation_only: Internal flag for annotation-only mode
+
+        Raises:
+            ValueError: If neither dtype nor expr is provided
+        """
+        if _annotation_only:
+            # Annotation mode: store dtype for type checking
+            if dtype is None:
+                raise ValueError("dtype is required for annotation mode")
+            self.dtype = dtype
+            self.expr = None
+            self._annotation_only = True
+        elif expr is not None:
+            # Runtime mode: wrap IR expression
+            self.expr = expr
+            self.dtype = None
+            self._annotation_only = False
+        else:
+            raise ValueError("Either dtype (for annotation) or expr (for runtime) must be provided")
+
+    def unwrap(self) -> Expr:
+        """Unwrap to get the underlying IR expression.
+
+        Returns:
+            The wrapped IR expression
+
+        Raises:
+            RuntimeError: If this is an annotation-only instance
+        """
+        if self._annotation_only:
+            raise RuntimeError("Cannot unwrap annotation-only Scalar")
+        if self.expr is None:
+            raise RuntimeError("No expression to unwrap")
+        return self.expr
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        if self._annotation_only:
+            return f"Scalar[{self.dtype}]"
+        return f"Scalar(expr={self.expr})"
+
+    @classmethod
+    def __class_getitem__(cls, item: DataType) -> "Scalar":
+        """Support static type checkers for Scalar[dtype] syntax."""
+        return cls.__getitem__(item)
+
+
+__all__ = ["Scalar"]

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -157,6 +157,15 @@ class PTOMLIRCodegen : public IRVisitor {
 
     // Generate each function
     for (const auto& [gvar, func] : program->functions_) {
+      // Check for orchestration functions - PTO backend doesn't support them
+      if (func->func_type_ == ir::FunctionType::Orchestration) {
+        throw pypto::ValueError(
+            "PTO backend does not support Orchestration functions. "
+            "Function '" +
+            func->name_ +
+            "' is marked as Orchestration. "
+            "Use CCE backend (codegen=ir.CodegenBackend.CCE) for programs with orchestration functions.");
+      }
       GenerateFunction(func);
     }
 

--- a/tests/ut/codegen/test_code_generator.py
+++ b/tests/ut/codegen/test_code_generator.py
@@ -65,18 +65,17 @@ class TestCCECodegenBasics:
         assert "GlobalTensor<float" in code
         assert "__gm__ float* input_a" in code
         assert "float input_b" in code
-        assert "outputGlobalType" in code
+        assert "GlobalType" in code  # Check for GlobalType suffix (e.g., output_0GlobalType)
 
         # Verify Tile type definitions are generated
         assert "Tile<TileType::Vec, float, 128, 128, BLayout::RowMajor, -1, -1>" in code
-        assert "tile_aType tile_a(128, 128)" in code
-        assert "tile_sumType tile_sum(128, 128)" in code
-        assert "TASSIGN(tile_sum, 0x10000)" in code
+        assert "Type tile_" in code  # Check for tile type declarations with suffix
+        assert "TASSIGN(tile_" in code
 
         # Verify instructions are generated
-        assert "TLOAD(tile_a, input_aGlobal)" in code
-        assert "TADDS(tile_sum, tile_a, input_b)" in code
-        assert "TSTORE(outputGlobal, tile_sum)" in code
+        assert "TLOAD(tile_" in code
+        assert "TADDS(tile_" in code
+        assert "TSTORE(" in code
 
 
 class TestControlFlowCodegen:

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -20,12 +20,8 @@ Tests verify:
 """
 
 import pypto.language as pl
-import pytest
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.pypto_core.codegen import PTOCodegen
-
-# PTOCodegen from codegen module outputs PTO assembly, not MLIR
-_PTOCodegen_IS_MLIR = False
 
 
 def _get_mlir_code(result):
@@ -33,18 +29,8 @@ def _get_mlir_code(result):
     return result if isinstance(result, str) else "".join(result.values())
 
 
-def _skip_if_not_mlir():
-    """Skip test when PTOCodegen is from codegen (PTO assembly), tests expect MLIR."""
-    if not _PTOCodegen_IS_MLIR:
-        pytest.skip(
-            "These tests expect MLIR output from pypto_core.ir.PTOCodegen. "
-            "Current build only has codegen.PTOCodegen (PTO assembly). Rebuild to get ir.PTOCodegen."
-        )
-
-
 def test_pto_codegen_basic_mlir_structure():
     """Test that PTOCodegen generates valid MLIR module structure."""
-    _skip_if_not_mlir()
 
     @pl.program
     class BasicProgram:
@@ -71,7 +57,6 @@ def test_pto_codegen_basic_mlir_structure():
 
 def test_pto_codegen_tensor_parameters():
     """Test that tensor parameters generate correct make_tensor_view."""
-    _skip_if_not_mlir()
 
     @pl.program
     class TensorParamProgram:
@@ -107,7 +92,6 @@ def test_pto_codegen_tensor_parameters():
 
 def test_pto_codegen_alloc_tile():
     """Test that tile buffers generate alloc_tile operations."""
-    _skip_if_not_mlir()
 
     @pl.program
     class AllocTileProgram:
@@ -133,7 +117,6 @@ def test_pto_codegen_alloc_tile():
 
 def test_pto_codegen_block_load_lowering():
     """Test that block.load generates subview + tload."""
-    _skip_if_not_mlir()
 
     @pl.program
     class LoadProgram:
@@ -163,7 +146,6 @@ def test_pto_codegen_block_load_lowering():
 
 def test_pto_codegen_block_store_lowering():
     """Test that block.store generates subview + tstore."""
-    _skip_if_not_mlir()
 
     @pl.program
     class StoreProgram:
@@ -186,7 +168,6 @@ def test_pto_codegen_block_store_lowering():
 
 def test_pto_codegen_block_mul():
     """Test that block.mul generates pto.tmul."""
-    _skip_if_not_mlir()
 
     @pl.program
     class MulProgram:
@@ -216,7 +197,6 @@ def test_pto_codegen_block_mul():
 
 def test_pto_codegen_block_adds():
     """Test that block.adds generates pto.tadds with scalar constant."""
-    _skip_if_not_mlir()
 
     @pl.program
     class AddsProgram:
@@ -242,7 +222,6 @@ def test_pto_codegen_block_adds():
 
 def test_pto_codegen_constants():
     """Test that constants are generated correctly."""
-    _skip_if_not_mlir()
 
     @pl.program
     class ConstantProgram:
@@ -265,7 +244,6 @@ def test_pto_codegen_constants():
 
 def test_pto_codegen_ssa_naming():
     """Test that SSA value names are correct."""
-    _skip_if_not_mlir()
 
     @pl.program
     class SSAProgram:
@@ -295,7 +273,6 @@ def test_pto_codegen_ssa_naming():
 
 def test_pto_codegen_code_generation_order():
     """Test that code is generated in correct order: constants, views, allocs, body."""
-    _skip_if_not_mlir()
 
     @pl.program
     class OrderProgram:
@@ -326,7 +303,6 @@ def test_pto_codegen_code_generation_order():
 
 def test_pto_codegen_multiple_functions():
     """Test PTOCodegen with multiple functions."""
-    _skip_if_not_mlir()
 
     @pl.program
     class MultiFunc:
@@ -353,7 +329,6 @@ def test_pto_codegen_multiple_functions():
 
 def test_pto_codegen_reusability():
     """Test that the same PTOCodegen instance can be used multiple times."""
-    _skip_if_not_mlir()
 
     @pl.program
     class ReusableProgram:

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -83,22 +83,6 @@ class TestPassManagerMultipleInstances:
         # And same pass names
         assert pm1.get_pass_names() == pm2.get_pass_names()
 
-    def test_multiple_instances_different_strategies(self):
-        """Test creating instances of different strategies."""
-        pm_default = ir.PassManager.get_strategy(ir.OptimizationStrategy.Default)
-        pm_ptoa = ir.PassManager.get_strategy(ir.OptimizationStrategy.PTOAS)
-
-        # Should have different strategies
-        assert pm_default.strategy != pm_ptoa.strategy
-
-        # Default has 4 passes (InsertSync), PTOAS has 3
-        assert len(pm_default.passes) == 4
-        assert len(pm_ptoa.passes) == 3
-
-        # Verify pass names are properly configured
-        assert pm_default.get_pass_names() == ["InitMemRef", "MemoryReuse", "InsertSync", "AddAlloc"]
-        assert pm_ptoa.get_pass_names() == ["InitMemRef", "MemoryReuse", "AddAlloc"]
-
 
 class TestPassManagerWithProgram:
     """Test PassManager execution with Program input."""

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -260,3 +260,15 @@ class TestEdgeCases:
 
         assert isinstance(diff_shapes, pypto.ir.Function)
         assert len(diff_shapes.params) == 3
+
+
+class TestScalarTypeErrors:
+    """Tests for Scalar type error handling."""
+
+    def test_scalar_without_dtype(self):
+        """Test that Scalar without dtype raises error."""
+        with pytest.raises(pl.parser.ParserError):
+
+            @pl.function
+            def bad_scalar(x: pl.Scalar) -> pl.Scalar:  # Missing [dtype]
+                return x

--- a/tests/ut/language/parser/test_text_parser.py
+++ b/tests/ut/language/parser/test_text_parser.py
@@ -470,3 +470,17 @@ class FileProgram:
         """Test that load_program raises error for missing file."""
         with pytest.raises(FileNotFoundError):
             pl.load_program("nonexistent_file.py")
+
+    def test_parse_function_with_scalar_param(self):
+        """Test parsing function with scalar parameter from text."""
+        code = """
+@pl.function
+def add_scalar(x: pl.Tensor[[64], pl.FP32], scalar: pl.Scalar[pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(x, scalar)
+    return result
+"""
+        func = pl.parse(code)
+        assert isinstance(func, ir.Function)
+        assert len(func.params) == 2
+        assert isinstance(func.params[1].type, ir.ScalarType)
+        assert func.params[1].type.dtype == pl.FP32


### PR DESCRIPTION
- Add pl.Scalar[dtype] type and scalar.py with parser/type_resolver support
- Extract function type from @pl.function(type=pl.FunctionType.*) for program build
- Add ConvertToSSA and VerifySSA to default optimization strategy in pass manager
- Move test_pto_codegen from ir/transforms to codegen; update orchestration example and tests