### PR TITLE
fix(pass): Handle OpStmts in InsertSync and MemoryReuse passes

### DIFF
--- a/src/ir/transforms/dependency_analyzer.cpp
+++ b/src/ir/transforms/dependency_analyzer.cpp
@@ -245,6 +245,11 @@ std::vector<BasicBlock> DependencyAnalyzer::IdentifyBasicBlocks(const StmtPtr& s
         for (const auto& sub_stmt : seq->stmts_) {
           CollectStmtsInBlock(sub_stmt, statements);
         }
+      } else if (auto op_stmts = As<OpStmts>(stmt)) {
+        // Flatten OpStmts into individual statements (AssignStmt/EvalStmt)
+        for (const auto& sub_stmt : op_stmts->stmts_) {
+          CollectStmtsInBlock(sub_stmt, statements);
+        }
       } else if (IsA<IfStmt>(stmt) || IsA<ForStmt>(stmt)) {
         // Control flow statements are not added to the current block
         // They create their own blocks

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -20,7 +20,7 @@ import unittest
 import pypto.language as pl
 from pypto import DataType, backend, ir
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import PassManager
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import codegen
 
 # ============================================================================
@@ -471,8 +471,8 @@ class Test910BBlockOpsCodegen(unittest.TestCase):
         for func_name in function_names:
             assert func_name.startswith("kernel_"), f"Function {func_name} should start with 'kernel_' prefix"
 
-        # Run PassManager optimization
-        pm = PassManager.get_strategy()
+        # Run PassManager optimization with PTOAS strategy (PTO assembly without sync)
+        pm = PassManager.get_strategy(OptimizationStrategy.PTOAS)
         optimized_program = pm.run_passes(program)
 
         # Generate PTO MLIR code for each function individually


### PR DESCRIPTION
FlattenCallExpr calls NormalizeStmtStructure which wraps consecutive AssignStmt/EvalStmt into OpStmts blocks. Both InsertSyncPass and DependencyAnalyzer (used by MemoryReuse) only handled SeqStmts, silently skipping OpStmts contents. This caused InsertSync to miss cross-pipe dependencies and MemoryReuse to find no TileType variables.

Fix by flattening OpStmts in InsertSync's SeqStmts visitor and adding OpStmts handling to all recursive helpers (ExtractMemRefs, ExtractPipesForMemRefs, HasMemRefAccess, FindFirstAccessIndex), and in DependencyAnalyzer's CollectStmtsInBlock. Also switch PTO codegen test to PTOAS strategy since PTO backend doesn't need sync insertion.