### PR TITLE
feat(backend): Add SoC hierarchy and backend architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,10 @@ set(PYPTO_SOURCES
     src/ir/serialization/deserializer.cpp
     src/ir/serialization/type_registry.cpp
     src/ir/serialization/type_deserializers.cpp
+    src/backend/soc.cpp
+    src/backend/backend.cpp
+    src/backend/backend_910b.cpp
+    src/backend/backend_registry.cpp
 )
 
 # Include Python bindings

--- a/include/pypto/backend/backend.h
+++ b/include/pypto/backend/backend.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_BACKEND_BACKEND_H_
+#define PYPTO_BACKEND_BACKEND_H_
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/backend/soc.h"
+#include "pypto/ir/memref.h"
+
+namespace pypto {
+namespace backend {
+
+/**
+ * @brief Abstract backend base class
+ *
+ * Represents a hardware backend configuration with SoC structure.
+ * Provides serialization/deserialization and abstract methods for
+ * backend-specific operations.
+ */
+class Backend {
+ public:
+  virtual ~Backend() = default;
+
+  // Disable copy and move to enforce unique ownership
+  Backend(const Backend&) = delete;
+  Backend& operator=(const Backend&) = delete;
+  Backend(Backend&&) = delete;
+  Backend& operator=(Backend&&) = delete;
+
+  /**
+   * @brief Export backend to msgpack file
+   *
+   * @param path File path to export to
+   * @throws RuntimeError if file cannot be written
+   */
+  void ExportToFile(const std::string& path) const;
+
+  /**
+   * @brief Import backend from msgpack file
+   *
+   * @param path File path to import from
+   * @return Unique pointer to backend instance
+   * @throws RuntimeError if file cannot be read or parsed
+   */
+  static std::unique_ptr<Backend> ImportFromFile(const std::string& path);
+
+  /**
+   * @brief Find memory path from source to destination
+   *
+   * Uses BFS to find shortest path through memory hierarchy.
+   *
+   * @param from Source memory space
+   * @param to Destination memory space
+   * @return Vector of memory spaces in the path (including from and to)
+   */
+  [[nodiscard]] std::vector<ir::MemorySpace> FindMemPath(ir::MemorySpace from, ir::MemorySpace to) const;
+
+  /**
+   * @brief Get memory size for a specific memory type
+   *
+   * Returns the size of a single memory component of the given type.
+   * If the type exists in multiple cores, returns the size from the first occurrence.
+   *
+   * @param mem_type Memory space type
+   * @return Memory size in bytes, or 0 if not found
+   */
+  [[nodiscard]] uint64_t GetMemSize(ir::MemorySpace mem_type) const;
+
+  /**
+   * @brief Get backend type name for serialization
+   *
+   * @return Backend type name (e.g., "910B")
+   */
+  [[nodiscard]] virtual std::string GetTypeName() const = 0;
+
+  /**
+   * @brief Get the SoC structure
+   *
+   * @return Shared pointer to const SoC
+   */
+  [[nodiscard]] SoCPtr GetSoC() const { return soc_; }
+
+  /**
+   * @brief Get the memory hierarchy graph
+   *
+   * @return Const reference to memory adjacency list
+   */
+  [[nodiscard]] const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& GetMemoryGraph() const {
+    return mem_graph_;
+  }
+
+ protected:
+  /**
+   * @brief Construct backend with SoC and memory hierarchy
+   *
+   * Protected constructor - only derived classes can instantiate Backend.
+   *
+   * @param soc Immutable SoC structure
+   * @param mem_graph Memory hierarchy adjacency list
+   */
+  Backend() = default;
+
+  SoCPtr soc_{nullptr};
+  std::map<ir::MemorySpace, std::vector<ir::MemorySpace>> mem_graph_{};
+};
+
+}  // namespace backend
+}  // namespace pypto
+
+#endif  // PYPTO_BACKEND_BACKEND_H_

--- a/include/pypto/backend/backend_910b.h
+++ b/include/pypto/backend/backend_910b.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_BACKEND_BACKEND_910B_H_
+#define PYPTO_BACKEND_BACKEND_910B_H_
+
+#include <string>
+
+#include "pypto/backend/backend.h"
+
+namespace pypto {
+namespace backend {
+
+/**
+ * @brief Backend implementation for 910B hardware
+ *
+ * Implements memory hierarchy and path finding for 910B architecture.
+ * The SoC structure is fixed and created internally in the constructor.
+ */
+class Backend910B : public Backend {
+ public:
+  /**
+   * @brief Construct 910B backend with standard configuration
+   *
+   * Creates the standard 910B SoC structure
+   */
+  Backend910B();
+
+  /**
+   * @brief Get backend type name
+   *
+   * @return "910B"
+   */
+  [[nodiscard]] std::string GetTypeName() const override { return "910B"; }
+};
+
+}  // namespace backend
+}  // namespace pypto
+
+#endif  // PYPTO_BACKEND_BACKEND_910B_H_

--- a/include/pypto/backend/backend_registry.h
+++ b/include/pypto/backend/backend_registry.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_BACKEND_BACKEND_REGISTRY_H_
+#define PYPTO_BACKEND_BACKEND_REGISTRY_H_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "pypto/backend/backend.h"
+#include "pypto/backend/soc.h"
+
+namespace pypto {
+namespace backend {
+
+/**
+ * @brief Registry for backend types
+ *
+ * Singleton registry that maps backend type names to factory functions.
+ * Used for deserialization to create the correct backend subclass.
+ */
+class BackendRegistry {
+ public:
+  using CreateFunc = std::function<std::unique_ptr<Backend>(
+      std::shared_ptr<const SoC>, std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>)>;
+
+  /**
+   * @brief Get the singleton instance
+   *
+   * @return Reference to the global registry
+   */
+  static BackendRegistry& Instance();
+
+  /**
+   * @brief Register a backend type
+   *
+   * @param type_name Backend type name (e.g., "910B")
+   * @param func Factory function that creates backend from SoC and memory graph
+   */
+  void Register(const std::string& type_name, CreateFunc func);
+
+  /**
+   * @brief Create a backend instance
+   *
+   * @param type_name Backend type name
+   * @param soc SoC structure
+   * @param mem_graph Memory hierarchy adjacency list
+   * @return Unique pointer to created backend
+   * @throws RuntimeError if type_name is not registered
+   */
+  std::unique_ptr<Backend> Create(const std::string& type_name, std::shared_ptr<const SoC> soc,
+                                  const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& mem_graph);
+
+  /**
+   * @brief Check if a type is registered
+   *
+   * @param type_name Backend type name to check
+   * @return true if registered, false otherwise
+   */
+  bool IsRegistered(const std::string& type_name) const;
+
+ private:
+  BackendRegistry() = default;
+  std::unordered_map<std::string, CreateFunc> registry_;
+};
+
+/**
+ * @brief Helper function for backend deserialization
+ *
+ * Called by Backend::ImportFromFile to create backend from registry.
+ *
+ * @param type_name Backend type name
+ * @param soc SoC structure
+ * @param mem_graph Memory hierarchy adjacency list
+ * @return Unique pointer to created backend
+ */
+std::unique_ptr<Backend> CreateBackendFromRegistry(
+    const std::string& type_name, std::shared_ptr<const SoC> soc,
+    const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& mem_graph);
+
+}  // namespace backend
+}  // namespace pypto
+
+#endif  // PYPTO_BACKEND_BACKEND_REGISTRY_H_

