### PR TITLE
feat(ir): Add BreakStmt and ContinueStmt IR nodes

### DIFF
--- a/docs/dev/ir/01-hierarchy.md
+++ b/docs/dev/ir/01-hierarchy.md
@@ -12,6 +12,7 @@ This document provides a complete reference of all IR node types, organized by c
 
 <stmt>       ::= <assign_stmt> | <if_stmt> | <for_stmt> | <while_stmt> | <yield_stmt>
                | <eval_stmt> | <seq_stmts> | <op_stmts> | <scope_stmt>
+               | <break_stmt> | <continue_stmt>
 
 <assign_stmt> ::= <var> "=" <expr>
 <if_stmt>    ::= "if" <expr> ":" <stmt_list> [ "else" ":" <stmt_list> ] [ "return" <var_list> ]
@@ -30,6 +31,8 @@ This document provides a complete reference of all IR node types, organized by c
 <seq_stmts>  ::= <stmt> { ";" <stmt> }
 <op_stmts>   ::= <assign_stmt> { ";" <assign_stmt> }
 <scope_stmt> ::= "with" "pl.incore" "(" ")" ":" <stmt_list>
+<break_stmt> ::= "break"
+<continue_stmt> ::= "continue"
 
 <expr>       ::= <var> | <const_int> | <const_bool> | <const_float> | <call>
                | <binary_op> | <unary_op> | <tuple_get_item>
@@ -122,6 +125,8 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 | **EvalStmt** | `expr_` | Evaluate expression for side effects |
 | **SeqStmts** | `stmts_` | General statement sequence |
 | **OpStmts** | `stmts_` | Assignment statement sequence |
+| **BreakStmt** | *(none)* | Exit loop |
+| **ContinueStmt** | *(none)* | Skip to next loop iteration |
 
 ### ForStmt Details
 
@@ -289,7 +294,7 @@ Functions stored in sorted map for deterministic ordering. GlobalVar names must 
 | **Unary Ops** | 5 | Abs, Neg, Not, BitNot, Cast |
 | **Call/Access** | 2 | Call, TupleGetItemExpr |
 | **Operations** | 2 | Op, GlobalVar |
-| **Statements** | 9 | AssignStmt, IfStmt, ForStmt, WhileStmt, ScopeStmt, YieldStmt, EvalStmt, SeqStmts, OpStmts |
+| **Statements** | 11 | AssignStmt, IfStmt, ForStmt, WhileStmt, ScopeStmt, YieldStmt, EvalStmt, SeqStmts, OpStmts, BreakStmt, ContinueStmt |
 | **Types** | 6 | ScalarType, TensorType, TileType, TupleType, PipeType, UnknownType |
 | **Functions** | 2 | Function, Program |
 

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -90,6 +90,8 @@ enum class ObjectKind {
   SeqStmts,
   OpStmts,
   EvalStmt,
+  BreakStmt,
+  ContinueStmt,
 
   // Type kinds
   UnknownType,

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -89,6 +89,8 @@ DEFINE_KIND_TRAIT(ScopeStmt, ObjectKind::ScopeStmt)
 DEFINE_KIND_TRAIT(SeqStmts, ObjectKind::SeqStmts)
 DEFINE_KIND_TRAIT(OpStmts, ObjectKind::OpStmts)
 DEFINE_KIND_TRAIT(EvalStmt, ObjectKind::EvalStmt)
+DEFINE_KIND_TRAIT(BreakStmt, ObjectKind::BreakStmt)
+DEFINE_KIND_TRAIT(ContinueStmt, ObjectKind::ContinueStmt)
 
 // Type types
 DEFINE_KIND_TRAIT(UnknownType, ObjectKind::UnknownType)
@@ -115,11 +117,11 @@ DEFINE_KIND_TRAIT(GlobalVar, ObjectKind::GlobalVar)
 // Stmt base class - matches any statement kind
 template <>
 struct KindTrait<Stmt> {
-  static constexpr ObjectKind kinds[] = {ObjectKind::AssignStmt, ObjectKind::IfStmt,   ObjectKind::YieldStmt,
-                                         ObjectKind::ReturnStmt, ObjectKind::ForStmt,  ObjectKind::WhileStmt,
-                                         ObjectKind::ScopeStmt,  ObjectKind::SeqStmts, ObjectKind::OpStmts,
-                                         ObjectKind::EvalStmt};
-  static constexpr size_t count = 10;
+  static constexpr ObjectKind kinds[] = {
+      ObjectKind::AssignStmt, ObjectKind::IfStmt,    ObjectKind::YieldStmt, ObjectKind::ReturnStmt,
+      ObjectKind::ForStmt,    ObjectKind::WhileStmt, ObjectKind::ScopeStmt, ObjectKind::SeqStmts,
+      ObjectKind::OpStmts,    ObjectKind::EvalStmt,  ObjectKind::BreakStmt, ObjectKind::ContinueStmt};
+  static constexpr size_t count = 12;
 };
 
 // Expr base class - matches any expression kind

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -627,6 +627,40 @@ class EvalStmt : public Stmt {
 
 using EvalStmtPtr = std::shared_ptr<const EvalStmt>;
 
+/**
+ * @brief Break statement
+ *
+ * Represents a break statement used to exit a loop: break
+ */
+class BreakStmt : public Stmt {
+ public:
+  explicit BreakStmt(Span span) : Stmt(std::move(span)) {}
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::BreakStmt; }
+  [[nodiscard]] std::string TypeName() const override { return "BreakStmt"; }
+
+  static constexpr auto GetFieldDescriptors() { return Stmt::GetFieldDescriptors(); }
+};
+
+using BreakStmtPtr = std::shared_ptr<const BreakStmt>;
+
+/**
+ * @brief Continue statement
+ *
+ * Represents a continue statement used to skip to the next loop iteration: continue
+ */
+class ContinueStmt : public Stmt {
+ public:
+  explicit ContinueStmt(Span span) : Stmt(std::move(span)) {}
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ContinueStmt; }
+  [[nodiscard]] std::string TypeName() const override { return "ContinueStmt"; }
+
+  static constexpr auto GetFieldDescriptors() { return Stmt::GetFieldDescriptors(); }
+};
+
+using ContinueStmtPtr = std::shared_ptr<const ContinueStmt>;
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transforms/base/functor.h
+++ b/include/pypto/ir/transforms/base/functor.h
@@ -187,6 +187,8 @@ class StmtFunctor {
   virtual R VisitStmt_(const SeqStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const OpStmtsPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const EvalStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const BreakStmtPtr& op, Args... args) = 0;
+  virtual R VisitStmt_(const ContinueStmtPtr& op, Args... args) = 0;
   virtual R VisitStmt_(const StmtPtr& op, Args... args) = 0;
 };
 
