### PR TITLE
feat(op): add tmp_tile argument to block.sum for CCE workspace support

### DIFF
--- a/examples/ir_builder/block_ops_example.py
+++ b/examples/ir_builder/block_ops_example.py
@@ -92,7 +92,8 @@ def build_block_reduction_example():
         )
 
         # Perform reduction sum along the last axis (axis=1)
-        tile_sum = ib.let("tile_sum", block.sum(tile_in, axis=1, keepdim=True))
+        tmp_tile = ib.let("tmp_tile", block.create_tile([tile_height, tile_width], DataType.FP32))
+        tile_sum = ib.let("tile_sum", block.sum(tile_in, tmp_tile, axis=1, keepdim=True))
 
         # Copy reduction result back to tensor
         result = ib.let("result", block.store(tile_sum, [row_offset, 0], [tile_height, 1], output_tensor))
@@ -189,7 +190,8 @@ def build_complex_block_computation():
         tile_sqrt = ib.let("tile_sqrt", block.sqrt(tile_add))
 
         # Perform reduction: sum(axis=1)
-        tile_sum = ib.let("tile_sum", block.sum(tile_sqrt, axis=1, keepdim=True))
+        tmp_tile = ib.let("tmp_tile", block.create_tile([tile_height, tile_width], DataType.FP32))
+        tile_sum = ib.let("tile_sum", block.sum(tile_sqrt, tmp_tile, axis=1, keepdim=True))
 
         # Copy result back to tensor
         result = ib.let("result", block.store(tile_sum, [row_offset, 0], [tile_height, 1], output))
@@ -669,7 +671,8 @@ def build_block_row_sum_example():
         tile_in = ib.let("tile_in", block.load(input_tensor, offsets=[0, 0], shapes=[32, 128]))
 
         # Compute row-wise sum (reduce along axis 1 with keepdim=True)
-        tile_sum = ib.let("tile_sum", block.sum(tile_in, axis=1, keepdim=True))
+        tmp_tile = ib.let("tmp_tile", block.create_tile([32, 128], DataType.FP32))
+        tile_sum = ib.let("tile_sum", block.sum(tile_in, tmp_tile, axis=1, keepdim=True))
 
         # Store result
         result = ib.let(
@@ -701,7 +704,8 @@ def build_block_col_sum_example():
         tile_in = ib.let("tile_in", block.load(input_tensor, offsets=[0, 0], shapes=[128, 32]))
 
         # Compute column-wise sum (reduce along axis 0 with keepdim=True)
-        tile_sum = ib.let("tile_sum", block.sum(tile_in, axis=0, keepdim=True))
+        tmp_tile = ib.let("tmp_tile", block.create_tile([128, 32], DataType.FP32))
+        tile_sum = ib.let("tile_sum", block.sum(tile_in, tmp_tile, axis=0, keepdim=True))
 
         # Store result
         result = ib.let(

--- a/python/pypto/ir/op/block_ops.py
+++ b/python/pypto/ir/op/block_ops.py
@@ -1428,11 +1428,12 @@ def mins(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
 # ============================================================================
 
 
-def sum(tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) -> Call:
+def sum(tile: Expr, tmp_tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) -> Call:
     """Sum reduction of a tile along specified axis.
 
     Args:
         tile: Input tile (TileType)
+        tmp_tile: Temporary tile for reduction workspace
         axis: Reduction axis (0 for row reduction, 1 for column reduction, -1 for last axis)
         keepdim: Whether to keep the reduced dimension as 1 (default: False)
         span: Optional source span for debugging (auto-captured if not provided)
@@ -1442,7 +1443,7 @@ def sum(tile: Expr, axis: int, keepdim: bool = False, span: Span | None = None) 
     """
 
     actual_span = _get_span_or_capture(span)
-    args = [tile]
+    args = [tile, tmp_tile]
 
     kwargs: dict[str, Any] = {
         "axis": axis,

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -871,18 +871,19 @@ def cmps(lhs: Tile, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tile
     return Tile(expr=call_expr)
 
 
-def sum(tile: Tile, axis: int, keepdim: bool = False) -> Tile:
+def sum(tile: Tile, tmp_tile: Tile, axis: int, keepdim: bool = False) -> Tile:
     """Sum reduction along specified axis.
 
     Args:
         tile: Input tile
+        tmp_tile: Temporary tile for reduction workspace
         axis: Reduction axis (0 for rows, 1 for columns, -1 for last)
         keepdim: Whether to keep the reduced dimension as 1
 
     Returns:
         Tile wrapping the sum operation
     """
-    call_expr = _ir_ops.sum(tile.unwrap(), axis, keepdim)
+    call_expr = _ir_ops.sum(tile.unwrap(), tmp_tile.unwrap(), axis, keepdim)
     return Tile(expr=call_expr)
 
 

--- a/tests/ut/ir/operators/test_block_ops.py
+++ b/tests/ut/ir/operators/test_block_ops.py
@@ -297,7 +297,10 @@ class TestBlockReductionOps:
                 output: pl.Tensor[[128, 128], pl.FP32],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
-                tile_c: pl.Tile[[1, 32], pl.FP32] = pl.sum(tile_a, axis=0)
+                tmp: pl.Tile[[1, 32], pl.FP32] = pl.create_tile(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                tile_c: pl.Tile[[1, 32], pl.FP32] = pl.sum(tile_a, tmp, axis=0)
                 result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], [1, 32], output)
                 return result
 
@@ -316,7 +319,10 @@ class TestBlockReductionOps:
                 output: pl.Tensor[[128, 128], pl.FP32],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
-                tile_c: pl.Tile[[32, 1], pl.FP32] = pl.sum(tile_a, axis=1)
+                tmp: pl.Tile[[32, 1], pl.FP32] = pl.create_tile(
+                    [32, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                tile_c: pl.Tile[[32, 1], pl.FP32] = pl.sum(tile_a, tmp, axis=1)
                 result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], [32, 1], output)
                 return result
 


### PR DESCRIPTION
Background
The CCE hardware intrinsics TCOLSUM and TROWSUM both require a workspace buffer (tmp_tile). Previously, block.sum only accepted one argument (tile), making it impossible to pass the required workspace at codegen time.

Changes
C++ IR (src/ir/op/block_ops)

block.sum now takes a second argument tmp_tile
Refactored type deduction into three functions:
ComputeReductionOutputType: shared helper that computes output shape from axis/keepdim kwargs
DeduceBlockSumType: used by block.sum (2 args, validates tmp_tile is TileType)
DeduceBlockReductionType: used by block.max/block.min (1 arg, unchanged behavior)
C++ Backend (src/backend/910B_CCE/backend_910b_cce_ops.cpp)

block.sum axis=0 → TCOLSUM(result, tile, tmp_tile, false) (2 args)
block.sum axis=1 → TROWSUM(result, tile, tmp_tile) (2 args)
block.max/block.min axis=1 → new MakeBlockRowReduction1ArgCodegenCCE emitting TROWMAX/TROWMIN(result, tile) (1 arg, no tmp_tile needed)
Python (python/pypto/ir/op/block_ops.py, python/pypto/language/op/block_ops.py)

Added tmp_tile parameter to sum()
Tests & Examples

tests/ut/ir/operators/test_block_ops.py: updated block.sum cases to pass tmp_tile
examples/ir_builder/block_ops_example.py: updated all block.sum call sites