### PR TITLE
refactor(ir): Use MakeTuple for shape and offset arguments

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -168,6 +168,22 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2);
  */
 bool IsBroadcastable(const ExprPtr& source_dim, const ExprPtr& target_dim);
 
+/**
+ * @brief Format a shape vector as a string for error messages
+ *
+ * Converts a shape (vector of ExprPtr) to a human-readable string.
+ * Constant dimensions show their values, symbolic dimensions show as "?".
+ *
+ * Examples:
+ * - [ConstInt(64), ConstInt(128)] -> "[64, 128]"
+ * - [ConstInt(64), Var("N")] -> "[64, ?]"
+ * - [] -> "[]"
+ *
+ * @param shape Shape vector to format
+ * @return String representation of the shape
+ */
+std::string FormatShape(const std::vector<ExprPtr>& shape);
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/pypto/ir/op/block_ops.py
+++ b/python/pypto/ir/op/block_ops.py
@@ -594,20 +594,16 @@ def view(
         Call expression creating a tile view
     """
     actual_span = _get_span_or_capture(span)
-    args = [tile]
 
-    # Add the number of shape dimensions as a ConstInt
-    # This allows the C++ side to correctly split shape and offset arguments
-    args.append(ConstInt(len(shape), DataType.INT32, actual_span))
+    # Convert shape to MakeTuple
+    shape_elements = [_normalize_expr(dim, actual_span, int_dtype=DataType.UINT64) for dim in shape]
+    shape_tuple = _ir_core.MakeTuple(shape_elements, actual_span)
 
-    # Add shape dimensions
-    for dim in shape:
-        args.append(_normalize_expr(dim, actual_span, int_dtype=DataType.INT32))
+    # Convert offset to MakeTuple
+    offset_elements = [_normalize_expr(off, actual_span, int_dtype=DataType.UINT64) for off in offset]
+    offset_tuple = _ir_core.MakeTuple(offset_elements, actual_span)
 
-    # Add offset dimensions
-    for off in offset:
-        args.append(_normalize_expr(off, actual_span, int_dtype=DataType.INT32))
-
+    args = [tile, shape_tuple, offset_tuple]
     return _ir_core.create_op_call("block.view", args, {}, actual_span)
 
 
@@ -623,16 +619,12 @@ def reshape(tile: Expr, shape: Sequence[Union[int, Expr]], span: Optional[Span] 
         Call expression for tile reshape
     """
     actual_span = _get_span_or_capture(span)
-    args = [tile]
 
-    # Add the number of shape dimensions as a ConstInt
-    # This allows the C++ side to correctly parse shape arguments
-    args.append(ConstInt(len(shape), DataType.INT32, actual_span))
+    # Convert shape to MakeTuple
+    shape_elements = [_normalize_expr(dim, actual_span, int_dtype=DataType.UINT64) for dim in shape]
+    shape_tuple = _ir_core.MakeTuple(shape_elements, actual_span)
 
-    # Add shape dimensions
-    for dim in shape:
-        args.append(_normalize_expr(dim, actual_span, int_dtype=DataType.INT32))
-
+    args = [tile, shape_tuple]
     return _ir_core.create_op_call("block.reshape", args, {}, actual_span)
 
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -236,7 +236,17 @@ class PTOMLIRCodegen : public IRVisitor {
     if (auto const_int = As<ir::ConstInt>(expr)) {
       return const_int->value_;
     }
-    LOG_ERROR << "Expected ConstInt expression";
+    // Handle TupleGetItemExpr: extract the element from the tuple
+    if (auto tuple_get = As<ir::TupleGetItemExpr>(expr)) {
+      // The tuple should be MakeTuple
+      if (auto make_tuple = As<ir::MakeTuple>(tuple_get->tuple_)) {
+        // Extract the element at the specified index
+        if (tuple_get->index_ >= 0 && tuple_get->index_ < static_cast<int>(make_tuple->elements_.size())) {
+          return GetConstIntValue(make_tuple->elements_[tuple_get->index_]);
+        }
+      }
+    }
+    LOG_ERROR << "Expected ConstInt expression or TupleGetItemExpr with ConstInt elements";
     return 0;
   }
 

--- a/src/ir/op/block_ops/elementwise.cpp
+++ b/src/ir/op/block_ops/elementwise.cpp
@@ -57,7 +57,8 @@ TypePtr DeduceBlockOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
 
   auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes, but got "
-                                  << tile_type1->shape_ << " and " << tile_type2->shape_;
+                                  << FormatShape(tile_type1->shape_) << " and "
+                                  << FormatShape(tile_type2->shape_);
 
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype);
 }

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -53,7 +53,8 @@ TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
 
   auto broadcast_result = BroadcastShapes(tensor_type1->shape_, tensor_type2->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes, but got "
-                                  << tensor_type1->shape_ << " and " << tensor_type2->shape_;
+                                  << FormatShape(tensor_type1->shape_) << " and "
+                                  << FormatShape(tensor_type2->shape_);
 
   return std::make_shared<TensorType>(broadcast_result.shape, *result_dtype);
 }

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -24,6 +24,7 @@
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
@@ -34,9 +35,10 @@ namespace ir {
 
 TypePtr DeduceTensorCreateType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.create: all args are shape dimensions (Expr)
+  // tensor.create: shape is a single TupleType argument
   // dtype comes from kwargs
-  CHECK(args.size() >= 1) << "tensor.create requires at least 1 shape dimension argument";
+  CHECK(args.size() == 1) << "tensor.create requires exactly 1 argument (shape tuple), but got "
+                          << args.size();
 
   // Extract dtype from kwargs
   bool found_dtype = false;
@@ -50,11 +52,35 @@ TypePtr DeduceTensorCreateType(const std::vector<ExprPtr>& args,
   }
   CHECK(found_dtype) << "tensor.create requires 'dtype' kwarg";
 
-  // All arguments are shape dimensions
+  // First argument must be TupleType (shape)
+  auto shape_tuple_type = As<TupleType>(args[0]->GetType());
+  CHECK(shape_tuple_type) << "tensor.create requires shape to be TupleType, but got "
+                          << args[0]->GetType()->TypeName();
+
+  // Validate all shape elements are ScalarType(INT64 or UINT64)
+  for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.create shape tuple element " << i << " must be ScalarType, but got "
+                       << shape_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
+        << "tensor.create shape tuple element " << i << " must have dtype INT64 or UINT64, but got "
+        << scalar_type->dtype_.ToString();
+  }
+
+  // Extract shape dimensions
+  // If args[0] is MakeTuple, extract elements directly to preserve constants
+  // Otherwise use TupleGetItemExpr for runtime tuples
   std::vector<ExprPtr> shape;
