### PR TITLE
feat(language): Add cross-module function reuse via external and inline calls

### DIFF
--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -120,7 +120,7 @@ from .op.unified_ops import (
     transpose,
     view,
 )
-from .parser.decorator import function, program
+from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
 from .typing import DynVar, InOut, IntLike, Out, Scalar, Tensor, Tile, dynamic
 
@@ -153,7 +153,9 @@ INDEX = DataType.INDEX
 
 __all__ = [
     "function",
+    "inline",
     "program",
+    "InlineFunction",
     "parse",
     "parser",
     "loads",

--- a/python/pypto/language/parser/__init__.py
+++ b/python/pypto/language/parser/__init__.py
@@ -29,13 +29,15 @@ from types import TracebackType
 # Import DSL helpers from parent language module
 from ..dsl_api import range, yield_
 from ..typing import Scalar, Tensor, Tile
-from .decorator import function, program
+from .decorator import InlineFunction, function, inline, program
 from .diagnostics import ErrorRenderer, ParserError
 from .text_parser import loads, loads_program, parse, parse_program
 
 __all__ = [
     "function",
+    "inline",
     "program",
+    "InlineFunction",
     "parse",
     "loads",
     "parse_program",


### PR DESCRIPTION
## Summary
- Add support for `@pl.function` methods to call functions defined in other `@pl.program` classes via closure capture (external calls generate `ir.Call` nodes with `ir.GlobalVar`)
- Add `@pl.inline` decorator for definition-site function inlining (body is expanded at each call site during parsing)
- Both mechanisms integrate with control flow (`for`, `if/else`) and support type propagation
- Extract shared helpers (`_strip_self_parameter`, `_make_call_with_return_type`, `_is_docstring`) to reduce duplication

## Testing
- [x] 31 new tests across 4 test classes: `TestExternalFunctionCalls`, `TestInlineFunctionCalls`, `TestExternalFunctionControlFlow`, `TestInlineFunctionControlFlow`
- [x] All 1701 tests pass
- [x] Pre-commit hooks pass (ruff, pyright, markdownlint)
- [x] Code review completed

## Related Issues
Closes #305