### PR TITLE
feat(codegen): Add PTO2 V2 orchestration codegen with scope inference

### DIFF
--- a/examples/ir_parser/vector_example_dag.py
+++ b/examples/ir_parser/vector_example_dag.py
@@ -1,0 +1,150 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Vector Example DAG - Kernel and Orchestration Code Generation
+
+Demonstrates a 5-task DAG with mixed kernel types and scalar parameters.
+
+Formula: f = (a + b + 1)(a + b + 2) + (a + b)
+
+Task Graph:
+  t0: c = kernel_add(a, b)           [outer scope]
+  t1: d = kernel_add_scalar(c, 1.0)  [inner scope]
+  t2: e = kernel_add_scalar(c, 2.0)  [inner scope]
+  t3: g = kernel_mul(d, e)           [inner scope]
+  t4: f = kernel_add(g, c)           [inner scope]
+
+Dependencies: t0->t1, t0->t2, t1->t3, t2->t3, t3->t4, t0->t4
+"""
+
+import os
+
+import pypto.language as pl
+from pypto import ir
+from pypto.backend import BackendType
+
+
+@pl.program
+class VectorExampleProgram:
+    """Vector example program with 3 InCore kernels and 1 Orchestration function."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Adds two tensors element-wise: result = a + b"""
+        a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.add(a_tile, b_tile)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_add_scalar(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        scalar: pl.Scalar[pl.FP32],
+        output: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Adds a scalar to each element: result = a + scalar"""
+        x: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.add(x, scalar)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_mul(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Multiplies two tensors element-wise: result = a * b"""
+        a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.mul(a_tile, b_tile)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orch_vector(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Orchestration for formula: f = (a + b + 1)(a + b + 2) + (a + b)
+
+        Task graph:
+          t0: c = kernel_add(a, b)
+          t1: d = kernel_add_scalar(c, 1.0)
+          t2: e = kernel_add_scalar(c, 2.0)
+          t3: g = kernel_mul(d, e)
+          t4: f = kernel_add(g, c)
+        """
+        c: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add(a, b)
+        d: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
+        e: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
+        g: pl.Tensor[[128, 128], pl.FP32] = self.kernel_mul(d, e)
+        f: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add(g, c)
+        return f
+
+
+def main():
+    """Main function - generate kernel and orchestration code."""
+    print("=" * 70)
+    print("Vector Example DAG - Code Generation")
+    print("Formula: f = (a + b + 1)(a + b + 2) + (a + b)")
+    print("=" * 70)
+
+    # Step 1: Print IR
+    print("\n[1] IR (Python syntax):")
+    print("-" * 70)
+    ir_text = ir.python_print(VectorExampleProgram)
+    print(ir_text)
+    print("-" * 70)
+
+    # Step 2: Compile (generates both kernel and orchestration code)
+    print("\n[2] Compiling with PassManager and CCECodegen...")
+    output_dir = ir.compile(
+        VectorExampleProgram,
+        strategy=ir.OptimizationStrategy.Default,
+        dump_passes=True,
+        backend_type=BackendType.CCE,
+    )
+    print(f"Output directory: {output_dir}")
+
+    # Step 3: List generated files
+    print("\n[3] Generated files:")
+    for root, _dirs, files in os.walk(output_dir):
+        for file in sorted(files):
+            filepath = os.path.join(root, file)
+            rel_path = os.path.relpath(filepath, output_dir)
+            file_size = os.path.getsize(filepath)
+            print(f"  - {rel_path} ({file_size} bytes)")
+
+    # Step 4: Show kernel code (walk subdirectories like kernels/aiv/)
+    kernel_dir = os.path.join(output_dir, "kernels")
+    if not os.path.isdir(kernel_dir):
+        print(f"\n[5] Warning: {kernel_dir} not found")
+
+    # Step 5: Show orchestration code
+    orch_file = os.path.join(output_dir, "orchestration", "orch_vector.cpp")
+    if not os.path.exists(orch_file):
+        print(f"\n[5] Warning: {orch_file} not found")
+
+    print("\n Kernel files generated:")
+    print(f"  - {kernel_dir}")
+    print(f"  - {orch_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -90,6 +90,19 @@ class CodegenBase : public ir::IRVisitor {
   virtual std::string GetVarName(const ir::VarPtr& var) = 0;
 
   /**
+   * @brief Get the data pointer expression for a tensor variable
+   *
+   * Returns the C++ expression to access a tensor's raw data pointer.
+   * Orchestration codegen returns "arg_<name>_ptr" for external tensors or "<name>.data" for local tensors.
+   *
+   * @param tensor_name Tensor variable name
+   * @return C++ expression for the data pointer (e.g., "arg_x_ptr", "x.data")
+   */
+  [[nodiscard]] virtual std::string GetTensorDataPtr(const std::string& tensor_name) const {
+    throw ValueError("GetTensorDataPtr not implemented for this codegen");
+  }
+
+  /**
    * @brief Try to extract variable name from expression
    *
    * Supports Var and IterArg expressions. Returns empty string if not a variable.

--- a/include/pypto/codegen/orchestration/orchestration_codegen.h
+++ b/include/pypto/codegen/orchestration/orchestration_codegen.h
@@ -35,10 +35,14 @@ struct OrchestrationResult {
 };
 
 /**
- * @brief Generate C++ orchestration code for a function (shared by PTOCodegen and CCECodegen)
+ * @brief Generate C++ orchestration code for a function
  *
- * Generates C++ code that builds task graphs using Runtime API.
- * Function signature: int BuildXXX(Runtime* runtime, uint64_t* args, int arg_count)
+ * Generates C++ code using PTO2 runtime API:
+ * - aicpu_orchestration_config() returns PTO2OrchestrationConfig
+ * - aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count)
+ * - make_tensor_external / make_tensor for tensor declarations
+ * - PTOParam + pto2_rt_submit_task for task submission
+ * - No manual dependency management (runtime handles automatically)
  *
  * @param program The IR Program (used to resolve callee functions and validate references)
  * @param func The orchestration function to generate code for

--- a/src/codegen/cce/cce_codegen.cpp
+++ b/src/codegen/cce/cce_codegen.cpp
@@ -114,11 +114,6 @@ std::map<std::string, std::string> CCECodegen::Generate(const ir::ProgramPtr& pr
 std::string CCECodegen::GenerateConfigFile(
     const std::string& orch_func_name, const std::map<std::string, int>& func_name_to_id,
     const std::map<std::string, ir::CoreType>& func_name_to_core_type) {
-  std::string func_name = "Build";
-  if (!orch_func_name.empty()) {
-    func_name += static_cast<char>(std::toupper(static_cast<unsigned char>(orch_func_name[0])));
-    func_name += orch_func_name.substr(1);
-  }
   std::ostringstream oss;
   oss << "# Kernel and Orchestration Configuration\n\n";
   oss << "from pathlib import Path\n\n";
@@ -126,13 +121,13 @@ std::string CCECodegen::GenerateConfigFile(
 
   oss << "ORCHESTRATION = {\n\t\"source\": str(_ROOT_DIR / \"orchestration\" / \"" << orch_func_name
       << ".cpp\"),\n"
-      << "\t\"function_name\": \"" << func_name << "\"\n}\n\n";
+      << "\t\"function_name\": \"aicpu_orchestration_entry\"\n}\n\n";
 
   oss << "KERNELS = [\n";
-  for (const auto& [func_name, func_id] : func_name_to_id) {
-    std::string core_type = func_name_to_core_type.at(func_name) == ir::CoreType::VECTOR ? "aiv" : "aic";
-    oss << "\t{\"func_id\": " << func_id << R"(, "source": str(_ROOT_DIR / "kernels" / ")" << core_type
-        << "\" / \"" << func_name << R"(.cpp"), "core_type": ")" << core_type << "\"},\n";
+  for (const auto& [name, id] : func_name_to_id) {
+    std::string core_type = func_name_to_core_type.at(name) == ir::CoreType::VECTOR ? "aiv" : "aic";
+    oss << "\t{\"func_id\": " << id << R"(, "source": str(_ROOT_DIR / "kernels" / ")" << core_type
+        << "\" / \"" << name << R"(.cpp"), "core_type": ")" << core_type << "\"},\n";
   }
   oss << "]\n";
   return oss.str();


### PR DESCRIPTION
## Summary

Add PTO2 (V2) orchestration code generation targeting the `PTO2Runtime*` API, with automatic `PTO2_SCOPE` inference for intermediate tensor lifetime management.

## Changes

### V2 Orchestration Codegen (`orchestration_codegen.cpp`)
- New `GenerateOrchestrationV2()` generating PTO2-format C++ code:
  - `#include "pto_orchestration_api.h"`, `ARG_PTR_`/`ARG_SIZE_` defines
  - `make_tensor_external()` for params/returns, `make_tensor()` for intermediates
  - `PTOParam` arrays with `make_input_param`/`make_output_param`/`make_scalar_param`
  - `pto2_rt_submit_task()` with func_id, worker type, kernel name
  - `float_to_u64()` helper for float scalar params
  - `PTO2OrchestrationConfig` via `aicpu_orchestration_config()`
- `OrchestrationStmtCodegenV2` visitor handling function calls, for-loops, tensor ops, scalar/bool constants, and tuple returns
- `TaskRecord`-based scope analysis: tasks with all-external inputs → outer scope; others → `PTO2_SCOPE(rt) { ... }` inner scope
- V2 config file generation (`kernel_config_v2.py`)

### CCE Codegen Integration (`cce_codegen.cpp`, `cce_codegen.h`)
- `CCECodegen::Generate()` now emits both V1 and V2 orchestration files (`<name>.cpp` + `<name>_v2.cpp`)
- `GenerateConfigFileV2()` for PTO2 kernel config

### Tests (`test_orchestration_codegen.py`)
- `TestOrchestrationV2` class with 4 test cases:
  - `test_v2_basic_structure`: V2 format, includes, ARG defines, external/intermediate tensors, PTO2_SCOPE
  - `test_v2_config_file`: V2 config file generation
  - `test_v2_independent_tasks`: all-external tasks → no PTO2_SCOPE
  - `test_v2_vector_example_dag`: 5-task DAG matching `vector_example` reference (`kernel_add`, `kernel_add_scalar`, `kernel_mul`), scalar params via `float_to_u64`, PTO2_SCOPE wrapping inner tasks

## Scope Inference Algorithm

Tasks are classified based on their input tensor dependencies:
- **Outer scope**: all input tensors are external (function params or return tensors)
- **Inner scope** (`PTO2_SCOPE(rt) { ... }`): any input tensor is an intermediate (produced by another task)

Intermediate tensors produced by outer tasks are declared before the scope; inner-only intermediates are declared inside the scope for proper lifetime management.