### PR TITLE
feat(ir): Add blayout, slayout, fractal, and pad fields to TileView

### DIFF
--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -309,15 +309,39 @@ void BindIR(nb::module_& m) {
       .value("CUBE", CoreType::CUBE, "Cube Core")
       .export_values();
 
+  // TileLayout enum - must be before TileView
+  nb::enum_<TileLayout>(ir, "TileLayout", "Tile layout enumeration")
+      .value("none_box", TileLayout::none_box, "No layout constraint")
+      .value("row_major", TileLayout::row_major, "Row-major layout")
+      .value("col_major", TileLayout::col_major, "Column-major layout")
+      .export_values();
+
+  // TilePad enum - must be before TileView
+  nb::enum_<TilePad>(ir, "TilePad", "Tile pad mode enumeration")
+      .value("null", TilePad::null, "No padding")
+      .value("zero", TilePad::zero, "Zero padding")
+      .value("max", TilePad::max, "Max value padding")
+      .value("min", TilePad::min, "Min value padding")
+      .export_values();
+
   // TileView - struct for tile view information
-  nb::class_<TileView>(ir, "TileView", "Tile view representation with valid shape, stride, and start offset")
+  nb::class_<TileView>(
+      ir, "TileView",
+      "Tile view representation with valid shape, stride, start offset, layouts, fractal, and pad")
       .def(nb::init<>(), "Create an empty tile view")
-      .def(nb::init<const std::vector<ExprPtr>&, const std::vector<ExprPtr>&, ExprPtr>(),
+      .def(nb::init<const std::vector<ExprPtr>&, const std::vector<ExprPtr>&, ExprPtr, TileLayout, TileLayout,
+                    uint64_t, TilePad>(),
            nb::arg("valid_shape"), nb::arg("stride"), nb::arg("start_offset"),
-           "Create a tile view with valid_shape, stride, and start_offset")
+           nb::arg("blayout") = TileLayout::row_major, nb::arg("slayout") = TileLayout::none_box,
+           nb::arg("fractal") = static_cast<uint64_t>(512), nb::arg("pad") = TilePad::null,
+           "Create a tile view with valid_shape, stride, start_offset, blayout, slayout, fractal, and pad")
       .def_rw("valid_shape", &TileView::valid_shape, "Valid shape dimensions")
       .def_rw("stride", &TileView::stride, "Stride for each dimension")
-      .def_rw("start_offset", &TileView::start_offset, "Starting offset");
+      .def_rw("start_offset", &TileView::start_offset, "Starting offset")
+      .def_rw("blayout", &TileView::blayout, "Block layout")
+      .def_rw("slayout", &TileView::slayout, "Scatter layout")
+      .def_rw("fractal", &TileView::fractal, "Fractal size")
+      .def_rw("pad", &TileView::pad, "Pad mode");
 
   // Dynamic dimension constant
   ir.attr("DYNAMIC_DIM") = kDynamicDim;

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -530,6 +530,10 @@ class IRBuilder:
         valid_shape: Sequence[int | ir.Expr],
         stride: Sequence[int | ir.Expr],
         start_offset: int | ir.Expr,
+        blayout: ir.TileLayout = ir.TileLayout.row_major,
+        slayout: ir.TileLayout = ir.TileLayout.none_box,
+        fractal: int = 512,
+        pad: ir.TilePad = ir.TilePad.null,
         span: ir.Span | None = None,
     ) -> ir.TileView:
         """Create a TileView with normalized expressions.
@@ -538,6 +542,10 @@ class IRBuilder:
             valid_shape: Valid shape dimensions (list of int or Expr)
             stride: Stride for each dimension (list of int or Expr)
             start_offset: Starting offset (int or Expr)
+            blayout: Block layout (default: row_major)
+            slayout: Scatter layout (default: none_box)
+            fractal: Fractal size (default: 512)
+            pad: Pad mode (default: null)
             span: Optional explicit span. If None, captured from call site.
 
         Returns:
@@ -553,7 +561,7 @@ class IRBuilder:
         valid_shape_exprs = [_normalize_expr(dim, actual_span) for dim in valid_shape]
         stride_exprs = [_normalize_expr(s, actual_span) for s in stride]
         start_offset_expr = _normalize_expr(start_offset, actual_span)
-        return ir.TileView(valid_shape_exprs, stride_exprs, start_offset_expr)
+        return ir.TileView(valid_shape_exprs, stride_exprs, start_offset_expr, blayout, slayout, fractal, pad)
 
     def tensor_view(
         self,

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -321,6 +321,33 @@ class TensorLayout(enum.Enum):
     NZ = ...
     """NZ layout."""
 
+class TileLayout(enum.Enum):
+    """Tile layout enumeration (shared by blayout and slayout)."""
+
+    none_box = ...
+    """No layout constraint."""
+
+    row_major = ...
+    """Row-major layout."""
+
+    col_major = ...
+    """Column-major layout."""
+
+class TilePad(enum.Enum):
+    """Tile pad mode enumeration."""
+
+    null = ...
+    """No padding."""
+
+    zero = ...
+    """Zero padding."""
+
+    max = ...
+    """Max value padding."""
+
+    min = ...
+    """Min value padding."""
+
 class TensorView:
     """Tensor view representation with stride and layout."""
 
@@ -422,7 +449,7 @@ class TensorType(ShapedType):
         """
 
 class TileView:
-    """Tile view representation with valid shape, stride, and start offset."""
+    """Tile view representation with valid shape, stride, start offset, layouts, fractal, and pad."""
 
     valid_shape: Sequence[Expr]
     """Valid shape dimensions."""
@@ -433,18 +460,43 @@ class TileView:
     start_offset: Expr
     """Starting offset."""
 
+    blayout: TileLayout
+    """Block layout."""
+
+    slayout: TileLayout
+    """Scatter layout."""
+
+    fractal: int
+    """Fractal size."""
+
+    pad: TilePad
+    """Pad mode."""
+
     @overload
     def __init__(self) -> None:
         """Create an empty tile view."""
 
     @overload
-    def __init__(self, valid_shape: Sequence[Expr], stride: Sequence[Expr], start_offset: Expr) -> None:
-        """Create a tile view with valid_shape, stride, and start_offset.
+    def __init__(
+        self,
+        valid_shape: Sequence[Expr],
+        stride: Sequence[Expr],
+        start_offset: Expr,
+        blayout: TileLayout = ...,
+        slayout: TileLayout = ...,
+        fractal: int = ...,
+        pad: TilePad = ...,
+    ) -> None:
+        """Create a tile view with all parameters.
 
         Args:
             valid_shape: Valid shape dimensions
             stride: Stride for each dimension
             start_offset: Starting offset
