### PR TITLE
test(st): Add full-pipeline paged attention ST with non-divisible tile handling

### DIFF
--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -9,20 +9,22 @@
 """
 Paged Attention Orchestration Example
 
-Builds a simplified paged attention orchestration function using the PyPTO DSL.
-Generates C++ orchestration code similar to target_page_attn_codegen.cpp.
+Builds a paged attention orchestration function using the PyPTO DSL with online
+softmax and a 4-kernel pipeline.  Use build_paged_attention_program() to
+obtain a @pl.program class parameterised by runtime tensor dimensions.
 
-Simplified 16x16 version:
-  - Query:       [batch * num_heads, head_dim] BF16
-  - Key cache:   [total_blocks * block_size, head_dim] BF16
-  - Value cache: [total_blocks * block_size, head_dim] BF16
-  - Output:      [batch * num_heads, head_dim] FP32
+Tensor layout (all 2D, flattened):
+  query:       [batch * num_heads, head_dim]                    BF16
+  key_cache:   [total_pool_blocks * block_size, head_dim]       BF16
+  value_cache: [total_pool_blocks * block_size, head_dim]       BF16
+  out:         [batch * num_heads, head_dim]                    FP32
 
-Task graph per (batch, block) iteration:
-  task0: sij     = qi @ kj^T           (kernel_qk_matmul,       CUBE)
-  task1: pij, mi, li = softmax(sij)    (kernel_softmax_prepare, VECTOR)
-  task2: oi_tmp  = pij @ vj            (kernel_pv_matmul,       CUBE)
-  task3: online_update(mi, li, oi_tmp) (kernel_online_update,   VECTOR)
+Pipeline per KV block iteration:
+  1. QK Matmul:       sij          = kernel_qk_matmul(qi, kj, sij)
+  2. Softmax Prepare: pij, mi, li  = kernel_softmax_prepare(sij_valid, scale, pij, mi, li)
+  3. PV Matmul:       oi_tmp       = kernel_pv_matmul(pij, vj, oi_tmp)
+  4. Online Update:   mi, li, oi, dst = kernel_online_update(
+                          mi_j, li_j, oi_new, mi, li, oi, dst, is_first, is_last)
 """
 
 import os
@@ -32,230 +34,321 @@ from pypto import ir
 from pypto.backend import BackendType
 
 
-@pl.program
-class PagedAttentionProgram:
-    """Paged attention program with CUBE and VECTOR kernels."""
+def build_paged_attention_program(
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    max_num_blocks_per_req: int,
+    q_tile: int = 16,
+):
+    """Build a parameterised paged-attention @pl.program for the given shapes.
 
-    # ── VECTOR kernel: init inplace tensors ─────────────────────────────
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_init_inplace(
-        self,
-        oi: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-        li: pl.Out[pl.Tensor[[16], pl.FP32]],
-        mi: pl.Out[pl.Tensor[[16], pl.FP32]],
-    ) -> tuple[
-        pl.Tensor[[16, 128], pl.FP32],
-        pl.Tensor[[16], pl.FP32],
-        pl.Tensor[[16], pl.FP32],
-    ]:
-        """Initialize inplace accumulators to zero (VECTOR)."""
-        return oi, li, mi
+    Returns the decorated program class (not an instance).  The tensor type
+    annotations in the orchestration function are filled in from the arguments
+    so that the PyPTO DSL can resolve static dimensions at compile time.
 
-    # ── CUBE kernel: QK matmul ──────────────────────────────────────────
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_qk_matmul(
-        self,
-        qi: pl.Tensor[[16, 128], pl.BF16],
-        kj: pl.Tensor[[128, 128], pl.BF16],
-        output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-    ) -> pl.Tensor[[16, 128], pl.FP32]:
-        """QK matmul: sij = qi @ kj (CUBE)."""
-        qi_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(qi, [0, 0], [16, 16])
-        kj_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(kj, [0, 0], [16, 16])
-        result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(qi_tile, kj_tile)
-        out: pl.Tensor[[16, 128], pl.FP32] = pl.l0c_store(result, [0, 0], [16, 16], output)
-        return out
+    Parameters
+    ----------
+    batch:                  number of requests in the batch
+    num_heads:              number of query heads
+    head_dim:               per-head feature dimension
+    block_size:             KV-cache block size (rows per physical block)
+    max_num_blocks_per_req: maximum number of KV blocks per request
+    q_tile:                 query-head tile size used by the InCore kernels
+    """
+    # Derived static dimension values for tensor type annotations
+    query_rows = batch * num_heads
+    key_cache_rows = batch * max_num_blocks_per_req * block_size
+    out_rows = batch * num_heads
+    block_table_flat_size = batch * max_num_blocks_per_req
 