--- a/include/pypto/backend/soc.h
+++ b/include/pypto/backend/soc.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_BACKEND_SOC_H_
+#define PYPTO_BACKEND_SOC_H_
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "pypto/ir/memref.h"
+#include "pypto/ir/pipe.h"
+
+namespace pypto {
+namespace backend {
+
+// Forward declarations
+class Mem;
+class Core;
+class Cluster;
+class Die;
+class SoC;
+
+using MemPtr = std::shared_ptr<const Mem>;
+using CorePtr = std::shared_ptr<const Core>;
+using ClusterPtr = std::shared_ptr<const Cluster>;
+using DiePtr = std::shared_ptr<const Die>;
+using SoCPtr = std::shared_ptr<const SoC>;
+
+/**
+ * @brief Memory component
+ *
+ * Represents a memory unit with type, size, and alignment requirements.
+ * Immutable once constructed.
+ */
+class Mem {
+ public:
+  /**
+   * @brief Construct a memory component
+   *
+   * @param mem_type Memory space type
+   * @param mem_size Memory size in bytes
+   * @param alignment Memory alignment requirement in bytes
+   */
+  Mem(ir::MemorySpace mem_type, uint64_t mem_size, uint64_t alignment);
+
+  // Allow copy and move for container storage
+  Mem(const Mem&) = default;
+  Mem& operator=(const Mem&) = default;
+  Mem(Mem&&) = default;
+  Mem& operator=(Mem&&) = default;
+
+  [[nodiscard]] ir::MemorySpace GetMemType() const { return mem_type_; }
+  [[nodiscard]] uint64_t GetMemSize() const { return mem_size_; }
+  [[nodiscard]] uint64_t GetAlignment() const { return alignment_; }
+
+  // Comparison operators for map key support
+  bool operator<(const Mem& other) const;
+  bool operator==(const Mem& other) const;
+
+ private:
+  ir::MemorySpace mem_type_;
+  uint64_t mem_size_;
+  uint64_t alignment_;
+};
+
+/**
+ * @brief Processing core with associated memories
+ *
+ * Contains core type and list of memory components.
+ * Immutable once constructed.
+ */
+class Core {
+ public:
+  /**
+   * @brief Construct a processing core
+   *
+   * @param core_type Type of core (CUBE or VECTOR)
+   * @param mems Vector of memory components
+   */
+  Core(ir::CoreType core_type, std::vector<Mem> mems);
+
+  // Allow copy and move for container storage
+  Core(const Core&) = default;
+  Core& operator=(const Core&) = default;
+  Core(Core&&) = default;
+  Core& operator=(Core&&) = default;
+
+  [[nodiscard]] ir::CoreType GetCoreType() const { return core_type_; }
+  [[nodiscard]] const std::vector<Mem>& GetMems() const { return mems_; }
+
+  // Comparison operators for map key support
+  bool operator<(const Core& other) const;
+  bool operator==(const Core& other) const;
+
+ private:
+  ir::CoreType core_type_;
+  std::vector<Mem> mems_;
+};
+
+/**
+ * @brief Cluster of processing cores
+ *
+ * Contains a map of core configurations to their counts.
+ * map<Core, int> stores different core types and how many of each.
+ * Immutable once constructed.
+ */
+class Cluster {
+ public:
+  /**
+   * @brief Construct a cluster
+   *
+   * @param core_counts Map from core configuration to count
+   */
+  explicit Cluster(std::map<Core, int> core_counts);
+
+  /**
+   * @brief Convenience constructor for single core type
+   *
+   * @param core Single core configuration
+   * @param count Number of cores with this configuration
+   */
+  Cluster(const Core& core, int count);
+
+  // Allow copy and move for container storage
+  Cluster(const Cluster&) = default;
+  Cluster& operator=(const Cluster&) = default;
+  Cluster(Cluster&&) = default;
+  Cluster& operator=(Cluster&&) = default;
+
+  [[nodiscard]] const std::map<Core, int>& GetCoreCounts() const { return core_counts_; }
+  [[nodiscard]] int TotalCoreCount() const;
+
+  // Comparison operators for map key support
+  bool operator<(const Cluster& other) const;
+  bool operator==(const Cluster& other) const;
+
+ private:
+  std::map<Core, int> core_counts_;
+};
+
+/**
+ * @brief Die containing clusters
+ *
+ * Contains a map of cluster configurations to their counts.
+ * map<Cluster, int> stores different cluster types and how many of each.
+ * Immutable once constructed.
+ */
+class Die {
+ public:
+  /**
+   * @brief Construct a die
+   *
+   * @param cluster_counts Map from cluster configuration to count
+   */
+  explicit Die(std::map<Cluster, int> cluster_counts);
+
+  /**
+   * @brief Convenience constructor for single cluster type
+   *
+   * @param cluster Single cluster configuration
+   * @param count Number of clusters with this configuration
+   */
+  Die(const Cluster& cluster, int count);
+
+  // Allow copy and move for container storage
+  Die(const Die&) = default;
+  Die& operator=(const Die&) = default;
+  Die(Die&&) = default;
+  Die& operator=(Die&&) = default;
+
+  [[nodiscard]] const std::map<Cluster, int>& GetClusterCounts() const { return cluster_counts_; }
+  [[nodiscard]] int TotalClusterCount() const;
+  [[nodiscard]] int TotalCoreCount() const;
+
+  // Comparison operators for map key support
+  bool operator<(const Die& other) const;
+  bool operator==(const Die& other) const;
+
+ private:
+  std::map<Cluster, int> cluster_counts_;
+};
+
+/**
+ * @brief System on Chip (SoC)
+ *
+ * Top-level structure containing dies.
+ * map<Die, int> stores different die types and how many of each.
+ * Immutable once constructed.
+ */
+class SoC {
+ public:
+  /**
+   * @brief Construct a SoC
+   *
+   * @param die_counts Map from die configuration to count
+   */
+  explicit SoC(std::map<Die, int> die_counts);
+
+  /**
+   * @brief Convenience constructor for single die type
+   *
+   * @param die Single die configuration
+   * @param count Number of dies with this configuration
+   */
+  SoC(const Die& die, int count);
+
+  // Disable copy and move to enforce immutability
+  SoC(const SoC&) = delete;
+  SoC& operator=(const SoC&) = delete;
+  SoC(SoC&&) = delete;
+  SoC& operator=(SoC&&) = delete;
+
+  [[nodiscard]] const std::map<Die, int>& GetDieCounts() const { return die_counts_; }
+  [[nodiscard]] int TotalDieCount() const;
+  [[nodiscard]] int TotalClusterCount() const;
+  [[nodiscard]] int TotalCoreCount() const;
+
+ private:
+  std::map<Die, int> die_counts_;
+};
+
+}  // namespace backend
+}  // namespace pypto
+
+#endif  // PYPTO_BACKEND_SOC_H_

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PYPTO_BINDING_SOURCES
     modules/ir_builder.cpp
     modules/passes.cpp
     modules/codegen.cpp