-  shape.reserve(args.size());
-  for (const auto& arg : args) {
-    shape.emplace_back(arg);
+  shape.reserve(shape_tuple_type->types_.size());
+
+  if (auto make_tuple = As<MakeTuple>(args[0])) {
+    // MakeTuple: extract elements directly to preserve ConstInt
+    shape = make_tuple->elements_;
+  } else {
+    // Runtime tuple: use TupleGetItemExpr
+    for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+      shape.emplace_back(std::make_shared<TupleGetItemExpr>(args[0], static_cast<int>(i), args[0]->span_));
+    }
   }
 
   return std::make_shared<TensorType>(shape, dtype);
@@ -62,9 +88,8 @@ TypePtr DeduceTensorCreateType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.view requires at least 2 arguments: input tensor and shape_ndim
-  // Followed by shape dimensions and offset dimensions
-  CHECK(args.size() >= 2) << "tensor.view requires at least 2 arguments (input, shape_ndim), but got "
+  // tensor.view requires exactly 3 arguments: input tensor, shape tuple, and offset tuple
+  CHECK(args.size() == 3) << "tensor.view requires exactly 3 arguments (input, shape, offset), but got "
                           << args.size();
 
   // First argument must be TensorType
@@ -72,37 +97,62 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
   CHECK(tensor_type) << "tensor.view requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
