### PR TITLE
feat(codegen): enhance orchestration codegen with tensor APIs, scalar ops, and paged attention

### DIFF
--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -1,0 +1,305 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Paged Attention Orchestration Example
+
+Builds a simplified paged attention orchestration function using the PyPTO DSL.
+Generates C++ orchestration code similar to target_page_attn_codegen.cpp.
+
+Simplified 16x16 version:
+  - Query:       [batch * num_heads, head_dim] BF16
+  - Key cache:   [total_blocks * block_size, head_dim] BF16
+  - Value cache: [total_blocks * block_size, head_dim] BF16
+  - Output:      [batch * num_heads, head_dim] FP32
+
+Task graph per (batch, block) iteration:
+  task0: sij     = qi @ kj^T           (kernel_qk_matmul,       CUBE)
+  task1: pij, mi, li = softmax(sij)    (kernel_softmax_prepare, VECTOR)
+  task2: oi_tmp  = pij @ vj            (kernel_pv_matmul,       CUBE)
+  task3: online_update(mi, li, oi_tmp) (kernel_online_update,   VECTOR)
+"""
+
+import os
+
+import pypto.language as pl
+from pypto import ir
+from pypto.backend import BackendType
+
+
+@pl.program
+class PagedAttentionProgram:
+    """Paged attention program with CUBE and VECTOR kernels."""
+
+    # ── VECTOR kernel: init inplace tensors ─────────────────────────────
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_init_inplace(
+        self,
+        oi: pl.Tensor[[16, 16], pl.FP32],
+        li: pl.Tensor[[16], pl.FP32],
+        mi: pl.Tensor[[16], pl.FP32],
+    ) -> tuple[
+        pl.Tensor[[16, 128], pl.FP32],
+        pl.Tensor[[16], pl.FP32],
+        pl.Tensor[[16], pl.FP32],
+    ]:
+        """Initialize inplace accumulators to zero (VECTOR)."""
+        return oi, li, mi
+
+    # ── CUBE kernel: QK matmul ──────────────────────────────────────────
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_qk_matmul(
+        self,
+        qi: pl.Tensor[[16, 128], pl.BF16],
+        kj: pl.Tensor[[128, 128], pl.BF16],
+        output: pl.Tensor[[16, 128], pl.FP32],
+    ) -> pl.Tensor[[16, 128], pl.FP32]:
+        """QK matmul: sij = qi @ kj (CUBE)."""
+        qi_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(qi, [0, 0], [16, 16])
+        kj_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(kj, [0, 0], [16, 16])
+        result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(qi_tile, kj_tile)
+        out: pl.Tensor[[16, 128], pl.FP32] = pl.l0c_store(result, [0, 0], [16, 16], output)
+        return out
+
+    # ── VECTOR kernel: softmax prepare ──────────────────────────────────
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_softmax_prepare(
+        self,
+        sij: pl.Tensor[[16, 128], pl.FP32],
+        scale: pl.Scalar[pl.FP32],
+        out_pij: pl.Tensor[[16, 128], pl.BF16],
+        out_mi: pl.Tensor[[16], pl.FP32],
+        out_li: pl.Tensor[[16], pl.FP32],
+    ) -> tuple[
+        pl.Tensor[[16, 128], pl.BF16],
+        pl.Tensor[[16], pl.FP32],
+        pl.Tensor[[16], pl.FP32],
+    ]:
+        """Softmax prepare: scale, row_max, exp, row_sum (VECTOR).
+
+        Simplified kernel body — the orchestration codegen only uses the
+        function signature, not the body implementation.
+        """
+        s_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(sij, [0, 0], [16, 16])
+        scaled: pl.Tile[[16, 16], pl.FP32] = pl.mul(s_tile, scale)
+        tmp_mi: pl.Tile[[16], pl.FP32] = pl.create_tile([16], dtype=pl.FP32)
+        mi_tile: pl.Tile[[16], pl.FP32] = pl.row_max(scaled, tmp_mi)
+        sub_tile: pl.Tile[[16, 16], pl.FP32] = pl.sub(scaled, mi_tile)
+        exp_tile: pl.Tile[[16, 16], pl.FP32] = pl.exp(sub_tile)
+        tmp_li: pl.Tile[[16], pl.FP32] = pl.create_tile([16], dtype=pl.FP32)
+        li_tile: pl.Tile[[16], pl.FP32] = pl.row_sum(exp_tile, tmp_li)
+        out_pij: pl.Tensor[[16, 128], pl.BF16] = pl.store(exp_tile, [0, 0], [16, 16], out_pij)
+        out_mi: pl.Tensor[[16], pl.FP32] = pl.store(mi_tile, [0], [16], out_mi)
+        out_li: pl.Tensor[[16], pl.FP32] = pl.store(li_tile, [0], [16], out_li)
+        return out_pij, out_mi, out_li
+
+    # ── CUBE kernel: PV matmul ──────────────────────────────────────────
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_pv_matmul(
+        self,
+        pij: pl.Tensor[[16, 128], pl.BF16],
+        vj: pl.Tensor[[128, 128], pl.BF16],
+        output: pl.Tensor[[16, 16], pl.FP32],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        """PV matmul: oi_tmp = pij @ vj (CUBE)."""
+        p_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(pij, [0, 0], [16, 16])
+        v_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(vj, [0, 0], [16, 16])
+        result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(p_tile, v_tile)
+        out: pl.Tensor[[16, 128], pl.FP32] = pl.l0c_store(result, [0, 0], [16, 16], output)
+        return out
+
+    # ── VECTOR kernel: online update (inplace) ──────────────────────────
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_online_update(
+        self,
+        mi: pl.Tensor[[16], pl.FP32],
+        li: pl.Tensor[[16], pl.FP32],
+        oi_tmp: pl.Tensor[[16, 128], pl.FP32],
+        mi_update: pl.Tensor[[16], pl.FP32],
+        li_update: pl.Tensor[[16], pl.FP32],
+        oi: pl.Tensor[[16, 128], pl.FP32],
+        out_view: pl.Tensor[[16, 128], pl.FP32],
+        is_first: pl.Scalar[pl.INT64],
+        is_last: pl.Scalar[pl.INT64],
+    ) -> tuple[
+        pl.Tensor[[16], pl.FP32],
+        pl.Tensor[[16], pl.FP32],
+        pl.Tensor[[16, 128], pl.FP32],
+        pl.Tensor[[16, 128], pl.FP32],
+    ]:
+        """Online softmax update with inplace mi/li/oi (VECTOR)."""
+        mi_tile: pl.Tile[[16], pl.FP32] = pl.load(mi_update, [0], [16])
+        li_tile: pl.Tile[[16], pl.FP32] = pl.load(li_update, [0], [16])
+        oi_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(oi, [0, 0], [16, 16])
+        out_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(out_view, [0, 0], [16, 16])
+        mi_r: pl.Tensor[[16], pl.FP32] = pl.store(mi_tile, [0], [16], mi_update)
+        li_r: pl.Tensor[[16], pl.FP32] = pl.store(li_tile, [0], [16], li_update)
+        oi_r: pl.Tensor[[16, 128], pl.FP32] = pl.store(oi_tile, [0, 0], [16, 16], oi)
+        out_r: pl.Tensor[[16, 128], pl.FP32] = pl.store(out_tile, [0, 0], [16, 16], out_view)
+        return mi_r, li_r, oi_r, out_r
+
+    # ── Orchestration function ──────────────────────────────────────────
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def paged_attention(
+        self,
+        query: pl.Tensor[[32, 128], pl.BF16],  # 2 * 16, 128
+        key_cache: pl.Tensor[[8192, 128], pl.BF16],  # [2 * 2048 * 128, 128]
+        value_cache: pl.Tensor[[8192, 128], pl.BF16],  # [2 * 2048 * 128, 128]
+        host_block_table: pl.Tensor[[2, 2048], pl.INT32],
+        context_lens: pl.Tensor[[2], pl.INT32],
+        out: pl.Tensor[[32, 128], pl.FP32],
+        config: pl.Tensor[[7], pl.UINT64],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        """Paged attention orchestration.
+
+        Config layout: [batch, num_heads, kv_head_num, head_dim, block_size, block_num, scale]
+        Loops over batch and KV blocks, calling CUBE/VECTOR kernels.
+        """
+        batch: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [0])
+        num_heads: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [1])
+        head_dim: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [3])
+        block_size: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [4])
+        _block_num: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [5])  # noqa: F841
+        q_tile = pl.min(num_heads, 128)
+        q_loop = (num_heads + q_tile - 1) // q_tile
+
+        for b_idx in pl.range(batch):
+            cur_seq = pl.tensor.read(context_lens, [b_idx])
+            bn_this_batch = (cur_seq + block_size - 1) // block_size
+            for q_idx in pl.range(q_loop):
+                cur_offset = b_idx * num_heads + q_idx * q_tile
+
+                # Create inplace accumulators for this q_tile group
+                oi: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
+                    [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                    dtype=pl.FP32,
+                )
+                li_update: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                mi_update: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+
+                # Initialize accumulators
+                oi, li_update, mi_update = self.kernel_init_inplace(oi, li_update, mi_update)
+
+                for bn in pl.range(bn_this_batch):
+                    # Dynamic views into Q/K/V for current batch and block
+                    qi: pl.Tensor[[q_tile, head_dim], pl.BF16] = pl.view(
+                        query,
+                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        [cur_offset, 0],
+                    )
+                    cur_block_idx = pl.tensor.read(host_block_table, [b_idx, bn])
+                    valid_len = pl.min(block_size, cur_seq - bn * block_size)
+                    kj: pl.Tensor[[valid_len, head_dim], pl.BF16] = pl.view(
+                        key_cache,
+                        [valid_len, head_dim],  # type: ignore[reportArgumentType]
+                        [cur_block_idx * block_size, 0],
+                    )
+                    vj: pl.Tensor[[valid_len, head_dim], pl.BF16] = pl.view(
+                        value_cache,
+                        [valid_len, head_dim],  # type: ignore[reportArgumentType]
+                        [cur_block_idx * block_size, 0],
+                    )
+
+                    sij: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.create_tensor(
+                        [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
+                    )
+
+                    # QK matmul (CUBE)
+                    sij = self.kernel_qk_matmul(qi, kj, sij)
+
+                    pij: pl.Tensor[[q_tile, valid_len], pl.BF16] = pl.create_tensor(
+                        [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                        dtype=pl.BF16,
+                    )
+                    mi: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                    li: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                    # Softmax prepare (VECTOR) — outputs are per-block mi/li, not the inplace accumulators
+                    pij, mi, li = self.kernel_softmax_prepare(sij, 1.0, pij, mi, li)  # type: ignore[reportArgumentType]
+
+                    oi_tmp: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
+                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
+                    )
+                    # PV matmul (CUBE)
+                    oi_tmp = self.kernel_pv_matmul(pij, vj, oi_tmp)
+
+                    # Conditional flags
+                    if bn == 0:
+                        is_first: pl.Scalar[pl.UINT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                    else:
+                        is_first: pl.Scalar[pl.UINT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                    if bn == bn_this_batch - 1:
+                        is_last: pl.Scalar[pl.UINT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                    else:
+                        is_last: pl.Scalar[pl.UINT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+
+                    # Online update (VECTOR): mi/li are inputs from softmax,
+                    # mi_update/li_update/oi are inplace accumulators, out_view is output
+                    out_view: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.view(
+                        out,
+                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        [cur_offset, 0],
+                    )
+                    mi_update, li_update, oi, out_view = self.kernel_online_update(
+                        mi, li, oi_tmp, mi_update, li_update, oi, out_view, is_first, is_last
+                    )
+
+        return out
+
+
+def main():
+    """Build IR, compile, and display generated orchestration C++ code."""
+    print("=" * 70)
+    print("Paged Attention Orchestration Code Generation")
+    print("=" * 70)
+
+    program = PagedAttentionProgram
+    print(f"\nProgram: {program.name}")
+    print(f"Functions: {[f.name for f in program.functions.values()]}")
+
+    # Print IR preview
+    print("\n[1] IR Preview:")
+    print("-" * 70)
+    ir_text = ir.python_print(program)
+    lines = ir_text.split("\n")
+    preview = min(60, len(lines))
+    print("\n".join(lines[:preview]))
+    if len(lines) > preview:
+        print(f"\n... ({len(lines) - preview} more lines)")
+    print("-" * 70)
+
+    # Compile
+    print("\n[2] Compiling...")
+    output_dir = ir.compile(
+        program,
+        strategy=ir.OptimizationStrategy.Default,
+        dump_passes=True,
+        backend_type=BackendType.CCE,
+    )
+    print(f"Output: {output_dir}")
+
+    # List generated files
+    print("\n[3] Generated files:")
+    for root, _dirs, files in os.walk(output_dir):
+        for f in files:
+            path = os.path.join(root, f)
+            rel = os.path.relpath(path, output_dir)
+            print(f"  - {rel} ({os.path.getsize(path)} bytes)")
+
+    # Show orchestration code path
+    orch_file = os.path.join(output_dir, "orchestration", "paged_attention.cpp")
+    if os.path.exists(orch_file):
+        print("\n[4] Generated Orchestration C++ path:")
+        print(orch_file)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -104,25 +104,52 @@ class CodegenBase : public ir::IRVisitor {
   }
 
   /**
+   * @brief Get the external tensor name for a variable
+   *
+   * Returns the name used to reference a tensor in generated code.
+   * For external tensors (params/returns), returns "ext_<name>".
+   * For local tensors, returns the name as-is.
+   *
+   * @param name Tensor variable name
+   * @return External tensor name (e.g., "ext_x" or "x")
+   */
+  [[nodiscard]] virtual std::string GetExternalTensorName(const std::string& name) const { return name; }
+
+  /**
+   * @brief Get the runtime DataType enum string for generated code
+   *
+   * Returns the fully qualified DataType enum name as used by the runtime
+   * (e.g., "DataType::FLOAT32", "DataType::INT64"). Subclasses can override
+   * to match their target runtime's DataType enum naming.
+   *
+   * @param dtype The data type to convert
+   * @return Runtime DataType string (e.g., "DataType::FLOAT32")
+   */
+  [[nodiscard]] virtual std::string GetRuntimeDataTypeString(const DataType& dtype) const;
+
+  /**
    * @brief Try to extract variable name from expression
    *
    * Supports Var and IterArg expressions. Returns empty string if not a variable.
+   * Subclasses can override to transform variable names (e.g., strip SSA suffixes).
    *
    * @param expr Expression to extract name from
    * @return Variable name or empty string
    */
-  static std::string TryGetVarName(const ir::ExprPtr& expr);
+  [[nodiscard]] virtual std::string TryGetVarName(const ir::ExprPtr& expr) const;
 
   /**
    * @brief Generate C++ code string for an IR expression
    *
    * Converts IR expressions to C++ code strings for inline operations.
    * Supports variables, constants, binary operations, and tuple access.
+   * Calls TryGetVarName() for variable name extraction, enabling subclass
+   * name resolution via virtual dispatch.
    *
    * @param expr Expression to convert
    * @return C++ code string
    */
-  static std::string GenerateExprString(const ir::ExprPtr& expr);
+  [[nodiscard]] std::string GenerateExprString(const ir::ExprPtr& expr) const;
 
  protected:
   /**

--- a/include/pypto/core/dtype.h
+++ b/include/pypto/core/dtype.h
@@ -344,6 +344,42 @@ inline constexpr DataType DataType::INDEX = DataType(kInt64Code);
 inline constexpr DataType DataType::DEFAULT_CONST_INT = DataType(kInt64Code);   // = INDEX
 inline constexpr DataType DataType::DEFAULT_CONST_FLOAT = DataType(kFp32Code);  // = FP32
 
+/**
+ * @brief Convert DataType to its canonical enum name string
+ *
+ * Returns the uppercase enum-style name for a DataType, suitable for use
+ * as a suffix in code generation (e.g., "FP32", "BFLOAT16", "INT32").
+ *
+ * Callers compose the full qualified name:
+ *   - Python printer: prefix + "." + DataTypeToString(dtype)
+ *   - C++ codegen:    "DataType::" + DataTypeToString(dtype)
+ *
+ * @param dtype The data type to convert
+ * @return Uppercase enum name string
+ */
+inline std::string DataTypeToString(const DataType& dtype) {
+  if (dtype == DataType::BOOL) return "BOOL";
+  if (dtype == DataType::INT4) return "INT4";
+  if (dtype == DataType::INT8) return "INT8";
+  if (dtype == DataType::INT16) return "INT16";
+  if (dtype == DataType::INT32) return "INT32";
+  if (dtype == DataType::INT64) return "INT64";
+  if (dtype == DataType::UINT4) return "UINT4";
+  if (dtype == DataType::UINT8) return "UINT8";
+  if (dtype == DataType::UINT16) return "UINT16";
+  if (dtype == DataType::UINT32) return "UINT32";
+  if (dtype == DataType::UINT64) return "UINT64";
+  if (dtype == DataType::FP4) return "FP4";
+  if (dtype == DataType::FP8E4M3FN) return "FP8E4M3FN";
+  if (dtype == DataType::FP8E5M2) return "FP8E5M2";
+  if (dtype == DataType::FP16) return "FP16";
+  if (dtype == DataType::FP32) return "FP32";
+  if (dtype == DataType::BF16) return "BFLOAT16";
+  if (dtype == DataType::HF4) return "HF4";
+  if (dtype == DataType::HF8) return "HF8";
+  return "UnknownType";
+}
+
 }  // namespace pypto
 
 #endif  // PYPTO_CORE_DTYPE_H_

--- a/include/pypto/ir/scalar_expr.h
+++ b/include/pypto/ir/scalar_expr.h
@@ -501,6 +501,16 @@ inline ExprPtr MakeBitShiftRight(const ExprPtr& left, const ExprPtr& right,
   return std::make_shared<BitShiftRight>(operands.left, operands.right, operands.dtype, span);
 }
 
+inline ExprPtr MakeMin(const ExprPtr& left, const ExprPtr& right, const Span& span = Span::unknown()) {
+  auto operands = PromoteBinaryOperands(left, right, "min", span);
+  return std::make_shared<Min>(operands.left, operands.right, operands.dtype, span);
+}
+
+inline ExprPtr MakeMax(const ExprPtr& left, const ExprPtr& right, const Span& span = Span::unknown()) {
+  auto operands = PromoteBinaryOperands(left, right, "max", span);
+  return std::make_shared<Max>(operands.left, operands.right, operands.dtype, span);
+}
+
 // ========== Unary Operator Construction Functions ==========
 
 inline ExprPtr MakeNeg(const ExprPtr& operand, const Span& span = Span::unknown()) {

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -812,6 +812,10 @@ void BindIR(nb::module_& m) {
          nb::arg("span") = Span::unknown(), "Bitwise right shift operator");
   ir.def("bit_not", &MakeBitNot, nb::arg("operand"), nb::arg("span") = Span::unknown(),
          "Bitwise not operator");
+  ir.def("min_", &MakeMin, nb::arg("lhs"), nb::arg("rhs"), nb::arg("span") = Span::unknown(),
+         "Minimum operator");
+  ir.def("max_", &MakeMax, nb::arg("lhs"), nb::arg("rhs"), nb::arg("span") = Span::unknown(),
+         "Maximum operator");
 
   // ParentStmtAnalysis - utility class for analyzing statement parent relationships
   auto parent_stmt_analysis_class = nb::class_<ParentStmtAnalysis>(

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2356,68 +2356,74 @@ def python_print_type(type: Type, prefix: str = "pl") -> str:
         String representation of the Type
     """
 
