### PR TITLE
refactor(ir): Move verifier code to independent src/ir/verifier directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,6 @@ set(PYPTO_SOURCES
     src/ir/transforms/flatten_single_stmt_pass.cpp
     src/ir/transforms/init_memref.cpp
     src/ir/transforms/ir_property.cpp
-    src/ir/transforms/property_verifier_registry.cpp
     src/ir/transforms/insert_sync_pass.cpp
     src/ir/transforms/mutator.cpp
     src/ir/transforms/normalize_stmt_structure_pass.cpp
@@ -133,14 +132,17 @@ set(PYPTO_SOURCES
     src/ir/transforms/python_printer.cpp
     src/ir/transforms/structural_equal.cpp
     src/ir/transforms/structural_hash.cpp
-    src/ir/transforms/type_check_pass.cpp
     src/ir/transforms/utils/flatten_single_stmt.cpp
     src/ir/transforms/utils/normalize_stmt_structure.cpp
     src/ir/transforms/utils/parent_stmt_analysis.cpp
-    src/ir/transforms/verifier.cpp
-    src/ir/transforms/verify_no_nested_call_pass.cpp
-    src/ir/transforms/verify_ssa_pass.cpp
     src/ir/transforms/visitor.cpp
+
+    # IR - Verifier
+    src/ir/verifier/verifier.cpp
+    src/ir/verifier/property_verifier_registry.cpp
+    src/ir/verifier/verify_ssa_pass.cpp
+    src/ir/verifier/verify_no_nested_call_pass.cpp
+    src/ir/verifier/type_check_pass.cpp
 
     # IR - Serialization
     src/ir/serialization/deserializer.cpp

--- a/include/pypto/ir/verifier/property_verifier_registry.h
+++ b/include/pypto/ir/verifier/property_verifier_registry.h
@@ -9,8 +9,8 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_
-#define PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_
+#ifndef PYPTO_IR_VERIFIER_PROPERTY_VERIFIER_REGISTRY_H_
+#define PYPTO_IR_VERIFIER_PROPERTY_VERIFIER_REGISTRY_H_
 
 #include <cstdint>
 #include <functional>
@@ -20,7 +20,7 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/ir_property.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {
@@ -76,4 +76,4 @@ class PropertyVerifierRegistry {
 }  // namespace ir
 }  // namespace pypto
 
-#endif  // PYPTO_IR_TRANSFORMS_PROPERTY_VERIFIER_REGISTRY_H_
+#endif  // PYPTO_IR_VERIFIER_PROPERTY_VERIFIER_REGISTRY_H_

--- a/include/pypto/ir/verifier/verification_error.h
+++ b/include/pypto/ir/verifier/verification_error.h
@@ -9,8 +9,8 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef PYPTO_IR_TRANSFORMS_VERIFICATION_ERROR_H_
-#define PYPTO_IR_TRANSFORMS_VERIFICATION_ERROR_H_
+#ifndef PYPTO_IR_VERIFIER_VERIFICATION_ERROR_H_
+#define PYPTO_IR_VERIFIER_VERIFICATION_ERROR_H_
 
 #include <string>
 
@@ -90,4 +90,4 @@ std::string ErrorTypeToString(ErrorType type);
 }  // namespace ir
 }  // namespace pypto
 
-#endif  // PYPTO_IR_TRANSFORMS_VERIFICATION_ERROR_H_
+#endif  // PYPTO_IR_VERIFIER_VERIFICATION_ERROR_H_

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -9,8 +9,8 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef PYPTO_IR_TRANSFORMS_VERIFIER_H_
-#define PYPTO_IR_TRANSFORMS_VERIFIER_H_
+#ifndef PYPTO_IR_VERIFIER_VERIFIER_H_
+#define PYPTO_IR_VERIFIER_VERIFIER_H_
 
 #include <memory>
 #include <string>
@@ -178,4 +178,4 @@ class IRVerifier {
 }  // namespace ir
 }  // namespace pypto
 
-#endif  // PYPTO_IR_TRANSFORMS_VERIFIER_H_
+#endif  // PYPTO_IR_VERIFIER_VERIFIER_H_

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -22,8 +22,8 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/transforms/ir_property.h"
 #include "pypto/ir/transforms/pass_context.h"
-#include "pypto/ir/transforms/verification_error.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verification_error.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace nb = nanobind;
 

--- a/src/ir/transforms/convert_tensor_to_block_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_block_ops_pass.cpp
@@ -34,8 +34,8 @@
 #include "pypto/ir/transforms/op_conversion_registry.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
-#include "pypto/ir/transforms/verifier.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/flatten_single_stmt_pass.cpp
+++ b/src/ir/transforms/flatten_single_stmt_pass.cpp
@@ -20,7 +20,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/flatten_single_stmt.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -32,8 +32,8 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
-#include "pypto/ir/transforms/verifier.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/normalize_stmt_structure_pass.cpp
+++ b/src/ir/transforms/normalize_stmt_structure_pass.cpp
@@ -22,7 +22,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/normalize_stmt_structure.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -29,8 +29,8 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
-#include "pypto/ir/transforms/verifier.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -19,8 +19,8 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/passes.h"
-#include "pypto/ir/transforms/property_verifier_registry.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/property_verifier_registry.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/transforms/passes.cpp
+++ b/src/ir/transforms/passes.cpp
@@ -22,7 +22,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/ir_property.h"
 #include "pypto/ir/transforms/pass_context.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/verifier/property_verifier_registry.cpp
+++ b/src/ir/verifier/property_verifier_registry.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include "pypto/ir/transforms/property_verifier_registry.h"
+#include "pypto/ir/verifier/property_verifier_registry.h"
 
 #include <cstdint>
 #include <functional>
@@ -19,7 +19,7 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/ir_property.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/verifier/type_check_pass.cpp
+++ b/src/ir/verifier/type_check_pass.cpp
@@ -24,9 +24,9 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
-#include "pypto/ir/transforms/verification_error.h"
-#include "pypto/ir/transforms/verifier.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verification_error.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/verifier/verifier.cpp
+++ b/src/ir/verifier/verifier.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verifier.h"
 
 #include <algorithm>
 #include <cstddef>

--- a/src/ir/verifier/verify_no_nested_call_pass.cpp
+++ b/src/ir/verifier/verify_no_nested_call_pass.cpp
@@ -22,8 +22,8 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
-#include "pypto/ir/transforms/verification_error.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verification_error.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {

--- a/src/ir/verifier/verify_ssa_pass.cpp
+++ b/src/ir/verifier/verify_ssa_pass.cpp
@@ -22,8 +22,8 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
-#include "pypto/ir/transforms/verification_error.h"
-#include "pypto/ir/transforms/verifier.h"
+#include "pypto/ir/verifier/verification_error.h"
+#include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {


### PR DESCRIPTION
Extract pure verifier files from src/ir/transforms/ into a dedicated src/ir/verifier/ directory to improve code organization:

- Move verifier.cpp, property_verifier_registry.cpp, verify_ssa_pass.cpp, verify_no_nested_call_pass.cpp, type_check_pass.cpp to src/ir/verifier/
- Move verifier.h, property_verifier_registry.h, verification_error.h to include/pypto/ir/verifier/
- Update all include paths across transforms/ and bindings/
- Update CMakeLists.txt with new source paths under # IR - Verifier group