### PR TITLE
test(st): Add example programs and fix runtime tests

### DIFF
--- a/examples/language/__init__.py
+++ b/examples/language/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/examples/language/beginner/__init__.py
+++ b/examples/language/beginner/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/examples/language/beginner/basic_ops.py
+++ b/examples/language/beginner/basic_ops.py
@@ -1,0 +1,171 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Basic fused operations using PyPTO language DSL.
+
+Four fused operation patterns:
+  FusedAddScaleProgram    — c = (a + b) * 2.0
+  FusedAddReluProgram     — c = relu(a + b)
+  FusedMatmulBiasProgram  — c = matmul(a, b) + bias
+  FusedLinearReluProgram  — y = relu(matmul(x, w) + bias)
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class FusedAddScaleProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def fused_add_scale(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Fused: load a, b → add → scale by 2.0 → store c."""
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[128, 128])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[128, 128])
+        tile_sum = pl.add(tile_a, tile_b)
+        tile_c = pl.mul(tile_sum, 2.0)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[128, 128], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        out_c = self.fused_add_scale(a, b, out_c)
+        return out_c
+
+
+@pl.program
+class FusedAddReluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def fused_add_relu(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Fused: load a, b → add → relu → store c."""
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[128, 128])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[128, 128])
+        tile_sum = pl.add(tile_a, tile_b)
+        tile_c = pl.relu(tile_sum)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[128, 128], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        out_c = self.fused_add_relu(a, b, out_c)
+        return out_c
+
+
+@pl.program
+class FusedMatmulBiasProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Cube InCore: compute a @ b and store to output."""
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out = pl.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def add_bias_kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        bias: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Vector InCore: add bias to x and store to output."""
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[64, 64])
+        tile_bias = pl.load(bias, offsets=[0, 0], shapes=[64, 64])
+        tile_c = pl.add(tile_x, tile_bias)
+        out = pl.store(tile_c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        bias: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Orchestrate: c = matmul(a, b) + bias"""
+        mm_out: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        mm_out = self.matmul_kernel(a, b, mm_out)
+        c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        c = self.add_bias_kernel(mm_out, bias, c)
+        return c
+
+
+@pl.program
+class FusedLinearReluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        w: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Cube InCore: compute x @ w and store to output."""
+        tile_x_l1 = pl.load(x, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_w_l1 = pl.load(w, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_x_l0a = pl.move(tile_x_l1, target_memory=pl.MemorySpace.Left)
+        tile_w_l0b = pl.move(tile_w_l1, target_memory=pl.MemorySpace.Right)
+        tile_out_l0c = pl.matmul(tile_x_l0a, tile_w_l0b)
+        out = pl.l0c_store(tile_out_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def add_bias_relu_kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        bias: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Vector InCore: fused bias add and relu activation."""
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[64, 64])
+        tile_bias = pl.load(bias, offsets=[0, 0], shapes=[64, 64])
+        tile_biased = pl.add(tile_x, tile_bias)
+        tile_y = pl.relu(tile_biased)
+        out = pl.store(tile_y, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        w: pl.Tensor[[64, 64], pl.FP32],
+        bias: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Orchestrate: y = relu(matmul(x, w) + bias)"""
+        mm_out: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        mm_out = self.matmul_kernel(x, w, mm_out)
+        y: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        y = self.add_bias_relu_kernel(mm_out, bias, y)
+        return y

--- a/examples/language/beginner/elementwise.py
+++ b/examples/language/beginner/elementwise.py
@@ -1,0 +1,116 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Tile element-wise operations: add and multiply, in 128x128 and 64x64 shapes.
+
+Programs:
+  TileAdd128Program  — c = a + b  (128x128)
+  TileAdd64Program   — c = a + b  (64x64)
+  TileMul128Program  — c = a * b  (128x128)
+  TileMul64Program   — c = a * b  (64x64)
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class TileAdd128Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[128, 128])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[128, 128])
+        tile_c = pl.add(tile_a, tile_b)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[128, 128], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        out_c = self.tile_add(a, b, out_c)
+        return out_c
+
+
+@pl.program
+class TileAdd64Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[64, 64])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[64, 64])
+        tile_c = pl.add(tile_a, tile_b)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[64, 64], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c = self.tile_add(a, b, out_c)
+        return out_c
+
+
+@pl.program
+class TileMul128Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_mul(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[128, 128])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[128, 128])
+        tile_c = pl.mul(tile_a, tile_b)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[128, 128], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        out_c = self.tile_mul(a, b, out_c)
+        return out_c
+
+
+@pl.program
+class TileMul64Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_mul(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[64, 64])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[64, 64])
+        tile_c = pl.mul(tile_a, tile_b)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[64, 64], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c = self.tile_mul(a, b, out_c)
+        return out_c