+    modules/backend.cpp
 )
 
 # Make paths absolute

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -51,4 +51,7 @@ NB_MODULE(pypto_core, m) {
 
   // Register code generation bindings
   pypto::python::BindCodegen(m);
+
+  // Register backend bindings
+  pypto::python::BindBackend(m);
 }

--- a/python/bindings/module.h
+++ b/python/bindings/module.h
@@ -106,6 +106,15 @@ void BindLogging(nanobind::module_& m);
  */
 void BindCodegen(nanobind::module_& m);
 
+/**
+ * @brief Register backend classes
+ *
+ * Registers SoC hierarchy, builders, and backend implementations.
+ *
+ * @param m The nanobind module object
+ */
+void BindBackend(nanobind::module_& m);
+
 // Future binding declarations can be added here:
 // void BindTensors(nanobind::module_& m);
 // void BindOps(nanobind::module_& m);

--- a/python/bindings/modules/backend.cpp
+++ b/python/bindings/modules/backend.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/backend/backend.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../module.h"
+#include "pypto/backend/backend_910b.h"
+#include "pypto/backend/soc.h"
+#include "pypto/ir/memref.h"
+#include "pypto/ir/pipe.h"
+
+namespace nb = nanobind;
+
+namespace pypto {
+namespace python {
+
+using pypto::backend::Backend;
+using pypto::backend::Backend910B;
+using pypto::backend::Cluster;
+using pypto::backend::Core;
+using pypto::backend::Die;
+using pypto::backend::Mem;
+using pypto::backend::SoC;
+using pypto::ir::CoreType;
+using pypto::ir::MemorySpace;
+
+void BindBackend(nb::module_& m) {
+  nb::module_ backend_mod = m.def_submodule("backend", "PyPTO Backend module");
+
+  // ========== Mem class ==========
+  nb::class_<Mem>(backend_mod, "Mem", "Memory component")
+      .def(nb::init<MemorySpace, uint64_t, uint64_t>(), nb::arg("mem_type"), nb::arg("mem_size"),
+           nb::arg("alignment"), "Create a memory component")
+      .def_prop_ro("mem_type", &Mem::GetMemType, "Memory space type")
+      .def_prop_ro("mem_size", &Mem::GetMemSize, "Memory size in bytes")
+      .def_prop_ro("alignment", &Mem::GetAlignment, "Memory alignment in bytes")
+      .def("__repr__", [](const Mem& mem) {
+        return "Mem(type=" + ir::MemorySpaceToString(mem.GetMemType()) +
+               ", size=" + std::to_string(mem.GetMemSize()) +
+               ", alignment=" + std::to_string(mem.GetAlignment()) + ")";
+      });
+
+  // ========== Core class ==========
+  nb::class_<Core>(backend_mod, "Core", "Processing core")
+      .def(nb::init<CoreType, std::vector<Mem>>(), nb::arg("core_type"), nb::arg("mems"),
+           "Create a processing core")
+      .def_prop_ro("core_type", &Core::GetCoreType, "Core type (CUBE or VECTOR)")
+      .def_prop_ro("mems", &Core::GetMems, "List of memory components")
+      .def("__repr__", [](const Core& core) {
+        return "Core(type=" + std::to_string(static_cast<int>(core.GetCoreType())) +
+               ", mems=" + std::to_string(core.GetMems().size()) + ")";
+      });
+
+  // ========== Cluster class ==========
+  nb::class_<Cluster>(backend_mod, "Cluster", "Cluster of processing cores")
+      .def(nb::init<std::map<Core, int>>(), nb::arg("core_counts"), "Create cluster from core counts map")
+      .def(nb::init<const Core&, int>(), nb::arg("core"), nb::arg("count"),
+           "Create cluster with single core type")
+      .def_prop_ro("core_counts", &Cluster::GetCoreCounts, "Map of core configurations to counts")
+      .def("total_core_count", &Cluster::TotalCoreCount, "Get total number of cores in cluster")
+      .def("__repr__", [](const Cluster& cluster) {
+        return "Cluster(total_cores=" + std::to_string(cluster.TotalCoreCount()) + ")";
+      });
+
+  // ========== Die class ==========
+  nb::class_<Die>(backend_mod, "Die", "Die containing clusters")
+      .def(nb::init<std::map<Cluster, int>>(), nb::arg("cluster_counts"),
+           "Create die from cluster counts map")
+      .def(nb::init<const Cluster&, int>(), nb::arg("cluster"), nb::arg("count"),
+           "Create die with single cluster type")
+      .def_prop_ro("cluster_counts", &Die::GetClusterCounts, "Map of cluster configurations to counts")
+      .def("total_cluster_count", &Die::TotalClusterCount, "Get total number of clusters in die")
+      .def("total_core_count", &Die::TotalCoreCount, "Get total number of cores in die")
+      .def("__repr__", [](const Die& die) {
+        return "Die(clusters=" + std::to_string(die.TotalClusterCount()) +
+               ", cores=" + std::to_string(die.TotalCoreCount()) + ")";
+      });
+
+  // ========== SoC class ==========
+  nb::class_<SoC>(backend_mod, "SoC", "System on Chip")
+      .def(nb::init<std::map<Die, int>>(), nb::arg("die_counts"), "Create SoC from die counts map")
+      .def(nb::init<const Die&, int>(), nb::arg("die"), nb::arg("count"), "Create SoC with single die type")
+      .def_prop_ro("die_counts", &SoC::GetDieCounts, "Map of die configurations to counts")
+      .def("total_die_count", &SoC::TotalDieCount, "Get total number of dies in SoC")
+      .def("total_cluster_count", &SoC::TotalClusterCount, "Get total number of clusters in SoC")
+      .def("total_core_count", &SoC::TotalCoreCount, "Get total number of cores in SoC")
+      .def("__repr__", [](const SoC& soc) {
+        return "SoC(dies=" + std::to_string(soc.TotalDieCount()) +
+               ", clusters=" + std::to_string(soc.TotalClusterCount()) +
+               ", cores=" + std::to_string(soc.TotalCoreCount()) + ")";
+      });
+
+  // ========== Backend abstract base class ==========
+  nb::class_<Backend>(backend_mod, "Backend", "Abstract backend base class")
+      .def("export_to_file", &Backend::ExportToFile, nb::arg("path"), "Export backend to msgpack file")
+      .def_static(
+          "import_from_file",
+          [](const std::string& path) -> Backend* {
+            // Return raw pointer that nanobind will manage
+            return Backend::ImportFromFile(path).release();
+          },
+          nb::arg("path"), nb::rv_policy::take_ownership, "Import backend from msgpack file")
+      .def("find_mem_path", &Backend::FindMemPath, nb::arg("from_mem"), nb::arg("to_mem"),
+           "Find memory path from source to destination")
+      .def("get_mem_size", &Backend::GetMemSize, nb::arg("mem_type"),
+           "Get total memory size for given memory type")
+      .def_prop_ro(
+          "soc", [](const Backend& backend) -> const SoC& { return *backend.GetSoC(); }, "Get SoC object");
+
+  // ========== Backend910B concrete implementation ==========
+  nb::class_<Backend910B, Backend>(backend_mod, "Backend910B", "910B backend implementation")
+      .def(nb::init<>(), "Create 910B backend with standard configuration");
+}
+
+}  // namespace python
+}  // namespace pypto

