### PR TITLE
feat(ops): Add transform operations for tensor and tile types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,12 +95,14 @@ set(PYPTO_SOURCES
     src/ir/op/tensor_ops/reduction.cpp
     src/ir/op/tensor_ops/unary.cpp
     src/ir/op/tensor_ops/memory.cpp
+    src/ir/op/tensor_ops/transform.cpp
     src/ir/op/block_ops/elementwise.cpp
     src/ir/op/block_ops/reduction.cpp
     src/ir/op/block_ops/unary.cpp
     src/ir/op/block_ops/memory.cpp
     src/ir/op/block_ops/matmul.cpp
     src/ir/op/block_ops/broadcast.cpp
+    src/ir/op/block_ops/transform.cpp
     src/ir/op/sync_ops/sync.cpp
     src/ir/op/testing.cpp
     src/ir/transforms/visitor.cpp

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -434,3 +434,51 @@ def assemble(target: Expr, source: Expr, offset: List[Union[int, Expr]], span: O
         args.append(_normalize_expr(off, actual_span, int_dtype=DataType.INT32))
 
     return _ir_core.create_op_call("tensor.assemble", args, {}, actual_span)
+
+
+def reshape(tensor: Expr, shape: List[Union[int, Expr]], span: Optional[Span] = None) -> Call:
+    """Reshape tensor to new shape.
+
+    Args:
+        tensor: Input tensor expression
+        shape: New shape dimensions
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for tensor reshape
+    """
+    actual_span = _get_span_or_capture(span)
+    args = [tensor]
+
+    # Add the number of shape dimensions as a ConstInt
+    # This allows the C++ side to correctly parse shape arguments
+    args.append(ConstInt(len(shape), DataType.INT32, actual_span))
+
+    # Add shape dimensions
+    for dim in shape:
+        args.append(_normalize_expr(dim, actual_span, int_dtype=DataType.INT32))
+
+    return _ir_core.create_op_call("tensor.reshape", args, {}, actual_span)
+
+
+def transpose(tensor: Expr, axis1: int, axis2: int, span: Optional[Span] = None) -> Call:
+    """Transpose tensor by swapping two axes.
+
+    Args:
+        tensor: Input tensor expression
+        axis1: First axis to swap (supports negative indexing)
+        axis2: Second axis to swap (supports negative indexing)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for tensor transpose
+    """
+    actual_span = _get_span_or_capture(span)
+
+    # Create ConstInt for axis indices
+    axis1_expr = ConstInt(axis1, DataType.INT32, actual_span)
+    axis2_expr = ConstInt(axis2, DataType.INT32, actual_span)
+
+    args = [tensor, axis1_expr, axis2_expr]
+
+    return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -13,7 +13,7 @@ This module provides type-safe wrappers around pypto.ir.op.block operations
 that accept and return Tile types instead of raw Expr/Call objects.
 """
 
-from typing import Union
+from typing import List, Union
 
 from pypto.ir.op import block_ops as _ir_ops
 from pypto.pypto_core.ir import Expr
@@ -377,4 +377,51 @@ def row_expand_mul(tile: Tile, row_vec: Tile) -> Tile:
         Tile wrapping the row_expand_mul operation
     """
     call_expr = _ir_ops.row_expand_mul(tile.unwrap(), row_vec.unwrap())
+    return Tile(expr=call_expr)
+
+
+def view(tile: Tile, shape: List[Union[int, Expr]], offset: List[Union[int, Expr]]) -> Tile:
+    """Create a view/slice of a tile with new shape and offset.
+
+    Args:
+        tile: Input tile
+        shape: New shape dimensions (at most 2 for TileType)
+        offset: Offset dimensions for the view
+
+    Returns:
+        Tile wrapping the view operation
+    """
+    tile_expr = tile.unwrap()
+    call_expr = _ir_ops.view(tile_expr, shape, offset)
+    return Tile(expr=call_expr)
+
+
+def reshape(tile: Tile, shape: List[Union[int, Expr]]) -> Tile:
+    """Reshape tile to new shape.
+
+    Args:
+        tile: Input tile
+        shape: New shape dimensions (at most 2 for TileType)
+
+    Returns:
+        Tile wrapping the reshape operation
+    """
+    tile_expr = tile.unwrap()
+    call_expr = _ir_ops.reshape(tile_expr, shape)
+    return Tile(expr=call_expr)
+
+
+def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
+    """Transpose tile by swapping two axes.
+
+    Args:
+        tile: Input tile
+        axis1: First axis to swap (supports negative indexing)
+        axis2: Second axis to swap (supports negative indexing)
+
+    Returns:
+        Tile wrapping the transpose operation
+    """
+    tile_expr = tile.unwrap()
+    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2)
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -329,3 +329,34 @@ def assemble(target: Tensor, source: Tensor, offset: List[Union[int, Expr]]) -> 
     source_expr = source.unwrap()
     call_expr = _ir_ops.assemble(target_expr, source_expr, offset)
     return Tensor(expr=call_expr)
+
+
+def reshape(tensor: Tensor, shape: List[Union[int, Expr]]) -> Tensor:
+    """Reshape tensor to new shape.
+
+    Args:
+        tensor: Input tensor
+        shape: New shape dimensions
+
+    Returns:
+        Tensor wrapping the reshape operation
+    """
+    tensor_expr = tensor.unwrap()
+    call_expr = _ir_ops.reshape(tensor_expr, shape)
+    return Tensor(expr=call_expr)
+
+
+def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
+    """Transpose tensor by swapping two axes.
+
+    Args:
+        tensor: Input tensor
+        axis1: First axis to swap (supports negative indexing)
+        axis2: Second axis to swap (supports negative indexing)
+
+    Returns:
+        Tensor wrapping the transpose operation
+    """
+    tensor_expr = tensor.unwrap()
+    call_expr = _ir_ops.transpose(tensor_expr, axis1, axis2)
+    return Tensor(expr=call_expr)

--- a/src/ir/op/block_ops/transform.cpp
+++ b/src/ir/op/block_ops/transform.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file transform.cpp
+ * @brief Shape transformation block operations (view, reshape, transpose)
+ *
+ * This file implements shape transformation operations for tiles including
+ * view, reshape and transpose operations.
+ */
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+// ============================================================================
+// Helper Functions (file-local)
+// ============================================================================
+
+/**
+ * @brief Normalize axis index to handle negative indexing
+ *
+ * @param axis The axis index (can be negative)
+ * @param ndim The number of dimensions
+ * @return The normalized axis index
+ */
+int NormalizeAxis(int axis, size_t ndim) {
+  if (axis < 0) {
+    axis += static_cast<int>(ndim);
+  }
+  CHECK(axis >= 0 && axis < static_cast<int>(ndim))
+      << "Axis " << axis << " is out of range for " << ndim << "D tile";
+  return axis;
+}
+
+/**
+ * @brief Compute the product of shape dimensions (for static shapes)
+ *
+ * @param shape The shape dimensions
+ * @return The product if all dimensions are ConstInt, -1 otherwise
+ */
+int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
+  int64_t product = 1;
+  for (const auto& dim : shape) {
+    auto const_dim = As<ConstInt>(dim);
+    if (!const_dim) {
+      return -1;  // Dynamic shape, cannot compute product
+    }
+    product *= const_dim->value_;
+  }
+  return product;
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// Type Inference Functions
+// ============================================================================
+
+TypePtr DeduceTileViewType(const std::vector<ExprPtr>& args,
+                           const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.view requires at least 2 arguments: input tile and shape_ndim
+  // Followed by shape dimensions and offset dimensions
+  CHECK(args.size() >= 2) << "tile.view requires at least 2 arguments (input, shape_ndim), but got "
+                          << args.size();
+
+  // First argument must be TileType
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "tile.view requires first argument to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+
+  // Second argument is the number of shape dimensions (ConstInt)
+  auto shape_ndim_const = As<ConstInt>(args[1]);
+  CHECK(shape_ndim_const)
+      << "tile.view requires second argument to be a ConstInt indicating number of shape dimensions";
+
+  size_t shape_ndim = static_cast<size_t>(shape_ndim_const->value_);
+  CHECK(shape_ndim > 0) << "tile.view requires at least 1 shape dimension";
+  CHECK(shape_ndim <= 2) << "tile.view: TileType supports at most 2 dimensions, but got " << shape_ndim;
+
+  // Check we have enough arguments: input + shape_ndim + shape_dims + offset_dims
+  CHECK(args.size() >= 2 + shape_ndim)
+      << "tile.view requires at least " << (2 + shape_ndim) << " arguments for shape_ndim=" << shape_ndim
+      << ", but got " << args.size();
+
+  // Extract new shape dimensions (args[2] to args[2 + shape_ndim - 1])
+  std::vector<ExprPtr> new_shape;
+  new_shape.reserve(shape_ndim);
+  for (size_t i = 0; i < shape_ndim; ++i) {
+    new_shape.emplace_back(args[2 + i]);
+  }
+
+  // The remaining arguments are offset dimensions (not used for type deduction)
+  // View preserves dtype but has new shape (which can have different rank than input)
+  return std::make_shared<TileType>(new_shape, tile_type->dtype_);
+}
+
+TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.reshape requires at least 2 arguments: input tile and shape_ndim
+  // Followed by shape dimensions
+  CHECK(args.size() >= 2) << "tile.reshape requires at least 2 arguments (input, shape_ndim), but got "
+                          << args.size();
+
+  // First argument must be TileType
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "tile.reshape requires first argument to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+
+  // Second argument is the number of shape dimensions (ConstInt)
+  auto shape_ndim_const = As<ConstInt>(args[1]);
+  CHECK(shape_ndim_const)
+      << "tile.reshape requires second argument to be a ConstInt indicating number of shape dimensions";
+
+  size_t shape_ndim = static_cast<size_t>(shape_ndim_const->value_);
+  CHECK(shape_ndim > 0) << "tile.reshape requires at least 1 shape dimension";
+  CHECK(shape_ndim <= 2) << "tile.reshape: TileType supports at most 2 dimensions, but got " << shape_ndim;
+
+  // Check we have correct number of arguments: input + shape_ndim + shape_dims
+  CHECK(args.size() == 2 + shape_ndim)
+      << "tile.reshape requires exactly " << (2 + shape_ndim) << " arguments for shape_ndim=" << shape_ndim
+      << ", but got " << args.size();
+
+  // Extract new shape dimensions (args[2] to args[2 + shape_ndim - 1])
+  std::vector<ExprPtr> new_shape;
+  new_shape.reserve(shape_ndim);
+  for (size_t i = 0; i < shape_ndim; ++i) {
+    new_shape.emplace_back(args[2 + i]);
+  }
+
+  // For static shapes, verify that the total number of elements matches
+  int64_t old_product = ComputeShapeProduct(tile_type->shape_);
+  int64_t new_product = ComputeShapeProduct(new_shape);
+
+  if (old_product > 0 && new_product > 0) {
+    CHECK(old_product == new_product) << "tile.reshape: cannot reshape tile of size " << old_product
+                                      << " into shape with size " << new_product;
+  }
+
+  // Return new TileType with reshaped dimensions and same dtype
+  return std::make_shared<TileType>(new_shape, tile_type->dtype_);
+}
+
+TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
+                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.transpose requires exactly 3 arguments: input tile, axis1, axis2
+  CHECK(args.size() == 3) << "tile.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
+                          << args.size();
+
+  // First argument must be TileType
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "tile.transpose requires first argument to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+
+  const auto& input_shape = tile_type->shape_;
+  size_t ndim = input_shape.size();
+
+  CHECK(ndim == 2) << "tile.transpose requires exactly 2 dimensions (TileType constraint), but got " << ndim;
+
+  // Second argument is axis1 (ConstInt)
+  auto axis1_const = As<ConstInt>(args[1]);
+  CHECK(axis1_const) << "tile.transpose requires second argument (axis1) to be a ConstInt";
+
+  // Third argument is axis2 (ConstInt)
+  auto axis2_const = As<ConstInt>(args[2]);
+  CHECK(axis2_const) << "tile.transpose requires third argument (axis2) to be a ConstInt";
+
+  // Normalize axes (handle negative indexing)
+  int axis1 = NormalizeAxis(static_cast<int>(axis1_const->value_), ndim);
+  int axis2 = NormalizeAxis(static_cast<int>(axis2_const->value_), ndim);
+
+  CHECK(axis1 != axis2) << "tile.transpose: axis1 and axis2 must be different, but got axis1=" << axis1
+                        << ", axis2=" << axis2;
+
+  // Create new shape by swapping the specified dimensions
+  std::vector<ExprPtr> new_shape = input_shape;
+  std::swap(new_shape[axis1], new_shape[axis2]);
+
+  // Return new TileType with transposed shape and same dtype
+  return std::make_shared<TileType>(new_shape, tile_type->dtype_);
+}
+
+// ============================================================================
+// Registration Function for Tile Transform Operations
+// ============================================================================
+
+REGISTER_OP("block.view")
+    .set_op_category("BlockOp")
+    .set_description("Create a view/slice of a tile with new shape and offset")
+    .add_argument("input", "Input tile (TileType)")
+    .add_argument("shape_ndim", "Number of shape dimensions (ConstInt)")
+    .add_argument("shape_dims", "New shape dimensions (variable number)")
+    .add_argument("offset_dims", "Offset dimensions (variable number)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileViewType(args, kwargs);
+    });
+
+REGISTER_OP("block.reshape")
+    .set_op_category("BlockOp")
+    .set_description("Reshape tile to new shape")
+    .add_argument("input", "Input tile (TileType)")
+    .add_argument("shape_ndim", "Number of shape dimensions (ConstInt)")
+    .add_argument("shape_dims", "New shape dimensions (variable number)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileReshapeType(args, kwargs);
+    });
+
+REGISTER_OP("block.transpose")
+    .set_op_category("BlockOp")
+    .set_description("Transpose tile by swapping two axes")
+    .add_argument("input", "Input tile (TileType)")
+    .add_argument("axis1", "First axis to swap (ConstInt)")
+    .add_argument("axis2", "Second axis to swap (ConstInt)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileTransposeType(args, kwargs);
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file transform.cpp
+ * @brief Shape transformation tensor operations (reshape, transpose)
+ *
+ * This file implements shape transformation operations for tensors including
+ * reshape and transpose operations.
+ */
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+// ============================================================================
+// Helper Functions (file-local)
+// ============================================================================
+
+/**
+ * @brief Normalize axis index to handle negative indexing
+ *
+ * @param axis The axis index (can be negative)
+ * @param ndim The number of dimensions
+ * @return The normalized axis index
+ */
+int NormalizeAxis(int axis, size_t ndim) {
+  if (axis < 0) {
+    axis += static_cast<int>(ndim);
+  }
+  CHECK(axis >= 0 && axis < static_cast<int>(ndim))
+      << "Axis " << axis << " is out of range for " << ndim << "D tensor";
+  return axis;
+}
+
+/**
+ * @brief Compute the product of shape dimensions (for static shapes)
+ *
+ * @param shape The shape dimensions
+ * @return The product if all dimensions are ConstInt, -1 otherwise
+ */
+int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
+  int64_t product = 1;
+  for (const auto& dim : shape) {
+    auto const_dim = As<ConstInt>(dim);
+    if (!const_dim) {
+      return -1;  // Dynamic shape, cannot compute product
+    }
+    product *= const_dim->value_;
+  }
+  return product;
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// Type Inference Functions
+// ============================================================================
+
+TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
+                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.reshape requires at least 2 arguments: input tensor and shape_ndim
+  // Followed by shape dimensions
+  CHECK(args.size() >= 2) << "tensor.reshape requires at least 2 arguments (input, shape_ndim), but got "
+                          << args.size();
+
+  // First argument must be TensorType
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.reshape requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  // Second argument is the number of shape dimensions (ConstInt)
+  auto shape_ndim_const = As<ConstInt>(args[1]);
+  CHECK(shape_ndim_const)
+      << "tensor.reshape requires second argument to be a ConstInt indicating number of shape dimensions";
+
+  size_t shape_ndim = static_cast<size_t>(shape_ndim_const->value_);
+  CHECK(shape_ndim > 0) << "tensor.reshape requires at least 1 shape dimension";
+
+  // Check we have correct number of arguments: input + shape_ndim + shape_dims
+  CHECK(args.size() == 2 + shape_ndim)
+      << "tensor.reshape requires exactly " << (2 + shape_ndim) << " arguments for shape_ndim=" << shape_ndim
+      << ", but got " << args.size();
+
+  // Extract new shape dimensions (args[2] to args[2 + shape_ndim - 1])
+  std::vector<ExprPtr> new_shape;
+  new_shape.reserve(shape_ndim);
+  for (size_t i = 0; i < shape_ndim; ++i) {
+    new_shape.emplace_back(args[2 + i]);
+  }
+
+  // For static shapes, verify that the total number of elements matches
+  int64_t old_product = ComputeShapeProduct(tensor_type->shape_);
+  int64_t new_product = ComputeShapeProduct(new_shape);
+
+  if (old_product > 0 && new_product > 0) {
+    CHECK(old_product == new_product) << "tensor.reshape: cannot reshape tensor of size " << old_product
+                                      << " into shape with size " << new_product;
+  }
+
+  // Return new TensorType with reshaped dimensions and same dtype
+  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
+}
+
+TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.transpose requires exactly 3 arguments: input tensor, axis1, axis2
+  CHECK(args.size() == 3) << "tensor.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
+                          << args.size();
+
+  // First argument must be TensorType
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.transpose requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  const auto& input_shape = tensor_type->shape_;
+  size_t ndim = input_shape.size();
+
+  CHECK(ndim >= 2) << "tensor.transpose requires at least 2 dimensions, but got " << ndim;
+
+  // Second argument is axis1 (ConstInt)
+  auto axis1_const = As<ConstInt>(args[1]);
+  CHECK(axis1_const) << "tensor.transpose requires second argument (axis1) to be a ConstInt";
+
+  // Third argument is axis2 (ConstInt)
+  auto axis2_const = As<ConstInt>(args[2]);
+  CHECK(axis2_const) << "tensor.transpose requires third argument (axis2) to be a ConstInt";
+
+  // Normalize axes (handle negative indexing)
+  int axis1 = NormalizeAxis(static_cast<int>(axis1_const->value_), ndim);
+  int axis2 = NormalizeAxis(static_cast<int>(axis2_const->value_), ndim);
+
+  CHECK(axis1 != axis2) << "tensor.transpose: axis1 and axis2 must be different, but got axis1=" << axis1
+                        << ", axis2=" << axis2;
+
+  // Create new shape by swapping the specified dimensions
+  std::vector<ExprPtr> new_shape = input_shape;
+  std::swap(new_shape[axis1], new_shape[axis2]);
+
+  // Return new TensorType with transposed shape and same dtype
+  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
+}
+
+// ============================================================================
+// Registration Function for Tensor Transform Operations
+// ============================================================================
+
+REGISTER_OP("tensor.reshape")
+    .set_op_category("TensorOp")
+    .set_description("Reshape tensor to new shape")
+    .add_argument("input", "Input tensor (TensorType)")
+    .add_argument("shape_ndim", "Number of shape dimensions (ConstInt)")
+    .add_argument("shape_dims", "New shape dimensions (variable number)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorReshapeType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.transpose")
+    .set_op_category("TensorOp")
+    .set_description("Transpose tensor by swapping two axes")
+    .add_argument("input", "Input tensor (TensorType)")
+    .add_argument("axis1", "First axis to swap (ConstInt)")
+    .add_argument("axis2", "Second axis to swap (ConstInt)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorTransposeType(args, kwargs);
+    });
+
+}  // namespace ir
+}  // namespace pypto


### PR DESCRIPTION
Implement reshape, transpose, and view operations for both tensor and tile types to support shape manipulation in the IR system.

New Operations:
- tensor.reshape: Change tensor shape with element count validation
- tensor.transpose: Swap any two axes with negative index support
- block.view: Create tile views with new shape and offset
- block.reshape: Reshape tiles (max 2D constraint enforced)
- block.transpose: Transpose tiles by swapping two axes

Implementation Details:
- Add C++ type inference and registration in transform.cpp files
- Add Python IR API wrappers in ir/op/{tensor,block}_ops.py
- Add Python Language DSL wrappers in language/op/{tensor,block}_ops.py
- Support negative axis indexing for transpose operations
- Validate element count preservation for static shapes in reshape
- Use anonymous namespace to avoid symbol duplication

Testing:
- Add comprehensive unit tests for all new operations
- Test dynamic shapes, negative indices, and edge cases
- Verify operator registration and type checking

Files Changed:
- New: src/ir/op/tensor_ops/transform.cpp (190 lines)
- New: src/ir/op/block_ops/transform.cpp (241 lines)
- Modified: CMakeLists.txt, Python IR/Language APIs, test files
- Total: 9 files changed, 832 insertions(+), 3 deletions(-)