### PR TITLE
feat(codegen/ir): Improve PTO codegen for reshape, create_tile, bool type, and reduction layout

### DIFF
--- a/src/backend/910B_PTO/backend_910b_pto_ops.cpp
+++ b/src/backend/910B_PTO/backend_910b_pto_ops.cpp
@@ -447,7 +447,6 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"block.move_fp",         "pto.tmov.fp",          2, PipeType::MTE1},
     {"block.transpose",       "pto.ttrans",           3},
     {"block.extract",         "pto.textract",         3},
-    {"block.reshape",         "pto.treshape",         1},
     // Gather/scatter operations
     {"block.gather",          "pto.tgather",          2},
     {"block.gatherb",         "pto.tgatherb",         2},
@@ -503,6 +502,14 @@ REGISTER_BACKEND_OP(Backend910B_PTO, "block.alloc")
     .set_pipe(ir::PipeType::MTE2)
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
       return MakeBlockAllocCodegenPTO(op, codegen);
+    });
+
+REGISTER_BACKEND_OP(Backend910B_PTO, "block.create_tile")
+    .set_pipe(ir::PipeType::MTE2)
+    .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+      (void)op;
+      (void)codegen_base;
+      return std::string("");  // No MLIR emission - tile allocation handled by pto.alloc_tile
     });
 
 REGISTER_BACKEND_OP(Backend910B_PTO, "block.store_fp")
@@ -565,6 +572,27 @@ REGISTER_BACKEND_OP(Backend910B_PTO, "block.print")
     .set_pipe(ir::PipeType::V)
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
       return MakePrintCodegenPTO("pto.tprint", op, codegen);
+    });
+
+REGISTER_BACKEND_OP(Backend910B_PTO, "block.reshape")
+    .set_pipe(ir::PipeType::V)
+    .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+      auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+      CHECK(op->args_.size() >= 1) << "Operation:[pto.treshape] requires at least 1 argument, but got "
+                                   << op->args_.size();
+      // Only use the first argument (source tile); shape tuple is metadata
+      std::string src = codegen.GetExprAsCode(op->args_[0]);
+      std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+      std::string result_target = codegen.GetCurrentResultTarget();
+      std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+      std::ostringstream oss;
+      oss << "pto.treshape ins(" << src;
+      if (!src_type.empty()) oss << " : " << src_type;
+      oss << ") outs(" << result_target;
+      if (!result_type.empty()) oss << " : " << result_type;
+      oss << ")";
+      codegen.Emit(oss.str());
+      return std::string("");
     });
 
 }  // namespace backend

--- a/src/backend/910B_PTO/backend_910b_pto_ops.cpp
+++ b/src/backend/910B_PTO/backend_910b_pto_ops.cpp
@@ -341,7 +341,7 @@ static std::string MakeBlockStoreCodegenPTO(const CallPtr& op, codegen::CodegenB
   }
   tstore_line << ") outs(" << partition_view << " : " << partition_type << ")";
   codegen.Emit(tstore_line.str());
-  return "";  // Multi-line emission
+  return "";
 }
 
 // Helper function for block.alloc (no-op: allocation handled elsewhere)
@@ -578,7 +578,7 @@ REGISTER_BACKEND_OP(Backend910B_PTO, "block.reshape")
     .set_pipe(ir::PipeType::V)
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
       auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-      CHECK(op->args_.size() >= 1) << "Operation:[pto.treshape] requires at least 1 argument, but got "
+      CHECK(op->args_.size() == 2) << "Operation:[block.reshape] requires 2 arguments (tile, shape), but got "
                                    << op->args_.size();
       // Only use the first argument (source tile); shape tuple is metadata
       std::string src = codegen.GetExprAsCode(op->args_[0]);

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -74,6 +74,8 @@ static std::string DataTypeToMLIRImpl(::pypto::DataType dtype) {
     return "i8";
   } else if (dtype == ::pypto::DataType::UINT8) {
     return "ui8";
+  } else if (dtype == ::pypto::DataType::BOOL) {
+    return "i1";
   } else {
     throw pypto::ValueError("Invalid DataType value");
   }

--- a/src/ir/op/block_ops/reduction.cpp
+++ b/src/ir/op/block_ops/reduction.cpp
@@ -145,8 +145,9 @@ TypePtr DeduceBlockRowReductionType(const std::vector<ExprPtr>& args,
   // Output shape is [...batch_dims, rows, 1] - reduce along last axis with keepdim=True
   std::vector<ExprPtr> output_shape(input_shape.begin(), input_shape.end() - 1);
   output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
-
-  return std::make_shared<TileType>(output_shape, tile_type->dtype_);
+  TileView tile_view;
+  tile_view.blayout = TileLayout::col_major;
+  return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
 
 // ============================================================================


### PR DESCRIPTION
feat(codegen/ir): Improve PTO codegen for reshape, create_tile, bool type, and reduction layout

- **block.reshape**: Move from simple op table to custom codegen that only emits the source tile argument (shape tuple is metadata, not an MLIR operand)
- **block.create_tile**: Register no-op codegen (tile allocation is handled by `pto.alloc_tile`)
- **BOOL type mapping**: Add `DataType::BOOL → i1` in PTO MLIR type conversion
- **Row reduction layout**: Set `col_major` TileView layout on row reduction output tile to match hardware requirements