### PR TITLE
feat(codegen): Add orchestration op registry and tensor.dim codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ set(PYPTO_SOURCES
     src/codegen/cce/code_context.cpp
     src/codegen/cce/type_converter.cpp
     src/codegen/cce/cce_codegen.cpp
+    src/codegen/codegen_base.cpp
+    src/codegen/orchestration_op_registry.cpp
+    src/codegen/tensor_op_codegen.cpp
     src/codegen/orchestration/orchestration_codegen.cpp
     src/ir/transforms/add_alloc_pass.cpp
     src/ir/transforms/verify_ssa_pass.cpp

--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -89,6 +89,27 @@ class CodegenBase : public ir::IRVisitor {
    */
   virtual std::string GetVarName(const ir::VarPtr& var) = 0;
 
+  /**
+   * @brief Try to extract variable name from expression
+   *
+   * Supports Var and IterArg expressions. Returns empty string if not a variable.
+   *
+   * @param expr Expression to extract name from
+   * @return Variable name or empty string
+   */
+  static std::string TryGetVarName(const ir::ExprPtr& expr);
+
+  /**
+   * @brief Generate C++ code string for an IR expression
+   *
+   * Converts IR expressions to C++ code strings for inline operations.
+   * Supports variables, constants, binary operations, and tuple access.
+   *
+   * @param expr Expression to convert
+   * @return C++ code string
+   */
+  static std::string GenerateExprString(const ir::ExprPtr& expr);
+
  protected:
   /**
    * @brief Throw when no codegen is registered for a Call

--- a/include/pypto/codegen/orchestration_op_registry.h
+++ b/include/pypto/codegen/orchestration_op_registry.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_CODEGEN_ORCHESTRATION_OP_REGISTRY_H_
+#define PYPTO_CODEGEN_ORCHESTRATION_OP_REGISTRY_H_
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "pypto/codegen/codegen_base.h"
+#include "pypto/ir/expr.h"
+
+namespace pypto {
+namespace codegen {
+
+/**
+ * @brief Registry for orchestration-level operation codegen functions
+ *
+ * Orchestration operations (tensor.create, tensor.read, etc.) are host-side operations
+ * that don't depend on backend hardware. This registry provides a mechanism to register
+ * codegen functions for these operations, similar to backend operation registration but
+ * at the orchestration layer.
+ */
+class OrchestrationOpRegistry {
+ public:
+  /**
+   * @brief Codegen function signature for orchestration operations
+   *
+   * Takes a Call expression and a CodegenBase reference, returns generated C++ code string.
+   */
+  using CodegenFunc = std::function<std::string(const ir::CallPtr&, CodegenBase&)>;
+
+  /**
+   * @brief Get the singleton instance
+   */
+  static OrchestrationOpRegistry& GetInstance();
+
+  /**
+   * @brief Register a codegen function for an operation
+   *
+   * @param op_name Operation name (e.g., "tensor.create")
+   * @param func Codegen function
+   */
+  void Register(const std::string& op_name, CodegenFunc func);
+
+  /**
+   * @brief Get the codegen function for an operation
+   *
+   * @param op_name Operation name
+   * @return Codegen function if registered, nullopt otherwise
+   */
+  std::optional<CodegenFunc> Get(const std::string& op_name) const;
+
+ private:
+  OrchestrationOpRegistry() = default;
+  std::unordered_map<std::string, CodegenFunc> registry_;
+};
+
+/**
+ * @brief Helper class for registering orchestration operations
+ *
+ * Used by REGISTER_ORCHESTRATION_OP macro to enable registration at static initialization time.
+ */
+class OrchestrationOpRegistryEntry {
+ public:
+  explicit OrchestrationOpRegistryEntry(const std::string& op_name) : op_name_(op_name) {}
+
+  /**
+   * @brief Set the codegen function
+   */
+  OrchestrationOpRegistryEntry& SetCodegen(OrchestrationOpRegistry::CodegenFunc func) {
+    OrchestrationOpRegistry::GetInstance().Register(op_name_, std::move(func));
+    return *this;
+  }
+
+ private:
+  std::string op_name_;
+};
+
+}  // namespace codegen
+}  // namespace pypto
+
+/**
+ * @brief Macro for registering orchestration operation codegen
+ *
+ * Usage:
+ *   REGISTER_ORCHESTRATION_OP(tensor_create, "tensor.create") {
+ *     // op: const ir::CallPtr&
+ *     // codegen: CodegenBase&
+ *     return "generated code";
+ *   }
+ */
+#define REGISTER_ORCHESTRATION_OP(func_name, op_name_str)                                      \
+  static std::string OrchestrationCodegen_##func_name(const ::pypto::ir::CallPtr& op,          \
+                                                      ::pypto::codegen::CodegenBase& codegen); \
+  static ::pypto::codegen::OrchestrationOpRegistryEntry __orch_op_entry_##func_name =          \
+      ::pypto::codegen::OrchestrationOpRegistryEntry(op_name_str)                              \
+          .SetCodegen(OrchestrationCodegen_##func_name);                                       \
+  static std::string OrchestrationCodegen_##func_name(const ::pypto::ir::CallPtr& op,          \
+                                                      ::pypto::codegen::CodegenBase& codegen)
+
+#endif  // PYPTO_CODEGEN_ORCHESTRATION_OP_REGISTRY_H_

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -62,6 +62,23 @@ def read(tensor: Expr, indices: list[Union[int, Expr]], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.read", args, {}, actual_span)
 
 
+def dim(tensor: Expr, axis: Union[int, Expr], span: Optional[Span] = None) -> Call:
+    """Extract a shape dimension from a tensor as a scalar value.
+
+    Args:
+        tensor: Input tensor expression
+        axis: Dimension index (supports negative indexing)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the dimension size as ScalarType(INT64)
+    """
+    actual_span = _get_span_or_capture(span)
+    axis_expr = _normalize_expr(axis, actual_span, int_dtype=DataType.INT64)
+    args = [tensor, axis_expr]
+    return _ir_core.create_op_call("tensor.dim", args, {}, actual_span)
+
+
 def view(
     tensor: Expr, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]], span: Optional[Span] = None
 ) -> Call:

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -75,7 +75,7 @@ from .op.block_ops import (
     store,
     sum,
 )
