### PR TITLE
fix(pass): Remove redundant sync pairs after scope crossing adjustment

### DIFF
--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -653,6 +653,8 @@ class SyncInserter {
     }
 
     DeduplicateSyncPairs(0);
+    RemoveTransitiveRedundantPairs(0);
+    RemoveLinearRedundantPairs(0);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Add RemoveTransitiveRedundantPairs and RemoveLinearRedundantPairs calls after DeduplicateSyncPairs in AdjustScopeCrossings phase, matching the cleanup pattern already used in CollectFromSeqStmts.