### PR TITLE
refactor(ir): replace target_memory int with MemorySpace enum

### DIFF
--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -78,6 +78,9 @@ class Expr : public IRNode {
 
 using ExprPtr = std::shared_ptr<const Expr>;
 
+// Forward declaration for MemorySpace enum (defined in memref.h)
+enum class MemorySpace;
+
 /**
  * @brief Base class for operations/functions
  *
@@ -98,7 +101,7 @@ class Op {
    * Defines that this operator accepts a kwarg with the given key and type.
    * This is used for validation when creating Call expressions.
    *
-   * Only specific types are allowed: bool, int, std::string, double, DataType
+   * Only specific types are allowed: bool, int, std::string, double, DataType, MemorySpace
    * This is enforced at compile-time via static_assert.
    *
    * @tparam T Expected type of the kwarg value (must be one of the allowed types)
@@ -108,8 +111,9 @@ class Op {
   void SetAttrType(const std::string& key) const {
     // Compile-time check: only allow specific types
     static_assert(std::is_same_v<T, bool> || std::is_same_v<T, int> || std::is_same_v<T, std::string> ||
-                      std::is_same_v<T, double> || std::is_same_v<T, DataType>,
-                  "SetAttrType only accepts: bool, int, std::string, double, DataType");
+                      std::is_same_v<T, double> || std::is_same_v<T, DataType> ||
+                      std::is_same_v<T, MemorySpace>,
+                  "SetAttrType only accepts: bool, int, std::string, double, DataType, MemorySpace");
 
     attrs_.emplace(key, std::type_index(typeid(T)));
   }

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -254,22 +254,23 @@ class OpRegistryEntry {
    * Note: This only defines the kwarg schema (what kwargs are allowed and their types).
    * Actual kwarg values are provided per-Call instance when calling OpRegistry::Create().
    *
-   * Only specific types are allowed: bool, int, std::string, double, DataType
+   * Only specific types are allowed: bool, int, std::string, double, DataType, MemorySpace
    * This is enforced at compile-time via static_assert in Op::SetAttrType.
    *
    * Example usage:
    * @code
    * REGISTER_OP("tensor.matmul")
-   *     .set_attr<DataType>("out_dtype")   // OK: DataType is allowed
-   *     .set_attr<bool>("a_trans")         // OK: bool is allowed
-   *     .set_attr<bool>("b_trans");        // OK: bool is allowed
+   *     .set_attr<DataType>("out_dtype")       // OK: DataType is allowed
+   *     .set_attr<bool>("a_trans")             // OK: bool is allowed
+   *     .set_attr<MemorySpace>("target_memory") // OK: MemorySpace is allowed
    *
    * // The following would cause a compile-time error:
    * // .set_attr<float>("bad_attr")       // ERROR: float is not allowed
    * // .set_attr<std::vector<int>>("bad") // ERROR: vector is not allowed
    * @endcode
    *
-   * @tparam T Expected type of the kwarg value (must be one of: bool, int, std::string, double, DataType)
+   * @tparam T Expected type of the kwarg value (must be one of: bool, int, std::string, double, DataType,
+   * MemorySpace)
    * @param key Kwarg key (string identifier)
    * @return Reference to this entry for method chaining
    */
@@ -424,7 +425,8 @@ class OpRegistry {
  * @brief Validate kwargs against allowed attributes
  *
  * Checks that all provided kwargs match registered attributes and have compatible types.
- * For DataType kwargs, accepts both DataType and int types for backward compatibility.
+ * For DataType kwargs, accepts both DataType and int for backward compatibility.
+ * MemorySpace kwargs require the MemorySpace enum type.
  *
  * @param kwargs The kwargs to validate
  * @param allowed_kwargs Map of allowed kwarg keys to expected types

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -97,9 +97,12 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     std::string key = nb::cast<std::string>(item.first);
 
     // Try to cast to common types
-    // NOTE: Check DataType BEFORE int, and bool BEFORE int (since they can be cast to int in Python)
+    // NOTE: Check DataType/MemorySpace BEFORE int, and bool BEFORE int (since they can be cast to int in
+    // Python)
     if (nb::isinstance<DataType>(item.second)) {
       kwargs.emplace_back(key, nb::cast<DataType>(item.second));
+    } else if (nb::isinstance<MemorySpace>(item.second)) {
+      kwargs.emplace_back(key, nb::cast<MemorySpace>(item.second));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<bool>(item.second));
     } else if (nb::isinstance<nb::int_>(item.second)) {

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -39,7 +39,7 @@ Typical usage:
 
 # Import decorators and parsing functions from local parser module
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import ForKind, FunctionType
+from pypto.pypto_core.ir import ForKind, FunctionType, MemorySpace
 
 from . import parser
 from .dsl_api import cond, incore, parallel, range, while_, yield_
@@ -190,6 +190,7 @@ __all__ = [
     "dim",
     "FunctionType",
     "ForKind",
+    "MemorySpace",
     "FP4",
     "FP8E4M3FN",
     "FP8E5M2",

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -70,7 +70,7 @@ __all__ = [
 
 from pypto.ir.op import block_ops as _ir_ops
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Expr
+from pypto.pypto_core.ir import Expr, MemorySpace
 
 from ..typing import Scalar, Tensor, Tile
 
@@ -78,14 +78,14 @@ from ..typing import Scalar, Tensor, Tile
 def create_tile(
     shape: list[int],
     dtype: DataType,
-    target_memory: int = 1,
+    target_memory: MemorySpace = MemorySpace.UB,
 ) -> Tile:
     """Create a tile from a shape.
 
     Args:
         shape: Shape of the tile
         dtype: Data type of the tile
-        target_memory: Target memory level (1=UB, 2=L1, 3=L0A, 4=L0B)
+        target_memory: Target memory space (MemorySpace.UB, .L1, .L0A, .L0B)
 
     Returns:
         Tile wrapping the create_tile operation
@@ -98,7 +98,7 @@ def load(
     tensor: Tensor,
     offsets: Sequence[int | Expr],
     shapes: Sequence[int | Expr],
-    target_memory: int = 1,
+    target_memory: MemorySpace = MemorySpace.UB,
 ) -> Tile:
     """Copy data from tensor to unified buffer (tile).
 
@@ -106,7 +106,7 @@ def load(
         tensor: Source tensor
         offsets: Offsets in each dimension
         sizes: Shape of the tile in each dimension
-        target_memory: Target memory space (1=UB default, 2=L1)
+        target_memory: Target memory space (MemorySpace.UB default, or MemorySpace.L1)
 
     Returns:
         Tile wrapping the load operation
@@ -175,12 +175,12 @@ def l0c_store(
     return Tensor(expr=call_expr)
 
 
-def move(tile: Tile, target_memory: int, transpose: bool = False) -> Tile:
+def move(tile: Tile, target_memory: MemorySpace, transpose: bool = False) -> Tile:
     """Move tile between memory levels with optional transpose.
 
     Args:
         tile: Input tile
-        target_memory: Target memory space (1=UB, 2=L1, 3=L0A, 4=L0B)
+        target_memory: Target memory space (MemorySpace.UB, .L1, .L0A, .L0B)
         transpose: Whether to transpose the tile
 
     Returns:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -35,7 +35,7 @@ __all__ = [
 ]
 
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Expr
+from pypto.pypto_core.ir import Expr, MemorySpace
 
 from ..typing import Scalar, Tensor, Tile
 from . import block_ops as _block
@@ -247,8 +247,6 @@ def cast(
 # ---------------------------------------------------------------------------
 
 
-def create_tile(shape: list[int], dtype: DataType, target_memory: int) -> Tile:
-    """Create a tile at specific memoryspace.
-    target_memory: (1=UB, 2=L1, 3=L0A, 4=L0B)
-    """
+def create_tile(shape: list[int], dtype: DataType, target_memory: MemorySpace) -> Tile:
+    """Create a tile at specific memory space."""
     return _block.create_tile(shape, dtype, target_memory)

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -731,7 +731,7 @@ class Call(Expr):
     args: Final[Sequence[Expr]]
     """Positional arguments."""
 
-    kwargs: Final[Mapping[str, int | bool | str | float | DataType]]
+    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace]]
     """Keyword arguments (metadata)."""
 
     @overload
@@ -769,7 +769,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
         span: Span,
     ) -> None:
         """Create a function call expression with kwargs.
@@ -787,7 +787,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
         type: Type,
         span: Span,
     ) -> None:
@@ -1868,7 +1868,7 @@ def create_op_call(op_name: str, args: Sequence[Expr], span: Span) -> Call:
 def create_op_call(
     op_name: str,
     args: Sequence[Expr],
-    kwargs: Mapping[str, int | bool | str | float | DataType],
+    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
     span: Span,
 ) -> Call:
     """Create a Call expression with args and kwargs.

--- a/src/backend/910B_CCE/backend_910b_cce_ops.cpp
+++ b/src/backend/910B_CCE/backend_910b_cce_ops.cpp
@@ -261,9 +261,9 @@ static std::string MakeBlockMoveCodegenCCE(const ir::CallPtr& op, codegen::Codeg
   INTERNAL_CHECK(src_type->memref_.has_value())
       << "Internal error: block.move source TileType must have MemRef (InitMemRef pass should have run)";
 
-  int target_memory = op->GetKwarg<int>("target_memory");
+  ir::MemorySpace target_memory = op->GetKwarg<ir::MemorySpace>("target_memory");
   ir::MemorySpace src_mem = src_type->memref_.value()->memory_space_;
-  CHECK(!(src_mem == ir::MemorySpace::UB && target_memory == 1))
+  CHECK(!(src_mem == ir::MemorySpace::UB && target_memory == ir::MemorySpace::UB))
       << "block.move: UB to UB move should use block.ub_copy";
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -30,6 +30,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memref.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
@@ -304,7 +305,7 @@ REGISTER_OP("block.create_tile")
     .set_description("Create a tile")
     .add_argument("shape", "Shape dimensions (TupleType of ScalarType(UINT64))")
     .set_attr<DataType>("dtype")
-    .set_attr<int>("target_memory")
+    .set_attr<MemorySpace>("target_memory")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceBlockCreateTileType(args, kwargs, "block.create_tile");
@@ -316,7 +317,7 @@ REGISTER_OP("block.load")
     .add_argument("tensor", "Source tensor (TensorType)")
     .add_argument("offsets", "Offsets in each dimension (TupleType of ScalarType)")
     .add_argument("shapes", "Shape of tile in each dimension (TupleType of ScalarType)")
-    .set_attr<int>("target_memory")
+    .set_attr<MemorySpace>("target_memory")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceBlockLoadType(args, kwargs, "block.load");
@@ -351,7 +352,7 @@ REGISTER_OP("block.move")
     .set_description("Move tile to memory levels (UB/L1/L0A/L0B) with optional transpose")
     .add_argument("tile", "Input tile (TileType)")
     .set_attr<bool>("transpose")
-    .set_attr<int>("target_memory")
+    .set_attr<MemorySpace>("target_memory")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceBlockMoveType(args, kwargs, "block.move");

--- a/src/ir/op_registry.cpp
+++ b/src/ir/op_registry.cpp
@@ -23,6 +23,7 @@
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/memref.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
 
@@ -44,6 +45,11 @@ void ValidateKwargs(const std::vector<std::pair<std::string, std::any>>& kwargs,
       if (value_type != std::type_index(typeid(DataType)) && value_type != std::type_index(typeid(int))) {
         throw TypeError("Kwarg '" + key + "' for operator '" + op_name +
                         "' expects DataType or int, but got incompatible type");
+      }
+    } else if (it->second == std::type_index(typeid(MemorySpace))) {
+      if (std::type_index(value.type()) != std::type_index(typeid(MemorySpace))) {
+        throw TypeError("Kwarg '" + key + "' for operator '" + op_name +
+                        "' expects MemorySpace, but got incompatible type");
       }
     } else if (std::type_index(value.type()) != it->second) {
       throw TypeError("Kwarg '" + key + "' for operator '" + op_name + "' has incompatible type");

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <map>
 #include <memory>
 #include <optional>
@@ -45,18 +44,7 @@ namespace {
 MemorySpace ExtractTargetMemory(const CallPtr& call) {
   for (const auto& [key, value] : call->kwargs_) {
     if (key == "target_memory") {
-      try {
-        int memory_val = AnyCast<int>(value, "target_memory");
-        // Validate range: MemorySpace enum values are 0-5 (DDR, UB, L1, L0A, L0B, L0C)
-        if (memory_val < 0 || memory_val > 5) {
-          LOG_ERROR << "Invalid target_memory value: " << memory_val << ", defaulting to UB";
-          return MemorySpace::UB;
-        }
-        return static_cast<MemorySpace>(memory_val);
-      } catch (const std::exception& e) {
-        LOG_ERROR << "Failed to cast 'target_memory' attribute: " << e.what() << ". Defaulting to UB.";
-        return MemorySpace::UB;
-      }
+      return AnyCast<MemorySpace>(value, "target_memory");
     }
   }
   // If target_memory not found, default to UB

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -469,9 +469,13 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       stream_ << FormatFloatLiteral(static_cast<double>(AnyCast<float>(value, "printing kwarg: " + key)));
     } else if (value.type() == typeid(DataType)) {
       stream_ << DataTypeToPythonString(AnyCast<DataType>(value, "printing kwarg: " + key), prefix_);
+    } else if (value.type() == typeid(MemorySpace)) {
+      stream_ << prefix_ << ".MemorySpace."
+              << MemorySpaceToString(AnyCast<MemorySpace>(value, "printing kwarg: " + key));
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
-                      ", expected int, bool, std::string, double, float, or DataType, but got " +
+                      ", expected int, bool, std::string, double, float, DataType, or MemorySpace, "
+                      "but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -44,10 +44,10 @@ class TestMatmul(PTOTestCase):
                 b: pl.Tensor[[64, 64], pl.FP32],
                 c: pl.Tensor[[64, 64], pl.FP32],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                tile_a_l1 = pl.block.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=2)
-                tile_b_l1 = pl.block.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=2)
-                tile_a_l0a = pl.block.move(tile_a_l1, target_memory=3)
-                tile_b_l0b = pl.block.move(tile_b_l1, target_memory=4)
+                tile_a_l1 = pl.block.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.L1)
+                tile_b_l1 = pl.block.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.L1)
+                tile_a_l0a = pl.block.move(tile_a_l1, target_memory=pl.MemorySpace.L0A)
+                tile_b_l0b = pl.block.move(tile_b_l1, target_memory=pl.MemorySpace.L0B)
                 tile_c_l0c = pl.block.matmul(tile_a_l0a, tile_b_l0b)
                 # store can support l0c -> GM directly
                 out_c = pl.block.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=c)

--- a/tests/ut/codegen/test_cce_codegen.py
+++ b/tests/ut/codegen/test_cce_codegen.py
@@ -256,12 +256,20 @@ class TestMatmulCodegen:
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 """Test matmul with L1/L0A/L0B/L0C memory spaces."""
                 # Load to L1 (Mat tiles), move to L0A/L0B, matmul
-                tile_a_l1: pl.Tile[[64, 64], pl.FP16] = pl.load(a, [0, 0], [64, 64], target_memory=2)  # L1
-                tile_b_l1: pl.Tile[[64, 64], pl.FP16] = pl.load(b, [0, 0], [64, 64], target_memory=2)
+                tile_a_l1: pl.Tile[[64, 64], pl.FP16] = pl.load(
+                    a, [0, 0], [64, 64], target_memory=pl.MemorySpace.L1
+                )  # L1
+                tile_b_l1: pl.Tile[[64, 64], pl.FP16] = pl.load(
+                    b, [0, 0], [64, 64], target_memory=pl.MemorySpace.L1
+                )
 
                 # Move to compute memory (L0A, L0B)
-                tile_a_l0a: pl.Tile[[64, 64], pl.FP16] = pl.move(tile_a_l1, target_memory=3)  # L0A
-                tile_b_l0b: pl.Tile[[64, 64], pl.FP16] = pl.move(tile_b_l1, target_memory=4)  # L0B
+                tile_a_l0a: pl.Tile[[64, 64], pl.FP16] = pl.move(
+                    tile_a_l1, target_memory=pl.MemorySpace.L0A
+                )  # L0A
+                tile_b_l0b: pl.Tile[[64, 64], pl.FP16] = pl.move(
+                    tile_b_l1, target_memory=pl.MemorySpace.L0B
+                )  # L0B
 
                 # Matmul
                 tile_c_l0c: pl.Tile[[64, 64], pl.FP32] = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -309,19 +317,35 @@ class TestMatmulCodegen:
             ) -> pl.Tensor[[32, 32], pl.FP32]:
                 """Test accumulating matmul operation."""
                 # Load tiles to L1 and move to compute buffers
-                tile_a0_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(a0, [0, 0], [32, 32], target_memory=2)
-                tile_b0_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(b0, [0, 0], [32, 32], target_memory=2)
-                tile_a0_l0a: pl.Tile[[32, 32], pl.FP16] = pl.move(tile_a0_l1, target_memory=3)
-                tile_b0_l0b: pl.Tile[[32, 32], pl.FP16] = pl.move(tile_b0_l1, target_memory=4)
+                tile_a0_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(
+                    a0, [0, 0], [32, 32], target_memory=pl.MemorySpace.L1
+                )
+                tile_b0_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(
+                    b0, [0, 0], [32, 32], target_memory=pl.MemorySpace.L1
+                )
+                tile_a0_l0a: pl.Tile[[32, 32], pl.FP16] = pl.move(
+                    tile_a0_l1, target_memory=pl.MemorySpace.L0A
+                )
+                tile_b0_l0b: pl.Tile[[32, 32], pl.FP16] = pl.move(
+                    tile_b0_l1, target_memory=pl.MemorySpace.L0B
+                )
 
                 # First matmul
                 tile_c0: pl.Tile[[32, 32], pl.FP32] = pl.matmul(tile_a0_l0a, tile_b0_l0b)
 
                 # Load second batch
-                tile_a1_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(a1, [0, 0], [32, 32], target_memory=2)
-                tile_b1_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(b1, [0, 0], [32, 32], target_memory=2)
-                tile_a1_l0a: pl.Tile[[32, 32], pl.FP16] = pl.move(tile_a1_l1, target_memory=3)
-                tile_b1_l0b: pl.Tile[[32, 32], pl.FP16] = pl.move(tile_b1_l1, target_memory=4)
+                tile_a1_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(
+                    a1, [0, 0], [32, 32], target_memory=pl.MemorySpace.L1
+                )
+                tile_b1_l1: pl.Tile[[32, 32], pl.FP16] = pl.load(
+                    b1, [0, 0], [32, 32], target_memory=pl.MemorySpace.L1
+                )
+                tile_a1_l0a: pl.Tile[[32, 32], pl.FP16] = pl.move(
+                    tile_a1_l1, target_memory=pl.MemorySpace.L0A
+                )
+                tile_b1_l0b: pl.Tile[[32, 32], pl.FP16] = pl.move(
+                    tile_b1_l1, target_memory=pl.MemorySpace.L0B
+                )
 
                 # Accumulating matmul
                 tile_c1: pl.Tile[[32, 32], pl.FP32] = pl.matmul_acc(tile_c0, tile_a1_l0a, tile_b1_l0b)

--- a/tests/ut/ir/operators/test_block_ops.py
+++ b/tests/ut/ir/operators/test_block_ops.py
@@ -371,7 +371,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 1], pl.FP32] = pl.block.create_tile(
-                    [32, 1], dtype=pl.FP32, target_memory=1
+                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
                 )
                 tile_max: pl.Tile[[32, 1], pl.FP32] = pl.row_max(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_max, [0, 0], [32, 1], output)
@@ -395,7 +395,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 1], pl.FP32] = pl.block.create_tile(
-                    [32, 1], dtype=pl.FP32, target_memory=1
+                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
                 )
                 tile_sum: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_sum, [0, 0], [32, 1], output)
@@ -421,7 +421,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 128], pl.FP32] = pl.block.create_tile(
-                    [32, 128], dtype=pl.FP32, target_memory=1
+                    [32, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
                 )
                 tile_row_min: pl.Tile[[32, 1], pl.FP32] = pl.row_min(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_row_min, [0, 0], [32, 1], output)

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -11,6 +11,7 @@
 
 import pytest
 from pypto import DataType, ir
+from pypto.pypto_core.ir import MemorySpace
 
 
 def test_python_print_basic_expressions():
@@ -570,10 +571,10 @@ def test_python_print_block_load_store():
     # Should contain output tensor
     assert "output_tensor" in store_result
 
-    # Test with target_memory kwarg
+    # Test with target_memory kwarg (using MemorySpace enum)
     # Correct signature: Call(op, args, kwargs, span)
     load_call_with_kwargs = ir.Call(
-        load_op, [input_tensor, offsets_tuple, shapes_tuple], {"target_memory": 1}, span
+        load_op, [input_tensor, offsets_tuple, shapes_tuple], {"target_memory": MemorySpace.UB}, span
     )
 
     load_kwargs_result = ir.python_print(load_call_with_kwargs)
@@ -581,7 +582,7 @@ def test_python_print_block_load_store():
     print(load_kwargs_result)
 
     assert "pl.block.load" in load_kwargs_result
-    assert "target_memory=1" in load_kwargs_result
+    assert "target_memory=pl.MemorySpace.UB" in load_kwargs_result
 
 
 def test_python_print_while_stmt_natural():

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -290,7 +290,9 @@ class TestUnifiedBlockDispatch:
             t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.block.load(t, offsets=[0, 0], shapes=[64, 64])
-            tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile([64, 16], dtype=pl.FP32, target_memory=1)
+            tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile(
+                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+            )
             b: pl.Tile[[64, 1], pl.FP32] = pl.row_sum(a, tmp)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.block.store(
                 b, offsets=[0, 0], shapes=[64, 1], output_tensor=out
@@ -302,7 +304,9 @@ class TestUnifiedBlockDispatch:
             t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.block.load(t, offsets=[0, 0], shapes=[64, 64])
-            tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile([64, 16], dtype=pl.FP32, target_memory=1)
+            tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile(
+                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+            )
             b: pl.Tile[[64, 1], pl.FP32] = pl.block.row_sum(a, tmp)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.block.store(
                 b, offsets=[0, 0], shapes=[64, 1], output_tensor=out


### PR DESCRIPTION
## Summary

Thread the existing `MemorySpace` enum through the `target_memory` kwarg path, replacing magic integers (`1=UB, 2=L1, 3=L0A, 4=L0B`) with typed enum values across the full stack.

- Store `MemorySpace` natively in `std::any` kwargs via `ConvertKwargsDict`
- Register `target_memory` as `set_attr<MemorySpace>` in op schemas (with `ValidateKwargs` enforcement)
- Print `MemorySpace` kwargs as `pl.MemorySpace.UB` etc. in the Python printer
- Expose `MemorySpace` in `pl` namespace (`pl.MemorySpace.UB`)
- Update all Python APIs (`ir.op.block_ops`, `language.op.block_ops`, `unified_ops`) to accept `MemorySpace`
- Update type stubs, all tests, and backend codegen

## Testing

- [x] All 1494 unit tests pass
- [x] Code review completed
- [x] clang-tidy clean
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

Fixes #220