### PR TITLE
chore(claude): strengthen git-commit prerequisite in github-pr skill

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Create a GitHub pull request after committing, rebasing, and pushin
 
 ## Prerequisites
 
-⚠️ **MANDATORY**: Uncommitted changes must go through the `/git-commit` skill (which runs code review, testing, and linting) before proceeding. Do not commit directly.
+⚠️ **MANDATORY**: Use the `/git-commit` skill to commit all changes. This runs the full code review, testing, and linting workflow. Do not commit directly.
 
 ## Workflow Steps
 


### PR DESCRIPTION
## Summary
- Make the `/git-commit` prerequisite in the github-pr skill mandatory and explicit
- Clarifies that the full workflow (code review, testing, linting) must run before proceeding
- Condensed wording per code review feedback

## Testing
- [x] No code changes, AI skill file only
- [x] Pre-commit checks pass
- [x] Code review completed