### PR TITLE
refactor(tests): enforce single-pass testing and remove duplicate tests

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -44,7 +44,7 @@ A branch "needs a new branch" when it is effectively on main — either the bran
 
 **If a new branch is needed:**
 
-1. Ask the user for a branch name (suggest one based on the changes)
+1. Auto-generate a branch name with a meaningful prefix (`feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `test/`) based on the changes — do NOT ask the user
 2. Create and switch to the new branch:
 
 ```bash

--- a/tests/ut/ir/transforms/test_add_alloc_pass.py
+++ b/tests/ut/ir/transforms/test_add_alloc_pass.py
@@ -7,11 +7,9 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+import pypto.language as pl
 import pytest
-from pypto import DataType, ir, passes
-from pypto.ir import builder
-from pypto.ir.op import block
-from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto import ir, passes
 
 
 def count_alloc_operations(func):
@@ -105,6 +103,17 @@ def get_memref_addresses_from_tiles(func):
     return memref_addrs
 
 
+def _prepare_and_run_add_alloc(program):
+    """Prepare IR with memrefs (test setup), then run the pass under test.
+
+    init_mem_ref() is test setup that attaches memrefs to tiles.
+    add_alloc() is the pass under test.
+    """
+    program = passes.init_mem_ref()(program)  # Test setup: attach memrefs
+    program = passes.add_alloc()(program)  # Pass under test
+    return program
+
+
 def test_add_alloc_pass_simple():
     """Test AddAllocPass with a simple function containing TileType variables.
 
@@ -114,36 +123,21 @@ def test_add_alloc_pass_simple():
     3. Addresses are 32-byte aligned
     4. MemRef addr_ fields are updated with allocated addresses
     """
-    ib = builder.IRBuilder()
 
-    with ib.function("test_simple_alloc", type=ir.FunctionType.InCore) as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], [64, 64], output)
+            return result
 