@@ -209,6 +211,8 @@ R StmtFunctor<R, Args...>::VisitStmt(const StmtPtr& stmt, Args... args) {
   STMT_FUNCTOR_DISPATCH(SeqStmts);
   STMT_FUNCTOR_DISPATCH(OpStmts);
   STMT_FUNCTOR_DISPATCH(EvalStmt);
+  STMT_FUNCTOR_DISPATCH(BreakStmt);
+  STMT_FUNCTOR_DISPATCH(ContinueStmt);
 
   // Should never reach here if all types are handled
   throw pypto::TypeError("Unknown statement type in StmtFunctor::VisitStmt");

--- a/include/pypto/ir/transforms/base/mutator.h
+++ b/include/pypto/ir/transforms/base/mutator.h
@@ -88,6 +88,8 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override;
   StmtPtr VisitStmt_(const OpStmtsPtr& op) override;
   StmtPtr VisitStmt_(const EvalStmtPtr& op) override;
+  StmtPtr VisitStmt_(const BreakStmtPtr& op) override;
+  StmtPtr VisitStmt_(const ContinueStmtPtr& op) override;
   StmtPtr VisitStmt_(const StmtPtr& op) override;
 };
 

--- a/include/pypto/ir/transforms/base/visitor.h
+++ b/include/pypto/ir/transforms/base/visitor.h
@@ -87,6 +87,8 @@ class IRVisitor : public IRFunctor<void> {
   void VisitStmt_(const SeqStmtsPtr& op) override;
   void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const EvalStmtPtr& op) override;
