### PR TITLE
test: Add fuzzing test framework for PyPTO

### DIFF
--- a/tests/st/fuzz/README.md
+++ b/tests/st/fuzz/README.md
@@ -1,0 +1,127 @@
+# PyPTO Fuzzing Test Framework
+
+Automated fuzzing framework for generating and validating multi-kernel test cases for PyPTO IR.
+
+## Overview
+
+This framework tests PyPTO compiler and runtime correctness by randomly generating operator combinations:
+
+- **Operator Fuzzing**: Random combinations of block-level operators (binary, unary, scalar, reduction, expand, etc.)
+- **Multi-Kernel Generation**: Auto-generates test cases with multiple InCore kernels and Orchestration functions
+- **Golden Reference**: Uses NumPy to generate expected results, validated through harness framework
+- **Shape Tracking**: Supports dynamic shape inference and memory alignment checks
+
+## Directory Structure
+
+```
+tests/st/fuzz/
+├── src/                          # Core generators
+│   ├── fuzzer.py                 # Operator fuzzing engine
+│   ├── kernel_generator.py       # InCore kernel code generation
+│   ├── orchestrator_generator.py # Orchestration function generation
+│   └── multi_kernel_test_generator.py  # Multi-kernel test case generation
+├── generated/                    # Generated test files
+│   └── test_fuzz_multi_kernel.py
+├── example_mutil_kernel.py       # Usage example
+└── README.md                     # This document
+```
+
+## Quick Start
+
+### Generate Test Cases
+
+Use the example script to generate tests:
+
+```bash
+# Generate tests with default configuration
+python tests/st/fuzz/example_mutil_kernel.py
+
+# Specify configuration index
+python tests/st/fuzz/example_mutil_kernel.py --config-index 0
+
+# Custom parameters
+python tests/st/fuzz/example_mutil_kernel.py \
+    --atol 1e-4 \
+    --rtol 1e-4 \
+    --advanced-ops-prob 0.7 \
+    --output tests/st/fuzz/generated/my_test.py
+```
+
+### Run Tests
+
+```bash
+# Run generated tests
+pytest tests/st/fuzz/generated/test_fuzz_multi_kernel.py
+
+# Run all fuzz tests
+pytest tests/st/fuzz/
+```
+
+## Core Components
+
+### OpFuzzer ([fuzzer.py](src/fuzzer.py))
+
+Operator fuzzing engine that:
+- Randomly generates operator chains (ensures all inputs and intermediates are used)
+- Checks shape compatibility and performs automatic inference
+- Tracks value ranges (avoids illegal inputs for sqrt/log/div operators)
+- Supports basic and advanced operators (row_expand, col_expand, reduction, etc.)
+
+### KernelGenerator ([kernel_generator.py](src/kernel_generator.py))
+
+Generates Python code for InCore kernels, including:
+- Tile allocation and memory management
+- Operator call sequences
+- Golden reference implementation (NumPy)
+
+### OrchestratorGenerator ([orchestrator_generator.py](src/orchestrator_generator.py))
+
+Generates Orchestration functions, supporting:
+- Sequential: Execute multiple kernels sequentially
+- Parallel: Execute independent kernels in parallel
+- Pipeline: Execute kernels in pipeline mode
+
+### MultiKernelTestGenerator ([multi_kernel_test_generator.py](src/multi_kernel_test_generator.py))
+
+Top-level test case generator that integrates the above components to generate complete pytest test classes.
+
+## Configuration Options
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--config-index` | Configuration index (starting from 0) | 0 |
+| `--output` | Output file path | `generated/test_fuzz_multi_kernel.py` |
+| `--atol` | Absolute error tolerance | 5e-5 |
+| `--rtol` | Relative error tolerance | 5e-5 |
+| `--advanced-ops-prob` | Advanced operator selection probability (0.0-1.0) | 0.5 |
+
+## Test Configuration Example
+
+Define test configurations in [example_mutil_kernel.py](example_mutil_kernel.py):
+
+```python
+all_configs = [
+    {
+        "name": "fuzz_sequential_simple",
+        "num_instances": 1,           # Generate 1 test instance
+        "seed": 40,                   # Random seed
+        "enable_advanced_ops": True,  # Enable advanced operators
+        "num_kernels": 1,             # Number of kernels
+        "mode": "sequential",         # Execution mode
+        "shape": (128, 128),          # Default shape
+        "num_ops_range": (5, 5),      # Operator count range per kernel
+        "tensor_init_type": "random", # Tensor initialization method
+        "input_shapes_list": [
+            [(128, 128), (128, 128)], # kernel_0: 2 inputs with same dimensions
+        ],
+        "description": "Simple sequential execution: 1 kernel, same dimension inputs",
+    },
+]
+```
+
+## Notes
+
+- Generated test files will overwrite existing files
+- Advanced operators (row_expand, reduction, etc.) require specific shape constraints
+- Start with small-scale configurations for validation before expanding to complex scenarios
+- Check `run.log` for detailed information when tests fail

--- a/tests/st/fuzz/__init__.py
+++ b/tests/st/fuzz/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""PyPTO Fuzzing Test Framework."""
+
+from .src import (
+    KernelGenerator,
+    MultiKernelTestGenerator,
+    OpFuzzer,
+    OpSpec,
+    OrchestratorGenerator,
+)
+
+__all__ = [
+    "OpFuzzer",
+    "OpSpec",
+    "KernelGenerator",
+    "OrchestratorGenerator",
+    "MultiKernelTestGenerator",
+]

--- a/tests/st/fuzz/example_mutil_kernel.py
+++ b/tests/st/fuzz/example_mutil_kernel.py
@@ -1,0 +1,301 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Multi-kernel fuzzing framework usage example
+
+This script demonstrates how to use the multi-kernel test generator to create test cases.
+Supports controlling the number and configuration of generated test cases via command-line arguments.
+
+Usage:
+    python example_multi_kernel.py --num-cases 5
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add tests/st to path for importing harness
+_SCRIPT_DIR = Path(__file__).parent
+_TESTS_ST_DIR = _SCRIPT_DIR.parent
+if str(_TESTS_ST_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_ST_DIR))
+
+# noqa: E402 - Import after path modification
+from fuzz.src.multi_kernel_test_generator import MultiKernelTestGenerator  # noqa: E402
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Create and configure argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Generate multi-kernel fuzzing test cases",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Example:
+  # Generate test cases with default configuration
+  python example_multi_kernel.py
+
+  # Generate 5 test cases
+  python example_multi_kernel.py --num-cases 5
+
+  # Specify configuration index (starting from 0)
+  python example_multi_kernel.py --config-index 0
+
+  # Generate 3 test cases from configuration 0
+  python example_multi_kernel.py --config-index 0 --num-cases 3
+
+  # Specify output file
+  python example_multi_kernel.py --output custom_test.py
+
+  # Set error tolerance
+  python example_multi_kernel.py --atol 1e-3 --rtol 1e-3
+
+  # Set advanced operators probability (0.0-1.0)
+  python example_multi_kernel.py --advanced-ops-prob 0.7
+
+  # Combined usage
+  python example_multi_kernel.py --config-index 1 --atol 1e-4 --rtol 1e-4 \\
+      --advanced-ops-prob 0.5 --output my_test.py
+        """,
+    )
+
+    parser.add_argument(
+        "--config-index",
+        type=int,
+        default=0,
+        help="Specify the configuration index to use (starting from 0)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path (default: generated/test_fuzz_multi_kernel.py)",
+    )
+    parser.add_argument("--atol", type=float, default=5e-5, help="Absolute error tolerance")
+    parser.add_argument("--rtol", type=float, default=5e-5, help="Relative error tolerance")
+    parser.add_argument(
+        "--advanced-ops-prob",
+        type=float,
+        default=0.5,
+        help="Probability of selecting advanced operators (0.0-1.0)",
+    )
+    parser.add_argument(
+        "--num-cases",
+        type=int,
+        default=None,
+        help="Number of test cases to generate",
+    )
+
+    return parser
+
+
+def get_default_configs() -> list[dict[str, Any]]:
+    """Get default test configurations."""
+    return [
+        {
+            "name": "fuzz_sequential_simple",
+            "num_instances": 1,
+            "seed": 40,
+            "enable_advanced_ops": False,
+            "num_kernels": 2,
+            "mode": "sequential",
+            "shape": (128, 128),
+            "num_ops_range": (7, 10),
+            "tensor_init_type": "random",
+            "input_shapes_list": [[(128, 128), (128, 128)]],
+            "description": "Branching execution: 2 kernels, same dimension inputs",
+        },
+    ]
+
+
+def select_configs(all_configs: list[dict[str, Any]], config_index: int | None) -> list[dict[str, Any]]:
+    """Select configurations based on config_index."""
+    if config_index is None:
+        return all_configs
+    if config_index < 0 or config_index >= len(all_configs):
+        print(f"Error: configuration index {config_index} out of range (0-{len(all_configs) - 1})")
+        sys.exit(1)
+    return [all_configs[config_index]]
+
+
+def apply_num_cases_override(configs: list[dict[str, Any]], num_cases: int | None) -> None:
+    """Override num_instances if num_cases is specified."""
+    if num_cases is None:
+        return
+    if num_cases <= 0:
+        print(f"Error: --num-cases must be positive, got {num_cases}")
+        sys.exit(1)
+    for config in configs:
+        config["num_instances"] = num_cases
+
+
+def print_summary(configs: list[dict[str, Any]], output_path: Path, args: argparse.Namespace) -> None:
+    """Print generation summary."""
+    total_test_cases = sum(config.get("num_instances", 1) for config in configs)
+
+    print("Multi-kernel fuzzing test generator")
+    print("=" * 60)
+    print(f"Number of configurations: {len(configs)}")
+    print(f"Total test cases: {total_test_cases}")
+    print(f"Output file: {output_path}")
+    print(f"Absolute error tolerance (atol): {args.atol}")
+    print(f"Relative error tolerance (rtol): {args.rtol}")
+    print(f"Advanced operators probability: {args.advanced_ops_prob}")
+    print("=" * 60)
+    print()
+
+
+def print_config_details(configs: list[dict[str, Any]]) -> None:
+    """Print detailed configuration information."""
+    print("Will generate the following test cases:")
+    print()
+    test_case_num = 1
+    for config_idx, config in enumerate(configs):
+        num_instances = config.get("num_instances", 1)
+        print(f"Configuration {config_idx}: {config['name']}")
+        print(f"   {config['description']}")
+        print(f"   Number of instances: {num_instances}")
+        print(f"   Random seed: {config.get('seed', 42)}")
+        print(f"   Enable advanced operators: {'Yes' if config.get('enable_advanced_ops', False) else 'No'}")
+        print(f"   Tensor initialization: {config.get('tensor_init_type', 'constant')}")
+        if num_instances > 1:
+            print(f"   Will generate test cases: {test_case_num} - {test_case_num + num_instances - 1}")
+        else:
+            print(f"   Will generate test case: {test_case_num}")
+        test_case_num += num_instances
+        print()
+
+
+def expand_configs(configs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Expand configurations to create individual test configs."""
+    expanded = []
+    for config in configs:
+        num_instances = config.get("num_instances", 1)
+        base_seed = config.get("seed")
+
+        for instance_idx in range(num_instances):
+            test_config = config.copy()
+            if num_instances > 1:
+                test_config["name"] = f"{config['name']}_{instance_idx}"
+                test_config["seed"] = (base_seed + instance_idx) if base_seed is not None else instance_idx
+            expanded.append(test_config)
+
+    return expanded
+
+
+def generate_test_cases(expanded_configs: list[dict[str, Any]], args: argparse.Namespace) -> list[str]:
+    """Generate test case code for all configurations."""
+    all_test_cases = []
+    for test_config in expanded_configs:
+        generator = MultiKernelTestGenerator(
+            seed=test_config.get("seed", 42),
+            enable_advanced_ops=test_config.get("enable_advanced_ops", False),
+            advanced_ops_probability=args.advanced_ops_prob,
+            tensor_init_type=test_config.get("tensor_init_type", "constant"),
+        )
+
+        test_code = generator.generate_test_case(
+            test_name=test_config["name"],
+            num_kernels=test_config.get("num_kernels", 3),
+            orchestration_mode=test_config.get("mode", "sequential"),
+            shape=test_config.get("shape", (128, 128)),
+            num_ops_range=test_config.get("num_ops_range", (3, 7)),
+            input_shapes_list=test_config.get("input_shapes_list"),
+            tensor_init_type=test_config.get("tensor_init_type"),
+            atol=args.atol,
+            rtol=args.rtol,
+        )
+        all_test_cases.append(test_code)
+
+    return all_test_cases
+
+
+def generate_test_suite(expanded_configs: list[dict[str, Any]]) -> str:
+    """Generate test suite class code."""
+    test_suite = '''
+class TestMultiKernelFuzzing:
+    """Multi-kernel fuzzing test suite"""
+
+'''
+    for test_config in expanded_configs:
+        test_name = test_config["name"]
+        test_suite += f'''    def test_{test_name}(self, test_runner):
+        """Test {test_name}"""
+        test_case = Test{test_name.title().replace("_", "")}()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {{result.error}}"
+
+'''
+    return test_suite
+
+
+def write_test_file(output_path: Path, test_cases: list[str], test_suite: str) -> None:
+    """Write generated test cases to file."""
+    file_header = '''"""
+Auto-generated multi-kernel fuzzing test cases
+
+This file is automatically generated by MultiKernelTestGenerator.
+Contains multiple test cases, each with multiple InCore kernels and an Orchestration function.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, List
+
+import torch
+import pytest
+
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+
+'''
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(file_header)
+        f.write("\n\n".join(test_cases))
+        f.write("\n\n")
+        f.write(test_suite)
+
+
+def main() -> None:
+    """Main function."""
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = _SCRIPT_DIR / "generated" / "test_fuzz_multi_kernel.py"
+
+    all_configs = get_default_configs()
+    selected_configs = select_configs(all_configs, args.config_index)
+    apply_num_cases_override(selected_configs, args.num_cases)
+
+    print_summary(selected_configs, output_path, args)
+    print_config_details(selected_configs)
+
+    print("Generating test file...")
+    expanded_configs = expand_configs(selected_configs)
+    test_cases = generate_test_cases(expanded_configs, args)
+    test_suite = generate_test_suite(expanded_configs)
+    write_test_file(output_path, test_cases, test_suite)
+
+    print()
+    print(f"✓ Successfully generated {len(expanded_configs)} test case(s)")
+    print(f"✓ Output file: {output_path}")
+    print()
+    print("Run tests:")
+    print(f"  pytest {output_path}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/st/fuzz/src/__init__.py
+++ b/tests/st/fuzz/src/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Internal implementation modules for the fuzzer framework.
+"""
+
+from .fuzzer import OpFuzzer, OpSpec
+from .kernel_generator import KernelGenerator
+from .multi_kernel_test_generator import MultiKernelTestGenerator
+from .orchestrator_generator import OrchestratorGenerator
+
+__all__ = [
+    "OpFuzzer",
+    "OpSpec",
+    "KernelGenerator",
+    "OrchestratorGenerator",
+    "MultiKernelTestGenerator",
+]

--- a/tests/st/fuzz/src/fuzzer.py
+++ b/tests/st/fuzz/src/fuzzer.py
@@ -1,0 +1,1450 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Operator fuzzer for generating random operator combinations.
+"""
+
+import inspect
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np  # Used in lambda functions for op equivalents
+
+# Data type byte sizes
+DTYPE_SIZES = {
+    "FP32": 4,
+    "FP16": 2,
+    "INT8": 1,
+    "INT32": 4,
+}
+
+
+def is_shape_aligned(shape: Tuple[int, int], dtype: str = "FP32") -> bool:
+    """Check if shape satisfies 32-byte alignment constraint
+
+    Args:
+        shape: (rows, cols) Shape tuple
+        dtype: Data type (default FP32)
+
+    Returns:
+        True if shape satisfies alignment requirement
+
+    Rules:
+        - trailing axis (cols) must be 1, or
+        - (trailing axis * sizeof(dtype)) must be a multiple of 32
+
+    Example (FP32, sizeof=4):
+        - (128, 1) ✓  trailing axis=1
+        - (128, 8) ✓  8*4=32, aligned
+        - (128, 16) ✓ 16*4=64, aligned
+        - (128, 32) ✓ 32*4=128, aligned
+        - (128, 5) ✗  5*4=20, not aligned
+    """
+    rows, cols = shape
+    dtype_size = DTYPE_SIZES.get(dtype, 4)
+
+    # trailing axis is 1, always aligned
+    if cols == 1:
+        return True
+
+    # Check if (trailing axis * sizeof(dtype)) is a multiple of 32
+    return (cols * dtype_size) % 32 == 0
+
+
+def get_aligned_shapes(dtype: str = "FP32", max_size: int = 128) -> List[Tuple[int, int]]:
+    """Get all common shapes that satisfy alignment constraint
+
+    Args:
+        dtype: Data type (default FP32)
+        max_size: Maximum dimension size (default 128, avoid memory overflow)
+
+    Returns:
+        List of aligned shapes
+    """
+    dtype_size = DTYPE_SIZES.get(dtype, 4)
+    # Calculate minimum aligned column count (except 1)
+    min_aligned_cols = 32 // dtype_size  # FP32: 8, FP16: 16, INT8: 32
+
+    aligned_shapes = []
+
+    # Common row counts - limit maximum to max_size
+    common_rows = [32, 64, 80, 96, 128]
+    common_rows = [r for r in common_rows if r <= max_size]
+
+    # Aligned column counts: 1, min_aligned_cols, 2*min_aligned_cols, ...
+    for rows in common_rows:
+        # Case where cols = 1
+        aligned_shapes.append((rows, 1))
+
+        # Aligned column counts
+        max_multiplier = max_size // min_aligned_cols
+        for multiplier in range(1, max_multiplier + 1):
+            cols = min_aligned_cols * multiplier
+            if cols <= max_size:
+                aligned_shapes.append((rows, cols))
+
+    return aligned_shapes
+
+
+def generate_aligned_shape(rng, dtype: str = "FP32", max_size: int = 128) -> Tuple[int, int]:
+    """Randomly generate an aligned shape
+
+    Args:
+        rng: Random number generator
+        dtype: Data type
+        max_size: Maximum dimension size (default 128, avoid memory overflow)
+
+    Returns:
+        Shape tuple satisfying alignment constraint
+    """
+    aligned_shapes = get_aligned_shapes(dtype, max_size)
+    return rng.choice(aligned_shapes) if aligned_shapes else (128, 128)
+
+
+@dataclass
+class ValueRange:
+    """Track value range properties for a variable.
+
+    Attributes:
+        can_be_negative: Whether the value can be negative
+        can_be_zero: Whether the value can be zero
+        can_be_positive: Whether the value can be positive
+    """
+
+    can_be_negative: bool = True
+    can_be_zero: bool = True
+    can_be_positive: bool = True
+
+    def is_always_positive(self) -> bool:
+        """Check if value is guaranteed to be positive (> 0)."""
+        return self.can_be_positive and not self.can_be_negative and not self.can_be_zero
+
+    def is_always_nonzero(self) -> bool:
+        """Check if value is guaranteed to be non-zero."""
+        return not self.can_be_zero
+
+    def is_safe_for_sqrt(self) -> bool:
+        """Check if value is safe for sqrt (>= 0)."""
+        return not self.can_be_negative
+
+    def is_safe_for_log(self) -> bool:
+        """Check if value is safe for log (> 0)."""
+        return self.is_always_positive()
+
+    def is_safe_for_div(self) -> bool:
+        """Check if value is safe as divisor (non-zero)."""
+        return self.is_always_nonzero()
+
+
+@dataclass
+class OpSpec:
+    """Operator specification for fuzzing.
+
+    Attributes:
+        name: Operator name (e.g., "block.add")
+        input_types: List of input types (e.g., ["tile", "tile"])
+        output_type: Output type (e.g., "tile")
+        constraints: Additional constraints (e.g., {"min_shape": [64, 64]})
+        np_equivalent: NumPy equivalent function for golden reference
+        shape_transform: Optional callable that computes output shape from input shapes
+        param_generator: Optional callable that generates operator parameters
+        requires_params: Whether this operator requires parameters (default: False)
+    """
+
+    name: str
+    input_types: List[str]
+    output_type: str
+    constraints: Dict[str, Any]
+    np_equivalent: Optional[Any] = None
+    shape_transform: Optional[Any] = None
+    param_generator: Optional[Any] = None
+    requires_params: bool = False
+
+    def compute_output_shape(
+        self, input_shapes: List[Tuple[int, int]], params: Optional[Dict[str, Any]] = None
+    ) -> Tuple[int, int]:
+        """Compute output shape from input shapes."""
+        if self.shape_transform:
+            sig = inspect.signature(self.shape_transform)
+            if len(sig.parameters) >= 2 and params is not None:
+                return self.shape_transform(input_shapes, params)
+            else:
+                return self.shape_transform(input_shapes)
+        return input_shapes[0] if input_shapes else (128, 128)
+
+    def generate_params(self, input_shapes: List[Tuple[int, int]], rng) -> Dict[str, Any]:
+        """Generate operator parameters based on input shapes."""
+        if self.param_generator and self.requires_params:
+            return self.param_generator(input_shapes, rng)
+        return {}
+
+    def _compute_mul_range(self, r1: ValueRange, r2: ValueRange) -> ValueRange:
+        """Compute range for multiplication operations."""
+        return ValueRange(
+            can_be_zero=r1.can_be_zero or r2.can_be_zero,
+            can_be_positive=(r1.can_be_positive and r2.can_be_positive)
+            or (r1.can_be_negative and r2.can_be_negative),
+            can_be_negative=(r1.can_be_positive and r2.can_be_negative)
+            or (r1.can_be_negative and r2.can_be_positive),
+        )
+
+    def _compute_unary_range(self, input_range: ValueRange) -> ValueRange:
+        """Compute range for unary operations."""
+        op_map = {
+            "block.abs": ValueRange(
+                False, input_range.can_be_zero, input_range.can_be_positive or input_range.can_be_negative
+            ),
+            "block.relu": ValueRange(False, True, input_range.can_be_positive),
+            "block.sqrt": ValueRange(False, input_range.can_be_zero, True),
+            "block.rsqrt": ValueRange(False, input_range.can_be_zero, True),
+            "block.exp": ValueRange(False, False, True),
+            "block.log": ValueRange(True, True, True),
+            "block.neg": ValueRange(
+                input_range.can_be_positive, input_range.can_be_zero, input_range.can_be_negative
+            ),
+            "block.recip": ValueRange(input_range.can_be_negative, False, input_range.can_be_positive),
+        }
+        return op_map.get(self.name, ValueRange())
+
+    def _compute_binary_range(self, input_ranges: List[ValueRange]) -> ValueRange:
+        """Compute range for binary operations."""
+        if self.name in ["block.add", "block.adds"]:
+            return ValueRange(input_ranges[0].can_be_negative, True, input_ranges[0].can_be_positive)
+        if self.name in ["block.sub", "block.subs"]:
+            return ValueRange(True, True, True)
+        if self.name in ["block.mul", "block.muls"] and len(input_ranges) >= 2:
+            return self._compute_mul_range(input_ranges[0], input_ranges[1])
+        if self.name in ["block.div", "block.divs", "block.row_expand_div"]:
+            return ValueRange(True, input_ranges[0].can_be_zero, True)
+        if self.name in ["block.maximum", "block.minimum"] and len(input_ranges) >= 2:
+            return ValueRange(
+                input_ranges[0].can_be_negative or input_ranges[1].can_be_negative,
+                input_ranges[0].can_be_zero or input_ranges[1].can_be_zero,
+                input_ranges[0].can_be_positive or input_ranges[1].can_be_positive,
+            )
+        return ValueRange()
+
+    def _compute_expand_range(self, input_ranges: List[ValueRange], op_type: str) -> ValueRange:
+        """Compute range for row/col expand operations."""
+        if len(input_ranges) < 2:
+            return ValueRange()
+        if "add" in op_type:
+            return ValueRange(input_ranges[0].can_be_negative, True, input_ranges[0].can_be_positive)
+        if "sub" in op_type:
+            return ValueRange(True, True, True)
+        if "mul" in op_type:
+            return self._compute_mul_range(input_ranges[0], input_ranges[1])
+        if "div" in op_type:
+            return ValueRange(True, input_ranges[0].can_be_zero, True)
+        return ValueRange()
+
+    def compute_output_range(self, input_ranges: List[ValueRange]) -> ValueRange:
+        """Compute output value range from input ranges."""
+        if not input_ranges:
+            return ValueRange()
+
+        # Unary operations
+        if self.name in [
+            "block.abs",
+            "block.relu",
+            "block.sqrt",
+            "block.rsqrt",
+            "block.exp",
+            "block.log",
+            "block.neg",
+            "block.recip",
+        ]:
+            return self._compute_unary_range(input_ranges[0])
+
+        # Binary operations
+        if self.name in [
+            "block.add",
+            "block.adds",
+            "block.sub",
+            "block.subs",
+            "block.mul",
+            "block.muls",
+            "block.div",
+            "block.divs",
+            "block.maximum",
+            "block.minimum",
+        ]:
+            return self._compute_binary_range(input_ranges)
+
+        # Row/col expand operations
+        if self.name.startswith("block.row_expand_") or self.name.startswith("block.col_expand_"):
+            return self._compute_expand_range(input_ranges, self.name)
+
+        # Reduction operations
+        if self.name in ["block.row_sum", "block.col_sum"]:
+            return ValueRange(input_ranges[0].can_be_negative, True, input_ranges[0].can_be_positive)
+        if self.name in ["block.row_max", "block.row_min", "block.col_max", "block.col_min"]:
+            return ValueRange(
+                input_ranges[0].can_be_negative, input_ranges[0].can_be_zero, input_ranges[0].can_be_positive
+            )
+
+        # Matrix operations
+        if self.name == "block.matmul":
+            return ValueRange(True, True, True)
+
+        return ValueRange()
+
+
+class OpFuzzer:
+    """Generates random operator combinations for fuzzing."""
+
+    # Block-level binary operators
+    BLOCK_BINARY_OPS = [
+        OpSpec("block.add", ["tile", "tile"], "tile", {}, lambda a, b: a + b),
+        OpSpec("block.sub", ["tile", "tile"], "tile", {}, lambda a, b: a - b),
+        OpSpec("block.mul", ["tile", "tile"], "tile", {}, lambda a, b: a * b),
+        OpSpec("block.div", ["tile", "tile"], "tile", {"avoid_zero": True}, lambda a, b: a / b),
+        OpSpec("block.maximum", ["tile", "tile"], "tile", {}, lambda a, b: np.maximum(a, b)),
+        OpSpec("block.minimum", ["tile", "tile"], "tile", {}, lambda a, b: np.minimum(a, b)),
+    ]
+
+    # Block-level scalar operators
+    BLOCK_SCALAR_OPS = [
+        OpSpec("block.adds", ["tile", "scalar"], "tile", {}, lambda a, s: a + s),
+        OpSpec("block.subs", ["tile", "scalar"], "tile", {}, lambda a, s: a - s),
+        OpSpec("block.muls", ["tile", "scalar"], "tile", {}, lambda a, s: a * s),
+        OpSpec("block.divs", ["tile", "scalar"], "tile", {"avoid_zero": True}, lambda a, s: a / s),
+    ]
+
+    # Block-level unary operators
+    BLOCK_UNARY_OPS = [
+        OpSpec("block.sqrt", ["tile"], "tile", {"positive_only": True}, lambda a: np.sqrt(a)),
+        OpSpec("block.rsqrt", ["tile"], "tile", {"positive_only": True}, lambda a: 1.0 / np.sqrt(a)),
+        OpSpec("block.exp", ["tile"], "tile", {}, lambda a: np.exp(np.clip(a, -10, 10))),
+        OpSpec("block.neg", ["tile"], "tile", {}, lambda a: -a),
+        OpSpec("block.recip", ["tile"], "tile", {"avoid_zero": True}, lambda a: 1.0 / a),
+        OpSpec("block.log", ["tile"], "tile", {"positive_only": True}, lambda a: np.log(a)),
+        OpSpec("block.abs", ["tile"], "tile", {}, lambda a: np.abs(a)),
+        OpSpec("block.relu", ["tile"], "tile", {}, lambda a: np.maximum(0, a)),
+    ]
+
+    # Block-level row expand operators ()
+    # :  [M, 1]
+    # （）
+    BLOCK_ROW_EXPAND_OPS = [
+        OpSpec(
+            "block.row_expand_add",
+            ["tile", "tile"],
+            "tile",
+            {"row_vec_required": True},
+            lambda a, b: a + b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),  # b is [M,1], broadcasts to [M,N], output is [M,N]
+        OpSpec(
+            "block.row_expand_sub",
+            ["tile", "tile"],
+            "tile",
+            {"row_vec_required": True},
+            lambda a, b: a - b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),
+        OpSpec(
+            "block.row_expand_mul",
+            ["tile", "tile"],
+            "tile",
+            {"row_vec_required": True},
+            lambda a, b: a * b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),
+        OpSpec(
+            "block.row_expand_div",
+            ["tile", "tile"],
+            "tile",
+            {"row_vec_required": True, "avoid_zero": True},
+            lambda a, b: a / b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),
+    ]
+
+    # Block-level reduction operators ()
+    # axis=1: , [M,N] -> [M,1]
+    #  [M, 1] ， row_expand
+    # Note: Second input is a temporary tile placeholder, not an actual input
+    BLOCK_REDUCTION_OPS = [
+        OpSpec(
+            "block.row_sum",
+            ["tile"],  # Only one actual input, tmp_tile is created during codegen
+            "tile",
+            {"produces_row_vec": True, "requires_tmp_tile": True},
+            lambda a: np.sum(a, axis=1, keepdims=True),
+            shape_transform=lambda shapes: (shapes[0][0], 1) if len(shapes) >= 1 else (128, 1),
+        ),
+        OpSpec(
+            "block.row_max",
+            ["tile"],  # Only one actual input, tmp_tile is created during codegen
+            "tile",
+            {"produces_row_vec": True, "requires_tmp_tile": True},
+            lambda a: np.max(a, axis=1, keepdims=True),
+            shape_transform=lambda shapes: (shapes[0][0], 1) if len(shapes) >= 1 else (128, 1),
+        ),
+        OpSpec(
+            "block.row_min",
+            ["tile"],  # Only one actual input, tmp_tile is created during codegen
+            "tile",
+            {"produces_row_vec": True, "requires_tmp_tile": True},
+            lambda a: np.min(a, axis=1, keepdims=True),
+            shape_transform=lambda shapes: (shapes[0][0], 1) if len(shapes) >= 1 else (128, 1),
+        ),
+    ]
+
+    # Block-level column reduction operators (column-wise reduction)
+    # axis=0: column reduction, [M, N] -> [1, N]
+    # Output [1, N] can be used with col_expand operations
+    # Note: Uses general reduction ops with axis=0, keepdim=True
+    BLOCK_COL_REDUCTION_OPS = [
+        OpSpec(
+            "block.col_sum",
+            ["tile"],
+            "tile",
+            {"produces_col_vec": True, "requires_params": True},
+            lambda a: np.sum(a, axis=0, keepdims=True),
+            shape_transform=lambda shapes: (1, shapes[0][1]) if len(shapes) >= 1 else (1, 128),
+            param_generator=lambda shapes, rng: {"axis": 0, "keepdim": True},
+            requires_params=True,
+        ),
+        OpSpec(
+            "block.col_max",
+            ["tile"],
+            "tile",
+            {"produces_col_vec": True, "requires_params": True},
+            lambda a: np.max(a, axis=0, keepdims=True),
+            shape_transform=lambda shapes: (1, shapes[0][1]) if len(shapes) >= 1 else (1, 128),
+            param_generator=lambda shapes, rng: {"axis": 0, "keepdim": True},
+            requires_params=True,
+        ),
+        OpSpec(
+            "block.col_min",
+            ["tile"],
+            "tile",
+            {"produces_col_vec": True, "requires_params": True},
+            lambda a: np.min(a, axis=0, keepdims=True),
+            shape_transform=lambda shapes: (1, shapes[0][1]) if len(shapes) >= 1 else (1, 128),
+            param_generator=lambda shapes, rng: {"axis": 0, "keepdim": True},
+            requires_params=True,
+        ),
+    ]
+
+    # Block-level column expand operators (column broadcast)
+    # Requirement: second operand must be [1, N] shaped (column vector)
+    # Operation: broadcasts column vector to each column of the tile
+    BLOCK_COL_EXPAND_OPS = [
+        OpSpec(
+            "block.col_expand_mul",
+            ["tile", "tile"],
+            "tile",
+            {"col_vec_required": True},
+            lambda a, b: a * b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),  # b is [1, N], broadcasts to [M, N], output is [M, N]
+        OpSpec(
+            "block.col_expand_div",
+            ["tile", "tile"],
+            "tile",
+            {"col_vec_required": True, "avoid_zero": True},
+            lambda a, b: a / b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),
+        OpSpec(
+            "block.col_expand_sub",
+            ["tile", "tile"],
+            "tile",
+            {"col_vec_required": True},
+            lambda a, b: a - b,
+            shape_transform=lambda shapes: shapes[0] if len(shapes) >= 1 else (128, 128),
+        ),
+    ]
+
+    # Block-level matrix operators
+    # Note: matmul requires special memory handling (L0A, L0B, L0C)
+    # The kernel generator will handle the memory management sequence
+    BLOCK_MATRIX_OPS = [
+        OpSpec(
+            "block.matmul",
+            ["tile", "tile"],
+            "tile",
+            {"matmul_shape": True, "requires_memory_management": True},
+            lambda a, b: a @ b,
+            shape_transform=lambda shapes, params=None: (shapes[0][0], shapes[1][1])
+            if len(shapes) >= 2
+            else shapes[0],
+        ),
+    ]
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        enable_advanced_ops: bool = False,
+        advanced_ops_probability: float = 0.5,
+    ):
+        """Initialize fuzzer with optional seed for reproducibility.
+
+        Args:
+            seed: Random seed for reproducibility
+            enable_advanced_ops: Enable advanced operations (row_expand, row_sum, matmul, etc.)
+            advanced_ops_probability: Probability of selecting advanced ops (default: 0.5)
+        """
+        self.rng = random.Random(seed)
+        # Basic operators (PipeType::V - VECTOR core)
+        self.basic_vector_ops = self.BLOCK_BINARY_OPS + self.BLOCK_SCALAR_OPS + self.BLOCK_UNARY_OPS
+        self.vector_ops = self.basic_vector_ops
+
+        # Advanced operators (PipeType::V - VECTOR core)
+        self.advanced_vector_ops = []
+
+        # Matrix operators (PipeType::M - CUBE core)
+        self.matrix_ops = []
+
+        # Advanced ops probability control
+        self.enable_advanced_ops = enable_advanced_ops
+        self.advanced_ops_probability = advanced_ops_probability
+
+        if enable_advanced_ops:
+            # Add reduction (row and col), row_expand, and col_expand operators
+            self.advanced_vector_ops = (
+                self.BLOCK_REDUCTION_OPS
+                # + self.BLOCK_COL_REDUCTION_OPS
+                + self.BLOCK_ROW_EXPAND_OPS
+                + self.BLOCK_COL_EXPAND_OPS
+            )
+            self.vector_ops = self.basic_vector_ops + self.advanced_vector_ops
+            self.matrix_ops = self.BLOCK_MATRIX_OPS
+
+        # Default to VECTOR operators
+        self.ops = self.vector_ops
+
+        # Track operator usage to avoid overuse
+        self.op_usage_count = {}
+        self.exp_count = 0
+        self.div_count = 0
+        self.matmul_count = 0  # Track matmul usage
+        # Current kernel's pipe type (None, 'M', 'V')
+        self.current_pipe_type = None
+
+    def generate_op_chain(  # noqa: PLR0912, PLR0915
+        self,
+        num_ops: int = 5,
+        input_count: int = 2,
+        allow_scalars: bool = True,
+        track_shapes: bool = False,
+        default_shape: Tuple[int, int] = (128, 128),
+        prefer_matrix_ops: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        """Generate a chain of operator calls.
+
+        All input tensors and intermediate results are guaranteed to contribute
+        to the final output through smart generation and post-processing.
+
+        :
+        1.
+        2.
+        3. (exp, div)
+        4.
+        5.
+        6.  M-pipe (matmul with memory management)  V-pipe (element-wise)
+
+        Args:
+            prefer_matrix_ops: If True, use matrix operations (M-pipe); if False, use vector
+                              operations (V-pipe). If None (default), randomly choose based on
+                              availability. Once a pipe type is chosen, all operations in the
+                              chain will use that type.
+        """
+        self.op_usage_count = {}
+        self.exp_count = 0
+        self.div_count = 0
+        self.matmul_count = 0  # Track matmul usage
+        self.current_pipe_type = None
+
+        # : ，
+        # ，
+        if prefer_matrix_ops is None:
+            # : ，1% （）
+            if self.matrix_ops and self.rng.random() < 0.01:
+                prefer_matrix_ops = True
+            else:
+                prefer_matrix_ops = False
+
+        if prefer_matrix_ops and self.matrix_ops:
+            self.ops = self.matrix_ops
+            self.current_pipe_type = "M"
+        else:
+            self.ops = self.vector_ops
+            self.current_pipe_type = "V"
+
+        # Initialize available variables
+        available_tiles = [f"tile_{chr(97 + i)}" for i in range(input_count)]
+        # Limit scalars: most of the time 1, at most 2
+        available_scalars = ["2.0"] if allow_scalars else []
+
+        # Track which initial inputs have been used
+        initial_inputs = set(available_tiles)
+        used_inputs = set()
+
+        # Track usage count for each variable
+        variable_usage_count = {tile: 0 for tile in available_tiles}
+
+        # Shape tracking (optional)
+        variable_shapes = {}
+        if track_shapes:
+            for tile in available_tiles:
+                variable_shapes[tile] = default_shape
+
+        # Value range tracking (always enabled for safety)
+        variable_ranges = {}
+        # Initialize input ranges: torch.randn can produce negative, zero, or positive values
+        for tile in available_tiles:
+            variable_ranges[tile] = ValueRange(can_be_negative=True, can_be_zero=True, can_be_positive=True)
+
+        operations = []
+        max_retries = 3
+        next_tmp_index = 0  #  tmp
+
+        for i in range(num_ops):
+            # Calculate urgency for using unused inputs
+            unused_count = len(initial_inputs - used_inputs)
+            remaining_ops = num_ops - i
+
+            # Dynamic priority
+            use_unused_priority = 0.7
+            if unused_count > 0:
+                if unused_count >= remaining_ops:
+                    use_unused_priority = 1.0
+                elif remaining_ops > 0:
+                    use_unused_priority = min(0.9, 0.7 + 0.3 * (unused_count / remaining_ops))
+
+            # Select eligible operators with safety checks
+            eligible_ops = self._get_eligible_ops_safe(
+                available_tiles,
+                available_scalars,
+                allow_scalars,
+                variable_shapes if track_shapes else None,
+                variable_ranges,  # Pass value ranges for constraint checking
+            )
+
+            if not eligible_ops:
+                break
+
+            # Prioritize binary ops if we need to use unused inputs
+            if unused_count > 0 and use_unused_priority >= 0.9:
+                binary_ops = [op for op in eligible_ops if sum(1 for t in op.input_types if t == "tile") >= 2]
+                if binary_ops:
+                    eligible_ops = binary_ops
+
+            op = None
+            for retry in range(max_retries):
+                candidate_op = self.rng.choice(eligible_ops)
+
+                # Check
+                op_name = candidate_op.name
+                usage = self.op_usage_count.get(op_name, 0)
+
+                # 40%，
+                if usage > num_ops * 0.4:
+                    if self.rng.random() < 0.3:  # 30%
+                        op = candidate_op
+                        break
+                else:
+                    op = candidate_op
+                    break
+
+            if op is None:
+                # ，
+                op = eligible_ops[0]
+
+            # Select inputs
+            inputs = []
+            scalar_value = None
+            input_idx = 0  # Track which input we're selecting
+            skip_operation = False  # Flag to skip this operation if inputs are incompatible
+
+            for input_type in op.input_types:
+                if input_type == "tile":
+                    candidate_tiles = available_tiles
+                    needs_abs_wrapper = False  # Flag to insert abs operation
+
+                    # Filter by value range constraints first
+                    if op.constraints.get("positive_only", False):
+                        # For sqrt/rsqrt/log, need non-negative or positive inputs
+                        if "log" in op.name:
+                            # log requires strictly positive
+                            safe_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if t in variable_ranges and variable_ranges[t].is_safe_for_log()
+                            ]
+                            if safe_tiles:
+                                candidate_tiles = safe_tiles
+                            else:
+                                # No safe tiles, need to insert abs operation
+                                needs_abs_wrapper = True
+                        else:  # sqrt, rsqrt
+                            # Need non-negative inputs
+                            safe_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if t in variable_ranges and variable_ranges[t].is_safe_for_sqrt()
+                            ]
+                            if safe_tiles:
+                                candidate_tiles = safe_tiles
+                            else:
+                                # No safe tiles, need to insert abs operation
+                                needs_abs_wrapper = True
+
+                    if op.constraints.get("avoid_zero", False):
+                        # For div/recip, divisor must be non-zero
+                        if len(op.input_types) == 2 and input_idx == 1:
+                            # Second operand of binary op (divisor)
+                            safe_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if t in variable_ranges and variable_ranges[t].is_safe_for_div()
+                            ]
+                            if safe_tiles:
+                                candidate_tiles = safe_tiles
+                            else:
+                                # No guaranteed non-zero tiles, but we can't easily fix this
+                                # Skip this operation
+                                skip_operation = True
+                                break
+                        elif len(op.input_types) == 1:
+                            # Unary op like recip
+                            safe_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if t in variable_ranges and variable_ranges[t].is_safe_for_div()
+                            ]
+                            if safe_tiles:
+                                candidate_tiles = safe_tiles
+                            else:
+                                skip_operation = True
+                                break
+
+                    if track_shapes:
+                        # Special handling for row_vec_required operators
+                        if op.constraints.get("row_vec_required", False):
+                            if input_idx == 0:
+                                # First argument must NOT be [M, 1] (should be [M, N] tile)
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t not in variable_shapes or variable_shapes[t][1] != 1
+                                ]
+                            elif input_idx == 1:
+                                # Second argument MUST be [M, 1] shaped
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t in variable_shapes and variable_shapes[t][1] == 1
+                                ]
+
+                            if not candidate_tiles:
+                                # No suitable tiles available, skip this operator
+                                skip_operation = True
+                                break
+                        # Special handling for col_vec_required operators
+                        elif op.constraints.get("col_vec_required", False):
+                            if input_idx == 0:
+                                # First argument must NOT be [1, N] (should be [M, N] tile)
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t not in variable_shapes or variable_shapes[t][0] != 1
+                                ]
+                            elif input_idx == 1:
+                                # Second argument MUST be [1, N] shaped
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t in variable_shapes and variable_shapes[t][0] == 1
+                                ]
+
+                            if not candidate_tiles:
+                                # No suitable tiles available, skip this operator
+                                skip_operation = True
+                                break
+                        else:
+                            # For non-row_expand operators, exclude [M, 1] vectors from ALL inputs
+                            # because they have ColMajor layout and cause TADD/TSUB/etc errors
+                            # CRITICAL: [M, 1] tiles can ONLY be used with row_expand_* operators
+                            candidate_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if t not in variable_shapes or variable_shapes[t][1] != 1
+                            ]
+
+                            # Also exclude [M, 1] tiles from reduction operators (row_sum, row_max, row_min)
+                            # because they produce [M, 1] output which is ColMajor
+                            if op.constraints.get("produces_row_vec", False):
+                                # For reduction ops, input must NOT be [M, 1]
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t not in variable_shapes or variable_shapes[t][1] != 1
+                                ]
+
+                            # Also exclude [1, N] tiles from col reduction operators
+                            # (col_sum, col_max, col_min) because they produce [1, N] output
+                            if op.constraints.get("produces_col_vec", False):
+                                # For col reduction ops, input must NOT be [1, N]
+                                candidate_tiles = [
+                                    t
+                                    for t in candidate_tiles
+                                    if t not in variable_shapes or variable_shapes[t][0] != 1
+                                ]
+
+                            # Apply general shape compatibility check
+                            candidate_tiles = [
+                                t
+                                for t in candidate_tiles
+                                if self._is_shape_compatible(op, t, variable_shapes)
+                            ]
+                            if not candidate_tiles:
+                                # No suitable tiles available, skip this operator
+                                skip_operation = True
+                                break
+
+                    # Smart selection: prioritize unused inputs
+                    unused_initial_inputs = {
+                        t for t in candidate_tiles if t in initial_inputs and t not in used_inputs
+                    }
+
+                    candidate_scores = []
+                    for t in candidate_tiles:
+                        score = 0
+
+                        if t in unused_initial_inputs:
+                            score += 50
+                            if use_unused_priority >= 0.9:
+                                score += 30
+
+                        usage = variable_usage_count.get(t, 0)
+                        score += max(0, 20 - usage * 5)
+
+                        if t.startswith("tmp_"):
+                            score += 5
+
+                        candidate_scores.append((t, score))
+
+                    if candidate_scores:
+                        max_score = max(score for _, score in candidate_scores)
+
+                        if max_score >= 40:
+                            threshold = max(max_score * 0.6, 30)
+                            top_candidates = [t for t, score in candidate_scores if score >= threshold]
+
+                            if top_candidates and self.rng.random() < 0.85:
+                                candidate_tiles = top_candidates
+                        else:
+                            min_score_needed = max(max_score * 0.7, 10)
+                            preferred = [t for t, score in candidate_scores if score >= min_score_needed]
+                            if preferred and self.rng.random() < 0.75:
+                                candidate_tiles = preferred
+
+                    selected_input = self.rng.choice(candidate_tiles)
+
+                    # If needs_abs_wrapper, insert abs operation before using this input
+                    if needs_abs_wrapper:
+                        abs_op = next((op for op in self.BLOCK_UNARY_OPS if op.name == "block.abs"), None)
+                        if abs_op:
+                            abs_output = f"tmp_{next_tmp_index}"
+                            next_tmp_index += 1
+
+                            abs_op_dict = {
+                                "op": abs_op,
+                                "inputs": [selected_input],
+                                "output": abs_output,
+                                "scalar_value": None,
+                                "params": None,
+                            }
+
+                            if track_shapes:
+                                abs_op_dict["output_shape"] = variable_shapes.get(
+                                    selected_input, default_shape
+                                )
+                                variable_shapes[abs_output] = abs_op_dict["output_shape"]
+
+                            # Compute output range for abs
+                            input_range = variable_ranges.get(selected_input, ValueRange())
+                            abs_output_range = abs_op.compute_output_range([input_range])
+                            variable_ranges[abs_output] = abs_output_range
+
+                            operations.append(abs_op_dict)
+                            available_tiles.append(abs_output)
+                            variable_usage_count[abs_output] = 0
+                            variable_usage_count[selected_input] = (
+                                variable_usage_count.get(selected_input, 0) + 1
+                            )
+
+                            # Use the abs output instead of the original input
+                            selected_input = abs_output
+
+                    inputs.append(selected_input)
+
+                    current_count = variable_usage_count.get(selected_input, 0)
+                    variable_usage_count[selected_input] = current_count + 1
+
+                    if selected_input in initial_inputs:
+                        used_inputs.add(selected_input)
+
+                    input_idx += 1
+
+                elif input_type == "scalar":
+                    # Limit to at most 2 unique scalars, prefer reusing existing ones
+                    if available_scalars:
+                        scalar_value = self.rng.choice(available_scalars)
+                    elif len(available_scalars) < 2:
+                        # Generate a new scalar only if we have less than 2
+                        scalar_value = f"{self.rng.uniform(0.1, 10.0):.2f}"
+                        available_scalars.append(scalar_value)
+                    else:
+                        # Already have 2 scalars, reuse one
+                        scalar_value = self.rng.choice(available_scalars)
+                    inputs.append(scalar_value)
+                    input_idx += 1
+
+            # Skip this operation if we couldn't find suitable inputs or if flagged to skip
+            if skip_operation or len(inputs) < len(op.input_types):
+                continue
+
+            output = f"tmp_{next_tmp_index}"
+            next_tmp_index += 1
+
+            # Generate operator parameters if required
+            params = None
+            if op.requires_params:
+                input_shapes = [variable_shapes[inp] for inp in inputs if inp in variable_shapes]
+                if input_shapes:
+                    params = op.generate_params(input_shapes, self.rng)
+
+            op_dict = {
+                "op": op,
+                "inputs": inputs,
+                "output": output,
+                "scalar_value": scalar_value,
+                "params": params,
+            }
+
+            # Compute output shape if tracking
+            if track_shapes:
+                input_shapes = [variable_shapes[inp] for inp in inputs if inp in variable_shapes]
+                output_shape = op.compute_output_shape(input_shapes, params)
+                op_dict["output_shape"] = output_shape
+                op_dict["input_shapes"] = input_shapes  # Store input shapes for reduction ops
+                variable_shapes[output] = output_shape
+
+            # Compute output value range
+            input_ranges = [variable_ranges[inp] for inp in inputs if inp in variable_ranges]
+            output_range = op.compute_output_range(input_ranges)
+            variable_ranges[output] = output_range
+
+            operations.append(op_dict)
+            available_tiles.append(output)
+            variable_usage_count[output] = 0
+
+            op_name = op.name
+            self.op_usage_count[op_name] = self.op_usage_count.get(op_name, 0) + 1
+
+            if "exp" in op_name:
+                self.exp_count += 1
+            if "div" in op_name:
+                self.div_count += 1
+            if "matmul" in op_name:
+                self.matmul_count += 1
+
+            # Auto-expand [M, 1] row vectors via row_expand to [M, N]
+            # Note: row_expand is V-pipe only, so check current_pipe_type
+            if track_shapes and output in variable_shapes and self.current_pipe_type == "V":
+                output_shape = variable_shapes[output]
+                if output_shape[1] == 1:  # Output is [M, 1]
+                    # Try to expand via row_expand to [M, N]
+                    next_tmp_index = self._try_expand_row_vec(
+                        output,
+                        operations,
+                        available_tiles,
+                        variable_shapes,
+                        variable_usage_count,
+                        default_shape,
+                        next_tmp_index,
+                    )
+                elif output_shape[0] == 1:  # Output is [1, N]
+                    # Try to expand via col_expand to [M, N]
+                    next_tmp_index = self._try_expand_col_vec(
+                        output,
+                        operations,
+                        available_tiles,
+                        variable_shapes,
+                        variable_usage_count,
+                        variable_ranges,
+                        default_shape,
+                        next_tmp_index,
+                    )
+
+        # Ensure all initial inputs are used
+        unused_inputs = initial_inputs - used_inputs
+        if unused_inputs:
+            # Select merge operator based on pipe type
+            if self.current_pipe_type == "M" and self.matrix_ops:
+                merge_op = self.matrix_ops[0]  # matmul
+            else:
+                merge_op = next((op for op in self.BLOCK_BINARY_OPS if op.name == "block.add"), None)
+
+            for unused_input in unused_inputs:
+                if operations:
+                    current_final = operations[-1]["output"]
+                    output = f"tmp_{len(operations)}"
+
+                    op_dict = {
+                        "op": merge_op,
+                        "inputs": [unused_input, current_final],
+                        "output": output,
+                        "scalar_value": None,
+                        "params": None,
+                    }
+
+                    if track_shapes:
+                        input_shapes = [
+                            variable_shapes.get(unused_input, default_shape),
+                            variable_shapes.get(current_final, default_shape),
+                        ]
+                        output_shape = merge_op.compute_output_shape(input_shapes)
+                        op_dict["output_shape"] = output_shape
+                        variable_shapes[output] = output_shape
+
+                    operations.append(op_dict)
+                    available_tiles.append(output)
+                    used_inputs.add(unused_input)
+                    variable_usage_count[output] = 0
+                    variable_usage_count[unused_input] = variable_usage_count.get(unused_input, 0) + 1
+                    variable_usage_count[current_final] = variable_usage_count.get(current_final, 0) + 1
+
+        # Ensure all intermediate results contribute to the final output
+        if operations:
+            final_output = operations[-1]["output"]
+            unused_intermediates = []
+
+            for var_name, usage_count in variable_usage_count.items():
+                if var_name.startswith("tmp_") and usage_count == 0 and var_name != final_output:
+                    unused_intermediates.append(var_name)
+
+            if unused_intermediates:
+                # Select merge operator based on pipe type
+                if self.current_pipe_type == "M" and self.matrix_ops:
+                    merge_op = self.matrix_ops[0]  # matmul
+                else:
+                    merge_op = next((op for op in self.BLOCK_BINARY_OPS if op.name == "block.add"), None)
+
+                for unused_var in unused_intermediates:
+                    current_final = operations[-1]["output"]
+                    output = f"tmp_{len(operations)}"
+
+                    op_dict = {
+                        "op": merge_op,
+                        "inputs": [unused_var, current_final],
+                        "output": output,
+                        "scalar_value": None,
+                        "params": None,
+                    }
+
+                    if track_shapes:
+                        input_shapes = [
+                            variable_shapes.get(unused_var, default_shape),
+                            variable_shapes.get(current_final, default_shape),
+                        ]
+                        output_shape = merge_op.compute_output_shape(input_shapes)
+                        op_dict["output_shape"] = output_shape
+                        variable_shapes[output] = output_shape
+
+                    operations.append(op_dict)
+                    available_tiles.append(output)
+                    variable_usage_count[output] = 0
+                    variable_usage_count[unused_var] = variable_usage_count.get(unused_var, 0) + 1
+                    variable_usage_count[current_final] = variable_usage_count.get(current_final, 0) + 1
+
+        return operations
+
+    def _try_expand_row_vec(
+        self,
+        row_vec_name: str,
+        operations: List[Dict[str, Any]],
+        available_tiles: List[str],
+        variable_shapes: Dict[str, Tuple[int, int]],
+        variable_usage_count: Dict[str, int],
+        default_shape: Tuple[int, int],
+        next_tmp_index: int,
+    ) -> int:
+        """[M, 1]  tile via row_expand  [M, N]
+
+        :
+        1.  [M, N]  tile (N != 1)
+        2.  row_expand
+        3. : expanded = row_expand_op(regular_tile, row_vec)
+        4.  expanded  tiles
+
+         [M, 1]  ColMajor tile  [M, N]  RowMajor tile，
+        。
+
+        Returns:
+             next_tmp_index
+        """
+        #  [M, N]  tile (N != 1)
+        row_vec_shape = variable_shapes[row_vec_name]
+        M = row_vec_shape[0]
+
+        #  [M, N]  N != 1  tile
+        candidate_regular_tiles = [
+            t
+            for t in available_tiles
+            if t in variable_shapes and variable_shapes[t][0] == M and variable_shapes[t][1] != 1  #  1
+        ]
+
+        if not candidate_regular_tiles:
+            #  tile，
+            return next_tmp_index
+
+        #  regular tile
+        regular_tile = self.rng.choice(candidate_regular_tiles)
+        regular_shape = variable_shapes[regular_tile]
+
+        #  row_expand
+        row_expand_ops = [
+            op
+            for op in self.BLOCK_ROW_EXPAND_OPS
+            if "div" not in op.name or self.div_count < 5  #  div
+        ]
+
+        if not row_expand_ops:
+            return next_tmp_index
+
+        expand_op = self.rng.choice(row_expand_ops)
+
+        output_name = f"tmp_{next_tmp_index}"
+        next_tmp_index += 1
+        op_dict = {
+            "op": expand_op,
+            "inputs": [regular_tile, row_vec_name],
+            "output": output_name,
+            "scalar_value": None,
+            "params": None,
+            "output_shape": regular_shape,  #  regular_tile
+        }
+
+        operations.append(op_dict)
+        available_tiles.append(output_name)
+        variable_shapes[output_name] = regular_shape
+        variable_usage_count[output_name] = 0
+
+        variable_usage_count[regular_tile] = variable_usage_count.get(regular_tile, 0) + 1
+        variable_usage_count[row_vec_name] = variable_usage_count.get(row_vec_name, 0) + 1
+
+        op_name = expand_op.name
+        self.op_usage_count[op_name] = self.op_usage_count.get(op_name, 0) + 1
+        if "div" in op_name:
+            self.div_count += 1
+
+        return next_tmp_index
+
+    def _try_expand_col_vec(
+        self,
+        col_vec_name: str,
+        operations: List[Dict[str, Any]],
+        available_tiles: List[str],
+        variable_shapes: Dict[str, Tuple[int, int]],
+        variable_usage_count: Dict[str, int],
+        variable_ranges: Dict[str, "ValueRange"],
+        default_shape: Tuple[int, int],
+        next_tmp_index: int,
+    ) -> int:
+        """Expand [1, N] column vector via col_expand to [M, N]
+
+        Steps:
+        1. Find a [M, N] tile (M != 1) with matching N dimension
+        2. Select a col_expand operation
+        3. Generate: expanded = col_expand_op(regular_tile, col_vec)
+        4. Add expanded to available tiles
+
+        [1, N] vectors are RowMajor, safer than [M, 1] ColMajor vectors.
+
+        Returns:
+            Updated next_tmp_index
+        """
+        # Get [1, N] shape
+        col_vec_shape = variable_shapes[col_vec_name]
+        N = col_vec_shape[1]
+
+        # Find [M, N] tiles where M != 1 and N matches
+        candidate_regular_tiles = [
+            t
+            for t in available_tiles
+            if t in variable_shapes and variable_shapes[t][1] == N and variable_shapes[t][0] != 1
+        ]
+
+        if not candidate_regular_tiles:
+            # No suitable tile, skip expansion
+            return next_tmp_index
+
+        # Select a regular tile
+        regular_tile = self.rng.choice(candidate_regular_tiles)
+        regular_shape = variable_shapes[regular_tile]
+
+        # Select col_expand operation
+        col_expand_ops = [
+            op
+            for op in self.BLOCK_COL_EXPAND_OPS
+            if "div" not in op.name or self.div_count < 5  # Limit div operations
+        ]
+
+        if not col_expand_ops:
+            return next_tmp_index
+
+        # For div operations, check if col_vec is safe (non-zero)
+        if "div" in col_expand_ops[0].name:
+            col_vec_range = variable_ranges.get(col_vec_name)
+            if col_vec_range and not col_vec_range.is_safe_for_div():
+                # Filter out div operations
+                col_expand_ops = [op for op in col_expand_ops if "div" not in op.name]
+                if not col_expand_ops:
+                    return next_tmp_index
+
+        expand_op = self.rng.choice(col_expand_ops)
+
+        output_name = f"tmp_{next_tmp_index}"
+        next_tmp_index += 1
+        op_dict = {
+            "op": expand_op,
+            "inputs": [regular_tile, col_vec_name],
+            "output": output_name,
+            "scalar_value": None,
+            "params": None,
+            "output_shape": regular_shape,  # Output shape matches regular_tile
+        }
+
+        operations.append(op_dict)
+        available_tiles.append(output_name)
+        variable_shapes[output_name] = regular_shape
+        variable_usage_count[output_name] = 0
+
+        # Compute output value range
+        input_ranges = [variable_ranges.get(regular_tile), variable_ranges.get(col_vec_name)]
+        if all(r is not None for r in input_ranges):
+            output_range = expand_op.compute_output_range(input_ranges)
+            variable_ranges[output_name] = output_range
+
+        variable_usage_count[regular_tile] = variable_usage_count.get(regular_tile, 0) + 1
+        variable_usage_count[col_vec_name] = variable_usage_count.get(col_vec_name, 0) + 1
+
+        op_name = expand_op.name
+        self.op_usage_count[op_name] = self.op_usage_count.get(op_name, 0) + 1
+        if "div" in op_name:
+            self.div_count += 1
+
+        return next_tmp_index
+
+    def _get_eligible_ops_safe(  # noqa: PLR0912
+        self,
+        available_tiles: List[str],
+        available_scalars: List[str],
+        allow_scalars: bool,
+        variable_shapes: Optional[Dict[str, Tuple[int, int]]] = None,
+        variable_ranges: Optional[Dict[str, ValueRange]] = None,
+    ) -> List[OpSpec]:
+        """Get operators that can be applied with current variables (with safety checks).
+
+        Checks:
+        1. Limit exp operator usage (max 3 times)
+        2. Limit div operator usage (max 5 times)
+        3. Limit matmul operator usage (max 3 times)
+        4. Check shape compatibility
+        5. Check value range constraints (positive_only, avoid_zero)
+        6. Select operator pool based on probability (only for V-pipe)
+        """
+        # Select operator pool based on current pipe type
+        if self.current_pipe_type == "M":
+            # For M-pipe, always use matrix ops
+            candidate_ops = self.ops
+        elif self.enable_advanced_ops and self.advanced_vector_ops:
+            # For V-pipe with advanced ops, mix basic and advanced ops
+            # Use probability to weight the selection, not to exclude entire pools
+            candidate_ops = self.ops  # Use all available ops (basic + advanced)
+        else:
+            candidate_ops = self.ops
+
+        eligible = []
+
+        for op in candidate_ops:
+            # Check: limit expensive operations
+            if "exp" in op.name and self.exp_count >= 3:
+                continue  #  exp ，
+
+            if "div" in op.name and self.div_count >= 5:
+                continue  #  div ，
+
+            # Limit matmul operations to 2-3 times max
+            if "matmul" in op.name and self.matmul_count >= 3:
+                continue  # Skip matmul if already used 3 times
+
+            tile_inputs = sum(1 for t in op.input_types if t == "tile")
+            scalar_inputs = sum(1 for t in op.input_types if t == "scalar")
+
+            has_tiles = len(available_tiles) >= tile_inputs
+            has_scalars = (scalar_inputs == 0) or (
+                allow_scalars and (len(available_scalars) >= scalar_inputs or scalar_inputs > 0)
+            )
+
+            # Check value range constraints
+            if variable_ranges is not None and tile_inputs > 0:
+                # Check if we have tiles that satisfy the operator's constraints
+                if op.constraints.get("positive_only", False):
+                    # Need at least one tile that is safe for sqrt/log
+                    safe_tiles = [
+                        t
+                        for t in available_tiles
+                        if t in variable_ranges
+                        and (
+                            variable_ranges[t].is_safe_for_sqrt()
+                            if "sqrt" in op.name or "rsqrt" in op.name
+                            else variable_ranges[t].is_safe_for_log()
+                        )
+                    ]
+                    if len(safe_tiles) < tile_inputs:
+                        continue  # Not enough safe tiles
+
+                if op.constraints.get("avoid_zero", False):
+                    # Need at least one tile that is guaranteed non-zero (for divisor)
+                    # For binary ops, only the second operand (divisor) needs to be non-zero
+                    if tile_inputs == 2:
+                        # For div operations, we need at least one non-zero tile for divisor
+                        nonzero_tiles = [
+                            t
+                            for t in available_tiles
+                            if t in variable_ranges and variable_ranges[t].is_safe_for_div()
+                        ]
+                        if len(nonzero_tiles) < 1:
+                            continue  # No safe divisor available
+                    elif tile_inputs == 1:
+                        # For recip, the single input must be non-zero
+                        nonzero_tiles = [
+                            t
+                            for t in available_tiles
+                            if t in variable_ranges and variable_ranges[t].is_safe_for_div()
+                        ]
+                        if len(nonzero_tiles) < 1:
+                            continue  # No safe input for recip
+
+            # Skip operators that require special shapes when shape tracking is disabled
+            if variable_shapes is None:
+                # Without shape tracking, skip row_expand ops (need [M, 1] vectors)
+                if op.constraints.get("row_vec_required", False):
+                    continue
+                # Without shape tracking, skip col_expand ops (need [1, N] vectors)
+                if op.constraints.get("col_vec_required", False):
+                    continue
+            else:
+                # With shape tracking, check if we have compatible shapes
+                if op.constraints.get("row_vec_required", False):
+                    # Need at least one [M, 1] shaped tile for second argument
+                    has_row_vec = any(variable_shapes.get(t, (0, 0))[1] == 1 for t in available_tiles)
+                    # Also need at least one non-[M, 1] tile for first argument
+                    has_regular_tile = any(variable_shapes.get(t, (0, 0))[1] != 1 for t in available_tiles)
+                    if not (has_row_vec and has_regular_tile):
+                        continue
+
+                if op.constraints.get("col_vec_required", False):
+                    # Need at least one [1, N] shaped tile for second argument
+                    has_col_vec = any(variable_shapes.get(t, (0, 0))[0] == 1 for t in available_tiles)
+                    if not has_col_vec:
+                        continue
+
+            if has_tiles and has_scalars:
+                eligible.append(op)
+
+        return eligible
+
+    def _get_eligible_ops(
+        self,
+        available_tiles: List[str],
+        available_scalars: List[str],
+        allow_scalars: bool,
+        variable_shapes: Optional[Dict[str, Tuple[int, int]]] = None,
+    ) -> List[OpSpec]:
+        """Get operators that can be applied with current variables."""
+        eligible = []
+
+        for op in self.ops:
+            tile_inputs = sum(1 for t in op.input_types if t == "tile")
+            scalar_inputs = sum(1 for t in op.input_types if t == "scalar")
+
+            has_tiles = len(available_tiles) >= tile_inputs
+            has_scalars = (scalar_inputs == 0) or (
+                allow_scalars and (len(available_scalars) >= scalar_inputs or scalar_inputs > 0)
+            )
+
+            # Skip operators that require special shapes when shape tracking is disabled
+            if variable_shapes is None:
+                # Without shape tracking, skip row_expand ops (need [M, 1] vectors)
+                if op.constraints.get("row_vec_required", False):
+                    continue
+                # Without shape tracking, skip col_expand ops (need [1, N] vectors)
+                if op.constraints.get("col_vec_required", False):
+                    continue
+            else:
+                # With shape tracking, check if we have compatible shapes
+                if op.constraints.get("row_vec_required", False):
+                    # Need at least one [M, 1] shaped tile for second argument
+                    has_row_vec = any(variable_shapes.get(t, (0, 0))[1] == 1 for t in available_tiles)
+                    if not has_row_vec:
+                        continue
+
+                if op.constraints.get("col_vec_required", False):
+                    # Need at least one [1, N] shaped tile for second argument
+                    has_col_vec = any(variable_shapes.get(t, (0, 0))[0] == 1 for t in available_tiles)
+                    if not has_col_vec:
+                        continue
+
+            if has_tiles and has_scalars:
+                eligible.append(op)
+
+        return eligible
+
+    def _is_shape_compatible(self, op: OpSpec, var: str, variable_shapes: Dict[str, Tuple[int, int]]) -> bool:
+        """Check if a variable's shape is compatible with an operator.
+
+        Args:
+            op: The operator specification
+            var: Variable name to check
+            variable_shapes: Dictionary mapping variable names to their shapes
+
+        Returns:
+            True if the variable's shape is compatible with the operator
+        """
+        if var not in variable_shapes:
+            return True
+
+        var_shape = variable_shapes[var]
+
+        # Check row_vec_required constraint: second argument must be [M, 1]
+        if op.constraints.get("row_vec_required", False):
+            # For row_expand operations, the second operand must have shape [M, 1]
+            # We can't determine which operand this is without more context,
+            # so we check if this variable could be a valid row vector
+            if var_shape[1] != 1:
+                return False
+
+        # Check col_vec_required constraint: second argument must be [1, N]
+        if op.constraints.get("col_vec_required", False):
+            # For col_expand operations, the second operand must have shape [1, N]
+            if var_shape[0] != 1:
+                return False
+
+        return True

--- a/tests/st/fuzz/src/kernel_generator.py
+++ b/tests/st/fuzz/src/kernel_generator.py
@@ -1,0 +1,414 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+InCore kernel function generator
+
+This module is responsible for generating @pl.function(type=pl.FunctionType.InCore) kernel functions.
+Each kernel contains a chain of randomly generated operator operations.
+"""
+
+import random
+from typing import Any, Dict, List, Optional, Tuple
+
+from .fuzzer import OpFuzzer, generate_aligned_shape, is_shape_aligned
+
+
+class KernelGenerator:
+    """Generator for InCore kernel functions with random operator chains.
+
+    This class generates @pl.function(type=pl.FunctionType.InCore) kernels containing
+    chains of randomly selected operators. Each kernel includes input loading, operator
+    operations, and output storing.
+    """
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        enable_advanced_ops: bool = False,
+        advanced_ops_probability: float = 0.5,
+    ):
+        """Initialize kernel generator
+
+        Args:
+            seed: Random seed for reproducibility
+            enable_advanced_ops: Enable advanced operators (row_expand, row_sum, matmul, etc.)
+            advanced_ops_probability: Probability of selecting advanced ops (default: 0.5)
+        """
+        self.rng = random.Random(seed)
+        self.fuzzer = OpFuzzer(
+            seed=seed,
+            enable_advanced_ops=enable_advanced_ops,
+            advanced_ops_probability=advanced_ops_probability,
+        )
+
+    def generate_kernel(
+        self,
+        kernel_name: str,
+        num_inputs: int = 2,
+        num_ops: int = 5,
+        shape: Tuple[int, int] = (128, 128),
+        allow_scalars: bool = True,
+        input_shapes: Optional[List[Tuple[int, int]]] = None,
+        output_shape: Optional[Tuple[int, int]] = None,
+    ) -> Dict[str, Any]:
+        """Generate an InCore kernel function.
+
+        Args:
+            kernel_name: Kernel function name
+            num_inputs: Number of input tensors (ignored if input_shapes is provided)
+            num_ops: Number of operations in the chain
+            shape: Default shape for inputs (ignored if input_shapes is provided)
+            allow_scalars: Whether to allow scalar operations
+            input_shapes: List of input shapes, overrides num_inputs and shape
+            output_shape: Output shape, defaults to first input shape
+
+        Returns:
+            Kernel metadata dictionary containing:
+            - name: Kernel function name
+            - inputs: Input tensor list [(name, shape), ...]
+            - scalars: Scalar parameter list [(scalar_name, value), ...]
+            - output_shape: Output tensor shape
+            - op_chain: Operation chain
+            - code: Generated PyPTO kernel code
+        """
+        if input_shapes is not None:
+            actual_num_inputs = len(input_shapes)
+            actual_shapes = input_shapes
+        else:
+            actual_num_inputs = num_inputs
+            actual_shapes = [shape] * num_inputs
+
+        # Validate input shape alignment
+        dtype = "FP32"  # Currently only FP32 is supported
+        for i, input_shape in enumerate(actual_shapes):
+            if not is_shape_aligned(input_shape, dtype):
+                # If not aligned, regenerate aligned shape
+                print(
+                    f"Warning: Input shape {input_shape} is not 32-byte aligned. Regenerating aligned shape."
+                )
+                actual_shapes[i] = generate_aligned_shape(self.rng, dtype)
+
+        # Validate output shape alignment
+        if output_shape is not None:
+            actual_output_shape = output_shape
+            if not is_shape_aligned(actual_output_shape, dtype):
+                print(
+                    f"Warning: Output shape {actual_output_shape} is not 32-byte aligned. "
+                    f"Regenerating aligned shape."
+                )
+                actual_output_shape = generate_aligned_shape(self.rng, dtype)
+        else:
+            actual_output_shape = actual_shapes[0]
+
+        op_chain = self.fuzzer.generate_op_chain(
+            num_ops=num_ops,
+            input_count=actual_num_inputs,
+            allow_scalars=allow_scalars,
+            track_shapes=True,  # Track shapes for operations like row_expand
+            default_shape=actual_output_shape,
+        )
+
+        input_names = [chr(97 + i) for i in range(actual_num_inputs)]  # a, b, c, ...
+        inputs = [(name, actual_shapes[i]) for i, name in enumerate(input_names)]
+
+        # Collect unique scalar values used in op_chain
+        scalar_values = set()
+        for op_dict in op_chain:
+            if op_dict.get("scalar_value"):
+                scalar_values.add(op_dict["scalar_value"])
+
+        # Create scalar parameter list: [(param_name, value), ...]
+        scalars = []
+        scalar_value_to_param = {}
+        for idx, value in enumerate(sorted(scalar_values)):
+            param_name = f"scalar_{idx}"
+            scalars.append((param_name, value))
+            scalar_value_to_param[value] = param_name
+
+        # Generate kernel code
+        code = self._generate_kernel_code(
+            kernel_name=kernel_name,
+            inputs=inputs,
+            scalars=scalars,
+            op_chain=op_chain,
+            output_shape=actual_output_shape,
+            scalar_value_to_param=scalar_value_to_param,
+        )
+
+        return {
+            "name": kernel_name,
+            "inputs": inputs,
+            "scalars": scalars,
+            "output_shape": actual_output_shape,
+            "op_chain": op_chain,
+            "code": code,
+        }
+
+    def _generate_matmul_memory_moves(
+        self,
+        input_var: str,
+        target_memory: int,
+        has_matmul: bool,
+    ) -> tuple[str, list[str]]:
+        """Generate memory move operations for matmul inputs.
+
+        Args:
+            input_var: Input variable name (e.g., "tile_a")
+            target_memory: Target memory type (3 for L0A, 4 for L0B)
+            has_matmul: Whether the kernel contains matmul operations
+
+        Returns:
+            Tuple of (final_var_name, list_of_code_lines)
+        """
+        code_lines = []
+
+        if input_var.startswith("tile_") and not input_var.endswith(("_l0a", "_l0b", "_l0c")):
+            input_l1 = f"{input_var}_l1" if has_matmul else input_var
+            memory_suffix = "l0a" if target_memory == 3 else "l0b"
+            output_var = f"{input_var}_{memory_suffix}"
+            code_lines.append(
+                f"        {output_var} = pl.block.move({input_l1}, target_memory={target_memory})"
+            )
+            return output_var, code_lines
+        else:
+            return input_var, code_lines
+
+    def _generate_input_loads(
+        self,
+        inputs: List[Tuple[str, Tuple[int, int]]],
+        has_matmul: bool,
+    ) -> list[str]:
+        """Generate input load operations."""
+        code_lines = []
+        for name, (r, c) in inputs:
+            if has_matmul:
+                code_lines.append(
+                    f"        tile_{name}_l1 = pl.block.load({name}, offsets=[0, 0], "
+                    f"shapes=[{r}, {c}], target_memory=2)"
+                )
+            else:
+                code_lines.append(f"        tile_{name} = pl.load({name}, offsets=[0, 0], shapes=[{r}, {c}])")
+        return code_lines
+
+    def _generate_matmul_op(
+        self,
+        op_dict: dict[str, Any],
+        has_matmul: bool,
+    ) -> list[str]:
+        """Generate matmul operation with memory moves."""
+        code_lines = []
+        inputs_list = op_dict["inputs"]
+        output = op_dict["output"]
+
+        input_a_l0a, move_lines_a = self._generate_matmul_memory_moves(inputs_list[0], 3, has_matmul)
+        code_lines.extend(move_lines_a)
+
+        input_b_l0b, move_lines_b = self._generate_matmul_memory_moves(inputs_list[1], 4, has_matmul)
+        code_lines.extend(move_lines_b)
+
+        code_lines.append(f"        {output} = pl.block.matmul({input_a_l0a}, {input_b_l0b})")
+        return code_lines
+
+    def _generate_reduction_op(
+        self,
+        op_dict: dict[str, Any],
+        output_shape: Tuple[int, int],
+    ) -> list[str]:
+        """Generate reduction operation with temporary tile.
+
+        For row_sum/row_max/row_min operations, the tmp_tile must have the same shape
+        as the input (e.g., [M, N]), not the output shape ([M, 1]).
+        """
+        code_lines = []
+        op = op_dict["op"]
+        inputs_list = op_dict["inputs"]
+        output = op_dict["output"]
+        op_name = op.name.replace("block.", "")
+
+        # Use input shape for tmp_tile, not output shape
+        # For row_sum: input is [M, N], output is [M, 1], tmp_tile should be [M, N]
+        input_shapes = op_dict.get("input_shapes", [])
+        if input_shapes:
+            tmp_shape = input_shapes[0]  # Use first input's shape
+        else:
+            # Fallback: use output_shape (this maintains backward compatibility)
+            tmp_shape = op_dict.get("output_shape", (output_shape[0], output_shape[1]))
+
+        tmp_tile_var = f"tmp_tile_{output}"
+        code_lines.append(
+            f"        {tmp_tile_var} = pl.block.create_tile([{tmp_shape[0]}, {tmp_shape[1]}], "
+            f"dtype=pl.FP32, target_memory=1)"
+        )
+        code_lines.append(f"        {output} = pl.{op_name}({inputs_list[0]}, {tmp_tile_var})")
+        return code_lines
+
+    def _generate_regular_op(self, op_dict: dict[str, Any], scalar_value_to_param: dict[str, str]) -> str:
+        """Generate regular operation."""
+        op = op_dict["op"]
+        inputs_list = op_dict["inputs"]
+        output = op_dict["output"]
+        params = op_dict.get("params")
+        op_name = op.name.replace("block.", "")
+
+        # Replace scalar literals with parameter references
+        processed_inputs = []
+        for inp in inputs_list:
+            if inp in scalar_value_to_param:
+                processed_inputs.append(scalar_value_to_param[inp])
+            else:
+                processed_inputs.append(inp)
+
+        inputs_str = ", ".join(processed_inputs)
+        if params:
+            params_str = ", ".join(f"{k}={v}" for k, v in params.items())
+            return f"        {output} = pl.{op_name}({inputs_str}, {params_str})"
+        return f"        {output} = pl.{op_name}({inputs_str})"
+
+    def _generate_store_op(
+        self,
+        op_chain: List[Dict[str, Any]],
+        inputs: List[Tuple[str, Tuple[int, int]]],
+        output_shape: Tuple[int, int],
+    ) -> list[str]:
+        """Generate store operation."""
+        code_lines = []
+        rows, cols = output_shape
+
+        if op_chain:
+            last_output = op_chain[-1]["output"]
+            last_op = op_chain[-1]["op"]
+
+            if last_op.name == "block.matmul":
+                code_lines.append(
+                    f"        result = pl.block.l0c_store({last_output}, offsets=[0, 0], "
+                    f"shapes=[{rows}, {cols}], output_tensor=output)"
+                )
+            else:
+                code_lines.append(
+                    f"        result = pl.store({last_output}, offsets=[0, 0], "
+                    f"shapes=[{rows}, {cols}], output_tensor=output)"
+                )
+        else:
+            first_input = inputs[0][0]
+            code_lines.append(
+                f"        result = pl.store(tile_{first_input}, offsets=[0, 0], "
+                f"shapes=[{rows}, {cols}], output_tensor=output)"
+            )
+
+        code_lines.append("        return result")
+        return code_lines
+
+    def _generate_kernel_code(
+        self,
+        kernel_name: str,
+        inputs: List[Tuple[str, Tuple[int, int]]],
+        scalars: List[Tuple[str, str]],
+        op_chain: List[Dict[str, Any]],
+        output_shape: Tuple[int, int],
+        scalar_value_to_param: Dict[str, str],
+    ) -> str:
+        """Generate kernel function code.
+
+        Args:
+            kernel_name: Kernel function name
+            inputs: Tensor input list
+            scalars: Scalar parameter list [(param_name, value), ...]
+            op_chain: Operation chain
+            output_shape: Output tensor shape
+            scalar_value_to_param: Mapping from scalar values to parameter names
+
+        Returns:
+            Generated PyPTO kernel code
+        """
+        rows, cols = output_shape
+
+        params = []
+        for name, (r, c) in inputs:
+            params.append(f"{name}: pl.Tensor[[{r}, {c}], pl.FP32]")
+
+        # Add scalar parameters
+        for scalar_name, _ in scalars:
+            params.append(f"{scalar_name}: pl.Scalar[pl.FP32]")
+
+        params.append(f"output: pl.Tensor[[{rows}, {cols}], pl.FP32]")
+
+        code_lines = [
+            "    @pl.function(type=pl.FunctionType.InCore)",
+            f"    def {kernel_name}(self, {', '.join(params)}) -> pl.Tensor[[{rows}, {cols}], pl.FP32]:",
+        ]
+
+        has_matmul = any(op_dict["op"].name == "block.matmul" for op_dict in op_chain)
+
+        code_lines.extend(self._generate_input_loads(inputs, has_matmul))
+
+        for op_dict in op_chain:
+            op = op_dict["op"]
+
+            if op.name == "block.matmul":
+                code_lines.extend(self._generate_matmul_op(op_dict, has_matmul))
+            elif op.constraints.get("requires_tmp_tile", False):
+                code_lines.extend(self._generate_reduction_op(op_dict, output_shape))
+            else:
+                code_lines.append(self._generate_regular_op(op_dict, scalar_value_to_param))
+
+        code_lines.extend(self._generate_store_op(op_chain, inputs, output_shape))
+
+        return "\n".join(code_lines)
+
+    def generate_multiple_kernels(
+        self,
+        num_kernels: int = 3,
+        num_inputs_range: Tuple[int, int] = (2, 3),
+        num_ops_range: Tuple[int, int] = (3, 7),
+        shape: Tuple[int, int] = (128, 128),
+        input_shapes_list: Optional[List[List[Tuple[int, int]]]] = None,
+        output_shapes: Optional[List[Tuple[int, int]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Generate multiple InCore kernel functions.
+
+        Args:
+            num_kernels: Number of kernels to generate
+            num_inputs_range: Range for number of inputs (min, max)
+            num_ops_range: Range for number of operations (min, max)
+            shape: Default shape for inputs
+            input_shapes_list: List of input shapes for each kernel,
+                              e.g., [[(128,128), (64,64)], [(256,256)], ...]
+            output_shapes: Output shapes for each kernel (optional)
+
+        Returns:
+            List of kernel metadata dictionaries
+        """
+        kernels = []
+        for i in range(num_kernels):
+            num_ops = self.rng.randint(*num_ops_range)
+
+            if input_shapes_list and i < len(input_shapes_list):
+                kernel_input_shapes = input_shapes_list[i]
+                kernel_output_shape = output_shapes[i] if output_shapes and i < len(output_shapes) else None
+                kernel = self.generate_kernel(
+                    kernel_name=f"kernel_{i}",
+                    num_ops=num_ops,
+                    shape=shape,
+                    input_shapes=kernel_input_shapes,
+                    output_shape=kernel_output_shape,
+                )
+            else:
+                num_inputs = self.rng.randint(*num_inputs_range)
+                kernel_output_shape = output_shapes[i] if output_shapes and i < len(output_shapes) else None
+                kernel = self.generate_kernel(
+                    kernel_name=f"kernel_{i}",
+                    num_inputs=num_inputs,
+                    num_ops=num_ops,
+                    shape=shape,
+                    output_shape=kernel_output_shape,
+                )
+            kernels.append(kernel)
+
+        return kernels

--- a/tests/st/fuzz/src/multi_kernel_test_generator.py
+++ b/tests/st/fuzz/src/multi_kernel_test_generator.py
@@ -1,0 +1,761 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Multi-kernel test case generator
+
+This module is responsible for generating:
+- Multiple InCore kernels
+- Orchestration function
+- PyTorch reference implementation
+- PTOTestCase test class
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from .fuzzer import OpFuzzer
+from .kernel_generator import KernelGenerator
+from .orchestrator_generator import OrchestratorGenerator
+
+
+class MultiKernelTestGenerator:
+    """kernels"""
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        enable_advanced_ops: bool = False,
+        advanced_ops_probability: float = 0.5,
+        tensor_init_type: str = "constant",
+        validate_golden: bool = True,
+    ):
+        """Initialize test generator
+
+        Args:
+            seed: Random seed for reproducibility
+            enable_advanced_ops: Enable advanced operators (row_expand, row_sum, matmul, etc.)
+            advanced_ops_probability: Probability of selecting advanced ops (default: 0.5)
+            tensor_init_type: Tensor initialization type (constant, random, range, normal)
+            validate_golden: Validate golden output (check for NaN/Inf)
+        """
+        self.seed = seed
+        self.enable_advanced_ops = enable_advanced_ops
+        self.advanced_ops_probability = advanced_ops_probability
+        self.tensor_init_type = tensor_init_type
+        self.validate_golden = validate_golden
+        self.kernel_gen = KernelGenerator(
+            seed=seed,
+            enable_advanced_ops=enable_advanced_ops,
+            advanced_ops_probability=advanced_ops_probability,
+        )
+        self.orch_gen = OrchestratorGenerator(seed=seed)
+        self.fuzzer = OpFuzzer(
+            seed=seed,
+            enable_advanced_ops=enable_advanced_ops,
+            advanced_ops_probability=advanced_ops_probability,
+        )
+
+    def _generate_tensor_init_value(self, tensor_index: int, init_type: str = None) -> str:
+        """
+
+        Args:
+            tensor_index: （）
+            init_type: ，Noneself.tensor_init_type
+
+        Returns:
+
+        """
+        if init_type is None:
+            init_type = self.tensor_init_type
+
+        if init_type == "constant":
+            # ：
+            init_val = 2.0 + tensor_index * 0.5
+            return f"init_value={init_val}"
+        elif init_type == "random":
+            # ：torch.randn，fuzzer
+            return "init_value=torch.randn"
+        elif init_type == "range":
+            # ：01torch.rand
+            return "init_value=torch.rand"
+        elif init_type == "normal":
+            # ：torch.randn，fuzzer
+            return "init_value=torch.randn"
+        elif init_type == "ones":
+            # 1
+            return "init_value=1.0"
+        elif init_type == "zeros":
+            # 0（，）
+            return "init_value=0.0"
+        else:
+            # default
+            init_val = 2.0 + tensor_index * 0.5
+            return f"init_value={init_val}"
+
+    def _compute_output_shapes_for_sequential(  # noqa: PLR0912
+        self,
+        num_kernels: int,
+        default_shape: Tuple[int, int],
+        input_shapes_list: Optional[List[List[Tuple[int, int]]]],
+        mode: str,
+    ) -> List[Tuple[int, int]]:
+        """kernels，
+
+        Args:
+            num_kernels: kernels
+            default_shape: default
+            input_shapes_list:
+            mode:
+
+        Returns:
+            kernels
+        """
+        output_shapes = []
+
+        if mode == "sequential":
+            # ：kernel_i  kernel_{i+1}
+            for i in range(num_kernels):
+                if i == num_kernels - 1:
+                    # kernels：
+                    if input_shapes_list and i < len(input_shapes_list):
+                        output_shapes.append(input_shapes_list[i][0])
+                    else:
+                        output_shapes.append(default_shape)
+                # kernels：kernels
+                elif input_shapes_list and i + 1 < len(input_shapes_list):
+                    next_kernel_first_input = input_shapes_list[i + 1][0]
+                    output_shapes.append(next_kernel_first_input)
+                else:
+                    output_shapes.append(default_shape)
+
+        elif mode == "branching":
+            # ：kernels（）
+            # kernels
+            if input_shapes_list and len(input_shapes_list) > 0:
+                unified_output_shape = input_shapes_list[0][0]
+            else:
+                unified_output_shape = default_shape
+
+            for i in range(num_kernels):
+                output_shapes.append(unified_output_shape)
+
+        elif mode == "mixed":
+            # ：，
+            mid = num_kernels // 2
+
+            # ：kernels
+            if input_shapes_list and len(input_shapes_list) > 0:
+                parallel_output_shape = input_shapes_list[0][0]
+            else:
+                parallel_output_shape = default_shape
+
+            for i in range(num_kernels):
+                if i < mid:
+                    # ：
+                    output_shapes.append(parallel_output_shape)
+                elif i == mid:
+                    # kernels：kernels（）
+                    if i == num_kernels - 1:
+                        # ，
+                        if input_shapes_list and i < len(input_shapes_list):
+                            output_shapes.append(input_shapes_list[i][0])
+                        else:
+                            output_shapes.append(default_shape)
+                    # kernels
+                    elif input_shapes_list and i + 1 < len(input_shapes_list):
+                        output_shapes.append(input_shapes_list[i + 1][0])
+                    else:
+                        output_shapes.append(default_shape)
+                # kernels
+                elif i == num_kernels - 1:
+                    # kernels
+                    if input_shapes_list and i < len(input_shapes_list):
+                        output_shapes.append(input_shapes_list[i][0])
+                    else:
+                        output_shapes.append(default_shape)
+                # kernels
+                elif input_shapes_list and i + 1 < len(input_shapes_list):
+                    output_shapes.append(input_shapes_list[i + 1][0])
+                else:
+                    output_shapes.append(default_shape)
+
+        return output_shapes
+
+    def _regenerate_kernel_code_with_unified_shapes(
+        self,
+        kernel: Dict[str, Any],
+        input_shapes_map: Dict[str, Tuple[int, int]],
+    ) -> str:
+        """Regenerate kernel code with unified input shapes
+
+        Args:
+            kernel: Kernel information
+            input_shapes_map: Mapping from input names to unified shapes
+
+        Returns:
+            Regenerated kernel code
+        """
+        # Update kernel inputs with unified shapes
+        unified_inputs = [(inp_name, input_shapes_map[inp_name]) for inp_name, _ in kernel["inputs"]]
+
+        # Get scalars from kernel
+        scalars = kernel.get("scalars", [])
+
+        # Build scalar value to param mapping
+        scalar_value_to_param = {}
+        for param_name, value in scalars:
+            scalar_value_to_param[value] = param_name
+
+        # Reuse the kernel generator's code generation logic
+        return self.kernel_gen._generate_kernel_code(
+            kernel_name=kernel["name"],
+            inputs=unified_inputs,
+            scalars=scalars,
+            op_chain=kernel["op_chain"],
+            output_shape=kernel["output_shape"],
+            scalar_value_to_param=scalar_value_to_param,
+        )
+
+    def generate_test_case(
+        self,
+        test_name: str,
+        num_kernels: int = 3,
+        orchestration_mode: str = "sequential",
+        shape: Tuple[int, int] = (128, 128),
+        num_ops_range: Tuple[int, int] = (3, 7),
+        input_shapes_list: Optional[List[List[Tuple[int, int]]]] = None,
+        tensor_init_type: Optional[str] = None,
+        atol: float = 1e-5,
+        rtol: float = 1e-5,
+    ) -> str:
+        """
+
+        Args:
+            test_name:
+            num_kernels: kernels
+            orchestration_mode:  ("sequential", "branching", "mixed")
+            shape:
+            num_ops_range: kernels
+            input_shapes_list: kernels（）
+            tensor_init_type: （，）
+            atol: Absolute error tolerance
+            rtol: Relative error tolerance
+
+        Returns:
+
+        """
+        #  sequential、branching  mixed ，
+        if orchestration_mode in ["sequential", "branching", "mixed"]:
+            output_shapes = self._compute_output_shapes_for_sequential(
+                num_kernels, shape, input_shapes_list, orchestration_mode
+            )
+        else:
+            output_shapes = None
+
+        # multiplekernels
+        kernels = self.kernel_gen.generate_multiple_kernels(
+            num_kernels=num_kernels,
+            num_inputs_range=(2, 3),
+            num_ops_range=num_ops_range,
+            shape=shape,
+            input_shapes_list=input_shapes_list,
+            output_shapes=output_shapes,
+        )
+
+        #  Orchestration
+        if orchestration_mode == "sequential":
+            orch_info = self.orch_gen.generate_sequential(kernels, shape)
+        elif orchestration_mode == "branching":
+            orch_info = self.orch_gen.generate_branching(kernels, shape)
+        elif orchestration_mode == "mixed":
+            orch_info = self.orch_gen.generate_mixed(kernels, shape)
+        else:
+            raise ValueError(f": {orchestration_mode}")
+
+        #  Torch reference implementation
+        torch_code = self._generate_torch_reference(kernels, orch_info)
+
+        # test class
+        test_code = self._generate_test_class(
+            test_name=test_name,
+            kernels=kernels,
+            orch_info=orch_info,
+            torch_code=torch_code,
+            shape=shape,
+            tensor_init_type=tensor_init_type,
+            atol=atol,
+            rtol=rtol,
+        )
+
+        #  golden （ NaN/Inf）
+        if self.validate_golden:
+            self._validate_golden_output(kernels, orch_info, shape, tensor_init_type or self.tensor_init_type)
+
+        return test_code
+
+    def _generate_torch_reference(
+        self,
+        kernels: List[Dict[str, Any]],
+        orch_info: Dict[str, Any],
+    ) -> str:
+        """Torch reference implementation
+
+        Args:
+            kernels: kernels
+            orch_info: Orchestration
+
+        Returns:
+            Torch reference implementation
+        """
+        code_lines = []
+
+        # kernels Torch
+        for kernel in kernels:
+            kernel_name = kernel["name"]
+            input_names = [inp[0] for inp in kernel["inputs"]]
+            op_chain = kernel["op_chain"]
+
+            #  self
+            code_lines.append(f"    def _torch_{kernel_name}({', '.join(input_names)}):")
+            code_lines.append(f'        """Torch reference implementation for {kernel_name}"""')
+
+            code_lines.append("        env = {}")
+            for name in input_names:
+                code_lines.append(f"        env['tile_{name}'] = {name}.clone()")
+
+            code_lines.append("")
+            for op_dict in op_chain:
+                op = op_dict["op"]
+                inputs = op_dict["inputs"]
+                output = op_dict["output"]
+
+                input_vals = []
+                for inp in inputs:
+                    if inp.startswith("tile_") or inp.startswith("tmp_"):
+                        input_vals.append(f"env['{inp}']")
+                    else:
+                        input_vals.append(inp)
+
+                if op.np_equivalent:
+                    torch_expr = self._get_torch_operation(op.name, input_vals)
+                    code_lines.append(f"        env['{output}'] = {torch_expr}")
+
+            code_lines.append(f"        return env['{op_chain[-1]['output']}']")
+            code_lines.append("")
+
+        return "\n".join(code_lines)
+
+    # Operation mapping: PyPTO op name -> torch expression template or callable
+    _TORCH_OP_MAP = {
+        # Binary arithmetic operations
+        "block.add": lambda v: f"{v[0]} + {v[1]}",
+        "block.sub": lambda v: f"{v[0]} - {v[1]}",
+        "block.mul": lambda v: f"{v[0]} * {v[1]}",
+        "block.div": lambda v: f"{v[0]} / {v[1]}",
+        "block.adds": lambda v: f"{v[0]} + {v[1]}",
+        "block.subs": lambda v: f"{v[0]} - {v[1]}",
+        "block.muls": lambda v: f"{v[0]} * {v[1]}",
+        "block.divs": lambda v: f"{v[0]} / {v[1]}",
+        # Binary comparison operations
+        "block.maximum": lambda v: f"torch.maximum({v[0]}, {v[1]})",
+        "block.minimum": lambda v: f"torch.minimum({v[0]}, {v[1]})",
+        # Unary operations
+        "block.sqrt": lambda v: f"torch.sqrt({v[0]})",
+        "block.rsqrt": lambda v: f"torch.rsqrt({v[0]})",
+        "block.exp": lambda v: f"torch.exp(torch.clamp({v[0]}, -10, 10))",
+        "block.neg": lambda v: f"-{v[0]}",
+        "block.recip": lambda v: f"torch.reciprocal({v[0]})",
+        "block.log": lambda v: f"torch.log({v[0]})",
+        "block.abs": lambda v: f"torch.abs({v[0]})",
+        "block.relu": lambda v: f"torch.relu({v[0]})",
+        # Row expand operations (broadcasting)
+        "block.row_expand_add": lambda v: f"{v[0]} + {v[1]}",
+        "block.row_expand_sub": lambda v: f"{v[0]} - {v[1]}",
+        "block.row_expand_mul": lambda v: f"{v[0]} * {v[1]}",
+        "block.row_expand_div": lambda v: f"{v[0]} / {v[1]}",
+        # Row reduction operations (produce [M, 1] output)
+        "block.row_sum": lambda v: f"torch.sum({v[0]}, dim=1, keepdim=True)",
+        "block.row_max": lambda v: f"torch.max({v[0]}, dim=1, keepdim=True)[0]",
+        "block.row_min": lambda v: f"torch.min({v[0]}, dim=1, keepdim=True)[0]",
+        # Column expand operations (broadcast [1, N] to [M, N])
+        "block.col_expand_mul": lambda v: f"{v[0]} * {v[1]}",
+        "block.col_expand_div": lambda v: f"{v[0]} / {v[1]}",
+        "block.col_expand_sub": lambda v: f"{v[0]} - {v[1]}",
+        # Column reduction operations (produce [1, N] output)
+        "block.col_sum": lambda v: f"torch.sum({v[0]}, dim=0, keepdim=True)",
+        "block.col_max": lambda v: f"torch.max({v[0]}, dim=0, keepdim=True)[0]",
+        "block.col_min": lambda v: f"torch.min({v[0]}, dim=0, keepdim=True)[0]",
+        # Matrix operations
+        "block.matmul": lambda v: f"torch.matmul({v[0]}, {v[1]})",
+    }
+
+    def _get_torch_operation(self, op_name: str, input_vals: List[str]) -> str:
+        """Convert PyPTO operation to Torch expression.
+
+        Args:
+            op_name: PyPTO operation name (e.g., "block.add")
+            input_vals: Input value expressions
+
+        Returns:
+            Torch expression string
+        """
+        op_func = self._TORCH_OP_MAP.get(op_name)
+        if op_func:
+            return op_func(input_vals)
+        return f"# Unsupported operation: {op_name}"
+
+    def _generate_test_class(  # noqa: PLR0912, PLR0915
+        self,
+        test_name: str,
+        kernels: List[Dict[str, Any]],
+        orch_info: Dict[str, Any],
+        torch_code: str,
+        shape: Tuple[int, int],
+        tensor_init_type: Optional[str] = None,
+        atol: float = 1e-5,
+        rtol: float = 1e-5,
+    ) -> str:
+        """test class
+
+        Args:
+            test_name:
+            kernels: kernels
+            orch_info: Orchestration
+            torch_code: Torch reference implementation
+            shape:
+            tensor_init_type: （，）
+            atol: Absolute error tolerance
+            rtol: Relative error tolerance
+
+        Returns:
+            test class
+        """
+        rows, cols = shape
+        class_name = f"Test{test_name.replace('_', ' ').title().replace(' ', '')}"
+
+        input_shapes_map = {}  # {input_name: shape}
+        for kernel in kernels:
+            for inp_name, inp_shape in kernel["inputs"]:
+                if inp_name not in input_shapes_map:
+                    input_shapes_map[inp_name] = inp_shape
+                # kernels，
+                elif inp_shape != input_shapes_map[inp_name]:
+                    existing_size = input_shapes_map[inp_name][0] * input_shapes_map[inp_name][1]
+                    new_size = inp_shape[0] * inp_shape[1]
+                    if new_size > existing_size:
+                        input_shapes_map[inp_name] = inp_shape
+
+        input_list = sorted(input_shapes_map.keys())
+
+        # kernels
+        output_shape = kernels[-1]["output_shape"] if kernels else shape
+
+        code_lines = [
+            f"class {class_name}(PTOTestCase):",
+            '    """',
+            f"    : {test_name}",
+            f"    : {orch_info['mode']}",
+            f"    kernels: {len(kernels)}",
+            '    """',
+            "",
+            f"    rows = {rows}",
+            f"    cols = {cols}",
+            "",
+            "    def __init__(self):",
+            "        super().__init__()",
+            f"        self.config.atol = {atol}",
+            f"        self.config.rtol = {rtol}",
+            "",
+            "    def get_name(self) -> str:",
+            f"        return '{test_name}'",
+            "",
+            "    def define_tensors(self) -> List[TensorSpec]:",
+            "        return [",
+        ]
+
+        #  -
+        for idx, inp_name in enumerate(input_list):
+            inp_shape = input_shapes_map[inp_name]
+            init_code = self._generate_tensor_init_value(idx, tensor_init_type)
+            code_lines.append(
+                f"            TensorSpec('{inp_name}', [{inp_shape[0]}, {inp_shape[1]}], "
+                f"DataType.FP32, {init_code}),"
+            )
+
+        #  -
+        code_lines.append(
+            f"            TensorSpec('output', [{output_shape[0]}, {output_shape[1]}], "
+            f"DataType.FP32, is_output=True),"
+        )
+        code_lines.append("        ]")
+        code_lines.append("")
+
+        #  PyPTO
+        code_lines.append("    def get_program(self) -> Any:")
+        code_lines.append("        import pypto.language as pl")
+        code_lines.append("")
+        code_lines.append("        @pl.program")
+        code_lines.append(f"        class {test_name.replace('_', ' ').title().replace(' ', '')}Program:")
+
+        # kernels（）
+        for kernel in kernels:
+            #  kernel
+            regenerated_code = self._regenerate_kernel_code_with_unified_shapes(kernel, input_shapes_map)
+            # kernels8（4get_program，4@pl.program）
+            kernel_lines = regenerated_code.split("\n")
+            for line in kernel_lines:
+                code_lines.append(f"        {line}")
+            code_lines.append("")
+
+        # kernels（）
+        if orch_info.get("needs_merge_kernel", False):
+            merge_code = self.orch_gen.generate_merge_kernel(shape)
+            merge_lines = merge_code.split("\n")
+            for line in merge_lines:
+                code_lines.append(f"        {line}")
+            code_lines.append("")
+
+        #  Orchestration
+        orch_lines = orch_info["code"].split("\n")
+        for line in orch_lines:
+            code_lines.append(f"        {line}")
+        code_lines.append("")
+
+        code_lines.append(f"        return {test_name.replace('_', ' ').title().replace(' ', '')}Program")
+        code_lines.append("")
+
+        #  Torch reference implementation
+        code_lines.append("    def compute_expected(self, tensors, params=None):")
+        code_lines.append('        """Compute expected output using Torch reference implementation"""')
+        code_lines.append("        torch_tensors = {}")
+        code_lines.append("        for name, arr in tensors.items():")
+        code_lines.append("            if not name.endswith('output'):")
+        code_lines.append("                if isinstance(arr, torch.Tensor):")
+        code_lines.append("                    torch_tensors[name] = arr")
+        code_lines.append("                else:")
+        code_lines.append("                    torch_tensors[name] = torch.from_numpy(arr)")
+        code_lines.append("")
+        # torch_code ， compute_expected ，
+        torch_lines = torch_code.split("\n")
+        for line in torch_lines:
+            if line.strip():
+                code_lines.append(f"    {line}")  # 4
+            else:
+                code_lines.append(line)
+        code_lines.append("")
+
+        if orch_info["mode"] == "sequential":
+            result_var = None
+            for i, kernel in enumerate(kernels):
+                kernel_name = kernel["name"]
+                kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+
+                if i > 0 and result_var:
+                    kernel_inputs[0] = result_var
+                    inputs_parts = [kernel_inputs[0]]
+                    for inp in kernel_inputs[1:]:
+                        inputs_parts.append(f"torch_tensors['{inp}']")
+                    inputs_str = ", ".join(inputs_parts)
+                else:
+                    inputs_str = ", ".join([f"torch_tensors['{inp}']" for inp in kernel_inputs])
+
+                result_var = f"result_{i}"
+                code_lines.append(f"        {result_var} = _torch_{kernel_name}({inputs_str})")
+
+            code_lines.append("        if isinstance(tensors['output'], torch.Tensor):")
+            code_lines.append(f"            tensors['output'][:] = {result_var}")
+            code_lines.append("        else:")
+            code_lines.append(f"            tensors['output'][:] = {result_var}.numpy()")
+
+        elif orch_info["mode"] == "branching":
+            branch_results = []
+            for i, kernel in enumerate(kernels):
+                kernel_name = kernel["name"]
+                kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+                result_var = f"branch_{i}"
+                branch_results.append(result_var)
+
+                inputs_str = ", ".join([f"torch_tensors['{inp}']" for inp in kernel_inputs])
+                code_lines.append(f"        {result_var} = _torch_{kernel_name}({inputs_str})")
+
+            if len(branch_results) == 1:
+                code_lines.append("        if isinstance(tensors['output'], torch.Tensor):")
+                code_lines.append(f"            tensors['output'][:] = {branch_results[0]}")
+                code_lines.append("        else:")
+                code_lines.append(f"            tensors['output'][:] = {branch_results[0]}.numpy()")
+            else:
+                merged = branch_results[0]
+                for i in range(1, len(branch_results)):
+                    new_merged = f"merged_{i}"
+                    code_lines.append(f"        {new_merged} = {merged} + {branch_results[i]}")
+                    merged = new_merged
+                code_lines.append("        if isinstance(tensors['output'], torch.Tensor):")
+                code_lines.append(f"            tensors['output'][:] = {merged}")
+                code_lines.append("        else:")
+                code_lines.append(f"            tensors['output'][:] = {merged}.numpy()")
+
+        elif orch_info["mode"] == "mixed":
+            mid = len(kernels) // 2
+            parallel_kernels = kernels[:mid]
+            sequential_kernels = kernels[mid:]
+
+            branch_results = []
+            for i, kernel in enumerate(parallel_kernels):
+                kernel_name = kernel["name"]
+                kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+                result_var = f"parallel_{i}"
+                branch_results.append(result_var)
+
+                inputs_str = ", ".join([f"torch_tensors['{inp}']" for inp in kernel_inputs])
+                code_lines.append(f"        {result_var} = _torch_{kernel_name}({inputs_str})")
+
+            if len(branch_results) > 1:
+                merged = branch_results[0]
+                for i in range(1, len(branch_results)):
+                    new_merged = f"merged_parallel_{i}"
+                    code_lines.append(f"        {new_merged} = {merged} + {branch_results[i]}")
+                    merged = new_merged
+                current_result = merged
+            else:
+                current_result = branch_results[0]
+
+            for i, kernel in enumerate(sequential_kernels):
+                kernel_name = kernel["name"]
+                kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+                kernel_inputs[0] = current_result
+
+                result_var = f"sequential_{i}"
+                inputs_parts = [kernel_inputs[0]]
+                for inp in kernel_inputs[1:]:
+                    inputs_parts.append(f"torch_tensors['{inp}']")
+                inputs_str = ", ".join(inputs_parts)
+                code_lines.append(f"        {result_var} = _torch_{kernel_name}({inputs_str})")
+                current_result = result_var
+
+            code_lines.append("        if isinstance(tensors['output'], torch.Tensor):")
+            code_lines.append(f"            tensors['output'][:] = {current_result}")
+            code_lines.append("        else:")
+            code_lines.append(f"            tensors['output'][:] = {current_result}.numpy()")
+
+        code_lines.append("")
+
+        return "\n".join(code_lines)
+
+    def _validate_golden_output(  # noqa: PLR0912
+        self,
+        kernels: List[Dict[str, Any]],
+        orch_info: Dict[str, Any],
+        shape: Tuple[int, int],
+        tensor_init_type: str,
+    ) -> None:
+        """golden ， NaN/Inf
+
+        Args:
+            kernels: kernels
+            orch_info: Orchestration
+            shape:
+            tensor_init_type:
+
+        Raises:
+            ValueError:  golden  NaN  Inf
+        """
+        tensors = {}
+        for i, kernel in enumerate(kernels):
+            for inp_name, inp_shape in kernel["inputs"]:
+                if inp_name not in tensors:
+                    if tensor_init_type == "constant":
+                        value = 2.0 + i * 0.5
+                        tensors[inp_name] = torch.full(inp_shape, value, dtype=torch.float32)
+                    elif tensor_init_type == "random":
+                        tensors[inp_name] = torch.randn(inp_shape, dtype=torch.float32)
+                    elif tensor_init_type == "range":
+                        tensors[inp_name] = torch.rand(inp_shape, dtype=torch.float32)
+                    elif tensor_init_type == "normal":
+                        tensors[inp_name] = torch.randn(inp_shape, dtype=torch.float32)
+                    elif tensor_init_type == "ones":
+                        tensors[inp_name] = torch.ones(inp_shape, dtype=torch.float32)
+                    elif tensor_init_type == "zeros":
+                        tensors[inp_name] = torch.zeros(inp_shape, dtype=torch.float32)
+                    else:
+                        tensors[inp_name] = torch.full(inp_shape, 2.0, dtype=torch.float32)
+
+        # kernels Torch
+        kernel_results = {}
+        for kernel in kernels:
+            kernel_name = kernel["name"]
+            input_names = [inp[0] for inp in kernel["inputs"]]
+            op_chain = kernel["op_chain"]
+
+            env = {}
+            for inp_name in input_names:
+                env[f"tile_{inp_name}"] = tensors[inp_name].clone()
+
+            for op_dict in op_chain:
+                op = op_dict["op"]
+                inputs = op_dict["inputs"]
+                output = op_dict["output"]
+
+                input_vals = []
+                for inp in inputs:
+                    if inp in env:
+                        val = env[inp]
+                    else:
+                        try:
+                            val = float(inp)
+                        except ValueError:
+                            val = env.get(inp, torch.tensor(0.0))
+                    input_vals.append(val)
+
+                if "avoid_zero" in op.constraints and op.constraints["avoid_zero"]:
+                    for i, val in enumerate(input_vals):
+                        if isinstance(val, torch.Tensor):
+                            input_vals[i] = torch.where(torch.abs(val) < 0.01, torch.tensor(1.0), val)
+
+                if "positive_only" in op.constraints and op.constraints["positive_only"]:
+                    for i, val in enumerate(input_vals):
+                        if isinstance(val, torch.Tensor):
+                            input_vals[i] = torch.abs(val) + 1e-6
+
+                # （，）
+                try:
+                    if op.np_equivalent:
+                        #  numpy
+                        np_inputs = [v.numpy() if isinstance(v, torch.Tensor) else v for v in input_vals]
+                        result = op.np_equivalent(*np_inputs)
+                        env[output] = (
+                            torch.from_numpy(result)
+                            if isinstance(result, np.ndarray)
+                            else torch.tensor(result)
+                        )
+                except Exception as e:
+                    print(f"Warning: Failed to execute {op.name}: {e}")
+                    env[output] = torch.zeros_like(
+                        input_vals[0] if isinstance(input_vals[0], torch.Tensor) else torch.tensor(0.0)
+                    )
+
+            if op_chain:
+                kernel_results[kernel_name] = env[op_chain[-1]["output"]]
+
+        # Check
+        if kernel_results:
+            final_result = list(kernel_results.values())[-1]
+            if torch.isnan(final_result).any():
+                raise ValueError("Golden output contains NaN! This test case is invalid.")
+            if torch.isinf(final_result).any():
+                raise ValueError("Golden output contains Inf! This test case is invalid.")
+
+            #  golden ，
+            # print(f"✓ Golden validation passed (no NaN/Inf detected)")
+            # print(f"  Golden output shape: {final_result.shape}")
+            # print(f"  Golden output sample values: min={final_result.min().item():.6f}, "
+            #       f"max={final_result.max().item():.6f}, mean={final_result.mean().item():.6f}")
+            # print(f"  Golden output[0,0] = {final_result[0,0].item():.6f}")

--- a/tests/st/fuzz/src/orchestrator_generator.py
+++ b/tests/st/fuzz/src/orchestrator_generator.py
@@ -1,0 +1,310 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Orchestration orchestration function
+
+This module is responsible for generating @pl.function(type=pl.FunctionType.Orchestration) ，
+multiple InCore kernels。：
+- Sequential: kernels
+- Branching: kernels
+- Mixed:
+"""
+
+import random
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class OrchestratorGenerator:
+    """Orchestration orchestration function"""
+
+    def __init__(self, seed: Optional[int] = None):
+        """orchestration function
+
+        Args:
+            seed: ，
+        """
+        self.rng = random.Random(seed)
+
+    def generate_sequential(
+        self,
+        kernels: List[Dict[str, Any]],
+        shape: Tuple[int, int] = (128, 128),
+    ) -> Dict[str, Any]:
+        """Orchestration
+
+        ，kernelskernels。
+
+        Args:
+            kernels: kernels
+            shape:
+
+        Returns:
+            orchestration function
+        """
+        if not kernels:
+            raise ValueError("kernels")
+
+        input_shapes_map = {}  # {input_name: shape}
+        for kernel in kernels:
+            for inp_name, inp_shape in kernel["inputs"]:
+                if inp_name not in input_shapes_map:
+                    input_shapes_map[inp_name] = inp_shape
+                # kernels，
+                elif inp_shape != input_shapes_map[inp_name]:
+                    existing_size = input_shapes_map[inp_name][0] * input_shapes_map[inp_name][1]
+                    new_size = inp_shape[0] * inp_shape[1]
+                    if new_size > existing_size:
+                        input_shapes_map[inp_name] = inp_shape
+
+        input_params = sorted(input_shapes_map.keys())
+        params = []
+        for name in input_params:
+            inp_shape = input_shapes_map[name]
+            params.append(f"{name}: pl.Tensor[[{inp_shape[0]}, {inp_shape[1]}], pl.FP32]")
+
+        # kernels
+        output_shape = kernels[-1]["output_shape"]
+        rows, cols = output_shape
+
+        code_lines = [
+            "    @pl.function(type=pl.FunctionType.Orchestration)",
+            f"    def orchestrator(self, {', '.join(params)}) -> pl.Tensor[[{rows}, {cols}], pl.FP32]:",
+        ]
+
+        # Call kernels sequentially - each returns a tensor
+        result_var = None
+        for i, kernel in enumerate(kernels):
+            kernel_name = kernel["name"]
+            kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+
+            # For subsequent kernels, use previous kernel's output as first input
+            if i > 0 and result_var:
+                kernel_inputs[0] = result_var
+
+            # Add scalar arguments
+            scalar_args = [value for _, value in kernel.get("scalars", [])]
+
+            # InCore kernels return a tensor
+            result_var = f"result_{i}"
+            all_args = kernel_inputs + scalar_args
+            inputs_str = ", ".join(all_args)
+            code_lines.append(f"        {result_var} = self.{kernel_name}({inputs_str})")
+
+        code_lines.append(f"        return {result_var}")
+
+        return {
+            "mode": "sequential",
+            "code": "\n".join(code_lines),
+            "inputs": input_params,
+            "output_shape": output_shape,
+        }
+
+    def generate_branching(
+        self,
+        kernels: List[Dict[str, Any]],
+        shape: Tuple[int, int] = (128, 128),
+    ) -> Dict[str, Any]:
+        """Orchestration
+
+        ，multiplekernels，。
+
+        Args:
+            kernels: kernels
+            shape:
+
+        Returns:
+            orchestration function
+        """
+        if not kernels:
+            raise ValueError("kernels")
+
+        input_shapes_map = {}  # {input_name: shape}
+        for kernel in kernels:
+            for inp_name, inp_shape in kernel["inputs"]:
+                if inp_name not in input_shapes_map:
+                    input_shapes_map[inp_name] = inp_shape
+                # kernels，
+                elif inp_shape != input_shapes_map[inp_name]:
+                    existing_size = input_shapes_map[inp_name][0] * input_shapes_map[inp_name][1]
+                    new_size = inp_shape[0] * inp_shape[1]
+                    if new_size > existing_size:
+                        input_shapes_map[inp_name] = inp_shape
+
+        input_params = sorted(input_shapes_map.keys())
+        params = []
+        for name in input_params:
+            inp_shape = input_shapes_map[name]
+            params.append(f"{name}: pl.Tensor[[{inp_shape[0]}, {inp_shape[1]}], pl.FP32]")
+
+        # ：，
+        # kernels
+        output_shape = kernels[0]["output_shape"]
+        rows, cols = output_shape
+
+        code_lines = [
+            "    @pl.function(type=pl.FunctionType.Orchestration)",
+            f"    def orchestrator(self, {', '.join(params)}) -> pl.Tensor[[{rows}, {cols}], pl.FP32]:",
+        ]
+
+        # kernels -  tensor
+        result_vars = []
+        for i, kernel in enumerate(kernels):
+            kernel_name = kernel["name"]
+            kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+            result_var = f"branch_{i}"
+            result_vars.append(result_var)
+
+            # Add scalar arguments
+            scalar_args = [value for _, value in kernel.get("scalars", [])]
+            all_args = kernel_inputs + scalar_args
+            inputs_str = ", ".join(all_args)
+            code_lines.append(f"        {result_var} = self.{kernel_name}({inputs_str})")
+
+        if len(result_vars) == 1:
+            code_lines.append(f"        return {result_vars[0]}")
+        else:
+            #  add
+            code_lines.append("        # ")
+            merged = result_vars[0]
+            for i in range(1, len(result_vars)):
+                new_merged = f"merged_{i}"
+                code_lines.append(f"        {new_merged} = self.merge_results({merged}, {result_vars[i]})")
+                merged = new_merged
+            code_lines.append(f"        return {merged}")
+
+        return {
+            "mode": "branching",
+            "code": "\n".join(code_lines),
+            "inputs": input_params,
+            "output_shape": output_shape,
+            "needs_merge_kernel": len(result_vars) > 1,
+        }
+
+    def generate_mixed(
+        self,
+        kernels: List[Dict[str, Any]],
+        shape: Tuple[int, int] = (128, 128),
+    ) -> Dict[str, Any]:
+        """Orchestration
+
+        。
+
+        Args:
+            kernels: kernels
+            shape:
+
+        Returns:
+            orchestration function
+        """
+        if len(kernels) < 2:
+            # kernels2，
+            return self.generate_sequential(kernels, shape)
+
+        input_shapes_map = {}  # {input_name: shape}
+        for kernel in kernels:
+            for inp_name, inp_shape in kernel["inputs"]:
+                if inp_name not in input_shapes_map:
+                    input_shapes_map[inp_name] = inp_shape
+                # kernels，
+                elif inp_shape != input_shapes_map[inp_name]:
+                    existing_size = input_shapes_map[inp_name][0] * input_shapes_map[inp_name][1]
+                    new_size = inp_shape[0] * inp_shape[1]
+                    if new_size > existing_size:
+                        input_shapes_map[inp_name] = inp_shape
+
+        input_params = sorted(input_shapes_map.keys())
+        params = []
+        for name in input_params:
+            inp_shape = input_shapes_map[name]
+            params.append(f"{name}: pl.Tensor[[{inp_shape[0]}, {inp_shape[1]}], pl.FP32]")
+
+        # kernels
+        output_shape = kernels[-1]["output_shape"]
+        rows, cols = output_shape
+
+        code_lines = [
+            "    @pl.function(type=pl.FunctionType.Orchestration)",
+            f"    def orchestrator(self, {', '.join(params)}) -> pl.Tensor[[{rows}, {cols}], pl.FP32]:",
+        ]
+
+        # kernels：，
+        mid = len(kernels) // 2
+        parallel_kernels = kernels[:mid]
+        sequential_kernels = kernels[mid:]
+
+        #  -  tensor
+        branch_results = []
+        for i, kernel in enumerate(parallel_kernels):
+            kernel_name = kernel["name"]
+            kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+            result_var = f"parallel_{i}"
+            branch_results.append(result_var)
+
+            # Add scalar arguments
+            scalar_args = [value for _, value in kernel.get("scalars", [])]
+            all_args = kernel_inputs + scalar_args
+            inputs_str = ", ".join(all_args)
+            code_lines.append(f"        {result_var} = self.{kernel_name}({inputs_str})")
+
+        if len(branch_results) > 1:
+            code_lines.append("        # ")
+            merged = branch_results[0]
+            for i in range(1, len(branch_results)):
+                new_merged = f"merged_parallel_{i}"
+                code_lines.append(f"        {new_merged} = self.merge_results({merged}, {branch_results[i]})")
+                merged = new_merged
+            current_result = merged
+        else:
+            current_result = branch_results[0]
+
+        for i, kernel in enumerate(sequential_kernels):
+            kernel_name = kernel["name"]
+            kernel_inputs = [inp[0] for inp in kernel["inputs"]]
+
+            kernel_inputs[0] = current_result
+
+            result_var = f"sequential_{i}"
+            # Add scalar arguments
+            scalar_args = [value for _, value in kernel.get("scalars", [])]
+            all_args = kernel_inputs + scalar_args
+            inputs_str = ", ".join(all_args)
+            code_lines.append(f"        {result_var} = self.{kernel_name}({inputs_str})")
+            current_result = result_var
+
+        code_lines.append(f"        return {current_result}")
+
+        return {
+            "mode": "mixed",
+            "code": "\n".join(code_lines),
+            "inputs": input_params,
+            "output_shape": output_shape,
+            "needs_merge_kernel": len(branch_results) > 1,
+        }
+
+    def generate_merge_kernel(self, shape: Tuple[int, int] = (128, 128)) -> str:
+        """kernels
+
+        Args:
+            shape:
+
+        Returns:
+            kernels
+        """
+        rows, cols = shape
+        code = f"""    @pl.function(type=pl.FunctionType.InCore)
+    def merge_results(self, a: pl.Tensor[[{rows}, {cols}], pl.FP32],
+                      b: pl.Tensor[[{rows}, {cols}], pl.FP32],
+                      output: pl.Tensor[[{rows}, {cols}], pl.FP32]) -> pl.Tensor[[{rows}, {cols}], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[{rows}, {cols}])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[{rows}, {cols}])
+        result_tile = pl.add(tile_a, tile_b)
+        result = pl.store(result_tile, offsets=[0, 0], shapes=[{rows}, {cols}], output_tensor=output)
+        return result"""
+        return code

--- a/tests/st/harness/adapters/golden_generator.py
+++ b/tests/st/harness/adapters/golden_generator.py
@@ -129,6 +129,8 @@ class GoldenGenerator:
         # faithfully represented in generated source code.
         if init_fn is torch.randn:
             return f"torch.randn({shape_str}, dtype={dtype_str})"
+        if init_fn is torch.rand:
+            return f"torch.rand({shape_str}, dtype={dtype_str})"
         if init_fn is torch.zeros:
             return f"torch.zeros({shape_str}, dtype={dtype_str})"
         if init_fn is torch.ones:
@@ -140,7 +142,7 @@ class GoldenGenerator:
             f"Callable init_value={init_fn!r} for tensor {spec.name!r} "
             "is not supported by GoldenGenerator. "
             "Use a scalar, a tensor, or a supported torch initializer "
-            "(torch.randn, torch.zeros, torch.ones)."
+            "(torch.randn, torch.rand, torch.zeros, torch.ones)."
         )
 
     def _generate_tensor_init(self, spec: "TensorSpec", shape_str: str, dtype_str: str) -> str:


### PR DESCRIPTION
## Add fuzzing test framework for PyPTO

This PR adds a fuzzing test framework for testing PyPTO IR compilation and execution.

### Supported operators

**Binary ops:** `add`, `sub`, `mul`, `div`, `maximum`, `minimum`  
**Scalar ops:** `adds`, `subs`, `muls`, `divs`  
**Unary ops:** `sqrt`, `rsqrt`, `exp`, `neg`, `recip`, `log`, `abs`, `relu`  
**Row operations:** `row_expand_add/sub/mul/div`, `row_sum/max/min`  
**Column operations:** `col_expand_mul/div/sub`, `col_sum/max/min`  
**Matrix ops:** `matmul`

### Features

- Random IR program generation with operator combinations
- Multi-kernel test generator for orchestration
- PyTorch golden reference validation
- Alignment constraint handling for memory operations

### Usage
Generate use cases：
```bash
python tests/st/fuzz/example_mutil_kernel.py
```
Config structure (tests/st/fuzz/example_mutil_kernel.py   def get_default_configs):

name - Config name
num_instances - Number of test cases to generate
seed - Random seed
enable_advanced_ops - Enable advanced operators
num_kernels - Number of kernels per test
mode - Execution mode (branching/sequential)
shape - Default tensor shape
num_ops_range - (min, max) operators per kernel
tensor_init_type - Tensor initialization (random/constant)

### Next steps
Add more operators: tile, transpose, reshape, concat, split
Add control flow statements: if, while, for
Add dynamic shape support