### PR TITLE
style(fuzz): Modernize type annotations to Python 3.10+ syntax

### DIFF
--- a/tests/st/fuzz/README.md
+++ b/tests/st/fuzz/README.md
@@ -13,7 +13,7 @@ This framework tests PyPTO compiler and runtime correctness by randomly generati
 
 ## Directory Structure
 
-```
+```text
 tests/st/fuzz/
 ├── src/                          # Core generators
 │   ├── fuzzer.py                 # Operator fuzzing engine
@@ -62,6 +62,7 @@ pytest tests/st/fuzz/
 ### OpFuzzer ([fuzzer.py](src/fuzzer.py))
 
 Operator fuzzing engine that:
+
 - Randomly generates operator chains (ensures all inputs and intermediates are used)
 - Checks shape compatibility and performs automatic inference
 - Tracks value ranges (avoids illegal inputs for sqrt/log/div operators)
@@ -70,6 +71,7 @@ Operator fuzzing engine that:
 ### KernelGenerator ([kernel_generator.py](src/kernel_generator.py))
 
 Generates Python code for InCore kernels, including:
+
 - Tile allocation and memory management
 - Operator call sequences
 - Golden reference implementation (NumPy)
@@ -77,6 +79,7 @@ Generates Python code for InCore kernels, including:
 ### OrchestratorGenerator ([orchestrator_generator.py](src/orchestrator_generator.py))
 
 Generates Orchestration functions, supporting:
+
 - Sequential: Execute multiple kernels sequentially
 - Parallel: Execute independent kernels in parallel
 - Pipeline: Execute kernels in pipeline mode
@@ -88,7 +91,7 @@ Top-level test case generator that integrates the above components to generate c
 ## Configuration Options
 
 | Parameter | Description | Default |
-|-----------|-------------|---------|
+| --------- | ----------- | ------- |
 | `--config-index` | Configuration index (starting from 0) | 0 |
 | `--output` | Output file path | `generated/test_fuzz_multi_kernel.py` |
 | `--atol` | Absolute error tolerance | 5e-5 |

--- a/tests/st/fuzz/src/kernel_generator.py
+++ b/tests/st/fuzz/src/kernel_generator.py
@@ -15,7 +15,7 @@ Each kernel contains a chain of randomly generated operator operations.
 """
 
 import random
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from .fuzzer import OpFuzzer, generate_aligned_shape, is_shape_aligned
 
@@ -30,7 +30,7 @@ class KernelGenerator:
 
     def __init__(
         self,
-        seed: Optional[int] = None,
+        seed: int | None = None,
         enable_advanced_ops: bool = False,
         advanced_ops_probability: float = 0.5,
     ):
@@ -53,11 +53,11 @@ class KernelGenerator:
         kernel_name: str,
         num_inputs: int = 2,
         num_ops: int = 5,
-        shape: Tuple[int, int] = (128, 128),
+        shape: tuple[int, int] = (128, 128),
         allow_scalars: bool = True,
-        input_shapes: Optional[List[Tuple[int, int]]] = None,
-        output_shape: Optional[Tuple[int, int]] = None,
-    ) -> Dict[str, Any]:
+        input_shapes: list[tuple[int, int]] | None = None,
+        output_shape: tuple[int, int] | None = None,
+    ) -> dict[str, Any]:
         """Generate an InCore kernel function.
 
         Args:
@@ -182,7 +182,7 @@ class KernelGenerator:
 
     def _generate_input_loads(
         self,
-        inputs: List[Tuple[str, Tuple[int, int]]],
+        inputs: list[tuple[str, tuple[int, int]]],
         has_matmul: bool,
     ) -> list[str]:
         """Generate input load operations."""