+  void VisitStmt_(const BreakStmtPtr& op) override;
+  void VisitStmt_(const ContinueStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
  private:

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -691,6 +691,17 @@ void BindIR(nb::module_& m) {
                       "Create an evaluation statement");
   BindFields<EvalStmt>(eval_stmt_class);
 
+  // BreakStmt - const shared_ptr
+  auto break_stmt_class = nb::class_<BreakStmt, Stmt>(ir, "BreakStmt", "Break statement: break");
+  break_stmt_class.def(nb::init<const Span&>(), nb::arg("span"), "Create a break statement");
+  BindFields<BreakStmt>(break_stmt_class);
+
+  // ContinueStmt - const shared_ptr
+  auto continue_stmt_class =
+      nb::class_<ContinueStmt, Stmt>(ir, "ContinueStmt", "Continue statement: continue");
+  continue_stmt_class.def(nb::init<const Span&>(), nb::arg("span"), "Create a continue statement");
+  BindFields<ContinueStmt>(continue_stmt_class);
+
   // FunctionType enum
   nb::enum_<FunctionType>(ir, "FunctionType", "Function type classification")
       .value("Opaque", FunctionType::Opaque, "Unspecified function type (default)")

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1530,6 +1530,26 @@ class EvalStmt(Stmt):
             span: Source location
         """
 
+class BreakStmt(Stmt):
+    """Break statement: break."""
+
+    def __init__(self, span: Span) -> None:
+        """Create a break statement.
+
+        Args:
+            span: Source location
+        """
+
+class ContinueStmt(Stmt):
+    """Continue statement: continue."""
+
+    def __init__(self, span: Span) -> None:
+        """Create a continue statement.
+
+        Args:
+            span: Source location
+        """
+
 class Function(IRNode):
     """Function definition with name, parameters, return types, and body."""
 

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -194,6 +194,8 @@ class IRSerializer::Impl {
     SERIALIZE_FIELDS(SeqStmts);
     SERIALIZE_FIELDS(OpStmts);
     SERIALIZE_FIELDS(EvalStmt);
+    SERIALIZE_FIELDS(BreakStmt);
+    SERIALIZE_FIELDS(ContinueStmt);
     SERIALIZE_FIELDS(Function);
     SERIALIZE_FIELDS(Program);
 

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -485,6 +485,20 @@ static IRNodePtr DeserializeEvalStmt(const msgpack::object& fields_obj, msgpack:
   return std::make_shared<EvalStmt>(expr, span);
 }
 
+// Deserialize BreakStmt
+static IRNodePtr DeserializeBreakStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
+                                      DeserializerContext& ctx) {
+  auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
+  return std::make_shared<BreakStmt>(span);
+}
+
+// Deserialize ContinueStmt
+static IRNodePtr DeserializeContinueStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
+                                         DeserializerContext& ctx) {
+  auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
+  return std::make_shared<ContinueStmt>(span);
+}
+
 // Deserialize Function
 static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack::zone& zone,
                                      DeserializerContext& ctx) {
@@ -635,6 +649,8 @@ static TypeRegistrar _scope_stmt_registrar("ScopeStmt", DeserializeScopeStmt);
 static TypeRegistrar _seq_stmts_registrar("SeqStmts", DeserializeSeqStmts);
 static TypeRegistrar _op_stmts_registrar("OpStmts", DeserializeOpStmts);
 static TypeRegistrar _eval_stmt_registrar("EvalStmt", DeserializeEvalStmt);
+static TypeRegistrar _break_stmt_registrar("BreakStmt", DeserializeBreakStmt);
+static TypeRegistrar _continue_stmt_registrar("ContinueStmt", DeserializeContinueStmt);
 
 static TypeRegistrar _function_registrar("Function", DeserializeFunction);
 static TypeRegistrar _program_registrar("Program", DeserializeProgram);

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -512,6 +512,16 @@ StmtPtr IRMutator::VisitStmt_(const EvalStmtPtr& op) {
   }
 }
 
+StmtPtr IRMutator::VisitStmt_(const BreakStmtPtr& op) {
+  // Leaf node, return original
+  return op;
+}
+
+StmtPtr IRMutator::VisitStmt_(const ContinueStmtPtr& op) {
+  // Leaf node, return original
+  return op;
+}
+
 StmtPtr IRMutator::VisitStmt_(const StmtPtr& op) {
   // Base Stmt is immutable, return original
   return op;

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -187,6 +187,8 @@ class IRPythonPrinter : public IRVisitor {
   void VisitStmt_(const SeqStmtsPtr& op) override;
   void VisitStmt_(const OpStmtsPtr& op) override;
   void VisitStmt_(const EvalStmtPtr& op) override;
+  void VisitStmt_(const BreakStmtPtr& op) override;
+  void VisitStmt_(const ContinueStmtPtr& op) override;
   void VisitStmt_(const StmtPtr& op) override;
 
   // Function and program visitors
@@ -801,6 +803,10 @@ void IRPythonPrinter::VisitStmt_(const EvalStmtPtr& op) {
   // Print expression statement: expr
   VisitExpr(op->expr_);
 }
+
+void IRPythonPrinter::VisitStmt_(const BreakStmtPtr& op) { stream_ << "break"; }
+
+void IRPythonPrinter::VisitStmt_(const ContinueStmtPtr& op) { stream_ << "continue"; }
 
 void IRPythonPrinter::VisitStmt_(const StmtPtr& op) { stream_ << op->TypeName(); }
 

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -606,6 +606,8 @@ bool StructuralEqualImpl<AssertMode>::Equal(const IRNodePtr& lhs, const IRNodePt
   EQUAL_DISPATCH(SeqStmts)
   EQUAL_DISPATCH(OpStmts)
   EQUAL_DISPATCH(EvalStmt)
+  EQUAL_DISPATCH(BreakStmt)
+  EQUAL_DISPATCH(ContinueStmt)
   EQUAL_DISPATCH(Function)
   EQUAL_DISPATCH(Program)
 

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -365,6 +365,8 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(SeqStmts)
   HASH_DISPATCH(OpStmts)
   HASH_DISPATCH(EvalStmt)
+  HASH_DISPATCH(BreakStmt)
+  HASH_DISPATCH(ContinueStmt)
   HASH_DISPATCH(Function)
   HASH_DISPATCH(Program)
 

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -234,6 +234,14 @@ void IRVisitor::VisitStmt_(const EvalStmtPtr& op) {
   VisitExpr(op->expr_);
 }
 
+void IRVisitor::VisitStmt_(const BreakStmtPtr& op) {
+  // Leaf node, no children to visit
+}
+
+void IRVisitor::VisitStmt_(const ContinueStmtPtr& op) {
+  // Leaf node, no children to visit
+}
+
 void IRVisitor::VisitStmt_(const StmtPtr& op) {
   // Base Stmt has no children to visit
 }

--- a/tests/ut/ir/statements/test_break_stmt.py
+++ b/tests/ut/ir/statements/test_break_stmt.py
@@ -1,0 +1,445 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+from pypto import DataType, ir
+
+
+def test_break_stmt_creation():
+    """Test creating a BreakStmt."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.BreakStmt(span)
+
+    assert isinstance(stmt, ir.BreakStmt)
+    assert isinstance(stmt, ir.Stmt)
+    assert stmt.span.filename == "test.py"
+
+
+def test_break_stmt_python_print():
+    """Test printing a BreakStmt as Python code."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.BreakStmt(span)
+
+    code = ir.python_print(stmt)
+    assert code == "break"
+
+
+def test_break_stmt_structural_hash():
+    """Test that two BreakStmts produce the same hash."""
+    span1 = ir.Span("a.py", 1, 1)
+    span2 = ir.Span("b.py", 2, 2)
+    stmt1 = ir.BreakStmt(span1)
+    stmt2 = ir.BreakStmt(span2)
+
+    assert ir.structural_hash(stmt1) == ir.structural_hash(stmt2)
+
+
+def test_break_stmt_structural_equal():
+    """Test structural equality of BreakStmts."""
+    span1 = ir.Span("a.py", 1, 1)
+    span2 = ir.Span("b.py", 2, 2)
+    stmt1 = ir.BreakStmt(span1)
+    stmt2 = ir.BreakStmt(span2)
+
+    ir.assert_structural_equal(stmt1, stmt2)
+
+
+def test_break_stmt_not_equal_to_continue():
+    """Test that BreakStmt is not structurally equal to ContinueStmt."""
+    span = ir.Span("test.py", 1, 1)
+    break_stmt = ir.BreakStmt(span)
+    continue_stmt = ir.ContinueStmt(span)
+
+    assert not ir.structural_equal(break_stmt, continue_stmt)
+
+
+def test_break_stmt_serialization():
+    """Test serializing and deserializing a BreakStmt."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.BreakStmt(span)
+
+    data = ir.serialize(stmt)
+    restored = ir.deserialize(data)
+
+    assert isinstance(restored, ir.BreakStmt)
+    ir.assert_structural_equal(stmt, restored)
+
+
+def test_break_stmt_not_equal_to_other_stmt_types():
+    """Test that BreakStmt is not structurally equal to other statement types."""
+    span = ir.Span("test.py", 1, 1)
+    dtype = DataType.INT64
+    break_stmt = ir.BreakStmt(span)
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+    yield_stmt = ir.YieldStmt([x], span)
+    return_stmt = ir.ReturnStmt([x], span)
+
+    assert not ir.structural_equal(break_stmt, assign)
+    assert not ir.structural_equal(break_stmt, yield_stmt)
+    assert not ir.structural_equal(break_stmt, return_stmt)
+
+
+def test_break_stmt_immutability():
+    """Test that BreakStmt span attribute is immutable."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.BreakStmt(span)
+
+    with pytest.raises(AttributeError):
+        stmt.span = ir.Span("other.py", 2, 2)  # type: ignore
+
+
+class TestBreakInForLoop:
+    """Test BreakStmt composed inside ForStmt bodies."""
+
+    def _make_for_with_body(self, body: ir.Stmt) -> ir.ForStmt:
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        return ir.ForStmt(i, start, stop, step, [], body, [], span)
+
+    def test_for_loop_with_break_body(self):
+        """Test ForStmt whose body is a single BreakStmt."""
+        span = ir.Span("test.py", 1, 1)
+        break_stmt = ir.BreakStmt(span)
+        for_stmt = self._make_for_with_body(break_stmt)
+
+        assert isinstance(for_stmt.body, ir.BreakStmt)
+
+    def test_for_loop_with_break_in_seq(self):
+        """Test ForStmt with break inside a SeqStmts body."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(42, dtype, span), span)
+        break_stmt = ir.BreakStmt(span)
+        seq = ir.SeqStmts([assign, break_stmt], span)
+        for_stmt = self._make_for_with_body(seq)
+
+        assert isinstance(for_stmt.body, ir.SeqStmts)
+        assert len(for_stmt.body.stmts) == 2
+        assert isinstance(for_stmt.body.stmts[0], ir.AssignStmt)
+        assert isinstance(for_stmt.body.stmts[1], ir.BreakStmt)
+
+    def test_for_loop_with_conditional_break(self):
+        """Test ForStmt with break inside an IfStmt (if cond: break).
+
+        Represents: for i in range(0, 10, 1): if i > 5: break
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        cond = ir.Gt(i, ir.ConstInt(5, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        if_stmt = ir.IfStmt(cond, break_stmt, None, [], span)
+        for_stmt = self._make_for_with_body(if_stmt)
+
+        assert isinstance(for_stmt.body, ir.IfStmt)
+        assert isinstance(for_stmt.body.then_body, ir.BreakStmt)
+
+    def test_for_loop_with_break_python_print(self):
+        """Test python_print of a ForStmt containing a conditional break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        cond = ir.Gt(i, ir.ConstInt(5, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        if_stmt = ir.IfStmt(cond, break_stmt, None, [], span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], if_stmt, [], span)
+
+        code = ir.python_print(for_stmt)
+        assert "for" in code
+        assert "break" in code
+        assert "if" in code
+
+    def test_for_loop_with_break_structural_equal(self):
+        """Test structural equality of two ForStmts with identical conditional break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+
+        def make_for_break():
+            i = ir.Var("i", ir.ScalarType(dtype), span)
+            start = ir.ConstInt(0, dtype, span)
+            stop = ir.ConstInt(10, dtype, span)
+            step = ir.ConstInt(1, dtype, span)
+            cond = ir.Gt(i, ir.ConstInt(5, dtype, span), dtype, span)
+            brk = ir.BreakStmt(span)
+            if_stmt = ir.IfStmt(cond, brk, None, [], span)
+            return ir.ForStmt(i, start, stop, step, [], if_stmt, [], span)
+
+        ir.assert_structural_equal(make_for_break(), make_for_break())
+
+    def test_for_loop_with_break_serialization(self):
+        """Test serialization roundtrip of a ForStmt containing a break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], break_stmt, [], span)
+
+        data = ir.serialize(for_stmt)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.ForStmt)
+        assert isinstance(restored.body, ir.BreakStmt)
+        ir.assert_structural_equal(for_stmt, restored)
+
+    def test_for_loop_break_vs_continue_not_equal(self):
+        """Test that for-with-break is not equal to for-with-continue."""
+        span = ir.Span("test.py", 1, 1)
+        for_break = self._make_for_with_body(ir.BreakStmt(span))
+        for_continue = self._make_for_with_body(ir.ContinueStmt(span))
+
+        assert not ir.structural_equal(for_break, for_continue)
+
+
+class TestBreakInWhileLoop:
+    """Test BreakStmt composed inside WhileStmt bodies."""
+
+    def test_while_loop_with_break_body(self):
+        """Test WhileStmt whose body is a single BreakStmt."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        while_stmt = ir.WhileStmt(cond, [], break_stmt, [], span)
+
+        assert isinstance(while_stmt.body, ir.BreakStmt)
+
+    def test_while_loop_with_conditional_break(self):
+        """Test WhileStmt with conditional break: while cond: if x > 5: break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        loop_cond = ir.Lt(x, ir.ConstInt(100, dtype, span), dtype, span)
+        break_cond = ir.Gt(x, ir.ConstInt(5, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        if_stmt = ir.IfStmt(break_cond, break_stmt, None, [], span)
+        while_stmt = ir.WhileStmt(loop_cond, [], if_stmt, [], span)
+
+        assert isinstance(while_stmt.body, ir.IfStmt)
+        assert isinstance(while_stmt.body.then_body, ir.BreakStmt)
+
+    def test_while_loop_with_break_serialization(self):
+        """Test serialization roundtrip of a WhileStmt containing a break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        while_stmt = ir.WhileStmt(cond, [], break_stmt, [], span)
+
+        data = ir.serialize(while_stmt)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.WhileStmt)
+        assert isinstance(restored.body, ir.BreakStmt)
+        # WhileStmt condition has free vars; use auto-mapping after deserialization
+        ir.assert_structural_equal(while_stmt, restored, enable_auto_mapping=True)
+
+    def test_while_loop_with_break_structural_hash(self):
+        """Test structural hash consistency for WhileStmt containing break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        # Share Var instance so pointer-based hash is stable
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        w1 = ir.WhileStmt(cond, [], ir.BreakStmt(span), [], span)
+        w2 = ir.WhileStmt(cond, [], ir.BreakStmt(span), [], span)
+
+        assert ir.structural_hash(w1) == ir.structural_hash(w2)
+
+
+class TestBreakInNestedStructures:
+    """Test BreakStmt in deeply nested IR structures."""
+
+    def test_break_in_if_else(self):
+        """Test break in then branch and continue in else branch of IfStmt."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Gt(x, ir.ConstInt(5, dtype, span), dtype, span)
+        break_stmt = ir.BreakStmt(span)
+        continue_stmt = ir.ContinueStmt(span)
+        if_stmt = ir.IfStmt(cond, break_stmt, continue_stmt, [], span)
+
+        assert isinstance(if_stmt.then_body, ir.BreakStmt)
+        assert isinstance(if_stmt.else_body, ir.ContinueStmt)
+
+        code = ir.python_print(if_stmt)
+        assert "break" in code
+        assert "continue" in code
+
+    def test_break_in_seq_with_multiple_stmts(self):
+        """Test break preceded by assignments in a SeqStmts."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)
+        assign2 = ir.AssignStmt(y, ir.Add(x, ir.ConstInt(2, dtype, span), dtype, span), span)
+        break_stmt = ir.BreakStmt(span)
+        seq = ir.SeqStmts([assign1, assign2, break_stmt], span)
+
+        assert len(seq.stmts) == 3
+        assert isinstance(seq.stmts[2], ir.BreakStmt)
+
+        # Serialization roundtrip
+        data = ir.serialize(seq)
+        restored = ir.deserialize(data)
+        assert isinstance(restored, ir.SeqStmts)
+        assert isinstance(restored.stmts[2], ir.BreakStmt)
+        ir.assert_structural_equal(seq, restored)
+
+    def test_nested_for_with_break_in_inner_loop(self):
+        """Test nested for loops where inner loop has a break.
+
+        Represents:
+            for i in range(0, 10, 1):
+                for j in range(0, 5, 1):
+                    break
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+
+        break_stmt = ir.BreakStmt(span)
+        inner_for = ir.ForStmt(
+            j,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            break_stmt,
+            [],
+            span,
+        )
+        outer_for = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for,
+            [],
+            span,
+        )
+
+        assert isinstance(outer_for.body, ir.ForStmt)
+        assert isinstance(outer_for.body.body, ir.BreakStmt)
+
+        # Structural equality
+        inner_for2 = ir.ForStmt(
+            ir.Var("j", ir.ScalarType(dtype), span),
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            ir.BreakStmt(span),
+            [],
+            span,
+        )
+        outer_for2 = ir.ForStmt(
+            ir.Var("i", ir.ScalarType(dtype), span),
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for2,
+            [],
+            span,
+        )
+        ir.assert_structural_equal(outer_for, outer_for2)
+
+    def test_nested_for_with_break_serialization(self):
+        """Test serialization of nested for loop with break."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+
+        inner_for = ir.ForStmt(
+            j,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            ir.BreakStmt(span),
+            [],
+            span,
+        )
+        outer_for = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for,
+            [],
+            span,
+        )
+
+        data = ir.serialize(outer_for)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.ForStmt)
+        assert isinstance(restored.body, ir.ForStmt)
+        assert isinstance(restored.body.body, ir.BreakStmt)
+        ir.assert_structural_equal(outer_for, restored)
+
+    def test_conditional_break_in_for_python_print(self):
+        """Test python_print output for a realistic conditional-break pattern.
+
+        Represents:
+            for i in range(0, 100, 1):
+                x = i + 1
+                if x > 50:
+                    break
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        assign = ir.AssignStmt(x, ir.Add(i, ir.ConstInt(1, dtype, span), dtype, span), span)
+        cond = ir.Gt(x, ir.ConstInt(50, dtype, span), dtype, span)
+        if_break = ir.IfStmt(cond, ir.BreakStmt(span), None, [], span)
+        body = ir.SeqStmts([assign, if_break], span)
+
+        for_stmt = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(100, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            body,
+            [],
+            span,
+        )
+
+        code = ir.python_print(for_stmt)
+        assert "for" in code
+        assert "range" in code
+        assert "break" in code
+        assert "if" in code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_continue_stmt.py
+++ b/tests/ut/ir/statements/test_continue_stmt.py
@@ -1,0 +1,445 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+from pypto import DataType, ir
+
+
+def test_continue_stmt_creation():
+    """Test creating a ContinueStmt."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.ContinueStmt(span)
+
+    assert isinstance(stmt, ir.ContinueStmt)
+    assert isinstance(stmt, ir.Stmt)
+    assert stmt.span.filename == "test.py"
+
+
+def test_continue_stmt_python_print():
+    """Test printing a ContinueStmt as Python code."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.ContinueStmt(span)
+
+    code = ir.python_print(stmt)
+    assert code == "continue"
+
+
+def test_continue_stmt_structural_hash():
+    """Test that two ContinueStmts produce the same hash."""
+    span1 = ir.Span("a.py", 1, 1)
+    span2 = ir.Span("b.py", 2, 2)
+    stmt1 = ir.ContinueStmt(span1)
+    stmt2 = ir.ContinueStmt(span2)
+
+    assert ir.structural_hash(stmt1) == ir.structural_hash(stmt2)
+
+
+def test_continue_stmt_structural_equal():
+    """Test structural equality of ContinueStmts."""
+    span1 = ir.Span("a.py", 1, 1)
+    span2 = ir.Span("b.py", 2, 2)
+    stmt1 = ir.ContinueStmt(span1)
+    stmt2 = ir.ContinueStmt(span2)
+
+    ir.assert_structural_equal(stmt1, stmt2)
+
+
+def test_continue_stmt_not_equal_to_break():
+    """Test that ContinueStmt is not structurally equal to BreakStmt."""
+    span = ir.Span("test.py", 1, 1)
+    continue_stmt = ir.ContinueStmt(span)
+    break_stmt = ir.BreakStmt(span)
+
+    assert not ir.structural_equal(continue_stmt, break_stmt)
+
+
+def test_continue_stmt_serialization():
+    """Test serializing and deserializing a ContinueStmt."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.ContinueStmt(span)
+
+    data = ir.serialize(stmt)
+    restored = ir.deserialize(data)
+
+    assert isinstance(restored, ir.ContinueStmt)
+    ir.assert_structural_equal(stmt, restored)
+
+
+def test_continue_stmt_not_equal_to_other_stmt_types():
+    """Test that ContinueStmt is not structurally equal to other statement types."""
+    span = ir.Span("test.py", 1, 1)
+    dtype = DataType.INT64
+    continue_stmt = ir.ContinueStmt(span)
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    assign = ir.AssignStmt(x, ir.ConstInt(0, dtype, span), span)
+    yield_stmt = ir.YieldStmt([x], span)
+    return_stmt = ir.ReturnStmt([x], span)
+
+    assert not ir.structural_equal(continue_stmt, assign)
+    assert not ir.structural_equal(continue_stmt, yield_stmt)
+    assert not ir.structural_equal(continue_stmt, return_stmt)
+
+
+def test_continue_stmt_immutability():
+    """Test that ContinueStmt span attribute is immutable."""
+    span = ir.Span("test.py", 1, 1)
+    stmt = ir.ContinueStmt(span)
+
+    with pytest.raises(AttributeError):
+        stmt.span = ir.Span("other.py", 2, 2)  # type: ignore
+
+
+class TestContinueInForLoop:
+    """Test ContinueStmt composed inside ForStmt bodies."""
+
+    def _make_for_with_body(self, body: ir.Stmt) -> ir.ForStmt:
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        return ir.ForStmt(i, start, stop, step, [], body, [], span)
+
+    def test_for_loop_with_continue_body(self):
+        """Test ForStmt whose body is a single ContinueStmt."""
+        span = ir.Span("test.py", 1, 1)
+        continue_stmt = ir.ContinueStmt(span)
+        for_stmt = self._make_for_with_body(continue_stmt)
+
+        assert isinstance(for_stmt.body, ir.ContinueStmt)
+
+    def test_for_loop_with_continue_in_seq(self):
+        """Test ForStmt with continue inside a SeqStmts body."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        assign = ir.AssignStmt(x, ir.ConstInt(42, dtype, span), span)
+        continue_stmt = ir.ContinueStmt(span)
+        seq = ir.SeqStmts([assign, continue_stmt], span)
+        for_stmt = self._make_for_with_body(seq)
+
+        assert isinstance(for_stmt.body, ir.SeqStmts)
+        assert len(for_stmt.body.stmts) == 2
+        assert isinstance(for_stmt.body.stmts[0], ir.AssignStmt)
+        assert isinstance(for_stmt.body.stmts[1], ir.ContinueStmt)
+
+    def test_for_loop_with_conditional_continue(self):
+        """Test ForStmt with continue inside an IfStmt (if cond: continue).
+
+        Represents: for i in range(0, 10, 1): if i < 3: continue
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        cond = ir.Lt(i, ir.ConstInt(3, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        if_stmt = ir.IfStmt(cond, continue_stmt, None, [], span)
+        for_stmt = self._make_for_with_body(if_stmt)
+
+        assert isinstance(for_stmt.body, ir.IfStmt)
+        assert isinstance(for_stmt.body.then_body, ir.ContinueStmt)
+
+    def test_for_loop_with_continue_python_print(self):
+        """Test python_print of a ForStmt containing a conditional continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        cond = ir.Lt(i, ir.ConstInt(3, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        if_stmt = ir.IfStmt(cond, continue_stmt, None, [], span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], if_stmt, [], span)
+
+        code = ir.python_print(for_stmt)
+        assert "for" in code
+        assert "continue" in code
+        assert "if" in code
+
+    def test_for_loop_with_continue_structural_equal(self):
+        """Test structural equality of two ForStmts with identical conditional continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+
+        def make_for_continue():
+            i = ir.Var("i", ir.ScalarType(dtype), span)
+            start = ir.ConstInt(0, dtype, span)
+            stop = ir.ConstInt(10, dtype, span)
+            step = ir.ConstInt(1, dtype, span)
+            cond = ir.Lt(i, ir.ConstInt(3, dtype, span), dtype, span)
+            cont = ir.ContinueStmt(span)
+            if_stmt = ir.IfStmt(cond, cont, None, [], span)
+            return ir.ForStmt(i, start, stop, step, [], if_stmt, [], span)
+
+        ir.assert_structural_equal(make_for_continue(), make_for_continue())
+
+    def test_for_loop_with_continue_serialization(self):
+        """Test serialization roundtrip of a ForStmt containing a continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        start = ir.ConstInt(0, dtype, span)
+        stop = ir.ConstInt(10, dtype, span)
+        step = ir.ConstInt(1, dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        for_stmt = ir.ForStmt(i, start, stop, step, [], continue_stmt, [], span)
+
+        data = ir.serialize(for_stmt)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.ForStmt)
+        assert isinstance(restored.body, ir.ContinueStmt)
+        ir.assert_structural_equal(for_stmt, restored)
+
+    def test_for_loop_continue_vs_break_not_equal(self):
+        """Test that for-with-continue is not equal to for-with-break."""
+        span = ir.Span("test.py", 1, 1)
+        for_continue = self._make_for_with_body(ir.ContinueStmt(span))
+        for_break = self._make_for_with_body(ir.BreakStmt(span))
+
+        assert not ir.structural_equal(for_continue, for_break)
+
+
+class TestContinueInWhileLoop:
+    """Test ContinueStmt composed inside WhileStmt bodies."""
+
+    def test_while_loop_with_continue_body(self):
+        """Test WhileStmt whose body is a single ContinueStmt."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        while_stmt = ir.WhileStmt(cond, [], continue_stmt, [], span)
+
+        assert isinstance(while_stmt.body, ir.ContinueStmt)
+
+    def test_while_loop_with_conditional_continue(self):
+        """Test WhileStmt with conditional continue: while cond: if x < 3: continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        loop_cond = ir.Lt(x, ir.ConstInt(100, dtype, span), dtype, span)
+        skip_cond = ir.Lt(x, ir.ConstInt(3, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        if_stmt = ir.IfStmt(skip_cond, continue_stmt, None, [], span)
+        while_stmt = ir.WhileStmt(loop_cond, [], if_stmt, [], span)
+
+        assert isinstance(while_stmt.body, ir.IfStmt)
+        assert isinstance(while_stmt.body.then_body, ir.ContinueStmt)
+
+    def test_while_loop_with_continue_serialization(self):
+        """Test serialization roundtrip of a WhileStmt containing a continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        while_stmt = ir.WhileStmt(cond, [], continue_stmt, [], span)
+
+        data = ir.serialize(while_stmt)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.WhileStmt)
+        assert isinstance(restored.body, ir.ContinueStmt)
+        # WhileStmt condition has free vars; use auto-mapping after deserialization
+        ir.assert_structural_equal(while_stmt, restored, enable_auto_mapping=True)
+
+    def test_while_loop_with_continue_structural_hash(self):
+        """Test structural hash consistency for WhileStmt containing continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        # Share Var instance so pointer-based hash is stable
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(10, dtype, span), dtype, span)
+        w1 = ir.WhileStmt(cond, [], ir.ContinueStmt(span), [], span)
+        w2 = ir.WhileStmt(cond, [], ir.ContinueStmt(span), [], span)
+
+        assert ir.structural_hash(w1) == ir.structural_hash(w2)
+
+
+class TestContinueInNestedStructures:
+    """Test ContinueStmt in deeply nested IR structures."""
+
+    def test_continue_in_if_else(self):
+        """Test continue in then branch and break in else branch of IfStmt."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        cond = ir.Lt(x, ir.ConstInt(3, dtype, span), dtype, span)
+        continue_stmt = ir.ContinueStmt(span)
+        break_stmt = ir.BreakStmt(span)
+        if_stmt = ir.IfStmt(cond, continue_stmt, break_stmt, [], span)
+
+        assert isinstance(if_stmt.then_body, ir.ContinueStmt)
+        assert isinstance(if_stmt.else_body, ir.BreakStmt)
+
+        code = ir.python_print(if_stmt)
+        assert "continue" in code
+        assert "break" in code
+
+    def test_continue_in_seq_with_multiple_stmts(self):
+        """Test continue preceded by assignments in a SeqStmts."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+        assign1 = ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)
+        assign2 = ir.AssignStmt(y, ir.Add(x, ir.ConstInt(2, dtype, span), dtype, span), span)
+        continue_stmt = ir.ContinueStmt(span)
+        seq = ir.SeqStmts([assign1, assign2, continue_stmt], span)
+
+        assert len(seq.stmts) == 3
+        assert isinstance(seq.stmts[2], ir.ContinueStmt)
+
+        # Serialization roundtrip
+        data = ir.serialize(seq)
+        restored = ir.deserialize(data)
+        assert isinstance(restored, ir.SeqStmts)
+        assert isinstance(restored.stmts[2], ir.ContinueStmt)
+        ir.assert_structural_equal(seq, restored)
+
+    def test_nested_for_with_continue_in_inner_loop(self):
+        """Test nested for loops where inner loop has a continue.
+
+        Represents:
+            for i in range(0, 10, 1):
+                for j in range(0, 5, 1):
+                    continue
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+
+        continue_stmt = ir.ContinueStmt(span)
+        inner_for = ir.ForStmt(
+            j,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            continue_stmt,
+            [],
+            span,
+        )
+        outer_for = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for,
+            [],
+            span,
+        )
+
+        assert isinstance(outer_for.body, ir.ForStmt)
+        assert isinstance(outer_for.body.body, ir.ContinueStmt)
+
+        # Structural equality
+        inner_for2 = ir.ForStmt(
+            ir.Var("j", ir.ScalarType(dtype), span),
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            ir.ContinueStmt(span),
+            [],
+            span,
+        )
+        outer_for2 = ir.ForStmt(
+            ir.Var("i", ir.ScalarType(dtype), span),
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for2,
+            [],
+            span,
+        )
+        ir.assert_structural_equal(outer_for, outer_for2)
+
+    def test_nested_for_with_continue_serialization(self):
+        """Test serialization of nested for loop with continue."""
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        j = ir.Var("j", ir.ScalarType(dtype), span)
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+
+        inner_for = ir.ForStmt(
+            j,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(5, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            ir.ContinueStmt(span),
+            [],
+            span,
+        )
+        outer_for = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(10, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            inner_for,
+            [],
+            span,
+        )
+
+        data = ir.serialize(outer_for)
+        restored = ir.deserialize(data)
+
+        assert isinstance(restored, ir.ForStmt)
+        assert isinstance(restored.body, ir.ForStmt)
+        assert isinstance(restored.body.body, ir.ContinueStmt)
+        ir.assert_structural_equal(outer_for, restored)
+
+    def test_conditional_continue_in_for_python_print(self):
+        """Test python_print output for a realistic conditional-continue pattern.
+
+        Represents:
+            for i in range(0, 100, 1):
+                if i < 10:
+                    continue
+                x = i * 2
+        """
+        span = ir.Span("test.py", 1, 1)
+        dtype = DataType.INT64
+        i = ir.Var("i", ir.ScalarType(dtype), span)
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        cond = ir.Lt(i, ir.ConstInt(10, dtype, span), dtype, span)
+        if_continue = ir.IfStmt(cond, ir.ContinueStmt(span), None, [], span)
+        assign = ir.AssignStmt(x, ir.Mul(i, ir.ConstInt(2, dtype, span), dtype, span), span)
+        body = ir.SeqStmts([if_continue, assign], span)
+
+        for_stmt = ir.ForStmt(
+            i,
+            ir.ConstInt(0, dtype, span),
+            ir.ConstInt(100, dtype, span),
+            ir.ConstInt(1, dtype, span),
+            [],
+            body,
+            [],
+            span,
+        )
+
+        code = ir.python_print(for_stmt)
+        assert "for" in code
+        assert "range" in code
+        assert "continue" in code
+        assert "if" in code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add `BreakStmt` and `ContinueStmt` IR nodes for loop control flow (`break` and `continue`). Both are minimal leaf statements with no fields (only inherited `Span`), used inside `ForStmt`/`WhileStmt` loop bodies.

Changes across all three layers (18 files):

- **C++ core**: `ObjectKind` enum entries, class definitions in `stmt.h`, `KindTrait` entries
- **Visitor/mutator framework**: functor dispatch, visitor (empty leaf), mutator (identity return)
- **IR infrastructure**: python printer (`"break"`/`"continue"`), structural hash, structural equality, serialization, deserialization
- **Python bindings**: nanobind class bindings with `BindFields`
- **Type stubs**: `.pyi` entries with docstrings
- **Documentation**: BNF grammar and statement tables in `01-hierarchy.md`

## Testing

- 48 new tests across `test_break_stmt.py` and `test_continue_stmt.py` covering:
  - Creation, type hierarchy, span, immutability
  - `python_print`, structural hash, structural equality
  - Serialization/deserialization roundtrip
  - Cross-type inequality (break != continue != other stmts)
  - Composition inside `ForStmt` and `WhileStmt` bodies
  - Conditional break/continue inside `IfStmt` within loops
  - Nested loop structures with break/continue
- Full test suite passes (1339 tests, 0 failures)

## Related Issues

Closes #166
Closes #167