### PR TITLE
feat: orchestration refactor with tensor ops and dynamic shapes

### DIFF
--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -17,6 +17,7 @@ from typing import Literal, Optional, Union
 
 __all__ = [
     "create",
+    "read",
     "view",
     "matmul",
     "mul",
@@ -44,11 +45,11 @@ from pypto.pypto_core.ir import Expr
 from ..typing import Scalar, Tensor
 
 
-def create(shape: list[int], dtype: DataType) -> Tensor:
+def create(shape: list[Union[int, Expr]], dtype: DataType) -> Tensor:
     """Create a new tensor with specified shape and dtype.
 
     Args:
-        shape: List of dimension sizes
+        shape: List of dimension sizes (int or Expr)
         dtype: Data type of tensor elements
 
     Returns:
@@ -56,6 +57,21 @@ def create(shape: list[int], dtype: DataType) -> Tensor:
     """
     call_expr = _ir_ops.create(shape, dtype)
     return Tensor(expr=call_expr)
+
+
+def read(tensor: Tensor, indices: list[Union[int, Expr]]) -> Scalar:
+    """Read a scalar value from a tensor at given indices.
+
+    Args:
+        tensor: Input tensor
+        indices: List of index expressions (one per tensor dimension)
+
+    Returns:
+        Scalar wrapping the read operation
+    """
+    tensor_expr = tensor.unwrap()
+    call_expr = _ir_ops.read(tensor_expr, indices)
+    return Scalar(expr=call_expr)
 
 
 def view(tensor: Tensor, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> Tensor:

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -94,13 +94,13 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   CHECK(shape_tuple_type) << "tensor.reshape requires shape to be TupleType, but got "
                           << args[1]->GetType()->TypeName();
 
-  // Validate all shape elements are ScalarType(INT64 or UINT64)
+  // Validate all shape elements are ScalarType with integer dtype
   for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
     auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
     CHECK(scalar_type) << "tensor.reshape shape tuple element " << i << " must be ScalarType, but got "
                        << shape_tuple_type->types_[i]->TypeName();
-    CHECK(scalar_type->dtype_ == DataType::INT64 || scalar_type->dtype_ == DataType::UINT64)
-        << "tensor.reshape shape tuple element " << i << " must have dtype INT64 or UINT64, but got "
+    CHECK(scalar_type->dtype_.IsInt())
+        << "tensor.reshape shape tuple element " << i << " must have integer dtype, but got "
         << scalar_type->dtype_.ToString();
   }
 

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -375,7 +375,7 @@ FunctionPtr TransformFlattenCallExpr(const FunctionPtr& func) {
   FlattenCallExprMutator mutator;
   auto new_body = mutator.VisitStmt(normalized->body_);
   auto result = std::make_shared<Function>(normalized->name_, normalized->params_, normalized->return_types_,
-                                           new_body, normalized->span_);
+                                           new_body, normalized->span_, normalized->func_type_);
 
   // Step 3: Flatten single-statement blocks
   return FlattenSingleStmt(result);

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -544,6 +544,42 @@ class TestFlattenWithVerifier:
         assert verified is not None
 
 
+class TestFlattenPreservesFuncType:
+    """Tests that flatten_call_expr preserves func_type_ on functions."""
+
+    def test_preserve_orchestration_func_type(self):
+        """Test that func_type is preserved after flattening for Orchestration functions."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(x, 1.0), 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(Before)
+
+        after_func = After.get_function("main")
+        assert after_func is not None
+        assert after_func.func_type == pl.FunctionType.Orchestration
+
+    def test_preserve_incore_func_type(self):
+        """Test that func_type is preserved after flattening for InCore functions."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(x, 1.0), 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(Before)
+
+        after_func = After.get_function("main")
+        assert after_func is not None
+        assert after_func.func_type == pl.FunctionType.InCore
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Summary

This PR extends orchestration with a new tensor read op, dynamic shapes, tuple returns/unpacking, and fixes function type preservation in the FlattenCallExpr pass.

---

### IR

**`tensor.read`**
- New op: `tensor.read(tensor, indices_tuple)` → scalar value. Implemented in C++ (`DeduceTensorReadType` in `memory.cpp`, registered), Python IR API (`tensor_ops.read`), and orchestration codegen (inline C++ for host-side read with linear index from shape).

**Dynamic shapes**
- `tensor.create` accepts `shape: list[Union[int, Expr]]`; dimensions are normalized via `_normalize_expr`. In orchestration codegen, `CalculateTensorSize` uses `GenerateExprString(dim)` so non-constant dimensions (e.g. variables, expressions) are supported instead of requiring constant tensor shapes.

**Dtype validation**
- Tensor ops that take shape/offset tuples (`tensor.create`, `tensor.view`, `tensor.reshape`, `tensor.assemble`) now require “integer dtype” via `dtype_.IsInt()` instead of only `INT64`/`UINT64`, allowing other integer dtypes where appropriate.

---

### Language

**Tuple return types**
- Return type annotations `tuple[T1, T2, ...]` are resolved in `TypeResolver` (`_resolve_tuple_type`) and yield multiple return types on the function. Parameters still cannot be annotated with tuple types (explicit error).

**Tuple unpacking from calls**
- Assignments like `(a, b, c) = some_call()` are supported for any call that returns a tuple: the RHS is evaluated once, bound to a temporary, and each LHS name is bound to the corresponding `TupleGetItemExpr`. Only simple variable names are allowed as unpacking targets (no nested tuples). Unpacking remains supported for `pl.yield_()` as before.

**`pl.tensor.read`**
- `read` is added to the tensor-only ops set so `pl.tensor.read` is available from the language layer and excluded from generic op dispatch.

---

### Codegen (orchestration)

- **Built-in vs user calls**: `IsBuiltinOp` treats `block.*`, `tensor.*`, and `system.*` as built-in; only non-built-in calls are emitted as task-graph function calls.
- **Tensor ops inline**: Tensor ops are collected separately. `tensor.create` and `tensor.read` get inline C++ (device allocation and host-side scalar read with linear index); `tensor.view` / `tensor.reshape` remain metadata-only (no extra inline code).
- **Dynamic shapes**: Size and index expressions use `GenerateExprString` so non-constant shapes and indices are code-generated correctly.
- **Helpers**: `TryGetVarName` supports both `Var` and `IterArg`; return value and tensor op results use it so orchestration works with iter args.

---

### Bugfix

- **FlattenCallExpr**: When building the new `Function` after the pass, the constructor now receives `normalized->func_type_` so that `FunctionType::Orchestration` (and other function types) are preserved instead of being dropped.