### PR TITLE
feat(ir): add IRVerifier system with configurable verification rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/init_memref.cpp
     src/ir/transforms/basic_memory_reuse_pass.cpp
     src/ir/transforms/insert_sync_pass.cpp
+    src/ir/transforms/verifier.cpp
     src/codegen/cce/code_emitter.cpp
     src/codegen/cce/code_context.cpp
     src/codegen/cce/type_converter.cpp

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "pypto/ir/reflection/field_traits.h"
+#include "pypto/ir/span.h"
 
 namespace pypto {
 namespace ir {
@@ -103,53 +104,6 @@ enum class ObjectKind {
   // Op kinds
   Op,
   GlobalVar
-};
-
-/**
- * @brief Source location information for IR nodes
- *
- * Tracks the exact position in source code where an IR node originated.
- * Immutable value type - all fields are const.
- */
-class Span {
- public:
-  const std::string filename_;  ///< Source filename
-  const int begin_line_;        ///< Beginning line number (1-indexed)
-  const int begin_column_;      ///< Beginning column number (1-indexed)
-  const int end_line_;          ///< Ending line number (1-indexed), -1 means unknown
-  const int end_column_;        ///< Ending column number (1-indexed), -1 means unknown
-
-  /**
-   * @brief Construct a source span
-   *
-   * @param file Source filename
-   * @param bl Begin line (1-indexed)
-   * @param bc Begin column (1-indexed)
-   * @param el End line (1-indexed)
-   * @param ec End column (1-indexed)
-   */
-  Span(std::string file, int begin_line, int begin_column, int end_line = -1, int end_column = -1);
-
-  /**
-   * @brief Convert span to string representation
-   *
-   * @return String in format "filename:begin_line:begin_column"
-   */
-  [[nodiscard]] std::string to_string() const;
-
-  /**
-   * @brief Check if the span is valid (has valid line/column numbers)
-   *
-   * @return true if all line/column numbers are positive
-   */
-  [[nodiscard]] bool is_valid() const;
-
-  /**
-   * @brief Create an unknown/invalid span
-   *
-   * @return Span with empty filename and invalid coordinates
-   */
-  static Span unknown();
 };
 
 /**

--- a/include/pypto/ir/span.h
+++ b/include/pypto/ir/span.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file span.h
+ * @brief Source location tracking for IR nodes
+ *
+ * This header provides the Span class for tracking source code locations
+ * throughout the IR. Span objects are immutable and can be shared across
+ * multiple IR nodes.
+ */
+
+#ifndef PYPTO_IR_SPAN_H_
+#define PYPTO_IR_SPAN_H_
+
+#include <string>
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Represents a source code location span
+ *
+ * Immutable structure that captures the location of an IR node in the original
+ * source code. Used for error reporting and debugging.
+ *
+ * The span includes:
+ * - Source filename
+ * - Beginning line and column (1-indexed)
+ * - Ending line and column (1-indexed, -1 means unknown)
+ */
+class Span {
+ public:
+  const std::string filename_;  ///< Source filename
+  const int begin_line_;        ///< Beginning line number (1-indexed)
+  const int begin_column_;      ///< Beginning column number (1-indexed)
+  const int end_line_;          ///< Ending line number (1-indexed), -1 means unknown
+  const int end_column_;        ///< Ending column number (1-indexed), -1 means unknown
+
+  /**
+   * @brief Construct a source span
+   *
+   * @param file Source filename
+   * @param begin_line Begin line (1-indexed)
+   * @param begin_column Begin column (1-indexed)
+   * @param end_line End line (1-indexed), -1 means unknown
+   * @param end_column End column (1-indexed), -1 means unknown
+   */
+  Span(std::string file, int begin_line, int begin_column, int end_line = -1, int end_column = -1);
+
+  /**
+   * @brief Convert span to string representation
+   *
+   * @return String in format "filename:begin_line:begin_column"
+   */
+  [[nodiscard]] std::string to_string() const;
+
+  /**
+   * @brief Check if the span is valid (has valid line/column numbers)
+   *
+   * @return true if all line/column numbers are positive
+   */
+  [[nodiscard]] bool is_valid() const;
+
+  /**
+   * @brief Create an unknown/invalid span
+   *
+   * @return Span with empty filename and invalid coordinates
+   */
+  static Span unknown();
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_SPAN_H_

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "pypto/ir/function.h"
 #include "pypto/ir/program.h"
@@ -237,6 +238,18 @@ Pass TypeCheck();
  * @return Pass that converts to SSA form
  */
 Pass ConvertToSSA();
+
+/**
+ * @brief Create a verifier pass with configurable rules
+ *
+ * This pass creates an IRVerifier with default rules (SSAVerify, TypeCheck)
+ * and allows disabling specific rules. The verifier collects all diagnostics
+ * and logs them without throwing exceptions (unless there are errors).
+ *
+ * @param disabled_rules Vector of rule names to disable (e.g., {"TypeCheck"})
+ * @return Pass that runs IR verification
+ */
+Pass RunVerifier(const std::vector<std::string>& disabled_rules = {});
 
 }  // namespace pass
 }  // namespace ir

--- a/include/pypto/ir/transforms/verification_error.h
+++ b/include/pypto/ir/transforms/verification_error.h
@@ -14,23 +14,10 @@
 
 #include <string>
 
-#include "pypto/ir/core.h"
+#include "pypto/ir/span.h"
 
 namespace pypto {
 namespace ir {
-
-/**
- * @brief Unified verification error structure
- *
- * This structure is used by all verification passes to report errors.
- * The error_code field contains the specific error type from different
- * error type enumerations (ssa::ErrorType, typecheck::ErrorType, etc.)
- */
-struct VerificationError {
-  int error_code;       // Error type code
-  std::string message;  // Error message
-  Span span;            // Source location
-};
 
 /**
  * @brief SSA verification error types and utilities

--- a/include/pypto/ir/transforms/verifier.h
+++ b/include/pypto/ir/transforms/verifier.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_VERIFIER_H_
+#define PYPTO_IR_TRANSFORMS_VERIFIER_H_
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Base class for verification rules
+ *
+ * Each verification rule implements a specific check on IR functions.
+ * Rules can detect errors or warnings and add them to a diagnostics vector.
+ *
+ * To create a new verification rule:
+ * 1. Inherit from VerifyRule
+ * 2. Implement GetName() to return a unique rule name
+ * 3. Implement Verify() to perform the verification logic
+ *
+ * Example:
+ * @code
+ *   class MyCustomRule : public VerifyRule {
+ *    public:
+ *     std::string GetName() const override { return "MyCustomRule"; }
+ *     void Verify(const FunctionPtr& func, std::vector<Diagnostic>& diagnostics) override {
+ *       // Verification logic
+ *     }
+ *   };
+ * @endcode
+ */
+class VerifyRule {
+ public:
+  virtual ~VerifyRule() = default;
+
+  /**
+   * @brief Get the name of this verification rule
+   * @return Unique name for this rule (e.g., "SSAVerify", "TypeCheck")
+   */
+  virtual std::string GetName() const = 0;
+
+  /**
+   * @brief Verify a function and collect diagnostics
+   * @param func Function to verify
+   * @param diagnostics Vector to append diagnostics to
+   *
+   * This method should examine the function and add any detected issues
+   * to the diagnostics vector. It should not throw exceptions - all issues
+   * should be reported through diagnostics.
+   */
+  virtual void Verify(const FunctionPtr& func, std::vector<Diagnostic>& diagnostics) = 0;
+};
+
+/// Shared pointer to a verification rule
+using VerifyRulePtr = std::shared_ptr<VerifyRule>;
+
+/**
+ * @brief IR verification system
+ *
+ * IRVerifier manages a collection of verification rules and applies them to programs.
+ * Rules can be enabled/disabled individually, and the verifier can operate in two modes:
+ * - Verify(): Collects all diagnostics without throwing
+ * - VerifyOrThrow(): Collects diagnostics and throws if errors are found
+ *
+ * Usage:
+ * @code
+ *   // Create default verifier with all built-in rules
+ *   auto verifier = IRVerifier::CreateDefault();
+ *
+ *   // Disable specific rules
+ *   verifier.DisableRule("TypeCheck");
+ *
+ *   // Run verification
+ *   auto diagnostics = verifier.Verify(program);
+ *   for (const auto& d : diagnostics) {
+ *     if (d.severity == DiagnosticSeverity::Error) {
+ *       LOG_ERROR << d.message;
+ *     }
+ *   }
+ *
+ *   // Or throw on errors
+ *   verifier.VerifyOrThrow(program);
+ * @endcode
+ */
+class IRVerifier {
+ public:
+  /**
+   * @brief Construct an empty verifier with no rules
+   */
+  IRVerifier();
+
+  /**
+   * @brief Add a verification rule to this verifier
+   * @param rule Shared pointer to the rule to add
+   *
+   * Rules are executed in the order they are added.
+   * If a rule with the same name already exists, it will not be added again.
+   */
+  void AddRule(VerifyRulePtr rule);
+
+  /**
+   * @brief Enable a previously disabled rule
+   * @param name Name of the rule to enable
+   *
+   * If the rule is not found or is already enabled, this is a no-op.
+   */
+  void EnableRule(const std::string& name);
+
+  /**
+   * @brief Disable a rule
+   * @param name Name of the rule to disable
+   *
+   * Disabled rules will be skipped during verification.
+   */
+  void DisableRule(const std::string& name);
+
+  /**
+   * @brief Check if a rule is currently enabled
+   * @param name Name of the rule to check
+   * @return true if the rule is enabled, false if disabled or not found
+   */
+  bool IsRuleEnabled(const std::string& name) const;
+
+  /**
+   * @brief Verify a program and collect diagnostics
+   * @param program Program to verify
+   * @return Vector of all diagnostics (errors and warnings)
+   *
+   * This method runs all enabled rules on all functions in the program
+   * and collects diagnostics. It does not throw exceptions even if errors
+   * are found - use VerifyOrThrow() if you want exception-based error handling.
+   */
+  std::vector<Diagnostic> Verify(const ProgramPtr& program) const;
+
+  /**
+   * @brief Verify a program and throw on errors
+   * @param program Program to verify
+   * @throws VerificationError if any errors are found
+   *
+   * This method runs verification and throws a VerificationError if any
+   * diagnostics with severity Error are found. Warnings do not cause an exception.
+   */
+  void VerifyOrThrow(const ProgramPtr& program) const;
+
+  /**
+   * @brief Generate a formatted report from diagnostics
+   * @param diagnostics Vector of diagnostics to format
+   * @return Formatted report string
+   *
+   * The report includes:
+   * - Total count of errors and warnings
+   * - Details for each diagnostic (severity, rule name, message, location)
+   * - Overall verification status
+   */
+  static std::string GenerateReport(const std::vector<Diagnostic>& diagnostics);
+
+  /**
+   * @brief Create a verifier with default built-in rules
+   * @return IRVerifier with SSAVerify and TypeCheck rules
+   *
+   * This factory method creates a verifier pre-configured with all
+   * standard verification rules enabled.
+   */
+  static IRVerifier CreateDefault();
+
+ private:
+  std::vector<VerifyRulePtr> rules_;                ///< All registered verification rules
+  std::unordered_set<std::string> disabled_rules_;  ///< Names of disabled rules
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_VERIFIER_H_

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -56,7 +56,7 @@ class PassManager:
         cls._strategy_passes = {
             OptimizationStrategy.Default: [
                 ("ConvertToSSA", lambda: passes.convert_to_ssa()),
-                ("VerifySSA", lambda: passes.verify_ssa()),
+                ("RunVerifier", lambda: passes.run_verifier()),
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),
                 ("InsertSync", lambda: passes.insert_sync()),

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -164,6 +164,125 @@ def convert_to_ssa() -> Pass:
         Pass object that converts to SSA form
     """
 
+class DiagnosticSeverity(Enum):
+    """Severity level for diagnostics."""
+
+    Error: int
+    Warning: int
+
+class Diagnostic:
+    """Single diagnostic message from verification.
+
+    Represents a single issue found during IR verification. Contains information
+    about the severity, which rule detected it, the specific error code, a
+    human-readable message, and the source location where the issue was found.
+    """
+
+    severity: DiagnosticSeverity
+    rule_name: str
+    error_code: int
+    message: str
+    span: Span
+
+class IRVerifier:
+    """IR verification system that manages verification rules.
+
+    IRVerifier collects verification rules and applies them to programs.
+    Rules can be enabled/disabled individually.
+
+    Example:
+        >>> verifier = IRVerifier.create_default()
+        >>> verifier.disable_rule("TypeCheck")
+        >>> diagnostics = verifier.verify(program)
+        >>> for d in diagnostics:
+        ...     print(f"[{d.severity}] {d.rule_name}: {d.message}")
+    """
+
+    def __init__(self) -> None:
+        """Create an empty verifier with no rules."""
+
+    @staticmethod
+    def create_default() -> IRVerifier:
+        """Create a verifier with default built-in rules.
+
+        Returns:
+            IRVerifier with SSAVerify and TypeCheck rules enabled
+        """
+
+    def enable_rule(self, name: str) -> None:
+        """Enable a previously disabled rule.
+
+        Args:
+            name: Name of the rule to enable
+        """
+
+    def disable_rule(self, name: str) -> None:
+        """Disable a rule.
+
+        Args:
+            name: Name of the rule to disable
+        """
+
+    def is_rule_enabled(self, name: str) -> bool:
+        """Check if a rule is enabled.
+
+        Args:
+            name: Name of the rule to check
+
+        Returns:
+            True if the rule is enabled, False otherwise
+        """
+
+    def verify(self, program: Program) -> list[Diagnostic]:
+        """Verify a program and collect diagnostics.
+
+        This method runs all enabled rules on the program and collects
+        diagnostics. It does not throw exceptions even if errors are found.
+
+        Args:
+            program: Program to verify
+
+        Returns:
+            List of all diagnostics (errors and warnings)
+        """
+
+    def verify_or_throw(self, program: Program) -> None:
+        """Verify a program and throw on errors.
+
+        This method runs verification and throws a VerificationError if any
+        diagnostics with severity Error are found. Warnings do not cause an exception.
+
+        Args:
+            program: Program to verify
+
+        Raises:
+            VerificationError: If any errors are found
+        """
+
+    @staticmethod
+    def generate_report(diagnostics: list[Diagnostic]) -> str:
+        """Generate a formatted report from diagnostics.
+
+        Args:
+            diagnostics: List of diagnostics to format
+
+        Returns:
+            Formatted report string
+        """
+
+def run_verifier(disabled_rules: list[str] | None = None) -> Pass:
+    """Create a verifier pass with configurable rules.
+
+    This pass creates an IRVerifier with default rules and allows disabling
+    specific rules. The verifier collects all diagnostics and logs them.
+
+    Args:
+        disabled_rules: List of rule names to disable (e.g., ["TypeCheck"])
+
+    Returns:
+        Pass that runs IR verification
+    """
+
 __all__ = [
     "Pass",
     "init_mem_ref",
@@ -176,4 +295,8 @@ __all__ = [
     "TypeCheckErrorType",
     "type_check",
     "convert_to_ssa",
+    "DiagnosticSeverity",
+    "Diagnostic",
+    "IRVerifier",
+    "run_verifier",
 ]

--- a/src/ir/transforms/verifier.cpp
+++ b/src/ir/transforms/verifier.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/verifier.h"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+
+namespace pypto {
+namespace ir {
+
+// Forward declarations of built-in rules (implemented in their respective files)
+class SSAVerifyRule;
+class TypeCheckRule;
+
+// External rule instances - these are defined in verify_ssa_pass.cpp and type_check_pass.cpp
+extern VerifyRulePtr CreateSSAVerifyRule();
+extern VerifyRulePtr CreateTypeCheckRule();
+
+IRVerifier::IRVerifier() = default;
+
+void IRVerifier::AddRule(VerifyRulePtr rule) {
+  if (!rule) {
+    return;
+  }
+
+  // Check if rule with same name already exists
+  auto it = std::find_if(rules_.begin(), rules_.end(),
+                         [&rule](const VerifyRulePtr& r) { return r->GetName() == rule->GetName(); });
+
+  if (it == rules_.end()) {
+    rules_.push_back(rule);
+  }
+}
+
+void IRVerifier::EnableRule(const std::string& name) { disabled_rules_.erase(name); }
+
+void IRVerifier::DisableRule(const std::string& name) { disabled_rules_.insert(name); }
+
+bool IRVerifier::IsRuleEnabled(const std::string& name) const { return disabled_rules_.count(name) == 0; }
+
+std::vector<Diagnostic> IRVerifier::Verify(const ProgramPtr& program) const {
+  if (!program) {
+    return {};
+  }
+
+  std::vector<Diagnostic> all_diagnostics;
+
+  // Run all enabled rules on all functions
+  // program->functions_ is a map from GlobalVar to Function
+  for (const auto& [global_var, func] : program->functions_) {
+    if (!func) {
+      continue;
+    }
+
+    for (const auto& rule : rules_) {
+      if (!rule) {
+        continue;
+      }
+
+      // Skip disabled rules
+      if (!IsRuleEnabled(rule->GetName())) {
+        continue;
+      }
+
+      // Run the rule
+      rule->Verify(func, all_diagnostics);
+    }
+  }
+
+  return all_diagnostics;
+}
+
+void IRVerifier::VerifyOrThrow(const ProgramPtr& program) const {
+  auto diagnostics = Verify(program);
+
+  // Check if there are any errors (not just warnings)
+  bool has_errors = std::any_of(diagnostics.begin(), diagnostics.end(),
+                                [](const Diagnostic& d) { return d.severity == DiagnosticSeverity::Error; });
+
+  if (has_errors) {
+    std::string report = GenerateReport(diagnostics);
+    throw VerificationError(report, std::move(diagnostics));
+  }
+}
+
+std::string IRVerifier::GenerateReport(const std::vector<Diagnostic>& diagnostics) {
+  std::ostringstream oss;
+
+  // Count errors and warnings
+  size_t error_count = 0;
+  size_t warning_count = 0;
+  for (const auto& d : diagnostics) {
+    if (d.severity == DiagnosticSeverity::Error) {
+      error_count++;
+    } else {
+      warning_count++;
+    }
+  }
+
+  // Header
+  oss << "IR Verification Report\n";
+  oss << "======================\n";
+  oss << "Total diagnostics: " << diagnostics.size() << " (";
+  oss << error_count << " errors, " << warning_count << " warnings)\n\n";
+
+  if (diagnostics.empty()) {
+    oss << "Status: PASSED\n";
+    return oss.str();
+  }
+
+  // List all diagnostics
+  for (size_t i = 0; i < diagnostics.size(); ++i) {
+    const auto& d = diagnostics[i];
+
+    // Severity label
+    std::string severity_str = (d.severity == DiagnosticSeverity::Error) ? "ERROR" : "WARNING";
+
+    oss << "[" << (i + 1) << "] " << severity_str << " - " << d.rule_name << "\n";
+    oss << "  Message: " << d.message << "\n";
+    oss << "  Location: " << d.span.filename_ << ":" << d.span.begin_line_ << ":" << d.span.begin_column_
+        << "\n";
+    oss << "  Error Code: " << d.error_code << "\n";
+    oss << "\n";
+  }
+
+  // Summary
+  if (error_count > 0) {
+    oss << "Status: FAILED (" << error_count << " error(s) found)\n";
+  } else {
+    oss << "Status: PASSED with " << warning_count << " warning(s)\n";
+  }
+
+  return oss.str();
+}
+
+IRVerifier IRVerifier::CreateDefault() {
+  IRVerifier verifier;
+
+  // Add built-in verification rules
+  verifier.AddRule(CreateSSAVerifyRule());
+  verifier.AddRule(CreateTypeCheckRule());
+
+  return verifier;
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/transforms/test_verifier.py
+++ b/tests/ut/ir/transforms/test_verifier.py
@@ -1,0 +1,268 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for IRVerifier."""
+
+import pytest
+from pypto import ir
+from pypto.ir import builder
+from pypto.pypto_core import DataType, passes
+
+
+def test_verifier_create_default():
+    """Test creating default verifier."""
+    verifier = passes.IRVerifier.create_default()
+    assert verifier is not None
+
+
+def test_verifier_empty():
+    """Test creating empty verifier."""
+    verifier = passes.IRVerifier()
+    assert verifier is not None
+
+
+def test_verifier_valid_program():
+    """Test verifier on valid SSA program."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_valid") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        b = f.param("b", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        x = ib.let("x", a)
+        ib.let("y", b)
+        z = ib.let("z", x)
+
+        ib.return_stmt(z)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    # Create verifier and run verification
+    verifier = passes.IRVerifier.create_default()
+    diagnostics = verifier.verify(program)
+
+    # Should have no diagnostics
+    assert len(diagnostics) == 0
+
+
+def test_verifier_ssa_error():
+    """Test verifier detects SSA errors."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_ssa_error") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)  # Multiple assignment
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    verifier = passes.IRVerifier.create_default()
+    diagnostics = verifier.verify(program)
+
+    # Should have at least one error
+    assert len(diagnostics) > 0
+    # All should be errors (not warnings)
+    assert all(d.severity == passes.DiagnosticSeverity.Error for d in diagnostics)
+    # At least one should be from SSAVerify rule
+    assert any(d.rule_name == "SSAVerify" for d in diagnostics)
+
+
+def test_verifier_disable_rule():
+    """Test disabling verification rules."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_disable") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)  # Multiple assignment
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    # Create verifier and disable SSA verification
+    verifier = passes.IRVerifier.create_default()
+    verifier.disable_rule("SSAVerify")
+
+    diagnostics = verifier.verify(program)
+
+    # Should have no SSA errors since the rule is disabled
+    assert all(d.rule_name != "SSAVerify" for d in diagnostics)
+
+
+def test_verifier_enable_rule():
+    """Test enabling a disabled rule."""
+    verifier = passes.IRVerifier.create_default()
+
+    # Disable and then re-enable
+    verifier.disable_rule("SSAVerify")
+    assert not verifier.is_rule_enabled("SSAVerify")
+
+    verifier.enable_rule("SSAVerify")
+    assert verifier.is_rule_enabled("SSAVerify")
+
+
+def test_verifier_or_throw_no_error():
+    """Test verify_or_throw on valid program (should not throw)."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_no_throw") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        x = ib.let("x", a)
+        ib.return_stmt(x)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    verifier = passes.IRVerifier.create_default()
+    # Should not raise exception
+    verifier.verify_or_throw(program)
+
+
+def test_verifier_or_throw_with_error():
+    """Test verify_or_throw on invalid program (should throw)."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_throw") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)  # Multiple assignment
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    verifier = passes.IRVerifier.create_default()
+
+    # Should raise VerificationError
+    with pytest.raises(Exception):  # The exact exception type from C++
+        verifier.verify_or_throw(program)
+
+
+def test_verifier_generate_report():
+    """Test generating verification report."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_report") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)  # Multiple assignment
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    verifier = passes.IRVerifier.create_default()
+    diagnostics = verifier.verify(program)
+
+    # Generate report
+    report = passes.IRVerifier.generate_report(diagnostics)
+
+    # Report should contain key information
+    assert "IR Verification Report" in report
+    assert "SSAVerify" in report
+    assert len(report) > 0
+
+
+def test_verifier_as_pass():
+    """Test using verifier as a Pass."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_pass") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        x = ib.let("x", a)
+        ib.return_stmt(x)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    # Create verifier pass
+    verify_pass = passes.run_verifier()
+    result_program = verify_pass(program)
+
+    # Should return the same program
+    assert result_program is not None
+
+
+def test_verifier_pass_with_disabled_rules():
+    """Test verifier pass with disabled rules."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_disabled") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)  # Multiple assignment
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    # Create verifier pass with SSA disabled
+    verify_pass = passes.run_verifier(disabled_rules=["SSAVerify"])
+    result_program = verify_pass(program)
+
+    # Should still return the program (no exception)
+    assert result_program is not None
+
+
+def test_diagnostic_fields():
+    """Test accessing Diagnostic fields."""
+    ib = builder.IRBuilder()
+
+    with ib.function("test_fields") as f:
+        a = f.param("a", ir.ScalarType(DataType.INT64))
+        f.return_type(ir.ScalarType(DataType.INT64))
+
+        _x = ib.let("x", a)
+        x2 = ib.let("x", a)
+
+        ib.return_stmt(x2)
+
+    func = f.get_result()
+    program = ir.Program([func], "test_program", ir.Span.unknown())
+
+    verifier = passes.IRVerifier.create_default()
+    diagnostics = verifier.verify(program)
+
+    assert len(diagnostics) > 0
+
+    # Check diagnostic fields
+    diag = diagnostics[0]
+    assert diag.severity in [passes.DiagnosticSeverity.Error, passes.DiagnosticSeverity.Warning]
+    assert isinstance(diag.rule_name, str)
+    assert isinstance(diag.error_code, int)
+    assert isinstance(diag.message, str)
+    assert diag.span is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Introduce a new IRVerifier system that provides a unified framework for IR validation:

- Add IRVerifier class as central verification orchestrator
  - Support dynamic enabling/disabling of individual verification rules
  - Collect all diagnostics without throwing exceptions during checks
  - Provide verify() for inspection and verify_or_throw() for enforcement

- Define VerifyRule interface for pluggable verification checks
  - Refactor SSA verification into SSAVerifyRule
  - Refactor type checking into TypeCheckRule

- Add Diagnostic infrastructure for structured error reporting
  - DiagnosticSeverity enum for Error/Warning levels
  - Diagnostic struct with severity, rule name, error code, message, and span
  - VerificationError exception for error-level diagnostics

- Extract Span class to separate header (span.h)
  - Reduce coupling by avoiding full core.h includes
  - Make Span independently usable in error reporting

- Integrate with Pass system
  - Add run_verifier() factory function to create verification pass
  - Enable verification to be inserted between transformation passes
  - Generate unified verification reports via IRVerifier::GenerateReport()

- Add comprehensive Python bindings and type stubs
  - Expose IRVerifier, Diagnostic, and DiagnosticSeverity to Python
  - Provide passes.run_verifier() in Python API

- Add full test coverage with 12 unit tests

This replaces the previous scattered error reporting with a unified diagnostic system, enabling better error collection and more flexible verification workflows.