### PR TITLE
refactor(test): import example programs in st tests to eliminate duplication

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/examples/ir_parser/__init__.py
+++ b/examples/ir_parser/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/examples/ir_parser/orchestration_example.py
+++ b/examples/ir_parser/orchestration_example.py
@@ -36,7 +36,7 @@ class ExampleOrchProgram:
         self,
         a: pl.Tensor[[16, 16], pl.FP32],
         b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Adds two tensors element-wise: result = a + b"""
         a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -50,7 +50,7 @@ class ExampleOrchProgram:
         self,
         a: pl.Tensor[[16, 16], pl.FP32],
         scalar: pl.Scalar[pl.FP32],
-        output: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Adds a scalar to each element: result = a + scalar"""
         x: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -63,7 +63,7 @@ class ExampleOrchProgram:
         self,
         a: pl.Tensor[[16, 16], pl.FP32],
         b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Multiplies two tensors element-wise: result = a * b"""
         a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
@@ -92,25 +92,25 @@ class ExampleOrchProgram:
         Args:
             a: Input tensor A
             b: Input tensor B
-            c: Temp buffer for a + b
-            d: Temp buffer for c + 1
-            e: Temp buffer for c + 2
-            output: Final output buffer for d * e
 
         Returns:
             Final result tensor
         """
         # Task 0: c = a + b (call kernel_add with output buffer c)
-        c: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add(a, b)
+        c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+        c = self.kernel_add(a, b, c)
 
         # Task 1: d = c + 1 (call kernel_add_scalar with output buffer d)
-        d: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
+        d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
 
         # Task 2: e = c + 2 (call kernel_add_scalar with output buffer e)