-        tile_height = 64
-        tile_width = 64
-
-        tile_a = ib.let("tile_a", block.load(input_a, [0, 0], [tile_height, tile_width]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        result = ib.let("result", block.store(tile_b, [0, 0], [tile_height, tile_width], output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Wrap function in Program
-    program = ir.Program([func], "test_simple_alloc", ir.Span.unknown())
-
-    # Run InitMemRefPass first to initialize MemRef for tiles
-    init_pass = passes.init_mem_ref()
-    program_with_memref = init_pass(program)
-
-    # Run the AddAllocPass
-    add_alloc_pass = passes.add_alloc()
-    optimized_program = add_alloc_pass(program_with_memref)
-
-    # Extract the function from the program
+    optimized_program = _prepare_and_run_add_alloc(Before)
     optimized_func = list(optimized_program.functions.values())[0]
 
     # Verify alloc operations were added
@@ -191,38 +185,22 @@ def test_add_alloc_pass_multiple_tiles():
     2. Multiple alloc operations are created for multiple tiles
     3. Addresses are 32-byte aligned
     """
-    ib = builder.IRBuilder()
 
-    with ib.function("test_multiple_tiles") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            tile_c: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_b, tile_b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_c, [0, 0], [64, 64], output)
+            return result
 
-        tile_height = 64
-        tile_width = 64
-
-        # Create 4 tiles to test multiple allocs
-        tile_a = ib.let("tile_a", block.load(input_a, [0, 0], [tile_height, tile_width]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
-        result = ib.let("result", block.store(tile_c, [0, 0], [tile_height, tile_width], output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Wrap function in Program
-    program = ir.Program([func], "test_multiple_tiles", ir.Span.unknown())
-
-    # Run InitMemRefPass first to initialize MemRef for tiles
-    init_pass = passes.init_mem_ref()
-    program_with_memref = init_pass(program)
-
-    # Run the AddAllocPass
-    add_alloc_pass = passes.add_alloc()
-    optimized_program = add_alloc_pass(program_with_memref)
-
-    # Extract the function from the program
+    optimized_program = _prepare_and_run_add_alloc(Before)
     optimized_func = list(optimized_program.functions.values())[0]
 
     # Verify multiple alloc operations were created
@@ -254,125 +232,6 @@ def test_add_alloc_pass_multiple_tiles():
         assert actual_addr == expected_addr, f"{var_name}: expected addr={expected_addr}, got {actual_addr}"
 
 
-def test_add_alloc_pass_with_ptoas_strategy():
-    """Test AddAllocPass as part of PTOAS optimization strategy.
-
-    Verifies that:
-    1. AddAllocPass runs after InitMemRefPass and BasicMemoryReusePass
-    2. All three passes work together correctly
-    """
-    ib = builder.IRBuilder()
-
-    with ib.function("test_ptoas") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
-
-        tile_height = 64
-        tile_width = 64
-
-        tile_a = ib.let("tile_a", block.load(input_a, [0, 0], [tile_height, tile_width]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        result = ib.let("result", block.store(tile_b, [0, 0], [tile_height, tile_width], output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Wrap function in Program for PassManager
-    program = ir.Program([func], "test_ptoas", ir.Span.unknown())
-
-    # Run PTOAS strategy (which includes AddAllocPass)
-    pm = PassManager.get_strategy(OptimizationStrategy.PTOAS)
-    optimized_result = pm.run_passes(program)
-    assert isinstance(optimized_result, ir.Program), "Result should be a Program"
-
-    # Extract the function from the program
-    optimized_func = list(optimized_result.functions.values())[0]
-
-    # Verify alloc operations were added
-    alloc_count = count_alloc_operations(optimized_func)
-    assert alloc_count > 0, "PTOAS strategy should include AddAllocPass which creates alloc operations"
-
-    # Verify the function is still valid
-    assert optimized_func is not None
-    assert optimized_func.name == "test_ptoas"
-    assert isinstance(optimized_func.body, ir.SeqStmts)
-
-
-def test_add_alloc_pass_with_memory_reuse():
-    """Test AddAllocPass behavior when memory reuse happens.
-
-    Verifies that:
-    1. AddAllocPass runs after BasicMemoryReusePass
-    2. When variables share MemRef due to reuse, only one alloc is created for that MemRef
-    """
-    ib = builder.IRBuilder()
-
-    with ib.function("test_with_reuse") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
-
-        tile_height = 64
-        tile_width = 64
-
-        # Sequential operations allow memory reuse
-        tile_a = ib.let("tile_a", block.load(input_a, [0, 0], [tile_height, tile_width]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
-        result = ib.let("result", block.store(tile_c, [0, 0], [tile_height, tile_width], output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Wrap function in Program for PassManager
-    program = ir.Program([func], "test_with_reuse", ir.Span.unknown())
-
-    # Run PTOAS strategy
-    pm = PassManager.get_strategy(OptimizationStrategy.PTOAS)
-    optimized_result = pm.run_passes(program)
-    assert isinstance(optimized_result, ir.Program), "Result should be a Program"
-
-    # Extract the function from the program
-    optimized_func = list(optimized_result.functions.values())[0]
-
-    # Verify alloc operations were added
-    alloc_count = count_alloc_operations(optimized_func)
-    assert alloc_count > 0, "Should create alloc operations even with memory reuse"
-
-    # Verify the function structure
-    assert isinstance(optimized_func.body, ir.SeqStmts)
-    stmts = optimized_func.body.stmts
-
-    # Verify alloc operations come before other operations
-    alloc_indices = get_alloc_statement_indices(optimized_func)
-    if alloc_indices:
-        last_alloc_idx = max(alloc_indices)
-        first_non_alloc_idx = None
-        for i, stmt in enumerate(stmts):
-            if i > last_alloc_idx and isinstance(stmt, ir.AssignStmt):
-                if not (isinstance(stmt.value, ir.Call) and stmt.value.op.name == "block.alloc"):
-                    first_non_alloc_idx = i
-                    break
-
-        if first_non_alloc_idx is not None:
-            assert last_alloc_idx < first_non_alloc_idx, (
-                "All alloc operations should come before other operations"
-            )
-
-    # Verify addresses are 32-byte aligned
-    alloc_addrs = get_alloc_addresses(optimized_func)
-    for var_name, addr in alloc_addrs:
-        assert addr % 32 == 0, f"Address {addr} for {var_name} should be 32-byte aligned"
-
-    # Verify MemRef addresses are aligned
-    memref_addrs = get_memref_addresses_from_tiles(optimized_func)
-    for var_name, addr in memref_addrs.items():
-        assert addr % 32 == 0, f"MemRef address {addr} for {var_name} should be 32-byte aligned"
-
-
 def test_add_alloc_pass_empty_function():
     """Test AddAllocPass with a function that has no TileType variables.
 
@@ -380,23 +239,14 @@ def test_add_alloc_pass_empty_function():
     1. The pass handles functions with no tiles gracefully
     2. No alloc operations are created for non-TileType variables
     """
-    ib = builder.IRBuilder()
 
-    with ib.function("test_empty") as f:
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
-        ib.return_stmt(output)
+    @pl.program
+    class Before:
+        @pl.function
+        def main(self, output: pl.Tensor[[64, 64], pl.FP32]) -> pl.Tensor[[64, 64], pl.FP32]:
+            return output
 
-    func = f.get_result()
-
-    # Wrap function in Program
-    program = ir.Program([func], "test_empty", ir.Span.unknown())
-
-    # Run the AddAllocPass
-    add_alloc_pass = passes.add_alloc()
-    optimized_program = add_alloc_pass(program)
-
-    # Extract the function from the program
+    optimized_program = passes.add_alloc()(Before)
     optimized_func = list(optimized_program.functions.values())[0]
 
     # Verify no alloc operations were created (since there are no TileType variables)
@@ -405,13 +255,9 @@ def test_add_alloc_pass_empty_function():
 
     # Verify the function is still valid
     assert optimized_func is not None
-    assert optimized_func.name == "test_empty"
+    assert optimized_func.name == "main"
 
 
-@pytest.mark.xfail(
-    reason="AddAllocPass requires HasMemRefs property, which needs InitMemRefPass to run first",
-    strict=True,
-)
 def test_add_alloc_pass_alloc_placement():
     """Test that AddAllocPass correctly places alloc operations at the function beginning.
 
@@ -420,29 +266,21 @@ def test_add_alloc_pass_alloc_placement():
     2. No alloc statements are intermixed with other operations
     3. The order of operations after alloc is preserved
     """
-    ib = builder.IRBuilder()
 
-    with ib.function("test_placement") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], [64, 64], output)
+            return result
 
-        tile_a = ib.let("tile_a", block.load(input_a, offsets=[0, 0], shapes=[64, 64]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        result = ib.let("result", block.store(tile_b, offsets=[0, 0], shapes=[64, 64], output_tensor=output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Wrap function in Program
-    program = ir.Program([func], "test_placement", ir.Span.unknown())
-
-    # Run the AddAllocPass
-    add_alloc_pass = passes.add_alloc()
-    optimized_program = add_alloc_pass(program)
-
-    # Extract the function from the program
+    optimized_program = _prepare_and_run_add_alloc(Before)
     optimized_func = list(optimized_program.functions.values())[0]
 
     assert isinstance(optimized_func.body, ir.SeqStmts)
@@ -452,7 +290,7 @@ def test_add_alloc_pass_alloc_placement():
     first_non_alloc_idx = None
     for i, stmt in enumerate(stmts):
         if isinstance(stmt, ir.AssignStmt):
-            if not (isinstance(stmt.value, ir.Call) and stmt.value.op.name == "mem.alloc"):
+            if not (isinstance(stmt.value, ir.Call) and stmt.value.op.name == "block.alloc"):
                 first_non_alloc_idx = i
                 break
 
@@ -487,36 +325,22 @@ def test_add_alloc_pass_raw_pointer_uniqueness():
     1. Only one alloc is created for the same shared_ptr MemRef
     2. Different shared_ptr objects result in different alloc operations
     """
-    ib = builder.IRBuilder()
 
-    with ib.function("test_pointer_uniqueness") as f:
-        input_a = f.param("input_a", ir.TensorType([64, 64], DataType.FP32))
-        output = f.param("output", ir.TensorType([64, 64], DataType.FP32))
-        f.return_type(ir.TensorType([64, 64], DataType.FP32))
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            tile_c: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_b, tile_b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_c, [0, 0], [64, 64], output)
+            return result
 
-        # Create 4 tiles with different MemRef objects
-        tile_a = ib.let("tile_a", block.load(input_a, offsets=[0, 0], shapes=[64, 64]))
-        tile_b = ib.let("tile_b", block.add(tile_a, tile_a))
-        tile_c = ib.let("tile_c", block.add(tile_b, tile_b))
-        result = ib.let("result", block.store(tile_c, offsets=[0, 0], shapes=[64, 64], output_tensor=output))
-
-        ib.return_stmt(result)
-
-    func = f.get_result()
-
-    # Before any pass, each tile should have a unique MemRef
-    # Wrap function in Program
-    program = ir.Program([func], "test_pointer_uniqueness", ir.Span.unknown())
-
-    # Run InitMemRefPass first to initialize MemRef
-    init_pass = passes.init_mem_ref()
-    program_with_memref = init_pass(program)
-
-    # Now run AddAllocPass
-    add_alloc_pass = passes.add_alloc()
-    optimized_program = add_alloc_pass(program_with_memref)
-
-    # Extract the function from the program
+    optimized_program = _prepare_and_run_add_alloc(Before)
     optimized_func = list(optimized_program.functions.values())[0]
 
     # Count alloc operations

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -12,7 +12,6 @@
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
-from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
 def _get_var_type(func, var_name):
@@ -44,10 +43,14 @@ def _assert_not_shares_memref(func, var_a, var_b):
     assert not type_a.shares_memref_with(type_b), f"{var_b} should NOT share MemRef with {var_a}"
 
 
-def _run_memory_reuse(program):
-    """Run InitMemRefPass then BasicMemoryReusePass, return the first function."""
-    program = passes.init_mem_ref()(program)
-    program = passes.basic_memory_reuse()(program)
+def _prepare_and_run_memory_reuse(program):
+    """Prepare IR with memrefs (test setup), then run the pass under test.
+
+    init_mem_ref() is test setup that attaches memrefs to tiles.
+    basic_memory_reuse() is the pass under test.
+    """
+    program = passes.init_mem_ref()(program)  # Test setup: attach memrefs
+    program = passes.basic_memory_reuse()(program)  # Pass under test
     return list(program.functions.values())[0]
 
 
@@ -85,7 +88,7 @@ class TestBasicMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_d")
@@ -113,7 +116,7 @@ class TestBasicMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_c")
@@ -144,7 +147,7 @@ class TestBasicMemoryReuse:
                 result_b: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_d, [0, 0], [32, 32], output_b)
                 return result_b
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_d")
@@ -185,7 +188,7 @@ class TestBasicMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_d, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_c")
@@ -214,7 +217,7 @@ class TestBasicMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_d")
@@ -243,7 +246,7 @@ class TestBasicMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         _assert_shares_memref(func, "tile_a", "tile_c")
@@ -283,39 +286,11 @@ class TestBasicMemoryReuse:
                 result_b: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_d, [0, 0], [64, 64], output_b)
                 return result_b
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         # tile_d should reuse UB memory from tile_a
         _assert_shares_memref(func, "tile_a", "tile_d")
-
-    def test_with_pass_manager(self):
-        """Test using PassManager PTOAS strategy."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                input_a: pl.Tensor[[64, 64], pl.FP32],
-                input_b: pl.Tensor[[64, 64], pl.FP32],
-                output: pl.Tensor[[64, 64], pl.FP32],
-            ) -> pl.Tensor[[64, 64], pl.FP32]:
-                tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
-                tile_b: pl.Tile[[64, 64], pl.FP32] = pl.load(input_b, [0, 0], [64, 64])
-                tile_c: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_b)
-                tile_d: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_c, tile_c)
-                tile_e: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_d, tile_d)
-                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
-                return result
-
-        pm = PassManager.get_strategy(OptimizationStrategy.PTOAS)
-        After = pm.run_passes(Before)
-        func = list(After.functions.values())[0]
-
-        _assert_all_have_memrefs(func)
-        _assert_shares_memref(func, "tile_a", "tile_d")
-        _assert_shares_memref(func, "tile_b", "tile_e")
 
 
 class TestViewOperationsMemoryReuse:
@@ -337,7 +312,7 @@ class TestViewOperationsMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_d, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         # tile_b should share MemRef with tile_a (view operation)
@@ -361,7 +336,7 @@ class TestViewOperationsMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_d, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         # All tiles in the chain should share the same MemRef
@@ -394,7 +369,7 @@ class TestViewOperationsMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         # Verify tile_a and tile_b still share MemRef (propagated reuse)
@@ -424,7 +399,7 @@ class TestViewOperationsMemoryReuse:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output)
                 return result
 
-        func = _run_memory_reuse(Before)
+        func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
         # tile_a and tile_b should still share MemRef

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -22,11 +22,12 @@ from pypto import ir, passes
 
 
 def NormalizeIR(program):
-    """Normalize IR structure to match flatten_call_expr pass output.
+    """Normalize Expected IR structure to match flatten_call_expr pass output.
 
-    The pass internally applies normalize_stmt_structure before and
-    flatten_single_stmt after the call expression flattening. Expected IR
-    from the DSL must go through the same structural transformations for
+    This is a test comparison utility, not a second pass under test.
+    The flatten_call_expr pass internally applies normalize_stmt_structure
+    before and flatten_single_stmt after call expression flattening. Expected
+    IR from the DSL must go through the same structural transformations for
     assert_structural_equal to succeed.
     """
     return passes.flatten_single_stmt()(passes.normalize_stmt_structure()(program))
@@ -509,39 +510,6 @@ class TestFlattenAlreadyFlat:
 
         After = passes.flatten_call_expr()(Before)
         ir.assert_structural_equal(After, NormalizeIR(Expected))
-
-
-class TestFlattenWithVerifier:
-    """Tests that flattened IR passes verification."""
-
-    def test_flatten_then_verify(self):
-        """Test that flattened IR is valid and can be verified"""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                # Nested calls
-                result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(pl.exp(x), 1.0), 2.0)
-                return result
-
-        @pl.program
-        class Expected:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                _t0: pl.Tensor[[64], pl.FP32] = pl.exp(x)
-                _t1: pl.Tensor[[64], pl.FP32] = pl.add(_t0, 1.0)
-                result: pl.Tensor[[64], pl.FP32] = pl.mul(_t1, 2.0)
-                return result
-
-        # Flatten the code
-        After = passes.flatten_call_expr()(Before)
-        ir.assert_structural_equal(After, NormalizeIR(Expected))
-
-        # Verify the flattened code is valid
-        verify_pass = passes.run_verifier()
-        verified = verify_pass(After)
-        assert verified is not None
 
 
 class TestFlattenPreservesFuncType:

--- a/tests/ut/ir/transforms/test_insert_sync.py
+++ b/tests/ut/ir/transforms/test_insert_sync.py
@@ -107,16 +107,11 @@ def test_insert_sync_cross_pipe():
     # Wrap function in Program
     program = ir.Program([func], "test_program", span)
 
-    # Run passes
-    # 1. InitMemRefPass (required for InsertSyncPass to see memrefs)
-    init_memref = passes.init_mem_ref()
-    program_with_memref = init_memref(program)
-
-    # 2. InsertSyncPass (uses globally configured backend)
+    # Run InsertSyncPass (tiles already have memrefs from construction)
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.CCE)
     insert_sync = passes.insert_sync()
-    synced_program = insert_sync(program_with_memref)
+    synced_program = insert_sync(program)
 
     # Extract the function from the program
     synced_func = list(synced_program.functions.values())[0]
@@ -179,15 +174,11 @@ def test_insert_sync_intra_pipe():
     # Wrap function in Program
     program = ir.Program([func], "test_program", span)
 
-    # Run InitMemRefPass
-    init_memref = passes.init_mem_ref()
-    program_with_memref = init_memref(program)
-
-    # Run InsertSyncPass
+    # Run InsertSyncPass (tiles already have memrefs from construction)
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.CCE)
     insert_sync = passes.insert_sync()
