### PR TITLE
feat(ir): Add ForKind enum for parallel for loop support

### DIFF
--- a/docs/dev/01-ir_hierarchy.md
+++ b/docs/dev/01-ir_hierarchy.md
@@ -126,7 +126,7 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 |-----------|--------|-------------|
 | **AssignStmt** | `var_` (DefField), `value_` (UsualField) | Variable assignment |
 | **IfStmt** | `condition_`, `then_stmts_`, `else_stmts_`, `return_vars_` | Conditional branching |
-| **ForStmt** | `loop_var_` (DefField), `start_`, `stop_`, `step_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField) | For loop with optional iteration args |
+| **ForStmt** | `loop_var_` (DefField), `start_`, `stop_`, `step_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField), `kind_` | For loop with optional iteration args |
 | **YieldStmt** | `values_` | Yield values in loop iteration |
 | **EvalStmt** | `expr_` | Evaluate expression for side effects |
 | **SeqStmts** | `stmts_` | General statement sequence |
@@ -147,6 +147,14 @@ for_stmt = ir.ForStmt(i, start, stop, step, [], body, [], span)
 # sum_final = sum
 for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 ```
+
+**Parallel for loop (ForKind):**
+```python
+# for i in pl.parallel(0, 10, 1): ...
+for_stmt = ir.ForStmt(i, start, stop, step, [], body, [], span, ir.ForKind.Parallel)
+```
+
+The `kind_` field (`ForKind` enum) distinguishes sequential (`ForKind.Sequential`, default) from parallel (`ForKind.Parallel`) loops. In the DSL, `pl.range()` produces sequential and `pl.parallel()` produces parallel loops. The printer emits `pl.parallel(...)` for parallel kind.
 
 **Requirements:**
 - Number of yielded values = number of IterArgs

--- a/docs/dev/07-python_syntax.md
+++ b/docs/dev/07-python_syntax.md
@@ -180,9 +180,13 @@ sum_init: pl.INT64 = 0
 for i, (sum,) in pl.range(0, n, 1, init_values=[sum_init]):
     sum = pl.yield_(sum + i)
 sum_final = sum
+
+# Parallel for loop
+for i in pl.parallel(start, stop, step):
+    body_statements
 ```
 
