### PR TITLE
feat(codegen): Add PTOAS-aware type annotations and update PTO naming

### DIFF
--- a/include/pypto/ir/scalar_expr.h
+++ b/include/pypto/ir/scalar_expr.h
@@ -388,7 +388,9 @@ inline BinaryOperands PromoteBinaryOperands(const ExprPtr& left, const ExprPtr& 
   DataType left_dtype = GetScalarDtype(left);
   DataType right_dtype = GetScalarDtype(right);
   DataType promoted_dtype = PromoteSameCategoryDtype(left_dtype, right_dtype, op_name);
-  return {MaybeCast(left, promoted_dtype, span), MaybeCast(right, promoted_dtype, span), promoted_dtype};
+  ExprPtr promoted_left = MaybeCast(left, promoted_dtype, span);
+  ExprPtr promoted_right = MaybeCast(right, promoted_dtype, span);
+  return {std::move(promoted_left), std::move(promoted_right), promoted_dtype};
 }
 
 inline BinaryOperands PromoteIntBinaryOperands(const ExprPtr& left, const ExprPtr& right,
@@ -400,7 +402,9 @@ inline BinaryOperands PromoteIntBinaryOperands(const ExprPtr& left, const ExprPt
                     " and " + right_dtype.ToString());
   }
   DataType promoted_dtype = PromoteSameCategoryDtype(left_dtype, right_dtype, op_name);
-  return {MaybeCast(left, promoted_dtype, span), MaybeCast(right, promoted_dtype, span), promoted_dtype};
+  ExprPtr promoted_left = MaybeCast(left, promoted_dtype, span);
+  ExprPtr promoted_right = MaybeCast(right, promoted_dtype, span);
+  return {std::move(promoted_left), std::move(promoted_right), promoted_dtype};
 }
 
 // ========== Binary Operator Construction Functions ==========

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -95,7 +95,7 @@ def test_pto_codegen_tensor_parameters():
     assert "pto.make_tensor_view" in mlir_code
     assert "shape = [%c64, %c64]" in mlir_code or "shape = [%c32, %c32]" in mlir_code
     assert "strides = " in mlir_code
-    assert "!pto.tensor_view<2xf32>" in mlir_code
+    assert "!pto.tensor_view<?x?xf32>" in mlir_code
 
 
 def test_pto_codegen_alloc_tile():
@@ -120,13 +120,13 @@ def test_pto_codegen_alloc_tile():
 
     # Verify alloc_tile operations
     assert "pto.alloc_tile" in mlir_code
-    assert "loc=ub" in mlir_code  # Unified buffer
+    assert "loc=vec" in mlir_code  # Vector buffer (PTO address space)
     assert "dtype=f32" in mlir_code
     assert "rows=32, cols=32" in mlir_code
 
 
 def test_pto_codegen_block_load_lowering():
-    """Test that block.load generates subview + tload."""
+    """Test that block.load generates partition_view + tload."""
 
     @pl.program
     class LoadProgram:
@@ -141,11 +141,11 @@ def test_pto_codegen_block_load_lowering():
     codegen = PTOCodegen()
     mlir_code = _get_mlir_code(codegen.generate(transformed_program))
 
-    # Verify subview generation
-    assert "pto.subview" in mlir_code
+    # Verify partition_view generation
+    assert "pto.partition_view" in mlir_code
     assert "offsets = [%c0, %c0]" in mlir_code
     assert "sizes = [%c32, %c32]" in mlir_code
-    assert "!pto.tile_view<32x32xf32>" in mlir_code
+    assert "!pto.partition_tensor_view<32x32xf32>" in mlir_code
 
     # Verify tload generation
     assert "pto.tload" in mlir_code
@@ -155,7 +155,7 @@ def test_pto_codegen_block_load_lowering():
 
 
 def test_pto_codegen_block_store_lowering():
-    """Test that block.store generates subview + tstore."""
+    """Test that block.store generates partition_view + tstore."""
 
     @pl.program
     class StoreProgram:

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -142,7 +142,9 @@ def validate_kernel_codegen(kernel_name: str, mlir_code: str) -> None:
     # Validate memory operations are present
     assert "pto.tload" in mlir_code, f"Kernel {kernel_name} should contain pto.tload operation"
     assert "pto.tstore" in mlir_code, f"Kernel {kernel_name} should contain pto.tstore operation"
-    assert "pto.subview" in mlir_code, f"Kernel {kernel_name} should contain pto.subview operation"
+    assert "pto.partition_view" in mlir_code, (
+        f"Kernel {kernel_name} should contain pto.partition_view operation"
+    )
 
     # Category-specific validations
     if category == "binary_tile_tile":


### PR DESCRIPTION
Emit accurate tile_buf/tensor_view type strings derived from TileType metadata instead of hardcoded defaults. Rename pto.subview to pto.partition_view and update memory space names (ub->vec, ddr->gm, l1->mat, etc.) to match current PTO-ISA specification. Add ins/outs type annotation support to operator codegen callbacks.