### PR TITLE
feat(orchestration): Simplify API and codegen for tensor-return kernels

### DIFF
--- a/examples/ir_builder/orchestration_example.py
+++ b/examples/ir_builder/orchestration_example.py
@@ -76,10 +76,6 @@ class ExampleOrchProgram:
         self,
         a: pl.Tensor[[16, 16], pl.FP32],
         b: pl.Tensor[[16, 16], pl.FP32],
-        c: pl.Tensor[[16, 16], pl.FP32],
-        d: pl.Tensor[[16, 16], pl.FP32],
-        e: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Tensor[[16, 16], pl.FP32],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Build BuildExampleGraph orchestration function.
 
@@ -104,17 +100,16 @@ class ExampleOrchProgram:
             Final result tensor
         """
         # Task 0: c = a + b (call kernel_add with output buffer c)
-        c_updated: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b, c)
+        c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
 
         # Task 1: d = c + 1 (call kernel_add_scalar with output buffer d)
-        d_updated: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c_updated, 1.0, d)  # type: ignore[reportArgumentType]
+        d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
 
         # Task 2: e = c + 2 (call kernel_add_scalar with output buffer e)
-        e_updated: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c_updated, 2.0, e)  # type: ignore[reportArgumentType]
+        e: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
 
         # Task 3: f = d * e (call kernel_mul with output buffer)
-        f_result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_mul(d_updated, e_updated, output)
-
+        f_result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_mul(d, e)
         return f_result
 
 

--- a/include/pypto/ir/pipe.h
+++ b/include/pypto/ir/pipe.h
@@ -30,11 +30,11 @@ enum PipeType : int {
 };
 
 /**
- * @brief Core type enumeration
+ * @brief Core type enumeration (numeric values must match runtime add_task expectation)
  */
 enum CoreType : int {
-  VECTOR,  ///< Vector Core (Alias for AIV)
-  CUBE     ///< Cube Core (Alias for AIC)
+  CUBE = 0,   ///< Cube Core (Alias for AIC)
+  VECTOR = 1  ///< Vector Core (Alias for AIV)
 };
 
 }  // namespace ir


### PR DESCRIPTION
## Summary

- **Orchestration API**: Orchestration functions no longer take pre-allocated output buffers; kernels now return tensors (e.g. `c = self.kernel_add(a, b)` instead of passing `c` as an argument).
- **CoreType enum**: Explicit values `CUBE = 0` and `VECTOR = 1` in `include/pypto/ir/pipe.h` to match runtime `add_task` expectations.
- **Orchestration codegen**:
  - Scalar task arguments (int/float/bool) are typed and encoded via union for correct `add_task` payload.
  - Argument layout: host pointers first, then sizes (aligned with validation).
  - Intermediate tensor allocation sizes are derived from callee return type via `CalculateTensorSize`.
  - Return variable name from IR is used when generating the orchestration entry (e.g. `f_result`).

## Changes

- `examples/ir_builder/orchestration_example.py`: Simplified `BuildExampleGraph` signature and kernel calls to tensor-return style.
- `include/pypto/ir/pipe.h`: CoreType enum reordered with explicit values and updated doc.
- `src/codegen/orchestration/orchestration_codegen.cpp`: DataType→C++ type mapping, const value formatting, argument extraction/allocation and task code generation updates.