--- a/python/pypto/backend/__init__.py
+++ b/python/pypto/backend/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""PyPTO Backend module - SoC hierarchy and backend implementations."""
+
+from pypto.pypto_core.backend import (
+    # Backend
+    Backend,
+    Backend910B,
+    Cluster,
+    Core,
+    Die,
+    # Components
+    Mem,
+    SoC,
+)
+
+__all__ = [
+    "Mem",
+    "Core",
+    "Cluster",
+    "Die",
+    "SoC",
+    "Backend",
+    "Backend910B",
+]

--- a/python/pypto/pypto_core/backend.pyi
+++ b/python/pypto/pypto_core/backend.pyi
@@ -1,0 +1,74 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Type stubs for backend module."""
+
+from typing import Dict, List
+
+from pypto import ir
+
+class Mem:
+    """Memory component."""
+
+    def __init__(self, mem_type: ir.MemorySpace, mem_size: int, alignment: int) -> None: ...
+    @property
+    def mem_type(self) -> ir.MemorySpace: ...
+    @property
+    def mem_size(self) -> int: ...
+    @property
+    def alignment(self) -> int: ...
+
+class Core:
+    """Processing core."""
+
+    def __init__(self, core_type: ir.CoreType, mems: List[Mem]) -> None: ...
+    @property
+    def core_type(self) -> ir.CoreType: ...
+    @property
+    def mems(self) -> List[Mem]: ...
+
+class Cluster:
+    """Cluster of cores."""
+
+    @property
+    def core_counts(self) -> Dict[Core, int]: ...
+    def total_core_count(self) -> int: ...
+
+class Die:
+    """Die containing clusters."""
+
+    @property
+    def cluster_counts(self) -> Dict[Cluster, int]: ...
+    def total_cluster_count(self) -> int: ...
+    def total_core_count(self) -> int: ...
+
+class SoC:
+    """System on Chip."""
+
+    @property
+    def die_counts(self) -> Dict[Die, int]: ...
+    def total_die_count(self) -> int: ...
+    def total_cluster_count(self) -> int: ...
+    def total_core_count(self) -> int: ...
+
+class Backend:
+    """Abstract backend base class."""
+
+    def export_to_file(self, path: str) -> None: ...
+    @staticmethod
+    def import_from_file(path: str) -> "Backend": ...
+    def find_mem_path(self, from_mem: ir.MemorySpace, to_mem: ir.MemorySpace) -> List[ir.MemorySpace]: ...
+    def get_mem_size(self, mem_type: ir.MemorySpace) -> int: ...
+    @property
+    def soc(self) -> SoC: ...
+
+class Backend910B(Backend):
+    """910B backend implementation."""
+
+    def __init__(self) -> None: ...

