### PR TITLE
refactor(ir): rename MemorySpace enum values to hardware-agnostic names

### DIFF
--- a/docs/dev/codegen/00-pto_codegen.md
+++ b/docs/dev/codegen/00-pto_codegen.md
@@ -365,11 +365,11 @@ The codegen:
 | PyPTO MemorySpace | PTO Address Space |
 | ----------------- | ----------------- |
 | `MemorySpace::DDR` | `gm` (global memory) |
-| `MemorySpace::UB` | `vec` (vector buffer) |
-| `MemorySpace::L1` | `mat` (matrix buffer) |
-| `MemorySpace::L0A` | `left` |
-| `MemorySpace::L0B` | `right` |
-| `MemorySpace::L0C` | `acc` (accumulator) |
+| `MemorySpace::Vec` | `vec` (vector buffer) |
+| `MemorySpace::Mat` | `mat` (matrix buffer) |
+| `MemorySpace::Left` | `left` |
+| `MemorySpace::Right` | `right` |
+| `MemorySpace::Acc` | `acc` (accumulator) |
 
 ### Tile Buffer Attributes
 

--- a/docs/dev/codegen/01-cce_codegen.md
+++ b/docs/dev/codegen/01-cce_codegen.md
@@ -66,7 +66,7 @@ Converts PyPTO IR types to pto-isa C++ type strings.
 | PyPTO DataType | C++ Type | PyPTO MemorySpace | Annotation |
 | -------------- | -------- | ----------------- | ---------- |
 | FP32 | `float` | DDR | `__gm__` |
-| FP16 | `half` | UB/L0A/L0B/L0C | (none) |
+| FP16 | `half` | UB/Left/Right/Acc | (none) |
 | INT32 | `int32_t` | - | - |
 | INT64 | `int64_t` | - | - |
 | BOOL | `bool` | - | - |

--- a/docs/dev/ir/01-hierarchy.md
+++ b/docs/dev/ir/01-hierarchy.md
@@ -210,7 +210,7 @@ Describes memory allocation for tensors/tiles:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `memory_space_` | MemorySpace enum | DDR, UB, L1, L0A, L0B, L0C |
+| `memory_space_` | MemorySpace enum | DDR, Vec, Mat, Left, Right, Acc |
 | `addr_` | ExprPtr | Base address |
 | `size_` | size_t | Size in bytes |
 

--- a/docs/dev/ir/02-types.md
+++ b/docs/dev/ir/02-types.md
@@ -51,7 +51,7 @@ dn_view = ir.TensorView(stride, ir.TensorLayout.DN)  # DN layout
 nz_view = ir.TensorView(stride, ir.TensorLayout.NZ)  # NZ layout
 
 # Tensor with both MemRef and TensorView
-memref = ir.MemRef(ir.MemorySpace.UB, ir.ConstInt(0x2000, DataType.INT64, span), 16384)
+memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0x2000, DataType.INT64, span), 16384)
 tensor_with_both = ir.TensorType(shape, DataType.FP16, memref=memref, tensor_view=tensor_view)
 ```
 
@@ -77,7 +77,7 @@ shape_3d = [ir.ConstInt(4, DataType.INT64, span),
 tile_type_3d = ir.TileType(shape_3d, DataType.FP16)
 
 # Tile with MemRef and TileView
-memref = ir.MemRef(ir.MemorySpace.L0A, ir.ConstInt(0, DataType.INT64, span), 512)
+memref = ir.MemRef(ir.MemorySpace.Left, ir.ConstInt(0, DataType.INT64, span), 512)
 
 tile_view = ir.TileView()
 tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
@@ -129,11 +129,11 @@ unknown = ir.UnknownType()
 | Value | Description |
 | ----- | ----------- |
 | `DDR` | Main memory (off-chip) |
-| `UB` | Unified Buffer (on-chip shared memory) |
-| `L1` | L1 cache |
-| `L0A` | L0A buffer (matrix A) |
-| `L0B` | L0B buffer (matrix B) |
-| `L0C` | L0C buffer (matrix C/result) |
+| `Vec` | Vector/unified buffer (on-chip) |
+| `Mat` | Matrix/L1 buffer |
+| `Left` | Left matrix operand buffer |
+| `Right` | Right matrix operand buffer |
+| `Acc` | Accumulator buffer |
 
 ## Python Usage Examples
 
@@ -244,9 +244,9 @@ program = ir.Program([square_func, main_func], "math", span)
 ### Example 6: Memory Layout with TileType
 
 ```python
-# 32x32 tile in L0A memory with custom stride
+# 32x32 tile in Left memory with custom stride
 shape = [ir.ConstInt(32, DataType.INT64, span)] * 2
-memref = ir.MemRef(ir.MemorySpace.L0A, ir.ConstInt(0, DataType.INT64, span), 2048)
+memref = ir.MemRef(ir.MemorySpace.Left, ir.ConstInt(0, DataType.INT64, span), 2048)
 
 tile_view = ir.TileView()
 tile_view.valid_shape = shape

--- a/docs/dev/ir/04-serialization.md
+++ b/docs/dev/ir/04-serialization.md
@@ -81,7 +81,7 @@ Hardware-specific memory allocation details are fully preserved:
 ```python
 # Create MemRef and TileView
 memref = ir.MemRef()
-memref.memory_space_ = ir.MemorySpace.L0A
+memref.memory_space_ = ir.MemorySpace.Left
 memref.addr_ = ir.ConstInt(0x1000, DataType.INT64, span)
 memref.size_ = 512
 
@@ -94,7 +94,7 @@ tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view)
 
 # Serialize and deserialize
 restored = ir.deserialize(ir.serialize(tile_var))
-assert restored.type.memref.memory_space_ == ir.MemorySpace.L0A
+assert restored.type.memref.memory_space_ == ir.MemorySpace.Left
 assert len(restored.type.tile_view.valid_shape) == 2
 ```
 

