### PR TITLE
refactor(printer): Change MakeTuple output format from parentheses to brackets

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -464,16 +464,12 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
 }
 
 void IRPythonPrinter::VisitExpr_(const MakeTuplePtr& op) {
-  stream_ << "(";
+  stream_ << "[";
   for (size_t i = 0; i < op->elements_.size(); ++i) {
     if (i > 0) stream_ << ", ";
     VisitExpr(op->elements_[i]);
   }
-  // Add trailing comma for single element tuples
-  if (op->elements_.size() == 1) {
-    stream_ << ",";
-  }
-  stream_ << ")";
+  stream_ << "]";
 }
 
 void IRPythonPrinter::VisitExpr_(const TupleGetItemExprPtr& op) {

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -548,9 +548,9 @@ def test_python_print_block_load_store():
     # Should contain tensor name
     assert "input_tensor" in load_result
     # Should contain tuple representation of offsets
-    assert "(0, 0)" in load_result
+    assert "[0, 0]" in load_result
     # Should contain tuple representation of shapes
-    assert "(64, 64)" in load_result
+    assert "[64, 64]" in load_result
 
     # Test block.store
     store_op = ir.Op("block.store")
@@ -565,8 +565,8 @@ def test_python_print_block_load_store():
     # Should contain tile name
     assert "tile" in store_result
     # Should contain tuple representation
-    assert "(0, 0)" in store_result
-    assert "(64, 64)" in store_result
+    assert "[0, 0]" in store_result
+    assert "[64, 64]" in store_result
     # Should contain output tensor
     assert "output_tensor" in store_result
 


### PR DESCRIPTION
Update Python printer to print MakeTuple expressions using square brackets [] instead of parentheses (). This makes the output format consistent with list syntax and improves readability for tensor operations like block.load/store.