### PR TITLE
refactor(codegen): use explicit In/Out/InOut declaration for orchestration param classification

### DIFF
--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -40,9 +40,9 @@ class PagedAttentionProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def kernel_init_inplace(
         self,
-        oi: pl.Tensor[[16, 16], pl.FP32],
-        li: pl.Tensor[[16], pl.FP32],
-        mi: pl.Tensor[[16], pl.FP32],
+        oi: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        li: pl.Out[pl.Tensor[[16], pl.FP32]],
+        mi: pl.Out[pl.Tensor[[16], pl.FP32]],
     ) -> tuple[
         pl.Tensor[[16, 128], pl.FP32],
         pl.Tensor[[16], pl.FP32],
@@ -57,7 +57,7 @@ class PagedAttentionProgram:
         self,
         qi: pl.Tensor[[16, 128], pl.BF16],
         kj: pl.Tensor[[128, 128], pl.BF16],
-        output: pl.Tensor[[16, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
     ) -> pl.Tensor[[16, 128], pl.FP32]:
         """QK matmul: sij = qi @ kj (CUBE)."""
         qi_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(qi, [0, 0], [16, 16])
@@ -72,9 +72,9 @@ class PagedAttentionProgram:
         self,
         sij: pl.Tensor[[16, 128], pl.FP32],
         scale: pl.Scalar[pl.FP32],
-        out_pij: pl.Tensor[[16, 128], pl.BF16],
-        out_mi: pl.Tensor[[16], pl.FP32],
-        out_li: pl.Tensor[[16], pl.FP32],
+        out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+        out_mi: pl.Out[pl.Tensor[[16], pl.FP32]],
+        out_li: pl.Out[pl.Tensor[[16], pl.FP32]],
     ) -> tuple[
         pl.Tensor[[16, 128], pl.BF16],
         pl.Tensor[[16], pl.FP32],
@@ -104,8 +104,8 @@ class PagedAttentionProgram:
         self,
         pij: pl.Tensor[[16, 128], pl.BF16],
         vj: pl.Tensor[[128, 128], pl.BF16],
-        output: pl.Tensor[[16, 16], pl.FP32],
-    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+    ) -> pl.Tensor[[16, 128], pl.FP32]:
         """PV matmul: oi_tmp = pij @ vj (CUBE)."""
         p_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(pij, [0, 0], [16, 16])
         v_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(vj, [0, 0], [16, 16])
@@ -120,10 +120,10 @@ class PagedAttentionProgram:
         mi: pl.Tensor[[16], pl.FP32],
         li: pl.Tensor[[16], pl.FP32],
         oi_tmp: pl.Tensor[[16, 128], pl.FP32],
-        mi_update: pl.Tensor[[16], pl.FP32],
-        li_update: pl.Tensor[[16], pl.FP32],
-        oi: pl.Tensor[[16, 128], pl.FP32],
-        out_view: pl.Tensor[[16, 128], pl.FP32],
+        mi_update: pl.InOut[pl.Tensor[[16], pl.FP32]],
+        li_update: pl.InOut[pl.Tensor[[16], pl.FP32]],
+        oi: pl.InOut[pl.Tensor[[16, 128], pl.FP32]],
+        out_view: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
         is_first: pl.Scalar[pl.INT64],
         is_last: pl.Scalar[pl.INT64],
     ) -> tuple[

--- a/tests/st/codegen/test_add_mul_orch_cce_codegen.py
+++ b/tests/st/codegen/test_add_mul_orch_cce_codegen.py
@@ -61,7 +61,7 @@ class TestAddMulOrchestration(PTOTestCase):
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 """Adds two tensors element-wise: result = a + b"""
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -75,7 +75,7 @@ class TestAddMulOrchestration(PTOTestCase):
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 scalar: pl.Scalar[pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 """Adds a scalar to each element: result = a + scalar"""
                 x: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -88,7 +88,7 @@ class TestAddMulOrchestration(PTOTestCase):
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 """Multiplies two tensors element-wise: result = a * b"""
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -122,16 +122,20 @@ class TestAddMulOrchestration(PTOTestCase):
                     Final result tensor
                 """
                 # Task 0: c = a + b (call kernel_add with output buffer c)
-                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
 
                 # Task 1: d = c + 1 (call kernel_add_scalar with output buffer d)
-                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
+                d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
 
                 # Task 2: e = c + 2 (call kernel_add_scalar with output buffer e)
-                e: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
+                e: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
 
                 # Task 3: f = d * e (call kernel_mul with output buffer)
-                f_result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_mul(d, e)
+                f_result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                f_result = self.kernel_mul(d, e, f_result)
                 return f_result
 
         return ExampleOrchProgram

--- a/tests/st/runtime/test_elementwise.py
+++ b/tests/st/runtime/test_elementwise.py
@@ -55,7 +55,7 @@ class TestTileAdd(PTOTestCase):
                 self,
                 a: pl.Tensor[[128, 128], pl.FP32],
                 b: pl.Tensor[[128, 128], pl.FP32],
-                c: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a = pl.block.load(a, offsets=[0, 0], shapes=[128, 128])
                 tile_b = pl.block.load(b, offsets=[0, 0], shapes=[128, 128])
@@ -67,7 +67,8 @@ class TestTileAdd(PTOTestCase):
             def orchestrator(
                 self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
             ) -> pl.Tensor[[128, 128], pl.FP32]:
-                out_c = self.tile_add(a, b)
+                out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+                out_c = self.tile_add(a, b, out_c)
                 return out_c
 
         return TileAddProgram
@@ -99,7 +100,7 @@ class TestTileAdd64x64(PTOTestCase):
                 self,
                 a: pl.Tensor[[64, 64], pl.FP32],
                 b: pl.Tensor[[64, 64], pl.FP32],
-                c: pl.Tensor[[64, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a = pl.block.load(a, offsets=[0, 0], shapes=[64, 64])
                 tile_b = pl.block.load(b, offsets=[0, 0], shapes=[64, 64])
@@ -111,7 +112,8 @@ class TestTileAdd64x64(PTOTestCase):
             def orchestrator(
                 self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                out_c = self.tile_add(a, b)
+                out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                out_c = self.tile_add(a, b, out_c)
                 return out_c
 
         return TileAddProgram
@@ -155,7 +157,7 @@ class TestTileMul(PTOTestCase):
                 self,
                 a: pl.Tensor[[128, 128], pl.FP32],
                 b: pl.Tensor[[128, 128], pl.FP32],
-                c: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a = pl.block.load(a, offsets=[0, 0], shapes=[128, 128])
                 tile_b = pl.block.load(b, offsets=[0, 0], shapes=[128, 128])
@@ -167,7 +169,8 @@ class TestTileMul(PTOTestCase):
             def orchestrator(
                 self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
             ) -> pl.Tensor[[128, 128], pl.FP32]:
-                out_c = self.tile_mul(a, b)
+                out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+                out_c = self.tile_mul(a, b, out_c)
                 return out_c
 
         return TileMulProgram
@@ -204,7 +207,7 @@ class TestTileMul64x64(PTOTestCase):
                 self,
                 a: pl.Tensor[[64, 64], pl.FP32],
                 b: pl.Tensor[[64, 64], pl.FP32],
-                c: pl.Tensor[[64, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a = pl.block.load(a, offsets=[0, 0], shapes=[64, 64])
                 tile_b = pl.block.load(b, offsets=[0, 0], shapes=[64, 64])
@@ -216,7 +219,8 @@ class TestTileMul64x64(PTOTestCase):
             def orchestrator(
                 self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                out_c = self.tile_mul(a, b)
+                out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                out_c = self.tile_mul(a, b, out_c)
                 return out_c
 
         return TileMulProgram

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -43,7 +43,7 @@ class TestMatmul(PTOTestCase):
                 self,
                 a: pl.Tensor[[64, 64], pl.FP32],
                 b: pl.Tensor[[64, 64], pl.FP32],
-                c: pl.Tensor[[64, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a_l1 = pl.block.load(
                     a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat
@@ -62,7 +62,8 @@ class TestMatmul(PTOTestCase):
             def orchestrator(
                 self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                out_c = self.matmul(a, b)
+                out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                out_c = self.matmul(a, b, out_c)
                 return out_c
 
         return MatmulProgram

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -50,7 +50,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -64,8 +64,10 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
-                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(c, b)
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
+                d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                d = self.kernel_add(c, b, d)
                 return d
 
         generator = codegen.CCECodegen()
@@ -161,7 +163,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -177,7 +179,8 @@ class TestOrchestration:
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [1, 3])  # noqa: F841
-                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                result = self.kernel_add(a, b, result)
                 return result
 
         generator = codegen.CCECodegen()
@@ -201,7 +204,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -215,7 +218,8 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
                 return c
 
         generator = codegen.CCECodegen()
@@ -238,7 +242,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -252,8 +256,10 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
-                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
-                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
+                d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                d = self.kernel_add(a, b, d)
                 return c, d
 
         generator = codegen.CCECodegen()
@@ -292,7 +298,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -305,7 +311,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 scalar: pl.Scalar[pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 x: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 result: pl.Tile[[16, 16], pl.FP32] = pl.add(x, scalar)
@@ -317,7 +323,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -331,11 +337,16 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
-                d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
-                e: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
-                g: pl.Tensor[[16, 16], pl.FP32] = self.kernel_mul(d, e)
-                f: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(g, c)
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
+                d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+                e: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+                g: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                g = self.kernel_mul(d, e, g)
+                f: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                f = self.kernel_add(g, c, f)
                 return f
 
         generator = codegen.CCECodegen()
@@ -461,8 +472,8 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                out_s: pl.Tensor[[16, 16], pl.FP32],
-                out_d: pl.Tensor[[16, 16], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -477,7 +488,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -491,8 +502,11 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                x, y = self.kernel_pair(a, b)
-                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(x, y)
+                x: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                y: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                x, y = self.kernel_pair(a, b, x, y)
+                result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                result = self.kernel_add(x, y, result)
                 return result
 
         generator = codegen.CCECodegen()
@@ -525,8 +539,8 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                out_s: pl.Tensor[[16, 16], pl.FP32],
-                out_d: pl.Tensor[[16, 16], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -542,7 +556,9 @@ class TestOrchestration:
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
             ) -> tuple[pl.Tensor[[16, 16], pl.FP32], pl.Tensor[[16, 16], pl.FP32]]:
-                x, y = self.kernel_pair(a, b)
+                x: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                y: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                x, y = self.kernel_pair(a, b, x, y)
                 return x, y
 
         generator = codegen.CCECodegen()
@@ -574,10 +590,10 @@ class TestOrchestration:
                 mij: pl.Tensor[[16, 1], pl.FP32],
                 lij: pl.Tensor[[16, 1], pl.FP32],
                 oi_new: pl.Tensor[[16, 16], pl.FP32],
-                mi: pl.Tensor[[16, 1], pl.FP32],
-                li: pl.Tensor[[16, 1], pl.FP32],
-                oi: pl.Tensor[[16, 16], pl.FP32],
-                dst: pl.Tensor[[16, 16], pl.FP32],
+                mi: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+                li: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+                oi: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                dst: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 1], pl.FP32],
                 pl.Tensor[[16, 1], pl.FP32],
@@ -599,7 +615,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -618,27 +634,36 @@ class TestOrchestration:
                 oi_in: pl.Tensor[[16, 16], pl.FP32],
                 dst_in: pl.Tensor[[16, 16], pl.FP32],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                mi, li, oi, dst = self.online_update(mij, lij, oi_new, mi_in, li_in, oi_in, dst_in)
-                final: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(oi, dst)
+                mi_in, li_in, oi_in, dst_in = self.online_update(
+                    mij, lij, oi_new, mi_in, li_in, oi_in, dst_in
+                )
+                final: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                final = self.kernel_add(oi_in, dst_in, final)
                 return final
 
         generator = codegen.CCECodegen()
         files = generator.generate(FourTupleProgram)
         code = files["orchestration/orch_four_tuple.cpp"]
 
-        # All 4 tuple elements are intermediate tensors with correct shapes
-        # [16, 1] FP32
-        assert "mi_shapes[2] = {16, 1}" in code
-        # [16, 16] FP32
-        assert "oi_shapes[2] = {16, 16}" in code
-        for name in ["mi", "li", "oi", "dst"]:
-            assert f"Tensor {name} = make_tensor(" in code, f"Missing make_tensor for {name}"
+        # All orch params are external tensors
+        assert "make_tensor_external(arg_mi_in_ptr" in code
+        assert "make_tensor_external(arg_oi_in_ptr" in code
+        assert "make_tensor_external(arg_dst_in_ptr" in code
 
         # Final return tensor is external
         assert "make_tensor_external(arg_final_ptr" in code
 
         # Two tasks: online_update + kernel_add
         assert code.count("pto2_rt_submit_task") == 2
+
+        # online_update: 3 In + 3 InOut + 1 Out = 7 params
+        assert "make_input_param(ext_mij)" in code
+        assert "make_inout_param(ext_mi_in)" in code
+        assert "make_output_param(ext_dst_in)" in code
+
+        # kernel_add: 2 In + 1 Out = 3 params
+        assert "make_input_param(ext_oi_in)" in code
+        assert "make_output_param(ext_final)" in code
 
         # No PTO2_SCOPE: no control flow
         assert "PTO2_SCOPE" not in code
@@ -654,7 +679,7 @@ class TestOrchestration:
             def kernel_fill(
                 self,
                 a: pl.Tensor[[32, 32], pl.FP16],
-                output: pl.Tensor[[32, 32], pl.FP16],
+                output: pl.Out[pl.Tensor[[32, 32], pl.FP16]],
             ) -> pl.Tensor[[32, 32], pl.FP16]:
                 t: pl.Tile[[32, 32], pl.FP16] = pl.load(a, [0, 0], [32, 32])
                 out: pl.Tensor[[32, 32], pl.FP16] = pl.store(t, [0, 0], [32, 32], output)
@@ -666,7 +691,8 @@ class TestOrchestration:
                 a: pl.Tensor[[32, 32], pl.FP16],
             ) -> pl.Tensor[[32, 32], pl.FP16]:
                 buf: pl.Tensor[[32, 32], pl.FP16] = pl.create_tensor([32, 32], dtype=pl.FP16)
-                result: pl.Tensor[[32, 32], pl.FP16] = self.kernel_fill(buf)
+                result: pl.Tensor[[32, 32], pl.FP16] = pl.create_tensor([32, 32], dtype=pl.FP16)
+                result = self.kernel_fill(buf, result)
                 return result
 
         generator = codegen.CCECodegen()
@@ -696,10 +722,10 @@ class TestOrchestration:
                 mij: pl.Tensor[[16, 1], pl.FP32],
                 lij: pl.Tensor[[16, 1], pl.FP32],
                 oi_new: pl.Tensor[[16, 16], pl.FP32],
-                mi: pl.Tensor[[16, 1], pl.FP32],
-                li: pl.Tensor[[16, 1], pl.FP32],
-                oi: pl.Tensor[[16, 16], pl.FP32],
-                dst: pl.Tensor[[16, 16], pl.FP32],
+                mi: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+                li: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+                oi: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                dst: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 1], pl.FP32],
                 pl.Tensor[[16, 1], pl.FP32],
@@ -731,7 +757,8 @@ class TestOrchestration:
                 pl.Tensor[[16, 16], pl.FP32],
                 pl.Tensor[[16, 16], pl.FP32],
             ]:
-                mi, li, oi, dst = self.online_update(mij, lij, oi_new, mi, li, oi)
+                dst: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                mi, li, oi, dst = self.online_update(mij, lij, oi_new, mi, li, oi, dst)
                 return mi, li, oi, dst
 
         generator = codegen.CCECodegen()
@@ -837,7 +864,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -852,7 +879,8 @@ class TestOrchestration:
                 b: pl.Tensor[[64, 128], pl.FP32],
             ) -> pl.Tensor[[64, 128], pl.FP32]:
                 d0: pl.Scalar[pl.INT64] = pl.tensor.dim(a, 0)  # noqa: F841
-                result: pl.Tensor[[64, 128], pl.FP32] = self.kernel_add(a, b)
+                result: pl.Tensor[[64, 128], pl.FP32] = pl.create_tensor([64, 128], dtype=pl.FP32)
+                result = self.kernel_add(a, b, result)
                 return result
 
         generator = codegen.CCECodegen()
@@ -878,7 +906,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 b: pl.Tensor[[16, 16], pl.FP32],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
@@ -897,7 +925,8 @@ class TestOrchestration:
                 out: pl.Tensor[[64, 16], pl.FP32] = data
                 for i in pl.range(n_blocks):
                     chunk: pl.Tensor[[16, 16], pl.FP32] = pl.view(data, [16, 16], [i * 16, 0])
-                    result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(chunk, bias)  # noqa: F841
+                    result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                    result = self.kernel_add(chunk, bias, result)  # noqa: F841
                 return out
 
         generator = codegen.CCECodegen()
@@ -931,7 +960,7 @@ class TestOrchestration:
                 self,
                 a: pl.Tensor[[16, 16], pl.FP32],
                 flag: pl.Scalar[pl.INT64],
-                output: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
                 out: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], [16, 16], output)
@@ -947,7 +976,8 @@ class TestOrchestration:
                         is_first: pl.Scalar[pl.INT64] = pl.yield_(1)
                     else:
                         is_first: pl.Scalar[pl.INT64] = pl.yield_(0)
-                    result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_process(a, is_first)
+                    result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                    result = self.kernel_process(a, is_first, result)
                 return result
 
         generator = codegen.CCECodegen()
@@ -980,8 +1010,8 @@ class TestOrchestration:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_a(
                 self,
-                x: pl.Tensor[[16, 16], pl.FP32],
-                y: pl.Tensor[[16, 16], pl.FP32],
+                x: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                y: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 16], pl.FP32],
                 pl.Tensor[[16, 16], pl.FP32],
@@ -995,8 +1025,8 @@ class TestOrchestration:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_b(
                 self,
-                a: pl.Tensor[[16, 16], pl.FP32],
-                b: pl.Tensor[[16, 16], pl.FP32],
+                a: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                b: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 16], pl.FP32],
                 pl.Tensor[[16, 16], pl.FP32],
@@ -1075,8 +1105,8 @@ class TestOrchestration:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_init(
                 self,
-                a: pl.Tensor[[16, 16], pl.FP32],
-                b: pl.Tensor[[16, 16], pl.FP32],
+                a: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                b: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 16], pl.FP32],
                 pl.Tensor[[16, 16], pl.FP32],
@@ -1091,8 +1121,8 @@ class TestOrchestration:
             def kernel_update(
                 self,
                 x: pl.Tensor[[16, 16], pl.FP32],
-                a: pl.Tensor[[16, 16], pl.FP32],
-                b: pl.Tensor[[16, 16], pl.FP32],
+                a: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                b: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
             ) -> tuple[
                 pl.Tensor[[16, 16], pl.FP32],
                 pl.Tensor[[16, 16], pl.FP32],
@@ -1132,7 +1162,8 @@ class TestOrchestration:
         assert "b_acc = b_acc;" not in code
 
         # make_tensor declarations exist (exactly once each)
-        assert code.count("Tensor a_acc = make_tensor(") == 1
+        # a_acc is a return value → external (make_tensor_external)
+        assert code.count("Tensor ext_a_acc = make_tensor_external(") == 1
         assert code.count("Tensor b_acc = make_tensor(") == 1
 
         # For loop exists with correct structure


### PR DESCRIPTION
## Summary

This PR replaces the heuristic SSA base-name matching approach in `OrchestrationStmtCodegen` with an authoritative lookup into `callee_func->param_directions_` (introduced in #279) to classify each call argument as `make_input_param`, `make_output_param`, or `make_inout_param`.

### Motivation

The previous approach inferred parameter direction by:
1. Collecting the call's result SSA variables as "outputs"
2. Stripping SSA suffixes (`GetSSABaseName`) from both input args and output vars, then matching on the shared base name

This was fragile: it relied on naming conventions surviving SSA transforms and could silently misclassify args when names diverged (e.g., after loop iter-arg renaming). It also required a separate post-loop pass to emit `make_tensor` for intermediate output tensors, adding ~60 lines of bookkeeping code.

### Changes

- **`orchestration_codegen.cpp`**
  - Replace `output_tensor_names` / `output_base_to_var` / `inout_output_vars` heuristic with a single index-driven lookup: `callee_func->param_directions_[arg_idx]`
  - Add `INTERNAL_CHECK` bounds guard before the index access
  - Add early-return for `tensor.create` on params/return-value vars (already declared as `make_tensor_external`, no re-declaration needed)
  - Remove the now-redundant inline `make_tensor` emission block for intermediate output tensors (~60 lines deleted)

- **`examples/ir_parser/paged_attention_example.py`**
  - Annotate output-only kernel params with `pl.Out[...]`
  - Annotate read-modify-write kernel params with `pl.InOut[...]`

- **`tests/ut/codegen/test_orchestration_codegen.py`**
  - Update all test kernels to use `pl.Out[...]` annotations
  - Update orchestration functions to pre-allocate output tensors via `pl.create_tensor(...)` and pass them explicitly

## Related Issues

Depends on #279 (`feat(ir): Add ParamDirection (In/Out/InOut) to Function`)