### PR TITLE
fix(printer): Fix sync ops printing

### DIFF
--- a/include/pypto/ir/pipe.h
+++ b/include/pypto/ir/pipe.h
@@ -12,6 +12,10 @@
 #ifndef PYPTO_IR_PIPE_H_
 #define PYPTO_IR_PIPE_H_
 
+#include <string>
+
+#include "pypto/core/error.h"
+
 namespace pypto {
 namespace ir {
 
@@ -28,6 +32,34 @@ enum PipeType : int {
   FIX,   ///< Fix Pipe (L0C -> UB)
   ALL    ///< All Pipes
 };
+
+/**
+ * @brief Convert PipeType to its string name
+ * @param pipe The pipeline type
+ * @return String representation (e.g., "MTE1", "MTE2", "V")
+ */
+inline std::string PipeTypeToString(PipeType pipe) {
+  switch (pipe) {
+    case PipeType::MTE1:
+      return "MTE1";
+    case PipeType::MTE2:
+      return "MTE2";
+    case PipeType::MTE3:
+      return "MTE3";
+    case PipeType::M:
+      return "M";
+    case PipeType::V:
+      return "V";
+    case PipeType::S:
+      return "S";
+    case PipeType::FIX:
+      return "FIX";
+    case PipeType::ALL:
+      return "ALL";
+    default:
+      throw pypto::TypeError("Unknown PipeType: " + std::to_string(static_cast<int>(pipe)));
+  }
+}
 
 /**
  * @brief Core type enumeration (numeric values must match runtime add_task expectation)

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -100,12 +100,17 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     std::string key = nb::cast<std::string>(item.first);
 
     // Try to cast to common types
-    // NOTE: Check DataType/MemorySpace BEFORE int, and bool BEFORE int (since they can be cast to int in
-    // Python)
+    // NOTE: Check DataType/MemorySpace/PipeType/CoreType BEFORE int, and bool BEFORE int
     if (nb::isinstance<DataType>(item.second)) {
       kwargs.emplace_back(key, nb::cast<DataType>(item.second));
     } else if (nb::isinstance<MemorySpace>(item.second)) {
       kwargs.emplace_back(key, nb::cast<MemorySpace>(item.second));
+    } else if (nb::isinstance<PipeType>(item.second)) {
+      // Cast enum to int for storage
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<PipeType>(item.second)));
+    } else if (nb::isinstance<CoreType>(item.second)) {
+      // Cast enum to int for storage
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<CoreType>(item.second)));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<bool>(item.second));
     } else if (nb::isinstance<nb::int_>(item.second)) {
@@ -114,12 +119,6 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       kwargs.emplace_back(key, nb::cast<std::string>(item.second));
     } else if (nb::isinstance<nb::float_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<double>(item.second));
-    } else if (nb::isinstance<PipeType>(item.second)) {
-      // Cast enum to int for storage
-      kwargs.emplace_back(key, static_cast<int>(nb::cast<PipeType>(item.second)));
-    } else if (nb::isinstance<CoreType>(item.second)) {
-      // Cast enum to int for storage
-      kwargs.emplace_back(key, static_cast<int>(nb::cast<CoreType>(item.second)));
     } else {
       throw pypto::TypeError("Unsupported kwarg type for key: " + key);
     }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -437,12 +438,23 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   }
 
   // Print kwargs as keyword arguments
+  bool need_comma = !op->args_.empty();
   for (const auto& [key, value] : op->kwargs_) {
-    stream_ << ", " << key << "=";
+    if (need_comma) {
+      stream_ << ", ";
+    }
+    need_comma = true;
+    stream_ << key << "=";
 
     // Print value based on type
     if (value.type() == typeid(int)) {
-      stream_ << AnyCast<int>(value, "printing kwarg: " + key);
+      int int_val = AnyCast<int>(value, "printing kwarg: " + key);
+      // Print pipe kwargs as PipeType enum names for readability
+      if (key == "set_pipe" || key == "wait_pipe") {
+        stream_ << prefix_ << ".PipeType." << PipeTypeToString(static_cast<PipeType>(int_val));
+      } else {
+        stream_ << int_val;
+      }
     } else if (value.type() == typeid(bool)) {
       stream_ << (AnyCast<bool>(value, "printing kwarg: " + key) ? "True" : "False");
     } else if (value.type() == typeid(std::string)) {

--- a/tests/ut/ir/statements/test_eval_stmt.py
+++ b/tests/ut/ir/statements/test_eval_stmt.py
@@ -37,12 +37,11 @@ def test_eval_stmt_python_print():
 
     # Print
     code = ir.python_print(stmt)
-    # The output should look like: system.sync_src(set_pipe=1, wait_pipe=4, event_id=1)
-    # Note: Enums are currently printed as their integer values in kwargs because they are stored as ints
     assert "system.sync_src(" in code
-    assert "set_pipe=" in code
-    assert "wait_pipe=" in code
+    assert "set_pipe=pl.PipeType.MTE2" in code
+    assert "wait_pipe=pl.PipeType.V" in code
     assert "event_id=1" in code
+    assert "(, " not in code  # no stray comma for no-argument ops
 
 
 def test_eval_stmt_serialization():


### PR DESCRIPTION
Fix python_printer to print PipeType enum names (e.g., pl.PipeType.MTE3) instead of raw integers for pipe-related kwargs. Reorder enum type checks in ConvertKwargsDict so PipeType and CoreType are matched before generic int, preventing loss of enum identity. Fix stray leading comma when printing kwargs with no positional arguments.

  Before: pl.set_sync(, set_pipe=2, wait_pipe=0)
  After:  pl.set_sync(set_pipe=pl.PipeType.MTE3, wait_pipe=pl.PipeType.MTE1)