-        e: pl.Tensor[[16, 16], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
+        e: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
 
         # Task 3: f = d * e (call kernel_mul with output buffer)
-        f_result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_mul(d, e)
+        f_result: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+        f_result = self.kernel_mul(d, e, f_result)
         return f_result
 
 

--- a/examples/ir_parser/vector_example_dag.py
+++ b/examples/ir_parser/vector_example_dag.py
@@ -39,7 +39,7 @@ class VectorExampleProgram:
         self,
         a: pl.Tensor[[128, 128], pl.FP32],
         b: pl.Tensor[[128, 128], pl.FP32],
-        output: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         """Adds two tensors element-wise: result = a + b"""
         a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
@@ -53,7 +53,7 @@ class VectorExampleProgram:
         self,
         a: pl.Tensor[[128, 128], pl.FP32],
         scalar: pl.Scalar[pl.FP32],
-        output: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         """Adds a scalar to each element: result = a + scalar"""
         x: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
@@ -66,7 +66,7 @@ class VectorExampleProgram:
         self,
         a: pl.Tensor[[128, 128], pl.FP32],
         b: pl.Tensor[[128, 128], pl.FP32],
-        output: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         """Multiplies two tensors element-wise: result = a * b"""
         a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
@@ -90,11 +90,16 @@ class VectorExampleProgram:
           t3: g = kernel_mul(d, e)
           t4: f = kernel_add(g, c)
         """
-        c: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add(a, b)
-        d: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add_scalar(c, 1.0)  # type: ignore[reportArgumentType]
-        e: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add_scalar(c, 2.0)  # type: ignore[reportArgumentType]
-        g: pl.Tensor[[128, 128], pl.FP32] = self.kernel_mul(d, e)
-        f: pl.Tensor[[128, 128], pl.FP32] = self.kernel_add(g, c)
+        c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        c = self.kernel_add(a, b, c)
+        d: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+        e: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+        g: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        g = self.kernel_mul(d, e, g)
+        f: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        f = self.kernel_add(g, c, f)
         return f
 
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -24,6 +24,11 @@ _ST_DIR = Path(__file__).parent
 if str(_ST_DIR) not in sys.path:
     sys.path.insert(0, str(_ST_DIR))
 
+# Add project root to path so tests can import from examples/
+_PROJECT_ROOT = _ST_DIR.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 import pytest  # noqa: E402
 from harness.core.environment import ensure_simpler_available  # noqa: E402
 from harness.core.harness import TestConfig  # noqa: E402

--- a/tests/st/runtime/test_dag.py
+++ b/tests/st/runtime/test_dag.py
@@ -12,15 +12,19 @@ Tests for DAG (Directed Acyclic Graph) operations using PyPTO frontend.
 
 This test validates complex multi-kernel orchestration with mixed operations,
 ensuring correct code generation and execution for DAG-structured computations.
+
+The program definition is imported from examples/ir_parser/vector_example_dag.py
+to keep a single source of truth and ensure examples are guarded by tests.
 """
 
 from typing import Any
 
-import pypto.language as pl
 import pytest
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
+
+from examples.ir_parser.vector_example_dag import VectorExampleProgram
 
 
 class TestVectorDAG(PTOTestCase):
@@ -49,79 +53,7 @@ class TestVectorDAG(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        @pl.program
-        class VectorDAGProgram:
-            """Vector example program with 3 InCore kernels and 1 Orchestration function."""
-
-            @pl.function(type=pl.FunctionType.InCore)
-            def kernel_add(
-                self,
-                a: pl.Tensor[[128, 128], pl.FP32],
-                b: pl.Tensor[[128, 128], pl.FP32],
-                output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-            ) -> pl.Tensor[[128, 128], pl.FP32]:
-                """Adds two tensors element-wise: result = a + b"""
-                a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
-                b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
-                result: pl.Tile[[128, 128], pl.FP32] = pl.add(a_tile, b_tile)
-                out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
-                return out
-
-            @pl.function(type=pl.FunctionType.InCore)
-            def kernel_add_scalar(
-                self,
-                a: pl.Tensor[[128, 128], pl.FP32],
-                scalar: pl.Scalar[pl.FP32],
-                output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-            ) -> pl.Tensor[[128, 128], pl.FP32]:
-                """Adds a scalar to each element: result = a + scalar"""
-                x: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
-                result: pl.Tile[[128, 128], pl.FP32] = pl.add(x, scalar)
-                out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
-                return out
-
-            @pl.function(type=pl.FunctionType.InCore)
-            def kernel_mul(
-                self,
-                a: pl.Tensor[[128, 128], pl.FP32],
-                b: pl.Tensor[[128, 128], pl.FP32],
-                output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-            ) -> pl.Tensor[[128, 128], pl.FP32]:
-                """Multiplies two tensors element-wise: result = a * b"""
-                a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
-                b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
-                result: pl.Tile[[128, 128], pl.FP32] = pl.mul(a_tile, b_tile)
-                out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
-                return out
-
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def orch_vector(
-                self,
-                a: pl.Tensor[[128, 128], pl.FP32],
-                b: pl.Tensor[[128, 128], pl.FP32],
-            ) -> pl.Tensor[[128, 128], pl.FP32]:
-                """Orchestration for formula: f = (a + b + 1)(a + b + 2) + (a + b)
-
-                Task graph:
-                t0: c = kernel_add(a, b)
-                t1: d = kernel_add_scalar(c, 1.0)
-                t2: e = kernel_add_scalar(c, 2.0)
-                t3: g = kernel_mul(d, e)
-                t4: f = kernel_add(g, c)
-                """
-                c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-                c = self.kernel_add(a, b, c)
-                d: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-                d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
-                e: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-                e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
-                g: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-                g = self.kernel_mul(d, e, g)
-                f: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-                f = self.kernel_add(g, c, f)
-                return f
-
-        return VectorDAGProgram
+        return VectorExampleProgram
 
     def compute_expected(self, tensors, params=None):
         """Compute expected result: f = (a + b + 1)(a + b + 2) + (a + b)"""


### PR DESCRIPTION
Update examples to use pl.Out pattern for InCore output params and explicit pl.create_tensor in orchestration functions. ST tests now import programs from examples/ instead of defining them inline, keeping a single source of truth and guarding examples via CI.

- examples/ir_parser/orchestration_example.py: pl.Out + create_tensor
- examples/ir_parser/vector_example_dag.py: pl.Out + create_tensor
- tests/st/codegen/test_add_mul_orch_cce_codegen.py: import ExampleOrchProgram
- tests/st/runtime/test_dag.py: import VectorExampleProgram
- tests/st/conftest.py: add project root to sys.path
- examples/__init__.py, examples/ir_parser/__init__.py: new (enable import)