### PR TITLE
feat(ir): extend OpStmts to support EvalStmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(PYPTO_SOURCES
     src/core/error.cpp
     src/ir/core.cpp
     src/ir/expr.cpp
+    src/ir/stmt.cpp
     src/ir/function.cpp
     src/ir/program.cpp
     src/ir/type.cpp

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -344,18 +344,22 @@ using SeqStmtsPtr = std::shared_ptr<const SeqStmts>;
 /**
  * @brief Operation statements
  *
- * Represents a sequence of assignment statements: assign1; assign2; ... assignN
- * where stmts is a list of assignment statements.
+ * Represents a sequence of assignment and/or evaluation statements.
+ * This is used to group operations that should be treated as a unit,
+ * such as a block of tensor operations with optional synchronization calls.
+ *
+ * OpStmts only accepts AssignStmt and EvalStmt types. An error will be raised
+ * at construction time if other statement types are provided.
  */
 class OpStmts : public Stmt {
  public:
   /**
    * @brief Create an operation statements
    *
-   * @param stmts List of assignment statements
+   * @param stmts List of assignment and/or evaluation statements
    * @param span Source location
    */
-  OpStmts(std::vector<AssignStmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
+  OpStmts(std::vector<StmtPtr> stmts, Span span);
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::OpStmts; }
   [[nodiscard]] std::string TypeName() const override { return "OpStmts"; }
@@ -371,7 +375,7 @@ class OpStmts : public Stmt {
   }
 
  public:
-  std::vector<AssignStmtPtr> stmts_;  // List of assignment statements
+  std::vector<StmtPtr> stmts_;  // List of assignment and/or evaluation statements
 };
 
 using OpStmtsPtr = std::shared_ptr<const OpStmts>;

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -621,10 +621,10 @@ void BindIR(nb::module_& m) {
   BindFields<SeqStmts>(seq_stmts_class);
 
   // OpStmts - const shared_ptr
-  auto op_stmts_class =
-      nb::class_<OpStmts, Stmt>(ir, "OpStmts", "Operation statements: a sequence of assignment statements");
-  op_stmts_class.def(nb::init<const std::vector<AssignStmtPtr>&, const Span&>(), nb::arg("stmts"),
-                     nb::arg("span"), "Create an operation statements");
+  auto op_stmts_class = nb::class_<OpStmts, Stmt>(
+      ir, "OpStmts", "Operation statements: a sequence of assignment and/or evaluation statements");
+  op_stmts_class.def(nb::init<const std::vector<StmtPtr>&, const Span&>(), nb::arg("stmts"), nb::arg("span"),
+                     "Create an operation statements");
   BindFields<OpStmts>(op_stmts_class);
 
   // EvalStmt - const shared_ptr

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1306,16 +1306,16 @@ class SeqStmts(Stmt):
         """
 
 class OpStmts(Stmt):
-    """Operation statements: a sequence of assignment statements."""
+    """Operation statements: a sequence of assignment and/or evaluation statements."""
 
-    stmts: Final[list[AssignStmt]]
-    """List of assignment statements."""
+    stmts: Final[list[AssignStmt | EvalStmt]]
+    """List of assignment and/or evaluation statements."""
 
-    def __init__(self, stmts: list[AssignStmt], span: Span) -> None:
+    def __init__(self, stmts: list[AssignStmt | EvalStmt], span: Span) -> None:
         """Create an operation statements.
 
         Args:
-            stmts: List of assignment statements
+            stmts: List of assignment and/or evaluation statements
             span: Source location
         """
 

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -411,12 +411,12 @@ static IRNodePtr DeserializeOpStmts(const msgpack::object& fields_obj, msgpack::
                                     DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
 
-  std::vector<AssignStmtPtr> stmts;
+  std::vector<StmtPtr> stmts;
   auto stmts_obj = GET_FIELD_OBJ("stmts");
   if (stmts_obj.type == msgpack::type::ARRAY) {
     for (uint32_t i = 0; i < stmts_obj.via.array.size; ++i) {
       stmts.push_back(
-          std::static_pointer_cast<const AssignStmt>(ctx.DeserializeNode(stmts_obj.via.array.ptr[i], zone)));
+          std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(stmts_obj.via.array.ptr[i], zone)));
     }
   }
 

--- a/src/ir/stmt.cpp
+++ b/src/ir/stmt.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/stmt.h"
+
+#include <utility>
+
+#include "pypto/core/error.h"
+
+namespace pypto {
+namespace ir {
+
+OpStmts::OpStmts(std::vector<StmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {
+  // Validate that all statements are AssignStmt or EvalStmt
+  for (size_t i = 0; i < stmts_.size(); ++i) {
+    const auto& stmt = stmts_[i];
+    INTERNAL_CHECK(stmt) << "OpStmts has null statement at index " << i;
+    auto kind = stmt->GetKind();
+    INTERNAL_CHECK(kind == ObjectKind::AssignStmt || kind == ObjectKind::EvalStmt)
+        << "OpStmts only accepts AssignStmt or EvalStmt, but got " << stmt->TypeName() << " at index " << i;
+  }
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -196,7 +196,7 @@ void IRVisitor::VisitStmt_(const SeqStmtsPtr& op) {
 
 void IRVisitor::VisitStmt_(const OpStmtsPtr& op) {
   for (size_t i = 0; i < op->stmts_.size(); ++i) {
-    INTERNAL_CHECK(op->stmts_[i]) << "OpStmts has null assignment statement at index " << i;
+    INTERNAL_CHECK(op->stmts_[i]) << "OpStmts has null statement at index " << i;
     VisitStmt(op->stmts_[i]);
   }
 }


### PR DESCRIPTION
Extend OpStmts to accept both AssignStmt and EvalStmt, enabling operation blocks to mix assignments with side-effect operations like synchronization calls.

Changes:
- Modified OpStmts to store vector<StmtPtr> instead of vector<AssignStmtPtr>
- Added runtime validation in OpStmts constructor to ensure only AssignStmt or EvalStmt are accepted
- Updated Python bindings and type stubs to reflect new signature
- Updated visitor, mutator, and deserializer to handle mixed statement types
- Added comprehensive tests for OpStmts with EvalStmt support including:
  * Creation and validation tests
  * Mixed AssignStmt/EvalStmt tests
  * Printing, hashing, and structural equality tests
  * Serialization/deserialization tests