--- a/docs/dev/ir/06-builder.md
+++ b/docs/dev/ir/06-builder.md
@@ -213,7 +213,7 @@ memref = ib.memref(
 
 # With symbolic address
 base_addr = ib.var("base_addr", ir.ScalarType(DataType.INT64))
-memref = ib.memref(ir.MemorySpace.UB, base_addr, 2048)
+memref = ib.memref(ir.MemorySpace.Vec, base_addr, 2048)
 ```
 
 ### TileView
@@ -243,7 +243,7 @@ memref = ib.memref(ir.MemorySpace.DDR, 0x1000, 8192)
 tensor_t = ib.tensor_type([64, 128], DataType.FP32, memref=memref)
 
 # Complete tile with memref and tile_view
-memref = ib.memref(ir.MemorySpace.L0A, 0, 512)
+memref = ib.memref(ir.MemorySpace.Left, 0, 512)
 tile_view = ib.tile_view([16, 16], [1, 16], 0)
 tile_t = ib.tile_type([16, 16], DataType.FP16, memref=memref, tile_view=tile_view)
 ```
@@ -255,16 +255,16 @@ ib = IRBuilder()
 
 with ib.function("matmul_tile") as f:
     # Create tile types with memory references
-    memref_a = ib.memref(ir.MemorySpace.L0A, 0, 512)
+    memref_a = ib.memref(ir.MemorySpace.Left, 0, 512)
     tile_t_a = ib.tile_type([16, 16], DataType.FP16, memref=memref_a)
 
-    memref_b = ib.memref(ir.MemorySpace.L0B, 0, 512)
+    memref_b = ib.memref(ir.MemorySpace.Right, 0, 512)
     tile_t_b = ib.tile_type([16, 16], DataType.FP16, memref=memref_b)
 
     a = f.param("a", tile_t_a)
     b = f.param("b", tile_t_b)
 
-    memref_c = ib.memref(ir.MemorySpace.L0C, 0, 512)
+    memref_c = ib.memref(ir.MemorySpace.Acc, 0, 512)
     tile_view_c = ib.tile_view([16, 16], [1, 16], 0)
     tile_t_c = ib.tile_type([16, 16], DataType.FP32, memref=memref_c, tile_view=tile_view_c)
     f.return_type(tile_t_c)

--- a/docs/dev/language/00-python_syntax.md
+++ b/docs/dev/language/00-python_syntax.md
@@ -59,7 +59,7 @@ t: pl.Tile[[16, 16], pl.FP16]
 addr_expr = pl.ConstInt(0x1000, pl.INT64, span)
 memref = pl.MemRef(pl.MemorySpace.DDR, addr_expr, 1024)
 
-# Memory spaces: DDR, UB, L1, L0A, L0B, L0C
+# Memory spaces: DDR, Vec, Mat, Left, Right, Acc
 
 # Tensor with memref
 tensor: pl.Tensor[[64, 128], pl.FP32], memref=pl.MemRef(pl.MemorySpace.DDR, addr, 8192))
