### PR TITLE
feat(language): Add unified pl.op.* dispatch API

### DIFF
--- a/docs/dev/07-python_syntax.md
+++ b/docs/dev/07-python_syntax.md
@@ -123,9 +123,18 @@ max(a, b)       # Max
 ### Function/Op Calls
 
 ```python
-op_name(arg1, arg2)                      # Op call
-tensor_add(a, b, broadcast=True, axis=0) # Op with kwargs
-my_function(x, y)                        # Function call
+# Explicit namespace
+pl.op.tensor.add(a, b)                  # Tensor addition
+pl.op.block.load(t, 0, 0, 64, 64)      # Block load
+
+# Unified dispatch (auto-selects tensor/block based on input type)
+pl.op.add(a, b)                          # Tensor or Tile — dispatched automatically
+pl.op.mul(tile, 2.0)                     # Tile + scalar → block.muls
+pl.op.exp(tile)                          # Tile → block.exp
+
+# Promoted ops (single-module ops accessible at pl.op.*)
+pl.op.load(t, 0, 0, 64, 64)            # Promoted from block
+pl.op.create([64], dtype=pl.FP32)       # Promoted from tensor
 ```
 
 ## Statements

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -14,13 +14,108 @@ This module organizes language-level operations by category:
 - tensor: High-level tensor operations (TensorType)
 - block: Block-level tile operations (TileType)
 