-    # ── VECTOR kernel: softmax prepare ──────────────────────────────────
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_softmax_prepare(
-        self,
-        sij: pl.Tensor[[16, 128], pl.FP32],
-        scale: pl.Scalar[pl.FP32],
-        out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
-        out_mi: pl.Out[pl.Tensor[[16], pl.FP32]],
-        out_li: pl.Out[pl.Tensor[[16], pl.FP32]],
-    ) -> tuple[
-        pl.Tensor[[16, 128], pl.BF16],
-        pl.Tensor[[16], pl.FP32],
-        pl.Tensor[[16], pl.FP32],
-    ]:
-        """Softmax prepare: scale, row_max, exp, row_sum (VECTOR).
+    @pl.program
+    class PagedAttentionProgram:
+        """Paged attention program with CUBE and VECTOR kernels (online softmax)."""
 
-        Simplified kernel body — the orchestration codegen only uses the
-        function signature, not the body implementation.
-        """
-        s_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(sij, [0, 0], [16, 16])
-        scaled: pl.Tile[[16, 16], pl.FP32] = pl.mul(s_tile, scale)
-        tmp_mi: pl.Tile[[16], pl.FP32] = pl.create_tile([16], dtype=pl.FP32)
-        mi_tile: pl.Tile[[16], pl.FP32] = pl.row_max(scaled, tmp_mi)
-        sub_tile: pl.Tile[[16, 16], pl.FP32] = pl.sub(scaled, mi_tile)
-        exp_tile: pl.Tile[[16, 16], pl.FP32] = pl.exp(sub_tile)
-        tmp_li: pl.Tile[[16], pl.FP32] = pl.create_tile([16], dtype=pl.FP32)
-        li_tile: pl.Tile[[16], pl.FP32] = pl.row_sum(exp_tile, tmp_li)
-        out_pij: pl.Tensor[[16, 128], pl.BF16] = pl.store(exp_tile, [0, 0], [16, 16], out_pij)
-        out_mi: pl.Tensor[[16], pl.FP32] = pl.store(mi_tile, [0], [16], out_mi)
-        out_li: pl.Tensor[[16], pl.FP32] = pl.store(li_tile, [0], [16], out_li)
-        return out_pij, out_mi, out_li
+        # ── VECTOR kernel: init inplace tensors ─────────────────────────────
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_init_inplace(
+            self,
+            oi: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            li: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            mi: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> tuple[
+            pl.Tensor[[16, 128], pl.FP32],
+            pl.Tensor[[16, 1], pl.FP32],
+            pl.Tensor[[16, 1], pl.FP32],
+        ]:
+            """Initialize inplace accumulators to zero (VECTOR)."""
+            return oi, li, mi
 
-    # ── CUBE kernel: PV matmul ──────────────────────────────────────────
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_pv_matmul(
-        self,
-        pij: pl.Tensor[[16, 128], pl.BF16],
-        vj: pl.Tensor[[128, 128], pl.BF16],
-        output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-    ) -> pl.Tensor[[16, 128], pl.FP32]:
-        """PV matmul: oi_tmp = pij @ vj (CUBE)."""
-        p_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(pij, [0, 0], [16, 16])
-        v_tile: pl.Tile[[16, 16], pl.BF16] = pl.load(vj, [0, 0], [16, 16])
-        result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(p_tile, v_tile)
-        out: pl.Tensor[[16, 128], pl.FP32] = pl.l0c_store(result, [0, 0], [16, 16], output)
-        return out
+        # ── CUBE kernel: QK matmul ──────────────────────────────────────────
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_qk_matmul(
+            self,
+            qi: pl.Tensor[[16, 128], pl.BF16],
+            kj: pl.Tensor[[128, 128], pl.BF16],
+            output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            """QK matmul: sij = qi @ kj.T (CUBE). kj transposed before move to L0B."""
+            qi_l1 = pl.load(qi, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            kj_l1 = pl.load(kj, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            qi_l0a = pl.move(qi_l1, target_memory=pl.MemorySpace.Left)
+            kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right, transpose=True)
+            sij_l0c = pl.matmul(qi_l0a, kj_l0b)
+            out: pl.Tensor[[16, 128], pl.FP32] = pl.l0c_store(sij_l0c, [0, 0], [16, 128], output)
+            return out
 
-    # ── VECTOR kernel: online update (inplace) ──────────────────────────
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_online_update(
-        self,
-        mi: pl.Tensor[[16], pl.FP32],
-        li: pl.Tensor[[16], pl.FP32],
-        oi_tmp: pl.Tensor[[16, 128], pl.FP32],
-        mi_update: pl.InOut[pl.Tensor[[16], pl.FP32]],
-        li_update: pl.InOut[pl.Tensor[[16], pl.FP32]],
-        oi: pl.InOut[pl.Tensor[[16, 128], pl.FP32]],
-        out_view: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-        is_first: pl.Scalar[pl.INT64],
-        is_last: pl.Scalar[pl.INT64],
-    ) -> tuple[
-        pl.Tensor[[16], pl.FP32],
-        pl.Tensor[[16], pl.FP32],
-        pl.Tensor[[16, 128], pl.FP32],
-        pl.Tensor[[16, 128], pl.FP32],
-    ]:
-        """Online softmax update with inplace mi/li/oi (VECTOR)."""
-        mi_tile: pl.Tile[[16], pl.FP32] = pl.load(mi_update, [0], [16])
-        li_tile: pl.Tile[[16], pl.FP32] = pl.load(li_update, [0], [16])
-        oi_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(oi, [0, 0], [16, 16])
-        out_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(out_view, [0, 0], [16, 16])
-        mi_r: pl.Tensor[[16], pl.FP32] = pl.store(mi_tile, [0], [16], mi_update)
-        li_r: pl.Tensor[[16], pl.FP32] = pl.store(li_tile, [0], [16], li_update)
-        oi_r: pl.Tensor[[16, 128], pl.FP32] = pl.store(oi_tile, [0, 0], [16, 16], oi)
-        out_r: pl.Tensor[[16, 128], pl.FP32] = pl.store(out_tile, [0, 0], [16, 16], out_view)
-        return mi_r, li_r, oi_r, out_r
+        # ── VECTOR kernel: softmax prepare ──────────────────────────────────
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_softmax_prepare(
+            self,
+            sij: pl.Tensor[[16, 128], pl.FP32],
+            scale: pl.Scalar[pl.FP32],
+            out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+            out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> tuple[
+            pl.Tensor[[16, 128], pl.BF16],
+            pl.Tensor[[16, 1], pl.FP32],
+            pl.Tensor[[16, 1], pl.FP32],
+        ]:
+            """Softmax prepare: scale, row_max, exp, row_sum (VECTOR)."""
+            s_tile = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+            scaled = pl.mul(s_tile, scale)
+            tmp_tile = pl.create_tile([16, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+            mi_tile = pl.row_max(scaled, tmp_tile)
+            sij_centered = pl.row_expand_sub(scaled, mi_tile)
+            exp_tile = pl.exp(sij_centered)
+            pij_tile_bf16 = pl.cast(exp_tile, target_type=pl.BF16)
+            pij_tile = pl.cast(pij_tile_bf16, target_type=pl.FP32)
+            li_tile = pl.row_sum(pij_tile, tmp_tile)
+            out_pij = pl.store(pij_tile_bf16, [0, 0], [16, 128], out_pij)
+            out_mi = pl.store(mi_tile, [0, 0], [16, 1], out_mi)
+            out_li = pl.store(li_tile, [0, 0], [16, 1], out_li)
+            return out_pij, out_mi, out_li
 
-    # ── Orchestration function ──────────────────────────────────────────
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def paged_attention(
-        self,
-        query: pl.Tensor[[32, 128], pl.BF16],  # 2 * 16, 128
-        key_cache: pl.Tensor[[8192, 128], pl.BF16],  # [2 * 2048 * 128, 128]
-        value_cache: pl.Tensor[[8192, 128], pl.BF16],  # [2 * 2048 * 128, 128]
-        host_block_table: pl.Tensor[[2 * 16], pl.INT32],
-        context_lens: pl.Tensor[[2], pl.INT32],
-        out: pl.Tensor[[32, 128], pl.FP32],
-        config: pl.Tensor[[7], pl.UINT64],
-    ) -> pl.Tensor[[32, 128], pl.FP32]:
-        """Paged attention orchestration.
+        # ── CUBE kernel: PV matmul ──────────────────────────────────────────
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_pv_matmul(
+            self,
+            pij: pl.Tensor[[16, 128], pl.BF16],
+            vj: pl.Tensor[[128, 128], pl.BF16],
+            output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            """PV matmul: oi_tmp = pij @ vj (CUBE)."""
+            pij_l1 = pl.load(pij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            vj_l1 = pl.load(vj, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            pij_l0a = pl.move(pij_l1, target_memory=pl.MemorySpace.Left)
+            vj_l0b = pl.move(vj_l1, target_memory=pl.MemorySpace.Right)
+            oi_l0c = pl.matmul(pij_l0a, vj_l0b)
+            out = pl.l0c_store(oi_l0c, [0, 0], [16, 128], output)
+            return out
 
-        Config layout: [batch, num_heads, kv_head_num, head_dim, block_size, block_num, scale]
-        Loops over batch and KV blocks, calling CUBE/VECTOR kernels.
-        """
-        batch: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [0])
-        num_heads: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [1])
-        head_dim: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [3])
-        block_size: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [4])
-        block_num: pl.Scalar[pl.UINT64] = pl.tensor.read(config, [5])
-        q_tile = pl.min(num_heads, 128)
-        q_loop = (num_heads + q_tile - 1) // q_tile
+        # ── VECTOR kernel: online update (inplace) ──────────────────────────
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_online_update(
+            self,
+            mij: pl.Tensor[[16, 1], pl.FP32],
+            lij: pl.Tensor[[16, 1], pl.FP32],
+            oi_new: pl.Tensor[[16, 128], pl.FP32],
+            mi: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+            li: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+            oi: pl.InOut[pl.Tensor[[16, 128], pl.FP32]],
+            dst: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            is_first: pl.Scalar[pl.BOOL],
+            is_last: pl.Scalar[pl.BOOL],
+        ) -> tuple[
+            pl.Tensor[[16, 1], pl.FP32],
+            pl.Tensor[[16, 1], pl.FP32],
+            pl.Tensor[[16, 128], pl.FP32],
+            pl.Tensor[[16, 128], pl.FP32],
+        ]:
+            """Online softmax update with inplace mi/li/oi (VECTOR)."""
+            mij_tile = pl.load(mij, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec)
+            lij_tile = pl.load(lij, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec)
+            oi_new_tile = pl.load(oi_new, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+            mi_tile = pl.load(mi, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec)
+            li_tile = pl.load(li, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec)
+            oi_tile = pl.load(oi, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
 
-        for b_idx in pl.range(batch):
-            cur_seq = pl.tensor.read(context_lens, [b_idx])
-            bn_this_batch = (cur_seq + block_size - 1) // block_size
-            for q_idx in pl.range(q_loop):
-                cur_offset = b_idx * num_heads + q_idx * q_tile
+            if is_first:
+                mi_out = pl.store(mij_tile, [0, 0], [16, 1], mi)
+                li_out = pl.store(lij_tile, [0, 0], [16, 1], li)
+                oi_out = pl.store(oi_new_tile, [0, 0], [16, 128], oi)
+                if is_last:
+                    dst_tile = pl.row_expand_div(oi_new_tile, lij_tile)
+                    dst_out = pl.store(dst_tile, [0, 0], [16, 128], dst)
+            else:
+                # Reshape DN [16,1] -> ND [1,16] for element-wise ops
+                mi_tile_nd = pl.reshape(mi_tile, [1, 16])
+                mij_tile_nd = pl.reshape(mij_tile, [1, 16])
+                li_tile_nd = pl.reshape(li_tile, [1, 16])
+                lij_tile_nd = pl.reshape(lij_tile, [1, 16])
 
-                # Create inplace accumulators for this q_tile group
-                oi: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
-                    [q_tile, head_dim],
-                    dtype=pl.FP32,
-                )
-                li_update: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)
-                mi_update: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)
+                mi_new = pl.maximum(mi_tile_nd, mij_tile_nd)
+                mi_diff = pl.sub(mi_tile_nd, mi_new)
+                alpha = pl.exp(mi_diff)
+                mij_diff = pl.sub(mij_tile_nd, mi_new)
+                beta = pl.exp(mij_diff)
 
-                # Initialize accumulators
-                oi, li_update, mi_update = self.kernel_init_inplace(oi, li_update, mi_update)
+                li_scaled = pl.mul(alpha, li_tile_nd)
+                lij_scaled = pl.mul(beta, lij_tile_nd)
+                li_updated = pl.add(li_scaled, lij_scaled)
 
-                for bn in pl.range(bn_this_batch):
-                    # Dynamic views into Q/K/V for current batch and block
-                    qi: pl.Tensor[[q_tile, head_dim], pl.BF16] = pl.view(
-                        query,
-                        [q_tile, head_dim],
-                        [cur_offset, 0],
-                    )
-                    cur_block_idx = pl.tensor.read(host_block_table, [b_idx * block_num + bn])
-                    valid_len = pl.min(block_size, cur_seq - bn * block_size)
-                    kj: pl.Tensor[[block_size, head_dim], pl.BF16] = pl.view(
-                        key_cache,
-                        [block_size, head_dim],
-                        [cur_block_idx * block_size, 0],
-                    )
-                    vj: pl.Tensor[[block_size, head_dim], pl.BF16] = pl.view(
-                        value_cache,
-                        [block_size, head_dim],
-                        [cur_block_idx * block_size, 0],
-                    )
+                alpha_dn = pl.reshape(alpha, [16, 1])  # Reshape [1,16] -> [16,1] DN for row_expand_mul
+                oi_scaled = pl.row_expand_mul(oi_tile, alpha_dn)
+                beta_dn = pl.reshape(beta, [16, 1])  # Reshape [1,16] -> [16,1] DN for row_expand_mul
+                oi_new_scaled = pl.row_expand_mul(oi_new_tile, beta_dn)
+                oi_updated = pl.add(oi_scaled, oi_new_scaled)
 
-                    sij: pl.Tensor[[q_tile, block_size], pl.FP32] = pl.create_tensor(
-                        [q_tile, block_size],
+                mi_new_dn = pl.reshape(mi_new, [16, 1])  # Reshape back to DN [16,1] for store
+                li_updated_dn = pl.reshape(li_updated, [16, 1])  # Reshape back to DN [16,1] for store
+
+                mi_out = pl.store(mi_new_dn, [0, 0], [16, 1], mi)
+                li_out = pl.store(li_updated_dn, [0, 0], [16, 1], li)
+
+                if is_last:
+                    dst_tile = pl.row_expand_div(oi_updated, li_updated_dn)
+                    dst_out = pl.store(dst_tile, [0, 0], [16, 128], dst)
+                    oi_out = pl.store(oi_updated, [0, 0], [16, 128], oi)
+                else:
+                    zero_tile = pl.block.full([16, 128], dtype=pl.FP32, value=0.0)
+                    dst_out = pl.store(zero_tile, [0, 0], [16, 128], dst)
+                    oi_out = pl.store(oi_updated, [0, 0], [16, 128], oi)
+
+            return mi_out, li_out, oi_out, dst_out
+
+        # ── Orchestration function ──────────────────────────────────────────
+        # Parameters: query, key_cache, value_cache, block_table, context_lens,
+        #             out, config (7 tensors) + size_query, size_key_cache,
+        #             size_value_cache (3 byte-size scalars)
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def paged_attention(
+            self,
+            query: pl.Tensor[[query_rows, head_dim], pl.BF16],
+            key_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
+            value_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
+            block_table: pl.Tensor[[block_table_flat_size], pl.INT32],
+            context_lens: pl.Tensor[[batch], pl.INT32],
+            out: pl.Tensor[[out_rows, head_dim], pl.FP32],
+            config: pl.Tensor[[7], pl.INT64],
+            size_query: pl.Tensor[[1], pl.INT64],
+            size_key_cache: pl.Tensor[[1], pl.INT64],
+            size_value_cache: pl.Tensor[[1], pl.INT64],
+        ) -> pl.Tensor[[out_rows, head_dim], pl.FP32]:
+            """Paged attention orchestration.
+
+            Outer loops: batch → q_tile groups → KV blocks (bn).
+            For each KV block, executes the 4-stage kernel pipeline.
+            Config layout: [batch, num_heads, kv_head_num, head_dim, block_size, block_num, scale_bits]
+            """
+            # Read runtime config parameters
+            batch_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+            num_heads_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+            head_dim_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [3])
+            block_size_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [4])
+            block_num_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [5])
+            # scale_bits at config[6] - decoded as float
+
+            q_head_num = num_heads_cfg
+            q_loop_cfg = (q_head_num + q_tile - 1) // q_tile
+
+            for b_idx in pl.range(batch_cfg):
+                cur_seq = pl.tensor.read(context_lens, [b_idx])
+                bn_this_batch = (cur_seq + block_size_cfg - 1) // block_size_cfg
+                for q_idx in pl.range(q_loop_cfg):
+                    cur_offset = b_idx * q_head_num + q_idx * q_tile
+
+                    # Create inplace accumulators for this q_tile group
+                    oi: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                        [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
                         dtype=pl.FP32,
                     )