-  // Second argument is the number of shape dimensions (ConstInt)
-  auto shape_ndim_const = As<ConstInt>(args[1]);
-  CHECK(shape_ndim_const)
-      << "tensor.view requires second argument to be a ConstInt indicating number of shape "
-         "dimensions";
+  // Second argument must be TupleType (shape)
+  auto shape_tuple_type = As<TupleType>(args[1]->GetType());
+  CHECK(shape_tuple_type) << "tensor.view requires shape to be TupleType, but got "
+                          << args[1]->GetType()->TypeName();
 
-  size_t shape_ndim = static_cast<size_t>(shape_ndim_const->value_);
-  CHECK(shape_ndim > 0) << "tensor.view requires at least 1 shape dimension";
-
-  // Check we have enough arguments: input + shape_ndim + shape_dims + offset_dims
-  CHECK(args.size() >= 2 + shape_ndim)
-      << "tensor.view requires at least " << (2 + shape_ndim) << " arguments for shape_ndim=" << shape_ndim
-      << ", but got " << args.size();
-
-  // Extract new shape dimensions (args[2] to args[2 + shape_ndim - 1])
-  std::vector<ExprPtr> new_shape;
-  new_shape.reserve(shape_ndim);
-  for (size_t i = 0; i < shape_ndim; ++i) {
-    new_shape.emplace_back(args[2 + i]);
+  // Validate all shape elements are ScalarType(INT64 or UINT64)
+  for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.view shape tuple element " << i << " must be ScalarType, but got "
+                       << shape_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
+        << "tensor.view shape tuple element " << i << " must have dtype INT64 or UINT64, but got "
+        << scalar_type->dtype_.ToString();
   }
 
-  // The remaining arguments are offset dimensions (not used for type deduction)
+  // Third argument must be TupleType (offset)
+  auto offset_tuple_type = As<TupleType>(args[2]->GetType());
+  CHECK(offset_tuple_type) << "tensor.view requires offset to be TupleType, but got "
+                           << args[2]->GetType()->TypeName();
+
+  // Validate all offset elements are ScalarType(INT64 or UINT64)
+  for (size_t i = 0; i < offset_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(offset_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.view offset tuple element " << i << " must be ScalarType, but got "
+                       << offset_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
+        << "tensor.view offset tuple element " << i << " must have dtype INT64 or UINT64, but got "
+        << scalar_type->dtype_.ToString();
+  }
+
+  // Extract shape dimensions
+  // If args[1] is MakeTuple, extract elements directly to preserve constants
+  // Otherwise use TupleGetItemExpr for runtime tuples
+  std::vector<ExprPtr> new_shape;
+  new_shape.reserve(shape_tuple_type->types_.size());
+
+  if (auto make_tuple = As<MakeTuple>(args[1])) {
+    // MakeTuple: extract elements directly to preserve ConstInt
+    new_shape = make_tuple->elements_;
+  } else {
+    // Runtime tuple: use TupleGetItemExpr
+    for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+      new_shape.emplace_back(
+          std::make_shared<TupleGetItemExpr>(args[1], static_cast<int>(i), args[1]->span_));
+    }
+  }
+
   // View preserves dtype but has new shape (which can have different rank than input)
   return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
 }
 
 TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
                                  const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.assemble requires at least 2 arguments (target, source)
-  // Followed by offset dimensions
-  CHECK(args.size() >= 2) << "tensor.assemble requires at least 2 arguments, but got " << args.size();
+  // tensor.assemble requires exactly 3 arguments: target, source, and offset tuple
+  CHECK(args.size() == 3) << "tensor.assemble requires exactly 3 arguments (target, source, offset), but got "
+                          << args.size();
 
   // First argument (target) must be TensorType
   auto target_type = As<TensorType>(args[0]->GetType());
@@ -114,8 +164,24 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
   CHECK(source_type) << "tensor.assemble requires second argument to be a TensorType, but got "
                      << args[1]->GetType()->TypeName();
 