-def add(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def add(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Addition operator (lhs + rhs)."""
 
-def sub(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def sub(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Subtraction operator (lhs - rhs)."""
 
-def mul(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def mul(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Multiplication operator (lhs * rhs)."""
 
-def truediv(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def truediv(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """True division operator (lhs / rhs)."""
 
-def floordiv(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def floordiv(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Floor division operator (lhs // rhs)."""
 
-def mod(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def mod(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Modulo operator (lhs % rhs)."""
 
-def pow(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def pow(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Power operator (lhs ** rhs)."""
 
-def eq(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def eq(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Equality operator (lhs == rhs)."""
 
-def ne(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def ne(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Inequality operator (lhs != rhs)."""
 
-def lt(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def lt(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Less than operator (lhs < rhs)."""
 
-def le(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def le(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Less than or equal operator (lhs <= rhs)."""
 
-def gt(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def gt(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Greater than operator (lhs > rhs)."""
 
-def ge(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def ge(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Greater than or equal operator (lhs >= rhs)."""
 
-def neg(operand: Expr, span: Span) -> Expr:
+def neg(operand: Expr, span: Span = ...) -> Expr:
     """Negation operator (-operand)."""
 
-def cast(operand: Expr, dtype: DataType, span: Span) -> Expr:
+def cast(operand: Expr, dtype: DataType, span: Span = ...) -> Expr:
     """Cast operator (cast operand to dtype)."""
 
-def bit_and(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def bit_and(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Bitwise and operator (lhs & rhs)."""
 
-def bit_or(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def bit_or(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Bitwise or operator (lhs | rhs)."""
 
-def bit_xor(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def bit_xor(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Bitwise xor operator (lhs ^ rhs)."""
 
-def bit_shift_left(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def bit_shift_left(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Bitwise left shift operator (lhs << rhs)."""
 
-def bit_shift_right(lhs: Expr, rhs: Expr, span: Span) -> Expr:
+def bit_shift_right(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
     """Bitwise right shift operator (lhs >> rhs)."""
 
-def bit_not(operand: Expr, span: Span) -> Expr:
+def bit_not(operand: Expr, span: Span = ...) -> Expr:
     """Bitwise not operator (~operand)."""
+
+def min_(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
+    """Minimum operator (min(lhs, rhs))."""
+
+def max_(lhs: Expr, rhs: Expr, span: Span = ...) -> Expr:
+    """Maximum operator (max(lhs, rhs))."""
 
 class ParentStmtAnalysis:
     """Utility class for analyzing parent-child relationships in statement trees.

--- a/src/backend/910B_CCE/backend_910b_cce_ops.cpp
+++ b/src/backend/910B_CCE/backend_910b_cce_ops.cpp
@@ -128,6 +128,7 @@ static std::string MakeBlockLoadCodegenCCE(const ir::CallPtr& op, codegen::Codeg
   // Extract offsets tuple
   auto offsets_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[1]);
   CHECK(offsets_tuple != nullptr) << "block.load second argument must be a tuple (offsets)";
+  CHECK(!offsets_tuple->elements_.empty()) << "block.load offsets tuple must have at least 1 element";
 
   // Extract shapes tuple
   auto shapes_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[2]);
@@ -135,7 +136,8 @@ static std::string MakeBlockLoadCodegenCCE(const ir::CallPtr& op, codegen::Codeg
 
   std::string src_tensor_var = codegen.GetVarName(src_tensor_var_ptr);
   std::string row_offset = codegen.GetExprAsCode(offsets_tuple->elements_[0]);
-  std::string col_offset = codegen.GetExprAsCode(offsets_tuple->elements_[1]);
+  std::string col_offset =
+      offsets_tuple->elements_.size() > 1 ? codegen.GetExprAsCode(offsets_tuple->elements_[1]) : "0";
 
   auto src_tensor_type = std::dynamic_pointer_cast<const ir::TensorType>(src_tensor_var_ptr->GetType());
   CHECK(src_tensor_type != nullptr) << "block.load source must be TensorType";
@@ -168,13 +170,15 @@ static std::string MakeBlockStoreCodegenCCE(const ir::CallPtr& op, codegen::Code
   // Extract offsets tuple
   auto offsets_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[1]);
   CHECK(offsets_tuple != nullptr) << "block.store second argument must be a tuple (offsets)";
+  CHECK(!offsets_tuple->elements_.empty()) << "block.store offsets tuple must have at least 1 element";
 
   // Extract shapes tuple
   auto shapes_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[2]);
   CHECK(shapes_tuple != nullptr) << "block.store third argument must be a tuple (shapes)";
 
   std::string row_offset = codegen.GetExprAsCode(offsets_tuple->elements_[0]);
-  std::string col_offset = codegen.GetExprAsCode(offsets_tuple->elements_[1]);
+  std::string col_offset =
+      offsets_tuple->elements_.size() > 1 ? codegen.GetExprAsCode(offsets_tuple->elements_[1]) : "0";
 
   auto dst_tensor_var_ptr = std::dynamic_pointer_cast<const ir::Var>(op->args_[3]);
   CHECK(dst_tensor_var_ptr != nullptr) << "block.store destination tensor must be a Var";
@@ -215,13 +219,15 @@ static std::string MakeBlockL0CStoreCodegenCCE(const ir::CallPtr& op, codegen::C
   // Extract offsets tuple
   auto offsets_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[1]);
   CHECK(offsets_tuple != nullptr) << "block.l0c_store second argument must be a tuple (offsets)";
+  CHECK(!offsets_tuple->elements_.empty()) << "block.l0c_store offsets tuple must have at least 1 element";
 
   // Extract shapes tuple
   auto shapes_tuple = std::dynamic_pointer_cast<const ir::MakeTuple>(op->args_[2]);
   CHECK(shapes_tuple != nullptr) << "block.l0c_store third argument must be a tuple (shapes)";
 
   std::string row_offset = codegen.GetExprAsCode(offsets_tuple->elements_[0]);
-  std::string col_offset = codegen.GetExprAsCode(offsets_tuple->elements_[1]);
+  std::string col_offset =
+      offsets_tuple->elements_.size() > 1 ? codegen.GetExprAsCode(offsets_tuple->elements_[1]) : "0";
 
   auto dst_tensor_var_ptr = std::dynamic_pointer_cast<const ir::Var>(op->args_[3]);
   CHECK(dst_tensor_var_ptr != nullptr) << "block.l0c_store destination tensor must be a Var";

--- a/src/codegen/cce/cce_codegen.cpp
+++ b/src/codegen/cce/cce_codegen.cpp
@@ -467,7 +467,7 @@ void CCECodegen::VisitStmt_(const ir::ForStmtPtr& op) {
   current_expr_value_ = "";
 
   // Emit for loop
-  emitter_.EmitLine("for (int64_t " + loop_var_name + " = " + start + "; " + loop_var_name + " < " + stop +
+  emitter_.EmitLine("for (uint64_t " + loop_var_name + " = " + start + "; " + loop_var_name + " < " + stop +
                     "; " + loop_var_name + " += " + step + ") {");
   emitter_.IncreaseIndent();
 

--- a/src/codegen/codegen_base.cpp
+++ b/src/codegen/codegen_base.cpp
@@ -13,6 +13,7 @@
 
 #include <string>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
@@ -23,7 +24,7 @@ namespace codegen {
 
 using namespace pypto::ir;  // NOLINT(build/namespaces)
 
-std::string CodegenBase::TryGetVarName(const ir::ExprPtr& expr) {
+std::string CodegenBase::TryGetVarName(const ir::ExprPtr& expr) const {
   if (auto var = As<Var>(expr)) {
     return var->name_;
   }
@@ -33,7 +34,7 @@ std::string CodegenBase::TryGetVarName(const ir::ExprPtr& expr) {
   return "";
 }
 
-std::string CodegenBase::GenerateExprString(const ir::ExprPtr& expr) {
+std::string CodegenBase::GenerateExprString(const ir::ExprPtr& expr) const {
   std::string var_name = TryGetVarName(expr);
   if (!var_name.empty()) {
     return var_name;
@@ -53,11 +54,65 @@ std::string CodegenBase::GenerateExprString(const ir::ExprPtr& expr) {
   if (auto floor_div = As<FloorDiv>(expr)) {
     return "(" + GenerateExprString(floor_div->left_) + " / " + GenerateExprString(floor_div->right_) + ")";
   }
+  if (auto floor_mod = As<FloorMod>(expr)) {
+    return "(" + GenerateExprString(floor_mod->left_) + " % " + GenerateExprString(floor_mod->right_) + ")";
+  }
+  if (auto min_expr = As<Min>(expr)) {
+    return "std::min(" + GenerateExprString(min_expr->left_) + ", " + GenerateExprString(min_expr->right_) +
+           ")";
+  }
+  if (auto max_expr = As<Max>(expr)) {
+    return "std::max(" + GenerateExprString(max_expr->left_) + ", " + GenerateExprString(max_expr->right_) +
+           ")";
+  }
+  if (auto eq = As<Eq>(expr)) {
+    return "(" + GenerateExprString(eq->left_) + " == " + GenerateExprString(eq->right_) + ")";
+  }
+  if (auto ne = As<Ne>(expr)) {
+    return "(" + GenerateExprString(ne->left_) + " != " + GenerateExprString(ne->right_) + ")";
+  }
+  if (auto lt = As<Lt>(expr)) {
+    return "(" + GenerateExprString(lt->left_) + " < " + GenerateExprString(lt->right_) + ")";
+  }
+  if (auto le = As<Le>(expr)) {
+    return "(" + GenerateExprString(le->left_) + " <= " + GenerateExprString(le->right_) + ")";
+  }
+  if (auto gt = As<Gt>(expr)) {
+    return "(" + GenerateExprString(gt->left_) + " > " + GenerateExprString(gt->right_) + ")";
+  }
+  if (auto ge = As<Ge>(expr)) {
+    return "(" + GenerateExprString(ge->left_) + " >= " + GenerateExprString(ge->right_) + ")";
+  }
+  if (auto const_float = As<ConstFloat>(expr)) {
+    return std::to_string(const_float->value_);
+  }
+  if (auto const_bool = As<ConstBool>(expr)) {
+    return const_bool->value_ ? "1" : "0";
+  }
+  if (auto neg = As<Neg>(expr)) {
+    return "(-" + GenerateExprString(neg->operand_) + ")";
+  }
+  if (auto cast_expr = As<Cast>(expr)) {
+    return GenerateExprString(cast_expr->operand_);
+  }
   if (auto tuple_get = As<TupleGetItemExpr>(expr)) {
     return GenerateExprString(tuple_get->tuple_) + "_" + std::to_string(tuple_get->index_);
   }
   throw pypto::NotImplementedError("GenerateExprString not implemented for expression type: " +
                                    expr->TypeName());
+}
+
+std::string CodegenBase::GetRuntimeDataTypeString(const DataType& dtype) const {
+  if (dtype == DataType::FP16) return "DataType::FLOAT16";
+  if (dtype == DataType::FP32) return "DataType::FLOAT32";
+  if (dtype == DataType::INT32) return "DataType::INT32";
+  if (dtype == DataType::INT16) return "DataType::INT16";
+  if (dtype == DataType::INT8) return "DataType::INT8";
+  if (dtype == DataType::UINT8) return "DataType::UINT8";
+  if (dtype == DataType::BF16) return "DataType::BFLOAT16";
+  if (dtype == DataType::INT64) return "DataType::INT64";
+  if (dtype == DataType::UINT64) return "DataType::UINT64";
+  return "DataType::UNKNOWN";
 }
 
 }  // namespace codegen

--- a/tests/ut/codegen/test_cce_codegen.py
+++ b/tests/ut/codegen/test_cce_codegen.py
@@ -120,7 +120,7 @@ class TestControlFlowCodegen:
         code = files["kernels/aiv/test_simple_for.cpp"]
 
         # Verify for loop structure
-        assert "for (int64_t i = 0; i < 4; i += 1) {" in code
+        assert "for (uint64_t i = 0; i < 4; i += 1) {" in code
         assert "TLOAD(tile_x, inputGlobal)" in code
         assert "TSTORE(outputGlobal, tile_x)" in code
 
@@ -158,10 +158,10 @@ class TestControlFlowCodegen:
         code = files["kernels/aiv/test_nested_for.cpp"]
 
         # Verify nested loop structure
-        assert "for (int64_t i = 0; i < 4; i += 1) {" in code
-        assert "for (int64_t j = 0; j < 4; j += 1) {" in code
+        assert "for (uint64_t i = 0; i < 4; i += 1) {" in code
+        assert "for (uint64_t j = 0; j < 4; j += 1) {" in code
         # Verify proper nesting (inner loop should appear after outer loop)
-        assert code.index("for (int64_t i") < code.index("for (int64_t j")
+        assert code.index("for (uint64_t i") < code.index("for (uint64_t j")
 
     def test_if_statement_simple(self):
         """Test simple if statement code generation."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -86,10 +86,6 @@ class TestOrchestration:
             #define ARG_PTR_B 1
             #define ARG_PTR_D 2
 
-            #define ARG_SIZE_A 3
-            #define ARG_SIZE_B 4
-            #define ARG_SIZE_D 5
-
             // Helper to encode float as uint64_t for scalar params
             static uint64_t float_to_u64(float f) {
                 union {
@@ -108,7 +104,7 @@ class TestOrchestration:
                 (void)args;
                 (void)arg_count;
                 return PTO2OrchestrationConfig{
-                    .expected_arg_count = 6,
+                    .expected_arg_count = 3,
                 };
             }
 
@@ -117,22 +113,20 @@ class TestOrchestration:
                 (void)arg_count;
 
                 // Extract device pointers
-                void* arg_a_ptr = (void*)(uintptr_t)args[ARG_PTR_A];
-                void* arg_b_ptr = (void*)(uintptr_t)args[ARG_PTR_B];
-                void* arg_d_ptr = (void*)(uintptr_t)args[ARG_PTR_D];
-
-                // Extract sizes
-                size_t size_a = (size_t)args[ARG_SIZE_A];
-                size_t size_b = (size_t)args[ARG_SIZE_B];
-                size_t size_d = (size_t)args[ARG_SIZE_D];
+                void* arg_a_ptr = reinterpret_cast<void*>(args[ARG_PTR_A]);
+                void* arg_b_ptr = reinterpret_cast<void*>(args[ARG_PTR_B]);
+                void* arg_d_ptr = reinterpret_cast<void*>(args[ARG_PTR_D]);
 
                 // External tensors
-                Tensor ext_a = make_tensor_external(arg_a_ptr, size_a);
-                Tensor ext_b = make_tensor_external(arg_b_ptr, size_b);
-                Tensor ext_d = make_tensor_external(arg_d_ptr, size_d);
+                uint64_t a_shapes[2] = {16, 16};
+                Tensor ext_a = make_tensor_external(arg_a_ptr, a_shapes, 2, DataType::FLOAT32);
+                uint64_t b_shapes[2] = {16, 16};
+                Tensor ext_b = make_tensor_external(arg_b_ptr, b_shapes, 2, DataType::FLOAT32);
+                uint64_t d_shapes[2] = {16, 16};
+                Tensor ext_d = make_tensor_external(arg_d_ptr, d_shapes, 2, DataType::FLOAT32);
 
-                // Intermediate tensors (outer scope)
-                Tensor c = make_tensor(16 * 16 * 4);
+                uint64_t c_shapes[2] = {16, 16};
+                Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
 
                 // Task 0: kernel_add
                 PTOParam params_t0[] = {
@@ -142,17 +136,13 @@ class TestOrchestration:
                 };
                 pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3);
 
-                // Inner scope: intermediates released on scope end
-                PTO2_SCOPE(rt) {
-
-                    // Task 1: kernel_add
-                    PTOParam params_t1[] = {
-                        make_input_param(c),
-                        make_input_param(ext_b),
-                        make_output_param(ext_d),
-                    };
-                    pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t1, 3);
-                }  // inner scope ends
+                // Task 1: kernel_add
+                PTOParam params_t1[] = {
+                    make_input_param(c),
+                    make_input_param(ext_b),
+                    make_output_param(ext_d),
+                };
+                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t1, 3);
             }
 
             }  // extern "C"
@@ -366,10 +356,6 @@ class TestOrchestration:
             #define ARG_PTR_B 1
             #define ARG_PTR_F 2
 
-            #define ARG_SIZE_A 3
-            #define ARG_SIZE_B 4
-            #define ARG_SIZE_F 5
-
             // Helper to encode float as uint64_t for scalar params
             static uint64_t float_to_u64(float f) {
                 union {
@@ -388,7 +374,7 @@ class TestOrchestration:
                 (void)args;
                 (void)arg_count;
                 return PTO2OrchestrationConfig{
-                    .expected_arg_count = 6,
+                    .expected_arg_count = 3,
                 };
             }
 
@@ -397,22 +383,20 @@ class TestOrchestration:
                 (void)arg_count;
 
                 // Extract device pointers
-                void* arg_a_ptr = (void*)(uintptr_t)args[ARG_PTR_A];
-                void* arg_b_ptr = (void*)(uintptr_t)args[ARG_PTR_B];
-                void* arg_f_ptr = (void*)(uintptr_t)args[ARG_PTR_F];
-
-                // Extract sizes
-                size_t size_a = (size_t)args[ARG_SIZE_A];
-                size_t size_b = (size_t)args[ARG_SIZE_B];
-                size_t size_f = (size_t)args[ARG_SIZE_F];
+                void* arg_a_ptr = reinterpret_cast<void*>(args[ARG_PTR_A]);
+                void* arg_b_ptr = reinterpret_cast<void*>(args[ARG_PTR_B]);
+                void* arg_f_ptr = reinterpret_cast<void*>(args[ARG_PTR_F]);
 
                 // External tensors
-                Tensor ext_a = make_tensor_external(arg_a_ptr, size_a);
-                Tensor ext_b = make_tensor_external(arg_b_ptr, size_b);
-                Tensor ext_f = make_tensor_external(arg_f_ptr, size_f);
+                uint64_t a_shapes[2] = {16, 16};
+                Tensor ext_a = make_tensor_external(arg_a_ptr, a_shapes, 2, DataType::FLOAT32);
+                uint64_t b_shapes[2] = {16, 16};
+                Tensor ext_b = make_tensor_external(arg_b_ptr, b_shapes, 2, DataType::FLOAT32);
+                uint64_t f_shapes[2] = {16, 16};
+                Tensor ext_f = make_tensor_external(arg_f_ptr, f_shapes, 2, DataType::FLOAT32);
 
-                // Intermediate tensors (outer scope)
-                Tensor c = make_tensor(16 * 16 * 4);
+                uint64_t c_shapes[2] = {16, 16};
+                Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
 
                 // Task 0: kernel_add
                 PTOParam params_t0[] = {
@@ -421,46 +405,44 @@ class TestOrchestration:
                     make_output_param(c),
                 };
                 pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3);
+                uint64_t d_shapes[2] = {16, 16};
+                Tensor d = make_tensor(d_shapes, 2, DataType::FLOAT32);
 
-                // Inner scope: intermediates released on scope end
-                PTO2_SCOPE(rt) {
-                    Tensor d = make_tensor(16 * 16 * 4);
-                    Tensor e = make_tensor(16 * 16 * 4);
-                    Tensor g = make_tensor(16 * 16 * 4);
+                // Task 1: kernel_add_scalar
+                PTOParam params_t1[] = {
+                    make_input_param(c),
+                    make_scalar_param(float_to_u64(1.000000f)),
+                    make_output_param(d),
+                };
+                pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 3);
+                uint64_t e_shapes[2] = {16, 16};
+                Tensor e = make_tensor(e_shapes, 2, DataType::FLOAT32);
 
+                // Task 2: kernel_add_scalar
+                PTOParam params_t2[] = {
+                    make_input_param(c),
+                    make_scalar_param(float_to_u64(2.000000f)),
+                    make_output_param(e),
+                };
+                pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 3);
+                uint64_t g_shapes[2] = {16, 16};
+                Tensor g = make_tensor(g_shapes, 2, DataType::FLOAT32);
 
-                    // Task 1: kernel_add_scalar
-                    PTOParam params_t1[] = {
-                        make_input_param(c),
-                        make_scalar_param(float_to_u64(1.000000f)),
-                        make_output_param(d),
-                    };
-                    pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 3);
+                // Task 3: kernel_mul
+                PTOParam params_t3[] = {
+                    make_input_param(d),
+                    make_input_param(e),
+                    make_output_param(g),
+                };
+                pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
 
-                    // Task 2: kernel_add_scalar
-                    PTOParam params_t2[] = {
-                        make_input_param(c),
-                        make_scalar_param(float_to_u64(2.000000f)),
-                        make_output_param(e),
-                    };
-                    pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 3);
-
-                    // Task 3: kernel_mul
-                    PTOParam params_t3[] = {
-                        make_input_param(d),
-                        make_input_param(e),
-                        make_output_param(g),
-                    };
-                    pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
-
-                    // Task 4: kernel_add
-                    PTOParam params_t4[] = {
-                        make_input_param(g),
-                        make_input_param(c),
-                        make_output_param(ext_f),
-                    };
-                    pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t4, 3);
-                }  // inner scope ends
+                // Task 4: kernel_add
+                PTOParam params_t4[] = {
+                    make_input_param(g),
+                    make_input_param(c),
+                    make_output_param(ext_f),
+                };
+                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t4, 3);
             }
 
             }  // extern "C"
@@ -520,7 +502,7 @@ class TestOrchestration:
         # Tuple elements x, y are intermediate: make_tensor (not external)
         assert "Tensor x = make_tensor(" in code
         assert "Tensor y = make_tensor(" in code
-        assert "16 * 16 * 4" in code
+        assert "DataType::FLOAT32" in code
 
         # Return tensor result is external
         assert "make_tensor_external(arg_result_ptr" in code
@@ -528,8 +510,8 @@ class TestOrchestration:
         # Two tasks: kernel_pair + kernel_add
         assert code.count("pto2_rt_submit_task") == 2
 
-        # PTO2_SCOPE needed: kernel_add depends on intermediate x, y
-        assert "PTO2_SCOPE(rt)" in code
+        # No PTO2_SCOPE: no control flow
+        assert "PTO2_SCOPE" not in code
 
     def test_tuple_output(self):
         """Test tuple return as final output: all elements are external tensors."""
@@ -644,11 +626,11 @@ class TestOrchestration:
         files = generator.generate(FourTupleProgram)
         code = files["orchestration/orch_four_tuple.cpp"]
 
-        # All 4 tuple elements are intermediate tensors with correct sizes
-        # [16, 1] FP32 = 16 * 1 * 4 = 64 bytes
-        assert "16 * 1 * 4" in code
-        # [16, 16] FP32 = 16 * 16 * 4 = 1024 bytes
-        assert "16 * 16 * 4" in code
+        # All 4 tuple elements are intermediate tensors with correct shapes
+        # [16, 1] FP32
+        assert "mi_shapes[2] = {16, 1}" in code
+        # [16, 16] FP32
+        assert "oi_shapes[2] = {16, 16}" in code
         for name in ["mi", "li", "oi", "dst"]:
             assert f"Tensor {name} = make_tensor(" in code, f"Missing make_tensor for {name}"
 
@@ -658,8 +640,8 @@ class TestOrchestration:
         # Two tasks: online_update + kernel_add
         assert code.count("pto2_rt_submit_task") == 2
 
-        # PTO2_SCOPE needed: kernel_add depends on intermediate oi, dst
-        assert "PTO2_SCOPE(rt)" in code
+        # No PTO2_SCOPE: no control flow
+        assert "PTO2_SCOPE" not in code
 
     def test_tensor_create(self):
         """Test tensor.create generates make_tensor with correct size."""
@@ -691,10 +673,10 @@ class TestOrchestration:
         files = generator.generate(TensorCreateProgram)
         code = files["orchestration/orch_create.cpp"]
 
-        # tensor.create generates make_tensor with byte size
-        # FP16 = 2 bytes per element
-        assert "32 * 32 * 2" in code
-        assert "Tensor buf = make_tensor(" in code
+        # tensor.create generates make_tensor with shape/dtype
+        # FP16 = DataType::FLOAT16
+        assert "buf_shapes[2] = {32, 32}" in code
+        assert "Tensor buf = make_tensor(buf_shapes, 2, DataType::FLOAT16)" in code
 
     def test_inplace_tensor(self):
         """Test inplace tensors use make_inout_param when a tensor is both input and output.
@@ -774,14 +756,6 @@ class TestOrchestration:
             #define ARG_PTR_OI 5
             #define ARG_PTR_DST 6
 
-            #define ARG_SIZE_MIJ 7
-            #define ARG_SIZE_LIJ 8
-            #define ARG_SIZE_OI_NEW 9
-            #define ARG_SIZE_MI 10
-            #define ARG_SIZE_LI 11
-            #define ARG_SIZE_OI 12
-            #define ARG_SIZE_DST 13
-
             // Helper to encode float as uint64_t for scalar params
             static uint64_t float_to_u64(float f) {
                 union {
@@ -800,7 +774,7 @@ class TestOrchestration:
                 (void)args;
                 (void)arg_count;
                 return PTO2OrchestrationConfig{
-                    .expected_arg_count = 14,
+                    .expected_arg_count = 7,
                 };
             }
 
@@ -809,31 +783,30 @@ class TestOrchestration:
                 (void)arg_count;
 
                 // Extract device pointers
-                void* arg_mij_ptr = (void*)(uintptr_t)args[ARG_PTR_MIJ];
-                void* arg_lij_ptr = (void*)(uintptr_t)args[ARG_PTR_LIJ];
-                void* arg_oi_new_ptr = (void*)(uintptr_t)args[ARG_PTR_OI_NEW];
-                void* arg_mi_ptr = (void*)(uintptr_t)args[ARG_PTR_MI];
-                void* arg_li_ptr = (void*)(uintptr_t)args[ARG_PTR_LI];
-                void* arg_oi_ptr = (void*)(uintptr_t)args[ARG_PTR_OI];
-                void* arg_dst_ptr = (void*)(uintptr_t)args[ARG_PTR_DST];
-
-                // Extract sizes
-                size_t size_mij = (size_t)args[ARG_SIZE_MIJ];
-                size_t size_lij = (size_t)args[ARG_SIZE_LIJ];
-                size_t size_oi_new = (size_t)args[ARG_SIZE_OI_NEW];
-                size_t size_mi = (size_t)args[ARG_SIZE_MI];
-                size_t size_li = (size_t)args[ARG_SIZE_LI];
-                size_t size_oi = (size_t)args[ARG_SIZE_OI];
-                size_t size_dst = (size_t)args[ARG_SIZE_DST];
+                void* arg_mij_ptr = reinterpret_cast<void*>(args[ARG_PTR_MIJ]);
+                void* arg_lij_ptr = reinterpret_cast<void*>(args[ARG_PTR_LIJ]);
+                void* arg_oi_new_ptr = reinterpret_cast<void*>(args[ARG_PTR_OI_NEW]);
+                void* arg_mi_ptr = reinterpret_cast<void*>(args[ARG_PTR_MI]);
+                void* arg_li_ptr = reinterpret_cast<void*>(args[ARG_PTR_LI]);
+                void* arg_oi_ptr = reinterpret_cast<void*>(args[ARG_PTR_OI]);
+                void* arg_dst_ptr = reinterpret_cast<void*>(args[ARG_PTR_DST]);
 
                 // External tensors
-                Tensor ext_mij = make_tensor_external(arg_mij_ptr, size_mij);
-                Tensor ext_lij = make_tensor_external(arg_lij_ptr, size_lij);
-                Tensor ext_oi_new = make_tensor_external(arg_oi_new_ptr, size_oi_new);
-                Tensor ext_mi = make_tensor_external(arg_mi_ptr, size_mi);
-                Tensor ext_li = make_tensor_external(arg_li_ptr, size_li);
-                Tensor ext_oi = make_tensor_external(arg_oi_ptr, size_oi);
-                Tensor ext_dst = make_tensor_external(arg_dst_ptr, size_dst);
+                uint64_t mij_shapes[2] = {16, 1};
+                Tensor ext_mij = make_tensor_external(arg_mij_ptr, mij_shapes, 2, DataType::FLOAT32);
+                uint64_t lij_shapes[2] = {16, 1};
+                Tensor ext_lij = make_tensor_external(arg_lij_ptr, lij_shapes, 2, DataType::FLOAT32);
+                uint64_t oi_new_shapes[2] = {16, 16};
+                Tensor ext_oi_new = make_tensor_external(arg_oi_new_ptr, oi_new_shapes, 2, DataType::FLOAT32);
+                uint64_t mi_shapes[2] = {16, 1};
+                Tensor ext_mi = make_tensor_external(arg_mi_ptr, mi_shapes, 2, DataType::FLOAT32);
+                uint64_t li_shapes[2] = {16, 1};
+                Tensor ext_li = make_tensor_external(arg_li_ptr, li_shapes, 2, DataType::FLOAT32);
+                uint64_t oi_shapes[2] = {16, 16};
+                Tensor ext_oi = make_tensor_external(arg_oi_ptr, oi_shapes, 2, DataType::FLOAT32);
+                uint64_t dst_shapes[2] = {16, 16};
+                Tensor ext_dst = make_tensor_external(arg_dst_ptr, dst_shapes, 2, DataType::FLOAT32);
+
 
                 // Task 0: online_update
                 PTOParam params_t0[] = {
@@ -888,6 +861,288 @@ class TestOrchestration:
 
         # tensor.dim generates int64_t assignment
         assert "int64_t d0 = 64" in code
+
+    def test_for_loop_with_view(self):
+        """Test for loop + tensor.view: simplified paged attention pattern.
+
+        Exercises: for loop with dynamic bound, tensor.view with dynamic offsets,
+        kernel calls inside loop body.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class ForViewProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_for_view(
+                self,
+                data: pl.Tensor[[64, 16], pl.FP32],
+                bias: pl.Tensor[[16, 16], pl.FP32],
+                config: pl.Tensor[[4], pl.INT64],
+            ) -> pl.Tensor[[64, 16], pl.FP32]:
+                n_blocks: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                out: pl.Tensor[[64, 16], pl.FP32] = data
+                for i in pl.range(n_blocks):
+                    chunk: pl.Tensor[[16, 16], pl.FP32] = pl.view(data, [16, 16], [i * 16, 0])
+                    result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(chunk, bias)  # noqa: F841
+                return out
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(ForViewProgram)
+        code = files["orchestration/orch_for_view.cpp"]
+
+        # For loop with dynamic bound from tensor.read
+        assert "for (int64_t i = 0; i < n_blocks; i += 1)" in code
+
+        # PTO2_SCOPE wraps the for loop body
+        assert "PTO2_SCOPE(rt)" in code
+
+        # tensor.view generates view call with dynamic offset
+        assert ".view({16, 16}, {(i * 16), 0})" in code
+
+        # tensor.read generates host pointer access
+        assert "static_cast<int64_t*>(arg_config_ptr)" in code
+
+        # kernel_add task submitted inside loop
+        assert "pto2_rt_submit_task" in code
+
+    def test_if_statement(self):
+        """Test if/else codegen with conditional scalar values."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class IfProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                flag: pl.Scalar[pl.INT64],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], [16, 16], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_if(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                for i in pl.range(4):
+                    if i == 0:
+                        is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                    else:
+                        is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                    result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_process(a, is_first)
+                return result
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(IfProgram)
+        code = files["orchestration/orch_if.cpp"]
+
+        # If statement with comparison
+        assert "if ((i == 0))" in code
+
+        # PTO2_SCOPE wraps for loop body and if/else bodies
+        assert "PTO2_SCOPE(rt)" in code
+
+        # Scalar assignment in both branches
+        assert "is_first = 1" in code
+        assert "is_first = 0" in code
+
+    def test_multiple_tuple_calls(self):
+        """Test that multiple tuple-returning calls produce correct per-call params.
+
+        When two different kernel calls both return tuples, each call's PTOParam
+        array should only contain outputs from that specific call, not outputs
+        from other calls. Regression test for SSA base name collision in
+        tuple_var_to_elements_ (all _tuple_tmp_N collapsed to _tuple_tmp).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class MultipleTupleProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_a(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                y: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                xt: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                yt: pl.Tile[[16, 16], pl.FP32] = pl.load(y, [0, 0], [16, 16])
+                x_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(xt, [0, 0], [16, 16], x)
+                y_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(yt, [0, 0], [16, 16], y)
+                return x_out, y_out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_b(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                at: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                bt: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                a_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(at, [0, 0], [16, 16], a)
+                b_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(bt, [0, 0], [16, 16], b)
+                return a_out, b_out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_multi_tuple(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                y: pl.Tensor[[16, 16], pl.FP32],
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                # First tuple-returning call
+                x, y = self.kernel_a(x, y)
+                # Second tuple-returning call
+                a, b = self.kernel_b(a, b)
+                return x
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(MultipleTupleProgram)
+        code = files["orchestration/orch_multi_tuple.cpp"]
+
+        # kernel_a should only have x and y params (2 inout), not a or b
+        assert code.count("params_t0") >= 2
+        # kernel_b should only have a and b params (2 inout), not x or y
+        assert code.count("params_t1") >= 2
+
+        # Count make_inout_param per task block: each should have exactly 2
+        lines = code.split("\n")
+        task0_params = []
+        task1_params = []
+        in_task0 = False
+        in_task1 = False
+        for line in lines:
+            if "params_t0[]" in line:
+                in_task0 = True
+            elif "params_t1[]" in line:
+                in_task1 = True
+            elif "};" in line:
+                in_task0 = False
+                in_task1 = False
+            if in_task0 and ("make_" in line):
+                task0_params.append(line.strip())
+            if in_task1 and ("make_" in line):
+                task1_params.append(line.strip())
+
+        # kernel_a: x, y as inout → 2 params
+        assert len(task0_params) == 2, (
+            f"kernel_a should have 2 params (x, y inout), got {len(task0_params)}: {task0_params}"
+        )
+        # kernel_b: a, b as inout → 2 params
+        assert len(task1_params) == 2, (
+            f"kernel_b should have 2 params (a, b inout), got {len(task1_params)}: {task1_params}"
+        )
+
+    def test_tuple_in_for_loop(self):
+        """Test tuple-returning call inside for-loop produces no self-assignments.
+
+        When a tuple-returning kernel is called both before and inside a for-loop,
+        SSA conversion creates iter_args for the tuple intermediate (_tuple_tmp) and
+        its unpacked elements. After SSA base name collapsing, these would produce
+        self-assignments like `auto _tuple_tmp = _tuple_tmp;` (C++ UB) and
+        `oi = oi;` (NOP). The codegen should skip these.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class TupleForLoopProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_init(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                at: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                bt: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                a_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(at, [0, 0], [16, 16], a)
+                b_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(bt, [0, 0], [16, 16], b)
+                return a_out, b_out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_update(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> tuple[
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                xt: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                at: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                a_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(xt, [0, 0], [16, 16], a)
+                b_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(at, [0, 0], [16, 16], b)
+                return a_out, b_out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_tuple_loop(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_acc: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                b_acc: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                # Tuple call BEFORE the loop — makes _tuple_tmp/a_acc/b_acc loop-carried
+                a_acc, b_acc = self.kernel_init(a_acc, b_acc)
+                for i in pl.range(4):
+                    # Tuple call INSIDE the loop — triggers iter_arg self-assignment
+                    a_acc, b_acc = self.kernel_update(x, a_acc, b_acc)
+                return a_acc
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(TupleForLoopProgram)
+        code = files["orchestration/orch_tuple_loop.cpp"]
+
+        # No self-assignment in iter_arg init
+        assert "auto _tuple_tmp = _tuple_tmp" not in code
+        assert "auto a_acc = a_acc" not in code
+        assert "auto b_acc = b_acc" not in code
+
+        # No self-assignment in yield
+        assert "_tuple_tmp = _tuple_tmp;" not in code
+        assert "a_acc = a_acc;" not in code
+        assert "b_acc = b_acc;" not in code
+
+        # make_tensor declarations exist (exactly once each)
+        assert code.count("Tensor a_acc = make_tensor(") == 1
+        assert code.count("Tensor b_acc = make_tensor(") == 1
+
+        # For loop exists with correct structure
+        assert "for (int64_t i = 0; i < 4; i += 1)" in code
+        assert "PTO2_SCOPE(rt)" in code
+
+        # Both tasks submitted
+        assert "kernel_init" in code
+        assert "kernel_update" in code
+        assert code.count("pto2_rt_submit_task") == 2
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/expressions/test_scalar_ops.py
+++ b/tests/ut/ir/expressions/test_scalar_ops.py
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for scalar Make helper functions (min_, max_)."""
+
+from typing import cast
+
+import pytest
+from pypto import DataType, ir
+
+
+class TestScalarMakeHelpers:
+    """Tests for ir.min_ and ir.max_."""
+
+    def test_min_creation(self):
+        """Test ir.min_ creates a Min expression with type promotion."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+
+        result = ir.min_(x, y, span)
+
+        assert isinstance(result, ir.Min)
+        assert cast(ir.Var, result.left).name == "x"
+        assert cast(ir.Var, result.right).name == "y"
+
+    def test_max_creation(self):
+        """Test ir.max_ creates a Max expression with type promotion."""
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+        y = ir.Var("y", ir.ScalarType(dtype), span)
+
+        result = ir.max_(x, y, span)
+
+        assert isinstance(result, ir.Max)
+        assert cast(ir.Var, result.left).name == "x"
+        assert cast(ir.Var, result.right).name == "y"
+
+    def test_min_type_promotion(self):
+        """Test that min_ promotes operand types (e.g. INT32 + INT64 -> INT64)."""
+        span = ir.Span.unknown()
+        x = ir.Var("x", ir.ScalarType(DataType.INT32), span)
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+
+        result = ir.min_(x, y, span)
+
+        assert isinstance(result, ir.Min)
+        assert result.type == ir.ScalarType(DataType.INT64)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -1,0 +1,93 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for scalar operation dispatch in the DSL parser.
+
+Verifies that pl.min, pl.max dispatch to scalar IR ops
+when called with scalar arguments.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.pypto_core import ir
+
+
+class TestScalarOpDispatch:
+    """Tests for scalar operation dispatch through pl.* interface."""
+
+    def test_scalar_min(self):
+        """Test pl.min(scalar, scalar) dispatches to ir.min_."""
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def test_min(
+            config: pl.Tensor[[2], pl.INT64],
+            out: pl.Tensor[[2, 16, 128], pl.FP32],
+        ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+            a: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [0])
+            b: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [1])
+            c = pl.min(a, b)
+            _ = c + 1
+            return out
+
+        assert isinstance(test_min, ir.Function)
+        ir_text = ir.python_print(test_min)
+        assert "min" in ir_text.lower()
+
+    def test_scalar_max(self):
+        """Test pl.max(scalar, scalar) dispatches to ir.max_."""
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def test_max(
+            config: pl.Tensor[[2], pl.INT64],
+            out: pl.Tensor[[2, 16, 128], pl.FP32],
+        ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+            a: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [0])
+            b: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [1])
+            c = pl.max(a, b)
+            _ = c + 1
+            return out
+
+        assert isinstance(test_max, ir.Function)
+        ir_text = ir.python_print(test_max)
+        assert "max" in ir_text.lower()
+
+    def test_scalar_min_with_literal(self):
+        """Test pl.min(scalar, int_literal) — the paged_attention use case."""
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def test_min_lit(
+            config: pl.Tensor[[2], pl.INT64],
+            out: pl.Tensor[[2, 16, 128], pl.FP32],
+        ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+            a: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [0])
+            c = pl.min(a, 128)
+            _ = c + 1
+            return out
+
+        assert isinstance(test_min_lit, ir.Function)
+        ir_text = ir.python_print(test_min_lit)
+        assert "min" in ir_text.lower()
+
+    def test_tile_min_still_works(self):
+        """Ensure pl.min(tile, axis=...) still works as tile reduction."""
+
+        @pl.function
+        def test_tile_min(
+            x: pl.Tensor[[32, 32], pl.FP32],
+        ) -> pl.Tensor[[32, 32], pl.FP32]:
+            tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(x, [0, 0], [32, 32])
+            tile_c: pl.Tile[[1, 32], pl.FP32] = pl.min(tile_a, axis=0)
+            out: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_c, [0, 0], [1, 32], x)
+            return out
+
+        assert isinstance(test_tile_min, ir.Function)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

- **Refactor orchestration codegen to use typed tensor APIs**: Replace raw string-based tensor allocation with shape/dtype-aware helpers (`EmitTensorDecl`, `EmitFunctionCall`). Add `GetRuntimeDataTypeString()` for runtime-compatible dtype name mapping (e.g. `DataType::FLOAT32`).
- **Extend `CodegenBase` expression support**: Make `TryGetVarName()` and `GenerateExprString()` virtual for subclass override. Add codegen for `FloorMod`, `Min`, `Max`, comparison ops (`Eq`/`Ne`/`Lt`/`Le`/`Gt`/`Ge`), `ConstFloat`, `ConstBool`, `Neg`, and `Cast`.
- **Add IfOp and ViewOp codegen**: Support `IfStmt` branching and `view` operations in the orchestration layer.
- **Add scalar min/max dispatch**: Introduce `_SCALAR_BINARY_OPS` in `ast_parser.py` so `pl.min(s1, s2)` / `pl.max(s1, s2)` dispatch to `ir.min_()` / `ir.max_()` when arguments are `ScalarType`.
- **Fix tuple param cross-contamination**: Multiple tuple-returning kernel calls (e.g. `kernel_init_inplace`, `kernel_softmax_prepare`) previously shared output params because `GetSSABaseName()` collapsed all `_tuple_tmp_N` names. Now uses per-call unique keys (`_tc_0`, `_tc_1`, ...) with `Call*` pointer coordination to isolate each call's tuple elements.
- **Add paged attention example**: End-to-end orchestration codegen example demonstrating multi-kernel paged attention with FlashDecoding-style online softmax.

## Changed files

| Area | Files | What changed |
|------|-------|-------------|
| **Codegen infra** | `codegen_base.h/cpp` | Virtual `TryGetVarName`/`GenerateExprString`, `GetRuntimeDataTypeString`, expanded expr codegen |
| **Orchestration** | `orchestration_codegen.cpp` | SSA-aware var resolution, typed tensor APIs, IfStmt/ViewOp, per-call tuple key isolation |
| **Tensor ops** | `tensor_op_codegen.cpp` | Updated tensor op codegen to use new helpers |
| **Language** | `ast_parser.py`, `block_ops.py` | Scalar min/max dispatch, moved `abs`/`min`/`max` to correct op categories |
| **Backend** | `backend_910b_cce_ops.cpp`, `cce_codegen.cpp` | Minor dtype/backend alignment |
| **Printer** | `python_printer.cpp` | Float constant formatting fix |
| **Bindings** | `ir.cpp`, `ir.pyi` | Expose `Min`/`Max` scalar expressions |
| **Example** | `paged_attention_example.py` | New paged attention orchestration example |

## Test plan

- [x] New `test_scalar_ops.py` — verifies `ir.min_()` / `ir.max_()` scalar expression construction
- [x] New `test_scalar_dispatch.py` — verifies `pl.min` / `pl.max` dispatches to scalar ops when args are `ScalarType`
- [x] Updated `test_orchestration_codegen.py` — expanded coverage for tensor API codegen, IfOp, ViewOp, and multi-tuple-call isolation
- [x] Updated `test_cce_codegen.py` — aligned with new codegen output format
- [ ] Full test suite: `python3 -m pytest . -v -s`