--- a/examples/language/beginner/hello_world.py
+++ b/examples/language/beginner/hello_world.py
@@ -1,0 +1,49 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Hello World: element-wise tensor addition using PyPTO language DSL.
+
+Program structure:
+  InCore function  ``tile_add``
+    - Loads tile_a and tile_b from global memory (GM) into registers (UB).
+    - Computes tile_c = tile_a + tile_b using the vector unit.
+    - Stores tile_c back to the output tensor in GM.
+
+  Orchestration function  ``orchestrator``
+    - Calls ``tile_add`` once to process the whole tensor in one shot.
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class HelloWorldProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, offsets=[0, 0], shapes=[128, 128])
+        tile_b = pl.load(b, offsets=[0, 0], shapes=[128, 128])
+        tile_c = pl.add(tile_a, tile_b)
+        out_c = pl.store(tile_c, offsets=[0, 0], shapes=[128, 128], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        out_c = self.tile_add(a, b, out_c)
+        return out_c

--- a/examples/language/beginner/matmul.py
+++ b/examples/language/beginner/matmul.py
@@ -1,0 +1,50 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Matrix multiplication using PyPTO language DSL (cube unit, 64x64).
+
+Program structure:
+  InCore function  ``matmul``
+    - Loads tiles from GM → L1 (Mat space), then to L0A/L0B.
+    - Computes matrix multiplication on the cube unit.
+    - Stores L0C result directly back to GM.
+
+  Orchestration function  ``orchestrator``
+    - Calls ``matmul`` once for the full 64x64 computation.
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class MatmulProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        # store can support l0c -> GM directly
+        out_c = pl.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 64], pl.FP32], b: pl.Tensor[[64, 64], pl.FP32]
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c = self.matmul(a, b, out_c)
+        return out_c