@@ -77,7 +77,7 @@ tile_view = pl.TileView(valid_shape=valid_shape, stride=stride, start_offset=sta
 # Tile with memref and tile_view
 tile: pl.Tile(
     (16, 16), pl.FP16,
-    memref=pl.MemRef(pl.MemorySpace.L0A, addr, 512),
+    memref=pl.MemRef(pl.MemorySpace.Left, addr, 512),
     tile_view=pl.TileView(valid_shape=..., stride=..., start_offset=...)
 )
 ```

--- a/docs/dev/passes/06-insert_sync.md
+++ b/docs/dev/passes/06-insert_sync.md
@@ -111,8 +111,8 @@ Matrix multiply requires moving data through L1 (MTE1) to L0 (CUBE/M pipe), with
 ```text
 tile_a = load(input_a)              # MTE2 -> L1
 tile_b = load(input_b)              # MTE2 -> L1
-tile_a_cube = move(tile_a)          # MTE1 -> L0A
-tile_b_cube = move(tile_b)          # MTE1 -> L0B
+tile_a_cube = move(tile_a)          # MTE1 -> Left
+tile_b_cube = move(tile_b)          # MTE1 -> Right
 tile_c = matmul(tile_a_cube, tile_b_cube)  # CUBE (M pipe)
 store(tile_c, output)               # MTE3
 ```

--- a/include/pypto/codegen/cce/type_converter.h
+++ b/include/pypto/codegen/cce/type_converter.h
@@ -49,11 +49,11 @@ class TypeConverter {
    * @brief Convert MemorySpace to pto-isa TileType string
    *
    * Maps PyPTO MemorySpace to pto-isa TileType enum values:
-   * - L0A → "TileType::Left"
-   * - L0B → "TileType::Right"
-   * - L0C → "TileType::Acc"
-   * - L1 → "TileType::Mat"
-   * - UB → "TileType::Vec"
+   * - Left → "TileType::Left"
+   * - Right → "TileType::Right"
+   * - Acc → "TileType::Acc"
+   * - Mat → "TileType::Mat"
+   * - Vec → "TileType::Vec"
    *
    * @param space The memory space
    * @return TileType string (e.g., "TileType::Left", "TileType::Vec")

--- a/include/pypto/ir/memref.h
+++ b/include/pypto/ir/memref.h
@@ -30,19 +30,19 @@ namespace ir {
  *
  * Defines the available memory spaces in the hardware hierarchy:
  * - DDR: Double Data Rate memory (off-chip)
- * - UB: Unified Buffer (on-chip shared memory)
- * - L1: L1 cache
- * - L0A: L0A buffer (matrix A operand)
- * - L0B: L0B buffer (matrix B operand)
- * - L0C: L0C buffer (matrix C/result)
+ * - Vec: Vector/unified buffer (on-chip shared memory)
+ * - Mat: Matrix/L1 buffer
+ * - Left: Left matrix operand buffer
+ * - Right: Right matrix operand buffer
+ * - Acc: Accumulator buffer
  */
 enum class MemorySpace {
-  DDR,  ///< DDR memory (off-chip)
-  UB,   ///< Unified Buffer (on-chip)
-  L1,   ///< L1 cache
-  L0A,  ///< L0A buffer
-  L0B,  ///< L0B buffer
-  L0C   ///< L0C buffer
+  DDR,    ///< DDR memory (off-chip)
+  Vec,    ///< Vector/unified buffer (on-chip)
+  Mat,    ///< Matrix/L1 buffer
+  Left,   ///< Left matrix operand buffer
+  Right,  ///< Right matrix operand buffer
+  Acc     ///< Accumulator buffer
 };
 
 /**
@@ -65,7 +65,7 @@ std::string MemorySpaceToString(MemorySpace space);
  */
 class MemRef : public Var {
  public:
-  MemorySpace memory_space_;  ///< Memory space (DDR, UB, L1, etc.)
+  MemorySpace memory_space_;  ///< Memory space (DDR, Vec, Mat, etc.)
   ExprPtr addr_;              ///< Starting address expression
   uint64_t size_;             ///< Size in bytes (64-bit unsigned)
   uint64_t id_;               ///< Unique identifier (used for name generation)
@@ -76,7 +76,7 @@ class MemRef : public Var {
    * Generates a variable name from the ID (e.g., "mem_123") and creates
    * a MemRefType for the type. Calls Var constructor with these values.
    *
-   * @param memory_space Memory space (DDR, UB, L1, etc.)
+   * @param memory_space Memory space (DDR, Vec, Mat, etc.)
    * @param addr Starting address expression
    * @param size Size in bytes
    * @param id Unique identifier (used to generate variable name)

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -284,11 +284,11 @@ void BindIR(nb::module_& m) {
   // MemorySpace enum
   nb::enum_<MemorySpace>(ir, "MemorySpace", "Memory space enumeration")
       .value("DDR", MemorySpace::DDR, "DDR memory (off-chip)")
-      .value("UB", MemorySpace::UB, "Unified Buffer (on-chip)")
-      .value("L1", MemorySpace::L1, "L1 cache")
-      .value("L0A", MemorySpace::L0A, "L0A buffer")
-      .value("L0B", MemorySpace::L0B, "L0B buffer")
-      .value("L0C", MemorySpace::L0C, "L0C buffer")
+      .value("Vec", MemorySpace::Vec, "Vector/unified buffer (on-chip)")
+      .value("Mat", MemorySpace::Mat, "Matrix/L1 buffer")
+      .value("Left", MemorySpace::Left, "Left matrix operand buffer")
+      .value("Right", MemorySpace::Right, "Right matrix operand buffer")
+      .value("Acc", MemorySpace::Acc, "Accumulator buffer")
       .export_values();
 
   // PipeType enum
@@ -398,7 +398,7 @@ void BindIR(nb::module_& m) {
       .def(nb::init<MemorySpace, ExprPtr, uint64_t, uint64_t, Span>(), nb::arg("memory_space"),
            nb::arg("addr"), nb::arg("size"), nb::arg("id"), nb::arg("span") = Span::unknown(),
            "Create a memory reference with memory_space, addr, size, id, and span")
-      .def_rw("memory_space_", &MemRef::memory_space_, "Memory space (DDR, UB, L1, etc.)")
+      .def_rw("memory_space_", &MemRef::memory_space_, "Memory space (DDR, Vec, Mat, Left, Right, Acc)")
       .def_rw("addr_", &MemRef::addr_, "Starting address expression")
       .def_rw("size_", &MemRef::size_, "Size in bytes (64-bit unsigned)")
       .def_rw("id_", &MemRef::id_, "Unique identifier for this MemRef instance");

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -508,7 +508,7 @@ class IRBuilder:
         """Create a MemRef with normalized address expression.
 
         Args:
-            memory_space: Memory space (DDR, UB, L1, L0A, L0B, L0C)
+            memory_space: Memory space (DDR, Vec, Mat, Left, Right, Acc)
             addr: Address expression (int or Expr)
             size: Size in bytes
             id: Unique identifier for this MemRef
@@ -645,7 +645,7 @@ class IRBuilder:
             >>> # Simple tile type
             >>> tile_t = ib.tile_type([16, 16], DataType.FP16)
             >>> # Tile type with memref and tile_view
-            >>> memref = ib.memref(ir.MemorySpace.L0A, 0, 512)
+            >>> memref = ib.memref(ir.MemorySpace.Left, 0, 512)
             >>> tv = ib.tile_view([16, 16], [1, 16], 0)
             >>> tile_t = ib.tile_type([16, 16], DataType.FP16, memref=memref, tile_view=tv)
         """

--- a/python/pypto/ir/op_conversion.py
+++ b/python/pypto/ir/op_conversion.py
@@ -80,8 +80,8 @@ def op_conversion(from_op: str) -> Callable:
 
         @op_conversion("tensor.matmul")
         def convert_matmul(ctx, args, kwargs, span):
-            lhs_l0a = ctx.let("lhs_l0a", block_ops.move(args[0], target_memory=MemorySpace.L0A))
-            rhs_l0b = ctx.let("rhs_l0b", block_ops.move(args[1], target_memory=MemorySpace.L0B))
+            lhs_l0a = ctx.let("lhs_l0a", block_ops.move(args[0], target_memory=MemorySpace.Left))
+            rhs_l0b = ctx.let("rhs_l0b", block_ops.move(args[1], target_memory=MemorySpace.Right))
             return block_ops.matmul(lhs_l0a, rhs_l0b)
     """
 

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -101,7 +101,7 @@ from .op.block_ops import (
     subc,
     subsc,
     sum,
-    ub_copy,
+    vec_move,
     xor,
     xors,
 )
@@ -189,7 +189,7 @@ __all__ = [
     "store",
     "l0c_store",
     "move",
-    "ub_copy",
+    "vec_move",
     "neg",
     "sqrt",
     "rsqrt",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -80,7 +80,7 @@ from .block_ops import (
     subc,
     subsc,
     sum,
-    ub_copy,
+    vec_move,
     xor,
     xors,
 )
@@ -131,7 +131,7 @@ __all__ = [
     "store",
     "l0c_store",
     "move",
-    "ub_copy",
+    "vec_move",
     "neg",
     "sqrt",
     "rsqrt",

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -22,7 +22,7 @@ __all__ = [
     "store",
     "l0c_store",
     "move",
-    "ub_copy",
+    "vec_move",
     "full",
     "fillpad",
     "get_block_idx",
@@ -108,14 +108,14 @@ from ..typing import Scalar, Tensor, Tile
 def create_tile(
     shape: list[int],
     dtype: DataType,
-    target_memory: MemorySpace = MemorySpace.UB,
+    target_memory: MemorySpace = MemorySpace.Vec,
 ) -> Tile:
     """Create a tile from a shape.
 
     Args:
         shape: Shape of the tile
         dtype: Data type of the tile
-        target_memory: Target memory space (MemorySpace.UB, .L1, .L0A, .L0B)
+        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right)
 
     Returns:
         Tile wrapping the create_tile operation
@@ -128,7 +128,7 @@ def load(
     tensor: Tensor,
     offsets: Sequence[int | Expr],
     shapes: Sequence[int | Expr],
-    target_memory: MemorySpace = MemorySpace.UB,
+    target_memory: MemorySpace = MemorySpace.Vec,
 ) -> Tile:
     """Copy data from tensor to unified buffer (tile).
 
@@ -136,7 +136,7 @@ def load(
         tensor: Source tensor
         offsets: Offsets in each dimension
         sizes: Shape of the tile in each dimension
-        target_memory: Target memory space (MemorySpace.UB default, or MemorySpace.L1)
+        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat)
 
     Returns:
         Tile wrapping the load operation
@@ -184,7 +184,7 @@ def l0c_store(
     shapes: list[int | Expr] | tuple[int | Expr, ...],
     output_tensor: Tensor,
 ) -> Tensor:
-    """Copy data from L0C tile to GM tensor.
+    """Copy data from Acc tile to GM tensor.
 
     Args:
         tile: Source tile
@@ -210,7 +210,7 @@ def move(tile: Tile, target_memory: MemorySpace, transpose: bool = False) -> Til
 
     Args:
         tile: Input tile
-        target_memory: Target memory space (MemorySpace.UB, .L1, .L0A, .L0B)
+        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right)
         transpose: Whether to transpose the tile
 
     Returns:
@@ -220,25 +220,25 @@ def move(tile: Tile, target_memory: MemorySpace, transpose: bool = False) -> Til
     return Tile(expr=call_expr)
 
 
-def ub_copy(tile: Tile) -> Tile:
-    """Copy tile within UB (Unified Buffer) memory.
+def vec_move(tile: Tile) -> Tile:
+    """Copy tile within Vec (vector/unified buffer) memory.
 
-    This is a specialized operation for copying tiles within UB memory (UB→UB).
-    Both source and destination must be on UB. For other memory transfers,
+    This is a specialized operation for copying tiles within Vec memory (Vec→Vec).
+    Both source and destination must be on Vec. For other memory transfers,
     use move() with the target_memory parameter.
 
     Args:
-        tile: Input tile (must be in UB memory)
+        tile: Input tile (must be in Vec memory)
 
     Returns:
-        Tile wrapping the ub_copy operation (result is in UB memory)
+        Tile wrapping the vec_move operation (result is in Vec memory)
     """
-    call_expr = _ir_ops.ub_copy(tile.unwrap())
+    call_expr = _ir_ops.vec_move(tile.unwrap())
     return Tile(expr=call_expr)
 
 
 def full(shape: list[int], dtype: DataType, value: int | float) -> Tile:
-    """Create a tile from a shape and fill with value in UB.
+    """Create a tile from a shape and fill with value in Vec.
 
     Args:
         shape: Shape of the tile

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -621,26 +621,26 @@ class MemorySpace(enum.Enum):
     DDR = ...
     """DDR memory (off-chip)."""
 
-    UB = ...
-    """Unified Buffer (on-chip)."""
+    Vec = ...
+    """Vector/unified buffer (on-chip)."""
 
-    L1 = ...
-    """L1 cache."""
+    Mat = ...
+    """Matrix/L1 buffer."""
 
-    L0A = ...
-    """L0A buffer."""
+    Left = ...
+    """Left matrix operand buffer."""
 
-    L0B = ...
-    """L0B buffer."""
+    Right = ...
+    """Right matrix operand buffer."""
 
-    L0C = ...
-    """L0C buffer."""
+    Acc = ...
+    """Accumulator buffer."""
 
 class MemRef(Var):
     """Memory reference variable for shaped types (inherits from Var)."""
 
     memory_space_: MemorySpace
-    """Memory space (DDR, UB, L1, etc.)."""
+    """Memory space (DDR, Vec, Mat, etc.)."""
 
     addr_: Expr
     """Starting address expression."""
@@ -655,7 +655,7 @@ class MemRef(Var):
         """Create a memory reference with memory_space, addr, size, id, and span.
 
         Args:
-            memory_space: Memory space (DDR, UB, L1, etc.)
+            memory_space: Memory space (DDR, Vec, Mat, etc.)
             addr: Starting address expression
             size: Size in bytes
             id: Unique identifier for this MemRef instance
@@ -1796,7 +1796,7 @@ def memref_init(func_or_program: Function | Program) -> Function | Program:
     that don't already have a MemRef attached.
 
     Default memory space allocation strategy:
-    - TileType → MemorySpace.UB (Unified Buffer)
+    - TileType → MemorySpace.Vec (Vector/unified buffer)
     - TensorType → MemorySpace.DDR (DDR memory)
 
     Args:

--- a/src/backend/common/soc.cpp
+++ b/src/backend/common/soc.cpp
@@ -121,15 +121,15 @@ const SoC& Create910BSoC() {
   static SoC soc = []() {
     // AIC (CUBE) core configuration
     Core aic_core(ir::CoreType::CUBE, {
-                                          Mem(ir::MemorySpace::L1, 512ULL * 1024, 128),  // 512KB L1
-                                          Mem(ir::MemorySpace::L0A, 64ULL * 1024, 64),   // 64KB L0A
-                                          Mem(ir::MemorySpace::L0B, 64ULL * 1024, 64),   // 64KB L0B
-                                          Mem(ir::MemorySpace::L0C, 128ULL * 1024, 128)  // 128KB L0C
+                                          Mem(ir::MemorySpace::Mat, 512ULL * 1024, 128),  // 512KB Mat
+                                          Mem(ir::MemorySpace::Left, 64ULL * 1024, 64),   // 64KB Left
+                                          Mem(ir::MemorySpace::Right, 64ULL * 1024, 64),  // 64KB Right
+                                          Mem(ir::MemorySpace::Acc, 128ULL * 1024, 128)   // 128KB Acc
                                       });
 
     // AIV (VECTOR) core configuration
     Core aiv_core(ir::CoreType::VECTOR, {
-                                            Mem(ir::MemorySpace::UB, 192ULL * 1024, 128),  // 192KB UB
+                                            Mem(ir::MemorySpace::Vec, 192ULL * 1024, 128),  // 192KB Vec
                                         });
 
     Cluster aic_cluster(aic_core, 1);  // 1 core per cluster
@@ -139,10 +139,10 @@ const SoC& Create910BSoC() {
 
     // Memory hierarchy graph for path finding
     std::map<ir::MemorySpace, std::vector<ir::MemorySpace>> mem_graph;
-    mem_graph[ir::MemorySpace::DDR] = {ir::MemorySpace::UB, ir::MemorySpace::L1};
-    mem_graph[ir::MemorySpace::UB] = {ir::MemorySpace::DDR};
-    mem_graph[ir::MemorySpace::L1] = {ir::MemorySpace::L0A, ir::MemorySpace::L0B};
-    mem_graph[ir::MemorySpace::L0C] = {ir::MemorySpace::L1, ir::MemorySpace::DDR};
+    mem_graph[ir::MemorySpace::DDR] = {ir::MemorySpace::Vec, ir::MemorySpace::Mat};
+    mem_graph[ir::MemorySpace::Vec] = {ir::MemorySpace::DDR};
+    mem_graph[ir::MemorySpace::Mat] = {ir::MemorySpace::Left, ir::MemorySpace::Right};
+    mem_graph[ir::MemorySpace::Acc] = {ir::MemorySpace::Mat, ir::MemorySpace::DDR};
 
     return SoC(die, 1, std::move(mem_graph));
   }();

--- a/src/codegen/cce/type_converter.cpp
+++ b/src/codegen/cce/type_converter.cpp
@@ -49,15 +49,15 @@ std::string TypeConverter::ConvertTileType(const ir::TileTypePtr& tile_type, int
 
 std::string TypeConverter::ConvertMemorySpaceToTileType(ir::MemorySpace space) const {
   switch (space) {
-    case ir::MemorySpace::L0A:
+    case ir::MemorySpace::Left:
       return "TileType::Left";
-    case ir::MemorySpace::L0B:
+    case ir::MemorySpace::Right:
       return "TileType::Right";
-    case ir::MemorySpace::L0C:
+    case ir::MemorySpace::Acc:
       return "TileType::Acc";
-    case ir::MemorySpace::L1:
+    case ir::MemorySpace::Mat:
       return "TileType::Mat";
-    case ir::MemorySpace::UB:
+    case ir::MemorySpace::Vec:
       return "TileType::Vec";
     case ir::MemorySpace::DDR:
       // DDR is for GlobalTensor, not Tile - should not reach here

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -78,15 +78,15 @@ static std::string DataTypeToMLIRImpl(::pypto::DataType dtype) {
 static std::string MemorySpaceToMLIR(ir::MemorySpace space) {
   if (space == ir::MemorySpace::DDR) {
     return "gm";
-  } else if (space == ir::MemorySpace::UB) {
+  } else if (space == ir::MemorySpace::Vec) {
     return "vec";
-  } else if (space == ir::MemorySpace::L1) {
+  } else if (space == ir::MemorySpace::Mat) {
     return "mat";
-  } else if (space == ir::MemorySpace::L0A) {
+  } else if (space == ir::MemorySpace::Left) {
     return "left";
-  } else if (space == ir::MemorySpace::L0B) {
+  } else if (space == ir::MemorySpace::Right) {
     return "right";
-  } else if (space == ir::MemorySpace::L0C) {
+  } else if (space == ir::MemorySpace::Acc) {
     return "acc";
   } else {
     throw pypto::ValueError("Invalid MemorySpace value");

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -28,16 +28,16 @@ std::string MemorySpaceToString(MemorySpace space) {
   switch (space) {
     case MemorySpace::DDR:
       return "DDR";
-    case MemorySpace::UB:
-      return "UB";
-    case MemorySpace::L1:
-      return "L1";
-    case MemorySpace::L0A:
-      return "L0A";
-    case MemorySpace::L0B:
-      return "L0B";
-    case MemorySpace::L0C:
-      return "L0C";
+    case MemorySpace::Vec:
+      return "Vec";
+    case MemorySpace::Mat:
+      return "Mat";
+    case MemorySpace::Left:
+      return "Left";
+    case MemorySpace::Right:
+      return "Right";
+    case MemorySpace::Acc:
+      return "Acc";
     default:
       return "Unknown";
   }

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -337,7 +337,7 @@ REGISTER_OP("block.store")
 
 REGISTER_OP("block.l0c_store")
     .set_op_category("BlockOp")
-    .set_description("Copy data from L0C tile to GM tensor")
+    .set_description("Copy data from Acc tile to GM tensor")
     .add_argument("tile", "Source tile (TileType)")
     .add_argument("offsets", "Offsets in each dimension (TupleType of ScalarType)")
     .add_argument("shapes", "Shape of tile in each dimension (TupleType of ScalarType)")
@@ -349,7 +349,7 @@ REGISTER_OP("block.l0c_store")
 
 REGISTER_OP("block.move")
     .set_op_category("BlockOp")
-    .set_description("Move tile to memory levels (UB/L1/L0A/L0B) with optional transpose")
+    .set_description("Move tile to memory levels (Vec/Mat/Left/Right) with optional transpose")
     .add_argument("tile", "Input tile (TileType)")
     .set_attr<bool>("transpose")
     .set_attr<MemorySpace>("target_memory")
@@ -358,13 +358,13 @@ REGISTER_OP("block.move")
       return DeduceBlockMoveType(args, kwargs, "block.move");
     });
 
-REGISTER_OP("block.ub_copy")
+REGISTER_OP("block.vec_move")
     .set_op_category("BlockOp")
-    .set_description("Copy tile within UB (Unified Buffer) memory - UB to UB only")
-    .add_argument("tile", "Input tile (TileType) in UB memory")
+    .set_description("Copy tile within Vec memory - Vec to Vec only")
+    .add_argument("tile", "Input tile (TileType) in Vec memory")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceBlockUbCopyType(args, kwargs, "block.ub_copy");
+      return DeduceBlockUbCopyType(args, kwargs, "block.vec_move");
     });
 
 REGISTER_OP("block.alloc")

--- a/src/ir/transforms/convert_tensor_to_block_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_block_ops_pass.cpp
@@ -495,10 +495,10 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
       continue;  // ScalarType params pass through unchanged
     }
 
-    // Create block.load(param, zeros, shape, target_memory=UB)
+    // Create block.load(param, zeros, shape, target_memory=Vec)
     auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
     auto shapes = MakeShapeTuple(tensor_type->shape_, span);
-    std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::UB}};
+    std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
     auto load_call = op_registry.Create("block.load", {param, offsets, shapes}, load_kwargs, span);
 
     // Create tile variable

--- a/tests/st/fuzz/src/fuzzer.py
+++ b/tests/st/fuzz/src/fuzzer.py
@@ -468,7 +468,7 @@ class OpFuzzer:
     ]
 
     # Block-level matrix operators
-    # Note: matmul requires special memory handling (L0A, L0B, L0C)
+    # Note: matmul requires special memory handling (Left, Right, Acc)
     # The kernel generator will handle the memory management sequence
     BLOCK_MATRIX_OPS = [
         OpSpec(

--- a/tests/st/fuzz/src/kernel_generator.py
+++ b/tests/st/fuzz/src/kernel_generator.py
@@ -161,7 +161,7 @@ class KernelGenerator:
 
         Args:
             input_var: Input variable name (e.g., "tile_a")
-            target_memory: Target memory type (3 for L0A, 4 for L0B)
+            target_memory: Target memory type (3 for Left, 4 for Right)
             has_matmul: Whether the kernel contains matmul operations
 
         Returns:

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -45,10 +45,14 @@ class TestMatmul(PTOTestCase):
                 b: pl.Tensor[[64, 64], pl.FP32],
                 c: pl.Tensor[[64, 64], pl.FP32],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                tile_a_l1 = pl.block.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.L1)
-                tile_b_l1 = pl.block.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.L1)
-                tile_a_l0a = pl.block.move(tile_a_l1, target_memory=pl.MemorySpace.L0A)
-                tile_b_l0b = pl.block.move(tile_b_l1, target_memory=pl.MemorySpace.L0B)
+                tile_a_l1 = pl.block.load(
+                    a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat
+                )
+                tile_b_l1 = pl.block.load(
+                    b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat
+                )
+                tile_a_l0a = pl.block.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.block.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
                 tile_c_l0c = pl.block.matmul(tile_a_l0a, tile_b_l0b)
                 # store can support l0c -> GM directly
                 out_c = pl.block.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=c)

--- a/tests/ut/backend/test_backend.py
+++ b/tests/ut/backend/test_backend.py
@@ -28,8 +28,8 @@ class TestSoCConstruction:
         core = Core(
             ir.CoreType.CUBE,
             [
-                Mem(ir.MemorySpace.L0A, 512 * 1024, 64),
-                Mem(ir.MemorySpace.L0B, 512 * 1024, 64),
+                Mem(ir.MemorySpace.Left, 512 * 1024, 64),
+                Mem(ir.MemorySpace.Right, 512 * 1024, 64),
             ],
         )
 
@@ -39,7 +39,7 @@ class TestSoCConstruction:
 
     def test_build_cluster_with_cores(self):
         """Test building cluster with multiple cores."""
-        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.L1, 1024 * 1024, 128)])
+        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.Mat, 1024 * 1024, 128)])
 
         cluster = Cluster(core, 4)  # 4 identical cores
 
@@ -47,7 +47,7 @@ class TestSoCConstruction:
 
     def test_build_complete_soc_nested(self):
         """Test building complete SoC with nested construction."""
-        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.Left, 256 * 1024, 64)])
         cluster = Cluster(core, 2)
         die = Die(cluster, 4)
         soc = SoC(die, 1)
@@ -59,7 +59,7 @@ class TestSoCConstruction:
     def test_build_multi_die_soc(self):
         """Test building SoC with multiple dies."""
         # Build a die first
-        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.UB, 512 * 1024, 64)])
+        core = Core(ir.CoreType.VECTOR, [Mem(ir.MemorySpace.Vec, 512 * 1024, 64)])
         cluster = Cluster(core, 2)
         die = Die(cluster, 2)
 
@@ -76,15 +76,15 @@ class TestSoCStructure:
 
     def test_mem_properties(self):
         """Test Mem component properties."""
-        mem = Mem(ir.MemorySpace.L0C, 1024 * 1024, 256)
+        mem = Mem(ir.MemorySpace.Acc, 1024 * 1024, 256)
 
-        assert mem.mem_type == ir.MemorySpace.L0C
+        assert mem.mem_type == ir.MemorySpace.Acc
         assert mem.mem_size == 1024 * 1024
         assert mem.alignment == 256
 
     def test_core_properties(self):
         """Test Core properties."""
-        mems = [Mem(ir.MemorySpace.L0A, 512 * 1024, 64), Mem(ir.MemorySpace.L0B, 512 * 1024, 64)]
+        mems = [Mem(ir.MemorySpace.Left, 512 * 1024, 64), Mem(ir.MemorySpace.Right, 512 * 1024, 64)]
         core = Core(ir.CoreType.CUBE, mems)
 
         assert core.core_type == ir.CoreType.CUBE
@@ -92,14 +92,14 @@ class TestSoCStructure:
 
     def test_cluster_convenience_constructor(self):
         """Test Cluster convenience constructor."""
-        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.Left, 256 * 1024, 64)])
         cluster = Cluster(core, 4)
 
         assert cluster.total_core_count() == 4
 
     def test_die_convenience_constructor(self):
         """Test Die convenience constructor."""
-        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.Left, 256 * 1024, 64)])
         cluster = Cluster(core, 2)
         die = Die(cluster, 3)
 
@@ -108,7 +108,7 @@ class TestSoCStructure:
 
     def test_soc_convenience_constructor(self):
         """Test SoC convenience constructor."""
-        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.L0A, 256 * 1024, 64)])
+        core = Core(ir.CoreType.CUBE, [Mem(ir.MemorySpace.Left, 256 * 1024, 64)])
         cluster = Cluster(core, 2)
         die = Die(cluster, 3)
         soc = SoC(die, 2)

--- a/tests/ut/backend/test_backend_910b.py
+++ b/tests/ut/backend/test_backend_910b.py
@@ -68,20 +68,20 @@ class TestBackend910BMemoryPath:
             # DDR connections
             (
                 ir.MemorySpace.DDR,
-                ir.MemorySpace.L0A,
-                [ir.MemorySpace.DDR, ir.MemorySpace.L1, ir.MemorySpace.L0A],
+                ir.MemorySpace.Left,
+                [ir.MemorySpace.DDR, ir.MemorySpace.Mat, ir.MemorySpace.Left],
             ),
-            (ir.MemorySpace.DDR, ir.MemorySpace.UB, [ir.MemorySpace.DDR, ir.MemorySpace.UB]),
+            (ir.MemorySpace.DDR, ir.MemorySpace.Vec, [ir.MemorySpace.DDR, ir.MemorySpace.Vec]),
             # UB connections
-            (ir.MemorySpace.UB, ir.MemorySpace.DDR, [ir.MemorySpace.UB, ir.MemorySpace.DDR]),
+            (ir.MemorySpace.Vec, ir.MemorySpace.DDR, [ir.MemorySpace.Vec, ir.MemorySpace.DDR]),
             # L1 connections
-            (ir.MemorySpace.L1, ir.MemorySpace.L0A, [ir.MemorySpace.L1, ir.MemorySpace.L0A]),
-            (ir.MemorySpace.L1, ir.MemorySpace.L0B, [ir.MemorySpace.L1, ir.MemorySpace.L0B]),
-            # L0C connections
-            (ir.MemorySpace.L0C, ir.MemorySpace.L1, [ir.MemorySpace.L0C, ir.MemorySpace.L1]),
-            (ir.MemorySpace.L0C, ir.MemorySpace.DDR, [ir.MemorySpace.L0C, ir.MemorySpace.DDR]),
+            (ir.MemorySpace.Mat, ir.MemorySpace.Left, [ir.MemorySpace.Mat, ir.MemorySpace.Left]),
+            (ir.MemorySpace.Mat, ir.MemorySpace.Right, [ir.MemorySpace.Mat, ir.MemorySpace.Right]),
+            # Acc connections
+            (ir.MemorySpace.Acc, ir.MemorySpace.Mat, [ir.MemorySpace.Acc, ir.MemorySpace.Mat]),
+            (ir.MemorySpace.Acc, ir.MemorySpace.DDR, [ir.MemorySpace.Acc, ir.MemorySpace.DDR]),
             # Same memory
-            (ir.MemorySpace.L1, ir.MemorySpace.L1, [ir.MemorySpace.L1]),
+            (ir.MemorySpace.Mat, ir.MemorySpace.Mat, [ir.MemorySpace.Mat]),
         ]
 
         for from_mem, to_mem, expected_path in test_cases:
@@ -100,11 +100,11 @@ class TestBackend910BMemorySize:
 
         # Test cases: (memory_type, expected_size_in_KB)
         test_cases = [
-            (ir.MemorySpace.L0A, 64),  # 64KB per AIC core
-            (ir.MemorySpace.L0B, 64),  # 64KB per AIC core
-            (ir.MemorySpace.L0C, 128),  # 128KB per AIC core
-            (ir.MemorySpace.L1, 512),  # 512KB per AIC core
-            (ir.MemorySpace.UB, 192),  # 192KB per AIV core
+            (ir.MemorySpace.Left, 64),  # 64KB per AIC core
+            (ir.MemorySpace.Right, 64),  # 64KB per AIC core
+            (ir.MemorySpace.Acc, 128),  # 128KB per AIC core
+            (ir.MemorySpace.Mat, 512),  # 512KB per AIC core
+            (ir.MemorySpace.Vec, 192),  # 192KB per AIV core
             (ir.MemorySpace.DDR, 0),  # DDR not in core memory
         ]
 
@@ -127,13 +127,13 @@ class TestBackend910BMemoryHierarchy:
         # Test cases: (from, to, expected_path_length)
         test_cases = [
             # Direct connections (length 2)
-            (ir.MemorySpace.DDR, ir.MemorySpace.UB, 2),
-            (ir.MemorySpace.DDR, ir.MemorySpace.L1, 2),
-            (ir.MemorySpace.UB, ir.MemorySpace.DDR, 2),
-            (ir.MemorySpace.L1, ir.MemorySpace.L0A, 2),
-            (ir.MemorySpace.L1, ir.MemorySpace.L0B, 2),
-            (ir.MemorySpace.L0C, ir.MemorySpace.L1, 2),
-            (ir.MemorySpace.L0C, ir.MemorySpace.DDR, 2),
+            (ir.MemorySpace.DDR, ir.MemorySpace.Vec, 2),
+            (ir.MemorySpace.DDR, ir.MemorySpace.Mat, 2),
+            (ir.MemorySpace.Vec, ir.MemorySpace.DDR, 2),
+            (ir.MemorySpace.Mat, ir.MemorySpace.Left, 2),
+            (ir.MemorySpace.Mat, ir.MemorySpace.Right, 2),
+            (ir.MemorySpace.Acc, ir.MemorySpace.Mat, 2),
+            (ir.MemorySpace.Acc, ir.MemorySpace.DDR, 2),
         ]
 
         for from_mem, to_mem, expected_len in test_cases:

--- a/tests/ut/ir/operators/test_block_ops.py
+++ b/tests/ut/ir/operators/test_block_ops.py
@@ -372,7 +372,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 1], pl.FP32] = pl.block.create_tile(
-                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_max: pl.Tile[[32, 1], pl.FP32] = pl.row_max(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_max, [0, 0], [32, 1], output)
@@ -398,7 +398,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 1], pl.FP32] = pl.block.create_tile(
-                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_sum: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_sum, [0, 0], [32, 1], output)
@@ -426,7 +426,7 @@ class TestBlockReductionOps:
             ) -> pl.Tensor[[128, 1], pl.FP32]:
                 tile_in: pl.Tile[[32, 128], pl.FP32] = pl.load(input, [0, 0], [32, 128])
                 tmp_tile: pl.Tile[[32, 128], pl.FP32] = pl.block.create_tile(
-                    [32, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                    [32, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_row_min: pl.Tile[[32, 1], pl.FP32] = pl.row_min(tile_in, tmp_tile)
                 result: pl.Tensor[[128, 1], pl.FP32] = pl.store(tile_row_min, [0, 0], [32, 1], output)
@@ -1257,7 +1257,7 @@ class TestBlockBitwiseArithmeticOps:
                 tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(a, [0, 0], [32, 32])
                 tile_b: pl.Tile[[32, 32], pl.INT32] = pl.load(b, [0, 0], [32, 32])
                 tmp: pl.Tile[[32, 32], pl.INT32] = pl.block.create_tile(
-                    [32, 32], dtype=pl.INT32, target_memory=pl.MemorySpace.UB
+                    [32, 32], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_c: pl.Tile[[32, 32], pl.INT32] = pl.xor(tile_a, tile_b, tmp)
                 result: pl.Tensor[[128, 128], pl.INT32] = pl.store(tile_c, [0, 0], [32, 32], output)
@@ -1280,7 +1280,7 @@ class TestBlockBitwiseArithmeticOps:
             ) -> pl.Tensor[[128, 128], pl.INT32]:
                 tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(a, [0, 0], [32, 32])
                 tmp: pl.Tile[[32, 32], pl.INT32] = pl.block.create_tile(
-                    [32, 32], dtype=pl.INT32, target_memory=pl.MemorySpace.UB
+                    [32, 32], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_c: pl.Tile[[32, 32], pl.INT32] = pl.xors(tile_a, scalar, tmp)
                 result: pl.Tensor[[128, 128], pl.INT32] = pl.store(tile_c, [0, 0], [32, 32], output)
@@ -1472,10 +1472,10 @@ class TestBlockBitwiseArithmeticOps:
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_x: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 slope: pl.Tile[[16, 16], pl.FP32] = pl.block.create_tile(
-                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
                 )
                 tmp: pl.Tile[[16, 16], pl.FP32] = pl.block.create_tile(
-                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
                 )
                 tile_c: pl.Tile[[16, 16], pl.FP32] = pl.prelu(tile_x, slope, tmp)
                 result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], [16, 16], output)

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -574,7 +574,7 @@ def test_python_print_block_load_store():
     # Test with target_memory kwarg (using MemorySpace enum)
     # Correct signature: Call(op, args, kwargs, span)
     load_call_with_kwargs = ir.Call(
-        load_op, [input_tensor, offsets_tuple, shapes_tuple], {"target_memory": MemorySpace.UB}, span
+        load_op, [input_tensor, offsets_tuple, shapes_tuple], {"target_memory": MemorySpace.Vec}, span
     )
 
     load_kwargs_result = ir.python_print(load_call_with_kwargs)
@@ -582,7 +582,7 @@ def test_python_print_block_load_store():
     print(load_kwargs_result)
 
     assert "pl.block.load" in load_kwargs_result
-    assert "target_memory=pl.MemorySpace.UB" in load_kwargs_result
+    assert "target_memory=pl.MemorySpace.Vec" in load_kwargs_result
 
 
 def test_python_print_while_stmt_natural():

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -291,7 +291,7 @@ class TestUnifiedBlockDispatch:
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.block.load(t, offsets=[0, 0], shapes=[64, 64])
             tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile(
-                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
             )
             b: pl.Tile[[64, 1], pl.FP32] = pl.row_sum(a, tmp)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.block.store(
@@ -305,7 +305,7 @@ class TestUnifiedBlockDispatch:
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.block.load(t, offsets=[0, 0], shapes=[64, 64])
             tmp: pl.Tile[[64, 16], pl.FP32] = pl.block.create_tile(
-                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.UB
+                [64, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
             )
             b: pl.Tile[[64, 1], pl.FP32] = pl.block.row_sum(a, tmp)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.block.store(


### PR DESCRIPTION
Fixes #268

Rename MemorySpace enum values from Ascend-specific hardware names to hardware-agnostic logical names:
- UB  -> Vec  (vector/unified buffer)
- L1  -> Mat  (matrix/L1 buffer)
- L0A -> Left (left matrix operand buffer)
- L0B -> Right (right matrix operand buffer)
- L0C -> Acc  (accumulator buffer)

Updates all usages across C++ core, Python bindings, type stubs, language API, tests, and documentation. MemRef auto-generated variable names update accordingly (e.g. mem_ub_N -> mem_vec_N).

Made-with: Cursor