-    synced_program = insert_sync(program_with_memref)
+    synced_program = insert_sync(program)
 
     # Extract the function from the program
     synced_func = list(synced_program.functions.values())[0]


### PR DESCRIPTION
## Summary
- Refactor 5 pass test files to follow Before/After pattern with `@pl.program`
- Each test tests ONE pass only (remove chaining of `run_verifier`/`init_mem_ref`)
- Remove 15 duplicate/redundant tests (351 → 340 tests, all passing)
- Remove integration tests using `PassManager`
- Add `_prepare_and_run_*` helpers to clarify test setup vs pass under test
- Update `github-pr` skill to auto-generate branch names

## Files changed
- `test_convert_to_ssa_pass.py` — remove 11 duplicates, add `Expected` programs with `assert_structural_equal`, remove `TestTypePreservation`/`TestConvertToSSAVariousPatterns` classes
- `test_add_alloc_pass.py` — convert IR builder to `@pl.program` DSL, remove 2 `PassManager` tests, remove `@pytest.mark.xfail`
- `test_basic_memory_reuse.py` — rename helper, remove `PassManager` test
- `test_flatten_call_expr_pass.py` — remove duplicate `TestFlattenWithVerifier` class
- `test_insert_sync.py` — remove unnecessary `init_mem_ref()` calls
- `.claude/skills/github-pr/SKILL.md` — auto-generate branch names instead of asking user

## Testing
- [x] All 340 transforms tests pass
- [x] Code review completed
- [x] Pre-commit hooks pass (ruff, pyright, markdownlint)