-from .op.tensor_ops import assemble, create
+from .op.tensor_ops import assemble, create, dim
 from .op.unified_ops import (
     add,
     cast,
@@ -178,6 +178,7 @@ __all__ = [
     # Promoted tensor-only
     "create",
     "assemble",
+    "dim",
     "FunctionType",
     "ForKind",
     "FP4",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -56,7 +56,7 @@ from .block_ops import (
 )
 
 # Promoted tensor-only ops (accessible as pl.create, etc.)
-from .tensor_ops import assemble, create
+from .tensor_ops import assemble, create, dim
 
 # Unified dispatch (overlapping ops)
 from .unified_ops import (
@@ -126,4 +126,5 @@ __all__ = [
     # Promoted tensor-only
     "create",
     "assemble",
+    "dim",
 ]

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -18,6 +18,7 @@ from typing import Literal, Optional, Union
 __all__ = [
     "create",
     "read",
+    "dim",
     "view",
     "matmul",
     "mul",
@@ -71,6 +72,21 @@ def read(tensor: Tensor, indices: list[Union[int, Expr]]) -> Scalar:
     """
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.read(tensor_expr, indices)
+    return Scalar(expr=call_expr)
+
+
+def dim(tensor: Tensor, axis: int) -> Scalar:
+    """Extract a shape dimension from a tensor as a scalar value.
+
+    Args:
+        tensor: Input tensor
+        axis: Dimension index (supports negative indexing)
+
+    Returns:
+        Scalar wrapping the dim operation (INT64)
+    """
+    tensor_expr = tensor.unwrap()
+    call_expr = _ir_ops.dim(tensor_expr, axis)
     return Scalar(expr=call_expr)
 
 

--- a/src/codegen/codegen_base.cpp
+++ b/src/codegen/codegen_base.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/codegen/codegen_base.h"
+
+#include <string>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/scalar_expr.h"
+
+namespace pypto {
+namespace codegen {
+
+using namespace pypto::ir;  // NOLINT(build/namespaces)
+
+std::string CodegenBase::TryGetVarName(const ir::ExprPtr& expr) {
+  if (auto var = As<Var>(expr)) {
+    return var->name_;
+  }
+  if (auto iter_arg = As<IterArg>(expr)) {
+    return iter_arg->name_;
+  }
+  return "";
+}
+
+std::string CodegenBase::GenerateExprString(const ir::ExprPtr& expr) {
+  std::string var_name = TryGetVarName(expr);
+  if (!var_name.empty()) {
+    return var_name;
+  }
+  if (auto const_int = As<ConstInt>(expr)) {
+    return std::to_string(const_int->value_);
+  }
+  if (auto add = As<Add>(expr)) {
+    return "(" + GenerateExprString(add->left_) + " + " + GenerateExprString(add->right_) + ")";
+  }
+  if (auto sub = As<Sub>(expr)) {
+    return "(" + GenerateExprString(sub->left_) + " - " + GenerateExprString(sub->right_) + ")";
+  }
+  if (auto mul = As<Mul>(expr)) {
+    return "(" + GenerateExprString(mul->left_) + " * " + GenerateExprString(mul->right_) + ")";
+  }
+  if (auto floor_div = As<FloorDiv>(expr)) {
+    return "(" + GenerateExprString(floor_div->left_) + " / " + GenerateExprString(floor_div->right_) + ")";
+  }
+  if (auto tuple_get = As<TupleGetItemExpr>(expr)) {
+    return GenerateExprString(tuple_get->tuple_) + "_" + std::to_string(tuple_get->index_);
+  }
+  throw pypto::NotImplementedError("GenerateExprString not implemented for expression type: " +
+                                   expr->TypeName());
+}
+
+}  // namespace codegen
+}  // namespace pypto

--- a/src/codegen/orchestration_op_registry.cpp
+++ b/src/codegen/orchestration_op_registry.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/codegen/orchestration_op_registry.h"
+
+#include <string>
+#include <utility>
+
+namespace pypto {
+namespace codegen {
+
+OrchestrationOpRegistry& OrchestrationOpRegistry::GetInstance() {
+  static OrchestrationOpRegistry instance;
+  return instance;
+}
+
+void OrchestrationOpRegistry::Register(const std::string& op_name, CodegenFunc func) {
+  registry_[op_name] = std::move(func);
+}
+
+std::optional<OrchestrationOpRegistry::CodegenFunc> OrchestrationOpRegistry::Get(
+    const std::string& op_name) const {
+  auto it = registry_.find(op_name);
+  if (it != registry_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+}  // namespace codegen
+}  // namespace pypto

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <sstream>
+#include <string>
+
+#include "pypto/codegen/orchestration_op_registry.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace codegen {
+
+using namespace pypto::ir;  // NOLINT(build/namespaces)
+
+// Helper function to calculate tensor size expression
+static std::string CalculateTensorSizeExpr(const TensorTypePtr& tensor_type, CodegenBase& codegen) {
+  std::ostringstream oss;
+
+  // Calculate total number of elements by multiplying all dimensions
+  bool first = true;
+  for (const auto& dim : tensor_type->shape_) {
+    if (first) {
+      oss << codegen.GenerateExprString(dim);
+      first = false;
+    } else {
+      oss << " * " << codegen.GenerateExprString(dim);
+    }
+  }
+
+  // If shape is empty, it's a scalar (1 element)
+  if (first) {
+    oss << "1";
+  }
+
+  // Multiply by element size in bytes
+  size_t element_bits = tensor_type->dtype_.GetBit();
+  size_t element_bytes = (element_bits + 7) / 8;  // Round up to nearest byte
+  oss << " * " << element_bytes;
+
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
+  // tensor.create(shape_tuple, dtype=dtype) -> allocate device memory
+  auto result_type = As<TensorType>(op->GetType());
+  CHECK(result_type) << "tensor.create must return TensorType";
+
+  std::string result_var = codegen.GetCurrentResultTarget();
+  std::string size_expr = CalculateTensorSizeExpr(result_type, codegen);
+
+  std::ostringstream oss;
+  oss << "size_t size_" << result_var << " = " << size_expr << ";\n";
+  oss << "void* dev_" << result_var << " = runtime->host_api.device_malloc(size_" << result_var << ");";
+
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
+  // tensor.read(tensor, indices_tuple) -> scalar value
+  CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments";
+
+  std::string input_name = codegen.TryGetVarName(op->args_[0]);
+  CHECK(!input_name.empty()) << "tensor.read input must be a variable";
+
+  auto input_type = As<TensorType>(op->args_[0]->GetType());
+  CHECK(input_type) << "tensor.read input must be TensorType";
+
+  auto result_type = As<ScalarType>(op->GetType());
+  CHECK(result_type) << "tensor.read must return ScalarType";
+  std::string cpp_type = result_type->dtype_.ToCTypeString();
+
+  std::string result_var = codegen.GetCurrentResultTarget();
+
+  // Extract indices from MakeTuple
+  auto indices_tuple = As<MakeTuple>(op->args_[1]);
+  CHECK(indices_tuple) << "tensor.read indices must be MakeTuple";
+
+  // Compute linear index
+  const auto& indices = indices_tuple->elements_;
+  const auto& shape = input_type->shape_;
+
+  std::ostringstream oss;
+  oss << "// tensor.read: " << result_var << " = " << input_name << "[...]\n";
+  oss << "size_t idx_" << result_var << " = ";
+  for (size_t i = 0; i < indices.size(); ++i) {
+    if (i > 0) oss << " + ";
+    oss << codegen.GenerateExprString(indices[i]);
+    for (size_t j = i + 1; j < shape.size(); ++j) {
+      oss << " * " << codegen.GenerateExprString(shape[j]);
+    }
+  }
+  oss << ";\n";
+  oss << cpp_type << " " << result_var << " = static_cast<" << cpp_type << "*>(host_" << input_name
+      << ")[idx_" << result_var << "];";
+
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_dim, ("tensor.dim")) {
+  // tensor.dim(tensor, axis) -> extract shape dimension as scalar
+  // Validation already performed by DeduceTensorDimType during type deduction.
+  INTERNAL_CHECK(op->args_.size() == 2) << "Internal error: tensor.dim expected 2 arguments";
+
+  auto tensor_type = As<TensorType>(op->args_[0]->GetType());
+  INTERNAL_CHECK(tensor_type) << "Internal error: tensor.dim input must be TensorType";
+
+  auto axis_const = As<ConstInt>(op->args_[1]);
+  INTERNAL_CHECK(axis_const) << "Internal error: tensor.dim axis must be ConstInt";
+
+  int64_t axis = axis_const->value_;
+  int64_t rank = static_cast<int64_t>(tensor_type->shape_.size());
+  if (axis < 0) {
+    axis += rank;
+  }
+  INTERNAL_CHECK(axis >= 0 && axis < rank) << "Internal error: tensor.dim axis out of range";
+
+  std::string result_var = codegen.GetCurrentResultTarget();
+  std::string dim_expr = codegen.GenerateExprString(tensor_type->shape_[axis]);
+
+  std::ostringstream oss;
+  oss << "int64_t " << result_var << " = " << dim_expr << ";";
+  return oss.str();
+}
+
+}  // namespace codegen
+}  // namespace pypto

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1,0 +1,588 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for orchestration code generation, including tuple return value handling."""
+
+import pypto.language as pl
+from pypto import backend
+from pypto.backend import BackendType
+from pypto.pypto_core import codegen
+
+
+class TestOrchestrationSingleReturn:
+    """Test orchestration codegen with single tensor return (regression)."""
+
+    def test_single_return_basic(self):
+        """Test basic orchestration with single tensor return and intermediate tensors."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class SingleReturnProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_single(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(c, b)
+                return d
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(SingleReturnProgram)
+        code = files["orchestration/orch_single.cpp"]
+
+        # Header and signature
+        assert "// Orchestration Function: orch_single" in code
+        assert "#include <cstdint>" in code
+        assert 'extern "C"' in code
+        assert "BuildOrch_single(Runtime* runtime, uint64_t* args, int arg_count)" in code
+
+        # Argument validation
+        assert "arg_count < 7" in code
+        assert "return -1" in code
+
+        # Input parameter extraction and device memory
+        assert "host_a" in code
+        assert "host_b" in code
+        assert "copy_to_device(dev_a, host_a, size_a)" in code
+        assert "copy_to_device(dev_b, host_b, size_b)" in code
+
+        # Output tensor: has host pointer and record_tensor_pair
+        assert "host_d" in code
+        assert "record_tensor_pair(host_d, dev_d, size_d)" in code
+
+        # Intermediate tensor c: device memory only, no host pointer
+        assert "size_c = 16 * 16 * 4" in code
+        assert "dev_c" in code
+        assert "host_c" not in code
+
+        # Task creation
+        assert code.count("add_task") == 2
+        assert "CoreType::AIV" in code
+
+        # Data-flow dependency between tasks
+        assert "add_successor(t0, t1)" in code
+        assert "return 0;" in code
+
+
+class TestOrchestrationTupleIntermediate:
+    """Test orchestration codegen with tuple return as intermediate tensors."""
+
+    def test_tuple_intermediate_basic(self):
+        """Test that tuple elements are individually allocated as intermediate tensors."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TupleIntermediateProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_pair(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                out_s: pl.Tensor[[16, 16], pl.FP32],
+                out_d: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                s: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                d: pl.Tile[[16, 16], pl.FP32] = pl.sub(a_tile, b_tile)
+                rs: pl.Tensor[[16, 16], pl.FP32] = pl.store(s, [0, 0], [16, 16], out_s)
+                rd: pl.Tensor[[16, 16], pl.FP32] = pl.store(d, [0, 0], [16, 16], out_d)
+                return rs, rd
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_tuple_mid(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                x, y = self.kernel_pair(a, b)
+                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(x, y)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TupleIntermediateProgram)
+        code = files["orchestration/orch_tuple_mid.cpp"]
+
+        # Each tuple element gets individual device memory allocation
+        assert "size_x = 16 * 16 * 4" in code
+        assert "size_y = 16 * 16 * 4" in code
+        assert "dev_x" in code
+        assert "dev_y" in code
+
+        # x and y are intermediate (no host pointers)
+        assert "host_x" not in code
+        assert "host_y" not in code
+
+        # Return tensor has host pointer and record_tensor_pair
+        assert "host_result" in code
+        assert "record_tensor_pair(host_result, dev_result, size_result)" in code
+
+        # Two tasks: kernel_pair + kernel_add
+        assert code.count("add_task") == 2
+
+
+class TestOrchestrationTupleOutput:
+    """Test orchestration codegen with tuple return as final output."""
+
+    def test_tuple_output_basic(self):
+        """Test that tuple return values each get host pointers and record_tensor_pair."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TupleOutputProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_pair(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                out_s: pl.Tensor[[16, 16], pl.FP32],
+                out_d: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                s: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                d: pl.Tile[[16, 16], pl.FP32] = pl.sub(a_tile, b_tile)
+                rs: pl.Tensor[[16, 16], pl.FP32] = pl.store(s, [0, 0], [16, 16], out_s)
+                rd: pl.Tensor[[16, 16], pl.FP32] = pl.store(d, [0, 0], [16, 16], out_d)
+                return rs, rd
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_tuple_out(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
+                x, y = self.kernel_pair(a, b)
+                return x, y
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TupleOutputProgram)
+        code = files["orchestration/orch_tuple_out.cpp"]
+
+        # Both x and y are return tensors - each should have host pointer
+        assert "host_x" in code
+        assert "host_y" in code
+        assert "record_tensor_pair(host_x, dev_x, size_x)" in code
+        assert "record_tensor_pair(host_y, dev_y, size_y)" in code
+
+        # Both should have device memory
+        assert "dev_x" in code
+        assert "dev_y" in code
+
+        # Only one task: kernel_pair
+        assert code.count("add_task") == 1
+
+        # No dependencies (single task)
+        assert "add_successor" not in code
+
+
+class TestOrchestrationTupleFourElements:
+    """Test orchestration codegen with 4-element tuple (paged attention pattern)."""
+
+    def test_four_element_tuple_intermediate(self):
+        """Test 4-element tuple unpacking with mixed shapes as intermediate."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class FourTupleProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def online_update(
+                self,
+                mij: pl.Tensor[[16, 1], pl.FP32],
+                lij: pl.Tensor[[16, 1], pl.FP32],
+                oi_new: pl.Tensor[[16, 16], pl.FP32],
+                mi: pl.Tensor[[16, 1], pl.FP32],
+                li: pl.Tensor[[16, 1], pl.FP32],
+                oi: pl.Tensor[[16, 16], pl.FP32],
+                dst: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[
+                pl.Tensor[[16, 1], pl.FP32],
+                pl.Tensor[[16, 1], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                mi_tile: pl.Tile[[16, 1], pl.FP32] = pl.load(mi, [0, 0], [16, 1])
+                li_tile: pl.Tile[[16, 1], pl.FP32] = pl.load(li, [0, 0], [16, 1])
+                oi_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(oi, [0, 0], [16, 16])
+                dst_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(dst, [0, 0], [16, 16])
+                mi_out: pl.Tensor[[16, 1], pl.FP32] = pl.store(mi_tile, [0, 0], [16, 1], mi)
+                li_out: pl.Tensor[[16, 1], pl.FP32] = pl.store(li_tile, [0, 0], [16, 1], li)
+                oi_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(oi_tile, [0, 0], [16, 16], oi)
+                dst_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(dst_tile, [0, 0], [16, 16], dst)
+                return mi_out, li_out, oi_out, dst_out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_four_tuple(
+                self,
+                mij: pl.Tensor[[16, 1], pl.FP32],
+                lij: pl.Tensor[[16, 1], pl.FP32],
+                oi_new: pl.Tensor[[16, 16], pl.FP32],
+                mi_in: pl.Tensor[[16, 1], pl.FP32],
+                li_in: pl.Tensor[[16, 1], pl.FP32],
+                oi_in: pl.Tensor[[16, 16], pl.FP32],
+                dst_in: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                mi, li, oi, dst = self.online_update(mij, lij, oi_new, mi_in, li_in, oi_in, dst_in)
+                final: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(oi, dst)
+                return final
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(FourTupleProgram)
+        code = files["orchestration/orch_four_tuple.cpp"]
+
+        # All 4 tuple elements are intermediate tensors with correct sizes
+        assert "size_mi = 16 * 1 * 4" in code
+        assert "size_li = 16 * 1 * 4" in code
+        assert "size_oi = 16 * 16 * 4" in code
+        assert "size_dst = 16 * 16 * 4" in code
+        for name in ["mi", "li", "oi", "dst"]:
+            assert f"dev_{name}" in code, f"Missing dev_{name}"
+
+        # Final return tensor has host pointer
+        assert "host_final" in code
+        assert "record_tensor_pair(host_final, dev_final, size_final)" in code
+
+        # Two tasks: online_update + kernel_add
+        assert code.count("add_task") == 2
+
+
+class TestOrchestrationDependencies:
+    """Test task dependency generation in orchestration codegen."""
+
+    def test_chain_three_tasks(self):
+        """Test 3 chained tasks produce 2 add_successor calls."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class ChainProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_chain(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(c, b)
+                e: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(d, b)
+                return e
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(ChainProgram)
+        code = files["orchestration/orch_chain.cpp"]
+
+        # Three tasks
+        assert code.count("add_task") == 3
+
+        # Two intermediate tensors (c, d), no host pointers
+        assert "host_c" not in code
+        assert "host_d" not in code
+        assert "dev_c" in code
+        assert "dev_d" in code
+
+        # Chain dependency: t0->t1, t1->t2
+        assert code.count("add_successor") == 2
+        assert "add_successor(t0, t1)" in code
+        assert "add_successor(t1, t2)" in code
+
+    def test_independent_tasks(self):
+        """Test independent tasks produce no add_successor calls."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class IndependentProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_independent(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
+                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                return c, d
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(IndependentProgram)
+        code = files["orchestration/orch_independent.cpp"]
+
+        # Two tasks, no data dependency between them
+        assert code.count("add_task") == 2
+        assert "add_successor" not in code
+
+    def test_codegen_metadata(self):
+        """Test that kernel_config.py contains func_name_to_id mapping."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class MetadataProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_meta(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                return c
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(MetadataProgram)
+
+        # kernel_config.py should contain function-to-id mapping
+        assert "kernel_config.py" in files
+        config = files["kernel_config.py"]
+        assert "kernel_add" in config
+
+
+class TestOrchestrationTensorOps:
+    """Test tensor operations (create, dim, read) in orchestration codegen."""
+
+    def test_tensor_create(self):
+        """Test tensor.create generates device_malloc with correct size."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TensorCreateProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_fill(
+                self,
+                a: pl.Tensor[[32, 32], pl.FP16],
+                output: pl.Tensor[[32, 32], pl.FP16],
+            ) -> pl.Tensor[[32, 32], pl.FP16]:
+                t: pl.Tile[[32, 32], pl.FP16] = pl.load(a, [0, 0], [32, 32])
+                out: pl.Tensor[[32, 32], pl.FP16] = pl.store(t, [0, 0], [32, 32], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_create(
+                self,
+                a: pl.Tensor[[32, 32], pl.FP16],
+            ) -> pl.Tensor[[32, 32], pl.FP16]:
+                buf: pl.Tensor[[32, 32], pl.FP16] = pl.create([32, 32], dtype=pl.FP16)
+                result: pl.Tensor[[32, 32], pl.FP16] = self.kernel_fill(buf)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TensorCreateProgram)
+        code = files["orchestration/orch_create.cpp"]
+
+        # tensor.create generates inline size calculation + device_malloc
+        # FP16 = 2 bytes per element
+        assert "size_buf = 32 * 32 * 2" in code
+        assert "device_malloc(size_buf)" in code
+
+        # Created tensor has no host pointer (device-only)
+        assert "host_buf" not in code
+
+    def test_tensor_dim(self):
+        """Test tensor.dim generates int64_t assignment with shape value."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TensorDimProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_dim(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[64, 128], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                d0: pl.Scalar[pl.INT64] = pl.tensor.dim(a, 0)  # noqa: F841
+                result: pl.Tensor[[64, 128], pl.FP32] = self.kernel_add(a, b)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TensorDimProgram)
+        code = files["orchestration/orch_dim.cpp"]
+
+        # tensor.dim generates int64_t assignment
+        assert "int64_t d0 = 64" in code
+
+    def test_tensor_read(self):
+        """Test tensor.read generates linear index computation and cast."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TensorReadProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_read(
+                self,
+                t: pl.Tensor[[4, 8], pl.FP32],
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [1, 3])  # noqa: F841
+                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TensorReadProgram)
+        code = files["orchestration/orch_read.cpp"]
+
+        # tensor.read generates index computation and typed cast
+        assert "idx_val" in code
+        assert "static_cast<float*>(host_t)" in code
+
+
+class TestOrchestrationScalarArgs:
+    """Test scalar/constant argument passing in orchestration codegen."""
+
+    def test_tensor_read_as_scalar_arg(self):
+        """Test that tensor.read result generates inline scalar code in orchestration."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class ScalarReadProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_read_scalar(
+                self,
+                t: pl.Tensor[[4, 8], pl.FP32],
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [1, 3])  # noqa: F841
+                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(ScalarReadProgram)
+        code = files["orchestration/orch_read_scalar.cpp"]
+
+        # tensor.read generates inline scalar assignment
+        assert "idx_val" in code
+        assert "static_cast<float*>(host_t)" in code
+        # Linear index for [1, 3] on shape [4, 8]: 1 * 8 + 3
+        assert "1 * 8 + 3" in code

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -385,6 +385,49 @@ def test_tensor_read_with_expr_indices():
     assert result_type.dtype == DataType.FP16
 
 
+def test_tensor_dim():
+    """Test tensor.dim operation extracts shape dimension as scalar."""
+    span = ir.Span.unknown()
+
+    # Create a 3D tensor [4, 8, 16]
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim4, dim8, dim16], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    # Extract dimension at axis 1
+    call = ir.op.tensor.dim(tensor_var, 1)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.dim"
+
+    # Result should be ScalarType(INT64)
+    result_type = call.type
+    assert isinstance(result_type, ir.ScalarType)
+    assert result_type.dtype == DataType.INT64
+
+
+def test_tensor_dim_negative_axis():
+    """Test tensor.dim with negative axis indexing."""
+    span = ir.Span.unknown()
+
+    # Create a 2D tensor [32, 64]
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim32, dim64], DataType.FP16)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    # Extract last dimension using negative index
+    call = ir.op.tensor.dim(tensor_var, -1)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.dim"
+    result_type = call.type
+    assert isinstance(result_type, ir.ScalarType)
+    assert result_type.dtype == DataType.INT64
+
+
 def test_tensor_create_dynamic_shape():
     """Test tensor.create with dynamic (Expr) shape dimensions."""
     span = ir.Span.unknown()
@@ -414,6 +457,7 @@ def test_operator_registration():
     assert ir.is_op_registered("tensor.cast")
     assert ir.is_op_registered("tensor.assemble")
     assert ir.is_op_registered("tensor.maximum")
+    assert ir.is_op_registered("tensor.dim")
     # Check transform operators
     assert ir.is_op_registered("tensor.reshape")
     assert ir.is_op_registered("tensor.transpose")

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -432,6 +432,19 @@ class TestPromotedOps:
 
         ir.assert_structural_equal(unified, explicit)
 
+    def test_promoted_dim(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Scalar[pl.INT64]:
+            d: pl.Scalar[pl.INT64] = pl.dim(a, 0)
+            return d
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Scalar[pl.INT64]:
+            d: pl.Scalar[pl.INT64] = pl.tensor.dim(a, 0)
+            return d
+
+        ir.assert_structural_equal(unified, explicit)
+
     def test_promoted_load_store(self):
         @pl.function
         def unified(


### PR DESCRIPTION
### Summary

Introduces a registry-based architecture for orchestration-level tensor operation codegen, adds the `tensor.dim` IR op, and refactors `orchestration_codegen` to support tuple return values and control flow (for loops, yield).

### Changes

#### New: OrchestrationOpRegistry (`orchestration_op_registry.h/.cpp`)
- Singleton registry mapping op names to codegen functions
- `REGISTER_ORCHESTRATION_OP` macro for static registration at init time
- Decouples tensor op codegen from the main orchestration codegen

#### New: tensor_op_codegen.cpp
- Registers codegen for `tensor.create`, `tensor.read`, `tensor.dim` via the registry
- Each op generates inline C++ code (device_malloc, linear index read, shape dimension extraction)

#### New: tensor.dim IR op
- C++ type deduction in `src/ir/op/tensor_ops/memory.cpp` — returns `ScalarType(INT64)`
- Python IR API: `ir.op.tensor.dim(tensor, axis)` with negative indexing support
- Language API: `pl.dim(tensor, axis)` / `pl.tensor.dim(tensor, axis)`

#### Refactored: CodegenBase (`codegen_base.h/.cpp`)
- Extracted `TryGetVarName` and `GenerateExprString` as static methods on `CodegenBase`
- Reusable across orchestration codegen and tensor op codegen

#### Refactored: orchestration_codegen.cpp
- Replaced flat function-call iteration with `OrchestrationStmtCodegen` (extends `CodegenBase`, implements `IRVisitor`)
- Supports `ForStmt`, `YieldStmt`, `EvalStmt`, `AssignStmt`, `ReturnStmt` — enabling for-loop codegen
- Supports tuple return values: multiple return tensors each get host pointers and `record_tensor_pair`
- Supports tuple intermediate values: `TupleGetItemExpr` unpacking with per-element device memory allocation
- Tensor ops dispatched via `OrchestrationOpRegistry` instead of hardcoded if-else

### Tests

- `tests/ut/codegen/test_orchestration_codegen.py` — 588 lines covering:
  - Single return, tuple intermediate, tuple output, 4-element tuple (paged attention pattern)
  - Task dependencies (chain, independent), codegen metadata
  - `tensor.create`, `tensor.dim`, `tensor.read` inline codegen
  - Scalar argument passing
- `tests/ut/ir/operators/test_tensor_ops.py` — `tensor.dim` positive/negative axis, op registration
- `tests/ut/language/test_unified_ops.py` — `pl.dim` promoted op equivalence