--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/backend/backend.h"
+
+#include <algorithm>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// clang-format off
+#include <msgpack.hpp>
+// clang-format on
+
+#include "pypto/core/logging.h"
+
+namespace pypto {
+namespace backend {
+
+// Forward declaration of registry
+class BackendRegistry;
+
+// ========== Serialization Helpers ==========
+
+namespace {
+
+// Serialize Mem to msgpack object
+msgpack::object SerializeMem(const Mem& mem, msgpack::zone& zone) {
+  std::map<std::string, msgpack::object> mem_map;
+  mem_map["mem_type"] = msgpack::object(static_cast<int>(mem.GetMemType()), zone);
+  mem_map["mem_size"] = msgpack::object(mem.GetMemSize(), zone);
+  mem_map["alignment"] = msgpack::object(mem.GetAlignment(), zone);
+  return msgpack::object(mem_map, zone);
+}
+
+// Serialize Core to msgpack object
+msgpack::object SerializeCore(const Core& core, msgpack::zone& zone) {
+  std::map<std::string, msgpack::object> core_map;
+  core_map["core_type"] = msgpack::object(static_cast<int>(core.GetCoreType()), zone);
+
+  // Serialize mems vector
+  std::vector<msgpack::object> mems_vec;
+  for (const auto& mem : core.GetMems()) {
+    mems_vec.emplace_back(SerializeMem(mem, zone));
+  }
+  core_map["mems"] = msgpack::object(mems_vec, zone);
+
+  return msgpack::object(core_map, zone);
+}
+
+// Serialize Cluster to msgpack object
+msgpack::object SerializeCluster(const Cluster& cluster, msgpack::zone& zone) {
+  std::map<std::string, msgpack::object> cluster_map;
+
+  // Serialize core_counts map as array of [core, count] pairs
+  std::vector<msgpack::object> cores_vec;
+  for (const auto& [core, count] : cluster.GetCoreCounts()) {
+    std::map<std::string, msgpack::object> entry;
+    entry["core"] = SerializeCore(core, zone);
+    entry["count"] = msgpack::object(count, zone);
+    cores_vec.emplace_back(msgpack::object(entry, zone));
+  }
+  cluster_map["cores"] = msgpack::object(cores_vec, zone);
+
+  return msgpack::object(cluster_map, zone);
+}
+
+// Serialize Die to msgpack object
+msgpack::object SerializeDie(const Die& die, msgpack::zone& zone) {
+  std::map<std::string, msgpack::object> die_map;
+
+  // Serialize cluster_counts map
+  std::vector<msgpack::object> clusters_vec;
+  for (const auto& [cluster, count] : die.GetClusterCounts()) {
+    std::map<std::string, msgpack::object> entry;
+    entry["cluster"] = SerializeCluster(cluster, zone);
+    entry["count"] = msgpack::object(count, zone);
+    clusters_vec.emplace_back(msgpack::object(entry, zone));
+  }
+  die_map["clusters"] = msgpack::object(clusters_vec, zone);
+
+  return msgpack::object(die_map, zone);
+}
+
+// Serialize SoC to msgpack object
+msgpack::object SerializeSoC(const SoC& soc, msgpack::zone& zone) {
+  std::map<std::string, msgpack::object> soc_map;
+
+  // Serialize die_counts map
+  std::vector<msgpack::object> dies_vec;
+  for (const auto& [die, count] : soc.GetDieCounts()) {
+    std::map<std::string, msgpack::object> entry;
+    entry["die"] = SerializeDie(die, zone);
+    entry["count"] = msgpack::object(count, zone);
+    dies_vec.emplace_back(msgpack::object(entry, zone));
+  }
+  soc_map["dies"] = msgpack::object(dies_vec, zone);
+
+  return msgpack::object(soc_map, zone);
+}
+
+// Serialize Backend to bytes
+std::vector<uint8_t> SerializeBackend(const Backend& backend) {
+  msgpack::sbuffer buffer;
+  msgpack::packer<msgpack::sbuffer> packer(buffer);
+
+  msgpack::zone zone;
+
+  // Create root object
+  std::map<std::string, msgpack::object> root;
+  root["type"] = msgpack::object(backend.GetTypeName(), zone);
+  root["soc"] = SerializeSoC(*backend.GetSoC(), zone);
+
+  // Serialize memory graph
+  std::vector<msgpack::object> mem_graph_vec;
+  for (const auto& [mem_space, neighbors] : backend.GetMemoryGraph()) {
+    std::map<std::string, msgpack::object> edge_entry;
+    edge_entry["from"] = msgpack::object(static_cast<int>(mem_space), zone);
+
+    std::vector<msgpack::object> neighbors_vec;
+    for (const auto& neighbor : neighbors) {
+      neighbors_vec.emplace_back(msgpack::object(static_cast<int>(neighbor), zone));
+    }
+    edge_entry["to"] = msgpack::object(neighbors_vec, zone);
+
+    mem_graph_vec.emplace_back(msgpack::object(edge_entry, zone));
+  }
+  root["mem_graph"] = msgpack::object(mem_graph_vec, zone);
+
+  packer.pack(msgpack::object(root, zone));
+
+  return std::vector<uint8_t>(buffer.data(), buffer.data() + buffer.size());
+}
+
+// ========== Deserialization Helpers ==========
+
+// Deserialize Mem from msgpack object
+Mem DeserializeMem(const msgpack::object& obj) {
+  auto mem_map = obj.as<std::map<std::string, msgpack::object>>();
+
+  auto mem_type = static_cast<ir::MemorySpace>(mem_map.at("mem_type").as<int>());
+  auto mem_size = mem_map.at("mem_size").as<uint64_t>();
+  auto alignment = mem_map.at("alignment").as<uint64_t>();
+
+  return Mem(mem_type, mem_size, alignment);
+}
+
+// Deserialize Core from msgpack object
+Core DeserializeCore(const msgpack::object& obj) {
+  auto core_map = obj.as<std::map<std::string, msgpack::object>>();
+
+  auto core_type = static_cast<ir::CoreType>(core_map.at("core_type").as<int>());
+
+  std::vector<Mem> mems;
+  auto mems_vec = core_map.at("mems").as<std::vector<msgpack::object>>();
+  for (const auto& mem_obj : mems_vec) {
+    mems.push_back(DeserializeMem(mem_obj));
+  }
+
+  return Core(core_type, std::move(mems));
+}
+
+// Deserialize Cluster from msgpack object
+std::shared_ptr<const Cluster> DeserializeCluster(const msgpack::object& obj) {
+  auto cluster_map = obj.as<std::map<std::string, msgpack::object>>();
+
+  std::map<Core, int> core_counts;
+  auto cores_vec = cluster_map.at("cores").as<std::vector<msgpack::object>>();
+  for (const auto& entry_obj : cores_vec) {
+    auto entry = entry_obj.as<std::map<std::string, msgpack::object>>();
+    auto core = DeserializeCore(entry.at("core"));
+    auto count = entry.at("count").as<int>();
+    core_counts[core] = count;
+  }
+
+  return std::make_shared<Cluster>(std::move(core_counts));
+}
+
+// Deserialize Die from msgpack object
+std::shared_ptr<const Die> DeserializeDie(const msgpack::object& obj) {
+  auto die_map = obj.as<std::map<std::string, msgpack::object>>();
+
+  std::map<Cluster, int> cluster_counts;
+  auto clusters_vec = die_map.at("clusters").as<std::vector<msgpack::object>>();
+  for (const auto& entry_obj : clusters_vec) {
+    auto entry = entry_obj.as<std::map<std::string, msgpack::object>>();
+    auto cluster = DeserializeCluster(entry.at("cluster"));
+    auto count = entry.at("count").as<int>();
+    cluster_counts[*cluster] = count;
+  }
+
+  return std::make_shared<Die>(std::move(cluster_counts));
+}
+
+// Deserialize SoC from msgpack object
+std::shared_ptr<const SoC> DeserializeSoC(const msgpack::object& obj) {
+  auto soc_map = obj.as<std::map<std::string, msgpack::object>>();
+
+  std::map<Die, int> die_counts;
+  auto dies_vec = soc_map.at("dies").as<std::vector<msgpack::object>>();
+  for (const auto& entry_obj : dies_vec) {
+    auto entry = entry_obj.as<std::map<std::string, msgpack::object>>();
+    auto die = DeserializeDie(entry.at("die"));
+    auto count = entry.at("count").as<int>();
+    die_counts[*die] = count;
+  }
+
+  return std::make_shared<SoC>(std::move(die_counts));
+}
+
+}  // namespace
+
+// ========== Backend Implementation ==========
+
+void Backend::ExportToFile(const std::string& path) const {
+  auto data = SerializeBackend(*this);
+  std::ofstream file(path, std::ios::binary);
+  CHECK(file) << "Failed to open file for writing: " + path;
+  file.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+  CHECK(file) << "Failed to write to file: " + path;
+}
+
+std::unique_ptr<Backend> Backend::ImportFromFile(const std::string& path) {
+  std::ifstream file(path, std::ios::binary);
+  CHECK(file.is_open()) << "Failed to open file for reading: " + path;
+
+  std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  CHECK(!file.fail()) << "Failed to read from file: " + path;
+
+  // Unpack msgpack data
+  msgpack::object_handle oh = msgpack::unpack(reinterpret_cast<const char*>(data.data()), data.size());
+  msgpack::object obj = oh.get();
+
+  auto root = obj.as<std::map<std::string, msgpack::object>>();
+  auto type_name = root.at("type").as<std::string>();
+  auto soc = DeserializeSoC(root.at("soc"));
+
+  // Deserialize memory graph
+  std::map<ir::MemorySpace, std::vector<ir::MemorySpace>> mem_graph;
+  auto mem_graph_vec = root.at("mem_graph").as<std::vector<msgpack::object>>();
+  for (const auto& edge_obj : mem_graph_vec) {
+    auto edge_entry = edge_obj.as<std::map<std::string, msgpack::object>>();
+    auto from = static_cast<ir::MemorySpace>(edge_entry.at("from").as<int>());
+
+    std::vector<ir::MemorySpace> neighbors;
+    auto neighbors_vec = edge_entry.at("to").as<std::vector<msgpack::object>>();
+    for (const auto& neighbor_obj : neighbors_vec) {
+      neighbors.push_back(static_cast<ir::MemorySpace>(neighbor_obj.as<int>()));
+    }
+
+    mem_graph[from] = neighbors;
+  }
+
+  // Use registry to create appropriate backend type
+  extern std::unique_ptr<Backend> CreateBackendFromRegistry(
+      const std::string& type_name, std::shared_ptr<const SoC> soc,
+      const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& mem_graph);
+  return CreateBackendFromRegistry(type_name, soc, mem_graph);
+}
+
+std::vector<ir::MemorySpace> Backend::FindMemPath(ir::MemorySpace from, ir::MemorySpace to) const {
+  if (from == to) {
+    return {from};
+  }
+
+  // BFS to find shortest path
+  std::queue<ir::MemorySpace> queue;
+  std::unordered_map<ir::MemorySpace, ir::MemorySpace> parent;
+  std::set<ir::MemorySpace> visited;
+
+  queue.push(from);
+  visited.insert(from);
+  parent[from] = from;  // Mark root
+
+  bool found = false;
+  while (!queue.empty() && !found) {
+    auto current = queue.front();
+    queue.pop();
+
+    auto it = mem_graph_.find(current);
+    if (it == mem_graph_.end()) {
+      continue;
+    }
+
+    for (auto neighbor : it->second) {
+      if (visited.find(neighbor) == visited.end()) {
+        visited.insert(neighbor);
+        parent[neighbor] = current;
+        queue.push(neighbor);
+
+        if (neighbor == to) {
+          found = true;
+          break;
+        }
+      }
+    }
+  }
+
+  CHECK(found) << "No path found from " << static_cast<int>(from) << " to " << static_cast<int>(to);
+
+  // Reconstruct path
+  std::vector<ir::MemorySpace> path;
+  ir::MemorySpace current = to;
+  while (current != from) {
+    path.push_back(current);
+    current = parent[current];
+  }
+  path.push_back(from);
+  std::reverse(path.begin(), path.end());
+
+  return path;
+}
+
+uint64_t Backend::GetMemSize(ir::MemorySpace mem_type) const {
+  // Find the first memory of the requested type and return its size
+  for (const auto& [die, die_count] : soc_->GetDieCounts()) {
+    for (const auto& [cluster, cluster_count] : die.GetClusterCounts()) {
+      for (const auto& [core, core_count] : cluster.GetCoreCounts()) {
+        for (const auto& mem : core.GetMems()) {
+          if (mem.GetMemType() == mem_type) {
+            return mem.GetMemSize();
+          }
+        }
+      }
+    }
+  }
+
+  // Memory type not found in SoC
+  return 0;
+}
+
+}  // namespace backend
+}  // namespace pypto