-Operations accept and return Tensor/Tile types for type-safe DSL code.
+A unified namespace (``pl.op.add``, ``pl.op.exp``, ...) auto-dispatches
+between tensor and block paths based on the input type (Tensor vs Tile).
+The explicit ``pl.op.tensor.*`` and ``pl.op.block.*`` namespaces remain
+available for cases where the caller wants to be explicit.
 """
 
 from . import block_ops as block
 from . import tensor_ops as tensor
 
+# Promoted block-only ops (accessible as pl.op.load, etc.)
+from .block_ops import (
+    abs,
+    cmp,
+    cmps,
+    col_expand,
+    col_expand_div,
+    col_expand_mul,
+    col_expand_sub,
+    expands,
+    l0c_store,
+    load,
+    log,
+    matmul_acc,
+    minimum,
+    move,
+    neg,
+    recip,
+    relu,
+    row_expand_add,
+    row_expand_div,
+    row_expand_mul,
+    row_expand_sub,
+    row_min,
+    rsqrt,
+    sqrt,
+    store,
+)
+
+# Promoted tensor-only ops (accessible as pl.op.create, etc.)
+from .tensor_ops import assemble, create
+
+# Unified dispatch (overlapping ops)
+from .unified_ops import (
+    add,
+    cast,
+    div,
+    exp,
+    matmul,
+    maximum,
+    mul,
+    reshape,
+    row_max,
+    row_sum,
+    sub,
+    transpose,
+    view,
+)
+
 __all__ = [
     "block",
     "tensor",
+    # Unified dispatch
+    "add",
+    "sub",
+    "mul",
+    "div",
+    "maximum",
+    "exp",
+    "cast",
+    "reshape",
+    "transpose",
+    "view",
+    "matmul",
+    "row_max",
+    "row_sum",
+    # Promoted block-only
+    "load",
+    "store",
+    "l0c_store",
+    "move",
+    "neg",
+    "sqrt",
+    "rsqrt",
+    "recip",
+    "log",
+    "abs",
+    "relu",
+    "matmul_acc",
+    "minimum",
+    "cmp",
+    "cmps",
+    "row_min",
+    "row_expand_add",
+    "row_expand_sub",
+    "row_expand_mul",
+    "row_expand_div",
+    "col_expand",
+    "col_expand_mul",
+    "col_expand_div",
+    "col_expand_sub",
+    "expands",
+    # Promoted tensor-only
+    "create",
+    "assemble",
 ]

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -1,0 +1,280 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unified operation dispatch for PyPTO Language DSL.
+
+Provides type-dispatched wrappers that auto-select between tensor and block
+operations based on the input type (Tensor vs Tile). Users can write
+``pl.op.add(a, b)`` instead of explicitly choosing ``pl.op.tensor.add``
+or ``pl.op.block.add``.
+"""
+
+from typing import Literal, Optional, Union, overload
+
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import Expr
+
+from ..scalar import Scalar
+from ..tensor import Tensor
+from ..tile import Tile
+from . import block_ops as _block
+from . import tensor_ops as _tensor
+
+# ---------------------------------------------------------------------------
+# Binary arithmetic with scalar auto-dispatch
+# ---------------------------------------------------------------------------
+
+# --- add ---
+
+
+@overload
+def add(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor: ...
+@overload
+def add(lhs: Tile, rhs: Union[int, float, Tile, Scalar]) -> Tile: ...
+
+
+def add(lhs, rhs):  # noqa: F811
+    """Element-wise addition, dispatched by input type."""
+    if isinstance(lhs, Tensor):
+        return _tensor.add(lhs, rhs)
+    if isinstance(lhs, Tile):
+        if isinstance(rhs, (Tile,)):
+            return _block.add(lhs, rhs)
+        return _block.adds(lhs, rhs)
+    raise TypeError(f"add: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+# --- sub ---
+
+
+@overload
+def sub(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor: ...
+@overload
+def sub(lhs: Tile, rhs: Union[int, float, Tile, Scalar]) -> Tile: ...
+
+
+def sub(lhs, rhs):  # noqa: F811
+    """Element-wise subtraction, dispatched by input type."""
+    if isinstance(lhs, Tensor):
+        return _tensor.sub(lhs, rhs)
+    if isinstance(lhs, Tile):
+        if isinstance(rhs, (Tile,)):
+            return _block.sub(lhs, rhs)
+        return _block.subs(lhs, rhs)
+    raise TypeError(f"sub: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+# --- mul ---
+
+
+@overload
+def mul(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor: ...
+@overload
+def mul(lhs: Tile, rhs: Union[int, float, Tile, Scalar]) -> Tile: ...
+
+
+def mul(lhs, rhs):  # noqa: F811
+    """Element-wise multiplication, dispatched by input type."""
+    if isinstance(lhs, Tensor):
+        return _tensor.mul(lhs, rhs)
+    if isinstance(lhs, Tile):
+        if isinstance(rhs, (Tile,)):
+            return _block.mul(lhs, rhs)
+        return _block.muls(lhs, rhs)
+    raise TypeError(f"mul: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+# --- div ---
+
+
+@overload
+def div(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor: ...
+@overload
+def div(lhs: Tile, rhs: Union[int, float, Tile, Scalar]) -> Tile: ...
+
+
+def div(lhs, rhs):  # noqa: F811
+    """Element-wise division, dispatched by input type."""
+    if isinstance(lhs, Tensor):
+        return _tensor.div(lhs, rhs)
+    if isinstance(lhs, Tile):
+        if isinstance(rhs, (Tile,)):
+            return _block.div(lhs, rhs)
+        return _block.divs(lhs, rhs)
+    raise TypeError(f"div: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Simple overlapping ops (dispatch on first arg type)
+# ---------------------------------------------------------------------------
+
+
+@overload
+def maximum(lhs: Tensor, rhs: Tensor) -> Tensor: ...
+@overload
+def maximum(lhs: Tile, rhs: Tile) -> Tile: ...
+
+
+def maximum(lhs, rhs):  # noqa: F811
+    """Element-wise maximum, dispatched by input type."""
+    if isinstance(lhs, Tensor):
+        return _tensor.maximum(lhs, rhs)
+    if isinstance(lhs, Tile):
+        return _block.maximum(lhs, rhs)
+    raise TypeError(f"maximum: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+@overload
+def exp(input: Tensor) -> Tensor: ...
+@overload
+def exp(input: Tile) -> Tile: ...
+
+
+def exp(input):  # noqa: F811
+    """Element-wise exponential, dispatched by input type."""
+    if isinstance(input, Tensor):
+        return _tensor.exp(input)
+    if isinstance(input, Tile):
+        return _block.exp(input)
+    raise TypeError(f"exp: expected Tensor or Tile, got {type(input).__name__}")
+
+
+@overload
+def reshape(input: Tensor, shape: list[Union[int, Expr]]) -> Tensor: ...
+@overload
+def reshape(input: Tile, shape: list[Union[int, Expr]]) -> Tile: ...
+
+
+def reshape(input, shape):  # noqa: F811
+    """Reshape operation, dispatched by input type."""
+    if isinstance(input, Tensor):
+        return _tensor.reshape(input, shape)
+    if isinstance(input, Tile):
+        return _block.reshape(input, shape)
+    raise TypeError(f"reshape: expected Tensor or Tile, got {type(input).__name__}")
+
+
+@overload
+def transpose(input: Tensor, axis1: int, axis2: int) -> Tensor: ...
+@overload
+def transpose(input: Tile, axis1: int, axis2: int) -> Tile: ...
+
+
+def transpose(input, axis1, axis2):  # noqa: F811
+    """Transpose operation, dispatched by input type."""
+    if isinstance(input, Tensor):
+        return _tensor.transpose(input, axis1, axis2)
+    if isinstance(input, Tile):
+        return _block.transpose(input, axis1, axis2)
+    raise TypeError(f"transpose: expected Tensor or Tile, got {type(input).__name__}")
+
+
+@overload
+def view(input: Tensor, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> Tensor: ...
+@overload
+def view(input: Tile, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> Tile: ...
+
+
+def view(input, shape, offset):  # noqa: F811
+    """View/slice operation, dispatched by input type."""
+    if isinstance(input, Tensor):
+        return _tensor.view(input, shape, offset)
+    if isinstance(input, Tile):
+        return _block.view(input, shape, offset)
+    raise TypeError(f"view: expected Tensor or Tile, got {type(input).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Different-signature ops (accept superset of kwargs)
+# ---------------------------------------------------------------------------
+
+
+@overload
+def matmul(
+    lhs: Tensor,
+    rhs: Tensor,
+    out_dtype: Optional[Union[int, DataType]] = ...,
+    a_trans: bool = ...,
+    b_trans: bool = ...,
+    c_matrix_nz: bool = ...,
+) -> Tensor: ...
+@overload
+def matmul(lhs: Tile, rhs: Tile) -> Tile: ...
+
+
+def matmul(  # noqa: F811
+    lhs,
+    rhs,
+    out_dtype=None,
+    a_trans=False,
+    b_trans=False,
+    c_matrix_nz=False,
+):
+    """Matrix multiplication, dispatched by input type.
+
+    Tensor path accepts extra kwargs (out_dtype, a_trans, b_trans, c_matrix_nz).
+    Tile path ignores them.
+    """
+    if isinstance(lhs, Tensor):
+        return _tensor.matmul(lhs, rhs, out_dtype, a_trans, b_trans, c_matrix_nz)
+    if isinstance(lhs, Tile):
+        return _block.matmul(lhs, rhs)
+    raise TypeError(f"matmul: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
+
+
+@overload
+def row_max(input: Tensor, axis: int = ..., keep_dim: Union[int, bool] = ...) -> Tensor: ...
+@overload
+def row_max(input: Tile) -> Tile: ...
+
+
+def row_max(input, axis=-1, keep_dim=1):  # noqa: F811
+    """Row-wise max reduction, dispatched by input type.
+
+    Tensor path accepts axis and keep_dim kwargs.
+    Tile path ignores them.
+    """
+    if isinstance(input, Tensor):
+        return _tensor.row_max(input, axis, keep_dim)
+    if isinstance(input, Tile):
+        return _block.row_max(input)
+    raise TypeError(f"row_max: expected Tensor or Tile, got {type(input).__name__}")
+
+
+@overload
+def row_sum(input: Tensor, axis: int = ..., keep_dim: Union[int, bool] = ...) -> Tensor: ...
+@overload
+def row_sum(input: Tile) -> Tile: ...
+
+
+def row_sum(input, axis=-1, keep_dim=1):  # noqa: F811
+    """Row-wise sum reduction, dispatched by input type.
+
+    Tensor path accepts axis and keep_dim kwargs.
+    Tile path ignores them.
+    """
+    if isinstance(input, Tensor):
+        return _tensor.row_sum(input, axis, keep_dim)
+    if isinstance(input, Tile):
+        return _block.row_sum(input)
+    raise TypeError(f"row_sum: expected Tensor or Tile, got {type(input).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Tensor-only ops promoted to unified namespace
+# ---------------------------------------------------------------------------
+
+
+def cast(
+    input: Tensor,
+    target_type: Union[int, DataType],
+    mode: Literal["round", "floor", "ceil"] = "round",
+) -> Tensor:
+    """Type casting (tensor-only at language level)."""
+    return _tensor.cast(input, target_type, mode)

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1,0 +1,442 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for unified operation dispatch (pl.op.*).
+
+Each test builds two functions — one using the unified ``pl.op.X`` API and one
+using the explicit ``pl.op.tensor.X`` / ``pl.op.block.X`` API — then asserts
+they produce structurally equal IR.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.language.op import unified_ops
+from pypto.pypto_core import ir
+
+
+class TestUnifiedTensorDispatch:
+    """pl.op.X with Tensor args produces the same IR as pl.op.tensor.X."""
+
+    def test_add(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.add(a, b)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_sub(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.sub(a, b)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.sub(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_mul(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.mul(a, b)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.mul(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_div(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.div(a, b)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.div(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_maximum(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.maximum(a, b)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.maximum(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_exp(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.exp(a)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.exp(a)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_add_scalar(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.add(a, 5)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(a, 5)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_matmul(self):
+        @pl.function
+        def unified(
+            a: pl.Tensor[[64, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+        ) -> pl.Tensor[[64, 64], pl.FP16]:
+            c: pl.Tensor[[64, 64], pl.FP16] = pl.op.matmul(a, b)
+            return c
+
+        @pl.function
+        def explicit(
+            a: pl.Tensor[[64, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+        ) -> pl.Tensor[[64, 64], pl.FP16]:
+            c: pl.Tensor[[64, 64], pl.FP16] = pl.op.tensor.matmul(a, b)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_row_max(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 1], pl.FP32]:
+            c: pl.Tensor[[64, 1], pl.FP32] = pl.op.row_max(a)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 1], pl.FP32]:
+            c: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.row_max(a)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_row_sum(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 1], pl.FP32]:
+            c: pl.Tensor[[64, 1], pl.FP32] = pl.op.row_sum(a)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 1], pl.FP32]:
+            c: pl.Tensor[[64, 1], pl.FP32] = pl.op.tensor.row_sum(a)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_reshape(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[128, 64], pl.FP32]:
+            c: pl.Tensor[[128, 64], pl.FP32] = pl.op.reshape(a, [128, 64])
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[128, 64], pl.FP32]:
+            c: pl.Tensor[[128, 64], pl.FP32] = pl.op.tensor.reshape(a, [128, 64])
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+
+class TestUnifiedBlockDispatch:
+    """pl.op.X with Tile args produces the same IR as pl.op.block.X."""
+
+    def test_add(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP32] = pl.op.add(a, b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP32] = pl.op.block.add(a, b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_sub(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP32] = pl.op.sub(a, b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP32] = pl.op.block.sub(a, b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_exp(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.exp(a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.exp(a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_matmul(self):
+        @pl.function
+        def unified(
+            t1: pl.Tensor[[64, 64], pl.FP16],
+            t2: pl.Tensor[[64, 64], pl.FP16],
+            out: pl.Tensor[[64, 64], pl.FP16],
+        ) -> pl.Tensor[[64, 64], pl.FP16]:
+            a: pl.Tile[[64, 64], pl.FP16] = pl.op.block.load(t1, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP16] = pl.op.block.load(t2, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP16] = pl.op.matmul(a, b)
+            result: pl.Tensor[[64, 64], pl.FP16] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t1: pl.Tensor[[64, 64], pl.FP16],
+            t2: pl.Tensor[[64, 64], pl.FP16],
+            out: pl.Tensor[[64, 64], pl.FP16],
+        ) -> pl.Tensor[[64, 64], pl.FP16]:
+            a: pl.Tile[[64, 64], pl.FP16] = pl.op.block.load(t1, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP16] = pl.op.block.load(t2, 0, 0, 64, 64)
+            c: pl.Tile[[64, 64], pl.FP16] = pl.op.block.matmul(a, b)
+            result: pl.Tensor[[64, 64], pl.FP16] = pl.op.block.store(c, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_row_sum(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 1], pl.FP32] = pl.op.row_sum(a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 1, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 1], pl.FP32] = pl.op.block.row_sum(a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 1, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+
+class TestScalarAutoDispatch:
+    """pl.op.add(Tile, scalar) produces the same IR as pl.op.block.adds."""
+
+    def test_add_tile_scalar(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.add(a, 5)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.adds(a, 5)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_mul_tile_scalar(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.mul(a, 3.14)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.muls(a, 3.14)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_sub_tile_scalar(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.sub(a, 2)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.subs(a, 2)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_div_tile_scalar(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.div(a, 4)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.op.block.divs(a, 4)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(b, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+
+class TestPromotedOps:
+    """Promoted single-module ops produce the same IR as their explicit form."""
+
+    def test_promoted_create(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.create([64], dtype=pl.FP32)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            c: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_promoted_load_store(self):
+        @pl.function
+        def unified(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.load(t, 0, 0, 64, 64)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.store(a, 0, 0, 64, 64, out)
+            return result
+
+        @pl.function
+        def explicit(
+            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.op.block.load(t, 0, 0, 64, 64)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.op.block.store(a, 0, 0, 64, 64, out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
+
+class TestUnifiedOpsTypeErrors:
+    """Passing invalid types to unified_ops raises TypeError."""
+
+    def test_add_invalid_lhs(self):
+        with pytest.raises(TypeError, match="expected Tensor or Tile"):
+            unified_ops.add("not_a_tensor", 1)  # type: ignore
+
+    def test_mul_invalid_lhs(self):
+        with pytest.raises(TypeError, match="expected Tensor or Tile"):
+            unified_ops.mul(42, 2)  # type: ignore
+
+    def test_exp_invalid_input(self):
+        with pytest.raises(TypeError, match="expected Tensor or Tile"):
+            unified_ops.exp("bad")  # type: ignore
+
+    def test_reshape_invalid_input(self):
+        with pytest.raises(TypeError, match="expected Tensor or Tile"):
+            unified_ops.reshape(123, [4, 4])  # type: ignore
+
+    def test_matmul_invalid_lhs(self):
+        with pytest.raises(TypeError, match="expected Tensor or Tile"):
+            unified_ops.matmul(1, 2)  # type: ignore
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add a unified `pl.op.*` namespace that auto-dispatches between tensor and block operations based on the first argument's type (`Tensor` vs `Tile`), eliminating the need to explicitly choose `pl.op.tensor.*` or `pl.op.block.*`.

### Key changes

- **`unified_ops.py`** — Dispatch functions for 13 overlapping ops (`add`, `sub`, `mul`, `div`, `maximum`, `exp`, `reshape`, `view`, `matmul`, `row_max`, `row_sum`, `cast`, `reshape`). Binary arithmetic ops auto-select scalar block variants (`adds`/`subs`/`muls`/`divs`) when the Tile rhs is a scalar.
- **`op/__init__.py`** — Exports unified dispatch functions and promotes block-only ops (`load`, `store`, `neg`, `sqrt`, etc.) and tensor-only ops (`create`, `assemble`) to `pl.op.*`.
- **`ast_parser.py`** — Supports 3-segment `pl.op.X` chains alongside existing 4-segment `pl.op.tensor.X` / `pl.op.block.X`. Refactors shared kwarg parsing into `_parse_op_kwargs` (DRY).
- **Tests** — 27 tests using `ir.assert_structural_equal` to verify unified and explicit paths produce identical IR.
- **Docs** — Updated `06-operator_organization.md` and `07-python_syntax.md`.

### Before / After

\`\`\`python
# Before: must choose namespace explicitly
tile_c = pl.op.block.add(tile_a, tile_b)
tile_d = pl.op.block.muls(tile_c, 2.0)
tensor_c = pl.op.tensor.add(tensor_a, tensor_b)

# After: unified dispatch (explicit namespaces still work)
tile_c = pl.op.add(tile_a, tile_b)       # → block.add
tile_d = pl.op.mul(tile_c, 2.0)          # → block.muls (scalar auto-dispatch)
tensor_c = pl.op.add(tensor_a, tensor_b) # → tensor.add
\`\`\`

### Scope

Language module only (\`python/pypto/language/\`). IR-level ops and C++ backend are unchanged.

## Testing

- [x] All 1110 tests pass
- [x] Code review completed
- [x] Pre-commit hooks pass (ruff, pyright, headers)
- [x] Documentation updated