### PR TITLE
Modernize Python type annotations to 3.10+ syntax

### DIFF
--- a/examples/ir_parser/orchestration_example.py
+++ b/examples/ir_parser/orchestration_example.py
@@ -191,7 +191,7 @@ def main():
     if os.path.exists(orch_file):
         print("\n[5] Generated Orchestration C++ (preview):")
         print("=" * 70)
-        with open(orch_file, "r") as f:
+        with open(orch_file) as f:
             content = f.read()
             lines = content.split("\n")
             preview_lines = min(50, len(lines))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ select = [
     "E",  # pycodestyle errors, https://docs.astral.sh/ruff/rules/#error-e
     "W",  # pycodestyle warnings, https://docs.astral.sh/ruff/rules/#warning-w
     "F",  # pyflakes, https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "UP", # pyupgrade, https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 ignore = [
   "ANN401",  # flake8-annotations: any-type

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -15,8 +15,8 @@ automatic span tracking via the inspect module.
 """
 
 import inspect
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from typing import Iterator, Optional, Sequence, Union
 
 from pypto.pypto_core import DataType, ir
 from pypto.pypto_core.ir import IRBuilder as CppIRBuilder
@@ -54,7 +54,7 @@ class IRBuilder:
 
     @contextmanager
     def function(
-        self, name: str, span: Optional[ir.Span] = None, type: ir.FunctionType = ir.FunctionType.Opaque
+        self, name: str, span: ir.Span | None = None, type: ir.FunctionType = ir.FunctionType.Opaque
     ) -> Iterator["FunctionBuilder"]:
         """Context manager for building functions.
 
@@ -94,10 +94,10 @@ class IRBuilder:
     def for_loop(
         self,
         loop_var: ir.Var,
-        start: Union[int, ir.Expr],
-        stop: Union[int, ir.Expr],
-        step: Union[int, ir.Expr],
-        span: Optional[ir.Span] = None,
+        start: int | ir.Expr,
+        stop: int | ir.Expr,
+        step: int | ir.Expr,
+        span: ir.Span | None = None,
         kind: ir.ForKind = ir.ForKind.Sequential,
     ) -> Iterator["ForLoopBuilder"]:
         """Context manager for building for loops.
@@ -141,7 +141,7 @@ class IRBuilder:
 
     @contextmanager
     def while_loop(
-        self, condition: Union[int, ir.Expr], span: Optional[ir.Span] = None
+        self, condition: int | ir.Expr, span: ir.Span | None = None
     ) -> Iterator["WhileLoopBuilder"]:
         """Context manager for building while loops.
 
@@ -176,9 +176,7 @@ class IRBuilder:
             del self._begin_spans[ctx_id]
 
     @contextmanager
-    def if_stmt(
-        self, condition: Union[int, ir.Expr], span: Optional[ir.Span] = None
-    ) -> Iterator["IfStmtBuilder"]:
+    def if_stmt(self, condition: int | ir.Expr, span: ir.Span | None = None) -> Iterator["IfStmtBuilder"]:
         """Context manager for building if statements.
 
         Args:
@@ -214,7 +212,7 @@ class IRBuilder:
             del self._begin_spans[ctx_id]
 
     @contextmanager
-    def scope(self, scope_kind: ir.ScopeKind, span: Optional[ir.Span] = None) -> Iterator["ScopeBuilder"]:
+    def scope(self, scope_kind: ir.ScopeKind, span: ir.Span | None = None) -> Iterator["ScopeBuilder"]:
         """Context manager for building scope statements.
 
         Args:
@@ -246,7 +244,7 @@ class IRBuilder:
             del self._begin_spans[ctx_id]
 
     @contextmanager
-    def program(self, name: str, span: Optional[ir.Span] = None) -> Iterator["ProgramBuilder"]:
+    def program(self, name: str, span: ir.Span | None = None) -> Iterator["ProgramBuilder"]:
         """Context manager for building programs.
 
         Args:
@@ -292,7 +290,7 @@ class IRBuilder:
 
     # ========== Single-line Methods with Optional Explicit Span ==========
 
-    def var(self, name: str, type: ir.Type, span: Optional[ir.Span] = None) -> ir.Var:
+    def var(self, name: str, type: ir.Type, span: ir.Span | None = None) -> ir.Var:
         """Create a variable with span from call site or explicit span.
 
         Args:
@@ -309,8 +307,8 @@ class IRBuilder:
     def assign(
         self,
         var: ir.Var,
-        value: Union[int, float, ir.Expr],
-        span: Optional[ir.Span] = None,
+        value: int | float | ir.Expr,
+        span: ir.Span | None = None,
     ) -> ir.AssignStmt:
         """Create assignment statement and emit it.
 
@@ -329,9 +327,9 @@ class IRBuilder:
     def let(
         self,
         name: str,
-        value: Union[int, float, ir.Expr],
-        type: Optional[ir.Type] = None,
-        span: Optional[ir.Span] = None,
+        value: int | float | ir.Expr,
+        type: ir.Type | None = None,
+        span: ir.Span | None = None,
     ) -> ir.Var:
         """Create a variable and assign a value to it in one statement.
 
@@ -401,8 +399,8 @@ class IRBuilder:
 
     def make_tuple(
         self,
-        elements: Sequence[Union[ir.Expr, ir.Var]],
-        span: Optional[ir.Span] = None,
+        elements: Sequence[ir.Expr | ir.Var],
+        span: ir.Span | None = None,
     ) -> ir.MakeTuple:
         """Create a tuple construction expression.
 
@@ -432,8 +430,8 @@ class IRBuilder:
 
     def return_stmt(
         self,
-        values: Optional[Union[int, float, ir.Expr, Sequence[Union[int, float, ir.Expr]]]] = None,
-        span: Optional[ir.Span] = None,
+        values: int | float | ir.Expr | Sequence[int | float | ir.Expr] | None = None,
+        span: ir.Span | None = None,
     ) -> ir.ReturnStmt:
         """Create return statement and emit it.
 
@@ -461,8 +459,8 @@ class IRBuilder:
 
     def eval_stmt(
         self,
-        expr: Union[int, float, ir.Expr],
-        span: Optional[ir.Span] = None,
+        expr: int | float | ir.Expr,
+        span: ir.Span | None = None,
     ) -> ir.EvalStmt:
         """Create evaluation statement and emit it.
 
@@ -502,10 +500,10 @@ class IRBuilder:
     def memref(
         self,
         memory_space: ir.MemorySpace,
-        addr: Union[int, ir.Expr],
+        addr: int | ir.Expr,
         size: int,
         id: int,
-        span: Optional[ir.Span] = None,
+        span: ir.Span | None = None,
     ) -> ir.MemRef:
         """Create a MemRef with normalized address expression.
 
@@ -529,10 +527,10 @@ class IRBuilder:
 
     def tile_view(
         self,
-        valid_shape: Sequence[Union[int, ir.Expr]],
-        stride: Sequence[Union[int, ir.Expr]],
-        start_offset: Union[int, ir.Expr],
-        span: Optional[ir.Span] = None,
+        valid_shape: Sequence[int | ir.Expr],
+        stride: Sequence[int | ir.Expr],
+        start_offset: int | ir.Expr,
+        span: ir.Span | None = None,
     ) -> ir.TileView:
         """Create a TileView with normalized expressions.
 
@@ -559,9 +557,9 @@ class IRBuilder:
 
     def tensor_view(
         self,
-        stride: Sequence[Union[int, ir.Expr]],
+        stride: Sequence[int | ir.Expr],
         layout: ir.TensorLayout,
-        span: Optional[ir.Span] = None,
+        span: ir.Span | None = None,
     ) -> ir.TensorView:
         """Create a TensorView with normalized stride expressions.
 
@@ -583,11 +581,11 @@ class IRBuilder:
 
     def tensor_type(
         self,
-        shape: Sequence[Union[int, ir.Expr]],
+        shape: Sequence[int | ir.Expr],
         dtype: DataType,
-        memref: Optional[ir.MemRef] = None,
-        tensor_view: Optional[ir.TensorView] = None,
-        span: Optional[ir.Span] = None,
+        memref: ir.MemRef | None = None,
+        tensor_view: ir.TensorView | None = None,
+        span: ir.Span | None = None,
     ) -> ir.TensorType:
         """Create a TensorType with normalized shape, optional memref and tensor_view.
 
@@ -617,11 +615,11 @@ class IRBuilder:
 
     def tile_type(
         self,
-        shape: Sequence[Union[int, ir.Expr]],
+        shape: Sequence[int | ir.Expr],
         dtype: DataType,
-        memref: Optional[ir.MemRef] = None,
-        tile_view: Optional[ir.TileView] = None,
-        span: Optional[ir.Span] = None,
+        memref: ir.MemRef | None = None,
+        tile_view: ir.TileView | None = None,
+        span: ir.Span | None = None,
     ) -> ir.TileType:
         """Create a TileType with normalized shape, optional memref and tile_view.
 
@@ -696,9 +694,9 @@ class FunctionBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.Function] = None
+        self._result: ir.Function | None = None
 
-    def param(self, name: str, type: ir.Type, span: Optional[ir.Span] = None) -> ir.Var:
+    def param(self, name: str, type: ir.Type, span: ir.Span | None = None) -> ir.Var:
         """Add function parameter.
 
         Args:
@@ -740,16 +738,16 @@ class ForLoopBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.ForStmt] = None
+        self._result: ir.ForStmt | None = None
         self._iter_args: list[ir.IterArg] = []  # Track iter_args for type inference
         self._return_var_count = 0  # Track number of return_vars added
 
     def iter_arg(
         self,
         name: str,
-        init_value: Union[int, float, ir.Expr],
-        type: Optional[ir.Type] = None,
-        span: Optional[ir.Span] = None,
+        init_value: int | float | ir.Expr,
+        type: ir.Type | None = None,
+        span: ir.Span | None = None,
     ) -> ir.IterArg:
         """Add iteration argument (loop-carried value).
 
@@ -794,7 +792,7 @@ class ForLoopBuilder:
         self._iter_args.append(iter_arg)  # Track for return_var type inference
         return iter_arg
 
-    def return_var(self, name: str, type: Optional[ir.Type] = None, span: Optional[ir.Span] = None) -> ir.Var:
+    def return_var(self, name: str, type: ir.Type | None = None, span: ir.Span | None = None) -> ir.Var:
         """Add return variable to capture final iteration value.
 
         The type can be automatically inferred from the corresponding iter_arg (by index).
@@ -925,16 +923,16 @@ class WhileLoopBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.WhileStmt] = None
+        self._result: ir.WhileStmt | None = None
         self._iter_args: list[ir.IterArg] = []  # Track iter_args for type inference
         self._return_var_count = 0  # Track number of return_vars added
 
     def iter_arg(
         self,
         name: str,
-        init_value: Union[int, float, ir.Expr],
-        type: Optional[ir.Type] = None,
-        span: Optional[ir.Span] = None,
+        init_value: int | float | ir.Expr,
+        type: ir.Type | None = None,
+        span: ir.Span | None = None,
     ) -> ir.IterArg:
         """Add iteration argument (loop-carried value).
 
@@ -979,7 +977,7 @@ class WhileLoopBuilder:
         self._iter_args.append(iter_arg)  # Track for return_var type inference
         return iter_arg
 
