### PR TITLE
feat(language): Support Scalar variables in range/parallel loops

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -285,7 +285,8 @@ std::string IRPythonPrinter::Print(const IRNodePtr& node) {
 
 std::string IRPythonPrinter::Print(const TypePtr& type) {
   if (auto scalar_type = As<ScalarType>(type)) {
-    return DataTypeToPythonString(scalar_type->dtype_, prefix_);
+    // Print as pl.Scalar[pl.INT64] for proper round-trip support
+    return prefix_ + ".Scalar[" + DataTypeToPythonString(scalar_type->dtype_, prefix_) + "]";
   }
 
   if (auto tensor_type = As<TensorType>(type)) {
@@ -675,6 +676,7 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
     if (op->iter_args_.size() == 1) {
       stream_ << ",";
     }
+    stream_ << ")";
   }
   stream_ << " in " << prefix_ << (is_parallel ? ".parallel(" : ".range(");
 

--- a/tests/ut/ir/statements/test_op_stmts.py
+++ b/tests/ut/ir/statements/test_op_stmts.py
@@ -158,7 +158,7 @@ class TestOpStmtsPrinting:
         y = ir.Var("y", ir.ScalarType(dtype), span)
         assign = ir.AssignStmt(x, y, span)
         op_stmts = ir.OpStmts([assign], span)
-        assert str(op_stmts) == "x: pl.INT64 = y"
+        assert str(op_stmts) == "x: pl.Scalar[pl.INT64] = y"
 
     def test_op_stmts_printing_multiple(self):
         """Test printing of OpStmts with multiple statements."""
@@ -171,7 +171,10 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, x, span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pl.INT64 = y\ny: pl.INT64 = z\nz: pl.INT64 = x"
+        assert (
+            str(op_stmts)
+            == "x: pl.Scalar[pl.INT64] = y\ny: pl.Scalar[pl.INT64] = z\nz: pl.Scalar[pl.INT64] = x"
+        )
 
     def test_op_stmts_printing_empty(self):
         """Test printing of OpStmts with empty statement list."""
@@ -190,7 +193,10 @@ class TestOpStmtsPrinting:
         assign2 = ir.AssignStmt(y, z, span)
         assign3 = ir.AssignStmt(z, ir.ConstInt(0, dtype, span), span)
         op_stmts = ir.OpStmts([assign1, assign2, assign3], span)
-        assert str(op_stmts) == "x: pl.INT64 = y\ny: pl.INT64 = z\nz: pl.INT64 = 0"
+        assert (
+            str(op_stmts)
+            == "x: pl.Scalar[pl.INT64] = y\ny: pl.Scalar[pl.INT64] = z\nz: pl.Scalar[pl.INT64] = 0"
+        )
 
     def test_op_stmts_printing_with_eval_stmt(self):
         """Test printing of OpStmts with EvalStmt."""
@@ -208,7 +214,7 @@ class TestOpStmtsPrinting:
         result = str(op_stmts)
 
         # Should contain both statements
-        assert "x: pl.INT64 = y" in result
+        assert "x: pl.Scalar[pl.INT64] = y" in result
         assert "system.bar_all()" in result
 
     def test_op_stmts_printing_only_eval_stmts(self):

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -44,7 +44,7 @@ class TestPythonPrinterProgram:
         assert "class SingleFunc:" in code
         assert "@pl.function" in code
         assert "def add(self," in code  # Should have self parameter
-        assert "x: pl.INT64" in code or "x: pl.INT64" in code
+        assert "x: pl.Scalar[pl.INT64]" in code
 
     def test_print_program_with_multiple_functions(self):
         """Test printing a program with multiple functions."""


### PR DESCRIPTION
- Add RangeArg type alias to accept int or Scalar in pl.range/parallel
- Update printer to output ScalarType as pl.Scalar[dtype] for round-trip
- Fix ForStmt iter_args tuple formatting with closing parenthesis
- Add comprehensive tests for Scalar range parameters and expressions
- Support complex expressions like pl.range(n * 2 + 1) where n is Scalar