### PR TITLE
feat(ir): Add scalar type validation for control flow statements

### DIFF
--- a/include/pypto/ir/transforms/verification_error.h
+++ b/include/pypto/ir/transforms/verification_error.h
@@ -49,11 +49,13 @@ namespace typecheck {
  * @brief Error types for type checking
  */
 enum class ErrorType : int {
-  TYPE_KIND_MISMATCH = 101,        // Type kind mismatch (e.g., ScalarType vs TensorType)
-  DTYPE_MISMATCH = 102,            // Data type mismatch
-  SHAPE_DIMENSION_MISMATCH = 103,  // Shape dimension count mismatch
-  SHAPE_VALUE_MISMATCH = 104,      // Shape dimension value mismatch
-  SIZE_MISMATCH = 105              // Vector size mismatch in control flow
+  TYPE_KIND_MISMATCH = 101,           // Type kind mismatch (e.g., ScalarType vs TensorType)
+  DTYPE_MISMATCH = 102,               // Data type mismatch
+  SHAPE_DIMENSION_MISMATCH = 103,     // Shape dimension count mismatch
+  SHAPE_VALUE_MISMATCH = 104,         // Shape dimension value mismatch
+  SIZE_MISMATCH = 105,                // Vector size mismatch in control flow
+  IF_CONDITION_MUST_BE_SCALAR = 106,  // IfStmt condition must be ScalarType
+  FOR_RANGE_MUST_BE_SCALAR = 107      // ForStmt range must be ScalarType
 };
 
 /**


### PR DESCRIPTION
Add type checking rules to verify that IfStmt condition and ForStmt range parameters (start/stop/step) must be ScalarType. This ensures type safety in control flow constructs and catches errors early during IR verification.

Changes:
- Add IF_CONDITION_MUST_BE_SCALAR (106) and FOR_RANGE_MUST_BE_SCALAR (107) error codes to TypeCheck rule
- Implement CheckIsScalarType helper method in TypeChecker visitor
- Extend VisitStmt_ methods to validate control flow expression types
- Add comprehensive test cases for both valid and invalid scenarios