+                    li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                    mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
 
-                    # QK matmul (CUBE)
-                    sij = self.kernel_qk_matmul(qi, kj, sij)
-                    sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.view(
-                        sij,
-                        [q_tile, valid_len],
-                        [0, 0],
-                    )
+                    # Initialize accumulators
+                    oi, li_update, mi_update = self.kernel_init_inplace(oi, li_update, mi_update)
 
-                    pij: pl.Tensor[[q_tile, block_size], pl.BF16] = pl.create_tensor(
-                        [q_tile, block_size],
-                        dtype=pl.BF16,
-                    )
-                    mi: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)
-                    li: pl.Tensor[[q_tile], pl.FP32] = pl.create_tensor([q_tile], dtype=pl.FP32)
-                    # Softmax prepare (VECTOR) — outputs are per-block mi/li, not the inplace accumulators
-                    pij, mi, li = self.kernel_softmax_prepare(sij_valid, 1.0, pij, mi, li)  # type: ignore[reportArgumentType]  # DSL: float literal auto-converts to Scalar
+                    for bn in pl.range(bn_this_batch):
+                        # Query view: row offset = b_idx * num_heads + q_idx * q_tile
+                        qi: pl.Tensor[[q_tile, head_dim_cfg], pl.BF16] = pl.view(
+                            query,
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [cur_offset, 0],
+                        )
 