+            blayout: Block layout (default: row_major)
+            slayout: Scatter layout (default: none_box)
+            fractal: Fractal size (default: 512)
+            pad: Pad mode (default: null)
         """
 
 class TileType(ShapedType):

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -213,6 +213,46 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
         }
       } else if (key == "start_offset") {
         tile_view.start_offset = std::static_pointer_cast<const Expr>(DeserializeNode(p->val, zone));
+      } else if (key == "blayout") {
+        std::string blayout_str;
+        p->val.convert(blayout_str);
+        if (blayout_str == "none_box") {
+          tile_view.blayout = TileLayout::none_box;
+        } else if (blayout_str == "row_major") {
+          tile_view.blayout = TileLayout::row_major;
+        } else if (blayout_str == "col_major") {
+          tile_view.blayout = TileLayout::col_major;
+        } else {
+          CHECK(false) << "Unknown TileLayout for blayout: " << blayout_str;
+        }
+      } else if (key == "slayout") {
+        std::string slayout_str;
+        p->val.convert(slayout_str);
+        if (slayout_str == "none_box") {
+          tile_view.slayout = TileLayout::none_box;
+        } else if (slayout_str == "row_major") {
+          tile_view.slayout = TileLayout::row_major;
+        } else if (slayout_str == "col_major") {
+          tile_view.slayout = TileLayout::col_major;
+        } else {
+          CHECK(false) << "Unknown TileLayout for slayout: " << slayout_str;
+        }
+      } else if (key == "fractal") {
+        p->val.convert(tile_view.fractal);
+      } else if (key == "pad") {
+        std::string pad_str;
+        p->val.convert(pad_str);
+        if (pad_str == "null") {
+          tile_view.pad = TilePad::null;
+        } else if (pad_str == "zero") {
+          tile_view.pad = TilePad::zero;
+        } else if (pad_str == "max") {
+          tile_view.pad = TilePad::max;
+        } else if (pad_str == "min") {
+          tile_view.pad = TilePad::min;
+        } else {
+          CHECK(false) << "Unknown TilePad: " << pad_str;
+        }
       }
     }
 

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -263,6 +263,57 @@ class IRSerializer::Impl {
     // Serialize start_offset
     tv_map["start_offset"] = SerializeNode(tile_view->start_offset, zone);
 
+    // Serialize blayout
+    std::string blayout_str;
+    switch (tile_view->blayout) {
+      case TileLayout::none_box:
+        blayout_str = "none_box";
+        break;
+      case TileLayout::row_major:
+        blayout_str = "row_major";
+        break;
+      case TileLayout::col_major:
+        blayout_str = "col_major";
+        break;
+    }
+    tv_map["blayout"] = msgpack::object(blayout_str, zone);
+
+    // Serialize slayout
+    std::string slayout_str;
+    switch (tile_view->slayout) {
+      case TileLayout::none_box:
+        slayout_str = "none_box";
+        break;
+      case TileLayout::row_major:
+        slayout_str = "row_major";
+        break;
+      case TileLayout::col_major:
+        slayout_str = "col_major";
+        break;
+    }
+    tv_map["slayout"] = msgpack::object(slayout_str, zone);
+
+    // Serialize fractal
+    tv_map["fractal"] = msgpack::object(tile_view->fractal);
+
+    // Serialize pad
+    std::string pad_str;
+    switch (tile_view->pad) {
+      case TilePad::null:
+        pad_str = "null";
+        break;
+      case TilePad::zero:
+        pad_str = "zero";
+        break;
+      case TilePad::max:
+        pad_str = "max";
+        break;
+      case TilePad::min:
+        pad_str = "min";
+        break;
+    }
+    tv_map["pad"] = msgpack::object(pad_str, zone);
+
     return msgpack::object(tv_map, zone);
   }
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1119,8 +1119,58 @@ std::string IRPythonPrinter::PrintTileView(const TileView& tile_view) {
   oss << "], start_offset=";
 
   // Print start_offset
-  IRPythonPrinter temp_printer(prefix_);
-  oss << temp_printer.Print(tile_view.start_offset);
+  {
+    IRPythonPrinter temp_printer(prefix_);
+    oss << temp_printer.Print(tile_view.start_offset);
+  }
+
+  // Print blayout
+  oss << ", blayout=" << prefix_ << ".TileLayout.";
+  switch (tile_view.blayout) {
+    case TileLayout::none_box:
+      oss << "none_box";
+      break;
+    case TileLayout::row_major:
+      oss << "row_major";
+      break;
+    case TileLayout::col_major:
+      oss << "col_major";
+      break;
+  }
+
+  // Print slayout
+  oss << ", slayout=" << prefix_ << ".TileLayout.";
+  switch (tile_view.slayout) {
+    case TileLayout::none_box:
+      oss << "none_box";
+      break;
+    case TileLayout::row_major:
+      oss << "row_major";
+      break;
+    case TileLayout::col_major:
+      oss << "col_major";
+      break;
+  }
+
+  // Print fractal
+  oss << ", fractal=" << tile_view.fractal;
+
+  // Print pad
+  oss << ", pad=" << prefix_ << ".TilePad.";
+  switch (tile_view.pad) {
+    case TilePad::null:
+      oss << "null";
+      break;
+    case TilePad::zero:
+      oss << "zero";
+      break;
+    case TilePad::max:
+      oss << "max";
+      break;
+    case TilePad::min:
+      oss << "min";
+      break;
+  }
 
   oss << ")";
   return oss.str();

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -762,6 +762,34 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       }
       // Compare start_offset
       if (!Equal(lhs_tv.start_offset, rhs_tv.start_offset)) return false;
+      // Compare blayout
+      if (lhs_tv.blayout != rhs_tv.blayout) {
+        if constexpr (AssertMode) {
+          ThrowMismatch("TileView blayout mismatch", IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+      // Compare slayout
+      if (lhs_tv.slayout != rhs_tv.slayout) {
+        if constexpr (AssertMode) {
+          ThrowMismatch("TileView slayout mismatch", IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+      // Compare fractal
+      if (lhs_tv.fractal != rhs_tv.fractal) {
+        if constexpr (AssertMode) {
+          ThrowMismatch("TileView fractal mismatch", IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+      // Compare pad
+      if (lhs_tv.pad != rhs_tv.pad) {
+        if constexpr (AssertMode) {
+          ThrowMismatch("TileView pad mismatch", IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
     }
     return true;
   } else if (auto lhs_tuple = As<TupleType>(lhs)) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -290,6 +290,14 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       // Hash start_offset
       INTERNAL_CHECK(tv.start_offset) << "structural_hash encountered null start_offset in TileView";
       h = hash_combine(h, HashNode(tv.start_offset));
+      // Hash blayout
+      h = hash_combine(h, static_cast<result_type>(tv.blayout));
+      // Hash slayout
+      h = hash_combine(h, static_cast<result_type>(tv.slayout));
+      // Hash fractal
+      h = hash_combine(h, static_cast<result_type>(tv.fractal));
+      // Hash pad
+      h = hash_combine(h, static_cast<result_type>(tv.pad));
     } else {
       h = hash_combine(h, static_cast<result_type>(0));  // indicate absence
     }


### PR DESCRIPTION
Introduce TileLayout (none_box/row_major/col_major) and TilePad (null/zero/max/min) enums, and extend TileView with four new fields:
- blayout: block layout (default: row_major)
- slayout: scatter layout (default: none_box)
- fractal: fractal size as uint64_t (default: 512)
- pad: pad mode (default: null)

Update Python bindings, type stubs, IRBuilder.tile_view(), Python printer, serializer/deserializer, structural equality and hash to support the new fields. Add comprehensive tests covering enum values, default values, constructor, and print output.