### PR TITLE
perf(lint): Speed up clang-tidy with diff-based filtering and batched execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       with:
         submodules: true
 
+    - name: Fetch base branch for diff
+      if: github.event_name == 'pull_request'
+      run: git fetch origin ${{ github.base_ref }} --depth=1
+
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -43,7 +47,12 @@ jobs:
         python -m pip install nanobind clang-tidy==21.1.0
 
     - name: Run clang-tidy
-      run: python tests/lint/clang_tidy.py --jobs=$(nproc)
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          python tests/lint/clang_tidy.py --jobs=$(nproc) --diff-base=origin/${{ github.base_ref }}
+        else
+          python tests/lint/clang_tidy.py --jobs=$(nproc)
+        fi
 
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `--diff-base` flag to only lint C/C++ files changed relative to a git ref, reducing file count from ~70 to typically 1-5 on PRs
- Batch files into `jobs` clang-tidy processes instead of spawning one per file, cutting LLVM startup overhead
- Update CI workflow to use `--diff-base=origin/main` for pull requests (pushes to main still lint everything)

### How diff-based filtering works
- Uses `git diff --name-only` to find changed files
- If only source files (`.c`/`.cpp`/`.cc`/`.cxx`) changed, lints only those
- If header files changed, conservatively falls back to full lint (since headers can affect any source)
- If no C/C++ files changed, exits immediately with success

## Test plan
- [x] Verify `python tests/lint/clang_tidy.py` still works without `--diff-base` (full lint)
- [x] Verify `python tests/lint/clang_tidy.py --diff-base=origin/main` correctly filters to changed files
- [x] Verify CI workflow passes on this PR (exercises the `--diff-base` path)