-  // Assemble returns the target tensor type (updated in-place semantically)
-  return target_type;
+  // Third argument must be TupleType (offset)
+  auto offset_tuple_type = As<TupleType>(args[2]->GetType());
+  CHECK(offset_tuple_type) << "tensor.assemble requires offset to be TupleType, but got "
+                           << args[2]->GetType()->TypeName();
+
+  // Validate all offset elements are ScalarType(INT64 or UINT64)
+  for (size_t i = 0; i < offset_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(offset_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.assemble offset tuple element " << i << " must be ScalarType, but got "
+                       << offset_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
+        << "tensor.assemble offset tuple element " << i << " must have dtype INT64 or UINT64, but got "
+        << scalar_type->dtype_.ToString();
+  }
+
+  // Assemble returns a new TensorType with the same shape and dtype as target
+  // We need to create a new type object to avoid sharing type instances
+  return std::make_shared<TensorType>(target_type->shape_, target_type->dtype_);
 }
 
 // ============================================================================
@@ -125,7 +191,7 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
 REGISTER_OP("tensor.create")
     .set_op_category("TensorOp")
     .set_description("Create a new tensor with specified shape and dtype")
-    .add_argument("shape_dims", "Shape dimensions (variable number of Expr)")
+    .add_argument("shape", "Shape dimensions (TupleType of ScalarType(UINT64))")
     .set_attr<DataType>("dtype")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -136,8 +202,8 @@ REGISTER_OP("tensor.view")
     .set_op_category("TensorOp")
     .set_description("Create a view/slice of a tensor with new shape and offset")
     .add_argument("input", "Input tensor (TensorType)")
-    .add_argument("shape_dims", "New shape dimensions (variable number)")
-    .add_argument("offset_dims", "Offset dimensions (variable number)")
+    .add_argument("shape", "New shape dimensions (TupleType of ScalarType(UINT64))")
+    .add_argument("offset", "Offset dimensions (TupleType of ScalarType(UINT64))")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorViewType(args, kwargs);
@@ -148,7 +214,7 @@ REGISTER_OP("tensor.assemble")
     .set_description("Write/update tensor values at specified offset")
     .add_argument("target", "Target tensor (TensorType)")
     .add_argument("source", "Source tensor to write (TensorType)")
-    .add_argument("offset_dims", "Offset dimensions (variable number)")
+    .add_argument("offset", "Offset dimensions (TupleType of ScalarType(UINT64))")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorAssembleType(args, kwargs);

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -24,6 +24,7 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
@@ -79,9 +80,8 @@ int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
 
 TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.reshape requires at least 2 arguments: input tensor and shape_ndim
-  // Followed by shape dimensions
-  CHECK(args.size() >= 2) << "tensor.reshape requires at least 2 arguments (input, shape_ndim), but got "
+  // tensor.reshape requires exactly 2 arguments: input tensor and shape tuple
+  CHECK(args.size() == 2) << "tensor.reshape requires exactly 2 arguments (input, shape), but got "
                           << args.size();
 
   // First argument must be TensorType
@@ -89,24 +89,36 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   CHECK(tensor_type) << "tensor.reshape requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
-  // Second argument is the number of shape dimensions (ConstInt)
-  auto shape_ndim_const = As<ConstInt>(args[1]);
-  CHECK(shape_ndim_const)
-      << "tensor.reshape requires second argument to be a ConstInt indicating number of shape dimensions";
+  // Second argument must be TupleType (shape)
+  auto shape_tuple_type = As<TupleType>(args[1]->GetType());
+  CHECK(shape_tuple_type) << "tensor.reshape requires shape to be TupleType, but got "
+                          << args[1]->GetType()->TypeName();
 
-  size_t shape_ndim = static_cast<size_t>(shape_ndim_const->value_);
-  CHECK(shape_ndim > 0) << "tensor.reshape requires at least 1 shape dimension";
+  // Validate all shape elements are ScalarType(INT64 or UINT64)
+  for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.reshape shape tuple element " << i << " must be ScalarType, but got "
+                       << shape_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
+        << "tensor.reshape shape tuple element " << i << " must have dtype INT64 or UINT64, but got "
+        << scalar_type->dtype_.ToString();
+  }
 
