### PR TITLE
refactor(passes): co-locate property verifiers with corresponding passes

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -111,12 +111,15 @@ When updating documentation:
 
 1. Explore `docs/dev/passes/` to find pass system documentation
 2. Read the pass manager docs to understand the pass system
-3. Implement the pass in C++ (`src/ir/transforms/`)
+3. Implement the pass in C++ (`src/ir/transforms/`) using `CreateFunctionPass`/`CreateProgramPass`
 4. Add factory function to `include/pypto/ir/transforms/passes.h`
-5. Add Python binding to `python/bindings/modules/passes.cpp`
-6. Create per-pass documentation following existing pass doc patterns
-7. Update pass manager documentation if adding to default strategy
-8. Add tests in `tests/ut/ir/transforms/`
+5. **Declare PassProperties** (required/produced/invalidated) in the factory call
+6. Add Python binding to `python/bindings/modules/passes.cpp`
+7. Update type stub in `python/pypto/pypto_core/passes.pyi`
+8. Create per-pass documentation following existing pass doc patterns
+9. Update pass manager documentation if adding to default strategy
+10. If the pass produces a new IRProperty, add a PropertyVerifier and register in PropertyVerifierRegistry
+11. Add tests in `tests/ut/ir/transforms/`
 
 ### Changing Build/Test Procedures
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,13 @@ set(PYPTO_SOURCES
     src/ir/transforms/convert_to_ssa_pass.cpp
     src/ir/transforms/dependency_analyzer.cpp
     src/ir/transforms/flatten_call_expr_pass.cpp
+    src/ir/transforms/flatten_single_stmt_pass.cpp
     src/ir/transforms/init_memref.cpp
+    src/ir/transforms/ir_property.cpp
+    src/ir/transforms/property_verifier_registry.cpp
     src/ir/transforms/insert_sync_pass.cpp
     src/ir/transforms/mutator.cpp
+    src/ir/transforms/normalize_stmt_structure_pass.cpp
     src/ir/transforms/outline_incore_scopes_pass.cpp
     src/ir/transforms/passes.cpp
     src/ir/transforms/python_printer.cpp

--- a/docs/dev/passes/00-pass_manager.md
+++ b/docs/dev/passes/00-pass_manager.md
@@ -1,301 +1,184 @@
-# Pass and PassManager
+# Pass, PassPipeline, and PassManager
 
-Framework for organizing and executing IR transformation passes on Programs with strategy-based optimization pipelines (Default/PTOAS).
+Framework for organizing and executing IR transformation passes on Programs with property tracking, requirement verification, and strategy-based optimization pipelines.
 
 ## Overview
 
 | Component | Description |
 | --------- | ----------- |
-| **Pass (C++)** | Standalone class for Program → Program transformations |
-| **PassManager (Python)** | Manages pass sequences and execution strategies |
-| **Factory Functions** | Create passes (e.g., `pass::InitMemRef()`, `pass::BasicMemoryReuse()`) |
+| **Pass (C++)** | Standalone class for Program → Program transformations with property declarations |
+| **IRProperty / IRPropertySet** | Enum + bitset for verifiable IR properties (SSAForm, HasMemRefs, etc.) |
+| **PassPipeline (C++)** | Ordered sequence of passes with property tracking and optional verification |
+| **PassManager (Python)** | High-level manager using PassPipeline, with strategy-based optimization |
 
 ### Key Features
 
-- **Program-Only Interface**: All passes transform Program → Program
+- **Property Tracking**: Passes declare required, produced, and invalidated properties
+- **Static Validation**: `PassPipeline.Validate()` checks property flow without executing
+- **Runtime Verification**: Optional property verifiers before/after each pass
+- **Strategy-based Pipelines**: Pre-configured optimization levels (Default/PTOAS)
 - **Immutable Transformations**: Return new IR nodes, don't modify in place
-- **Strategy-based Pipelines**: Pre-configured optimization levels
-- **Factory Pattern**: Passes created via factory functions, implementation details hidden
-- **Unified Header**: All declarations in `include/pypto/ir/transforms/passes.h`
+
+## IRProperty System
+
+### IRProperty Enum
+
+**Header**: `include/pypto/ir/transforms/ir_property.h`
+
+| Property | Description |
+| -------- | ----------- |
+| `SSAForm` | IR is in SSA form |
+| `TypeChecked` | IR has passed type checking |
+| `NoNestedCalls` | No nested call expressions |
+| `NormalizedStmtStructure` | Statement structure normalized |
+| `FlattenedSingleStmt` | Single-statement blocks flattened |
+| `SplitIncoreOrch` | InCore scopes outlined into separate functions |
+| `HasMemRefs` | MemRef objects initialized on variables |
+
+### IRPropertySet
+
+Efficient bitset-backed set with `Insert`, `Remove`, `Contains`, `ContainsAll`, `Union`, `Difference`, `ToString`.
+
+### PassProperties
+
+```cpp
+struct PassProperties {
+  IRPropertySet required;      // Preconditions
+  IRPropertySet produced;      // New properties guaranteed after running
+  IRPropertySet invalidated;   // Properties this pass breaks
+};
+```
+
+**Property update rule**: `new_props = (current - invalidated) | produced`. Required properties are auto-preserved.
+
+## Per-Pass Property Declarations
+
+| Pass | Required | Produced | Invalidated |
+| ---- | -------- | -------- | ----------- |
+| ConvertToSSA | — | SSAForm | NormalizedStmtStructure, FlattenedSingleStmt |
+| VerifySSA | SSAForm | — | — |
+| TypeCheck | — | TypeChecked | — |
+| FlattenCallExpr | — | NoNestedCalls | NormalizedStmtStructure, FlattenedSingleStmt |
+| NormalizeStmtStructure | — | NormalizedStmtStructure | FlattenedSingleStmt |
+| FlattenSingleStmt | — | FlattenedSingleStmt | NormalizedStmtStructure |
+| OutlineIncoreScopes | SSAForm | SplitIncoreOrch | — |
+| InitMemRef | — | HasMemRefs | — |
+| BasicMemoryReuse | HasMemRefs | — | — |
+| InsertSync | HasMemRefs | — | — |
+| AddAlloc | HasMemRefs | — | — |
+| RunVerifier | — | — | — |
 
 ## C++ Pass Infrastructure
 
-### Pass Base Class
-
-**Header**: `include/pypto/ir/transforms/passes.h`
+### Pass Class
 
 ```cpp
 class Pass {
- public:
-  ProgramPtr operator()(const ProgramPtr& program) const;  // Execute pass
+  ProgramPtr operator()(const ProgramPtr& program) const;
+  std::string GetName() const;
+  IRPropertySet GetRequiredProperties() const;
+  IRPropertySet GetProducedProperties() const;
+  IRPropertySet GetInvalidatedProperties() const;
 };
-
-// Factory functions for built-in passes
-namespace pass {
-  Pass ConvertToSSA();           // Convert to SSA form
-  Pass FlattenCallExpr();        // Flatten nested call expressions
-  Pass RunVerifier(...);         // Run IR verification
-  Pass InitMemRef();             // Initializes MemRef for variables
-  Pass BasicMemoryReuse();       // Dependency-based memory reuse
-  Pass InsertSync();             // Inserts synchronization operations
-  Pass AddAlloc();               // Creates alloc operations for MemRefs
-  Pass OutlineIncoreScopes();    // Outline InCore scopes to functions
-  Pass NormalizeStmtStructure(); // Normalize statement structure
-  Pass FlattenSingleStmt();      // Flatten single-statement blocks
-}
 ```
 
-**Key points**: Pimpl pattern hides implementation; all declarations in single header; Program → Program transformations only.
-
-### Pass Implementation Patterns
-
-| Pattern | Use When | Implementation |
-| ------- | -------- | -------------- |
-| **Simple Function-Level** (90% of cases) | Per-function transformations | Use `CreateFunctionPass()` helper |
-| **Complex Custom** | State, helpers, or program-level analysis | Inherit from `PassImpl` |
-
-**Pattern 1: Simple** (e.g. `src/ir/transforms/init_memref.cpp` uses helpers; most passes use `CreateFunctionPass` with a lambda.)
-
-**Pattern 2: Complex** (with state)
+### Creating Passes with Properties
 
 ```cpp
-namespace {
-class ComplexPassImpl : public PassImpl {
- public:
-  ProgramPtr operator()(const ProgramPtr& program) override {
-    for (const auto& [name, func] : program->functions_)
-      state_ += ComputeSomething(func);
-    return program;
-  }
-  std::string GetName() const override { return "ComplexPass"; }
- private:
-  int state_ = 0;
-};
-}
 namespace pass {
-Pass ComplexPass() { return Pass(std::make_shared<ComplexPassImpl>()); }
+Pass YourPass() {
+  return CreateFunctionPass(TransformFunc, "YourPass",
+      {.required = {IRProperty::SSAForm},
+       .produced = {IRProperty::SomeProperty},
+       .invalidated = {IRProperty::AnotherProperty}});
+}
 }
 ```
 
-### Python Bindings
-
-**File**: `python/bindings/modules/passes.cpp`
+### PassPipeline (C++)
 
 ```cpp
-void BindPass(nb::module_& m) {
-  nb::module_ passes = m.def_submodule("passes", "IR transformation passes");
+enum class VerificationMode { None, Before, After, BeforeAndAfter };
 
-  // Opaque pass object
-  nb::class_<Pass>(passes, "Pass")
-      .def("__call__", &Pass::operator(), nb::arg("program"));
-
-  // Factory functions (snake_case)
-  passes.def("convert_to_ssa", &pass::ConvertToSSA);
-  passes.def("flatten_call_expr", &pass::FlattenCallExpr);
-  passes.def("run_verifier", &pass::RunVerifier);
-  passes.def("init_mem_ref", &pass::InitMemRef);
-  passes.def("basic_memory_reuse", &pass::BasicMemoryReuse);
-  passes.def("insert_sync", &pass::InsertSync);
-  passes.def("add_alloc", &pass::AddAlloc);
-  passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes);
-  passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure);
-  passes.def("flatten_single_stmt", &pass::FlattenSingleStmt);
-}
+class PassPipeline {
+  void AddPass(Pass pass);
+  void SetVerificationMode(VerificationMode mode);
+  void SetInitialProperties(const IRPropertySet& properties);
+  ProgramPtr Run(const ProgramPtr& program) const;  // throws on unmet requirements
+  std::vector<std::string> Validate() const;         // static check without executing
+  std::vector<std::string> GetPassNames() const;
+};
 ```
 
-Creates `pypto.pypto_core.passes` module with opaque `Pass` class and factory functions.
+`Run()` tracks `current_props`, checks requirements before each pass, and updates properties after. `Validate()` simulates the flow without executing.
 
 ## Python PassManager
 
 **File**: `python/pypto/ir/pass_manager.py`
 
-### Optimization Strategies
-
-```python
-class OptimizationStrategy(Enum):
-    Default = "Default"      # Full pipeline with SSA conversion, verification, and all optimizations
-    PTOAS = "PTOAS"         # PTO assembly: Memory management only (no SSA, scheduling, or sync)
-```
-
-### PassManager API
+### API
 
 | Method | Description |
 | ------ | ----------- |
-| `get_strategy(strategy)` | Get PassManager configured for strategy |
-| `run_passes(program, dump_ir=False, output_dir=None, prefix='pl')` | Execute all passes sequentially on Program; optionally dump IR |
-| `get_pass_names()` | Get names of all passes in manager |
+| `get_strategy(strategy, verification_mode)` | Get PassManager configured for strategy |
+| `run_passes(program, dump_ir, output_dir, prefix)` | Execute passes via PassPipeline |
+| `validate()` | Static property flow validation |
+| `get_pass_names()` | Get names of all passes |
 
-### Strategy Configuration
-
-Strategies configured in `_register_passes`:
-
-```python
-@classmethod
-def _register_passes(cls):
-    cls._strategy_passes = {
-        OptimizationStrategy.Default: [
-            ("ConvertToSSA", lambda: passes.convert_to_ssa()),
-            ("FlattenCallExpr", lambda: passes.flatten_call_expr()),
-            ("RunVerifier", lambda: passes.run_verifier()),
-            ("InitMemRef", lambda: passes.init_mem_ref()),
-            ("MemoryReuse", lambda: passes.basic_memory_reuse()),
-            ("InsertSync", lambda: passes.insert_sync()),
-            ("AddAlloc", lambda: passes.add_alloc()),
-        ],
-        OptimizationStrategy.PTOAS: [
-            ("InitMemRef", lambda: passes.init_mem_ref()),
-            ("MemoryReuse", lambda: passes.basic_memory_reuse()),
-            ("AddAlloc", lambda: passes.add_alloc()),
-        ],
-    }
-```
-
-## Usage Examples
+### Usage
 
 ```python
-from pypto import ir, DataType
+from pypto import ir
 
-# Create program with multiple functions
-span = ir.Span.unknown()
-dtype = DataType.INT64
-x1, y1 = ir.Var("x", ir.ScalarType(dtype), span), ir.Var("y", ir.ScalarType(dtype), span)
-func1 = ir.Function("func1", [x1], [ir.ScalarType(dtype)], ir.AssignStmt(x1, y1, span), span)
-x2, y2 = ir.Var("x", ir.ScalarType(dtype), span), ir.Var("y", ir.ScalarType(dtype), span)
-func2 = ir.Function("func2", [x2], [ir.ScalarType(dtype)], ir.AssignStmt(x2, y2, span), span)
-program = ir.Program([func1, func2], "test_program", span)
-
-# Run passes with PTOAS strategy
-pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.PTOAS)
+# Default usage
+pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.Default)
 result = pm.run_passes(program)
-# Result has same function names; passes apply InitMemRef, MemoryReuse, AddAlloc
 
-# One-liner shorthand
-result = ir.PassManager.get_strategy(ir.OptimizationStrategy.PTOAS).run_passes(program)
+# With verification
+pm = ir.PassManager.get_strategy(
+    ir.OptimizationStrategy.Default,
+    verification_mode=ir.VerificationMode.BEFORE_AND_AFTER,
+)
+result = pm.run_passes(program)
+
+# Static validation
+errors = pm.validate()  # [] if valid
 ```
 
-## Implementation Details
-
-### Program Transformation Flow
+### Using PassPipeline Directly
 
 ```python
-def run_passes(
-    self,
-    input_ir: core_ir.Program,
-    dump_ir: bool = False,
-    output_dir: Optional[str] = None,
-    prefix: str = "pl",
-) -> core_ir.Program:
-    current = input_ir
-    for pass_instance in self.passes:
-        current = pass_instance(current)  # Program → Program
-        if dump_ir:
-            # Optionally dump IR after each pass to output_dir
-            dump_to_file(current, output_dir, prefix)
-    return current
-```
+from pypto.pypto_core import passes
 
-**Parameters**:
+pipeline = passes.PassPipeline()
+pipeline.add_pass(passes.convert_to_ssa())
+pipeline.add_pass(passes.init_mem_ref())
+pipeline.add_pass(passes.basic_memory_reuse())
 
-- `input_ir`: Input Program to transform
-- `dump_ir`: Whether to dump IR after each pass (default: False)
-- `output_dir`: Directory to dump IR files (required when dump_ir=True)
-- `prefix`: Module prefix for python_print (default: 'pl')
+# Static validation
+errors = pipeline.validate()
 
-Pipeline composition: `Pass3(Pass2(Pass1(program)))` - each pass receives and returns a Program.
+# Execute with property tracking
+result = pipeline.run(program)
 
-### Pass Registration Pattern
-
-- Each strategy maps to `(name, factory)` tuples
-- Factories are lambdas creating fresh pass instances
-- Enables independent PassManager instances
-
-## Testing
-
-**Location**: `tests/ut/ir/transforms/test_pass_manager.py`
-
-**Example**: PTOAS runs InitMemRef, MemoryReuse, AddAlloc; function names unchanged:
-
-```python
-def test_run_passes_on_program_with_ptoa_strategy(self):
-    program = ir.Program([func1, func2], "test_program", span)
-    pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.PTOAS)
-    result = pm.run_passes(program)
-    func_names = [func.name for func in result.functions.values()]
-    assert "func1" in func_names
-    assert "func2" in func_names
+# Inspect pass properties
+p = passes.convert_to_ssa()
+print(p.get_name())                  # "ConvertToSSA"
+print(p.get_produced_properties())   # {SSAForm}
 ```
 
 ## Adding New Passes
 
-1. **Declare in `passes.h`**: `Pass YourNewPass();`
+1. **Declare** in `passes.h`: `Pass YourNewPass();`
+2. **Implement** in `src/ir/transforms/` with `PassProperties`
+3. **Python binding** in `python/bindings/modules/passes.cpp`
+4. **Property declarations**: Set required/produced/invalidated in factory
+5. **Type stub** in `python/pypto/pypto_core/passes.pyi`
+6. **Register** in PassManager if part of a strategy
+7. **Test** in `tests/ut/ir/transforms/`
 
-2. **Implement** (`src/ir/transforms/your_new_pass.cpp`):
+## Testing
 
-   ```cpp
-   // Simple (recommended)
-   namespace pass {
-   Pass YourNewPass() {
-     return CreateFunctionPass([](const FunctionPtr& func) {
-       // Transform function
-       return func;
-     }, "YourNewPass");
-   }
-   }
-
-   // Complex with state
-   namespace {
-   class YourNewPassImpl : public PassImpl {
-    public:
-     ProgramPtr operator()(const ProgramPtr& program) override { /* ... */ }
-     std::string GetName() const override { return "YourNewPass"; }
-    private:
-     int state_ = 0;
-   };
-   }
-   namespace pass {
-   Pass YourNewPass() { return Pass(std::make_shared<YourNewPassImpl>()); }
-   }
-   ```
-
-3. **Python binding** (`python/bindings/modules/passes.cpp`):
-
-   ```cpp
-   passes.def("your_new_pass", &pass::YourNewPass, "Description");
-   ```
-
-4. **Register in PassManager** (`python/pypto/ir/pass_manager.py`):
-
-   ```python
-   ("YourNewPass", lambda: passes.your_new_pass()),
-   ```
-
-5. **Type stub** (`python/pypto/pypto_core/passes.pyi`):
-
-   ```python
-   def your_new_pass() -> Pass: """Description."""
-   ```
-
-6. **Test** (`tests/ut/ir/transforms/test_your_new_pass.py`)
-
-## Design Rationale
-
-| Design Choice | Rationale |
-| ------------- | --------- |
-| **Immutable Transformations** | Thread safety, debugging (preserve original IR), easy rollback, functional style |
-| **Strategy-Based Config** | Ease of use, consistency, centralized maintenance, extensibility |
-| **Program-Only Interface** | Uniform API, enables inter-procedural optimizations, simpler mental model |
-| **Single Header (`passes.h`)** | Reduced bloat, clear discovery, opaque implementation via pimpl |
-
-## Summary
-
-The Pass and PassManager system provides:
-
-- **Extensible Framework**: Easy to add passes via factory functions
-- **Strategy-Based Optimization**: Pre-configured levels (Default/PTOAS)
-- **Unified Interface**: All passes transform Program → Program
-- **Clean API**: Opaque pass objects with factory functions
-- **Well-Tested**: Comprehensive test coverage
-- **Immutable Transformations**: Safe, functional-style IR transformations
-- **Organized Structure**: Single header file with all declarations
-
-This infrastructure provides the foundation for building sophisticated optimization pipelines in PyPTO.
+- `tests/ut/ir/transforms/test_ir_property.py` — IRProperty/IRPropertySet tests
+- `tests/ut/ir/transforms/test_pass_pipeline.py` — Pipeline validation and execution
+- `tests/ut/ir/transforms/test_pass_manager.py` — PassManager backward compatibility

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_IR_PROPERTY_H_
+#define PYPTO_IR_TRANSFORMS_IR_PROPERTY_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Enumeration of verifiable IR properties
+ *
+ * Each value represents a property that the IR may or may not satisfy.
+ * Passes can declare which properties they require, produce, and invalidate.
+ * Not all passes produce properties — performance optimization passes
+ * (BasicMemoryReuse, InsertSync, AddAlloc) only have requirements but
+ * don't produce new verifiable properties. This is by design.
+ */
+enum class IRProperty : uint32_t {
+  SSAForm = 0,              ///< IR is in SSA form
+  TypeChecked,              ///< IR has passed type checking
+  NoNestedCalls,            ///< No nested call expressions
+  NormalizedStmtStructure,  ///< Statement structure normalized
+  FlattenedSingleStmt,      ///< Single-statement blocks flattened
+  SplitIncoreOrch,          ///< InCore scopes outlined into separate functions
+  HasMemRefs,               ///< MemRef objects initialized on variables
+  kCount                    ///< Sentinel (must be last)
+};
+
+/**
+ * @brief Convert an IRProperty to its string name
+ */
+std::string IRPropertyToString(IRProperty prop);
+
+/**
+ * @brief A set of IR properties backed by a uint64_t bitset
+ *
+ * Efficient O(1) insert/remove/contains operations. Supports up to 64 properties.
+ */
+class IRPropertySet {
+ public:
+  IRPropertySet() : bits_(0) {}
+
+  /**
+   * @brief Construct from a list of properties
+   */
+  IRPropertySet(std::initializer_list<IRProperty> props) : bits_(0) {  // NOLINT(google-explicit-constructor)
+    for (auto p : props) {
+      Insert(p);
+    }
+  }
+
+  /**
+   * @brief Insert a property into the set
+   */
+  void Insert(IRProperty prop) { bits_ |= Bit(prop); }
+
+  /**
+   * @brief Remove a property from the set
+   */
+  void Remove(IRProperty prop) { bits_ &= ~Bit(prop); }
+
+  /**
+   * @brief Check if the set contains a property
+   */
+  [[nodiscard]] bool Contains(IRProperty prop) const { return (bits_ & Bit(prop)) != 0; }
+
+  /**
+   * @brief Check if this set contains all properties in another set
+   */
+  [[nodiscard]] bool ContainsAll(const IRPropertySet& other) const {
+    return (bits_ & other.bits_) == other.bits_;
+  }
+
+  /**
+   * @brief Return the union of this set and another
+   */
+  [[nodiscard]] IRPropertySet Union(const IRPropertySet& other) const {
+    IRPropertySet result;
+    result.bits_ = bits_ | other.bits_;
+    return result;
+  }
+
+  /**
+   * @brief Return the intersection of this set and another
+   */
+  [[nodiscard]] IRPropertySet Intersection(const IRPropertySet& other) const {
+    IRPropertySet result;
+    result.bits_ = bits_ & other.bits_;
+    return result;
+  }
+
+  /**
+   * @brief Return this set minus another (set difference)
+   */
+  [[nodiscard]] IRPropertySet Difference(const IRPropertySet& other) const {
+    IRPropertySet result;
+    result.bits_ = bits_ & ~other.bits_;
+    return result;
+  }
+
+  /**
+   * @brief Check if the set is empty
+   */
+  [[nodiscard]] bool Empty() const { return bits_ == 0; }
+
+  /**
+   * @brief Convert to a vector of the contained properties
+   */
+  [[nodiscard]] std::vector<IRProperty> ToVector() const;
+
+  /**
+   * @brief Convert to a human-readable string (e.g., "{SSAForm, TypeChecked}")
+   */
+  [[nodiscard]] std::string ToString() const;
+
+  bool operator==(const IRPropertySet& other) const { return bits_ == other.bits_; }
+  bool operator!=(const IRPropertySet& other) const { return bits_ != other.bits_; }
+
+ private:
+  uint64_t bits_;
+
+  static uint64_t Bit(IRProperty prop) { return uint64_t{1} << static_cast<uint32_t>(prop); }
+};
+
+/**
+ * @brief Property declarations for a pass
+ *
+ * Used with CreateFunctionPass/CreateProgramPass to declare pass requirements.
+ */
+struct PassProperties {
+  IRPropertySet required;     ///< Preconditions: must hold before the pass runs
+  IRPropertySet produced;     ///< New properties guaranteed after running
+  IRPropertySet invalidated;  ///< Properties this pass breaks
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_IR_PROPERTY_H_

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -19,6 +19,7 @@
 
 #include "pypto/ir/function.h"
 #include "pypto/ir/program.h"
+#include "pypto/ir/transforms/ir_property.h"
 
 namespace pypto {
 namespace ir {
@@ -26,17 +27,8 @@ namespace ir {
 /**
  * @brief Internal base class for pass implementations
  *
- * This is an internal class used for implementing passes via pimpl pattern.
- *
- * Most passes should use CreateFunctionPass() or CreateProgramPass() helpers instead
- * of directly inheriting from this class. Only inherit from PassImpl for complex
- * passes that need:
- * - Custom state management
- * - Complex helper methods
- * - Program-level analysis (not just per-function transformations)
- *
- * For simple function-level transformations, use CreateFunctionPass() which
- * automatically handles the Program → Program transformation.
+ * Most passes should use CreateFunctionPass() or CreateProgramPass() helpers.
+ * Only inherit from PassImpl for complex passes with custom state.
  */
 class PassImpl {
  public:
@@ -44,9 +36,6 @@ class PassImpl {
 
   /**
    * @brief Execute the pass on a program
-   *
-   * @param program Input program to transform
-   * @return Transformed program
    */
   virtual ProgramPtr operator()(const ProgramPtr& program) = 0;
 
@@ -54,18 +43,28 @@ class PassImpl {
    * @brief Get the name of the pass (for debugging)
    */
   [[nodiscard]] virtual std::string GetName() const { return "UnnamedPass"; }
+
+  /**
+   * @brief Get properties required before this pass can run
+   */
+  [[nodiscard]] virtual IRPropertySet GetRequiredProperties() const { return {}; }
+
+  /**
+   * @brief Get properties produced (guaranteed) after this pass runs
+   */
+  [[nodiscard]] virtual IRPropertySet GetProducedProperties() const { return {}; }
+
+  /**
+   * @brief Get properties invalidated (broken) by this pass
+   */
+  [[nodiscard]] virtual IRPropertySet GetInvalidatedProperties() const { return {}; }
 };
 
 /**
  * @brief Base class for IR transformation passes
  *
- * Pass is a standalone class (not inheriting from IRMutator) that provides transformations
- * on Program level. Each pass operates on entire Programs, returning transformed IR.
- * Passes maintain immutability - they return new IR instances rather than modifying in place.
- *
- * The Pass class uses a pimpl pattern to hide implementation details.
- * Users should create passes using factory functions (CreateInitMemRef, etc.)
- * rather than instantiating Pass directly.
+ * Pass uses a pimpl pattern to hide implementation details.
+ * Users should create passes using factory functions.
  */
 class Pass {
  public:
@@ -73,7 +72,7 @@ class Pass {
   explicit Pass(std::shared_ptr<PassImpl> impl);
   ~Pass();
 
-  // Copy and move constructors/assignment
+  // Copy and move
   Pass(const Pass& other);
   Pass& operator=(const Pass& other);
   Pass(Pass&& other) noexcept;
@@ -81,24 +80,33 @@ class Pass {
 
   /**
    * @brief Execute the pass on a program (primary API)
-   *
-   * This is the main entry point for pass execution using function call operator.
-   *
-   * @param program Input program to transform
-   * @return Transformed program (may be the same pointer if no changes were made)
    */
   ProgramPtr operator()(const ProgramPtr& program) const;
 
   /**
    * @brief Execute the pass on a program (backward compatible API)
-   *
-   * This method provides backward compatibility with existing code.
-   * It delegates to operator().
-   *
-   * @param program Input program to transform
-   * @return Transformed program
    */
   [[nodiscard]] ProgramPtr run(const ProgramPtr& program) const;
+
+  /**
+   * @brief Get the name of the pass
+   */
+  [[nodiscard]] std::string GetName() const;
+
+  /**
+   * @brief Get properties required before this pass can run
+   */
+  [[nodiscard]] IRPropertySet GetRequiredProperties() const;
+
+  /**
+   * @brief Get properties produced (guaranteed) after this pass runs
+   */
+  [[nodiscard]] IRPropertySet GetProducedProperties() const;
+
+  /**
+   * @brief Get properties invalidated (broken) by this pass
+   */
+  [[nodiscard]] IRPropertySet GetInvalidatedProperties() const;
 
  private:
   std::shared_ptr<PassImpl> impl_;
@@ -107,45 +115,27 @@ class Pass {
 // Factory functions for built-in passes
 namespace pass {
 
-// Utility functions for creating custom passes
-//
-// These helpers simplify pass creation by eliminating boilerplate code.
-// Most passes should use these instead of inheriting from PassImpl.
-
 /**
  * @brief Create a pass from a function-level transform function (RECOMMENDED)
  *
- * This is the recommended way to create passes that apply transformations to each
- * function independently. The helper automatically handles the Program → Program
- * transformation by applying your function to each function in the program.
- *
- * Example:
- *   Pass MyPass() {
- *     return CreateFunctionPass([](const FunctionPtr& func) {
- *       // Transform the function
- *       return transformed_func;
- *     }, "MyPass");
- *   }
- *
  * @param transform Function that transforms a Function
  * @param name Optional name for the pass (for debugging)
+ * @param properties Optional property declarations
  * @return Pass that applies the transform to each function
  */
 Pass CreateFunctionPass(std::function<FunctionPtr(const FunctionPtr&)> transform,
-                        const std::string& name = "");
+                        const std::string& name = "", const PassProperties& properties = {});
 
 /**
  * @brief Create a pass from a program-level transform function
  *
- * Use this for passes that need to transform the entire program at once,
- * such as inter-procedural optimizations or whole-program analysis.
- * For most cases, prefer CreateFunctionPass() instead.
- *
  * @param transform Function that transforms a Program
  * @param name Optional name for the pass (for debugging)
+ * @param properties Optional property declarations
  * @return Pass that applies the transform
  */
-Pass CreateProgramPass(std::function<ProgramPtr(const ProgramPtr&)> transform, const std::string& name = "");
+Pass CreateProgramPass(std::function<ProgramPtr(const ProgramPtr&)> transform, const std::string& name = "",
+                       const PassProperties& properties = {});
 
 /**
  * @brief Create an init memref pass
@@ -175,167 +165,135 @@ Pass InsertSync();
 /**
  * @brief Create an add alloc pass
  *
- * This pass traverses all TileType variables in each Function and creates alloc operations
- * for each unique MemRef. The alloc operations are added at the beginning of the function.
- *
- * The pass:
- * 1. Identifies all TileType variables in the function
- * 2. Collects all unique MemRef objects from these TileType variables
- * 3. Creates an alloc operation for each unique MemRef
- * 4. Prepends these alloc operations to the function body
- *
- * Each alloc operation has no input/output arguments but is bound to a MemRef pointer
- * to track memory allocation for that specific buffer.
- *
- * @return Pass that adds alloc operations
+ * Traverses all TileType variables and creates alloc operations for each unique MemRef.
+ * The alloc operations are added at the beginning of the function.
  */
 Pass AddAlloc();
 
 /**
  * @brief Create an SSA verification pass
- *
- * This pass verifies SSA form of IR by checking:
- * 1. Each variable is assigned only once (MULTIPLE_ASSIGNMENT)
- * 2. No variable name shadowing across scopes (NAME_SHADOWING)
- * 3. ForStmt with iter_args must have YieldStmt as last statement (MISSING_YIELD)
- * 4. IfStmt with return_vars must have YieldStmt in both then and else branches (MISSING_YIELD)
- *
- * The pass collects all errors and generates a verification report instead of
- * throwing exceptions, allowing detection of all issues in a single run.
- *
- * @return Pass that performs SSA verification
  */
 Pass VerifySSA();
 
 /**
  * @brief Create a type checking pass
- *
- * This pass checks type consistency in control flow constructs:
- * 1. ForStmt: iter_args initValue, yield values, and return_vars must have matching types
- * 2. IfStmt: then and else yield values must have matching types
- * 3. Shape consistency for TensorType and TileType
- *
- * The pass collects all errors and generates a type checking report instead of
- * throwing exceptions, allowing detection of all issues in a single run.
- *
- * @return Pass that performs type checking
  */
 Pass TypeCheck();
 
 /**
  * @brief Create an SSA conversion pass
- *
- * This pass converts non-SSA IR to SSA form by:
- * 1. Renaming variables with version suffixes (x -> x_0, x_1, x_2)
- * 2. Adding phi nodes (return_vars + YieldStmt) for IfStmt control flow divergence
- * 3. Converting loop-modified variables to iter_args + return_vars pattern
- *
- * The pass handles:
- * - Straight-line code: multiple assignments to the same variable
- * - If statements: variables modified in one or both branches
- * - For loops: variables modified inside the loop body
- * - Mixed SSA/non-SSA: preserves existing SSA structure while converting non-SSA parts
- *
- * @return Pass that converts to SSA form
  */
 Pass ConvertToSSA();
 
 /**
  * @brief Outline InCore scopes into separate functions
  *
- * This pass transforms ScopeStmt(InCore) nodes into separate Function(InCore) definitions
- * and replaces the scope with a Call to the outlined function.
- *
  * Requirements:
  * - Input IR must be in SSA form (run ConvertToSSA first)
- * - Only processes Opaque functions (InCore functions are left unchanged)
- *
- * Transformation:
- * 1. For each ScopeStmt(InCore) in an Opaque function:
- *    - Analyze body to determine external variable references (inputs)
- *    - Analyze body to determine internal definitions used after scope (outputs)
- *    - Extract body into new Function(InCore) with appropriate params/returns
- *    - Replace scope with Call to the outlined function + output assignments
- * 2. Add outlined functions to the program
- *
- * @return Pass that outlines InCore scopes
+ * - Only processes Opaque functions
  */
 Pass OutlineIncoreScopes();
 
 /**
  * @brief Create a verifier pass with configurable rules
  *
- * This pass creates an IRVerifier with default rules (SSAVerify, TypeCheck)
- * and allows disabling specific rules. The verifier collects all diagnostics
- * and logs them without throwing exceptions (unless there are errors).
- *
- * @param disabled_rules Vector of rule names to disable (e.g., {"TypeCheck"})
+ * @param disabled_rules Vector of rule names to disable
  * @return Pass that runs IR verification
  */
 Pass RunVerifier(const std::vector<std::string>& disabled_rules = {});
 
 /**
- * @brief Create a pass that flattens nested call expressions into three-address code
- *
- * This pass ensures that call expressions do not appear in nested contexts:
- * 1. Call arguments cannot be calls
- * 2. If conditions cannot be calls
- * 3. For loop ranges (start/stop/step) cannot be calls
- * 4. Binary/unary expression operands cannot be calls
- *
- * Nested calls are extracted into temporary variables (named _t0, _t1, etc.)
- * and inserted as AssignStmt before the statement containing the nested call.
- * For if/for statements, extracted statements are inserted into the last OpStmts
- * before the if/for, or a new OpStmts is created if needed.
- *
- * Example transformation:
- *   c = foo(bar(a))  =>  _t0 = bar(a); c = foo(_t0)
- *
- * @return Pass that flattens nested call expressions
+ * @brief Create a pass that flattens nested call expressions
  */
 Pass FlattenCallExpr();
 
 /**
  * @brief Create a pass that normalizes statement structure
- *
- * This pass ensures IR is in a normalized form:
- * 1. Function/IfStmt/ForStmt body must be SeqStmts
- * 2. Consecutive AssignStmt/EvalStmt in SeqStmts are wrapped in OpStmts
- *
- * Example transformations:
- *   Function body = AssignStmt(x, 1)
- *   => Function body = SeqStmts([OpStmts([AssignStmt(x, 1)])])
- *
- *   SeqStmts([AssignStmt(a, 1), AssignStmt(b, 2), IfStmt(...)])
- *   => SeqStmts([OpStmts([AssignStmt(a, 1), AssignStmt(b, 2)]), IfStmt(...)])
- *
- * @return Pass that normalizes statement structure
  */
 Pass NormalizeStmtStructure();
 
 /**
  * @brief Create a pass that recursively flattens single-statement blocks
- *
- * This pass simplifies IR by removing unnecessary nesting:
- * - SeqStmts with only one statement is replaced by that statement
- * - OpStmts with only one statement is replaced by that statement
- * - Process is applied recursively
- *
- * Example transformations:
- *   SeqStmts([OpStmts([AssignStmt(x, 1)])])
- *   => AssignStmt(x, 1)
- *
- *   SeqStmts([OpStmts([AssignStmt(x, 1), AssignStmt(y, 2)])])
- *   => OpStmts([AssignStmt(x, 1), AssignStmt(y, 2)])
- *
- * Note: This pass does NOT enforce that Function/IfStmt/ForStmt body must be SeqStmts.
- * It will flatten them if they contain only a single statement.
- *
- * @return Pass that flattens single-statement blocks
  */
 Pass FlattenSingleStmt();
 
 }  // namespace pass
+
+/**
+ * @brief Controls when property verification runs in a PassPipeline
+ */
+enum class VerificationMode {
+  None,           ///< No automatic verification
+  Before,         ///< Verify required properties before each pass
+  After,          ///< Verify produced properties after each pass
+  BeforeAndAfter  ///< Verify both before and after each pass
+};
+
+/**
+ * @brief A pipeline of passes with property tracking and verification
+ *
+ * PassPipeline maintains a sequence of passes and tracks IR properties
+ * as passes are executed. It validates that pass requirements are met
+ * and optionally runs property verifiers before/after each pass.
+ *
+ * Usage:
+ * @code
+ *   PassPipeline pipeline;
+ *   pipeline.AddPass(pass::ConvertToSSA());
+ *   pipeline.AddPass(pass::FlattenCallExpr());
+ *   pipeline.AddPass(pass::RunVerifier());
+ *
+ *   // Static validation (no execution)
+ *   auto errors = pipeline.Validate();
+ *
+ *   // Execute with property tracking
+ *   auto result = pipeline.Run(program);
+ * @endcode
+ */
+class PassPipeline {
+ public:
+  PassPipeline();
+
+  /**
+   * @brief Add a pass to the pipeline
+   */
+  void AddPass(Pass pass);
+
+  /**
+   * @brief Set verification mode
+   */
+  void SetVerificationMode(VerificationMode mode);
+
+  /**
+   * @brief Set initial properties (properties known to hold before the pipeline runs)
+   */
+  void SetInitialProperties(const IRPropertySet& properties);
+
+  /**
+   * @brief Execute all passes with property tracking
+   * @param program Input program
+   * @return Transformed program
+   * @throws ValueError if a pass's required properties are not satisfied
+   */
+  [[nodiscard]] ProgramPtr Run(const ProgramPtr& program) const;
+
+  /**
+   * @brief Static validation: check property flow without executing passes
+   * @return List of error messages (empty if valid)
+   */
+  [[nodiscard]] std::vector<std::string> Validate() const;
+
+  /**
+   * @brief Get the names of all passes in the pipeline
+   */
+  [[nodiscard]] std::vector<std::string> GetPassNames() const;
+
+ private:
+  std::vector<Pass> passes_;
+  VerificationMode verification_mode_;
+  IRPropertySet initial_properties_;
+};
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transforms/property_verifier_registry.h
+++ b/include/pypto/ir/transforms/property_verifier_registry.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_
+#define PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/transforms/ir_property.h"
+#include "pypto/ir/transforms/verifier.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Registry mapping IRProperty values to their PropertyVerifier factories
+ *
+ * The registry is a singleton that holds factory functions for creating verifiers
+ * for each IR property. This allows the PassPipeline to automatically verify
+ * properties before/after passes.
+ */
+class PropertyVerifierRegistry {
+ public:
+  /**
+   * @brief Get the singleton registry instance
+   */
+  static PropertyVerifierRegistry& GetInstance();
+
+  /**
+   * @brief Register a verifier factory for a property
+   * @param prop The property this verifier checks
+   * @param factory Function that creates a new PropertyVerifier instance
+   */
+  void Register(IRProperty prop, std::function<PropertyVerifierPtr()> factory);
+
+  /**
+   * @brief Get the verifier for a property
+   * @param prop The property to get a verifier for
+   * @return New PropertyVerifier instance, or nullptr if none registered
+   */
+  [[nodiscard]] PropertyVerifierPtr GetVerifier(IRProperty prop) const;
+
+  /**
+   * @brief Check if a verifier is registered for a property
+   */
+  [[nodiscard]] bool HasVerifier(IRProperty prop) const;
+
+  /**
+   * @brief Verify a set of properties on a program
+   * @param properties Properties to verify
+   * @param program Program to verify against
+   * @return Diagnostics from all verifiers (empty if all pass)
+   */
+  [[nodiscard]] std::vector<Diagnostic> VerifyProperties(const IRPropertySet& properties,
+                                                         const ProgramPtr& program) const;
+
+ private:
+  PropertyVerifierRegistry();
+
+  std::unordered_map<uint32_t, std::function<PropertyVerifierPtr()>> factories_;
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_

--- a/include/pypto/ir/transforms/verifier.h
+++ b/include/pypto/ir/transforms/verifier.h
@@ -18,189 +18,155 @@
 #include <vector>
 
 #include "pypto/core/error.h"
-#include "pypto/ir/function.h"
 #include "pypto/ir/program.h"
 
 namespace pypto {
 namespace ir {
 
 /**
- * @brief Base class for verification rules
+ * @brief Base class for IR property verifiers
  *
- * Each verification rule implements a specific check on IR functions.
- * Rules can detect errors or warnings and add them to a diagnostics vector.
+ * Each verifier implements a specific check on IR programs.
+ * Verifiers can detect errors or warnings and add them to a diagnostics vector.
+ * Each verifier receives a ProgramPtr and internally decides whether to iterate
+ * over functions or check program-level properties.
  *
- * To create a new verification rule:
- * 1. Inherit from VerifyRule
- * 2. Implement GetName() to return a unique rule name
+ * To create a new property verifier:
+ * 1. Inherit from PropertyVerifier
+ * 2. Implement GetName() to return a unique name
  * 3. Implement Verify() to perform the verification logic
  *
  * Example:
  * @code
- *   class MyCustomRule : public VerifyRule {
+ *   class MyVerifier : public PropertyVerifier {
  *    public:
- *     std::string GetName() const override { return "MyCustomRule"; }
- *     void Verify(const FunctionPtr& func, std::vector<Diagnostic>& diagnostics) override {
- *       // Verification logic
+ *     std::string GetName() const override { return "MyVerifier"; }
+ *     void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+ *       for (const auto& [gv, func] : program->functions_) {
+ *         // Verification logic per function
+ *       }
  *     }
  *   };
  * @endcode
  */
-class VerifyRule {
+class PropertyVerifier {
  public:
-  virtual ~VerifyRule() = default;
+  virtual ~PropertyVerifier() = default;
 
   /**
-   * @brief Get the name of this verification rule
-   * @return Unique name for this rule (e.g., "SSAVerify", "TypeCheck")
+   * @brief Get the name of this verifier
+   * @return Unique name (e.g., "SSAVerify", "TypeCheck")
    */
   [[nodiscard]] virtual std::string GetName() const = 0;
 
   /**
-   * @brief Verify a function and collect diagnostics
-   * @param func Function to verify
+   * @brief Verify a program and collect diagnostics
+   * @param program Program to verify
    * @param diagnostics Vector to append diagnostics to
    *
-   * This method should examine the function and add any detected issues
+   * This method should examine the program and add any detected issues
    * to the diagnostics vector. It should not throw exceptions - all issues
    * should be reported through diagnostics.
    */
-  virtual void Verify(const FunctionPtr& func, std::vector<Diagnostic>& diagnostics) = 0;
+  virtual void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) = 0;
 };
 
-/// Shared pointer to a verification rule
-using VerifyRulePtr = std::shared_ptr<VerifyRule>;
+/// Shared pointer to a property verifier
+using PropertyVerifierPtr = std::shared_ptr<PropertyVerifier>;
+
+// Backward compatibility aliases
+using VerifyRule = PropertyVerifier;
+using VerifyRulePtr = PropertyVerifierPtr;
 
 /**
- * @brief Factory function for creating SSA verification rule
- * @return Shared pointer to SSAVerifyRule
+ * @brief Factory function for creating SSA property verifier
+ * @return Shared pointer to SSA PropertyVerifier
  */
-VerifyRulePtr CreateSSAVerifyRule();
+PropertyVerifierPtr CreateSSAPropertyVerifier();
 
 /**
- * @brief Factory function for creating type check verification rule
- * @return Shared pointer to TypeCheckRule
+ * @brief Factory function for creating type check property verifier
+ * @return Shared pointer to TypeCheck PropertyVerifier
  */
-VerifyRulePtr CreateTypeCheckRule();
+PropertyVerifierPtr CreateTypeCheckPropertyVerifier();
 
 /**
- * @brief Factory function for creating no nested call verification rule
- * @return Shared pointer to NoNestedCallVerifyRule
+ * @brief Factory function for creating no nested call property verifier
+ * @return Shared pointer to NoNestedCall PropertyVerifier
  */
-VerifyRulePtr CreateNoNestedCallVerifyRule();
+PropertyVerifierPtr CreateNoNestedCallPropertyVerifier();
+
+/**
+ * @brief Factory function for creating NormalizedStmtStructure property verifier
+ * @return Shared pointer to NormalizedStmtStructure PropertyVerifier
+ */
+PropertyVerifierPtr CreateNormalizedStmtPropertyVerifier();
+
+/**
+ * @brief Factory function for creating FlattenedSingleStmt property verifier
+ * @return Shared pointer to FlattenedSingleStmt PropertyVerifier
+ */
+PropertyVerifierPtr CreateFlattenedSingleStmtPropertyVerifier();
+
+/**
+ * @brief Factory function for creating SplitIncoreOrch property verifier
+ * @return Shared pointer to SplitIncoreOrch PropertyVerifier
+ */
+PropertyVerifierPtr CreateSplitIncoreOrchPropertyVerifier();
+
+/**
+ * @brief Factory function for creating HasMemRefs property verifier
+ * @return Shared pointer to HasMemRefs PropertyVerifier
+ */
+PropertyVerifierPtr CreateHasMemRefsPropertyVerifier();
+
+// Backward compatibility aliases for factory functions
+inline VerifyRulePtr CreateSSAVerifyRule() { return CreateSSAPropertyVerifier(); }
+inline VerifyRulePtr CreateTypeCheckRule() { return CreateTypeCheckPropertyVerifier(); }
+inline VerifyRulePtr CreateNoNestedCallVerifyRule() { return CreateNoNestedCallPropertyVerifier(); }
 
 /**
  * @brief IR verification system
  *
- * IRVerifier manages a collection of verification rules and applies them to programs.
- * Rules can be enabled/disabled individually, and the verifier can operate in two modes:
+ * IRVerifier manages a collection of property verifiers and applies them to programs.
+ * Verifiers can be enabled/disabled individually, and the verifier can operate in two modes:
  * - Verify(): Collects all diagnostics without throwing
  * - VerifyOrThrow(): Collects diagnostics and throws if errors are found
  *
  * Usage:
  * @code
- *   // Create default verifier with all built-in rules
  *   auto verifier = IRVerifier::CreateDefault();
- *
- *   // Disable specific rules
  *   verifier.DisableRule("TypeCheck");
- *
- *   // Run verification
  *   auto diagnostics = verifier.Verify(program);
- *   for (const auto& d : diagnostics) {
- *     if (d.severity == DiagnosticSeverity::Error) {
- *       LOG_ERROR << d.message;
- *     }
- *   }
- *
- *   // Or throw on errors
  *   verifier.VerifyOrThrow(program);
  * @endcode
  */
 class IRVerifier {
  public:
-  /**
-   * @brief Construct an empty verifier with no rules
-   */
   IRVerifier();
 
   /**
-   * @brief Add a verification rule to this verifier
-   * @param rule Shared pointer to the rule to add
+   * @brief Add a property verifier
+   * @param rule Shared pointer to the verifier to add
    *
-   * Rules are executed in the order they are added.
-   * If a rule with the same name already exists, it will not be added again.
+   * Verifiers are executed in the order they are added.
+   * If a verifier with the same name already exists, it will not be added again.
    */
-  void AddRule(VerifyRulePtr rule);
+  void AddRule(PropertyVerifierPtr rule);
 
-  /**
-   * @brief Enable a previously disabled rule
-   * @param name Name of the rule to enable
-   *
-   * If the rule is not found or is already enabled, this is a no-op.
-   */
   void EnableRule(const std::string& name);
-
-  /**
-   * @brief Disable a rule
-   * @param name Name of the rule to disable
-   *
-   * Disabled rules will be skipped during verification.
-   */
   void DisableRule(const std::string& name);
-
-  /**
-   * @brief Check if a rule is currently enabled
-   * @param name Name of the rule to check
-   * @return true if the rule is enabled, false if disabled or not found
-   */
   [[nodiscard]] bool IsRuleEnabled(const std::string& name) const;
 
-  /**
-   * @brief Verify a program and collect diagnostics
-   * @param program Program to verify
-   * @return Vector of all diagnostics (errors and warnings)
-   *
-   * This method runs all enabled rules on all functions in the program
-   * and collects diagnostics. It does not throw exceptions even if errors
-   * are found - use VerifyOrThrow() if you want exception-based error handling.
-   */
   [[nodiscard]] std::vector<Diagnostic> Verify(const ProgramPtr& program) const;
-
-  /**
-   * @brief Verify a program and throw on errors
-   * @param program Program to verify
-   * @throws VerificationError if any errors are found
-   *
-   * This method runs verification and throws a VerificationError if any
-   * diagnostics with severity Error are found. Warnings do not cause an exception.
-   */
   void VerifyOrThrow(const ProgramPtr& program) const;
 
-  /**
-   * @brief Generate a formatted report from diagnostics
-   * @param diagnostics Vector of diagnostics to format
-   * @return Formatted report string
-   *
-   * The report includes:
-   * - Total count of errors and warnings
-   * - Details for each diagnostic (severity, rule name, message, location)
-   * - Overall verification status
-   */
   static std::string GenerateReport(const std::vector<Diagnostic>& diagnostics);
-
-  /**
-   * @brief Create a verifier with default built-in rules
-   * @return IRVerifier with SSAVerify and TypeCheck rules
-   *
-   * This factory method creates a verifier pre-configured with all
-   * standard verification rules enabled.
-   */
   static IRVerifier CreateDefault();
 
  private:
-  std::vector<VerifyRulePtr> rules_;                ///< All registered verification rules
-  std::unordered_set<std::string> disabled_rules_;  ///< Names of disabled rules
+  std::vector<PropertyVerifierPtr> rules_;
+  std::unordered_set<std::string> disabled_rules_;
 };
 
 }  // namespace ir

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -31,8 +31,8 @@ from .builder import IRBuilder
 # Import high-level API functions
 from .compile import compile
 
-# Import PassManager and OptimizationStrategy
-from .pass_manager import OptimizationStrategy, PassManager
+# Import PassManager, OptimizationStrategy, and VerificationMode
+from .pass_manager import OptimizationStrategy, PassManager, VerificationMode
 
 # Import python_print utility
 from .printer import python_print
@@ -72,4 +72,5 @@ __all__ = [
     "compile",
     "PassManager",
     "OptimizationStrategy",
+    "VerificationMode",
 ]  # fmt: skip

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -12,89 +12,98 @@ from enum import Enum
 
 from pypto.pypto_core.ir import Program, Span
 
-class Pass:
-    """Opaque pass object. Do not instantiate directly - use factory functions.
+class IRProperty(Enum):
+    """Verifiable IR properties."""
 
-    A Pass represents a transformation that can be applied to a Program.
-    Pass objects should be created using factory functions (init_mem_ref, etc.)
-    rather than being instantiated directly.
-    """
+    SSAForm = ...
+    TypeChecked = ...
+    NoNestedCalls = ...
+    NormalizedStmtStructure = ...
+    FlattenedSingleStmt = ...
+    SplitIncoreOrch = ...
+    HasMemRefs = ...
+
+class IRPropertySet:
+    """A set of IR properties backed by a bitset."""
+
+    def __init__(self) -> None: ...
+    def insert(self, prop: IRProperty) -> None: ...
+    def remove(self, prop: IRProperty) -> None: ...
+    def contains(self, prop: IRProperty) -> bool: ...
+    def contains_all(self, other: IRPropertySet) -> bool: ...
+    def union_with(self, other: IRPropertySet) -> IRPropertySet: ...
+    def intersection(self, other: IRPropertySet) -> IRPropertySet: ...
+    def difference(self, other: IRPropertySet) -> IRPropertySet: ...
+    def empty(self) -> bool: ...
+    def to_list(self) -> list[IRProperty]: ...
+    def __str__(self) -> str: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __ne__(self, other: object) -> bool: ...
+
+class VerificationMode(Enum):
+    """Controls when property verification runs in a PassPipeline."""
+
+    NONE = ...
+    BEFORE = ...
+    AFTER = ...
+    BEFORE_AND_AFTER = ...
+
+class Pass:
+    """Opaque pass object. Do not instantiate directly - use factory functions."""
 
     def __call__(self, program: Program) -> Program:
-        """Execute the pass on a program.
+        """Execute the pass on a program."""
 
-        Args:
-            program: Input Program to transform
+    def get_name(self) -> str:
+        """Get the name of the pass."""
 
-        Returns:
-            Transformed Program after the pass has been applied
-        """
+    def get_required_properties(self) -> IRPropertySet:
+        """Get properties required before this pass can run."""
+
+    def get_produced_properties(self) -> IRPropertySet:
+        """Get properties produced after this pass runs."""
+
+    def get_invalidated_properties(self) -> IRPropertySet:
+        """Get properties invalidated by this pass."""
+
+class PassPipeline:
+    """A pipeline of passes with property tracking and verification."""
+
+    def __init__(self) -> None:
+        """Create an empty pipeline."""
+
+    def add_pass(self, pass_obj: Pass) -> None:
+        """Add a pass to the pipeline."""
+
+    def set_verification_mode(self, mode: VerificationMode) -> None:
+        """Set verification mode."""
+
+    def set_initial_properties(self, properties: IRPropertySet) -> None:
+        """Set initial properties."""
 
     def run(self, program: Program) -> Program:
-        """Execute the pass on a program (backward compatible).
+        """Execute all passes with property tracking."""
 
-        Args:
-            program: Input Program to transform
+    def validate(self) -> list[str]:
+        """Static validation: check property flow without executing."""
 
-        Returns:
-            Transformed Program after the pass has been applied
-        """
+    def get_pass_names(self) -> list[str]:
+        """Get names of all passes."""
 
-# Factory functions with snake_case names
+# Factory functions
 
 def init_mem_ref() -> Pass:
-    """Create an init memref pass.
-
-    Initializes MemRef for all variables in functions.
-    Sets memory space to UB by default, or DDR for block.load/block.store operands.
-
-    Returns:
-        Pass object that initializes memrefs
-    """
+    """Create an init memref pass."""
 
 def basic_memory_reuse() -> Pass:
-    """Create a basic memory reuse pass.
-
-    Uses dependency analysis to identify memory reuse opportunities.
-    Variables with non-overlapping lifetimes in the same memory space can
-    share MemRef objects.
-
-    Returns:
-        Pass object that performs basic memory reuse optimization
-    """
+    """Create a basic memory reuse pass."""
 
 def insert_sync() -> Pass:
-    """Create an insert sync pass.
-
-    Analyzes data dependencies and inserts synchronization operations
-    (sync_src, sync_dst, bar_v, bar_m) for correct execution across hardware pipes.
-    Uses the globally configured backend to obtain pipe information.
-
-    Returns:
-        Pass object that inserts synchronization operations
-
-    Raises:
-        ValueError: If backend type has not been configured
-    """
+    """Create an insert sync pass."""
 
 def add_alloc() -> Pass:
-    """Create an add alloc pass.
-
-    This pass traverses all TileType variables in each Function and creates alloc operations
-    for each unique MemRef. The alloc operations are added at the beginning of the function.
-
-    The pass performs the following steps:
-    1. Identifies all TileType variables in the function
-    2. Collects all unique MemRef objects from these TileType variables
-    3. Creates an alloc operation for each unique MemRef
-    4. Prepends these alloc operations to the function body
-
-    Each alloc operation has no input/output arguments but is bound to a MemRef pointer
-    to track memory allocation for that specific buffer.
-
-    Returns:
-        Pass object that adds alloc operations
-    """
+    """Create an add alloc pass."""
 
 class VerificationError:
     """Unified verification error information."""
@@ -106,173 +115,57 @@ class VerificationError:
 class SSAErrorType(Enum):
     """SSA verification error types."""
 
-    MULTIPLE_ASSIGNMENT: int
-    NAME_SHADOWING: int
-    MISSING_YIELD: int
+    MULTIPLE_ASSIGNMENT = ...
+    NAME_SHADOWING = ...
+    MISSING_YIELD = ...
 
 def verify_ssa() -> Pass:
-    """Create an SSA verification pass.
-
-    This pass verifies SSA form of IR by checking:
-    1. Each variable is assigned only once (MULTIPLE_ASSIGNMENT)
-    2. No variable name shadowing across scopes (NAME_SHADOWING)
-    3. ForStmt with iter_args must have YieldStmt as last statement (MISSING_YIELD)
-    4. IfStmt with return_vars must have YieldStmt in both then and else branches (MISSING_YIELD)
-
-    The pass collects all errors and generates a verification report instead of
-    throwing exceptions, allowing detection of all issues in a single run.
-
-    Returns:
-        Pass object that performs SSA verification
-    """
+    """Create an SSA verification pass."""
 
 class TypeCheckErrorType(Enum):
     """Type checking error types."""
 
-    TYPE_KIND_MISMATCH: int
-    DTYPE_MISMATCH: int
-    SHAPE_DIMENSION_MISMATCH: int
-    SHAPE_VALUE_MISMATCH: int
-    SIZE_MISMATCH: int
+    TYPE_KIND_MISMATCH = ...
+    DTYPE_MISMATCH = ...
+    SHAPE_DIMENSION_MISMATCH = ...
+    SHAPE_VALUE_MISMATCH = ...
+    SIZE_MISMATCH = ...
 
 def type_check() -> Pass:
-    """Create a type checking pass.
-
-    This pass checks type consistency in control flow constructs:
-    1. ForStmt: iter_args initValue, yield values, and return_vars must have matching types
-    2. IfStmt: then and else yield values must have matching types
-    3. Shape consistency for TensorType and TileType
-
-    The pass collects all errors and generates a type checking report instead of
-    throwing exceptions, allowing detection of all issues in a single run.
-
-    Returns:
-        Pass object that performs type checking
-    """
+    """Create a type checking pass."""
 
 def convert_to_ssa() -> Pass:
-    """Create an SSA conversion pass.
-
-    This pass converts non-SSA IR to SSA form by:
-    1. Renaming variables with version suffixes (x -> x_0, x_1, x_2)
-    2. Adding phi nodes (return_vars + YieldStmt) for IfStmt control flow divergence
-    3. Converting loop-modified variables to iter_args + return_vars pattern
-
-    The pass handles:
-    - Straight-line code: multiple assignments to the same variable
-    - If statements: variables modified in one or both branches
-    - For loops: variables modified inside the loop body
-    - Mixed SSA/non-SSA: preserves existing SSA structure while converting non-SSA parts
-
-    Returns:
-        Pass object that converts to SSA form
-    """
+    """Create an SSA conversion pass."""
 
 def outline_incore_scopes() -> Pass:
-    """Create a pass that outlines InCore scopes into separate functions.
-
-    This pass transforms ScopeStmt(InCore) nodes into separate Function(InCore) definitions
-    and replaces the scope with a Call to the outlined function.
-
-    Requirements:
-    - Input IR must be in SSA form (run convert_to_ssa first)
-    - Only processes Opaque functions (InCore functions are left unchanged)
-
-    Transformation:
-    1. For each ScopeStmt(InCore) in an Opaque function:
-       - Analyze body to determine external variable references (inputs)
-       - Analyze body to determine internal definitions used after scope (outputs)
-       - Extract body into new Function(InCore) with appropriate params/returns
-       - Replace scope with Call to the outlined function + output assignments
-    2. Add outlined functions to the program
-
-    Returns:
-        Pass object that outlines InCore scopes
-    """
+    """Create a pass that outlines InCore scopes."""
 
 def flatten_call_expr() -> Pass:
-    """Create a pass that flattens nested call expressions into three-address code.
-
-    This pass ensures that call expressions do not appear in nested contexts:
-    1. Call arguments cannot be calls
-    2. If conditions cannot be calls
-    3. For loop ranges (start/stop/step) cannot be calls
-    4. Binary/unary expression operands cannot be calls
-
-    Nested calls are extracted into temporary variables (named _t0, _t1, etc.)
-    and inserted as AssignStmt before the statement containing the nested call.
-    For if/for statements, extracted statements are inserted into the last OpStmts
-    before the if/for, or a new OpStmts is created if needed.
-
-    Example transformation:
-        c = foo(bar(a))  =>  _t0 = bar(a); c = foo(_t0)
-
-    Returns:
-        Pass object that flattens nested call expressions
-    """
+    """Create a pass that flattens nested call expressions."""
 
 def normalize_stmt_structure() -> Pass:
-    """Create a pass that normalizes statement structure.
-
-    This pass ensures IR is in a normalized form:
-    1. Function/IfStmt/ForStmt body must be SeqStmts
-    2. Consecutive AssignStmt/EvalStmt in SeqStmts are wrapped in OpStmts
-
-    Example transformations:
-        Function body = AssignStmt(x, 1)
-        => Function body = SeqStmts([OpStmts([AssignStmt(x, 1)])])
-
-        SeqStmts([AssignStmt(a, 1), AssignStmt(b, 2), IfStmt(...)])
-        => SeqStmts([OpStmts([AssignStmt(a, 1), AssignStmt(b, 2)]), IfStmt(...)])
-
-    Returns:
-        Pass object that normalizes statement structure
-    """
+    """Create a pass that normalizes statement structure."""
 
 def flatten_single_stmt() -> Pass:
-    """Create a pass that recursively flattens single-statement blocks.
-
-    This pass simplifies IR by removing unnecessary nesting:
-    - SeqStmts with only one statement is replaced by that statement
-    - OpStmts with only one statement is replaced by that statement
-    - Process is applied recursively
-
-    Example transformations:
-        SeqStmts([OpStmts([AssignStmt(x, 1)])])
-        => AssignStmt(x, 1)
-
-        SeqStmts([OpStmts([AssignStmt(x, 1), AssignStmt(y, 2)])])
-        => OpStmts([AssignStmt(x, 1), AssignStmt(y, 2)])
-
-    Note: This pass does NOT enforce that Function/IfStmt/ForStmt body must be SeqStmts.
-    It will flatten them if they contain only a single statement.
-
-    Returns:
-        Pass object that flattens single-statement blocks
-    """
+    """Create a pass that flattens single-statement blocks."""
 
 class NestedCallErrorType(Enum):
     """Nested call verification error types."""
 
-    CALL_IN_CALL_ARGS: int
-    CALL_IN_IF_CONDITION: int
-    CALL_IN_FOR_RANGE: int
-    CALL_IN_BINARY_EXPR: int
-    CALL_IN_UNARY_EXPR: int
+    CALL_IN_CALL_ARGS = ...
+    CALL_IN_IF_CONDITION = ...
+    CALL_IN_FOR_RANGE = ...
+    CALL_IN_BINARY_EXPR = ...
+    CALL_IN_UNARY_EXPR = ...
 
 class DiagnosticSeverity(Enum):
     """Severity level for diagnostics."""
 
-    Error: int
-    Warning: int
+    Error = ...
+    Warning = ...
 
 class Diagnostic:
-    """Single diagnostic message from verification.
-
-    Represents a single issue found during IR verification. Contains information
-    about the severity, which rule detected it, the specific error code, a
-    human-readable message, and the source location where the issue was found.
-    """
+    """Single diagnostic message from verification."""
 
     severity: DiagnosticSeverity
     rule_name: str
@@ -281,106 +174,28 @@ class Diagnostic:
     span: Span
 
 class IRVerifier:
-    """IR verification system that manages verification rules.
+    """IR verification system that manages verification rules."""
 
-    IRVerifier collects verification rules and applies them to programs.
-    Rules can be enabled/disabled individually.
-
-    Example:
-        >>> verifier = IRVerifier.create_default()
-        >>> verifier.disable_rule("TypeCheck")
-        >>> diagnostics = verifier.verify(program)
-        >>> for d in diagnostics:
-        ...     print(f"[{d.severity}] {d.rule_name}: {d.message}")
-    """
-
-    def __init__(self) -> None:
-        """Create an empty verifier with no rules."""
-
+    def __init__(self) -> None: ...
     @staticmethod
-    def create_default() -> IRVerifier:
-        """Create a verifier with default built-in rules.
-
-        Returns:
-            IRVerifier with SSAVerify and TypeCheck rules enabled
-        """
-
-    def enable_rule(self, name: str) -> None:
-        """Enable a previously disabled rule.
-
-        Args:
-            name: Name of the rule to enable
-        """
-
-    def disable_rule(self, name: str) -> None:
-        """Disable a rule.
-
-        Args:
-            name: Name of the rule to disable
-        """
-
-    def is_rule_enabled(self, name: str) -> bool:
-        """Check if a rule is enabled.
-
-        Args:
-            name: Name of the rule to check
-
-        Returns:
-            True if the rule is enabled, False otherwise
-        """
-
-    def verify(self, program: Program) -> list[Diagnostic]:
-        """Verify a program and collect diagnostics.
-
-        This method runs all enabled rules on the program and collects
-        diagnostics. It does not throw exceptions even if errors are found.
-
-        Args:
-            program: Program to verify
-
-        Returns:
-            List of all diagnostics (errors and warnings)
-        """
-
-    def verify_or_throw(self, program: Program) -> None:
-        """Verify a program and throw on errors.
-
-        This method runs verification and throws a VerificationError if any
-        diagnostics with severity Error are found. Warnings do not cause an exception.
-
-        Args:
-            program: Program to verify
-
-        Raises:
-            VerificationError: If any errors are found
-        """
-
+    def create_default() -> IRVerifier: ...
+    def enable_rule(self, name: str) -> None: ...
+    def disable_rule(self, name: str) -> None: ...
+    def is_rule_enabled(self, name: str) -> bool: ...
+    def verify(self, program: Program) -> list[Diagnostic]: ...
+    def verify_or_throw(self, program: Program) -> None: ...
     @staticmethod
-    def generate_report(diagnostics: list[Diagnostic]) -> str:
-        """Generate a formatted report from diagnostics.
-
-        Args:
-            diagnostics: List of diagnostics to format
-
-        Returns:
-            Formatted report string
-        """
+    def generate_report(diagnostics: list[Diagnostic]) -> str: ...
 
 def run_verifier(disabled_rules: list[str] | None = None) -> Pass:
-    """Create a verifier pass with configurable rules.
-
-    This pass creates an IRVerifier with default rules and allows disabling
-    specific rules. The verifier collects all diagnostics and logs them.
-
-    Args:
-        disabled_rules: List of rule names to disable (e.g., ["TypeCheck"])
-
-    Returns:
-        Pass that runs IR verification
-    """
+    """Create a verifier pass with configurable rules."""
 
 __all__ = [
+    "IRProperty",
+    "IRPropertySet",
+    "VerificationMode",
     "Pass",
+    "PassPipeline",
     "init_mem_ref",
     "basic_memory_reuse",
     "insert_sync",
@@ -391,6 +206,7 @@ __all__ = [
     "TypeCheckErrorType",
     "type_check",
     "convert_to_ssa",
+    "outline_incore_scopes",
     "flatten_call_expr",
     "normalize_stmt_structure",
     "flatten_single_stmt",

--- a/src/ir/transforms/add_alloc_pass.cpp
+++ b/src/ir/transforms/add_alloc_pass.cpp
@@ -319,7 +319,9 @@ FunctionPtr TransformAddAlloc(const FunctionPtr& func) {
 
 // Factory function
 namespace pass {
-Pass AddAlloc() { return CreateFunctionPass(TransformAddAlloc, "AddAlloc"); }
+Pass AddAlloc() {
+  return CreateFunctionPass(TransformAddAlloc, "AddAlloc", {.required = {IRProperty::HasMemRefs}});
+}
 }  // namespace pass
 
 }  // namespace ir

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -472,7 +472,10 @@ FunctionPtr TransformBasicMemoryReuse(const FunctionPtr& func) {
 }  // namespace
 
 namespace pass {
-Pass BasicMemoryReuse() { return CreateFunctionPass(TransformBasicMemoryReuse, "BasicMemoryReuse"); }
+Pass BasicMemoryReuse() {
+  return CreateFunctionPass(TransformBasicMemoryReuse, "BasicMemoryReuse",
+                            {.required = {IRProperty::HasMemRefs}});
+}
 }  // namespace pass
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -675,7 +675,12 @@ FunctionPtr TransformConvertToSSA(const FunctionPtr& func) {
 
 // Factory function
 namespace pass {
-Pass ConvertToSSA() { return CreateFunctionPass(TransformConvertToSSA, "ConvertToSSA"); }
+Pass ConvertToSSA() {
+  return CreateFunctionPass(
+      TransformConvertToSSA, "ConvertToSSA",
+      {.produced = {IRProperty::SSAForm},
+       .invalidated = {IRProperty::NormalizedStmtStructure, IRProperty::FlattenedSingleStmt}});
+}
 }  // namespace pass
 
 }  // namespace ir

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -409,7 +409,12 @@ FunctionPtr TransformFlattenCallExpr(const FunctionPtr& func) {
 
 // Factory function
 namespace pass {
-Pass FlattenCallExpr() { return CreateFunctionPass(TransformFlattenCallExpr, "FlattenCallExpr"); }
+Pass FlattenCallExpr() {
+  return CreateFunctionPass(
+      TransformFlattenCallExpr, "FlattenCallExpr",
+      {.produced = {IRProperty::NoNestedCalls},
+       .invalidated = {IRProperty::NormalizedStmtStructure, IRProperty::FlattenedSingleStmt}});
+}
 }  // namespace pass
 
 }  // namespace ir

--- a/src/ir/transforms/flatten_single_stmt_pass.cpp
+++ b/src/ir/transforms/flatten_single_stmt_pass.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/flatten_single_stmt.h"
+#include "pypto/ir/transforms/verifier.h"
+
+namespace pypto {
+namespace ir {
+
+// ============================================================================
+// FlattenedSingleStmt verifier
+// ============================================================================
+
+namespace {
+
+/**
+ * @brief Checks no single-element SeqStmts or OpStmts exist.
+ */
+class FlattenedSingleStmtVerifier : public IRVisitor {
+ public:
+  explicit FlattenedSingleStmtVerifier(std::vector<Diagnostic>& diagnostics) : diagnostics_(diagnostics) {}
+
+  void VisitStmt_(const SeqStmtsPtr& op) override {
+    if (!op) return;
+    if (op->stmts_.size() == 1) {
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "FlattenedSingleStmt", 0,
+                                "SeqStmts with single element should be flattened", op->span_);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const OpStmtsPtr& op) override {
+    if (!op) return;
+    if (op->stmts_.size() == 1) {
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "FlattenedSingleStmt", 0,
+                                "OpStmts with single element should be flattened", op->span_);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  std::vector<Diagnostic>& diagnostics_;
+};
+
+}  // namespace
+
+class FlattenedSingleStmtPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "FlattenedSingleStmt"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+    for (const auto& [gv, func] : program->functions_) {
+      if (!func || !func->body_) continue;
+      FlattenedSingleStmtVerifier verifier(diagnostics);
+      verifier.VisitStmt(func->body_);
+    }
+  }
+};
+
+PropertyVerifierPtr CreateFlattenedSingleStmtPropertyVerifier() {
+  return std::make_shared<FlattenedSingleStmtPropertyVerifierImpl>();
+}
+
+// ============================================================================
+// FlattenSingleStmt pass
+// ============================================================================
+
+namespace pass {
+
+Pass FlattenSingleStmt() {
+  return CreateFunctionPass(
+      ir::FlattenSingleStmt, "FlattenSingleStmt",
+      {.produced = {IRProperty::FlattenedSingleStmt}, .invalidated = {IRProperty::NormalizedStmtStructure}});
+}
+
+}  // namespace pass
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -847,7 +847,7 @@ Pass InsertSync() {
         SyncInserter inserter;
         return inserter.Run(func);
       },
-      "InsertSync");
+      "InsertSync", {.required = {IRProperty::HasMemRefs}});
 }
 }  // namespace pass
 }  // namespace ir

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/ir_property.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace pypto {
+namespace ir {
+
+std::string IRPropertyToString(IRProperty prop) {
+  switch (prop) {
+    case IRProperty::SSAForm:
+      return "SSAForm";
+    case IRProperty::TypeChecked:
+      return "TypeChecked";
+    case IRProperty::NoNestedCalls:
+      return "NoNestedCalls";
+    case IRProperty::NormalizedStmtStructure:
+      return "NormalizedStmtStructure";
+    case IRProperty::FlattenedSingleStmt:
+      return "FlattenedSingleStmt";
+    case IRProperty::SplitIncoreOrch:
+      return "SplitIncoreOrch";
+    case IRProperty::HasMemRefs:
+      return "HasMemRefs";
+    default:
+      return "Unknown";
+  }
+}
+
+std::vector<IRProperty> IRPropertySet::ToVector() const {
+  std::vector<IRProperty> result;
+  for (uint32_t i = 0; i < static_cast<uint32_t>(IRProperty::kCount); ++i) {
+    auto prop = static_cast<IRProperty>(i);
+    if (Contains(prop)) {
+      result.push_back(prop);
+    }
+  }
+  return result;
+}
+
+std::string IRPropertySet::ToString() const {
+  auto props = ToVector();
+  if (props.empty()) {
+    return "{}";
+  }
+
+  std::ostringstream oss;
+  oss << "{";
+  for (size_t i = 0; i < props.size(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << IRPropertyToString(props[i]);
+  }
+  oss << "}";
+  return oss.str();
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/normalize_stmt_structure_pass.cpp
+++ b/src/ir/transforms/normalize_stmt_structure_pass.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/normalize_stmt_structure.h"
+#include "pypto/ir/transforms/verifier.h"
+
+namespace pypto {
+namespace ir {
+
+// ============================================================================
+// NormalizedStmtStructure verifier
+// ============================================================================
+
+namespace {
+
+/**
+ * @brief Checks that Function/If/For bodies are SeqStmts and consecutive
+ * AssignStmt/EvalStmt in SeqStmts are wrapped in OpStmts.
+ */
+class NormalizedStmtVerifier : public IRVisitor {
+ public:
+  explicit NormalizedStmtVerifier(std::vector<Diagnostic>& diagnostics) : diagnostics_(diagnostics) {}
+
+  void CheckBody(const StmtPtr& body, const std::string& context, const Span& span) {
+    if (!body) return;
+    if (!As<SeqStmts>(body)) {
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "NormalizedStmtStructure", 0,
+                                context + " body is not a SeqStmts", span);
+      return;
+    }
+    auto seq = As<SeqStmts>(body);
+    for (const auto& stmt : seq->stmts_) {
+      if (As<AssignStmt>(stmt) || As<EvalStmt>(stmt)) {
+        diagnostics_.emplace_back(DiagnosticSeverity::Error, "NormalizedStmtStructure", 0,
+                                  context + " SeqStmts contains unwrapped AssignStmt/EvalStmt", stmt->span_);
+      }
+    }
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    if (!op) return;
+    CheckBody(op->then_body_, "IfStmt then", op->span_);
+    if (op->else_body_.has_value()) {
+      CheckBody(op->else_body_.value(), "IfStmt else", op->span_);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (!op) return;
+    CheckBody(op->body_, "ForStmt", op->span_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  std::vector<Diagnostic>& diagnostics_;
+};
+
+}  // namespace
+
+class NormalizedStmtPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "NormalizedStmtStructure"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+    for (const auto& [gv, func] : program->functions_) {
+      if (!func) continue;
+      NormalizedStmtVerifier verifier(diagnostics);
+      verifier.CheckBody(func->body_, "Function '" + func->name_ + "'", func->span_);
+      if (func->body_) {
+        verifier.VisitStmt(func->body_);
+      }
+    }
+  }
+};
+
+PropertyVerifierPtr CreateNormalizedStmtPropertyVerifier() {
+  return std::make_shared<NormalizedStmtPropertyVerifierImpl>();
+}
+
+// ============================================================================
+// NormalizeStmtStructure pass
+// ============================================================================
+
+namespace pass {
+
+Pass NormalizeStmtStructure() {
+  return CreateFunctionPass(
+      ir::NormalizeStmtStructure, "NormalizeStmtStructure",
+      {.produced = {IRProperty::NormalizedStmtStructure}, .invalidated = {IRProperty::FlattenedSingleStmt}});
+}
+
+}  // namespace pass
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/verifier.h"
 
 namespace pypto {
 namespace ir {
@@ -465,10 +466,60 @@ Pass OutlineIncoreScopes() {
     return std::make_shared<Program>(all_outlined_functions, program->name_, program->span_);
   };
 
-  return CreateProgramPass(pass_func, "OutlineIncoreScopes");
+  return CreateProgramPass(pass_func, "OutlineIncoreScopes",
+                           {.required = {IRProperty::SSAForm}, .produced = {IRProperty::SplitIncoreOrch}});
 }
 
 }  // namespace pass
+
+// ============================================================================
+// SplitIncoreOrch property verifier
+// ============================================================================
+
+namespace {
+
+/**
+ * @brief Checks no InCore ScopeStmts remain in Opaque functions.
+ */
+class SplitIncoreOrchVerifier : public IRVisitor {
+ public:
+  explicit SplitIncoreOrchVerifier(std::vector<Diagnostic>& diagnostics) : diagnostics_(diagnostics) {}
+
+  void VisitStmt_(const ScopeStmtPtr& op) override {
+    if (!op) return;
+    if (op->scope_kind_ == ScopeKind::InCore) {
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "SplitIncoreOrch", 0,
+                                "InCore ScopeStmt found in Opaque function (should have been outlined)",
+                                op->span_);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  std::vector<Diagnostic>& diagnostics_;
+};
+
+}  // namespace
+
+class SplitIncoreOrchPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "SplitIncoreOrch"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+    for (const auto& [gv, func] : program->functions_) {
+      if (!func || !func->body_) continue;
+      // Only check Opaque functions — InCore functions are expected to have InCore content
+      if (func->func_type_ != FunctionType::Opaque) continue;
+      SplitIncoreOrchVerifier verifier(diagnostics);
+      verifier.VisitStmt(func->body_);
+    }
+  }
+};
+
+PropertyVerifierPtr CreateSplitIncoreOrchPropertyVerifier() {
+  return std::make_shared<SplitIncoreOrchPropertyVerifierImpl>();
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/property_verifier_registry.cpp
+++ b/src/ir/transforms/property_verifier_registry.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/property_verifier_registry.h"
+
+#include <utility>
+#include <vector>
+
+namespace pypto {
+namespace ir {
+
+// ============================================================================
+// PropertyVerifierRegistry implementation
+// ============================================================================
+
+PropertyVerifierRegistry& PropertyVerifierRegistry::GetInstance() {
+  static PropertyVerifierRegistry instance;
+  return instance;
+}
+
+PropertyVerifierRegistry::PropertyVerifierRegistry() {
+  // Register all built-in property verifiers
+  Register(IRProperty::SSAForm, CreateSSAPropertyVerifier);
+  Register(IRProperty::TypeChecked, CreateTypeCheckPropertyVerifier);
+  Register(IRProperty::NoNestedCalls, CreateNoNestedCallPropertyVerifier);
+  Register(IRProperty::NormalizedStmtStructure, CreateNormalizedStmtPropertyVerifier);
+  Register(IRProperty::FlattenedSingleStmt, CreateFlattenedSingleStmtPropertyVerifier);
+  Register(IRProperty::SplitIncoreOrch, CreateSplitIncoreOrchPropertyVerifier);
+  Register(IRProperty::HasMemRefs, CreateHasMemRefsPropertyVerifier);
+}
+
+void PropertyVerifierRegistry::Register(IRProperty prop, std::function<PropertyVerifierPtr()> factory) {
+  factories_[static_cast<uint32_t>(prop)] = std::move(factory);
+}
+
+PropertyVerifierPtr PropertyVerifierRegistry::GetVerifier(IRProperty prop) const {
+  auto it = factories_.find(static_cast<uint32_t>(prop));
+  if (it == factories_.end()) {
+    return nullptr;
+  }
+  return it->second();
+}
+
+bool PropertyVerifierRegistry::HasVerifier(IRProperty prop) const {
+  return factories_.count(static_cast<uint32_t>(prop)) > 0;
+}
+
+std::vector<Diagnostic> PropertyVerifierRegistry::VerifyProperties(const IRPropertySet& properties,
+                                                                   const ProgramPtr& program) const {
+  std::vector<Diagnostic> all_diagnostics;
+  if (!program) {
+    return all_diagnostics;
+  }
+
+  for (auto prop : properties.ToVector()) {
+    auto verifier = GetVerifier(prop);
+    if (verifier) {
+      verifier->Verify(program, all_diagnostics);
+    }
+  }
+  return all_diagnostics;
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/verifier.cpp
+++ b/src/ir/transforms/verifier.cpp
@@ -20,25 +20,16 @@
 namespace pypto {
 namespace ir {
 
-// Forward declarations of built-in rules (implemented in their respective files)
-class SSAVerifyRule;
-class TypeCheckRule;
-
-// External rule instances - these are defined in verify_ssa_pass.cpp and type_check_pass.cpp
-extern VerifyRulePtr CreateSSAVerifyRule();
-extern VerifyRulePtr CreateTypeCheckRule();
-extern VerifyRulePtr CreateNoNestedCallVerifyRule();
-
 IRVerifier::IRVerifier() = default;
 
-void IRVerifier::AddRule(VerifyRulePtr rule) {
+void IRVerifier::AddRule(PropertyVerifierPtr rule) {
   if (!rule) {
     return;
   }
 
   // Check if rule with same name already exists
   auto it = std::find_if(rules_.begin(), rules_.end(),
-                         [&rule](const VerifyRulePtr& r) { return r->GetName() == rule->GetName(); });
+                         [&rule](const PropertyVerifierPtr& r) { return r->GetName() == rule->GetName(); });
 
   if (it == rules_.end()) {
     rules_.push_back(rule);
@@ -58,26 +49,20 @@ std::vector<Diagnostic> IRVerifier::Verify(const ProgramPtr& program) const {
 
   std::vector<Diagnostic> all_diagnostics;
 
-  // Run all enabled rules on all functions
-  // program->functions_ is a map from GlobalVar to Function
-  for (const auto& [global_var, func] : program->functions_) {
-    if (!func) {
+  // Run all enabled verifiers on the program
+  // Each verifier internally decides whether to iterate over functions
+  for (const auto& rule : rules_) {
+    if (!rule) {
       continue;
     }
 
-    for (const auto& rule : rules_) {
-      if (!rule) {
-        continue;
-      }
-
-      // Skip disabled rules
-      if (!IsRuleEnabled(rule->GetName())) {
-        continue;
-      }
-
-      // Run the rule
-      rule->Verify(func, all_diagnostics);
+    // Skip disabled rules
+    if (!IsRuleEnabled(rule->GetName())) {
+      continue;
     }
+
+    // Run the verifier with the full program
+    rule->Verify(program, all_diagnostics);
   }
 
   return all_diagnostics;
@@ -149,10 +134,10 @@ std::string IRVerifier::GenerateReport(const std::vector<Diagnostic>& diagnostic
 IRVerifier IRVerifier::CreateDefault() {
   IRVerifier verifier;
 
-  // Add built-in verification rules
-  verifier.AddRule(CreateSSAVerifyRule());
-  verifier.AddRule(CreateTypeCheckRule());
-  verifier.AddRule(CreateNoNestedCallVerifyRule());
+  // Add built-in property verifiers
+  verifier.AddRule(CreateSSAPropertyVerifier());
+  verifier.AddRule(CreateTypeCheckPropertyVerifier());
+  verifier.AddRule(CreateNoNestedCallPropertyVerifier());
 
   return verifier;
 }

--- a/tests/ut/ir/transforms/test_ir_property.py
+++ b/tests/ut/ir/transforms/test_ir_property.py
@@ -1,0 +1,201 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for IRProperty and IRPropertySet."""
+
+from pypto.pypto_core import passes
+
+
+class TestIRProperty:
+    """Test IRProperty enum."""
+
+    def test_property_values_exist(self):
+        """Test that all IR properties exist."""
+        assert passes.IRProperty.SSAForm is not None
+        assert passes.IRProperty.TypeChecked is not None
+        assert passes.IRProperty.NoNestedCalls is not None
+        assert passes.IRProperty.NormalizedStmtStructure is not None
+        assert passes.IRProperty.FlattenedSingleStmt is not None
+        assert passes.IRProperty.SplitIncoreOrch is not None
+        assert passes.IRProperty.HasMemRefs is not None
+
+    def test_property_values_are_different(self):
+        """Test that all property values are distinct."""
+        props = [
+            passes.IRProperty.SSAForm,
+            passes.IRProperty.TypeChecked,
+            passes.IRProperty.NoNestedCalls,
+            passes.IRProperty.NormalizedStmtStructure,
+            passes.IRProperty.FlattenedSingleStmt,
+            passes.IRProperty.SplitIncoreOrch,
+            passes.IRProperty.HasMemRefs,
+        ]
+        assert len(props) == len(set(props))
+
+
+class TestIRPropertySet:
+    """Test IRPropertySet operations."""
+
+    def test_empty_set(self):
+        """Test creating an empty property set."""
+        ps = passes.IRPropertySet()
+        assert ps.empty()
+        assert ps.to_list() == []
+
+    def test_insert_and_contains(self):
+        """Test insert and contains."""
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        assert ps.contains(passes.IRProperty.SSAForm)
+        assert not ps.contains(passes.IRProperty.TypeChecked)
+        assert not ps.empty()
+
+    def test_remove(self):
+        """Test removing a property."""
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        ps.insert(passes.IRProperty.TypeChecked)
+        ps.remove(passes.IRProperty.SSAForm)
+        assert not ps.contains(passes.IRProperty.SSAForm)
+        assert ps.contains(passes.IRProperty.TypeChecked)
+
+    def test_contains_all(self):
+        """Test contains_all check."""
+        ps1 = passes.IRPropertySet()
+        ps1.insert(passes.IRProperty.SSAForm)
+        ps1.insert(passes.IRProperty.TypeChecked)
+        ps1.insert(passes.IRProperty.NoNestedCalls)
+
+        ps2 = passes.IRPropertySet()
+        ps2.insert(passes.IRProperty.SSAForm)
+        ps2.insert(passes.IRProperty.TypeChecked)
+
+        assert ps1.contains_all(ps2)
+        assert not ps2.contains_all(ps1)
+
+    def test_union(self):
+        """Test union operation."""
+        ps1 = passes.IRPropertySet()
+        ps1.insert(passes.IRProperty.SSAForm)
+
+        ps2 = passes.IRPropertySet()
+        ps2.insert(passes.IRProperty.TypeChecked)
+
+        result = ps1.union_with(ps2)
+        assert result.contains(passes.IRProperty.SSAForm)
+        assert result.contains(passes.IRProperty.TypeChecked)
+
+    def test_difference(self):
+        """Test difference operation."""
+        ps1 = passes.IRPropertySet()
+        ps1.insert(passes.IRProperty.SSAForm)
+        ps1.insert(passes.IRProperty.TypeChecked)
+
+        ps2 = passes.IRPropertySet()
+        ps2.insert(passes.IRProperty.SSAForm)
+
+        result = ps1.difference(ps2)
+        assert not result.contains(passes.IRProperty.SSAForm)
+        assert result.contains(passes.IRProperty.TypeChecked)
+
+    def test_intersection(self):
+        """Test intersection operation."""
+        ps1 = passes.IRPropertySet()
+        ps1.insert(passes.IRProperty.SSAForm)
+        ps1.insert(passes.IRProperty.TypeChecked)
+
+        ps2 = passes.IRPropertySet()
+        ps2.insert(passes.IRProperty.SSAForm)
+        ps2.insert(passes.IRProperty.NoNestedCalls)
+
+        result = ps1.intersection(ps2)
+        assert result.contains(passes.IRProperty.SSAForm)
+        assert not result.contains(passes.IRProperty.TypeChecked)
+        assert not result.contains(passes.IRProperty.NoNestedCalls)
+
+    def test_equality(self):
+        """Test equality comparison."""
+        ps1 = passes.IRPropertySet()
+        ps1.insert(passes.IRProperty.SSAForm)
+
+        ps2 = passes.IRPropertySet()
+        ps2.insert(passes.IRProperty.SSAForm)
+
+        ps3 = passes.IRPropertySet()
+        ps3.insert(passes.IRProperty.TypeChecked)
+
+        assert ps1 == ps2
+        assert ps1 != ps3
+
+    def test_to_list(self):
+        """Test converting to a list."""
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        ps.insert(passes.IRProperty.TypeChecked)
+
+        props = ps.to_list()
+        assert len(props) == 2
+        assert passes.IRProperty.SSAForm in props
+        assert passes.IRProperty.TypeChecked in props
+
+    def test_to_string(self):
+        """Test string representation."""
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        s = str(ps)
+        assert "SSAForm" in s
+
+    def test_empty_to_string(self):
+        """Test string representation of empty set."""
+        ps = passes.IRPropertySet()
+        assert str(ps) == "{}"
+
+
+class TestPassPropertyAccessors:
+    """Test Pass property accessor methods."""
+
+    def test_convert_to_ssa_properties(self):
+        """Test ConvertToSSA produces SSAForm."""
+        p = passes.convert_to_ssa()
+        assert p.get_name() == "ConvertToSSA"
+        assert p.get_required_properties().empty()
+        assert p.get_produced_properties().contains(passes.IRProperty.SSAForm)
+
+    def test_init_memref_properties(self):
+        """Test InitMemRef produces HasMemRefs."""
+        p = passes.init_mem_ref()
+        assert p.get_name() == "InitMemRef"
+        assert p.get_produced_properties().contains(passes.IRProperty.HasMemRefs)
+
+    def test_basic_memory_reuse_requires_memrefs(self):
+        """Test BasicMemoryReuse requires HasMemRefs."""
+        p = passes.basic_memory_reuse()
+        assert p.get_required_properties().contains(passes.IRProperty.HasMemRefs)
+
+    def test_flatten_call_expr_produces_no_nested_calls(self):
+        """Test FlattenCallExpr produces NoNestedCalls."""
+        p = passes.flatten_call_expr()
+        assert p.get_produced_properties().contains(passes.IRProperty.NoNestedCalls)
+
+    def test_outline_incore_requires_ssa(self):
+        """Test OutlineIncoreScopes requires SSAForm."""
+        p = passes.outline_incore_scopes()
+        assert p.get_required_properties().contains(passes.IRProperty.SSAForm)
+        assert p.get_produced_properties().contains(passes.IRProperty.SplitIncoreOrch)
+
+    def test_type_check_produces_type_checked(self):
+        """Test TypeCheck produces TypeChecked."""
+        p = passes.type_check()
+        assert p.get_produced_properties().contains(passes.IRProperty.TypeChecked)
+
+    def test_run_verifier_no_properties(self):
+        """Test RunVerifier has no property declarations."""
+        p = passes.run_verifier()
+        assert p.get_required_properties().empty()
+        assert p.get_produced_properties().empty()

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -1,0 +1,333 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for PassPipeline."""
+
+import pypto.language as pl
+import pytest
+from pypto import DataType, ir
+from pypto.pypto_core import passes
+
+
+def _make_simple_program():
+    """Create a simple valid program for testing."""
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    x = ir.Var("x", ir.ScalarType(dtype), span)
+    y = ir.Var("y", ir.ScalarType(dtype), span)
+    assign = ir.AssignStmt(x, y, span)
+    func = ir.Function("test_func", [x], [ir.ScalarType(dtype)], assign, span)
+    return ir.Program([func], "test_program", span)
+
+
+class TestPassPipeline:
+    """Test PassPipeline creation and basic operations."""
+
+    def test_empty_pipeline(self):
+        """Test creating an empty pipeline."""
+        pipeline = passes.PassPipeline()
+        assert pipeline.get_pass_names() == []
+
+    def test_add_passes(self):
+        """Test adding passes to pipeline."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        assert pipeline.get_pass_names() == ["ConvertToSSA", "FlattenCallExpr"]
+
+    def test_run_empty_pipeline(self):
+        """Test running an empty pipeline returns the same program."""
+        pipeline = passes.PassPipeline()
+        program = _make_simple_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+    def test_run_single_pass(self):
+        """Test running a pipeline with a single pass."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.convert_to_ssa())
+        program = _make_simple_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+
+class TestPassPipelineValidation:
+    """Test PassPipeline static validation."""
+
+    def test_valid_pipeline(self):
+        """Test validation of a valid pipeline."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        errors = pipeline.validate()
+        assert errors == []
+
+    def test_invalid_pipeline_missing_requirement(self):
+        """Test validation catches missing requirements."""
+        pipeline = passes.PassPipeline()
+        # BasicMemoryReuse requires HasMemRefs but no InitMemRef before it
+        pipeline.add_pass(passes.basic_memory_reuse())
+        errors = pipeline.validate()
+        assert len(errors) == 1
+        assert "HasMemRefs" in errors[0]
+        assert "BasicMemoryReuse" in errors[0]
+
+    def test_valid_pipeline_with_requirement_met(self):
+        """Test validation passes when requirements are met."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.init_mem_ref())
+        pipeline.add_pass(passes.basic_memory_reuse())
+        errors = pipeline.validate()
+        assert errors == []
+
+    def test_outline_incore_requires_ssa(self):
+        """Test validation catches OutlineIncoreScopes without SSA."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.outline_incore_scopes())
+        errors = pipeline.validate()
+        assert len(errors) == 1
+        assert "SSAForm" in errors[0]
+
+    def test_outline_incore_with_ssa_valid(self):
+        """Test OutlineIncoreScopes after ConvertToSSA is valid."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.outline_incore_scopes())
+        errors = pipeline.validate()
+        assert errors == []
+
+    def test_initial_properties(self):
+        """Test setting initial properties satisfies requirements."""
+        pipeline = passes.PassPipeline()
+        initial = passes.IRPropertySet()
+        initial.insert(passes.IRProperty.HasMemRefs)
+        pipeline.set_initial_properties(initial)
+        pipeline.add_pass(passes.basic_memory_reuse())
+        errors = pipeline.validate()
+        assert errors == []
+
+    def test_full_default_strategy_valid(self):
+        """Test that the default strategy pipeline validates."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        pipeline.add_pass(passes.run_verifier())
+        pipeline.add_pass(passes.init_mem_ref())
+        pipeline.add_pass(passes.basic_memory_reuse())
+        pipeline.add_pass(passes.insert_sync())
+        pipeline.add_pass(passes.add_alloc())
+        errors = pipeline.validate()
+        assert errors == []
+
+
+class TestPassPipelineRequirementEnforcement:
+    """Test PassPipeline requirement enforcement during Run."""
+
+    def test_run_fails_on_missing_requirement(self):
+        """Test that Run throws when requirements are not met."""
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.basic_memory_reuse())
+        program = _make_simple_program()
+        with pytest.raises(Exception, match="HasMemRefs"):
+            pipeline.run(program)
+
+    def test_run_succeeds_with_initial_properties(self):
+        """Test Run succeeds with initial properties set."""
+        pipeline = passes.PassPipeline()
+        initial = passes.IRPropertySet()
+        initial.insert(passes.IRProperty.HasMemRefs)
+        pipeline.set_initial_properties(initial)
+        pipeline.add_pass(passes.basic_memory_reuse())
+        program = _make_simple_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+
+class TestVerificationMode:
+    """Test VerificationMode enum."""
+
+    def test_verification_mode_values(self):
+        """Test that all verification modes exist."""
+        assert passes.VerificationMode.NONE is not None
+        assert passes.VerificationMode.BEFORE is not None
+        assert passes.VerificationMode.AFTER is not None
+        assert passes.VerificationMode.BEFORE_AND_AFTER is not None
+
+    def test_set_verification_mode(self):
+        """Test setting verification mode on pipeline."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE_AND_AFTER)
+        # Should not raise
+        assert True
+
+
+def _make_non_ssa_program():
+    """Create a program with SSA violations (duplicate assignment)."""
+
+    @pl.program
+    class NonSSA:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result = pl.add(x, 1.0)
+            result = pl.add(result, 2.0)  # noqa: F841 - SSA violation
+            return result
+
+    return NonSSA
+
+
+def _make_valid_ssa_program():
+    """Create a valid SSA program (unique variable names)."""
+
+    @pl.program(strict_ssa=True)
+    class ValidSSA:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+            return result
+
+    return ValidSSA
+
+
+class TestVerificationModeAfter:
+    """Test AFTER verification mode: checks produced properties after each pass."""
+
+    def test_after_mode_succeeds_on_valid_pipeline(self):
+        """AFTER mode succeeds when pass actually produces its claimed property."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.AFTER)
+        pipeline.add_pass(passes.convert_to_ssa())
+        program = _make_non_ssa_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+    def test_after_mode_succeeds_with_multiple_passes(self):
+        """AFTER mode verifies produced properties after each pass in sequence."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.AFTER)
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        program = _make_non_ssa_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+    def test_after_mode_succeeds_with_normalize_and_flatten(self):
+        """AFTER mode verifies NormalizedStmtStructure and FlattenedSingleStmt."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.AFTER)
+        pipeline.add_pass(passes.normalize_stmt_structure())
+        program = _make_valid_ssa_program()
+        result = pipeline.run(program)  # type: ignore[arg-type]  # @pl.program returns Program at runtime
+        assert result is not None
+
+
+class TestVerificationModeBefore:
+    """Test BEFORE verification mode: checks required properties before each pass."""
+
+    def test_before_mode_catches_false_ssa_claim(self):
+        """BEFORE mode detects that claimed SSAForm doesn't actually hold."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE)
+        # Lie about initial properties — claim SSAForm holds
+        initial = passes.IRPropertySet()
+        initial.insert(passes.IRProperty.SSAForm)
+        pipeline.set_initial_properties(initial)
+        # OutlineIncoreScopes requires SSAForm — BEFORE mode will verify it
+        pipeline.add_pass(passes.outline_incore_scopes())
+        program = _make_non_ssa_program()
+        with pytest.raises(Exception, match="Pre-verification failed"):
+            pipeline.run(program)
+
+    def test_before_mode_succeeds_when_property_holds(self):
+        """BEFORE mode passes when the claimed property actually holds."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE)
+        # First produce SSAForm, then use a pass that requires it
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.outline_incore_scopes())
+        program = _make_non_ssa_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+    def test_none_mode_skips_verification_of_false_claim(self):
+        """NONE mode doesn't verify — false initial properties pass unchecked."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.NONE)
+        # Same false claim as above, but NONE mode won't check
+        initial = passes.IRPropertySet()
+        initial.insert(passes.IRProperty.SSAForm)
+        pipeline.set_initial_properties(initial)
+        pipeline.add_pass(passes.outline_incore_scopes())
+        program = _make_non_ssa_program()
+        # Should NOT raise — no verification is performed
+        result = pipeline.run(program)
+        assert result is not None
+
+
+class TestVerificationModeBeforeAndAfter:
+    """Test BEFORE_AND_AFTER verification mode."""
+
+    def test_before_and_after_succeeds_on_valid_pipeline(self):
+        """BEFORE_AND_AFTER mode succeeds when all properties are correct."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE_AND_AFTER)
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        program = _make_non_ssa_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+    def test_before_and_after_catches_pre_violation(self):
+        """BEFORE_AND_AFTER catches pre-pass property violations."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE_AND_AFTER)
+        initial = passes.IRPropertySet()
+        initial.insert(passes.IRProperty.SSAForm)
+        pipeline.set_initial_properties(initial)
+        pipeline.add_pass(passes.outline_incore_scopes())
+        program = _make_non_ssa_program()
+        with pytest.raises(Exception, match="Pre-verification failed"):
+            pipeline.run(program)
+
+    def test_before_and_after_full_default_strategy(self):
+        """Full default strategy succeeds with BEFORE_AND_AFTER verification."""
+        pipeline = passes.PassPipeline()
+        pipeline.set_verification_mode(passes.VerificationMode.BEFORE_AND_AFTER)
+        pipeline.add_pass(passes.convert_to_ssa())
+        pipeline.add_pass(passes.flatten_call_expr())
+        pipeline.add_pass(passes.normalize_stmt_structure())
+        pipeline.add_pass(passes.flatten_single_stmt())
+        program = _make_non_ssa_program()
+        result = pipeline.run(program)
+        assert result is not None
+
+
+class TestPassManagerWithPipeline:
+    """Test PassManager uses PassPipeline correctly."""
+
+    def test_pass_manager_validate(self):
+        """Test PassManager.validate() works."""
+        pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.Default)
+        errors = pm.validate()
+        assert errors == []
+
+    def test_pass_manager_ptoas_validate(self):
+        """Test PTOAS strategy validates."""
+        pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.PTOAS)
+        errors = pm.validate()
+        assert errors == []
+
+    def test_pass_manager_with_verification_mode(self):
+        """Test PassManager with verification mode."""
+        pm = ir.PassManager.get_strategy(
+            ir.OptimizationStrategy.Default,
+            verification_mode=ir.VerificationMode.AFTER,
+        )
+        assert pm is not None
+        errors = pm.validate()
+        assert errors == []


### PR DESCRIPTION
## Summary
- Move 4 property verifiers from `property_verifier_registry.cpp` to their corresponding pass files for better cohesion
- Consolidate factory declarations in `verifier.h` and introduce `ir_property.h` / `property_verifier_registry.h` headers
- Fix enum stub syntax in `passes.pyi` and add verification mode integration tests
- Condense pass manager and verifier documentation

## Testing
- [x] New `test_ir_property.py` for IRProperty enum and verification modes
- [x] New `test_pass_pipeline.py` for pass pipeline integration
- [x] Existing tests pass

## Related Issues
N/A