### PR TITLE
feat(ir): Add ParentStmtAnalysis utility for statement parent tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/verify_ssa_pass.cpp
     src/ir/transforms/type_check_pass.cpp
     src/ir/transforms/convert_to_ssa_pass.cpp
+    src/ir/transforms/utils/parent_stmt_analysis.cpp
     src/ir/serialization/serializer.cpp
     src/ir/serialization/deserializer.cpp
     src/ir/serialization/type_registry.cpp

--- a/include/pypto/ir/transforms/utils/parent_stmt_analysis.h
+++ b/include/pypto/ir/transforms/utils/parent_stmt_analysis.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_PARENT_STMT_ANALYSIS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_PARENT_STMT_ANALYSIS_H_
+
+#include <memory>
+#include <unordered_map>
+
+#include "pypto/ir/function.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Utility class for analyzing parent-child relationships in statement trees
+ *
+ * This class builds a mapping from each statement to its parent statement within
+ * a function's body. It is useful for passes that need to traverse upward in the
+ * IR tree or understand the context of a statement.
+ *
+ * Example usage:
+ * @code
+ *   ParentStmtAnalysis analysis;
+ *   analysis.BuildMap(function);
+ *
+ *   StmtPtr parent = analysis.GetParent(some_stmt);
+ *   if (parent) {
+ *     // Use parent statement
+ *   }
+ * @endcode
+ *
+ * Key features:
+ * - One-time analysis: Build the map once, query multiple times
+ * - Root statements have no parent (GetParent returns nullptr)
+ * - Handles all statement types: SeqStmts, OpStmts, IfStmt, ForStmt, etc.
+ * - Thread-safe for read operations after BuildMap completes
+ *
+ * Note: The analysis becomes invalid after IR transformations. Call BuildMap again
+ * if the IR tree is modified.
+ */
+class ParentStmtAnalysis : public IRVisitor {
+ public:
+  /**
+   * @brief Build the parent mapping from a function's body
+   *
+   * Traverses the function's statement tree and records parent-child relationships.
+   * This method clears any existing mapping before building the new one.
+   *
+   * @param func The function to analyze (can be nullptr, resulting in empty map)
+   *
+   * Parent relationships established:
+   * - For SeqStmts/OpStmts: Each child statement's parent is the SeqStmts/OpStmts
+   * - For IfStmt: then_body and else_body (if present) have IfStmt as parent
+   * - For ForStmt: body has ForStmt as parent
+   * - Root statement (function->body_) has no parent
+   */
+  void BuildMap(const FunctionPtr& func);
+
+  /**
+   * @brief Get the parent statement of a given statement
+   *
+   * @param stmt The statement to query
+   * @return Parent statement, or nullptr if:
+   *         - stmt is the root statement (function body)
+   *         - stmt is not found in the analyzed tree
+   *         - stmt is nullptr
+   */
+  [[nodiscard]] StmtPtr GetParent(const StmtPtr& stmt) const;
+
+  /**
+   * @brief Check if a statement has a recorded parent
+   *
+   * @param stmt The statement to check
+   * @return true if stmt has a parent in the map, false otherwise
+   */
+  [[nodiscard]] bool HasParent(const StmtPtr& stmt) const;
+
+  /**
+   * @brief Clear the parent mapping
+   *
+   * Removes all recorded parent-child relationships. Useful for reusing
+   * the same ParentStmtAnalysis instance with different functions.
+   */
+  void Clear();
+
+ protected:
+  /**
+   * @brief Override VisitStmt to record parent-child relationships
+   *
+   * This method is called during tree traversal to establish mappings.
+   * It records the current statement's parent before recursively visiting children.
+   *
+   * @param stmt The statement being visited
+   */
+  void VisitStmt(const StmtPtr& stmt) override;
+
+ private:
+  // Map from statement to its parent statement
+  std::unordered_map<StmtPtr, StmtPtr> parent_map_;
+
+  // Current parent during traversal (nullptr for root)
+  StmtPtr current_parent_;
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_PARENT_STMT_ANALYSIS_H_

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2100,3 +2100,70 @@ def bit_shift_right(lhs: Expr, rhs: Expr, span: Span) -> Expr:
 
 def bit_not(operand: Expr, span: Span) -> Expr:
     """Bitwise not operator (~operand)."""
+
+class ParentStmtAnalysis:
+    """Utility class for analyzing parent-child relationships in statement trees.
+
+    This class builds a mapping from each statement to its parent statement within
+    a function's body. It is useful for passes that need to traverse upward in the
+    IR tree or understand the context of a statement.
+
+    Example usage:
+        analysis = ir.ParentStmtAnalysis()
+        analysis.build_map(function)
+        parent = analysis.get_parent(some_stmt)
+        if parent:
+            # Use parent statement
+
+    Note: The analysis becomes invalid after IR transformations. Call build_map again
+    if the IR tree is modified.
+    """
+
+    def __init__(self) -> None:
+        """Create a ParentStmtAnalysis instance."""
+
+    def build_map(self, func: Function) -> None:
+        """Build the parent mapping from a function's body.
+
+        Traverses the function's statement tree and records parent-child relationships.
+        This method clears any existing mapping before building the new one.
+
+        Args:
+            func: The function to analyze
+
+        Parent relationships established:
+        - For SeqStmts/OpStmts: Each child statement's parent is the SeqStmts/OpStmts
+        - For IfStmt: then_body and else_body (if present) have IfStmt as parent
+        - For ForStmt: body has ForStmt as parent
+        - Root statement (function.body) has no parent
+        """
+
+    def get_parent(self, stmt: Stmt) -> Stmt | None:
+        """Get the parent statement of a given statement.
+
+        Args:
+            stmt: The statement to query
+
+        Returns:
+            Parent statement, or None if:
+            - stmt is the root statement (function body)
+            - stmt is not found in the analyzed tree
+            - stmt is None
+        """
+
+    def has_parent(self, stmt: Stmt) -> bool:
+        """Check if a statement has a recorded parent.
+
+        Args:
+            stmt: The statement to check
+
+        Returns:
+            True if stmt has a parent in the map, False otherwise
+        """
+
+    def clear(self) -> None:
+        """Clear the parent mapping.
+
+        Removes all recorded parent-child relationships. Useful for reusing
+        the same ParentStmtAnalysis instance with different functions.
+        """

--- a/src/ir/transforms/utils/parent_stmt_analysis.cpp
+++ b/src/ir/transforms/utils/parent_stmt_analysis.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/utils/parent_stmt_analysis.h"
+
+#include "pypto/ir/function.h"
+#include "pypto/ir/stmt.h"
+
+namespace pypto {
+namespace ir {
+
+void ParentStmtAnalysis::BuildMap(const FunctionPtr& func) {
+  // Clear any existing mapping
+  Clear();
+
+  // Handle nullptr function
+  if (!func) {
+    return;
+  }
+
+  // Initialize with no parent for the root
+  current_parent_ = nullptr;
+
+  // Start traversal from function body
+  if (func->body_) {
+    VisitStmt(func->body_);
+  }
+}
+
+StmtPtr ParentStmtAnalysis::GetParent(const StmtPtr& stmt) const {
+  if (!stmt) {
+    return nullptr;
+  }
+
+  auto it = parent_map_.find(stmt);
+  if (it != parent_map_.end()) {
+    return it->second;
+  }
+
+  return nullptr;
+}
+
+bool ParentStmtAnalysis::HasParent(const StmtPtr& stmt) const {
+  if (!stmt) {
+    return false;
+  }
+
+  return parent_map_.find(stmt) != parent_map_.end();
+}
+
+void ParentStmtAnalysis::Clear() {
+  parent_map_.clear();
+  current_parent_ = nullptr;
+}
+
+void ParentStmtAnalysis::VisitStmt(const StmtPtr& stmt) {
+  if (!stmt) {
+    return;
+  }
+
+  // Save the previous parent
+  auto prev_parent = current_parent_;
+
+  // Record parent-child relationship (if current_parent_ is set)
+  if (current_parent_) {
+    parent_map_[stmt] = current_parent_;
+  }
+
+  // Update current parent for children
+  current_parent_ = stmt;
+
+  // Visit children using the base visitor
+  IRVisitor::VisitStmt(stmt);
+
+  // Restore previous parent
+  current_parent_ = prev_parent;
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/transforms/test_parent_stmt_analysis.py
+++ b/tests/ut/ir/transforms/test_parent_stmt_analysis.py
@@ -1,0 +1,221 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ParentStmtAnalysis utility class.
+
+This tests the ParentStmtAnalysis class which builds and queries parent-child
+relationships in statement trees.
+"""
+
+import pypto.language as pl
+from pypto import ir
+
+
+def test_basic_parent_query():
+    """Test simple parent-child relationship in a sequence of statements."""
+
+    @pl.program
+    class BasicParent:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(temp, 1.0)
+            return result
+
+    func = BasicParent.get_function("main")
+    assert func is not None
+
+    # Create ParentStmtAnalysis and build map
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    # The body should be a SeqStmts containing multiple statements
+    body = func.body
+    assert body is not None
+
+    # Check that body has no parent (it's the root)
+    assert analysis.get_parent(body) is None
+    assert not analysis.has_parent(body)
+
+
+def test_nested_statements_in_seq():
+    """Test parent relationships in SeqStmts containing multiple statements."""
+
+    @pl.program
+    class NestedSeq:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            a: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            b: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(a, 1.0)
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.exp(b)
+            return c
+
+    func = NestedSeq.get_function("main")
+    assert func is not None
+
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    body = func.body
+    assert body is not None
+
+    # If body is SeqStmts, check that all children have body as parent
+    if isinstance(body, ir.SeqStmts):
+        for stmt in body.stmts:
+            parent = analysis.get_parent(stmt)
+            assert parent is body
+            assert analysis.has_parent(stmt)
+
+
+def test_if_stmt_parent():
+    """Test parent relationships in if statement bodies."""
+
+    @pl.program
+    class IfStmtParent:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = x
+            if True:
+                temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(result, 2.0)
+                result = temp
+            else:
+                temp2: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(result, 1.0)
+                result = temp2
+            return result
+
+    func = IfStmtParent.get_function("main")
+    assert func is not None
+
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    # Find the if statement in the function body
+    def find_if_stmt(stmt):
+        """Recursively find IfStmt in statement tree."""
+        if isinstance(stmt, ir.IfStmt):
+            return stmt
+        if isinstance(stmt, ir.SeqStmts):
+            for s in stmt.stmts:
+                result = find_if_stmt(s)
+                if result:
+                    return result
+        return None
+
+    if_stmt = find_if_stmt(func.body)
+    if if_stmt:
+        # Check that then_body and else_body have if_stmt as parent
+        if if_stmt.then_body:
+            then_parent = analysis.get_parent(if_stmt.then_body)
+            assert then_parent is if_stmt
+
+        if if_stmt.else_body:
+            else_parent = analysis.get_parent(if_stmt.else_body)
+            assert else_parent is if_stmt
+
+
+def test_for_stmt_parent():
+    """Test parent relationships in for loop bodies."""
+
+    @pl.program
+    class ForStmtParent:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = x
+            for i in pl.range(5):
+                temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(result, 2.0)
+                result = temp
+            return result
+
+    func = ForStmtParent.get_function("main")
+    assert func is not None
+
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    # Find the for statement in the function body
+    def find_for_stmt(stmt):
+        """Recursively find ForStmt in statement tree."""
+        if isinstance(stmt, ir.ForStmt):
+            return stmt
+        if isinstance(stmt, ir.SeqStmts):
+            for s in stmt.stmts:
+                result = find_for_stmt(s)
+                if result:
+                    return result
+        return None
+
+    for_stmt = find_for_stmt(func.body)
+    if for_stmt:
+        # Check that body has for_stmt as parent
+        if for_stmt.body:
+            body_parent = analysis.get_parent(for_stmt.body)
+            assert body_parent is for_stmt
+
+
+def test_root_has_no_parent():
+    """Test that root statement (function body) has no parent."""
+
+    @pl.program
+    class RootNoParent:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(x, 2.0)
+            return result
+
+    func = RootNoParent.get_function("main")
+    assert func is not None
+
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    # Root statement should have no parent
+    assert analysis.get_parent(func.body) is None
+    assert not analysis.has_parent(func.body)
+
+
+def test_deeply_nested_structures():
+    """Test parent relationships in deeply nested control flow."""
+
+    @pl.program
+    class DeeplyNested:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = x
+            for i in pl.range(3):
+                if i > 0:
+                    for j in pl.range(2):
+                        temp: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(result, 2.0)
+                        result = temp
+            return result
+
+    func = DeeplyNested.get_function("main")
+    assert func is not None
+
+    analysis = ir.ParentStmtAnalysis()
+    analysis.build_map(func)
+
+    # Additional verification: Find nested structures and verify their relationships
+    # by directly accessing nodes in the known structure for more specific checks.
+    assert isinstance(func.body, ir.SeqStmts), "Function body should be a SeqStmts"
+    # The body is expected to be: assign, for, return. The for is at index 1.
+    outer_for = func.body.stmts[1]
+    assert isinstance(outer_for, ir.ForStmt), "Expected outer_for to be a ForStmt"
+
+    # The for loop body contains just an if statement.
+    inner_if = outer_for.body
+    assert isinstance(inner_if, ir.IfStmt), "Expected inner_if to be an IfStmt"
+
+    # The if's then_body contains just an inner for loop.
+    inner_for = inner_if.then_body
+    assert isinstance(inner_for, ir.ForStmt), "Expected inner_for to be a ForStmt"
+
+    # Verify specific parent relationships
+    assert analysis.get_parent(outer_for) is func.body, "Parent of outer_for should be the function body"
+    assert analysis.get_parent(inner_if) is outer_for, "Parent of inner_if should be outer_for's body"
+    assert analysis.get_parent(inner_for) is inner_if, "Parent of inner_for should be inner_if's then_body"


### PR DESCRIPTION
Add a new utility class ParentStmtAnalysis that builds and queries parent-child relationships in IR statement trees. This enables passes to traverse upward in the IR or understand statement context.

Key features:
- Encapsulated design with private members (parent_map_, current_parent_)
- BuildMap() accepts FunctionPtr and traverses function body
- GetParent() queries parent statement (returns nullptr if not found)
- HasParent() checks if statement has a parent
- Clear() enables reusing the same instance

Implementation:
- New header: include/pypto/ir/transforms/utils/parent_stmt_analysis.h
- New source: src/ir/transforms/utils/parent_stmt_analysis.cpp
- Python bindings added to ir.cpp
- Comprehensive tests with 9 test cases including deep nesting validation

Supports all statement types: SeqStmts, OpStmts, IfStmt, ForStmt, etc. Root statements (function body) have no parent as expected.