### PR TITLE
feat(harness): Add PTO backend support and PTOAS on-board tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
       - name: Clone simpler repository
         run: git clone https://github.com/ChaoWao/simpler $GITHUB_WORKSPACE/simpler

--- a/tests/st/harness/adapters/program_generator.py
+++ b/tests/st/harness/adapters/program_generator.py
@@ -50,17 +50,23 @@ class ProgramCodeGenerator:
     def __init__(
         self,
         strategy: OptimizationStrategy | None = None,
+        backend_type: BackendType | None = None,
     ):
         """Initialize kernel generator.
 
         Args:
             strategy: Optimization strategy for pass pipeline.
                       If None, uses OptimizationStrategy.Default.
+            backend_type: Backend type for code generation.
+                          If None, uses BackendType.CCE.
         """
         if strategy is None:
             strategy = OptimizationStrategy.Default
+        if backend_type is None:
+            backend_type = BackendType.CCE
 
         self.strategy = strategy
+        self.backend_type = backend_type
 
     def _add_headers_to_orch_file(self, orch_file: Path) -> None:
         """Add required headers to orchestration file if not already present.
@@ -144,7 +150,7 @@ class ProgramCodeGenerator:
             output_dir=str(output_dir),
             strategy=self.strategy,
             dump_passes=dump_passes,
-            backend_type=BackendType.CCE,
+            backend_type=self.backend_type,
         )
         # Files are now in output_dir with structure:
         #   output_dir/kernels/aiv/*.cpp and output_dir/kernels/aic/*.cpp

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -21,6 +21,7 @@ from enum import Enum
 from typing import Any
 
 import torch
+from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 
@@ -251,6 +252,17 @@ class PTOTestCase(ABC):
             OptimizationStrategy enum value.
         """
         return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        """Return the backend type for code generation.
+
+        Override to use PTO backend (e.g., for PTOAS optimization).
+        Default is BackendType.CCE.
+
+        Returns:
+            BackendType enum value.
+        """
+        return BackendType.CCE
 
     @abstractmethod
     def compute_expected(

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from pypto.backend import BackendType, set_backend_type
+from pypto.backend import set_backend_type
 
 from harness.adapters.golden_generator import GoldenGenerator
 from harness.adapters.program_generator import ProgramCodeGenerator
@@ -120,8 +120,9 @@ class TestRunner:
             use_temp = True
 
         try:
-            # Set PyPTO backend type to CCE for code generation
-            set_backend_type(BackendType.CCE)
+            # Set PyPTO backend type for code generation
+            backend_type = test_case.get_backend_type()
+            set_backend_type(backend_type)
 
             # 1. Generate kernel C++ files
             program = test_case.get_program()
@@ -132,7 +133,7 @@ class TestRunner:
                 )
 
             strategy = test_case.get_strategy()
-            codegen = ProgramCodeGenerator(strategy=strategy)
+            codegen = ProgramCodeGenerator(strategy=strategy, backend_type=backend_type)
             codegen_result = codegen.generate(
                 program,
                 work_dir,  # Pass work_dir instead of kernels_dir

--- a/tests/st/runtime/test_dag.py
+++ b/tests/st/runtime/test_dag.py
@@ -19,6 +19,8 @@ from typing import Any
 import pypto.language as pl
 import pytest
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TestVectorDAG(PTOTestCase):
@@ -125,6 +127,21 @@ class TestVectorDAG(PTOTestCase):
         tensors["f"][:] = g + c
 
 
+class TestVectorDAGPTO(TestVectorDAG):
+    """Test vector DAG with PTO backend and PTOAS optimization."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "vector_dag_pto_128x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.PTOAS
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.PTO
+
+
 class TestDAGOperations:
     """Test suite for DAG operations."""
 
@@ -133,6 +150,12 @@ class TestDAGOperations:
         test_case = TestVectorDAG()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed for vector DAG: {result.error}"
+
+    def test_vector_dag_pto_128x128(self, test_runner):
+        """Test vector DAG with PTO backend and PTOAS optimization."""
+        test_case = TestVectorDAGPTO()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed for vector DAG (PTO): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -20,6 +20,8 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TestMatmul(PTOTestCase):
@@ -71,6 +73,21 @@ class TestMatmul(PTOTestCase):
         tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
 
 
+class TestMatmulPTO(TestMatmul):
+    """Test matmul with PTO backend and PTOAS optimization."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmul_pto_64x64"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.PTOAS
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.PTO
+
+
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
@@ -79,6 +96,12 @@ class TestMatmulOperations:
         test_case = TestMatmul()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
+
+    def test_matmul_pto_64x64(self, test_runner):
+        """Test matmul with PTO backend and PTOAS optimization."""
+        test_case = TestMatmulPTO()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (PTO): {result.error}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
feat(harness): Add PTO backend support and PTOAS on-board tests

Enable test harness to use PTO backend (via ptoas compiler) in addition
to the default CCE backend.

Harness changes:
- Add get_backend_type() to PTOTestCase (default CCE, backward compatible)
- Accept backend_type in ProgramCodeGenerator, replacing hardcoded CCE
- Propagate backend_type from test case through TestRunner

Runtime tests:
- Add PTO+PTOAS variants for DAG, elementwise (add/mul), and matmul
- Fix TestTileAddWithPTOAS: was missing backend_type override, causing
  PTOAS strategy to run with CCE backend (sync not inserted → wrong results)
- Remove skip marker on elementwise PTOAS test now that root cause is fixed

CI:
- chmod +x ptoas-bin/bin/ptoas (actual binary, not just wrapper script)