### PR TITLE
[WIP] ci: Split system tests into hardware (a2a3) and simulation (a2a3sim)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Test unit tests
       run: pytest tests/ut -v
 
-  system-tests:
+  system-tests-a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
@@ -129,12 +129,12 @@ jobs:
         env:
           SIMPLER_ROOT: ${{ github.workspace }}/simpler
           PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-        run: pytest tests/st -v --device=$DEVICE_ID --forked
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --platform=a2a3
 
       - name: Checkout stable simpler commit on failure
         if: steps.test_first_attempt.outcome == 'failure'
         working-directory: ${{ github.workspace }}/simpler
-        run: git checkout b3ed5878fd0aef153d5359c645ecd0b8947ddf8e
+        run: git checkout c875955b22483f96597d30dc743f2472cc723fad
 
       - name: Test system tests (retry with stable version)
         id: test_retry
@@ -142,7 +142,73 @@ jobs:
         env:
           SIMPLER_ROOT: ${{ github.workspace }}/simpler
           PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-        run: pytest tests/st -v --device=$DEVICE_ID --forked
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --platform=a2a3
+
+      - name: Check final test result
+        if: steps.test_first_attempt.outcome == 'failure' && steps.test_retry.outcome == 'failure'
+        run: exit 1
+
+  system-tests-a2a3sim:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up C++ compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+          if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install numpy
+          pip install ml_dtypes
+          pip install pytest
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install project and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -v .[dev]
+
+      - name: Clone simpler repository
+        run: git clone https://github.com/ChaoWao/simpler $GITHUB_WORKSPACE/simpler
+
+      - name: Test system tests (first attempt)
+        id: test_first_attempt
+        continue-on-error: true
+        env:
+          SIMPLER_ROOT: ${{ github.workspace }}/simpler
+        run: pytest tests/st -v --forked --platform=a2a3sim
+
+      - name: Checkout stable simpler commit on failure
+        if: steps.test_first_attempt.outcome == 'failure'
+        working-directory: ${{ github.workspace }}/simpler
+        run: git checkout c875955b22483f96597d30dc743f2472cc723fad
+
+      - name: Test system tests (retry with stable version)
+        id: test_retry
+        if: steps.test_first_attempt.outcome == 'failure'
+        env:
+          SIMPLER_ROOT: ${{ github.workspace }}/simpler
+        run: pytest tests/st -v --forked --platform=a2a3sim
 
       - name: Check final test result
         if: steps.test_first_attempt.outcome == 'failure' && steps.test_retry.outcome == 'failure'


### PR DESCRIPTION
Split the system-tests job into two separate CI jobs to support both hardware and simulation testing platforms:

- system-tests-a2a3: Runs on self-hosted NPU hardware (existing behavior)
  - Uses Docker container with Ascend drivers
  - Installs PTOAS binary for optimization
  - Explicitly sets --platform=a2a3 flag
  - Requires DEVICE_ID environment variable

- system-tests-a2a3sim: Runs on ubuntu-latest using software simulation
  - No hardware or Docker container required
  - Uses Simpler's software simulator
  - Sets --platform=a2a3sim flag
  - Provides faster feedback for development

Both jobs maintain retry logic with stable Simpler commit fallback for improved reliability. The simulation job enables testing without specialized hardware, making the CI more accessible.

Also updates stable Simpler commit to c875955b22483f96597d30dc743f2472cc723fad.