### PR TITLE
feat(codegen/ir): Propagate TileView layout in block ops and CCE codegen

### DIFF
--- a/src/codegen/cce/type_converter.cpp
+++ b/src/codegen/cce/type_converter.cpp
@@ -41,13 +41,20 @@ std::string TypeConverter::ConvertTileType(const ir::TileTypePtr& tile_type, int
 
   // TODO(YunjiQin): BLayout and SLayout should be determined by the tile format
   std::string BLayout = "RowMajor";
+  std::string SLayout = "NoneBox";
+  std::string fractal = "512";
+
   if (cols == 1) {
     BLayout = "ColMajor";
   } else if (tile_type->tile_view_.has_value()) {
-    BLayout = ConvertTileLayout((*tile_type->tile_view_).blayout);
+    const auto& tv = tile_type->tile_view_.value();
+    BLayout = ConvertTileLayout(tv.blayout);
+    SLayout = ConvertTileLayout(tv.slayout);
+    fractal = std::to_string(tv.fractal);
   }
   type_alias << "Tile<" << tile_type_str << ", " << tile_type->dtype_.ToCTypeString() << ", " << rows << ", "
-             << cols << ", BLayout::" << BLayout << ", -1, -1>";
+             << cols << ", BLayout::" << BLayout << ", -1, -1, " << "SLayout::" << SLayout << ", " << fractal
+             << ">";
 
   return type_alias.str();
 }

--- a/tests/ut/codegen/test_cce_codegen.py
+++ b/tests/ut/codegen/test_cce_codegen.py
@@ -76,7 +76,8 @@ class TestCCECodegenBasics:
         assert "GlobalType" in code  # Check for GlobalType suffix (e.g., output_0GlobalType)
 
         # Verify Tile type definitions are generated
-        assert "Tile<TileType::Vec, float, 128, 128, BLayout::RowMajor, -1, -1>" in code
+        expected = "Tile<TileType::Vec, float, 128, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512>"
+        assert expected in code
         assert "Type tile_" in code  # Check for tile type declarations with suffix
         assert "TASSIGN(tile_" in code
 


### PR DESCRIPTION
## Summary
- Extends `ConvertTileType` in CCE type converter to always emit `SLayout` and fractal template arguments (defaulting to `NoneBox`/512 when no `tile_view` is set)
- Updates `DeduceBlockLoadType` and `DeduceBlockMoveType` to populate `TileView` with correct `Nz`/`Left`/`Right` layout metadata
- Simplifies `DeduceBlockMatMulAccType` to enforce identical input dtypes (A2A3 hardware requirement) instead of type promotion
- Fixes BF16 input types in the paged attention system test
- Updates codegen assertion to match the new Tile type format

## Testing
- [ ] All tests pass
- [ ] Code review completed
- [ ] Documentation updated