### PR TITLE
chore: add PR template, security policy, and update github-pr skill

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -74,26 +74,20 @@ gh auth status
 
 **If gh available**:
 
+1. Read `.github/PULL_REQUEST_TEMPLATE.md` to understand the expected PR format
+2. Fill in all template sections based on the actual changes (from commit history and diff)
+3. Create the PR:
+
 ```bash
 gh pr create \
   --title "Brief description of changes" \
   --body "$(cat <<'EOF'
-## Summary
-- Key change 1
-- Key change 2
-
-## Testing
-- [ ] All tests pass
-- [ ] Code review completed
-- [ ] Documentation updated
-
-## Related Issues
-Fixes #ISSUE_NUMBER (if applicable)
+<body follows .github/PULL_REQUEST_TEMPLATE.md structure, filled in from commits and diff>
 EOF
 )"
 ```
 
-**PR Title/Body**: Auto-extracted from commit messages since upstream/main.
+**PR Title/Body**: Auto-extracted from commit messages since upstream/main. Body must follow the PR template structure.
 
 **Important**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Change type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code cleanup
+- [ ] Documentation
+- [ ] Tests
+- [ ] Other (describe below)
+
+## Cross-layer checklist
+
+If this PR modifies public APIs, ensure all layers are synchronized:
+
+- [ ] C++ header (`include/pypto/`) and implementation (`src/`)
+- [ ] Python bindings (`python/bindings/`)
+- [ ] Type stubs (`python/pypto/pypto_core/__init__.pyi`)
+- [ ] N/A — no public API changes
+
+## Test plan
+
+<!-- How were these changes verified? -->
+
+- [ ] Existing tests pass (`ctest --test-dir build`)
+- [ ] New tests added (describe below)
+- [ ] Manual verification (describe below)
+
+## Related issues
+
+<!-- Link to relevant GitHub issues, e.g., Fixes #123 -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+| Version / Branch | Supported |
+|------------------|-----------|
+| `main`           | Yes       |
+| Feature branches | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open public issues for security vulnerabilities.**
+
+To report a vulnerability:
+
+1. Go to the [Security Advisories](https://github.com/hw-native-sys/pypto/security/advisories) page
+2. Click **"Report a vulnerability"**
+3. Provide a description of the issue, steps to reproduce, and any potential impact
+
+### What to expect
+
+- **Acknowledgement** within 3 business days
+- **Initial assessment** within 10 business days
+- Regular updates until the issue is resolved or determined to be non-applicable
+
+## Scope
+
+The following are considered security issues:
+
+- Arbitrary code execution via crafted IR or model inputs
+- Memory safety issues in the C++ layer (buffer overflows, use-after-free)
+- Vulnerabilities in third-party dependencies
+- Unsafe deserialization of untrusted data
+
+The following are generally **not** security issues:
+
+- Crashes from intentionally malformed internal IR (developer-facing)
+- Performance issues or denial-of-service from large inputs
+- Issues requiring local filesystem access beyond normal usage
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Reporter submits vulnerability privately via GitHub Security Advisories
+2. Team confirms, develops, and tests a fix
+3. Fix is released and advisory is published
+4. Reporter is credited (unless they prefer anonymity)
+
+We ask reporters to allow a reasonable timeframe for fixes before public disclosure.


### PR DESCRIPTION
## Summary

Add community health files to the repository:
- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — standardized PR format with cross-layer checklist, change type, and test plan sections
- **Security policy** (`SECURITY.md`) — vulnerability reporting instructions via GitHub Security Advisories
- **Updated `github-pr` skill** — reads the PR template instead of hardcoding the body format

## Change type

- [x] Other (describe below)

Community health files and CI/tooling configuration.

## Cross-layer checklist

- [x] N/A — no public API changes

## Test plan

- [x] Manual verification (describe below)

Pre-commit hooks pass. No code changes — only markdown and skill configuration files.

## Related issues

None.