-                    oi_tmp: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
-                        [q_tile, head_dim],
-                        dtype=pl.FP32,
-                    )
-                    # PV matmul (CUBE)
-                    oi_tmp = self.kernel_pv_matmul(pij, vj, oi_tmp)
+                        # Get block index from block_table
+                        cur_block_idx = pl.tensor.read(block_table, [b_idx * block_num_cfg + bn])
+                        valid_len = pl.min(block_size_cfg, cur_seq - bn * block_size_cfg)
 
-                    # Conditional flags
-                    if bn == 0:
-                        is_first: pl.Scalar[pl.UINT64] = pl.yield_(1)
-                    else:
-                        is_first: pl.Scalar[pl.UINT64] = pl.yield_(0)
-                    if bn == bn_this_batch - 1:
-                        is_last: pl.Scalar[pl.UINT64] = pl.yield_(1)
-                    else:
-                        is_last: pl.Scalar[pl.UINT64] = pl.yield_(0)
+                        # Key/Value views: physical block row = cur_block_idx * block_size
+                        kv_block_row = cur_block_idx * block_size_cfg
+                        kj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.view(
+                            key_cache,
+                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [kv_block_row, 0],
+                        )
+                        vj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.view(
+                            value_cache,
+                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [kv_block_row, 0],
+                        )
 
