### PR TITLE
chore(gitignore): add .devcontainer/ to ignored paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ ENV/
 .vscode/
 .idea/
 .claude/
+.devcontainer/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Add `.devcontainer/` to the IDEs section of `.gitignore` to prevent VS Code Dev Container configuration files from being tracked

## Testing
- [x] Pre-commit checks pass
- [x] No functional code changes