-  // Check we have correct number of arguments: input + shape_ndim + shape_dims
-  CHECK(args.size() == 2 + shape_ndim)
-      << "tensor.reshape requires exactly " << (2 + shape_ndim) << " arguments for shape_ndim=" << shape_ndim
-      << ", but got " << args.size();
-
-  // Extract new shape dimensions (args[2] to args[2 + shape_ndim - 1])
+  // Extract new shape dimensions
+  // If args[1] is MakeTuple, extract elements directly to preserve constants
+  // Otherwise use TupleGetItemExpr for runtime tuples
   std::vector<ExprPtr> new_shape;
-  new_shape.reserve(shape_ndim);
-  for (size_t i = 0; i < shape_ndim; ++i) {
-    new_shape.emplace_back(args[2 + i]);
+  new_shape.reserve(shape_tuple_type->types_.size());
+
+  if (auto make_tuple = As<MakeTuple>(args[1])) {
+    // MakeTuple: extract elements directly to preserve ConstInt
+    new_shape = make_tuple->elements_;
+  } else {
+    // Runtime tuple: use TupleGetItemExpr
+    for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+      new_shape.emplace_back(
+          std::make_shared<TupleGetItemExpr>(args[1], static_cast<int>(i), args[1]->span_));
+    }
   }
 
   // For static shapes, verify that the total number of elements matches
@@ -169,8 +181,7 @@ REGISTER_OP("tensor.reshape")
     .set_op_category("TensorOp")
     .set_description("Reshape tensor to new shape")
     .add_argument("input", "Input tensor (TensorType)")
-    .add_argument("shape_ndim", "Number of shape dimensions (ConstInt)")
-    .add_argument("shape_dims", "New shape dimensions (variable number)")
+    .add_argument("shape", "New shape dimensions (TupleType of ScalarType(UINT64))")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorReshapeType(args, kwargs);

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -237,6 +238,28 @@ bool IsBroadcastable(const ExprPtr& source_dim, const ExprPtr& target_dim) {
   }
 
   return false;
+}
+
+std::string FormatShape(const std::vector<ExprPtr>& shape) {
+  if (shape.empty()) {
+    return "[]";
+  }
+
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    auto const_dim = GetConstantDimension(shape[i]);
+    if (const_dim) {
+      oss << *const_dim;
+    } else {
+      oss << "?";
+    }
+  }
+  oss << "]";
+  return oss.str();
 }
 
 }  // namespace ir

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -392,13 +392,13 @@ def test_tensor_reshape_dynamic():
     span = ir.Span.unknown()
 
     # Create a tensor with dynamic dimensions
-    dim_n = ir.Var("n", ir.ScalarType(DataType.INT32), span)
-    dim_m = ir.Var("m", ir.ScalarType(DataType.INT32), span)
+    dim_n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+    dim_m = ir.Var("m", ir.ScalarType(DataType.INT64), span)
     tensor_type = ir.TensorType([dim_n, dim_m], DataType.FP16)
     tensor_var = ir.Var("t", tensor_type, span)
 
     # Reshape with dynamic shape (cannot verify element count at compile time)
-    dim_k = ir.Var("k", ir.ScalarType(DataType.INT32), span)
+    dim_k = ir.Var("k", ir.ScalarType(DataType.INT64), span)
     call = ir.op.tensor.reshape(tensor_var, [dim_k])
 
     assert isinstance(call, ir.Call)


### PR DESCRIPTION
Replace variadic shape/offset arguments with MakeTuple expressions for tensor and block operators. This provides better type safety and enables more consistent tuple handling across the IR.

Changes:
- tensor.create, tensor.view, tensor.reshape, tensor.assemble
- block.view, block.reshape
- Update Python bindings to construct MakeTuple for shape/offset
- Add FormatShape helper for better error messages
- Fix PTO codegen to handle TupleGetItemExpr for constant extraction