-    def set_condition(self, condition: Union[int, ir.Expr]) -> None:
+    def set_condition(self, condition: int | ir.Expr) -> None:
         """Set the condition for the while loop.
 
         Used to update the loop condition after setting up iter_args. This allows
@@ -997,7 +995,7 @@ class WhileLoopBuilder:
         condition_expr = _normalize_expr(condition, actual_span)
         self._builder._builder.set_while_loop_condition(condition_expr)
 
-    def return_var(self, name: str, type: Optional[ir.Type] = None, span: Optional[ir.Span] = None) -> ir.Var:
+    def return_var(self, name: str, type: ir.Type | None = None, span: ir.Span | None = None) -> ir.Var:
         """Add return variable to capture final iteration value.
 
         The type can be automatically inferred from the corresponding iter_arg (by index).
@@ -1125,7 +1123,7 @@ class ScopeBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.ScopeStmt] = None
+        self._result: ir.ScopeStmt | None = None
 
     def get_result(self) -> ir.ScopeStmt:
         """Get the built ScopeStmt.
@@ -1147,9 +1145,9 @@ class IfStmtBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.IfStmt] = None
+        self._result: ir.IfStmt | None = None
 
-    def else_(self, span: Optional[ir.Span] = None) -> None:
+    def else_(self, span: ir.Span | None = None) -> None:
         """Begin else branch of the if statement.
 
         Args:
@@ -1158,7 +1156,7 @@ class IfStmtBuilder:
         actual_span = span if span is not None else self._builder._capture_call_span()
         self._builder._builder.begin_else(actual_span)
 
-    def return_var(self, name: str, type: ir.Type, span: Optional[ir.Span] = None) -> None:
+    def return_var(self, name: str, type: ir.Type, span: ir.Span | None = None) -> None:
         """Add return variable for SSA phi node.
 
         Note: Type must be provided explicitly. Type inference is not supported for
@@ -1253,7 +1251,7 @@ class ProgramBuilder:
             builder: Parent IR builder
         """
         self._builder = builder
-        self._result: Optional[ir.Program] = None
+        self._result: ir.Program | None = None
 
     def declare_function(self, name: str) -> ir.GlobalVar:
         """Declare a function and get its GlobalVar for cross-function calls.

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -11,7 +11,6 @@
 
 import os
 from datetime import datetime
-from typing import Optional
 
 from pypto.backend import BackendType
 from pypto.pypto_core import backend as _backend_core
@@ -23,7 +22,7 @@ from .pass_manager import OptimizationStrategy, PassManager
 
 def compile(
     program: _ir_core.Program,
-    output_dir: Optional[str] = None,
+    output_dir: str | None = None,
     strategy: OptimizationStrategy = OptimizationStrategy.Default,
     dump_passes: bool = True,
     backend_type: BackendType = BackendType.PTO,

--- a/python/pypto/ir/op/block_ops.py
+++ b/python/pypto/ir/op/block_ops.py
@@ -14,7 +14,8 @@ These operations include memory operations (load, store), element-wise operation
 unary operations, and reduction operations.
 """
 