-**Key points:** Loop-carried values use `pl.range()` with `init_values`, tuple unpacking `(sum,)` declares iter_args, `pl.yield_()` updates values for next iteration, after loop iter_args contain final values.
+**Key points:** Loop-carried values use `pl.range()` or `pl.parallel()` with `init_values`, tuple unpacking `(sum,)` declares iter_args, `pl.yield_()` updates values for next iteration, after loop iter_args contain final values. `pl.parallel()` produces a `ForKind.Parallel` loop while `pl.range()` produces `ForKind.Sequential` (default).
 
 ### Yield Statement
 

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -131,10 +131,11 @@ class IRBuilder {
    * @param stop Stop value expression
    * @param step Step value expression
    * @param span Source location for loop definition
+   * @param kind Loop kind (Sequential or Parallel, default: Sequential)
    * @throws RuntimeError if not inside a function or another loop
    */
   void BeginForLoop(const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop, const ExprPtr& step,
-                    const Span& span);
+                    const Span& span, ForKind kind = ForKind::Sequential);
 
   /**
    * @brief Add an iteration argument to the current for loop
@@ -450,12 +451,14 @@ class FunctionContext : public BuildContext {
  */
 class ForLoopContext : public BuildContext {
  public:
-  ForLoopContext(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, Span span)
+  ForLoopContext(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, Span span,
+                 ForKind kind = ForKind::Sequential)
       : BuildContext(Type::FOR_LOOP, std::move(span)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
         stop_(std::move(stop)),
-        step_(std::move(step)) {}
+        step_(std::move(step)),
+        kind_(kind) {}
 
   void AddIterArg(const IterArgPtr& iter_arg) { iter_args_.push_back(iter_arg); }
   void AddReturnVar(const VarPtr& var) { return_vars_.push_back(var); }
@@ -467,12 +470,14 @@ class ForLoopContext : public BuildContext {
   [[nodiscard]] const ExprPtr& GetStep() const { return step_; }
   [[nodiscard]] const std::vector<IterArgPtr>& GetIterArgs() const { return iter_args_; }
   [[nodiscard]] const std::vector<VarPtr>& GetReturnVars() const { return return_vars_; }
+  [[nodiscard]] ForKind GetKind() const { return kind_; }
 
  private:
   VarPtr loop_var_;
   ExprPtr start_;
   ExprPtr stop_;
   ExprPtr step_;
+  ForKind kind_;
   std::vector<IterArgPtr> iter_args_;
   std::vector<VarPtr> return_vars_;
 };

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -54,9 +54,8 @@ inline std::string FunctionTypeToString(FunctionType type) {
       return "Orchestration";
     case FunctionType::InCore:
       return "InCore";
-    default:
-      return "Unknown";
   }
+  throw pypto::TypeError("Unknown FunctionType");
 }
 
 /**

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -610,14 +610,21 @@ void BindIR(nb::module_& m) {
   return_stmt_class.def(nb::init<const Span&>(), nb::arg("span"), "Create a return statement without values");
   BindFields<ReturnStmt>(return_stmt_class);
 
+  // ForKind enum (must be before ForStmt which uses it)
+  nb::enum_<ForKind>(ir, "ForKind", "For loop kind classification")
+      .value("Sequential", ForKind::Sequential, "Standard sequential for loop (default)")
+      .value("Parallel", ForKind::Parallel, "Parallel for loop")
+      .export_values();
+
   // ForStmt - const shared_ptr
   auto for_stmt_class = nb::class_<ForStmt, Stmt>(
       ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
   for_stmt_class.def(
       nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&, const std::vector<IterArgPtr>&,
-               const StmtPtr&, const std::vector<VarPtr>&, const Span&>(),
+               const StmtPtr&, const std::vector<VarPtr>&, const Span&, ForKind>(),
       nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("iter_args"),
-      nb::arg("body"), nb::arg("return_vars"), nb::arg("span"), "Create a for loop statement");
+      nb::arg("body"), nb::arg("return_vars"), nb::arg("span"), nb::arg("kind") = ForKind::Sequential,
+      "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);
 
   // SeqStmts - const shared_ptr

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -88,7 +88,7 @@ void BindIRBuilder(nb::module_& m) {
 
       // For loop building
       .def("begin_for_loop", &IRBuilder::BeginForLoop, nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"),
-           nb::arg("step"), nb::arg("span"),
+           nb::arg("step"), nb::arg("span"), nb::arg("kind") = ForKind::Sequential,
            "Begin building a for loop.\n\n"
            "Creates a new for loop context. Must be closed with end_for_loop().\n\n"
            "Args:\n"
@@ -96,7 +96,8 @@ void BindIRBuilder(nb::module_& m) {
            "    start: Start value expression\n"
            "    stop: Stop value expression\n"
            "    step: Step value expression\n"
-           "    span: Source location for loop definition\n\n"
+           "    span: Source location for loop definition\n"
+           "    kind: Loop kind (Sequential or Parallel, default: Sequential)\n\n"
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -96,6 +96,7 @@ class IRBuilder:
         stop: Union[int, ir.Expr],
         step: Union[int, ir.Expr],
         span: Optional[ir.Span] = None,
+        kind: ir.ForKind = ir.ForKind.Sequential,
     ) -> Iterator["ForLoopBuilder"]:
         """Context manager for building for loops.
 
@@ -105,6 +106,7 @@ class IRBuilder:
             stop: Stop value (int or Expr)
             step: Step value (int or Expr)
             span: Optional explicit span. If None, automatically captured.
+            kind: Loop kind (default: Sequential)
 
         Yields:
             ForLoopBuilder: Helper object for building the loop
@@ -123,7 +125,7 @@ class IRBuilder:
         stop_expr = _normalize_expr(stop, begin_span)
         step_expr = _normalize_expr(step, begin_span)
 
-        self._builder.begin_for_loop(loop_var, start_expr, stop_expr, step_expr, begin_span)
+        self._builder.begin_for_loop(loop_var, start_expr, stop_expr, step_expr, begin_span, kind)
         builder_obj = ForLoopBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -39,10 +39,10 @@ Typical usage:
 
 # Import decorators and parsing functions from local parser module
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import FunctionType
+from pypto.pypto_core.ir import ForKind, FunctionType
 
 from . import op, parser
-from .dsl_api import range, yield_
+from .dsl_api import parallel, range, yield_
 from .parser.decorator import function, program
 from .parser.text_parser import load, load_program, parse, parse_program
 from .scalar import Scalar
@@ -82,9 +82,11 @@ __all__ = [
     "Tile",
     "Scalar",
     "range",
+    "parallel",
     "yield_",
     "op",
     "FunctionType",
+    "ForKind",
     "FP4",
     "FP8E4M3FN",
     "FP8E5M2",

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -477,6 +477,20 @@ class FunctionType(enum.Enum):
     InCore = ...
     """AICore sub-graph execution."""
 
+class ForKind(enum.Enum):
+    """For loop kind classification.
+
+    Distinguishes sequential vs parallel for loops:
+    - Sequential: Standard sequential for loop (default)
+    - Parallel: Parallel for loop
+    """
+
+    Sequential = ...
+    """Standard sequential for loop (default)."""
+
+    Parallel = ...
+    """Parallel for loop."""
+
 class MemorySpace(enum.Enum):
     """Memory space enumeration."""
 
@@ -1271,6 +1285,9 @@ class ForStmt(Stmt):
     return_vars: Final[list[Var]]
     """Return variables (can be empty)."""
 
+    kind: Final[ForKind]
+    """Loop kind (Sequential or Parallel)."""
+
     def __init__(
         self,
         loop_var: Var,
@@ -1281,6 +1298,7 @@ class ForStmt(Stmt):
         body: Stmt,
         return_vars: list[Var],
         span: Span,
+        kind: ForKind = ForKind.Sequential,
     ) -> None:
         """Create a for loop statement.
 
@@ -1289,9 +1307,11 @@ class ForStmt(Stmt):
             start: Start value expression
             stop: Stop value expression
             step: Step value expression
+            iter_args: Iteration arguments (can be empty)
             body: Loop body statements
             return_vars: Return variables (can be empty)
             span: Source location
+            kind: Loop kind (default: Sequential)
         """
 
 class SeqStmts(Stmt):
@@ -1775,7 +1795,15 @@ class IRBuilder:
         """
 
     # For loop building
-    def begin_for_loop(self, loop_var: Var, start: Expr, stop: Expr, step: Expr, span: Span) -> None:
+    def begin_for_loop(
+        self,
+        loop_var: Var,
+        start: Expr,
+        stop: Expr,
+        step: Expr,
+        span: Span,
+        kind: ForKind = ForKind.Sequential,
+    ) -> None:
         """Begin building a for loop.
 
         Args:
@@ -1784,6 +1812,7 @@ class IRBuilder:
             stop: Stop value expression
             step: Step value expression
             span: Source location for loop definition
+            kind: Loop kind (default: Sequential)
         """
 
     def add_iter_arg(self, iter_arg: IterArg) -> None:

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -89,13 +89,13 @@ FunctionPtr IRBuilder::EndFunction(const Span& end_span) {
 // ========== For Loop Building ==========
 
 void IRBuilder::BeginForLoop(const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop,
-                             const ExprPtr& step, const Span& span) {
+                             const ExprPtr& step, const Span& span, ForKind kind) {
   if (context_stack_.empty()) {
     throw pypto::RuntimeError("Cannot begin for loop: not inside a function or another valid context at " +
                               span.to_string());
   }
 
-  context_stack_.push_back(std::make_unique<ForLoopContext>(loop_var, start, stop, step, span));
+  context_stack_.push_back(std::make_unique<ForLoopContext>(loop_var, start, stop, step, span, kind));
 }
 
 void IRBuilder::AddIterArg(const IterArgPtr& iter_arg) {
@@ -143,7 +143,7 @@ StmtPtr IRBuilder::EndForLoop(const Span& end_span) {
   // Create for statement
   auto for_stmt = std::make_shared<ForStmt>(loop_ctx->GetLoopVar(), loop_ctx->GetStart(), loop_ctx->GetStop(),
                                             loop_ctx->GetStep(), loop_ctx->GetIterArgs(), body,
-                                            loop_ctx->GetReturnVars(), combined_span);
+                                            loop_ctx->GetReturnVars(), combined_span, loop_ctx->GetKind());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -78,6 +78,7 @@ class FieldSerializerVisitor {
   result_type VisitLeafField(const std::string& field);
   result_type VisitLeafField(const DataType& field);
   result_type VisitLeafField(const FunctionType& field);
+  result_type VisitLeafField(const ForKind& field);
   result_type VisitLeafField(const TypePtr& field);
   result_type VisitLeafField(const OpPtr& field);
   result_type VisitLeafField(const Span& field);
@@ -415,6 +416,10 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(const DataType& field) {
 }
 
 msgpack::object FieldSerializerVisitor::VisitLeafField(const FunctionType& field) {
+  return msgpack::object(static_cast<uint8_t>(field), zone_);
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const ForKind& field) {
   return msgpack::object(static_cast<uint8_t>(field), zone_);
 }
 

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -387,7 +387,14 @@ static IRNodePtr DeserializeForStmt(const msgpack::object& fields_obj, msgpack::
     }
   }
 
-  return std::make_shared<ForStmt>(loop_var, start, stop, step, iter_args, body, return_vars, span);
+  // Deserialize kind with backward compatibility (defaults to Sequential)
+  ForKind kind = ForKind::Sequential;
+  auto kind_obj = GetOptionalFieldObj(fields_obj, "kind", ctx);
+  if (kind_obj.has_value()) {
+    kind = static_cast<ForKind>(kind_obj->via.u64);
+  }
+
+  return std::make_shared<ForStmt>(loop_var, start, stop, step, iter_args, body, return_vars, span, kind);
 }
 
 // Deserialize SeqStmts

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -432,7 +432,7 @@ class SSAConverter : public IRMutator {
     }
 
     return std::make_shared<ForStmt>(new_loop_var, new_start, new_stop, new_step, new_iter_args, final_body,
-                                     return_vars, op->span_);
+                                     return_vars, op->span_, op->kind_);
   }
 
  private:

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -294,7 +294,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ForStmtPtr& op) {
   pending_stmts_ = range_pending;
 
   return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                   op->return_vars_, op->span_);
+                                   op->return_vars_, op->span_, op->kind_);
 }
 
 // Expression visitors implementation

--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -761,7 +761,7 @@ class SyncInserter : public IRMutator {
     new_body = AppendSyncsToBody(new_body, sync_stmts);
 
     return std::make_shared<const ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                           new_body, op->return_vars_, op->span_);
+                                           new_body, op->return_vars_, op->span_, op->kind_);
   }
 };
 

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -379,7 +379,7 @@ StmtPtr IRMutator::VisitStmt_(const ForStmtPtr& op) {
       body_changed || return_vars_changed) {
     return std::make_shared<const ForStmt>(std::move(new_loop_var), std::move(new_start), std::move(new_stop),
                                            std::move(new_step), std::move(new_iter_args), std::move(new_body),
-                                           std::move(new_return_vars), op->span_);
+                                           std::move(new_return_vars), op->span_, op->kind_);
   } else {
     return op;
   }

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -295,6 +295,18 @@ class StructuralEqualImpl {
     return true;
   }
 
+  result_type VisitLeafField(const ForKind& lhs, const ForKind& rhs) {
+    if (lhs != rhs) {
+      if constexpr (AssertMode) {
+        std::ostringstream msg;
+        msg << "ForKind mismatch (" << ForKindToString(lhs) << " != " << ForKindToString(rhs) << ")";
+        ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    return true;
+  }
+
   // Compare kwargs (vector of pairs to preserve order)
   result_type VisitLeafField(const std::vector<std::pair<std::string, std::any>>& lhs,
                              const std::vector<std::pair<std::string, std::any>>& rhs) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -148,6 +148,10 @@ class StructuralHasher {
     return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
   }
 
+  result_type VisitLeafField(const ForKind& field) {
+    return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
+  }
+
   result_type VisitLeafField(const MemorySpace& field) {
     return static_cast<result_type>(std::hash<int>{}(static_cast<int>(field)));
   }

--- a/src/ir/transforms/utils/flatten_single_stmt.cpp
+++ b/src/ir/transforms/utils/flatten_single_stmt.cpp
@@ -132,7 +132,7 @@ StmtPtr FlattenSingleStmtMutator::VisitStmt_(const ForStmtPtr& op) {
 
   if (changed) {
     return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_);
+                                     op->return_vars_, op->span_, op->kind_);
   }
   return op;
 }

--- a/src/ir/transforms/utils/normalize_stmt_structure.cpp
+++ b/src/ir/transforms/utils/normalize_stmt_structure.cpp
@@ -161,7 +161,7 @@ StmtPtr NormalizeStmtStructureMutator::VisitStmt_(const ForStmtPtr& op) {
     auto new_step = VisitExpr(op->step_);
 
     return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_);
+                                     op->return_vars_, op->span_, op->kind_);
   }
   return op;
 }

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -154,7 +154,7 @@ def test_python_print_for_stmt_basic():
     result = ir.python_print(for_stmt)
 
     assert "for" in result
-    assert "for i in range" in result  # No type annotation in for loop header
+    assert "for i in pl.range" in result  # No type annotation in for loop header
     assert "pl.INT64" in result  # Type annotation in body assignment
     assert "range" in result
     assert "0" in result

--- a/tests/ut/ir/statements/test_for_stmt.py
+++ b/tests/ut/ir/statements/test_for_stmt.py
@@ -583,5 +583,177 @@ class TestForStmtAutoMapping:
         assert hash_without_auto1 == hash_without_auto2
 
 
+class TestForKind:
+    """Tests for ForKind enum and ForStmt kind field."""
+
+    def test_for_kind_enum_values(self):
+        """Test ForKind enum has Sequential and Parallel values."""
+        assert ir.ForKind.Sequential is not None
+        assert ir.ForKind.Parallel is not None
+        assert ir.ForKind.Sequential != ir.ForKind.Parallel
+
+    def test_for_stmt_default_kind_is_sequential(self):
+        """Test ForStmt defaults to Sequential kind."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], assign, [], span)
+
+        assert for_stmt.kind == ir.ForKind.Sequential
+
+    def test_for_stmt_with_parallel_kind(self):
+        """Test ForStmt with explicit Parallel kind."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], assign, [], span, ir.ForKind.Parallel)
+
+        assert for_stmt.kind == ir.ForKind.Parallel
+
+    def test_for_stmt_with_sequential_kind(self):
+        """Test ForStmt with explicit Sequential kind."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], assign, [], span, ir.ForKind.Sequential)
+
+        assert for_stmt.kind == ir.ForKind.Sequential
+
+    def test_for_stmt_kind_immutability(self):
+        """Test ForStmt kind attribute is immutable."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        assign = ir.AssignStmt(i, start, span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], assign, [], span)
+
+        with pytest.raises(AttributeError):
+            for_stmt.kind = ir.ForKind.Parallel  # type: ignore
+
+
+class TestForKindHash:
+    """Tests for ForKind impact on structural hash."""
+
+    def test_same_kind_same_hash(self):
+        """Test ForStmt nodes with same kind have same hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [], assign1, [], span, ir.ForKind.Parallel)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [], assign2, [], span, ir.ForKind.Parallel)
+
+        assert ir.structural_hash(for_stmt1) == ir.structural_hash(for_stmt2)
+
+    def test_different_kind_different_hash(self):
+        """Test ForStmt nodes with different kind have different hash."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [], assign1, [], span, ir.ForKind.Sequential)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [], assign2, [], span, ir.ForKind.Parallel)
+
+        assert ir.structural_hash(for_stmt1) != ir.structural_hash(for_stmt2)
+
+
+class TestForKindEquality:
+    """Tests for ForKind impact on structural equality."""
+
+    def test_same_kind_equal(self):
+        """Test ForStmt nodes with same kind are structurally equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [], assign1, [], span, ir.ForKind.Parallel)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [], assign2, [], span, ir.ForKind.Parallel)
+
+        ir.assert_structural_equal(for_stmt1, for_stmt2)
+
+    def test_different_kind_not_equal(self):
+        """Test ForStmt nodes with different kind are not structurally equal."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [], assign1, [], span, ir.ForKind.Sequential)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [], assign2, [], span, ir.ForKind.Parallel)
+
+        assert not ir.structural_equal(for_stmt1, for_stmt2)
+
+    def test_assert_structural_equal_different_kind_raises(self):
+        """Test assert_structural_equal raises on ForKind mismatch."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        i1 = ir.Var("i", ir.ScalarType(dtype), span)
+        start1 = ir.ConstInt(0, dtype, span)
+        stop1 = ir.ConstInt(10, dtype, span)
+        step1 = ir.ConstInt(1, dtype, span)
+        assign1 = ir.AssignStmt(i1, start1, span)
+        for_stmt1 = ir.ForStmt(i1, start1, stop1, step1, [], assign1, [], span, ir.ForKind.Sequential)
+
+        i2 = ir.Var("i", ir.ScalarType(dtype), span)
+        start2 = ir.ConstInt(0, dtype, span)
+        stop2 = ir.ConstInt(10, dtype, span)
+        step2 = ir.ConstInt(1, dtype, span)
+        assign2 = ir.AssignStmt(i2, start2, span)
+        for_stmt2 = ir.ForStmt(i2, start2, stop2, step2, [], assign2, [], span, ir.ForKind.Parallel)
+
+        with pytest.raises(ValueError, match=r"ForKind mismatch"):
+            ir.assert_structural_equal(for_stmt1, for_stmt2)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -9,7 +9,9 @@
 
 """Unit tests for control flow parsing (for loops, if statements)."""
 
+import pypto
 import pypto.language as pl
+import pytest
 from pypto.pypto_core import ir
 
 
@@ -188,3 +190,178 @@ class TestComplexControlFlow:
             return result
 
         assert isinstance(loop_without_iter_args, ir.Function)
+
+
+class TestParallelForLoops:
+    """Tests for parallel for loop parsing with pl.parallel()."""
+
+    def test_simple_parallel_for_loop(self):
+        """Test simple parallel for loop with one iter_arg."""
+
+        @pl.function
+        def parallel_sum(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (sum_val,) in pl.parallel(10, init_values=[init]):
+                new_sum: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(sum_val, i)
+                result = pl.yield_(new_sum)
+
+            return result
+
+        assert isinstance(parallel_sum, ir.Function)
+        assert parallel_sum.name == "parallel_sum"
+
+    def test_parallel_for_loop_without_iter_args(self):
+        """Test parallel for loop without iter_args."""
+
+        @pl.function
+        def parallel_no_iter(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = x
+            for i in pl.parallel(3):
+                temp = pl.op.tensor.mul(result, 2.0)
+                result = temp
+            return result
+
+        assert isinstance(parallel_no_iter, ir.Function)
+
+    def test_parallel_for_loop_with_range_params(self):
+        """Test parallel for loop with start, stop, step parameters."""
+
+        @pl.function
+        def parallel_range(n: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            init: pl.Tensor[[1], pl.INT32] = pl.op.tensor.create([1], dtype=pl.INT32)
+
+            for i, (acc,) in pl.parallel(0, 10, 2, init_values=[init]):
+                new_acc: pl.Tensor[[1], pl.INT32] = pl.op.tensor.add(acc, i)
+                result = pl.yield_(new_acc)
+
+            return result
+
+        assert isinstance(parallel_range, ir.Function)
+
+    def test_parallel_for_produces_parallel_kind(self):
+        """Test that pl.parallel() produces ForKind.Parallel in the IR."""
+
+        @pl.function
+        def par_func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+            for i, (acc,) in pl.parallel(10, init_values=[init]):
+                new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                result = pl.yield_(new_acc)
+            return result
+
+        # Find the ForStmt in the function body
+        body = par_func.body
+        if isinstance(body, ir.SeqStmts):
+            for_stmt = None
+            for stmt in body.stmts:
+                if isinstance(stmt, ir.ForStmt):
+                    for_stmt = stmt
+                    break
+        elif isinstance(body, ir.ForStmt):
+            for_stmt = body
+        else:
+            for_stmt = None
+
+        assert for_stmt is not None, "Expected ForStmt in function body"
+        assert for_stmt.kind == ir.ForKind.Parallel
+
+    def test_range_for_produces_sequential_kind(self):
+        """Test that pl.range() produces ForKind.Sequential in the IR."""
+
+        @pl.function
+        def seq_func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+            for i, (acc,) in pl.range(10, init_values=[init]):
+                new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                result = pl.yield_(new_acc)
+            return result
+
+        # Find the ForStmt in the function body
+        body = seq_func.body
+        if isinstance(body, ir.SeqStmts):
+            for_stmt = None
+            for stmt in body.stmts:
+                if isinstance(stmt, ir.ForStmt):
+                    for_stmt = stmt
+                    break
+        elif isinstance(body, ir.ForStmt):
+            for_stmt = body
+        else:
+            for_stmt = None
+
+        assert for_stmt is not None, "Expected ForStmt in function body"
+        assert for_stmt.kind == ir.ForKind.Sequential
+
+    def test_parallel_for_printer_output(self):
+        """Test that parallel for loop prints with pl.parallel()."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+                for i, (acc,) in pl.parallel(10, init_values=[init]):
+                    new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                    result = pl.yield_(new_acc)
+                return result
+
+        printed = pypto.ir.python_print(Before)
+        assert "pl.parallel(" in printed
+        assert "pl.range(" not in printed
+
+    def test_sequential_for_printer_no_parallel(self):
+        """Test that sequential for loop does not print pl.parallel()."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+                for i, (acc,) in pl.range(10, init_values=[init]):
+                    new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                    result = pl.yield_(new_acc)
+                return result
+
+        printed = pypto.ir.python_print(Before)
+        assert "pl.parallel(" not in printed
+        assert "pl.range(" in printed
+
+    def test_parallel_for_structural_not_equal_to_sequential(self):
+        """Test that parallel and sequential loops with same body are not structurally equal."""
+
+        @pl.program
+        class ParallelProg:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+                for i, (acc,) in pl.parallel(10, init_values=[init]):
+                    new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                    result = pl.yield_(new_acc)
+                return result
+
+        @pl.program
+        class SequentialProg:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                init: pl.Tensor[[64], pl.FP32] = pl.op.tensor.create([64], dtype=pl.FP32)
+                for i, (acc,) in pl.range(10, init_values=[init]):
+                    new_acc: pl.Tensor[[64], pl.FP32] = pl.op.tensor.add(acc, x)
+                    result = pl.yield_(new_acc)
+                return result
+
+        assert not ir.structural_equal(ParallelProg, SequentialProg)
+
+    def test_invalid_iterator_rejected(self):
+        """Test that invalid iterator (not range or parallel) is rejected."""
+        with pytest.raises(Exception):
+
+            @pl.function
+            def bad_func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.yield_(10):  # type: ignore
+                    pass
+                return x
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add ForKind enum (Sequential/Parallel) to ForStmt across the full stack:
- C++ core: enum, field, builder, reflection, serialization (backward-compat)
- All 7 transform passes propagate kind_ when reconstructing ForStmt
- Printer emits pl.parallel() for Parallel kind
- Python bindings, type stubs, DSL (pl.parallel()), parser, builder
- Fix single-element iter_arg tuple printing (trailing comma)