--- a/src/backend/backend_910b.cpp
+++ b/src/backend/backend_910b.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/backend/backend_910b.h"
+
+#include <memory>
+
+namespace pypto {
+namespace backend {
+
+Backend910B::Backend910B() : Backend() {
+  Core aic_core(ir::CoreType::CUBE, {
+                                        Mem(ir::MemorySpace::L1, 512ULL * 1024, 128),  // 512KB L1
+                                        Mem(ir::MemorySpace::L0A, 64ULL * 1024, 64),   // 64KB L0A
+                                        Mem(ir::MemorySpace::L0B, 64ULL * 1024, 64),   // 64KB L0B
+                                        Mem(ir::MemorySpace::L0C, 128ULL * 1024, 128)  // 128KB L0C
+                                    });
+
+  Core aiv_core(ir::CoreType::VECTOR, {
+                                          Mem(ir::MemorySpace::UB, 192ULL * 1024, 128),  // 192KB UB
+                                      });
+
+  Cluster aic_cluster(aic_core, 1);  // 1 core per cluster
+  Cluster aiv_cluster(aiv_core, 1);  // 1 core per cluster
+
+  Die die({{aic_cluster, 24}, {aiv_cluster, 48}});  // 24 AIC cores and 48 AIV cores per die
+  soc_ = std::make_shared<SoC>(die, 1);             // 1 die
+
+  mem_graph_[ir::MemorySpace::DDR] = {ir::MemorySpace::UB, ir::MemorySpace::L1};
+  mem_graph_[ir::MemorySpace::UB] = {ir::MemorySpace::DDR};
+  mem_graph_[ir::MemorySpace::L1] = {ir::MemorySpace::L0A, ir::MemorySpace::L0B};
+  mem_graph_[ir::MemorySpace::L0C] = {ir::MemorySpace::L1, ir::MemorySpace::DDR};
+}
+
+}  // namespace backend
+}  // namespace pypto

--- a/src/backend/backend_registry.cpp
+++ b/src/backend/backend_registry.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/backend/backend_registry.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/backend/backend_910b.h"
+#include "pypto/core/logging.h"
+
+namespace pypto {
+namespace backend {
+
+BackendRegistry& BackendRegistry::Instance() {
+  static BackendRegistry instance;
+  return instance;
+}
+
+void BackendRegistry::Register(const std::string& type_name, CreateFunc func) {
+  CHECK(registry_.find(type_name) == registry_.end()) << "Backend type already registered: " << type_name;
+  registry_[type_name] = func;
+}
+
+std::unique_ptr<Backend> BackendRegistry::Create(
+    const std::string& type_name, std::shared_ptr<const SoC> soc,
+    const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& mem_graph) {
+  auto it = registry_.find(type_name);
+  CHECK(it != registry_.end()) << "Unknown backend type: " << type_name;
+  return it->second(soc, mem_graph);
+}
+
+bool BackendRegistry::IsRegistered(const std::string& type_name) const {
+  return registry_.find(type_name) != registry_.end();
+}
+
+std::unique_ptr<Backend> CreateBackendFromRegistry(
+    const std::string& type_name, std::shared_ptr<const SoC> soc,
+    const std::map<ir::MemorySpace, std::vector<ir::MemorySpace>>& mem_graph) {
+  return BackendRegistry::Instance().Create(type_name, soc, mem_graph);
+}
+
+// Auto-register Backend910B
+namespace {
+bool RegisterBackend910B() {
+  BackendRegistry::Instance().Register(
+      "910B", [](std::shared_ptr<const SoC> /*unused*/,
+                 std::map<ir::MemorySpace, std::vector<ir::MemorySpace>> /*unused*/) {
+        // Backend910B creates its own SoC and memory hierarchy, ignore parameters
+        return std::make_unique<Backend910B>();
+      });
+  return true;
+}
+
+static bool backend_910b_registered = RegisterBackend910B();
+}  // namespace
+
+}  // namespace backend
+}  // namespace pypto

