### PR TITLE
fix(ssa): Sort phi_vars alphabetically to ensure deterministic yield order

### DIFF
--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -244,6 +245,9 @@ class SSAConverter : public IRMutator {
         phi_vars.push_back(base_name);
       }
     }
+
+    // Sort phi_vars for deterministic ordering across platforms
+    std::sort(phi_vars.begin(), phi_vars.end());
 
     // If no variables diverged, just return the updated if statement
     if (phi_vars.empty() && op->return_vars_.empty()) {

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1090,10 +1090,10 @@ class TestPlainSyntax:
                         for j_0, (a_iter_3,) in pl.range(0, 2, 1, init_values=(a_iter_1,)):
                             a_5: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_3, 1.0)
                             a_4 = pl.yield_(a_5)
-                        b_4, a_6 = pl.yield_(b_iter_1, a_4)
+                        a_6, b_4 = pl.yield_(a_4, b_iter_1)
                     else:
                         b_3: pl.Tensor[[64], pl.FP32] = pl.mul(b_iter_1, 2.0)
-                        b_4, a_6 = pl.yield_(b_3, a_iter_1)
+                        a_6, b_4 = pl.yield_(a_iter_1, b_3)
                     a_2, b_2 = pl.yield_(a_6, b_4)
                 result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_2, b_2)
                 return result_0
@@ -1157,10 +1157,10 @@ class TestPlainSyntax:
                 for i_0, (a_iter_1, b_iter_1) in pl.range(0, 1, 1, init_values=(a_0, b_0)):
                     if i_0 == 0:
                         a_3: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_1, 1.0)
-                        b_4, a_4 = pl.yield_(b_iter_1, a_3)
+                        a_4, b_4 = pl.yield_(a_3, b_iter_1)
                     else:
                         b_3: pl.Tensor[[64], pl.FP32] = pl.add(b_iter_1, 1.0)
-                        b_4, a_4 = pl.yield_(b_3, a_iter_1)
+                        a_4, b_4 = pl.yield_(a_iter_1, b_3)
                     a_2, b_2 = pl.yield_(a_4, b_4)
                 result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_2, b_2)
                 return result_0


### PR DESCRIPTION
IfStmt SSA conversion iterated over std::unordered_map to collect phi variables, producing non-deterministic ordering across platforms (macOS/AppleClang vs Linux/GCC). Sort phi_vars before building return_vars and yield expressions to guarantee consistent output.

Update test expected values to match the new alphabetical order.