### PR TITLE
feat(verifier): Add AllocatedMemoryAddr property verifier

### DIFF
--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -26,8 +26,8 @@ namespace ir {
  * Each value represents a property that the IR may or may not satisfy.
  * Passes can declare which properties they require, produce, and invalidate.
  * Not all passes produce properties — performance optimization passes
- * (BasicMemoryReuse, InsertSync, AllocateMemoryAddr) only have requirements but
- * don't produce new verifiable properties. This is by design.
+ * (BasicMemoryReuse, InsertSync) only have requirements but don't
+ * produce new verifiable properties. This is by design.
  */
 enum class IRProperty : uint64_t {
   SSAForm = 0,              ///< IR is in SSA form
@@ -38,6 +38,7 @@ enum class IRProperty : uint64_t {
   SplitIncoreOrch,          ///< InCore scopes outlined into separate functions
   HasMemRefs,               ///< MemRef objects initialized on variables
   IncoreBlockOps,           ///< InCore functions use block ops (tile types, load/store)
+  AllocatedMemoryAddr,      ///< All MemRefs have valid addresses within buffer limits
   kCount                    ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -76,7 +76,8 @@ inline const PassProperties kInsertSyncProperties{
 
 inline const PassProperties kAllocateMemoryAddrProperties{
     .required = {IRProperty::TypeChecked, IRProperty::SplitIncoreOrch, IRProperty::IncoreBlockOps,
-                 IRProperty::HasMemRefs}};
+                 IRProperty::HasMemRefs},
+    .produced = {IRProperty::AllocatedMemoryAddr}};
 
 }  // namespace pass
 }  // namespace ir

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -126,6 +126,15 @@ PropertyVerifierPtr CreateHasMemRefsPropertyVerifier();
  */
 PropertyVerifierPtr CreateIncoreBlockOpsPropertyVerifier();
 
+/**
+ * @brief Factory function for creating AllocatedMemoryAddr property verifier
+ *
+ * Verifies that all non-DDR MemRefs have valid allocated addresses and
+ * that total memory usage per space does not exceed platform buffer limits.
+ * @return Shared pointer to AllocatedMemoryAddr PropertyVerifier
+ */
+PropertyVerifierPtr CreateAllocatedMemoryAddrPropertyVerifier();
+
 // Backward compatibility aliases for factory functions
 inline VerifyRulePtr CreateSSAVerifyRule() { return CreateSSAPropertyVerifier(); }
 inline VerifyRulePtr CreateTypeCheckRule() { return CreateTypeCheckPropertyVerifier(); }

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -38,6 +38,8 @@ std::string IRPropertyToString(IRProperty prop) {
       return "HasMemRefs";
     case IRProperty::IncoreBlockOps:
       return "IncoreBlockOps";
+    case IRProperty::AllocatedMemoryAddr:
+      return "AllocatedMemoryAddr";
     default:
       return "Unknown";
   }

--- a/src/ir/verifier/property_verifier_registry.cpp
+++ b/src/ir/verifier/property_verifier_registry.cpp
@@ -43,6 +43,7 @@ PropertyVerifierRegistry::PropertyVerifierRegistry() {
   Register(IRProperty::SplitIncoreOrch, CreateSplitIncoreOrchPropertyVerifier);
   Register(IRProperty::HasMemRefs, CreateHasMemRefsPropertyVerifier);
   Register(IRProperty::IncoreBlockOps, CreateIncoreBlockOpsPropertyVerifier);
+  Register(IRProperty::AllocatedMemoryAddr, CreateAllocatedMemoryAddrPropertyVerifier);
 }
 
 void PropertyVerifierRegistry::Register(IRProperty prop, std::function<PropertyVerifierPtr()> factory) {


### PR DESCRIPTION
Verify that all non-DDR MemRefs have valid allocated addresses and that per-space memory usage does not exceed platform buffer limits from the configured backend.

- Add IRProperty::AllocatedMemoryAddr enum value
- Implement AllocatedMemoryAddrPropertyVerifierImpl in allocate_memory_addr_pass.cpp
- Register verifier in PropertyVerifierRegistry
- Update AllocateMemoryAddr pass to produce the new property
- Add unit tests for address validity and pipeline integration

Made-with: Cursor