--- a/examples/language/intermediate/__init__.py
+++ b/examples/language/intermediate/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/examples/language/intermediate/ffn_activations.py
+++ b/examples/language/intermediate/ffn_activations.py
@@ -1,0 +1,144 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+FFN activation functions using PyPTO language DSL.
+
+Programs:
+  GeluProgram    — GELU:   output = x * sigmoid(1.702 * x)        (128x128)
+  SwigluProgram  — SwiGLU: output = gate * sigmoid(gate) * up     (64x64)
+  SiluProgram    — SiLU:   output = x * sigmoid(x)                (64x64)
+  GegluProgram   — GeGLU:  output = gate * sigmoid(1.702 * gate) * up  (64x64)
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class GeluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_gelu(
+        self,
+        x: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_x: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+        x_scaled: pl.Tile[[128, 128], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
+        x_neg: pl.Tile[[128, 128], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[128, 128], pl.FP32] = pl.exp(x_neg)
+        denom: pl.Tile[[128, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[128, 128], pl.FP32] = pl.recip(denom)
+        result: pl.Tile[[128, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def gelu_orch(
+        self,
+        x: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        output: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        output = self.kernel_gelu(x, output)
+        return output
+
+
+@pl.program
+class SwigluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_swiglu(
+        self,
+        gate: pl.Tensor[[64, 64], pl.FP32],
+        up: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # Swish(gate) = gate * sigmoid(gate) = gate / (1 + exp(-gate))
+        # Note: -1.0 and 1.0 are inlined as literals; outer variables
+        # are not accessible inside the DSL kernel closure.
+        tile_gate: pl.Tile[[64, 64], pl.FP32] = pl.load(gate, [0, 0], [64, 64])
+        tile_up: pl.Tile[[64, 64], pl.FP32] = pl.load(up, [0, 0], [64, 64])
+        gate_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(gate_neg)
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
+        swish: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, sigmoid)
+        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(swish, tile_up)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def swiglu_orch(
+        self,
+        gate: pl.Tensor[[64, 64], pl.FP32],
+        up: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.kernel_swiglu(gate, up, output)
+        return output
+
+
+@pl.program
+class SiluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_silu(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+        tile_x: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+        x_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(x_neg)
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
+        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, sigmoid)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def silu_orch(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.kernel_silu(x, output)
+        return output
+
+
+@pl.program
+class GegluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_geglu(
+        self,
+        gate: pl.Tensor[[64, 64], pl.FP32],
+        up: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # GeGLU(gate, up) = GELU(gate) * up
+        # GELU approximation: gate * sigmoid(1.702 * gate)
+        tile_gate: pl.Tile[[64, 64], pl.FP32] = pl.load(gate, [0, 0], [64, 64])
+        tile_up: pl.Tile[[64, 64], pl.FP32] = pl.load(up, [0, 0], [64, 64])
+        gate_scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, 1.702)  # type: ignore[reportArgumentType]
+        gate_scaled_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(gate_scaled, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(gate_scaled_neg)
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
+        gelu_gate: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, sigmoid)
+        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(gelu_gate, tile_up)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def geglu_orch(
+        self,
+        gate: pl.Tensor[[64, 64], pl.FP32],
+        up: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.kernel_geglu(gate, up, output)
+        return output

--- a/examples/language/intermediate/layer_norm.py
+++ b/examples/language/intermediate/layer_norm.py
@@ -1,0 +1,88 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Layer normalization using PyPTO language DSL.
+
+Formula: output = (x - mean) / sqrt(var + eps) * gamma + beta
+
+Computed on 32x64 input, normalizing across the hidden dimension (64).
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class LayerNormProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_layer_norm(
+        self,
+        x: pl.Tensor[[32, 64], pl.FP32],
+        gamma: pl.Tensor[[1, 64], pl.FP32],
+        beta: pl.Tensor[[1, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
+    ) -> pl.Tensor[[32, 64], pl.FP32]:
+        tile_x: pl.Tile[[32, 64], pl.FP32] = pl.load(x, [0, 0], [32, 64])
+        tile_gamma: pl.Tile[[1, 64], pl.FP32] = pl.load(gamma, [0, 0], [1, 64])
+        tile_beta: pl.Tile[[1, 64], pl.FP32] = pl.load(beta, [0, 0], [1, 64])
+
+        # [32, 1] tiles are ColMajor; scalar ops (mul/add) need RowMajor.
+        # Workaround: reshape [32, 1] -> [1, 32], apply op, reshape back.
+
+        # mean = sum(x, dim=-1, keepdim=True) / hidden_size
+        tmp: pl.Tile[[32, 64], pl.FP32] = pl.create_tile(
+            [32, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        mean: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(tile_x, tmp)
+        mean_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean, [1, 32])
+        mean_T = pl.mul(mean_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        mean = pl.reshape(mean_T, [32, 1])
+
+        # centered = x - mean (broadcast mean across hidden dim)
+        centered: pl.Tile[[32, 64], pl.FP32] = pl.row_expand_sub(tile_x, mean)
+
+        # var = sum(centered^2, dim=-1, keepdim=True) / hidden_size
+        squared: pl.Tile[[32, 64], pl.FP32] = pl.mul(centered, centered)
+        tmp2: pl.Tile[[32, 64], pl.FP32] = pl.create_tile(
+            [32, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        var: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(squared, tmp2)
+        var_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(var, [1, 32])
+        var_T = pl.mul(var_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        var = pl.reshape(var_T, [32, 1])
+
+        # std = sqrt(var + eps)
+        var_T2: pl.Tile[[1, 32], pl.FP32] = pl.reshape(var, [1, 32])
+        var_eps_T: pl.Tile[[1, 32], pl.FP32] = pl.add(var_T2, 1e-5)  # type: ignore[reportArgumentType]
+        std_T: pl.Tile[[1, 32], pl.FP32] = pl.sqrt(var_eps_T)
+        std: pl.Tile[[32, 1], pl.FP32] = pl.reshape(std_T, [32, 1])
+
+        # normalized = centered / std (broadcast std across hidden dim)
+        normalized: pl.Tile[[32, 64], pl.FP32] = pl.row_expand_div(centered, std)
+
+        # scaled = normalized * gamma (broadcast gamma across batch)
+        scaled: pl.Tile[[32, 64], pl.FP32] = pl.col_expand_mul(normalized, tile_gamma)
+
+        # result = scaled + beta (broadcast beta across batch)
+        beta_full: pl.Tile[[32, 64], pl.FP32] = pl.col_expand(scaled, tile_beta)
+        result: pl.Tile[[32, 64], pl.FP32] = pl.add(scaled, beta_full)
+
+        out: pl.Tensor[[32, 64], pl.FP32] = pl.store(result, [0, 0], [32, 64], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def layer_norm_orch(
+        self,
+        x: pl.Tensor[[32, 64], pl.FP32],
+        gamma: pl.Tensor[[1, 64], pl.FP32],
+        beta: pl.Tensor[[1, 64], pl.FP32],
+    ) -> pl.Tensor[[32, 64], pl.FP32]:
+        output: pl.Tensor[[32, 64], pl.FP32] = pl.create_tensor([32, 64], dtype=pl.FP32)
+        output = self.kernel_layer_norm(x, gamma, beta, output)
+        return output

--- a/examples/language/intermediate/rms_norm.py
+++ b/examples/language/intermediate/rms_norm.py
@@ -1,0 +1,71 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+RMS normalization using PyPTO language DSL.
+
+Formula: output = x / sqrt(mean(x^2) + eps) * gamma
+
+Computed on 32x64 input, normalizing across the hidden dimension (64).
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class RMSNormProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_rms_norm(
+        self,
+        x: pl.Tensor[[32, 64], pl.FP32],
+        gamma: pl.Tensor[[1, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
+    ) -> pl.Tensor[[32, 64], pl.FP32]:
+        tile_x: pl.Tile[[32, 64], pl.FP32] = pl.load(x, [0, 0], [32, 64])
+        tile_gamma: pl.Tile[[1, 64], pl.FP32] = pl.load(gamma, [0, 0], [1, 64])
+
+        # [32, 1] tiles are ColMajor; scalar ops (mul/add) need RowMajor.
+        # Workaround: reshape [32, 1] -> [1, 32], apply op, reshape back.
+
+        # squared = x * x
+        squared: pl.Tile[[32, 64], pl.FP32] = pl.mul(tile_x, tile_x)
+
+        # mean_sq = sum(x^2, dim=-1, keepdim=True) / hidden_size
+        tmp: pl.Tile[[32, 64], pl.FP32] = pl.create_tile(
+            [32, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        mean_sq: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(squared, tmp)
+        mean_sq_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean_sq, [1, 32])
+        mean_sq_T = pl.mul(mean_sq_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        mean_sq = pl.reshape(mean_sq_T, [32, 1])
+
+        # rms = sqrt(mean_sq + eps)
+        mean_sq_T2: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean_sq, [1, 32])
+        rms_T: pl.Tile[[1, 32], pl.FP32] = pl.add(mean_sq_T2, 1e-5)  # type: ignore[reportArgumentType]
+        rms_T = pl.sqrt(rms_T)
+        rms: pl.Tile[[32, 1], pl.FP32] = pl.reshape(rms_T, [32, 1])
+
+        # normalized = x / rms (broadcast rms across hidden dim)
+        normalized: pl.Tile[[32, 64], pl.FP32] = pl.row_expand_div(tile_x, rms)
+
+        # result = normalized * gamma (broadcast gamma across batch)
+        result: pl.Tile[[32, 64], pl.FP32] = pl.col_expand_mul(normalized, tile_gamma)
+
+        out: pl.Tensor[[32, 64], pl.FP32] = pl.store(result, [0, 0], [32, 64], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def rms_norm_orch(
+        self,
+        x: pl.Tensor[[32, 64], pl.FP32],
+        gamma: pl.Tensor[[1, 64], pl.FP32],
+    ) -> pl.Tensor[[32, 64], pl.FP32]:
+        output: pl.Tensor[[32, 64], pl.FP32] = pl.create_tensor([32, 64], dtype=pl.FP32)
+        output = self.kernel_rms_norm(x, gamma, output)
+        return output

--- a/examples/language/intermediate/softmax.py
+++ b/examples/language/intermediate/softmax.py
@@ -1,0 +1,59 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Row-wise softmax using PyPTO language DSL.
+
+Formula: output[i] = exp(a[i] - max(a[i])) / sum(exp(a[i] - max(a[i])))
+
+Computed on 64x64 input using numerically stable algorithm.
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class TileSoftmaxProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_softmax(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+
+        # Step 1: row-wise max for numerical stability
+        max_tmp: pl.Tile[[64, 1], pl.FP32] = pl.create_tile(
+            [64, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        row_max: pl.Tile[[64, 1], pl.FP32] = pl.row_max(tile_a, max_tmp)
+
+        # Step 2: subtract row max from each row: x - max(x)
+        shifted: pl.Tile[[64, 64], pl.FP32] = pl.row_expand_sub(tile_a, row_max)
+
+        # Step 3: exp(x - max(x))
+        exp_shifted: pl.Tile[[64, 64], pl.FP32] = pl.exp(shifted)
+
+        # Step 4: row-wise sum of exp values
+        sum_tmp: pl.Tile[[64, 1], pl.FP32] = pl.create_tile(
+            [64, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        row_sum: pl.Tile[[64, 1], pl.FP32] = pl.row_sum(exp_shifted, sum_tmp)
+
+        # Step 5: divide each row by its sum
+        result: pl.Tile[[64, 64], pl.FP32] = pl.row_expand_div(exp_shifted, row_sum)
+
+        output_new: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
+        return output_new
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(self, a: pl.Tensor[[64, 64], pl.FP32]) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.tile_softmax(a, output)
+        return output

--- a/examples/language/intermediate/vector_dag.py
+++ b/examples/language/intermediate/vector_dag.py
@@ -1,0 +1,96 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Vector DAG computation using PyPTO language DSL.
+
+Implements: f = (a + b + 1)(a + b + 2) + (a + b)
+
+Task graph:
+  t0: c = kernel_add(a, b)
+  t1: d = kernel_add_scalar(c, 1.0)
+  t2: e = kernel_add_scalar(c, 2.0)
+  t3: g = kernel_mul(d, e)
+  t4: f = kernel_add(g, c)
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class VectorDAGProgram:
+    """Vector example program with 3 InCore kernels and 1 Orchestration function."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Adds two tensors element-wise: result = a + b"""
+        a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.add(a_tile, b_tile)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_add_scalar(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        scalar: pl.Scalar[pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Adds a scalar to each element: result = a + scalar"""
+        x: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.add(x, scalar)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_mul(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Multiplies two tensors element-wise: result = a * b"""
+        a_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        b_tile: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        result: pl.Tile[[128, 128], pl.FP32] = pl.mul(a_tile, b_tile)
+        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orch_vector(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        """Orchestration for formula: f = (a + b + 1)(a + b + 2) + (a + b)
+
+        Task graph:
+        t0: c = kernel_add(a, b)
+        t1: d = kernel_add_scalar(c, 1.0)
+        t2: e = kernel_add_scalar(c, 2.0)
+        t3: g = kernel_mul(d, e)
+        t4: f = kernel_add(g, c)
+        """
+        c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        c = self.kernel_add(a, b, c)
+        d: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+        e: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+        g: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        g = self.kernel_mul(d, e, g)
+        f: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
+        f = self.kernel_add(g, c, f)
+        return f

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -24,7 +24,7 @@ _ST_DIR = Path(__file__).parent
 if str(_ST_DIR) not in sys.path:
     sys.path.insert(0, str(_ST_DIR))
 
-# Add project root to path so tests can import from examples/
+# Add project root to path (for examples package)
 _PROJECT_ROOT = _ST_DIR.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))

--- a/tests/st/examples/00_hello_world/test_hello_world.py
+++ b/tests/st/examples/00_hello_world/test_hello_world.py
@@ -1,0 +1,81 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Hello World Example for PyPTO — element-wise tensor addition.
+
+This is the simplest end-to-end PyPTO program:
+  1. Load two tiles from global memory into local registers.
+  2. Add them element-wise on the AI Vector core.
+  3. Store the result back to global memory.
+
+Run:
+    pytest tests/st/examples/00_hello_world/hello_world.py -v --forked --platform=a2a3sim
+    pytest tests/st/examples/00_hello_world/hello_world.py -v --forked --platform=a2a3 --device=0
+"""
+
+from typing import Any
+
+import pytest
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.beginner.hello_world import HelloWorldProgram
+
+
+class HelloWorldAdd(PTOTestCase):
+    """Hello World: add two [128, 128] FP32 tensors element-wise.
+
+    Program structure
+    -----------------
+    InCore function  ``tile_add``
+        - Loads tile_a and tile_b from global memory (GM) into registers (UB).
+        - Computes tile_c = tile_a + tile_b using the vector unit.
+        - Stores tile_c back to the output tensor in GM.
+
+    Orchestration function  ``orchestrator``
+        - Calls ``tile_add`` once to process the whole tensor in one shot.
+    """
+
+    __test__ = False  # Prevent pytest from collecting this base class directly
+
+    def get_name(self) -> str:
+        return "hello_world_add_128x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [128, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return HelloWorldProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: c = a + b (element-wise)."""
+        tensors["c"][:] = tensors["a"] + tensors["b"]
+
+
+# =============================================================================
+# pytest test functions
+# =============================================================================
+
+
+class TestHelloWorld:
+    """Hello World test suite — verifies the simplest PyPTO kernel."""
+
+    def test_hello_world_add(self, test_runner):
+        """Compile and run element-wise addition; compare result to torch reference."""
+        test_case = HelloWorldAdd()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Hello world add failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/examples/01_beginner/basic/test_basic_ops.py
+++ b/tests/st/examples/01_beginner/basic/test_basic_ops.py
@@ -1,0 +1,192 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Basic Fused Operations System Tests for PyPTO.
+
+Corresponds to examples/language/beginner/basic/basic_ops.py but implemented
+using the PyPTO language DSL (@pl.program / pl.block).
+
+Four fused operation patterns are demonstrated:
+  1. FusedAddScale     — vector: c = (a + b) * 2.0
+  2. FusedAddRelu      — vector: c = relu(a + b)
+  3. FusedMatmulBias   — cube + vector: c = matmul(a, b) + bias
+  4. FusedLinearRelu   — cube + vector: y = relu(matmul(x, w) + bias)
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.beginner.basic_ops import (
+    FusedAddReluProgram,
+    FusedAddScaleProgram,
+    FusedLinearReluProgram,
+    FusedMatmulBiasProgram,
+)
+
+
+class FusedAddScale(PTOTestCase):
+    """Fused element-wise add and scale: c = (a + b) * 2.0
+
+    Corresponds to basic_ops.py Example 2: Element-wise Operations.
+    Two vector ops (add, scalar mul) are fused in a single InCore kernel,
+    avoiding an intermediate global memory write-back.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "fused_add_scale_128x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [128, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FusedAddScaleProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: c = (a + b) * 2.0"""
+        tensors["c"][:] = (tensors["a"] + tensors["b"]) * 2.0
+
+
+class FusedAddRelu(PTOTestCase):
+    """Fused element-wise add and relu: c = relu(a + b)
+
+    Corresponds to basic_ops.py Example 4: Activation Functions.
+    Add and relu activation are fused in a single vector InCore kernel.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "fused_add_relu_128x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [128, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FusedAddReluProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: c = relu(a + b)"""
+        tensors["c"][:] = torch.relu(tensors["a"] + tensors["b"])
+
+
+class FusedMatmulBias(PTOTestCase):
+    """Fused matmul and bias add: c = matmul(a, b) + bias
+
+    Corresponds to part of basic_ops.py Example 6: Combined Operations.
+    Orchestrates two InCore kernels — cube matmul followed by vector add_bias —
+    without exposing the intermediate result as a program output.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "fused_matmul_bias_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=3.0),
+            TensorSpec("bias", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FusedMatmulBiasProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: c = matmul(a, b) + bias"""
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
+
+
+class FusedLinearRelu(PTOTestCase):
+    """Fused linear layer with relu: y = relu(matmul(x, w) + bias)
+
+    Corresponds to basic_ops.py Example 6: Combined Operations.
+    Orchestrates two InCore kernels:
+      - matmul_kernel: cube unit computes x @ w
+      - add_bias_relu_kernel: vector unit fuses bias add and relu in one pass
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "fused_linear_relu_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [64, 64], DataType.FP32, init_value=2.0),
+            TensorSpec("w", [64, 64], DataType.FP32, init_value=3.0),
+            TensorSpec("bias", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("y", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FusedLinearReluProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: y = relu(matmul(x, w) + bias)"""
+        tensors["y"][:] = torch.relu(torch.matmul(tensors["x"], tensors["w"]) + tensors["bias"])
+
+
+# =============================================================================
+# pytest test functions
+# =============================================================================
+
+
+class TestBasicFusedOps:
+    """System tests for basic fused operator kernels.
+
+    Verifies that fused kernels produce results matching PyTorch reference
+    implementations across three fusion patterns:
+      - Vector-only fusion (add+scale, add+relu)
+      - Cube+vector fusion (matmul+bias)
+      - Full linear layer (matmul+bias+relu)
+    """
+
+    def test_fused_add_scale(self, test_runner):
+        """Test fused add and scale: c = (a + b) * 2.0"""
+        test_case = FusedAddScale()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Fused add+scale failed: {result.error}"
+
+    def test_fused_add_relu(self, test_runner):
+        """Test fused add and relu: c = relu(a + b)"""
+        test_case = FusedAddRelu()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Fused add+relu failed: {result.error}"
+
+    def test_fused_matmul_bias(self, test_runner):
+        """Test fused matmul and bias add: c = matmul(a, b) + bias"""
+        test_case = FusedMatmulBias()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Fused matmul+bias failed: {result.error}"
+
+    def test_fused_linear_relu(self, test_runner):
+        """Test fused linear layer with relu: y = relu(matmul(x, w) + bias)"""
+        test_case = FusedLinearRelu()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Fused linear+relu failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/examples/02_intermediate/test_ffn_activations.py
+++ b/tests/st/examples/02_intermediate/test_ffn_activations.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+FFN Module Activation System Tests for PyPTO.
+
+Four FFN activation patterns are demonstrated:
+  1. GELU       — x * sigmoid(1.702 * x)
+  2. SiLU       — x * sigmoid(x)
+  3. SwiGLU     — gate * sigmoid(gate) * up
+  4. GeGLU      — gate * sigmoid(1.702 * gate) * up
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.intermediate.ffn_activations import (
+    GegluProgram,
+    GeluProgram,
+    SiluProgram,
+    SwigluProgram,
+)
+
+
+class TestGeluActivation(PTOTestCase):
+    """GELU activation with 128x128 input: output = x * sigmoid(1.702 * x)"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "gelu_activation_128x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [128, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [128, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GeluProgram
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        tensors["output"][:] = x * torch.sigmoid(1.702 * x)
+
+
+class TestSwigluActivation(PTOTestCase):
+    """SwiGLU activation with 64x64 input: output = gate * sigmoid(gate) * up"""
+
+    """"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "swiglu_activation_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("gate", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("up", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SwigluProgram
+
+    def compute_expected(self, tensors, params=None):
+        gate = tensors["gate"]
+        up = tensors["up"]
+        tensors["output"][:] = gate * torch.sigmoid(gate) * up
+
+
+class TestSiluActivation(PTOTestCase):
+    """SiLU (Swish) activation with 64x64 input: output = x * sigmoid(x)"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "silu_activation_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SiluProgram
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        tensors["output"][:] = x * torch.sigmoid(x)
+
+
+class TestGegluActivation(PTOTestCase):
+    """GeGLU activation with 64x64 input: output = GELU(gate) * up = gate * sigmoid(1.702 * gate) * up"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "geglu_activation_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("gate", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("up", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GegluProgram
+
+    def compute_expected(self, tensors, params=None):
+        gate = tensors["gate"]
+        up = tensors["up"]
+        tensors["output"][:] = gate * torch.sigmoid(1.702 * gate) * up
+
+
+class TestFFNActivationOperations:
+    """Test suite for FFN activation operations."""
+
+    def test_gelu_activation_128x128(self, test_runner):
+        """Test GELU activation with 128x128 input."""
+        test_case = TestGeluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_swiglu_activation_64x64(self, test_runner):
+        """Test SwiGLU activation with 64x64 input."""
+        test_case = TestSwigluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_silu_activation_64x64(self, test_runner):
+        """Test SiLU (Swish) activation with 64x64 input."""
+        test_case = TestSiluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_geglu_activation_64x64(self, test_runner):
+        """Test GeGLU activation with 64x64 input."""
+        test_case = TestGegluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/examples/02_intermediate/test_layer_norm.py
+++ b/tests/st/examples/02_intermediate/test_layer_norm.py
@@ -1,0 +1,71 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+LayerNorm System Tests for PyPTO.
+
+One layer normalization pattern is demonstrated:
+  1. LayerNorm  — (x - mean) / sqrt(var + eps) * gamma + beta
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.intermediate.layer_norm import LayerNormProgram
+
+
+class TestLayerNormCore(PTOTestCase):
+    """LayerNorm with 4x64 input: normalize across hidden dim, then scale and shift."""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "layer_norm_core_4x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("gamma", [1, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("beta", [1, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return LayerNormProgram
+
+    def compute_expected(self, tensors, _params=None):
+        x = tensors["x"]
+        gamma = tensors["gamma"]
+        beta = tensors["beta"]
+        hidden_size = 64
+        eps = 1e-5
+
+        mean = x.sum(dim=-1, keepdim=True) / hidden_size
+        centered = x - mean
+        var = (centered**2).sum(dim=-1, keepdim=True) / hidden_size
+        std = torch.sqrt(var + eps)
+        normalized = centered / std
+        tensors["output"][:] = normalized * gamma + beta
+
+
+class TestLayerNormOperations:
+    """Test suite for LayerNorm operations."""
+
+    def test_layer_norm_core_4x64(self, test_runner):
+        """Test LayerNorm: normalize across hidden dim (64), scale by gamma, shift by beta."""
+        test_case = TestLayerNormCore()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/examples/02_intermediate/test_rms_norm.py
+++ b/tests/st/examples/02_intermediate/test_rms_norm.py
@@ -1,0 +1,67 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+RMSNorm System Tests for PyPTO.
+
+One RMS normalization pattern is demonstrated:
+  1. RMSNorm  — x / sqrt(mean(x^2) + eps) * gamma
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.intermediate.rms_norm import RMSNormProgram
+
+
+class TestRMSNormCore(PTOTestCase):
+    """RMSNorm with 32x64 input: normalize by RMS across hidden dim, then scale by gamma."""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "rms_norm_core_32x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("gamma", [1, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return RMSNormProgram
+
+    def compute_expected(self, tensors, _params=None):
+        x = tensors["x"]
+        gamma = tensors["gamma"]
+        hidden_size = 64
+        eps = 1e-5
+
+        mean_sq = (x**2).sum(dim=-1, keepdim=True) / hidden_size
+        rms = torch.sqrt(mean_sq + eps)
+        normalized = x / rms
+        tensors["output"][:] = normalized * gamma
+
+
+class TestRMSNormOperations:
+    """Test suite for RMSNorm operations."""
+
+    def test_rms_norm_core_32x64(self, test_runner):
+        """Test RMSNorm: normalize by RMS across hidden dim (64), scale by gamma."""
+        test_case = TestRMSNormCore()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/examples/02_intermediate/test_softmax.py
+++ b/tests/st/examples/02_intermediate/test_softmax.py
@@ -1,0 +1,61 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Softmax System Tests for PyPTO.
+
+One tile reduction pattern is demonstrated:
+  1. Softmax    — exp(x - max(x)) / sum(exp(x - max(x)))
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.intermediate.softmax import TileSoftmaxProgram
+
+
+class TestTileSoftmax(PTOTestCase):
+    """Test row-wise softmax: output[i] = exp(a[i] - max(a[i])) / sum(exp(a[i] - max(a[i])))."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "tile_softmax_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileSoftmaxProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["output"][:] = torch.softmax(tensors["a"], dim=1)
+
+
+class TestReductionOps:
+    """Test suite for reduction-based tile ops."""
+
+    def test_tile_softmax(self, test_runner):
+        """Test row-wise softmax."""
+        result = test_runner.run(TestTileSoftmax())
+        assert result.passed, (
+            f"tile_softmax failed: {result.error}\n"
+            f"  max_abs_error={result.max_abs_error}, max_rel_error={result.max_rel_error}\n"
+            f"  mismatches={result.mismatch_count}, sample_indices={result.mismatch_indices}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/test_dag.py
+++ b/tests/st/runtime/test_dag.py
@@ -13,7 +13,7 @@ Tests for DAG (Directed Acyclic Graph) operations using PyPTO frontend.
 This test validates complex multi-kernel orchestration with mixed operations,
 ensuring correct code generation and execution for DAG-structured computations.
 
-The program definition is imported from examples/ir_parser/vector_example_dag.py
+The program definition is imported from examples/language/intermediate/vector_dag.py
 to keep a single source of truth and ensure examples are guarded by tests.
 """
 
@@ -24,10 +24,10 @@ from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
-from examples.ir_parser.vector_example_dag import VectorExampleProgram
+from examples.language.intermediate.vector_dag import VectorDAGProgram
 
 
-class TestVectorDAG(PTOTestCase):
+class VectorDAGTestCase(PTOTestCase):
     """Test case for vector DAG computation.
 
     Implements the formula: f = (a + b + 1)(a + b + 2) + (a + b)
@@ -40,8 +40,6 @@ class TestVectorDAG(PTOTestCase):
       t4: f = kernel_add(g, c)
     """
 
-    __test__ = False  # Not a pytest test class
-
     def get_name(self) -> str:
         return "vector_dag_128x128"
 
@@ -53,7 +51,7 @@ class TestVectorDAG(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        return VectorExampleProgram
+        return VectorDAGProgram
 
     def compute_expected(self, tensors, params=None):
         """Compute expected result: f = (a + b + 1)(a + b + 2) + (a + b)"""
@@ -64,10 +62,8 @@ class TestVectorDAG(PTOTestCase):
         tensors["f"][:] = g + c
 
 
-class TestVectorDAGPTO(TestVectorDAG):
+class VectorDAGPTOTestCase(VectorDAGTestCase):
     """Test vector DAG with PTO backend and PTOAS optimization."""
-
-    __test__ = False
 
     def get_name(self) -> str:
         return "vector_dag_pto_128x128"
@@ -84,13 +80,13 @@ class TestDAGOperations:
 
     def test_vector_dag_128x128(self, test_runner):
         """Test vector DAG computation with 128x128 shape."""
-        test_case = TestVectorDAG()
+        test_case = VectorDAGTestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed for vector DAG: {result.error}"
 
     def test_vector_dag_pto_128x128(self, test_runner):
         """Test vector DAG with PTO backend and PTOAS optimization."""
-        test_case = TestVectorDAGPTO()
+        test_case = VectorDAGPTOTestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed for vector DAG (PTO): {result.error}"
 


### PR DESCRIPTION
## Summary

Expand the system test suite with progressive example programs organized by difficulty level, covering hello world, basic operators, and intermediate DSL composition patterns.

- **`00_hello_world`**: Element-wise tensor addition as a minimal end-to-end example
- **`01_beginner/basic`**: Basic operator coverage including arithmetic, comparison, and type-cast operations
- **`02_intermediate`**: FFN module, softmax, and layer norm examples showcasing composition of block-level operations
- **Runtime tests**: Fix `test_elementwise.py` and `test_matmul.py` for correctness