-from typing import Any, Literal, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Literal
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
@@ -31,7 +32,7 @@ def create_tile(
     shape: Sequence[int],
     dtype: DataType,
     target_memory: int = 1,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Create a tile from a shape.
 
@@ -53,10 +54,10 @@ def create_tile(
 
 def load(
     tensor: Expr,
-    offsets: Sequence[Union[int, Expr]],
-    shapes: Sequence[Union[int, Expr]],
+    offsets: Sequence[int | Expr],
+    shapes: Sequence[int | Expr],
     target_memory: int = 1,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Copy data from tensor to specified memory level.
 
@@ -111,10 +112,10 @@ def load(
 
 def store(
     tile: Expr,
-    offsets: Sequence[Union[int, Expr]],
-    shapes: Sequence[Union[int, Expr]],
+    offsets: Sequence[int | Expr],
+    shapes: Sequence[int | Expr],
     output_tensor: Expr,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Copy data from unified buffer (tile) to tensor.
 
@@ -161,10 +162,10 @@ def store(
 
 def l0c_store(
     tile: Expr,
-    offsets: Sequence[Union[int, Expr]],
-    shapes: Sequence[Union[int, Expr]],
+    offsets: Sequence[int | Expr],
+    shapes: Sequence[int | Expr],
     output_tensor: Expr,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Copy data from L0C tile to GM tensor.
 
@@ -213,7 +214,7 @@ def move(
     tile: Expr,
     target_memory: int,
     transpose: bool = False,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Move tile between memory levels with optional transpose.
 
@@ -240,7 +241,7 @@ def move(
 
 def ub_copy(
     tile: Expr,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Copy tile within UB (Unified Buffer) memory.
 
@@ -258,7 +259,7 @@ def ub_copy(
     return _ir_core.create_op_call("block.ub_copy", [tile], {}, actual_span)
 
 
-def get_block_idx(span: Optional[Span] = None) -> Call:
+def get_block_idx(span: Span | None = None) -> Call:
     """Get the current block index.
 
     This operation returns the index of the current compute block. It is typically
@@ -283,8 +284,8 @@ def get_block_idx(span: Optional[Span] = None) -> Call:
 def full(
     shape: Sequence[int],
     dtype: DataType,
-    value: Union[int, float],
-    span: Optional[Span] = None,
+    value: int | float,
+    span: Span | None = None,
 ) -> Call:
     """Create a tile from a shape and fill with value in UB.
 
@@ -313,7 +314,7 @@ def full(
 # ============================================================================
 
 
-def mul(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def mul(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise multiplication of two tiles.
 
     Supports broadcasting for two tiles.
@@ -330,7 +331,7 @@ def mul(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.mul", [lhs, rhs], {}, actual_span)
 
 
-def add(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def add(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise addition of two tiles.
 
     Supports broadcasting for two tiles.
@@ -347,7 +348,7 @@ def add(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.add", [lhs, rhs], {}, actual_span)
 
 
-def div(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def div(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise division of two tiles.
 
     Supports broadcasting for two tiles.
@@ -364,7 +365,7 @@ def div(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.div", [lhs, rhs], {}, actual_span)
 
 
-def sub(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def sub(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise subtraction of two tiles.
 
     Supports broadcasting for two tiles.
@@ -381,7 +382,7 @@ def sub(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.sub", [lhs, rhs], {}, actual_span)
 
 
-def muls(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def muls(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise multiplication of tile and scalar.
 
     Args:
@@ -401,7 +402,7 @@ def muls(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -
     return _ir_core.create_op_call("block.muls", [lhs, rhs_expr], {}, actual_span)
 
 
-def adds(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def adds(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise addition of tile and scalar.
 
     Args:
@@ -421,7 +422,7 @@ def adds(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -
     return _ir_core.create_op_call("block.adds", [lhs, rhs_expr], {}, actual_span)
 
 
-def divs(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def divs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise division of tile and scalar.
 
     Args:
@@ -441,7 +442,7 @@ def divs(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -
     return _ir_core.create_op_call("block.divs", [lhs, rhs_expr], {}, actual_span)
 
 
-def subs(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def subs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise subtraction of tile and scalar.
 
     Args:
@@ -461,7 +462,7 @@ def subs(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -
     return _ir_core.create_op_call("block.subs", [lhs, rhs_expr], {}, actual_span)
 
 
-def cmp(lhs: Expr, rhs: Expr, cmp_type: int = 0, span: Optional[Span] = None) -> Call:
+def cmp(lhs: Expr, rhs: Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
     """Element-wise comparison of two tiles (returns boolean tile).
 
     Args:
@@ -483,9 +484,9 @@ def cmp(lhs: Expr, rhs: Expr, cmp_type: int = 0, span: Optional[Span] = None) ->
 
 def cmps(
     lhs: Expr,
-    rhs: Union[int, float, Expr],
+    rhs: int | float | Expr,
     cmp_type: int = 0,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Element-wise comparison of tile and scalar (returns boolean tile).
 
@@ -515,7 +516,7 @@ def cmps(
 # ============================================================================
 
 
-def neg(tile: Expr, span: Optional[Span] = None) -> Call:
+def neg(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise negation of a tile.
 
     Args:
@@ -529,7 +530,7 @@ def neg(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.neg", [tile], {}, actual_span)
 
 
-def exp(tile: Expr, span: Optional[Span] = None) -> Call:
+def exp(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise exponential function of a tile.
 
     Args:
@@ -543,7 +544,7 @@ def exp(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.exp", [tile], {}, actual_span)
 
 
-def recip(tile: Expr, span: Optional[Span] = None) -> Call:
+def recip(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise reciprocal (1/x) of a tile.
 
     Args:
@@ -557,7 +558,7 @@ def recip(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.recip", [tile], {}, actual_span)
 
 
-def sqrt(tile: Expr, span: Optional[Span] = None) -> Call:
+def sqrt(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise square root of a tile.
 
     Args:
@@ -571,7 +572,7 @@ def sqrt(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.sqrt", [tile], {}, actual_span)
 
 
-def rsqrt(tile: Expr, span: Optional[Span] = None) -> Call:
+def rsqrt(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise reciprocal square root (1/sqrt(x)) of a tile.
 
     Args:
@@ -587,9 +588,9 @@ def rsqrt(tile: Expr, span: Optional[Span] = None) -> Call:
 
 def cast(
     tile: Expr,
-    target_type: Union[int, DataType],
+    target_type: int | DataType,
     mode: Literal["none", "rint", "round", "floor", "ceil", "trunc", "odd"] = "round",
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Cast tile to target data type (element-wise).
 
@@ -616,7 +617,7 @@ def cast(
     return _ir_core.create_op_call("block.cast", [tile], kwargs, actual_span)
 
 
-def log(tile: Expr, span: Optional[Span] = None) -> Call:
+def log(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise natural logarithm of a tile.
 
     Args:
@@ -630,7 +631,7 @@ def log(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.log", [tile], {}, actual_span)
 
 
-def abs(tile: Expr, span: Optional[Span] = None) -> Call:
+def abs(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise absolute value of a tile.
 
     Args:
@@ -644,7 +645,7 @@ def abs(tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.abs", [tile], {}, actual_span)
 
 
-def relu(tile: Expr, span: Optional[Span] = None) -> Call:
+def relu(tile: Expr, span: Span | None = None) -> Call:
     """Element-wise ReLU activation function (max(0, x)) of a tile.
 
     Args:
@@ -663,7 +664,7 @@ def relu(tile: Expr, span: Optional[Span] = None) -> Call:
 # ============================================================================
 
 
-def matmul(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def matmul(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Matrix multiplication of two tiles.
 
     Args:
@@ -678,7 +679,7 @@ def matmul(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.matmul", [lhs, rhs], {}, actual_span)
 
 
-def matmul_acc(acc: Expr, lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def matmul_acc(acc: Expr, lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Matrix multiplication with accumulation.
 
     Performs matrix multiplication and accumulates the result: acc = acc + lhs @ rhs.
@@ -703,7 +704,7 @@ def matmul_acc(acc: Expr, lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> 
 # ============================================================================
 
 
-def row_expand_sub(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Call:
+def row_expand_sub(tile: Expr, row_vec: Expr, span: Span | None = None) -> Call:
     """Row-wise broadcast subtraction.
 
     Subtracts a row vector from each row of the tile.
@@ -721,7 +722,7 @@ def row_expand_sub(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.row_expand_sub", [tile, row_vec], {}, actual_span)
 
 
-def row_expand_div(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Call:
+def row_expand_div(tile: Expr, row_vec: Expr, span: Span | None = None) -> Call:
     """Row-wise broadcast division.
 
     Divides each row of the tile by the corresponding row vector value.
@@ -739,7 +740,7 @@ def row_expand_div(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.row_expand_div", [tile, row_vec], {}, actual_span)
 
 
-def row_expand_mul(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Call:
+def row_expand_mul(tile: Expr, row_vec: Expr, span: Span | None = None) -> Call:
     """Row-wise broadcast multiplication.
 
     Multiplies each row of the tile by the corresponding row vector value.
@@ -757,7 +758,7 @@ def row_expand_mul(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.row_expand_mul", [tile, row_vec], {}, actual_span)
 
 
-def row_expand_add(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Call:
+def row_expand_add(tile: Expr, row_vec: Expr, span: Span | None = None) -> Call:
     """Row-wise broadcast addition.
 
     Adds a row vector to each row of the tile.
@@ -775,7 +776,7 @@ def row_expand_add(tile: Expr, row_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.row_expand_add", [tile, row_vec], {}, actual_span)
 
 
-def col_expand(target: Expr, col_vec: Expr, span: Optional[Span] = None) -> Call:
+def col_expand(target: Expr, col_vec: Expr, span: Span | None = None) -> Call:
     """Expand column vector [1, cols] to target shape [rows, cols].
 
     Args:
@@ -790,7 +791,7 @@ def col_expand(target: Expr, col_vec: Expr, span: Optional[Span] = None) -> Call
     return _ir_core.create_op_call("block.col_expand", [target, col_vec], {}, actual_span)
 
 
-def col_expand_mul(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Call:
+def col_expand_mul(tile: Expr, col_vec: Expr, span: Span | None = None) -> Call:
     """Expand column vector and multiply with target tile.
 
     Multiplies each column of the tile by the corresponding column vector value.
@@ -808,7 +809,7 @@ def col_expand_mul(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.col_expand_mul", [tile, col_vec], {}, actual_span)
 
 
-def col_expand_div(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Call:
+def col_expand_div(tile: Expr, col_vec: Expr, span: Span | None = None) -> Call:
     """Expand column vector and divide target tile by it.
 
     Divides each column of the tile by the corresponding column vector value.
@@ -826,7 +827,7 @@ def col_expand_div(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.col_expand_div", [tile, col_vec], {}, actual_span)
 
 
-def col_expand_sub(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Call:
+def col_expand_sub(tile: Expr, col_vec: Expr, span: Span | None = None) -> Call:
     """Expand column vector and subtract from target tile.
 
     Subtracts a column vector from each column of the tile.
@@ -844,7 +845,7 @@ def col_expand_sub(tile: Expr, col_vec: Expr, span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("block.col_expand_sub", [tile, col_vec], {}, actual_span)
 
 
-def expands(target: Expr, scalar: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def expands(target: Expr, scalar: int | float | Expr, span: Span | None = None) -> Call:
     """Expand scalar to target tile shape.
 
     Broadcasts a scalar value to match the shape of the target tile.
@@ -866,7 +867,7 @@ def expands(target: Expr, scalar: Union[int, float, Expr], span: Optional[Span] 
     return _ir_core.create_op_call("block.expands", [target, scalar_expr], {}, actual_span)
 
 
-def maximum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def maximum(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise maximum of two tiles.
 
     Supports broadcasting for two tiles.
@@ -883,7 +884,7 @@ def maximum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.maximum", [lhs, rhs], {}, actual_span)
 
 
-def minimum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def minimum(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise minimum of two tiles.
 
     Supports broadcasting for two tiles.
@@ -905,7 +906,7 @@ def minimum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
 # ============================================================================
 
 
-def sum(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = None) -> Call:
+def sum(tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) -> Call:
     """Sum reduction of a tile along specified axis.
 
     Args:
@@ -930,7 +931,7 @@ def sum(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = Non
     return _ir_core.create_op_call("block.sum", args, kwargs, actual_span)
 
 
-def max(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = None) -> Call:
+def max(tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) -> Call:
     """Max reduction of a tile along specified axis.
 
     Args:
@@ -954,7 +955,7 @@ def max(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = Non
     return _ir_core.create_op_call("block.max", args, kwargs, actual_span)
 
 
-def min(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = None) -> Call:
+def min(tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) -> Call:
     """Min reduction of a tile along specified axis.
 
     Args:
@@ -978,7 +979,7 @@ def min(tile: Expr, axis: int, keepdim: bool = False, span: Optional[Span] = Non
     return _ir_core.create_op_call("block.min", args, kwargs, actual_span)
 
 
-def row_max(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
+def row_max(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
     """Row-wise max reduction of a tile.
 
     This is a convenience function equivalent to max(tile, axis=1, keepdim=True).
@@ -996,7 +997,7 @@ def row_max(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.row_max", [tile, tmp_tile], {}, actual_span)
 
 
-def row_sum(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
+def row_sum(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
     """Row-wise sum reduction of a tile.
 
     This is a convenience function equivalent to sum(tile, axis=1, keepdim=True).
@@ -1014,7 +1015,7 @@ def row_sum(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("block.row_sum", [tile, tmp_tile], {}, actual_span)
 
 
-def row_min(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
+def row_min(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
     """Row-wise min reduction (reduces along axis=1, maps to TROWMIN).
 
     Reduces each row to a single value, producing output shape [rows, 1].
@@ -1038,9 +1039,9 @@ def row_min(tile: Expr, tmp_tile: Expr, span: Optional[Span] = None) -> Call:
 
 def view(
     tile: Expr,
-    shape: Sequence[Union[int, Expr]],
-    offset: Sequence[Union[int, Expr]],
-    span: Optional[Span] = None,
+    shape: Sequence[int | Expr],
+    offset: Sequence[int | Expr],
+    span: Span | None = None,
 ) -> Call:
     """Create a view/slice of a tile with new shape and offset.
 
@@ -1067,7 +1068,7 @@ def view(
     return _ir_core.create_op_call("block.view", args, {}, actual_span)
 
 
-def reshape(tile: Expr, shape: Sequence[Union[int, Expr]], span: Optional[Span] = None) -> Call:
+def reshape(tile: Expr, shape: Sequence[int | Expr], span: Span | None = None) -> Call:
     """Reshape tile to new shape.
 
     Args:
@@ -1088,7 +1089,7 @@ def reshape(tile: Expr, shape: Sequence[Union[int, Expr]], span: Optional[Span] 
     return _ir_core.create_op_call("block.reshape", args, {}, actual_span)
 
 
-def transpose(tile: Expr, axis1: int, axis2: int, span: Optional[Span] = None) -> Call:
+def transpose(tile: Expr, axis1: int, axis2: int, span: Span | None = None) -> Call:
     """Transpose tile by swapping two axes.
 
     Args:

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -9,7 +9,8 @@
 
 """Tensor operations for PyPTO IR."""
 
-from typing import Any, Literal, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Literal
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
@@ -18,7 +19,7 @@ from pypto.pypto_core.ir import Call, ConstInt, Expr, ScalarType, Span
 from ..utils import _get_span_or_capture, _normalize_expr
 
 
-def create(shape: Sequence[Union[int, Expr]], dtype: DataType, span: Optional[Span] = None) -> Call:
+def create(shape: Sequence[int | Expr], dtype: DataType, span: Span | None = None) -> Call:
     """Create a new tensor with specified shape and dtype.
 
     Args:
@@ -41,7 +42,7 @@ def create(shape: Sequence[Union[int, Expr]], dtype: DataType, span: Optional[Sp
     return _ir_core.create_op_call("tensor.create", args, kwargs, actual_span)
 
 
-def read(tensor: Expr, indices: list[Union[int, Expr]], span: Optional[Span] = None) -> Call:
+def read(tensor: Expr, indices: list[int | Expr], span: Span | None = None) -> Call:
     """Read a scalar value from a tensor at given indices.
 
     Args:
@@ -62,7 +63,7 @@ def read(tensor: Expr, indices: list[Union[int, Expr]], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.read", args, {}, actual_span)
 
 
-def dim(tensor: Expr, axis: Union[int, Expr], span: Optional[Span] = None) -> Call:
+def dim(tensor: Expr, axis: int | Expr, span: Span | None = None) -> Call:
     """Extract a shape dimension from a tensor as a scalar value.
 
     Args:
@@ -79,9 +80,7 @@ def dim(tensor: Expr, axis: Union[int, Expr], span: Optional[Span] = None) -> Ca
     return _ir_core.create_op_call("tensor.dim", args, {}, actual_span)
 
 
-def view(
-    tensor: Expr, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]], span: Optional[Span] = None
-) -> Call:
+def view(tensor: Expr, shape: list[int | Expr], offset: list[int | Expr], span: Span | None = None) -> Call:
     """Create a view/slice of a tensor with new shape and offset.
 
     Args:
@@ -110,11 +109,11 @@ def view(
 def matmul(
     lhs: Expr,
     rhs: Expr,
-    out_dtype: Optional[Union[int, DataType]] = None,
+    out_dtype: int | DataType | None = None,
     a_trans: bool = False,
     b_trans: bool = False,
     c_matrix_nz: bool = False,
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Matrix multiplication with optional transpose.
 
@@ -146,7 +145,7 @@ def matmul(
     return _ir_core.create_op_call("tensor.matmul", args, kwargs, actual_span)
 
 
-def mul(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def mul(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise multiplication of tensor and tensor or scalar.
 
     Automatically selects between tensor.mul (tensor x tensor) and
@@ -174,7 +173,7 @@ def mul(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) ->
         return _ir_core.create_op_call("tensor.mul", [lhs, rhs_expr], {}, actual_span)
 
 
-def mul_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def mul_scalar(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise multiplication of tensor and scalar.
 
     Args:
@@ -194,7 +193,7 @@ def mul_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.mul_scalar", [lhs, rhs_expr], {}, actual_span)
 
 
-def add(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def add(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise addition of tensor and tensor or scalar.
 
     Automatically selects between tensor.add (tensor + tensor) and
@@ -222,7 +221,7 @@ def add(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) ->
         return _ir_core.create_op_call("tensor.add", [lhs, rhs_expr], {}, actual_span)
 
 
-def add_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def add_scalar(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise addition of tensor and scalar.
 
     Args:
@@ -242,7 +241,7 @@ def add_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.add_scalar", [lhs, rhs_expr], {}, actual_span)
 
 
-def sub(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def sub(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise subtraction of tensor and tensor or scalar.
 
     Automatically selects between tensor.sub (tensor - tensor) and
@@ -270,7 +269,7 @@ def sub(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) ->
         return _ir_core.create_op_call("tensor.sub", [lhs, rhs_expr], {}, actual_span)
 
 
-def sub_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def sub_scalar(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise subtraction of tensor and scalar.
 
     Args:
@@ -290,7 +289,7 @@ def sub_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.sub_scalar", [lhs, rhs_expr], {}, actual_span)
 
 
-def div(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def div(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise division of tensor and tensor or scalar.
 
     Automatically selects between tensor.div (tensor / tensor) and
@@ -318,7 +317,7 @@ def div(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) ->
         return _ir_core.create_op_call("tensor.div", [lhs, rhs_expr], {}, actual_span)
 
 
-def div_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = None) -> Call:
+def div_scalar(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
     """Element-wise division of tensor and scalar.
 
     Args:
@@ -338,7 +337,7 @@ def div_scalar(lhs: Expr, rhs: Union[int, float, Expr], span: Optional[Span] = N
     return _ir_core.create_op_call("tensor.div_scalar", [lhs, rhs_expr], {}, actual_span)
 
 
-def maximum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
+def maximum(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """Element-wise maximum of two tensors.
 
     Args:
@@ -353,7 +352,7 @@ def maximum(lhs: Expr, rhs: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("tensor.maximum", [lhs, rhs], {}, actual_span)
 
 
-def row_max(input: Expr, span: Optional[Span] = None) -> Call:
+def row_max(input: Expr, span: Span | None = None) -> Call:
     """Row-wise max reduction (reduces along last axis, keeps dim).
 
     Args:
@@ -367,7 +366,7 @@ def row_max(input: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("tensor.row_max", [input], {}, actual_span)
 
 
-def row_sum(input: Expr, span: Optional[Span] = None) -> Call:
+def row_sum(input: Expr, span: Span | None = None) -> Call:
     """Row-wise sum reduction (reduces along last axis, keeps dim).
 
     Args:
@@ -381,7 +380,7 @@ def row_sum(input: Expr, span: Optional[Span] = None) -> Call:
     return _ir_core.create_op_call("tensor.row_sum", [input], {}, actual_span)
 
 
-def exp(input: Expr, span: Optional[Span] = None) -> Call:
+def exp(input: Expr, span: Span | None = None) -> Call:
     """Element-wise exponential operation.
 
     Args:
@@ -397,9 +396,9 @@ def exp(input: Expr, span: Optional[Span] = None) -> Call:
 
 def cast(
     input: Expr,
-    target_type: Union[int, DataType],
+    target_type: int | DataType,
     mode: Literal["none", "rint", "round", "floor", "ceil", "trunc", "odd"] = "round",
-    span: Optional[Span] = None,
+    span: Span | None = None,
 ) -> Call:
     """Type casting operation.
 
@@ -428,7 +427,7 @@ def cast(
     return _ir_core.create_op_call("tensor.cast", args, kwargs, actual_span)
 
 
-def assemble(target: Expr, source: Expr, offset: list[Union[int, Expr]], span: Optional[Span] = None) -> Call:
+def assemble(target: Expr, source: Expr, offset: list[int | Expr], span: Span | None = None) -> Call:
     """Write/update tensor values at specified offset.
 
     Args:
@@ -450,7 +449,7 @@ def assemble(target: Expr, source: Expr, offset: list[Union[int, Expr]], span: O
     return _ir_core.create_op_call("tensor.assemble", args, {}, actual_span)
 
 
-def reshape(tensor: Expr, shape: list[Union[int, Expr]], span: Optional[Span] = None) -> Call:
+def reshape(tensor: Expr, shape: list[int | Expr], span: Span | None = None) -> Call:
     """Reshape tensor to new shape.
 
     Args:
@@ -471,7 +470,7 @@ def reshape(tensor: Expr, shape: list[Union[int, Expr]], span: Optional[Span] = 
     return _ir_core.create_op_call("tensor.reshape", args, {}, actual_span)
 
 
-def transpose(tensor: Expr, axis1: int, axis2: int, span: Optional[Span] = None) -> Call:
+def transpose(tensor: Expr, axis1: int, axis2: int, span: Span | None = None) -> Call:
     """Transpose tensor by swapping two axes.
 
     Args:

--- a/python/pypto/ir/operators.py
+++ b/python/pypto/ir/operators.py
@@ -10,7 +10,6 @@
 """Operator overloading with automatic span capture and expression normalization."""
 
 import inspect
-from typing import Union
 
 from pypto.pypto_core import ir as _ir
 
@@ -50,7 +49,7 @@ def _make_binary_op(op_name: str):
         Wrapper function
     """
 
-    def wrapper(self: _ir.Expr, other: Union[int, float, _ir.Expr]) -> _ir.Expr:
+    def wrapper(self: _ir.Expr, other: int | float | _ir.Expr) -> _ir.Expr:
         span = _capture_call_span()
         other_expr = _normalize_expr(other, span)
         return getattr(_ir, op_name)(self, other_expr, span)
@@ -68,7 +67,7 @@ def _make_reverse_binary_op(op_name: str):
         Wrapper function
     """
 
-    def wrapper(self: _ir.Expr, other: Union[int, float, _ir.Expr]) -> _ir.Expr:
+    def wrapper(self: _ir.Expr, other: int | float | _ir.Expr) -> _ir.Expr:
         span = _capture_call_span()
         other_expr = _normalize_expr(other, span)
         return getattr(_ir, op_name)(other_expr, self, span)

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -10,8 +10,8 @@
 """Pass manager for IR transformations."""
 
 import os
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable, Optional
 
 from pypto.pypto_core import ir as core_ir
 from pypto.pypto_core import passes
@@ -105,7 +105,7 @@ class PassManager:
         self,
         input_ir: core_ir.Program,
         dump_ir: bool = False,
-        output_dir: Optional[str] = None,
+        output_dir: str | None = None,
         prefix: str = "pl",
     ) -> core_ir.Program:
         """Execute all passes in sequence on a Program.

--- a/python/pypto/ir/printer.py
+++ b/python/pypto/ir/printer.py
@@ -9,12 +9,10 @@
 
 """Utilities for printing IR nodes in Python syntax."""
 
-from typing import Union
-
 from pypto.pypto_core import ir as _ir_core
 
 
-def python_print(node: Union[_ir_core.IRNode, _ir_core.Type], prefix: str = "pl") -> str:
+def python_print(node: _ir_core.IRNode | _ir_core.Type, prefix: str = "pl") -> str:
     """
     Print IR node or Type object in Python IR syntax.
 

--- a/python/pypto/ir/type.py
+++ b/python/pypto/ir/type.py
@@ -9,7 +9,7 @@
 
 """Type utilities and wrappers for PyPTO IR."""
 
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr, MemRef, TensorType, TensorView, TileType, TileView
@@ -23,10 +23,10 @@ _native_tile_type_init = TileType.__init__
 
 def _tensor_type_init_wrapper(
     self,
-    shape: Sequence[Union[int, Expr]],
+    shape: Sequence[int | Expr],
     dtype: DataType,
-    memref: Optional[MemRef] = None,
-    tensor_view: Optional[TensorView] = None,
+    memref: MemRef | None = None,
+    tensor_view: TensorView | None = None,
 ):
     """Wrapped __init__ for TensorType that supports integer shapes, optional MemRef and TensorView.
 
@@ -44,10 +44,10 @@ def _tensor_type_init_wrapper(
 
 def _tile_type_init_wrapper(
     self,
-    shape: Sequence[Union[int, Expr]],
+    shape: Sequence[int | Expr],
     dtype: DataType,
-    memref: Optional[MemRef] = None,
-    tile_view: Optional[TileView] = None,
+    memref: MemRef | None = None,
+    tile_view: TileView | None = None,
 ):
     """Wrapped __init__ for TileType that supports integer shapes, optional MemRef and TileView.
 

--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -10,13 +10,13 @@
 """Utility functions for IR construction."""
 
 import inspect
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
 
 
-def _get_span_or_capture(span: Optional[_ir.Span] = None, frame_offset: int = 1) -> _ir.Span:
+def _get_span_or_capture(span: _ir.Span | None = None, frame_offset: int = 1) -> _ir.Span:
     """Get explicit span or capture from caller.
 
     Args:
@@ -46,8 +46,8 @@ def _get_span_or_capture(span: Optional[_ir.Span] = None, frame_offset: int = 1)
 
 
 def _normalize_expr(
-    value: Union[int, float, _ir.Expr],
-    span: Optional[_ir.Span] = None,
+    value: int | float | _ir.Expr,
+    span: _ir.Span | None = None,
     int_dtype: DataType = DataType.INT64,
     float_dtype: DataType = DataType.FP32,
 ) -> _ir.Expr:
@@ -79,8 +79,8 @@ def _normalize_expr(
 
 
 def _normalize_shape(
-    shape: Sequence[Union[int, _ir.Expr]],
-    span: Optional[_ir.Span] = None,
+    shape: Sequence[int | _ir.Expr],
+    span: _ir.Span | None = None,
 ) -> list[_ir.Expr]:
     """Convert shape dimensions to IR expressions.
 

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, overload
 
 if TYPE_CHECKING:
     from pypto.language.typing import Scalar, Tensor, Tile
@@ -44,7 +44,7 @@ class RangeIterator(Generic[T]):
         stop: RangeArg,
         start: RangeArg = 0,
         step: RangeArg = 1,
-        init_values: Optional[tuple[Any, ...]] = None,
+        init_values: tuple[Any, ...] | None = None,
     ):
         """Initialize range iterator.
 
@@ -60,39 +60,39 @@ class RangeIterator(Generic[T]):
         self.init_values = init_values or ()
         self.current = start
 
-    def __iter__(self) -> "RangeIterator[T]":
+    def __iter__(self) -> RangeIterator[T]:
         """Return iterator."""
         return self
 
     @overload
-    def __next__(self: "RangeIterator[int]") -> int: ...
+    def __next__(self: RangeIterator[int]) -> int: ...
 
     @overload
     def __next__(
-        self: "RangeIterator[tuple[int, tuple[T1]]]",
+        self: RangeIterator[tuple[int, tuple[T1]]],
     ) -> tuple[int, tuple[T1]]: ...
 
     @overload
     def __next__(
-        self: "RangeIterator[tuple[int, tuple[T1, T2]]]",
+        self: RangeIterator[tuple[int, tuple[T1, T2]]],
     ) -> tuple[int, tuple[T1, T2]]: ...
 
     @overload
     def __next__(
-        self: "RangeIterator[tuple[int, tuple[T1, T2, T3]]]",
+        self: RangeIterator[tuple[int, tuple[T1, T2, T3]]],
     ) -> tuple[int, tuple[T1, T2, T3]]: ...
 
     @overload
     def __next__(
-        self: "RangeIterator[tuple[int, tuple[T1, T2, T3, T4]]]",
+        self: RangeIterator[tuple[int, tuple[T1, T2, T3, T4]]],
     ) -> tuple[int, tuple[T1, T2, T3, T4]]: ...
 
     @overload
     def __next__(
-        self: "RangeIterator[tuple[int, tuple[T1, T2, T3, T4, T5]]]",
+        self: RangeIterator[tuple[int, tuple[T1, T2, T3, T4, T5]]],
     ) -> tuple[int, tuple[T1, T2, T3, T4, T5]]: ...
 
-    def __next__(self) -> Union[int, tuple[int, tuple[Any, ...]]]:
+    def __next__(self) -> int | tuple[int, tuple[Any, ...]]:
         """Get next iteration value.
 
         Returns:
@@ -112,8 +112,8 @@ class RangeIterator(Generic[T]):
 
 
 def _make_range_iterator(
-    *args: RangeArg, init_values: Optional[tuple[Any, ...]] = None, func_name: str = "range"
-) -> Union[RangeIterator[int], RangeIterator[tuple[int, tuple[Any, ...]]]]:
+    *args: RangeArg, init_values: tuple[Any, ...] | None = None, func_name: str = "range"
+) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
     """Shared implementation for range() and parallel()."""
     if len(args) == 1:
         return RangeIterator(args[0], init_values=init_values)
@@ -156,8 +156,8 @@ def range(
 
 
 def range(
-    *args: RangeArg, init_values: Optional[tuple[Any, ...]] = None
-) -> Union[RangeIterator[int], RangeIterator[tuple[int, tuple[Any, ...]]]]:
+    *args: RangeArg, init_values: tuple[Any, ...] | None = None
+) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
     """Create a range iterator for for loops.
 
     Supports two patterns:
@@ -221,8 +221,8 @@ def parallel(
 
 
 def parallel(
-    *args: RangeArg, init_values: Optional[tuple[Any, ...]] = None
-) -> Union[RangeIterator[int], RangeIterator[tuple[int, tuple[Any, ...]]]]:
+    *args: RangeArg, init_values: tuple[Any, ...] | None = None
+) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
     """Create a parallel range iterator for parallel for loops.
 
     Behaves identically to range() at runtime. The distinction is used by the
@@ -243,7 +243,7 @@ def parallel(
 class WhileIterator(Generic[W]):
     """Iterator for pl.while_() that supports tuple unpacking for iter_args."""
 
-    def __init__(self, *, init_values: Optional[tuple[Any, ...]] = None):
+    def __init__(self, *, init_values: tuple[Any, ...] | None = None):
         """Initialize while iterator.
 
         Args:
@@ -254,31 +254,31 @@ class WhileIterator(Generic[W]):
         self.init_values = init_values
         self._exhausted = False
 
-    def __iter__(self) -> "WhileIterator[W]":
+    def __iter__(self) -> WhileIterator[W]:
         """Return iterator."""
         return self
 
     @overload
-    def __next__(self: "WhileIterator[tuple[T1]]") -> tuple[T1]: ...
+    def __next__(self: WhileIterator[tuple[T1]]) -> tuple[T1]: ...
 
     @overload
-    def __next__(self: "WhileIterator[tuple[T1, T2]]") -> tuple[T1, T2]: ...
+    def __next__(self: WhileIterator[tuple[T1, T2]]) -> tuple[T1, T2]: ...
 
     @overload
-    def __next__(self: "WhileIterator[tuple[T1, T2, T3]]") -> tuple[T1, T2, T3]: ...
+    def __next__(self: WhileIterator[tuple[T1, T2, T3]]) -> tuple[T1, T2, T3]: ...
 
     @overload
     def __next__(
-        self: "WhileIterator[tuple[T1, T2, T3, T4]]",
+        self: WhileIterator[tuple[T1, T2, T3, T4]],
     ) -> tuple[T1, T2, T3, T4]: ...
 
     @overload
     def __next__(
-        self: "WhileIterator[tuple[T1, T2, T3, T4, T5]]",
+        self: WhileIterator[tuple[T1, T2, T3, T4, T5]],
     ) -> tuple[T1, T2, T3, T4, T5]: ...
 
     @overload
-    def __next__(self: "WhileIterator[tuple[Any, ...]]") -> tuple[Any, ...]: ...
+    def __next__(self: WhileIterator[tuple[Any, ...]]) -> tuple[Any, ...]: ...
 
     def __next__(self) -> tuple[Any, ...]:
         """Get next iteration value.
@@ -314,7 +314,7 @@ def while_(*, init_values: tuple[T1, T2, T3, T4]) -> WhileIterator[tuple[T1, T2,
 def while_(*, init_values: tuple[T1, T2, T3, T4, T5]) -> WhileIterator[tuple[T1, T2, T3, T4, T5]]: ...
 
 
-def while_(*, init_values: Optional[tuple[ExprType, ...]] = None) -> WhileIterator[tuple[ExprType, ...]]:
+def while_(*, init_values: tuple[ExprType, ...] | None = None) -> WhileIterator[tuple[ExprType, ...]]:
     """Create a while iterator for while loops.
 
     Always requires init_values to specify loop-carried state.
@@ -370,7 +370,7 @@ def yield_(v1: T1, v2: T2, v3: T3, v4: T4, /) -> tuple[T1, T2, T3, T4]: ...
 def yield_(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, /) -> tuple[T1, T2, T3, T4, T5]: ...
 
 
-def yield_(*values: Any) -> Union[Any, tuple[Any, ...]]:
+def yield_(*values: Any) -> Any | tuple[Any, ...]:
     """Yield values from a scope (for, if).
 
     This function is used to explicitly return values from nested scopes

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -13,7 +13,8 @@ This module provides type-safe wrappers around pypto.ir.op.block operations
 that accept and return Tile types instead of raw Expr/Call objects.
 """
 
-from typing import Literal, Sequence, Union
+from collections.abc import Sequence
+from typing import Literal
 
 __all__ = [
     "create_tile",
@@ -149,8 +150,8 @@ def store(
 
 def l0c_store(
     tile: Tile,
-    offsets: Union[list[Union[int, Expr]], tuple[Union[int, Expr], ...]],
-    shapes: Union[list[Union[int, Expr]], tuple[Union[int, Expr], ...]],
+    offsets: list[int | Expr] | tuple[int | Expr, ...],
+    shapes: list[int | Expr] | tuple[int | Expr, ...],
     output_tensor: Tensor,
 ) -> Tensor:
     """Copy data from L0C tile to GM tensor.
@@ -206,7 +207,7 @@ def ub_copy(tile: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def full(shape: list[int], dtype: DataType, value: Union[int, float]) -> Tile:
+def full(shape: list[int], dtype: DataType, value: int | float) -> Tile:
     """Create a tile from a shape and fill with value in UB.
 
     Args:
@@ -297,7 +298,7 @@ def div(lhs: Tile, rhs: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def adds(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
+def adds(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     """Element-wise addition of tile and scalar.
 
     Args:
@@ -312,7 +313,7 @@ def adds(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def subs(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
+def subs(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     """Element-wise subtraction of tile and scalar.
 
     Args:
@@ -327,7 +328,7 @@ def subs(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def muls(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
+def muls(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     """Element-wise multiplication of tile and scalar.
 
     Args:
@@ -342,7 +343,7 @@ def muls(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def divs(lhs: Tile, rhs: Union[int, float, Expr, Scalar]) -> Tile:
+def divs(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     """Element-wise division of tile and scalar.
 
     Args:
@@ -463,7 +464,7 @@ def relu(tile: Tile) -> Tile:
 
 def cast(
     tile: Tile,
-    target_type: Union[int, DataType],
+    target_type: int | DataType,
     mode: Literal["none", "rint", "round", "floor", "ceil", "trunc", "odd"] = "round",
 ):
     """Cast tile to target data type (element-wise).
@@ -677,7 +678,7 @@ def col_expand_sub(tile: Tile, col_vec: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def expands(target: Tile, scalar: Union[int, float, Expr, Scalar]) -> Tile:
+def expands(target: Tile, scalar: int | float | Expr | Scalar) -> Tile:
     """Expand scalar to target tile shape.
 
     Args:
@@ -721,7 +722,7 @@ def cmp(lhs: Tile, rhs: Tile, cmp_type: int = 0) -> Tile:
     return Tile(expr=call_expr)
 
 
-def cmps(lhs: Tile, rhs: Union[int, float, Expr, Scalar], cmp_type: int = 0) -> Tile:
+def cmps(lhs: Tile, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tile:
     """Element-wise comparison of tile and scalar.
 
     Args:
@@ -782,7 +783,7 @@ def min(tile: Tile, axis: int, keepdim: bool = False) -> Tile:
     return Tile(expr=call_expr)
 
 
-def view(tile: Tile, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> Tile:
+def view(tile: Tile, shape: list[int | Expr], offset: list[int | Expr]) -> Tile:
     """Create a view/slice of a tile with new shape and offset.
 
     Args:
@@ -798,7 +799,7 @@ def view(tile: Tile, shape: list[Union[int, Expr]], offset: list[Union[int, Expr
     return Tile(expr=call_expr)
 
 
-def reshape(tile: Tile, shape: list[Union[int, Expr]]) -> Tile:
+def reshape(tile: Tile, shape: list[int | Expr]) -> Tile:
     """Reshape tile to new shape.
 
     Args:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -13,7 +13,7 @@ This module provides type-safe wrappers around pypto.ir.op.tensor operations
 that accept and return Tensor types instead of raw Expr/Call objects.
 """
 
-from typing import Literal, Optional, Union
+from typing import Literal
 
 __all__ = [
     "create_tensor",
@@ -60,7 +60,7 @@ def create_tensor(shape: list[int], dtype: DataType) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def read(tensor: Tensor, indices: list[Union[int, Expr]]) -> Scalar:
+def read(tensor: Tensor, indices: list[int | Expr]) -> Scalar:
     """Read a scalar value from a tensor at given indices.
 
     Args:
@@ -90,7 +90,7 @@ def dim(tensor: Tensor, axis: int) -> Scalar:
     return Scalar(expr=call_expr)
 
 
-def view(tensor: Tensor, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> Tensor:
+def view(tensor: Tensor, shape: list[int | Expr], offset: list[int | Expr]) -> Tensor:
     """Create a view/slice of a tensor with new shape and offset.
 
     Args:
@@ -109,7 +109,7 @@ def view(tensor: Tensor, shape: list[Union[int, Expr]], offset: list[Union[int, 
 def matmul(
     lhs: Tensor,
     rhs: Tensor,
-    out_dtype: Optional[Union[int, DataType]] = None,
+    out_dtype: int | DataType | None = None,
     a_trans: bool = False,
     b_trans: bool = False,
     c_matrix_nz: bool = False,
@@ -133,7 +133,7 @@ def matmul(
     return Tensor(expr=call_expr)
 
 
-def mul(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
+def mul(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
     """Element-wise multiplication of tensor and tensor or scalar.
 
     Automatically selects between tensor.mul (tensor x tensor) and
@@ -157,7 +157,7 @@ def mul(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def mul_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+def mul_scalar(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
     """Element-wise multiplication of tensor and scalar.
 
     Args:
@@ -172,7 +172,7 @@ def mul_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def add(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
+def add(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
     """Element-wise addition of tensor and tensor or scalar.
 
     Automatically selects between tensor.add (tensor + tensor) and
@@ -196,7 +196,7 @@ def add(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def add_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+def add_scalar(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
     """Element-wise addition of tensor and scalar.
 
     Args:
@@ -211,7 +211,7 @@ def add_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def sub(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
+def sub(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
     """Element-wise subtraction of tensor and tensor or scalar.
 
     Automatically selects between tensor.sub (tensor - tensor) and
@@ -235,7 +235,7 @@ def sub(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def sub_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
+def sub_scalar(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
     """Element-wise subtraction of tensor and scalar.
 
     Args:
@@ -250,7 +250,7 @@ def sub_scalar(lhs: Tensor, rhs: Union[int, float, Expr]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def div(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
+def div(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
     """Element-wise division of tensor and tensor or scalar.
 
     Automatically selects between tensor.div (tensor / tensor) and
@@ -274,7 +274,7 @@ def div(lhs: Tensor, rhs: Union[int, float, Tensor, Scalar]) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def div_scalar(lhs: Tensor, rhs: Union[int, float, Expr, Scalar]) -> Tensor:
+def div_scalar(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     """Element-wise division of tensor and scalar.
 
     Args:
@@ -353,7 +353,7 @@ def exp(input: Tensor) -> Tensor:
 
 def cast(
     input: Tensor,
-    target_type: Union[int, DataType],
+    target_type: int | DataType,
     mode: Literal["none", "rint", "round", "floor", "ceil", "trunc", "odd"] = "round",
 ) -> Tensor:
     """Type casting operation.
@@ -371,7 +371,7 @@ def cast(
     return Tensor(expr=call_expr)
 
 
-def assemble(target: Tensor, source: Tensor, offset: list[Union[int, Expr]]) -> Tensor:
+def assemble(target: Tensor, source: Tensor, offset: list[int | Expr]) -> Tensor:
     """Write/update tensor values at specified offset.
 
     Args:
@@ -388,7 +388,7 @@ def assemble(target: Tensor, source: Tensor, offset: list[Union[int, Expr]]) -> 
     return Tensor(expr=call_expr)
 
 
-def reshape(tensor: Tensor, shape: list[Union[int, Expr]]) -> Tensor:
+def reshape(tensor: Tensor, shape: list[int | Expr]) -> Tensor:
     """Reshape tensor to new shape.
 
     Args:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -15,7 +15,7 @@ operations based on the input type (Tensor vs Tile). Users can write
 or ``pl.block.add``.
 """
 
-from typing import Literal, Optional, TypeVar, Union, overload
+from typing import Literal, TypeVar, overload
 
 __all__ = [
     "add",
@@ -54,7 +54,7 @@ T = TypeVar("T", Tensor, Tile)
 # --- add ---
 
 
-def add(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
+def add(lhs: T, rhs: T | int | float | Scalar) -> T:
     """Element-wise addition, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.add(lhs, rhs)
@@ -68,7 +68,7 @@ def add(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
 # --- sub ---
 
 
-def sub(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
+def sub(lhs: T, rhs: T | int | float | Scalar) -> T:
     """Element-wise subtraction, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.sub(lhs, rhs)
@@ -82,7 +82,7 @@ def sub(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
 # --- mul ---
 
 
-def mul(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
+def mul(lhs: T, rhs: T | int | float | Scalar) -> T:
     """Element-wise multiplication, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.mul(lhs, rhs)
@@ -96,7 +96,7 @@ def mul(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
 # --- div ---
 
 
-def div(lhs: T, rhs: Union[T, int, float, Scalar]) -> T:
+def div(lhs: T, rhs: T | int | float | Scalar) -> T:
     """Element-wise division, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.div(lhs, rhs)
@@ -130,7 +130,7 @@ def exp(input: T) -> T:
     raise TypeError(f"exp: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def reshape(input: T, shape: list[Union[int, Expr]]) -> T:
+def reshape(input: T, shape: list[int | Expr]) -> T:
     """Reshape operation, dispatched by input type."""
     if isinstance(input, Tensor):
         return _tensor.reshape(input, shape)
@@ -148,7 +148,7 @@ def transpose(input: T, axis1: int, axis2: int) -> T:
     raise TypeError(f"transpose: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def view(input: T, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]) -> T:
+def view(input: T, shape: list[int | Expr], offset: list[int | Expr]) -> T:
     """View/slice operation, dispatched by input type."""
     if isinstance(input, Tensor):
         return _tensor.view(input, shape, offset)
@@ -166,7 +166,7 @@ def view(input: T, shape: list[Union[int, Expr]], offset: list[Union[int, Expr]]
 def matmul(
     lhs: Tensor,
     rhs: Tensor,
-    out_dtype: Optional[Union[int, DataType]] = ...,
+    out_dtype: int | DataType | None = ...,
     a_trans: bool = ...,
     b_trans: bool = ...,
     c_matrix_nz: bool = ...,
@@ -178,7 +178,7 @@ def matmul(lhs: Tile, rhs: Tile) -> Tile: ...
 def matmul(
     lhs: T,
     rhs: T,
-    out_dtype: Optional[Union[int, DataType]] = None,
+    out_dtype: int | DataType | None = None,
     a_trans: bool = False,
     b_trans: bool = False,
     c_matrix_nz: bool = False,
@@ -195,7 +195,7 @@ def matmul(
     raise TypeError(f"matmul: expected Tensor or Tile for lhs, got {type(lhs).__name__}")
 
 
-def row_max(input: T, tmp_tile: Optional[Tile] = None) -> T:
+def row_max(input: T, tmp_tile: Tile | None = None) -> T:
     """Row-wise max reduction, dispatched by input type.
 
     For Tile inputs, tmp_tile is required as a temporary buffer.
@@ -210,7 +210,7 @@ def row_max(input: T, tmp_tile: Optional[Tile] = None) -> T:
     raise TypeError(f"row_max: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def row_sum(input: T, tmp_tile: Optional[Tile] = None) -> T:
+def row_sum(input: T, tmp_tile: Tile | None = None) -> T:
     """Row-wise sum reduction, dispatched by input type.
 
     For Tile inputs, tmp_tile is required as a temporary buffer.
@@ -227,7 +227,7 @@ def row_sum(input: T, tmp_tile: Optional[Tile] = None) -> T:
 
 def cast(
     input: T,
-    target_type: Union[int, DataType],
+    target_type: int | DataType,
     mode: Literal["none", "rint", "round", "floor", "ceil", "trunc", "odd"] = "round",
 ) -> T:
     """Type casting."""

--- a/python/pypto/language/parser/__init__.py
+++ b/python/pypto/language/parser/__init__.py
@@ -25,7 +25,6 @@ Part of the pypto.language package - use via:
 import os
 import sys
 from types import TracebackType
-from typing import Optional
 
 # Import DSL helpers from parent language module
 from ..dsl_api import range, yield_
@@ -57,7 +56,7 @@ def _install_parser_excepthook():
     def parser_excepthook(
         exc_type: type,
         exc_value: BaseException,
-        exc_traceback: Optional[TracebackType],
+        exc_traceback: TracebackType | None,
     ) -> None:
         """Custom exception hook that pretty-prints ParserError exceptions."""
         if isinstance(exc_value, ParserError):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -10,7 +10,7 @@
 """AST parsing for converting Python DSL to IR builder calls."""
 
 import ast
-from typing import Any, Optional
+from typing import Any
 
 from pypto.ir import IRBuilder
 from pypto.ir import op as ir_op
@@ -42,10 +42,10 @@ class ASTParser:
         source_lines: list[str],
         line_offset: int = 0,
         col_offset: int = 0,
-        global_vars: Optional[dict[str, ir.GlobalVar]] = None,
-        gvar_to_func: Optional[dict[ir.GlobalVar, ir.Function]] = None,
+        global_vars: dict[str, ir.GlobalVar] | None = None,
+        gvar_to_func: dict[ir.GlobalVar, ir.Function] | None = None,
         strict_ssa: bool = False,
-        closure_vars: Optional[dict[str, Any]] = None,
+        closure_vars: dict[str, Any] | None = None,
     ):
         """Initialize AST parser.
 
@@ -390,7 +390,7 @@ class ASTParser:
             hint="Use pl.range(), pl.parallel(), or pl.while_() as the iterator",
         )
 
-    def _parse_for_loop_target(self, stmt: ast.For) -> tuple[str, Optional[ast.AST], bool]:
+    def _parse_for_loop_target(self, stmt: ast.For) -> tuple[str, ast.AST | None, bool]:
         """Parse for loop target, returning (loop_var_name, iter_args_node, is_simple_for)."""
         if isinstance(stmt.target, ast.Name):
             return stmt.target.id, None, True
@@ -596,7 +596,7 @@ class ASTParser:
 
         return False
 
-    def _extract_cond_call(self, stmt: ast.stmt) -> Optional[ir.Expr]:
+    def _extract_cond_call(self, stmt: ast.stmt) -> ir.Expr | None:
         """Extract condition from pl.cond() call statement.
 
         Args:
@@ -1642,7 +1642,7 @@ class ASTParser:
         # Create TupleGetItemExpr
         return ir.TupleGetItemExpr(value_expr, index, span)
 
-    def _resolve_yield_var_type(self, annotation: Optional[ast.expr]) -> ir.Type:
+    def _resolve_yield_var_type(self, annotation: ast.expr | None) -> ir.Type:
         """Resolve type annotation for a yield variable.
 
         Args:
@@ -1669,7 +1669,7 @@ class ASTParser:
         # Single type
         return resolved
 
-    def _scan_for_yields(self, stmts: list[ast.stmt]) -> list[tuple[str, Optional[ast.expr]]]:
+    def _scan_for_yields(self, stmts: list[ast.stmt]) -> list[tuple[str, ast.expr | None]]:
         """Scan statements for yield assignments to determine output variable names and types.
 
         Args:

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -13,7 +13,8 @@ import ast
 import inspect
 import sys
 import textwrap
-from typing import Callable, Optional, TypeVar, Union
+from collections.abc import Callable
+from typing import TypeVar
 
 from pypto.pypto_core import ir
 
@@ -61,7 +62,7 @@ def _parse_ast_tree(source_code: str, entity_type: str) -> ast.AST:
         )
 
 
-TypeASTNode = TypeVar("TypeASTNode", bound=Union[ast.FunctionDef, ast.ClassDef])
+TypeASTNode = TypeVar("TypeASTNode", bound=ast.FunctionDef | ast.ClassDef)
 
 
 def _find_ast_node(tree: ast.AST, node_type: type[TypeASTNode], name: str, entity_type: str) -> TypeASTNode:
@@ -222,7 +223,7 @@ def _is_class_method(func: Callable) -> bool:
 
 
 def function(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     *,
     type: ir.FunctionType = ir.FunctionType.Opaque,
     strict_ssa: bool = False,
@@ -325,7 +326,7 @@ def function(
         return _decorator(func)
 
 
-def program(cls: Optional[type] = None, *, strict_ssa: bool = False) -> ir.Program:
+def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program:
     """Decorator that parses a class with @pl.function methods into a Program.
 
     The class should contain one or more methods decorated with @pl.function.

--- a/python/pypto/language/parser/diagnostics/error_codes.py
+++ b/python/pypto/language/parser/diagnostics/error_codes.py
@@ -14,7 +14,6 @@ unless PTO_BACKTRACE is enabled.
 """
 
 from enum import Enum
-from typing import Optional
 
 from .exceptions import (
     InvalidOperationError,
@@ -76,7 +75,7 @@ class ErrorCode(Enum):
     UNSUPPORTED_COMPARISON = "E305"
 
 
-def get_error_code(exception_type: type) -> Optional[ErrorCode]:
+def get_error_code(exception_type: type) -> ErrorCode | None:
     """Get error code for exception type.
 
     Args:

--- a/python/pypto/language/parser/diagnostics/exceptions.py
+++ b/python/pypto/language/parser/diagnostics/exceptions.py
@@ -9,8 +9,6 @@
 
 """Parser error exceptions with rich diagnostic information."""
 
-from typing import Optional
-
 from pypto.pypto_core import ir
 
 
@@ -24,10 +22,10 @@ class ParserError(Exception):
     def __init__(
         self,
         message: str,
-        span: Optional[ir.Span] = None,
-        hint: Optional[str] = None,
-        note: Optional[str] = None,
-        source_lines: Optional[list[str]] = None,
+        span: ir.Span | None = None,
+        hint: str | None = None,
+        note: str | None = None,
+        source_lines: list[str] | None = None,
     ):
         """Initialize parser error.
 
@@ -84,11 +82,11 @@ class SSAViolationError(ParserError):
     def __init__(
         self,
         message: str,
-        span: Optional[ir.Span] = None,
-        hint: Optional[str] = None,
-        note: Optional[str] = None,
-        source_lines: Optional[list[str]] = None,
-        previous_span: Optional[ir.Span] = None,
+        span: ir.Span | None = None,
+        hint: str | None = None,
+        note: str | None = None,
+        source_lines: list[str] | None = None,
+        previous_span: ir.Span | None = None,
     ):
         """Initialize SSA violation error.
 

--- a/python/pypto/language/parser/diagnostics/renderer.py
+++ b/python/pypto/language/parser/diagnostics/renderer.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-from typing import Optional
 
 from .exceptions import ParserError, SSAViolationError
 
@@ -27,7 +26,7 @@ class ErrorRenderer:
     - Help/hint messages
     """
 
-    def __init__(self, use_color: Optional[bool] = None):
+    def __init__(self, use_color: bool | None = None):
         """Initialize error renderer.
 
         Args:

--- a/python/pypto/language/parser/scope_manager.py
+++ b/python/pypto/language/parser/scope_manager.py
@@ -9,7 +9,7 @@
 
 """Scope management and SSA verification for IR parsing."""
 
-from typing import Any, Optional
+from typing import Any
 
 from pypto.ir import Span
 
@@ -75,9 +75,7 @@ class ScopeManager:
 
         return scope_vars
 
-    def define_var(
-        self, name: str, value: Any, allow_redef: bool = False, span: Optional[Any] = None
-    ) -> None:
+    def define_var(self, name: str, value: Any, allow_redef: bool = False, span: Any | None = None) -> None:
         """Define a variable in the current scope.
 
         Args:
@@ -116,7 +114,7 @@ class ScopeManager:
             self.assignments[name] = 0
         self.assignments[name] += 1
 
-    def lookup_var(self, name: str) -> Optional[Any]:
+    def lookup_var(self, name: str) -> Any | None:
         """Lookup variable in scope chain.
 
         Args:
@@ -153,7 +151,7 @@ class ScopeManager:
             self.yielded_vars[scope_id] = set()
         self.yielded_vars[scope_id].add(var_name)
 
-    def get_yielded_vars(self, scope_id: Optional[int] = None) -> set[str]:
+    def get_yielded_vars(self, scope_id: int | None = None) -> set[str]:
         """Get variables yielded from a specific scope.
 
         Args:

--- a/python/pypto/language/parser/span_tracker.py
+++ b/python/pypto/language/parser/span_tracker.py
@@ -10,7 +10,7 @@
 """Span tracking for preserving source location information during parsing."""
 
 import ast
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 from pypto.pypto_core import ir
 
@@ -34,7 +34,7 @@ class SpanTracker:
         self.line_offset = line_offset
         self.col_offset = col_offset
 
-    def get_span(self, ast_node: Optional[ast.AST]) -> ir.Span:
+    def get_span(self, ast_node: ast.AST | None) -> ir.Span:
         """Extract span from AST node.
 
         Args:

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -12,14 +12,13 @@
 import linecache
 import sys
 import types
-from typing import Union
 
 from pypto.pypto_core import ir
 
 from .diagnostics.exceptions import ParserError
 
 
-def parse(code: str, filename: str = "<string>") -> Union[ir.Function, ir.Program]:
+def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
     """Parse a DSL function or program from a string.
 
     This function takes Python source code containing a @pl.function decorated
@@ -151,7 +150,7 @@ def parse(code: str, filename: str = "<string>") -> Union[ir.Function, ir.Progra
         return programs[0][1]
 
 
-def loads(filepath: str) -> Union[ir.Function, ir.Program]:
+def loads(filepath: str) -> ir.Function | ir.Program:
     """Load a DSL function or program from a file.
 
     This function reads a Python file containing a @pl.function decorated
@@ -186,7 +185,7 @@ def loads(filepath: str) -> Union[ir.Function, ir.Program]:
         >>> print(prog.name)
     """
     # Read file content
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         code = f.read()
 
     # Parse using parse() with the filepath for proper error reporting

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -10,7 +10,8 @@
 """Type annotation resolution for IR parsing."""
 
 import ast
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from pypto.language.typing.dynamic import DynVar
 from pypto.pypto_core import DataType, ir

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -9,7 +9,7 @@
 
 """Scalar wrapper type for PyPTO Language DSL."""
 
-from typing import Any, Optional
+from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr
@@ -30,7 +30,7 @@ class ScalarMeta(type):
         return cls(dtype, _annotation_only=True)
 
     def __call__(
-        cls, dtype: Any = None, expr: Optional[Expr] = None, _annotation_only: bool = False
+        cls, dtype: Any = None, expr: Expr | None = None, _annotation_only: bool = False
     ) -> "Scalar":  # type: ignore[misc]
         """Enable both Scalar(dtype) syntax and runtime wrapping.
 
@@ -77,8 +77,8 @@ class Scalar(metaclass=ScalarMeta):
 
     def __init__(
         self,
-        dtype: Optional[DataType] = None,
-        expr: Optional[Expr] = None,
+        dtype: DataType | None = None,
+        expr: Expr | None = None,
         _annotation_only: bool = False,
     ):
         """Initialize Scalar.

--- a/python/pypto/language/typing/tensor.py
+++ b/python/pypto/language/typing/tensor.py
@@ -9,7 +9,8 @@
 
 """Tensor wrapper type for PyPTO Language DSL."""
 
-from typing import Any, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr
@@ -34,7 +35,7 @@ class TensorMeta(type):
         return cls(shape, dtype, _annotation_only=True)
 
     def __call__(
-        cls, shape: Any = None, dtype: Any = None, expr: Optional[Expr] = None, _annotation_only: bool = False
+        cls, shape: Any = None, dtype: Any = None, expr: Expr | None = None, _annotation_only: bool = False
     ) -> "Tensor":  # type: ignore[misc]
         """Enable both Tensor((shape), dtype) syntax and runtime wrapping.
 
@@ -87,9 +88,9 @@ class Tensor(metaclass=TensorMeta):
 
     def __init__(
         self,
-        shape: Optional[Sequence[int]] = None,
-        dtype: Optional[DataType] = None,
-        expr: Optional[Expr] = None,
+        shape: Sequence[int] | None = None,
+        dtype: DataType | None = None,
+        expr: Expr | None = None,
         _annotation_only: bool = False,
     ):
         """Initialize Tensor.

--- a/python/pypto/language/typing/tile.py
+++ b/python/pypto/language/typing/tile.py
@@ -13,7 +13,6 @@ Tile represents a block in unified buffer memory, used for block-level programmi
 """
 
 from collections.abc import Sequence
-from typing import Optional
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr
@@ -38,7 +37,7 @@ class TileMeta(type):
         return cls(shape, dtype, _annotation_only=True)
 
     def __call__(
-        cls, shape=None, dtype=None, expr: Optional[Expr] = None, _annotation_only: bool = False
+        cls, shape=None, dtype=None, expr: Expr | None = None, _annotation_only: bool = False
     ) -> "Tile":
         """Enable both Tile((shape), dtype) syntax and runtime wrapping."""
         if (
@@ -78,9 +77,9 @@ class Tile(metaclass=TileMeta):
 
     def __init__(
         self,
-        shape: Optional[Sequence[int]] = None,
-        dtype: Optional[DataType] = None,
-        expr: Optional[Expr] = None,
+        shape: Sequence[int] | None = None,
+        dtype: DataType | None = None,
+        expr: Expr | None = None,
         _annotation_only: bool = False,
     ):
         """Initialize Tile.

--- a/python/pypto/pypto_core/backend.pyi
+++ b/python/pypto/pypto_core/backend.pyi
@@ -14,8 +14,8 @@ from pypto import ir
 class BackendType:
     """Backend type for passes and codegen (CCE or PTO)."""
 
-    CCE: "BackendType"
-    PTO: "BackendType"
+    CCE: BackendType
+    PTO: BackendType
 
 class Mem:
     """Memory component."""
@@ -67,7 +67,7 @@ class Backend:
     def get_type_name(self) -> str: ...
     def export_to_file(self, path: str) -> None: ...
     @staticmethod
-    def import_from_file(path: str) -> "Backend": ...
+    def import_from_file(path: str) -> Backend: ...
     def find_mem_path(self, from_mem: ir.MemorySpace, to_mem: ir.MemorySpace) -> list[ir.MemorySpace]: ...
     def get_mem_size(self, mem_type: ir.MemorySpace) -> int: ...
     @property
@@ -77,7 +77,7 @@ class Backend910B_CCE(Backend):
     """910B CCE backend implementation (singleton)."""
 
     @staticmethod
-    def instance() -> "Backend910B_CCE":
+    def instance() -> Backend910B_CCE:
         """Get singleton instance of 910B CCE backend."""
         ...
 
@@ -85,7 +85,7 @@ class Backend910B_PTO(Backend):
     """910B PTO backend implementation (singleton)."""
 
     @staticmethod
-    def instance() -> "Backend910B_PTO":
+    def instance() -> Backend910B_PTO:
         """Get singleton instance of 910B PTO backend."""
         ...
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -9,7 +9,8 @@
 """Type stubs for PyPTO IR (Intermediate Representation) module."""
 
 import enum
-from typing import Final, Mapping, Optional, Sequence, Union, overload
+from collections.abc import Mapping, Sequence
+from typing import Final, overload
 
 from pypto import DataType
 
@@ -80,7 +81,7 @@ class Op:
     name: Final[str]
     """Operation name."""
 
-    pipe: Final[Optional[PipeType]]
+    pipe: Final[PipeType | None]
     """Pipeline type associated with this operation."""
 
     def __init__(self, name: str) -> None:
@@ -294,7 +295,7 @@ class ShapedType(Type):
     shape: Final[Sequence[Expr]]
     """Shape dimensions."""
 
-    memref: Final[Optional[MemRef]]
+    memref: Final[MemRef | None]
     """Optional memory reference."""
 
     def shares_memref_with(self, other: ShapedType) -> bool:
@@ -345,7 +346,7 @@ class TensorView:
 class TensorType(ShapedType):
     """Tensor type representation."""
 
-    tensor_view: Final[Optional[TensorView]]
+    tensor_view: Final[TensorView | None]
     """Optional tensor view information."""
 
     @overload
@@ -358,7 +359,7 @@ class TensorType(ShapedType):
         """
 
     @overload
-    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef]) -> None:
+    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: MemRef | None) -> None:
         """Create a tensor type with memory reference.
 
         Args:
@@ -372,8 +373,8 @@ class TensorType(ShapedType):
         self,
         shape: Sequence[Expr],
         dtype: DataType,
-        memref: Optional[MemRef],
-        tensor_view: Optional[TensorView],
+        memref: MemRef | None,
+        tensor_view: TensorView | None,
     ) -> None:
         """Create a tensor type with memory reference and tensor view.
 
@@ -394,7 +395,7 @@ class TensorType(ShapedType):
         """
 
     @overload
-    def __init__(self, shape: Sequence[int], dtype: DataType, memref: Optional[MemRef]) -> None:
+    def __init__(self, shape: Sequence[int], dtype: DataType, memref: MemRef | None) -> None:
         """Create a tensor type with memory reference.
 
         Args:
@@ -408,8 +409,8 @@ class TensorType(ShapedType):
         self,
         shape: Sequence[int],
         dtype: DataType,
-        memref: Optional[MemRef],
-        tensor_view: Optional[TensorView],
+        memref: MemRef | None,
+        tensor_view: TensorView | None,
     ) -> None:
         """Create a tensor type with memory reference and tensor view.
 
@@ -449,7 +450,7 @@ class TileView:
 class TileType(ShapedType):
     """Tile type representation (multi-dimensional tensor)."""
 
-    tile_view: Final[Optional[TileView]]
+    tile_view: Final[TileView | None]
     """Optional tile view information."""
 
     @overload
@@ -462,7 +463,7 @@ class TileType(ShapedType):
         """
 
     @overload
-    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef]) -> None:
+    def __init__(self, shape: Sequence[Expr], dtype: DataType, memref: MemRef | None) -> None:
         """Create a tile type with memory reference.
 
         Args:
@@ -473,7 +474,7 @@ class TileType(ShapedType):
 
     @overload
     def __init__(
-        self, shape: Sequence[Expr], dtype: DataType, memref: Optional[MemRef], tile_view: Optional[TileView]
+        self, shape: Sequence[Expr], dtype: DataType, memref: MemRef | None, tile_view: TileView | None
     ) -> None:
         """Create a tile type with memory reference and tile view.
 
@@ -615,7 +616,7 @@ DYNAMIC_DIM: Final[int]
 Used to indicate dimensions with runtime-determined sizes.
 """
 
-ScalarExprType = Union[Expr, int, float]
+ScalarExprType = Expr | int | float
 
 class Var(Expr):
     """Variable reference expression."""
@@ -730,7 +731,7 @@ class Call(Expr):
     args: Final[Sequence[Expr]]
     """Positional arguments."""
 
-    kwargs: Final[Mapping[str, Union[int, bool, str, float, DataType]]]
+    kwargs: Final[Mapping[str, int | bool | str | float | DataType]]
     """Keyword arguments (metadata)."""
 
     @overload
@@ -768,7 +769,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, Union[int, bool, str, float, DataType]],
+        kwargs: Mapping[str, int | bool | str | float | DataType],
         span: Span,
     ) -> None:
         """Create a function call expression with kwargs.
@@ -786,7 +787,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, Union[int, bool, str, float, DataType]],
+        kwargs: Mapping[str, int | bool | str | float | DataType],
         type: Type,
         span: Span,
     ) -> None:

--- a/tests/lint/check_english_only.py
+++ b/tests/lint/check_english_only.py
@@ -88,7 +88,7 @@ def check_file_english_only(file_path: Path) -> tuple[bool, list[tuple[int, str]
         Tuple of (is_english_only, list of (line_number, non_english_text) violations)
     """
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as e:
         print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)

--- a/tests/lint/check_headers.py
+++ b/tests/lint/check_headers.py
@@ -115,7 +115,7 @@ def check_file_header(file_path: Path) -> tuple[bool, str]:
     expected_lines = expected_header.strip().split("\n")
 
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as e:
         return False, f"Error reading file: {e}"

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -28,7 +28,6 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -44,7 +43,7 @@ DEFAULT_SOURCE_DIRS = ("src", "include")
 # ---------------------------------------------------------------------------
 
 
-def get_clang_tidy_version() -> Optional[str]:
+def get_clang_tidy_version() -> str | None:
     """Return the installed clang-tidy version string (e.g. ``"21.1.0"``), or ``None``."""
     try:
         result = subprocess.run(
@@ -61,7 +60,7 @@ def get_clang_tidy_version() -> Optional[str]:
     return None
 
 
-def check_version() -> Optional[str]:
+def check_version() -> str | None:
     """Return a warning string if the clang-tidy version mismatches, else ``None``."""
     version = get_clang_tidy_version()
     if version is None:
@@ -98,7 +97,7 @@ def collect_source_files() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _detect_nanobind_cmake_dir() -> Optional[str]:
+def _detect_nanobind_cmake_dir() -> str | None:
     """Detect the nanobind CMake directory, or ``None`` on failure."""
     try:
         result = subprocess.run(
@@ -245,7 +244,7 @@ def parse_args(argv: Sequence[str]) -> Namespace:
 # ---------------------------------------------------------------------------
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """Run the clang-tidy linting workflow.
 
     Steps:

--- a/tests/st/harness/adapters/program_generator.py
+++ b/tests/st/harness/adapters/program_generator.py
@@ -15,7 +15,7 @@ using the ir.compile() API.
 """
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from pypto import ir
 from pypto.backend import BackendType
@@ -49,7 +49,7 @@ class ProgramCodeGenerator:
 
     def __init__(
         self,
-        strategy: Optional[OptimizationStrategy] = None,
+        strategy: OptimizationStrategy | None = None,
     ):
         """Initialize kernel generator.
 
@@ -120,7 +120,7 @@ class ProgramCodeGenerator:
         program: Any,
         output_dir: Path,
         dump_passes: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate CCE C++ kernel files from a PyPTO Program.
 
         Args:

--- a/tests/st/harness/core/environment.py
+++ b/tests/st/harness/core/environment.py
@@ -15,7 +15,6 @@ to the PyPTO project and required for test execution.
 
 import os
 from pathlib import Path
-from typing import Optional
 
 
 class PtoEnvironmentError(Exception):
@@ -24,7 +23,7 @@ class PtoEnvironmentError(Exception):
     pass
 
 
-def get_simpler_root() -> Optional[Path]:
+def get_simpler_root() -> Path | None:
     """Get Simpler root directory from SIMPLER_ROOT environment variable.
 
     Returns:
@@ -35,7 +34,7 @@ def get_simpler_root() -> Optional[Path]:
     return None
 
 
-def get_simpler_python_path() -> Optional[Path]:
+def get_simpler_python_path() -> Path | None:
     """Get Simpler Python package path (simpler/python directory)."""
     root = get_simpler_root()
     if root is None:
@@ -43,7 +42,7 @@ def get_simpler_python_path() -> Optional[Path]:
     return root / "python"
 
 
-def get_simpler_scripts_path() -> Optional[Path]:
+def get_simpler_scripts_path() -> Path | None:
     """Get Simpler scripts path (simpler/examples/scripts directory)."""
     root = get_simpler_root()
     if root is None:

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -15,9 +15,10 @@ executed on both simulation and hardware platforms.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any
 
 import torch
 from pypto.ir.pass_manager import OptimizationStrategy
@@ -62,9 +63,9 @@ class TensorSpec:
     """
 
     name: str
-    shape: List[int]
+    shape: list[int]
     dtype: DataType
-    init_value: Optional[Union[int, float, torch.Tensor, Callable]] = None
+    init_value: int | float | torch.Tensor | Callable | None = None
     is_output: bool = False
 
     def create_array(self) -> torch.Tensor:
@@ -112,7 +113,7 @@ class TestConfig:
     block_dim: int = 1
     aicpu_thread_num: int = 1
     save_kernels: bool = False
-    save_kernels_dir: Optional[str] = None
+    save_kernels_dir: str | None = None
     dump_passes: bool = False
     codegen_only: bool = False
 
@@ -140,12 +141,12 @@ class TestResult:
 
     passed: bool
     test_name: str
-    error: Optional[str] = None
-    max_abs_error: Optional[float] = None
-    max_rel_error: Optional[float] = None
+    error: str | None = None
+    max_abs_error: float | None = None
+    max_rel_error: float | None = None
     mismatch_count: int = 0
-    mismatch_indices: Optional[List[tuple]] = None
-    execution_time: Optional[float] = None
+    mismatch_indices: list[tuple] | None = None
+    execution_time: float | None = None
 
     def __str__(self) -> str:
         if self.passed:
@@ -208,14 +209,14 @@ class PTOTestCase(ABC):
                 tensors["c"][:] = tensors["a"] + tensors["b"]
     """
 
-    def __init__(self, config: Optional[TestConfig] = None):
+    def __init__(self, config: TestConfig | None = None):
         """Initialize test case.
 
         Args:
             config: Test configuration. If None, uses default config.
         """
         self.config = config or TestConfig()
-        self._tensor_specs: Optional[List[TensorSpec]] = None
+        self._tensor_specs: list[TensorSpec] | None = None
 
     @abstractmethod
     def get_name(self) -> str:
@@ -223,7 +224,7 @@ class PTOTestCase(ABC):
         pass
 
     @abstractmethod
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         """Define all input and output tensors for this test.
 
         Returns:
@@ -253,7 +254,7 @@ class PTOTestCase(ABC):
 
     @abstractmethod
     def compute_expected(
-        self, tensors: Dict[str, torch.Tensor], params: Optional[Dict[str, Any]] = None
+        self, tensors: dict[str, torch.Tensor], params: dict[str, Any] | None = None
     ) -> None:
         """Compute expected outputs using torch (modifies tensors in-place).
 
@@ -280,7 +281,7 @@ class PTOTestCase(ABC):
         pass
 
     @property
-    def tensor_specs(self) -> List[TensorSpec]:
+    def tensor_specs(self) -> list[TensorSpec]:
         """Get cached tensor specifications."""
         if self._tensor_specs is None:
             self._tensor_specs = self.define_tensors()

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -24,7 +24,6 @@ import time
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional
 
 from pypto.backend import BackendType, set_backend_type
 
@@ -81,7 +80,7 @@ class TestRunner:
 
     __test__ = False  # Not a pytest test class
 
-    def __init__(self, config: Optional[TestConfig] = None):
+    def __init__(self, config: TestConfig | None = None):
         """Initialize test runner.
 
         Args:
@@ -224,7 +223,7 @@ class TestSuite:
 
     __test__ = False  # Not a pytest test class
 
-    def __init__(self, name: str, config: Optional[TestConfig] = None):
+    def __init__(self, name: str, config: TestConfig | None = None):
         """Initialize test suite.
 
         Args:
@@ -240,7 +239,7 @@ class TestSuite:
         self._test_cases.append(test_case)
         return self
 
-    def run_all(self, runner: Optional[TestRunner] = None) -> Dict[str, TestResult]:
+    def run_all(self, runner: TestRunner | None = None) -> dict[str, TestResult]:
         """Run all test cases in the suite."""
         if runner is None:
             runner = TestRunner(self.config)
@@ -253,7 +252,7 @@ class TestSuite:
 
         return results
 
-    def summary(self, results: Dict[str, TestResult]) -> str:
+    def summary(self, results: dict[str, TestResult]) -> str:
         """Generate summary of test results."""
         passed = sum(1 for r in results.values() if r.passed)
         total = len(results)

--- a/tests/st/runtime/test_dag.py
+++ b/tests/st/runtime/test_dag.py
@@ -14,7 +14,7 @@ This test validates complex multi-kernel orchestration with mixed operations,
 ensuring correct code generation and execution for DAG-structured computations.
 """
 
-from typing import Any, List
+from typing import Any
 
 import pypto.language as pl
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
@@ -38,7 +38,7 @@ class TestVectorDAG(PTOTestCase):
     def get_name(self) -> str:
         return "vector_dag_128x128"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
             TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),

--- a/tests/st/runtime/test_elementwise.py
+++ b/tests/st/runtime/test_elementwise.py
@@ -15,7 +15,7 @@ kernels implemented with the internal PTOTestCase harness, including
 variants for different shapes and optimization strategies.
 """
 
-from typing import Any, List
+from typing import Any
 
 import pypto.language as pl
 import pytest
@@ -40,7 +40,7 @@ class TestTileAdd(PTOTestCase):
     def get_name(self) -> str:
         return "tile_add_128x128"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
             TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
@@ -84,7 +84,7 @@ class TestTileAdd64x64(PTOTestCase):
     def get_name(self) -> str:
         return "tile_add_64x64"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [64, 64], DataType.FP32, init_value=2.0),
             TensorSpec("b", [64, 64], DataType.FP32, init_value=3.0),
@@ -128,7 +128,7 @@ class TestTileMul(PTOTestCase):
     def get_name(self) -> str:
         return "tile_mul_128x128"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             # Method 1: Use Callable to generate random data (different on each run)
             TensorSpec(
@@ -184,7 +184,7 @@ class TestTileMul64x64(PTOTestCase):
     def get_name(self) -> str:
         return "tile_mul_64x64"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec(
                 "a",
@@ -248,7 +248,7 @@ class TestCustomArrayInit(PTOTestCase):
     def get_name(self) -> str:
         return "custom_array_init"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             # Small array: custom values (will be serialized)
             TensorSpec(

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -14,7 +14,7 @@ This test validates the matmul operation implementation through the
 pto-testing-framework, ensuring correct code generation and execution.
 """
 
-from typing import Any, List
+from typing import Any
 
 import pypto.language as pl
 import torch
@@ -27,7 +27,7 @@ class TestMatmul(PTOTestCase):
     def get_name(self) -> str:
         return "matmul_64x64"
 
-    def define_tensors(self) -> List[TensorSpec]:
+    def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [64, 64], DataType.FP32, init_value=2.0),
             TensorSpec("b", [64, 64], DataType.FP32, init_value=3.0),


### PR DESCRIPTION
## Summary
- Batch-convert legacy `typing` syntax (`Optional[X]`, `Union[X, Y]`, `List[X]`, `Dict[K, V]`) to modern Python 3.10+ syntax (`X | None`, `X | Y`, `list[X]`, `dict[K, V]`) across ~40 files using ruff auto-fix
- Update deprecated `typing` imports (e.g., `Sequence`, `Callable`) to `collections.abc`
- Remove unnecessary `"r"` mode in `open()` calls and unnecessary quoted annotations
- Add `UP` (pyupgrade) to ruff lint rules in `pyproject.toml` to prevent regressions

## Testing
- [x] `ruff check python/ tests/` passes clean (zero violations)
- [x] All pre-commit hooks pass (ruff check, ruff format, pyright)
- [x] Build succeeds (`cmake --build build`)
- [x] All 1455 unit tests pass (`pytest tests/ut/`)