### PR TITLE
feat(ir): Change get_block_idx return type to UINT64 and add flatten tests

### DIFF
--- a/python/pypto/ir/op/block_ops.py
+++ b/python/pypto/ir/op/block_ops.py
@@ -169,6 +169,28 @@ def move(
     return _ir_core.create_op_call("block.move", args, kwargs, actual_span)
 
 
+def get_block_idx(span: Optional[Span] = None) -> Call:
+    """Get the current block index.
+
+    This operation returns the index of the current compute block. It is typically
+    used in block-level programming to identify which block of data is being processed.
+
+    Args:
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns a UINT64 scalar representing the block index
+
+    Example:
+        >>> block_idx = pl.op.block.get_block_idx()
+        >>> if block_idx < 10:
+        >>>     # Process first 10 blocks differently
+        >>>     ...
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("block.get_block_idx", [], {}, actual_span)
+
+
 def zeros(
     shape: Sequence[Union[int, Expr]],
     dtype: DataType,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -56,6 +56,7 @@ class PassManager:
         cls._strategy_passes = {
             OptimizationStrategy.Default: [
                 ("ConvertToSSA", lambda: passes.convert_to_ssa()),
+                ("FlattenCallExpr", lambda: passes.flatten_call_expr()),
                 ("RunVerifier", lambda: passes.run_verifier()),
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -115,6 +115,25 @@ def move(tile: Tile, target_memory: int, transpose: bool = False) -> Tile:
     return Tile(expr=call_expr)
 
 
+def get_block_idx() -> Scalar:
+    """Get the current block index.
+
+    This operation returns the index of the current compute block. It is typically
+    used in block-level programming to identify which block of data is being processed.
+
+    Returns:
+        Scalar wrapping the get_block_idx operation (UINT64 type)
+
+    Example:
+        >>> block_idx = pl.op.block.get_block_idx()
+        >>> if block_idx < 10:
+        >>>     # Process first 10 blocks differently
+        >>>     ...
+    """
+    call_expr = _ir_ops.get_block_idx()
+    return Scalar(expr=call_expr)
+
+
 def add(lhs: Tile, rhs: Tile) -> Tile:
     """Element-wise addition of two tiles.
 

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -58,8 +58,8 @@ TypePtr DeduceBlockGetBlockIdxType(const std::vector<ExprPtr>& args,
                                    const std::string& op_name) {
   CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
 
-  // get_block_idx returns INT32 scalar
-  return std::make_shared<ScalarType>(DataType::INT32);
+  // get_block_idx returns UINT64 scalar
+  return std::make_shared<ScalarType>(DataType::UINT64);
 }
 
 TypePtr DeduceBlockLoadType(const std::vector<ExprPtr>& args,


### PR DESCRIPTION
Change get_block_idx operator to return UINT64 instead of INT32 for better support of large block indices. Add Python API wrapper and test cases for flatten_call_expr pass with get_block_idx in control flow.

Changes:
- Change DeduceBlockGetBlockIdxType to return UINT64 scalar type
- Add get_block_idx Python API wrapper in block_ops.py
- Add test for get_block_idx in if condition expressions
- Add test for get_block_idx in for range expressions