-                    # Online update (VECTOR): mi/li are inputs from softmax,
-                    # mi_update/li_update/oi are inplace accumulators, out_view is output
-                    out_view: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.view(
-                        out,
-                        [q_tile, head_dim],
-                        [cur_offset, 0],
-                    )
-                    mi_update, li_update, oi, out_view = self.kernel_online_update(
-                        mi, li, oi_tmp, mi_update, li_update, oi, out_view, is_first, is_last
-                    )
+                        sij: pl.Tensor[[q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
+                        )
 
-        return out
+                        # QK matmul (CUBE)
+                        sij = self.kernel_qk_matmul(qi, kj, sij)
+                        sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.view(
+                            sij,
+                            [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                            [0, 0],
+                        )
+
+                        pij_f16: pl.Tensor[[q_tile, block_size_cfg], pl.BF16] = pl.create_tensor(
+                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.BF16,
+                        )
+                        mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                        li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+
+                        # Softmax prepare (VECTOR) — use valid slice of sij
+                        pij_f16, mi, li = self.kernel_softmax_prepare(sij_valid, 1.0, pij_f16, mi, li)  # type: ignore[reportArgumentType]
+
+                        oi_tmp: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
+                        )
+                        # PV matmul (CUBE)
+                        oi_tmp = self.kernel_pv_matmul(pij_f16, vj, oi_tmp)
+
+                        # Conditional flags
+                        if bn == 0:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        else:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                        if bn == bn_this_batch - 1:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        else:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+
+                        # Output view: same row offset as query view
+                        out_view: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.view(
+                            out,
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [cur_offset, 0],
+                        )
+                        mi_update, li_update, oi, out_view = self.kernel_online_update(
+                            mi, li, oi_tmp, mi_update, li_update, oi, out_view, is_first, is_last
+                        )
+
+            return out
+
+    return PagedAttentionProgram
 
 
 def main():
@@ -264,7 +357,13 @@ def main():
     print("Paged Attention Orchestration Code Generation")
     print("=" * 70)
 
-    program = PagedAttentionProgram
+    program = build_paged_attention_program(
+        batch=2,
+        num_heads=16,
+        head_dim=128,
+        block_size=128,
+        max_num_blocks_per_req=32,
+    )
     print(f"\nProgram: {program.name}")
     print(f"Functions: {[f.name for f in program.functions.values()]}")
 

--- a/tests/st/harness/adapters/golden_generator.py
+++ b/tests/st/harness/adapters/golden_generator.py
@@ -81,6 +81,7 @@ class GoldenGenerator:
             '"""',
             "",
             "import ctypes",
+            "import struct",
             "import torch",
             "",
             f"__outputs__ = {output_names!r}",


### PR DESCRIPTION
- Refactor `paged_attention_example.py`: replace the static `@pl.program`
  class with a `build_paged_attention_program()` factory that accepts
  shape parameters (batch, num_heads, head_dim, block_size,
  max_num_blocks_per_req, q_tile), enabling shape-parameterised code
  generation and import reuse from system tests
- Fix all four InCore kernel implementations with correct memory-space
  annotations:
  - `kernel_qk_matmul`: L1 load → `pl.move` to L0A/L0B (kj with
    `transpose=True`) → `pl.matmul` → `l0c_store`
  - `kernel_softmax_prepare`: `row_expand_sub` → exp → BF16 cast → store
    into 2D `[16, 1]` mi/li accumulators
  - `kernel_pv_matmul`: L1→L0A/L0B→L0C memory path, same as QK matmul
  - `kernel_online_update`: full online normalizer with `row_expand_mul` /
    `row_expand_div` / `reshape`; `is_first`/`is_last` as `BOOL`;
    mi/li as `[16, 1]` 2D column vectors
- Update orchestration signature: config tensor as `INT64`;
  block_table as `[batch * max_num_blocks_per_req]` INT32; add three
  byte-size scalar tensors (size_query, size_key_cache, size_value_cache)
- Add `PagedAttentionTestCase` to `test_paged_attention.py`: drives the
  complete 4-kernel pipeline through the `PTOTestCase` framework by
  implementing `define_tensors()`, `get_program()`, and `compute_expected()`
- `compute_expected()` provides a PyTorch online-softmax golden reference:
  ceiling-division KV-block loop, per-block valid_lens masking (preventing
  padding tokens from corrupting row-max / row-sum), and
  `struct.pack/unpack` to round-trip the float scale through the INT64
  config tensor
- Add `import struct` to the test module and import
  `build_paged_attention_program` from the example; add
  `test_paged_attention` parametrized test case to `TestPagedAttentionKernels`