### PR TITLE
fix(ci): install nanobind for clang-tidy CMake configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install project and dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install nanobind
         pip install -v .[dev]
 
     - name: Run clang-tidy


### PR DESCRIPTION
## Summary
- PR #212 consolidated CI deps to `pip install .[dev]`, but `nanobind` is only a build-system requirement (PEP 517 isolated build env) and is not persisted after wheel installation
- The clang-tidy job's CMake configuration fails because `find_package(nanobind CONFIG REQUIRED)` can't find nanobind
- Fix: install `nanobind` separately in the clang-tidy job

## Testing
- [ ] CI clang-tidy job passes