@@ -219,7 +219,7 @@ class KernelGenerator:
     def _generate_reduction_op(
         self,
         op_dict: dict[str, Any],
-        output_shape: Tuple[int, int],
+        output_shape: tuple[int, int],
     ) -> list[str]:
         """Generate reduction operation with temporary tile.
 
@@ -273,9 +273,9 @@ class KernelGenerator:
 
     def _generate_store_op(
         self,
-        op_chain: List[Dict[str, Any]],
-        inputs: List[Tuple[str, Tuple[int, int]]],
-        output_shape: Tuple[int, int],
+        op_chain: list[dict[str, Any]],
+        inputs: list[tuple[str, tuple[int, int]]],
+        output_shape: tuple[int, int],
     ) -> list[str]:
         """Generate store operation."""
         code_lines = []
@@ -308,11 +308,11 @@ class KernelGenerator:
     def _generate_kernel_code(
         self,
         kernel_name: str,
-        inputs: List[Tuple[str, Tuple[int, int]]],
-        scalars: List[Tuple[str, str]],
-        op_chain: List[Dict[str, Any]],
-        output_shape: Tuple[int, int],
-        scalar_value_to_param: Dict[str, str],
+        inputs: list[tuple[str, tuple[int, int]]],
+        scalars: list[tuple[str, str]],
+        op_chain: list[dict[str, Any]],
+        output_shape: tuple[int, int],
+        scalar_value_to_param: dict[str, str],
     ) -> str:
         """Generate kernel function code.
 
@@ -365,12 +365,12 @@ class KernelGenerator:
     def generate_multiple_kernels(
         self,
         num_kernels: int = 3,
-        num_inputs_range: Tuple[int, int] = (2, 3),
-        num_ops_range: Tuple[int, int] = (3, 7),
-        shape: Tuple[int, int] = (128, 128),
-        input_shapes_list: Optional[List[List[Tuple[int, int]]]] = None,
-        output_shapes: Optional[List[Tuple[int, int]]] = None,
-    ) -> List[Dict[str, Any]]:
+        num_inputs_range: tuple[int, int] = (2, 3),
+        num_ops_range: tuple[int, int] = (3, 7),
+        shape: tuple[int, int] = (128, 128),
+        input_shapes_list: list[list[tuple[int, int]]] | None = None,
+        output_shapes: list[tuple[int, int]] | None = None,
+    ) -> list[dict[str, Any]]:
         """Generate multiple InCore kernel functions.
 
         Args:

--- a/tests/st/fuzz/src/multi_kernel_test_generator.py
+++ b/tests/st/fuzz/src/multi_kernel_test_generator.py
@@ -17,7 +17,7 @@ This module is responsible for generating:
 - PTOTestCase test class
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import numpy as np
 import torch
@@ -32,7 +32,7 @@ class MultiKernelTestGenerator:
 
     def __init__(
         self,
-        seed: Optional[int] = None,
+        seed: int | None = None,
         enable_advanced_ops: bool = False,
         advanced_ops_probability: float = 0.5,
         tensor_init_type: str = "constant",
@@ -64,7 +64,7 @@ class MultiKernelTestGenerator:
             advanced_ops_probability=advanced_ops_probability,
         )
 
-    def _generate_tensor_init_value(self, tensor_index: int, init_type: str = None) -> str:
+    def _generate_tensor_init_value(self, tensor_index: int, init_type: str | None = None) -> str:
         """
 
         Args:
@@ -104,10 +104,10 @@ class MultiKernelTestGenerator:
     def _compute_output_shapes_for_sequential(  # noqa: PLR0912
         self,
         num_kernels: int,
-        default_shape: Tuple[int, int],
-        input_shapes_list: Optional[List[List[Tuple[int, int]]]],
+        default_shape: tuple[int, int],
+        input_shapes_list: list[list[tuple[int, int]]] | None,
         mode: str,
-    ) -> List[Tuple[int, int]]:
+    ) -> list[tuple[int, int]]:
         """kernels，
 
         Args:
@@ -192,8 +192,8 @@ class MultiKernelTestGenerator:
 
     def _regenerate_kernel_code_with_unified_shapes(
         self,
-        kernel: Dict[str, Any],
-        input_shapes_map: Dict[str, Tuple[int, int]],
+        kernel: dict[str, Any],
+        input_shapes_map: dict[str, tuple[int, int]],
     ) -> str:
         """Regenerate kernel code with unified input shapes
 
@@ -230,10 +230,10 @@ class MultiKernelTestGenerator:
         test_name: str,
         num_kernels: int = 3,
         orchestration_mode: str = "sequential",
-        shape: Tuple[int, int] = (128, 128),
-        num_ops_range: Tuple[int, int] = (3, 7),
-        input_shapes_list: Optional[List[List[Tuple[int, int]]]] = None,
-        tensor_init_type: Optional[str] = None,
+        shape: tuple[int, int] = (128, 128),
+        num_ops_range: tuple[int, int] = (3, 7),
+        input_shapes_list: list[list[tuple[int, int]]] | None = None,
+        tensor_init_type: str | None = None,
         atol: float = 1e-5,
         rtol: float = 1e-5,
     ) -> str:
@@ -304,8 +304,8 @@ class MultiKernelTestGenerator:
 
     def _generate_torch_reference(
         self,
-        kernels: List[Dict[str, Any]],
-        orch_info: Dict[str, Any],
+        kernels: list[dict[str, Any]],
+        orch_info: dict[str, Any],
     ) -> str:
         """Torch reference implementation
 
@@ -398,7 +398,7 @@ class MultiKernelTestGenerator:
         "block.matmul": lambda v: f"torch.matmul({v[0]}, {v[1]})",
     }
 
-    def _get_torch_operation(self, op_name: str, input_vals: List[str]) -> str:
+    def _get_torch_operation(self, op_name: str, input_vals: list[str]) -> str:
         """Convert PyPTO operation to Torch expression.
 
         Args:
@@ -416,11 +416,11 @@ class MultiKernelTestGenerator:
     def _generate_test_class(  # noqa: PLR0912, PLR0915
         self,
         test_name: str,
-        kernels: List[Dict[str, Any]],
-        orch_info: Dict[str, Any],
+        kernels: list[dict[str, Any]],
+        orch_info: dict[str, Any],
         torch_code: str,
-        shape: Tuple[int, int],
-        tensor_init_type: Optional[str] = None,
+        shape: tuple[int, int],
+        tensor_init_type: str | None = None,
         atol: float = 1e-5,
         rtol: float = 1e-5,
     ) -> str:
@@ -652,9 +652,9 @@ class MultiKernelTestGenerator:
 
     def _validate_golden_output(  # noqa: PLR0912
         self,
-        kernels: List[Dict[str, Any]],
-        orch_info: Dict[str, Any],
-        shape: Tuple[int, int],
+        kernels: list[dict[str, Any]],
+        orch_info: dict[str, Any],
+        shape: tuple[int, int],
         tensor_init_type: str,
     ) -> None:
         """golden ， NaN/Inf

--- a/tests/st/fuzz/src/orchestrator_generator.py
+++ b/tests/st/fuzz/src/orchestrator_generator.py
@@ -18,13 +18,13 @@ multiple InCore kernels。：
 """
 
 import random
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 
 class OrchestratorGenerator:
     """Orchestration orchestration function"""
 
-    def __init__(self, seed: Optional[int] = None):
+    def __init__(self, seed: int | None = None):
         """orchestration function
 
         Args:
@@ -34,9 +34,9 @@ class OrchestratorGenerator:
 
     def generate_sequential(
         self,
-        kernels: List[Dict[str, Any]],
-        shape: Tuple[int, int] = (128, 128),
-    ) -> Dict[str, Any]:
+        kernels: list[dict[str, Any]],
+        shape: tuple[int, int] = (128, 128),
+    ) -> dict[str, Any]:
         """Orchestration
 
         ，kernelskernels。
@@ -108,9 +108,9 @@ class OrchestratorGenerator:
 
     def generate_branching(
         self,
-        kernels: List[Dict[str, Any]],
-        shape: Tuple[int, int] = (128, 128),
-    ) -> Dict[str, Any]:
+        kernels: list[dict[str, Any]],
+        shape: tuple[int, int] = (128, 128),
+    ) -> dict[str, Any]:
         """Orchestration
 
         ，multiplekernels，。
@@ -189,9 +189,9 @@ class OrchestratorGenerator:
 
     def generate_mixed(
         self,
-        kernels: List[Dict[str, Any]],
-        shape: Tuple[int, int] = (128, 128),
-    ) -> Dict[str, Any]:
+        kernels: list[dict[str, Any]],
+        shape: tuple[int, int] = (128, 128),
+    ) -> dict[str, Any]:
         """Orchestration
 
         。
@@ -288,7 +288,7 @@ class OrchestratorGenerator:
             "needs_merge_kernel": len(branch_results) > 1,
         }
 
-    def generate_merge_kernel(self, shape: Tuple[int, int] = (128, 128)) -> str:
+    def generate_merge_kernel(self, shape: tuple[int, int] = (128, 128)) -> str:
         """kernels
 
         Args:


### PR DESCRIPTION
style(fuzz): modernize type annotations to Python 3.10+ syntax

Replace legacy typing imports (Dict, List, Tuple, Optional) with
built-in generics (dict, list, tuple) and union syntax (X | None)
across all fuzz test source files. Also fix minor README formatting
(code block language tag, blank lines before lists, table alignment).