--- a/src/backend/soc.cpp
+++ b/src/backend/soc.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/backend/soc.h"
+
+#include <map>
+#include <numeric>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace pypto {
+namespace backend {
+
+// ========== Mem Implementation ==========
+
+Mem::Mem(ir::MemorySpace mem_type, uint64_t mem_size, uint64_t alignment)
+    : mem_type_(mem_type), mem_size_(mem_size), alignment_(alignment) {}
+
+bool Mem::operator<(const Mem& other) const {
+  return std::tie(mem_type_, mem_size_, alignment_) <
+         std::tie(other.mem_type_, other.mem_size_, other.alignment_);
+}
+
+bool Mem::operator==(const Mem& other) const {
+  return mem_type_ == other.mem_type_ && mem_size_ == other.mem_size_ && alignment_ == other.alignment_;
+}
+
+// ========== Core Implementation ==========
+
+Core::Core(ir::CoreType core_type, std::vector<Mem> mems) : core_type_(core_type), mems_(std::move(mems)) {}
+
+bool Core::operator<(const Core& other) const {
+  if (core_type_ != other.core_type_) {
+    return core_type_ < other.core_type_;
+  }
+  return mems_ < other.mems_;
+}
+
+bool Core::operator==(const Core& other) const {
+  return core_type_ == other.core_type_ && mems_ == other.mems_;
+}
+
+// ========== Cluster Implementation ==========
+
+Cluster::Cluster(std::map<Core, int> core_counts) : core_counts_(std::move(core_counts)) {}
+
+Cluster::Cluster(const Core& core, int count) : core_counts_({{core, count}}) {}
+
+int Cluster::TotalCoreCount() const {
+  return std::accumulate(core_counts_.begin(), core_counts_.end(), 0,
+                         [](int sum, const auto& pair) { return sum + pair.second; });
+}
+
+bool Cluster::operator<(const Cluster& other) const { return core_counts_ < other.core_counts_; }
+
+bool Cluster::operator==(const Cluster& other) const { return core_counts_ == other.core_counts_; }
+
+// ========== Die Implementation ==========
+
+Die::Die(std::map<Cluster, int> cluster_counts) : cluster_counts_(std::move(cluster_counts)) {}
+
+Die::Die(const Cluster& cluster, int count) : cluster_counts_({{cluster, count}}) {}
+
+int Die::TotalClusterCount() const {
+  return std::accumulate(cluster_counts_.begin(), cluster_counts_.end(), 0,
+                         [](int sum, const auto& pair) { return sum + pair.second; });
+}
+
+int Die::TotalCoreCount() const {
+  return std::accumulate(cluster_counts_.begin(), cluster_counts_.end(), 0, [](int sum, const auto& pair) {
+    return sum + pair.first.TotalCoreCount() * pair.second;
+  });
+}
+
+bool Die::operator<(const Die& other) const { return cluster_counts_ < other.cluster_counts_; }
+
+bool Die::operator==(const Die& other) const { return cluster_counts_ == other.cluster_counts_; }
+
+// ========== SoC Implementation ==========
+
+SoC::SoC(std::map<Die, int> die_counts) : die_counts_(std::move(die_counts)) {}
+
+SoC::SoC(const Die& die, int count) : die_counts_({{die, count}}) {}
+
+int SoC::TotalDieCount() const {
+  return std::accumulate(die_counts_.begin(), die_counts_.end(), 0,
+                         [](int sum, const auto& pair) { return sum + pair.second; });
+}
+
+int SoC::TotalClusterCount() const {
+  return std::accumulate(die_counts_.begin(), die_counts_.end(), 0, [](int sum, const auto& pair) {
+    return sum + pair.first.TotalClusterCount() * pair.second;
+  });
+}
+
+int SoC::TotalCoreCount() const {
+  return std::accumulate(die_counts_.begin(), die_counts_.end(), 0, [](int sum, const auto& pair) {
+    return sum + pair.first.TotalCoreCount() * pair.second;
+  });
+}
+
+}  // namespace backend
+}  // namespace pypto

--- a/tests/ut/backend/__init__.py
+++ b/tests/ut/backend/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Backend unit tests."""

--- a/tests/ut/backend/test_backend.py
+++ b/tests/ut/backend/test_backend.py
@@ -1,0 +1,117 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for Backend, SoC construction, and serialization."""
+
+from pypto import ir
+from pypto.backend import (
+    Cluster,
+    Core,
+    Die,
+    Mem,
+    SoC,
+)
+
+
+class TestSoCConstruction:
+    """Tests for direct SoC construction."""
+
+    def test_build_simple_core(self):
+        """Test building a simple core with direct construction."""
+        core = Core(
+            ir.CoreType.CUBE,
+            [
+                Mem(ir.MemorySpace.L0A, 512 * 1024, 64),
+                Mem(ir.MemorySpace.L0B, 512 * 1024, 64),
+            ],
+        )
+
+        assert core.core_type == ir.CoreType.CUBE
+        assert len(core.mems) == 2
+        assert core.mems[0].mem_size == 512 * 1024
+
+    def test_build_cluster_with_cores(self):
+        """Test building cluster with multiple cores."""
+        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.L1, 1024 * 1024, 128)])
+
+        cluster = Cluster(core, 4)  # 4 identical cores
+
+        assert cluster.total_core_count() == 4
+
+    def test_build_complete_soc_nested(self):
+        """Test building complete SoC with nested construction."""
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        cluster = Cluster(core, 2)
+        die = Die(cluster, 4)
+        soc = SoC(die, 1)
+
+        assert soc.total_die_count() == 1
+        assert soc.total_cluster_count() == 4
+        assert soc.total_core_count() == 8
+
+    def test_build_multi_die_soc(self):
+        """Test building SoC with multiple dies."""
+        # Build a die first
+        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.UB, 512 * 1024, 64)])
+        cluster = Cluster(core, 2)
+        die = Die(cluster, 2)
+
+        # Create SoC with 2 dies
+        soc = SoC(die, 2)
+
+        assert soc.total_die_count() == 2
+        assert soc.total_cluster_count() == 4
+        assert soc.total_core_count() == 8
+
+
+class TestSoCStructure:
+    """Tests for SoC structure and hierarchy."""
+
+    def test_mem_properties(self):
+        """Test Mem component properties."""
+        mem = Mem(ir.MemorySpace.L0C, 1024 * 1024, 256)
+
+        assert mem.mem_type == ir.MemorySpace.L0C
+        assert mem.mem_size == 1024 * 1024
+        assert mem.alignment == 256
+
+    def test_core_properties(self):
+        """Test Core properties."""
+        mems = [Mem(ir.MemorySpace.L0A, 512 * 1024, 64), Mem(ir.MemorySpace.L0B, 512 * 1024, 64)]
+        core = Core(ir.CoreType.CUBE, mems)
+
+        assert core.core_type == ir.CoreType.CUBE
+        assert len(core.mems) == 2
+
+    def test_cluster_convenience_constructor(self):
+        """Test Cluster convenience constructor."""
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        cluster = Cluster(core, 4)
+
+        assert cluster.total_core_count() == 4
+
+    def test_die_convenience_constructor(self):
+        """Test Die convenience constructor."""
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        cluster = Cluster(core, 2)
+        die = Die(cluster, 3)
+
+        assert die.total_cluster_count() == 3
+        assert die.total_core_count() == 6
+
+    def test_soc_convenience_constructor(self):
+        """Test SoC convenience constructor."""
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        cluster = Cluster(core, 2)
+        die = Die(cluster, 3)
+        soc = SoC(die, 2)
+
+        assert soc.total_die_count() == 2
+        assert soc.total_cluster_count() == 6
+        assert soc.total_core_count() == 12

--- a/tests/ut/backend/test_backend_910b.py
+++ b/tests/ut/backend/test_backend_910b.py
@@ -1,0 +1,173 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for Backend910B implementation."""
+
+import tempfile
+from pathlib import Path
+
+from pypto import ir
+from pypto.backend import Backend910B
+
+
+class TestBackend910BConstruction:
+    """Tests for 910B backend construction and basic properties."""
+
+    def test_backend_910b_construction(self):
+        """Test Backend910B constructs successfully with standard configuration."""
+        backend = Backend910B()
+
+        # Backend910B should construct successfully
+        assert backend is not None
+        assert backend.soc is not None
+
+    def test_soc_structure(self):
+        """Test SoC structure matches 910B specification."""
+        backend = Backend910B()
+        soc = backend.soc
+
+        # 910B has 1 die with 24 AIC cores + 48 AIV cores = 72 total cores
+        assert soc.total_die_count() == 1
+        assert soc.total_core_count() == 24 + 48
+
+
+class TestBackend910BMemoryPath:
+    """Tests for 910B backend memory path finding."""
+
+    def test_find_mem_paths(self):
+        """Test finding memory paths between different memory spaces."""
+        backend = Backend910B()
+
+        # Test cases: (from, to, expected_path)
+        test_cases = [
+            # DDR connections
+            (
+                ir.MemorySpace.DDR,
+                ir.MemorySpace.L0A,
+                [ir.MemorySpace.DDR, ir.MemorySpace.L1, ir.MemorySpace.L0A],
+            ),
+            (ir.MemorySpace.DDR, ir.MemorySpace.UB, [ir.MemorySpace.DDR, ir.MemorySpace.UB]),
+            # UB connections
+            (ir.MemorySpace.UB, ir.MemorySpace.DDR, [ir.MemorySpace.UB, ir.MemorySpace.DDR]),
+            # L1 connections
+            (ir.MemorySpace.L1, ir.MemorySpace.L0A, [ir.MemorySpace.L1, ir.MemorySpace.L0A]),
+            (ir.MemorySpace.L1, ir.MemorySpace.L0B, [ir.MemorySpace.L1, ir.MemorySpace.L0B]),
+            # L0C connections
+            (ir.MemorySpace.L0C, ir.MemorySpace.L1, [ir.MemorySpace.L0C, ir.MemorySpace.L1]),
+            (ir.MemorySpace.L0C, ir.MemorySpace.DDR, [ir.MemorySpace.L0C, ir.MemorySpace.DDR]),
+            # Same memory
+            (ir.MemorySpace.L1, ir.MemorySpace.L1, [ir.MemorySpace.L1]),
+        ]
+
+        for from_mem, to_mem, expected_path in test_cases:
+            path = backend.find_mem_path(from_mem, to_mem)
+            assert path == expected_path, (
+                f"Path from {from_mem} to {to_mem} should be {expected_path}, got {path}"
+            )
+
+
+class TestBackend910BMemorySize:
+    """Tests for 910B backend memory size calculation."""
+
+    def test_get_mem_sizes(self):
+        """Test getting memory sizes for different memory types."""
+        backend = Backend910B()
+
+        # Test cases: (memory_type, expected_size_in_KB)
+        test_cases = [
+            (ir.MemorySpace.L0A, 64),  # 64KB per AIC core
+            (ir.MemorySpace.L0B, 64),  # 64KB per AIC core
+            (ir.MemorySpace.L0C, 128),  # 128KB per AIC core
+            (ir.MemorySpace.L1, 512),  # 512KB per AIC core
+            (ir.MemorySpace.UB, 192),  # 192KB per AIV core
+            (ir.MemorySpace.DDR, 0),  # DDR not in core memory
+        ]
+
+        for mem_type, expected_kb in test_cases:
+            mem_size = backend.get_mem_size(mem_type)
+            expected_size = expected_kb * 1024
+            assert mem_size == expected_size, (
+                f"Memory size for {mem_type} should be {expected_kb}KB ({expected_size} bytes), "
+                f"got {mem_size} bytes"
+            )
+
+
+class TestBackend910BMemoryHierarchy:
+    """Tests for 910B memory hierarchy configuration."""
+
+    def test_memory_hierarchy_connections(self):
+        """Test memory hierarchy connections are correctly configured."""
+        backend = Backend910B()
+
+        # Test cases: (from, to, expected_path_length)
+        test_cases = [
+            # Direct connections (length 2)
+            (ir.MemorySpace.DDR, ir.MemorySpace.UB, 2),
+            (ir.MemorySpace.DDR, ir.MemorySpace.L1, 2),
+            (ir.MemorySpace.UB, ir.MemorySpace.DDR, 2),
+            (ir.MemorySpace.L1, ir.MemorySpace.L0A, 2),
+            (ir.MemorySpace.L1, ir.MemorySpace.L0B, 2),
+            (ir.MemorySpace.L0C, ir.MemorySpace.L1, 2),
+            (ir.MemorySpace.L0C, ir.MemorySpace.DDR, 2),
+        ]
+
+        for from_mem, to_mem, expected_len in test_cases:
+            path = backend.find_mem_path(from_mem, to_mem)
+            assert len(path) == expected_len, (
+                f"Path from {from_mem} to {to_mem} should have length {expected_len}, got {len(path)}: {path}"
+            )
+            assert path[0] == from_mem, f"Path should start with {from_mem}"
+            assert path[-1] == to_mem, f"Path should end with {to_mem}"
+
+
+class TestBackend910BSerialization:
+    """Tests for 910B backend serialization and deserialization."""
+
+    def test_export_import_backend(self):
+        """Test exporting and importing Backend910B."""
+        backend = Backend910B()
+
+        with tempfile.NamedTemporaryFile(suffix=".msgpack", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            # Export backend
+            backend.export_to_file(temp_path)
+
+            # Import backend
+            restored = Backend910B.import_from_file(temp_path)
+
+            # Verify structure is preserved
+            assert restored.soc.total_die_count() == 1
+            assert restored.soc.total_core_count() == 72
+
+            # Verify memory sizes are preserved (single mem size, not total)
+            assert restored.get_mem_size(ir.MemorySpace.L0A) == 64 * 1024
+            assert restored.get_mem_size(ir.MemorySpace.UB) == 192 * 1024
+        finally:
+            Path(temp_path).unlink()
+
+    def test_export_import_memory_hierarchy(self):
+        """Test that memory hierarchy is preserved after serialization."""
+        backend = Backend910B()
+
+        with tempfile.NamedTemporaryFile(suffix=".msgpack", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            backend.export_to_file(temp_path)
+            restored = Backend910B.import_from_file(temp_path)
+
+            # Verify memory paths work after deserialization
+            path = restored.find_mem_path(ir.MemorySpace.DDR, ir.MemorySpace.L0A)
+            assert len(path) == 3
+            assert path[0] == ir.MemorySpace.DDR
+            assert path[-1] == ir.MemorySpace.L0A
+        finally:
+            Path(temp_path).unlink()


### PR DESCRIPTION
Introduces a new backend module for hardware modeling with hierarchical SoC structure (Mem -> Core -> Cluster -> Die -> SoC). Implements 910B backend with memory graph for data movement planning.

Key features:
- Hierarchical SoC modeling with configurable memory/core layouts
- Backend registry pattern for extensible backend types
- Serialization/deserialization support via msgpack
- Memory path finding using BFS for data movement planning
- Python bindings with comprehensive type stubs
- Full test coverage for SoC hierarchy and 910B backend

Implementation follows project standards:
- [[nodiscard]] attributes on getter functions
- Explicit uint64_t literals for large constants
- emplace_back() for vector insertions
- Clean includes without unused headers
- Cross-layer consistency (C++, Python, type stubs, tests)