### PR TITLE
feat: Add end-to-end FFN pipeline examples and extract activation examples

### DIFF
--- a/examples/language/intermediate/activation.py
+++ b/examples/language/intermediate/activation.py
@@ -1,0 +1,143 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Activation functions using PyPTO language DSL.
+
+Programs:
+  SiluProgram   — SiLU:   output = x * sigmoid(x)                    (32x128)
+  GeluProgram   — GELU:   output = x * sigmoid(1.702 * x)            (32x128)
+  SwigluProgram — SwiGLU: output = gate * sigmoid(gate) * up         (32x128)
+  GegluProgram  — GeGLU:  output = gate * sigmoid(1.702 * gate) * up (32x128)
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class SiluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_silu(
+        self,
+        x: pl.Tensor[[32, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        # SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+        tile_x: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
+        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(x_neg)
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
+        result: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
+        out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], [32, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def silu_orch(
+        self,
+        x: pl.Tensor[[32, 128], pl.FP32],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        output: pl.Tensor[[32, 128], pl.FP32] = pl.create_tensor([32, 128], dtype=pl.FP32)
+        output = self.kernel_silu(x, output)
+        return output
+
+
+@pl.program
+class GeluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_gelu(
+        self,
+        x: pl.Tensor[[32, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        # GELU(x) = x * sigmoid(1.702 * x)  (fast approximation)
+        tile_x: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
+        x_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
+        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(x_neg)
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
+        result: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
+        out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], [32, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def gelu_orch(
+        self,
+        x: pl.Tensor[[32, 128], pl.FP32],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        output: pl.Tensor[[32, 128], pl.FP32] = pl.create_tensor([32, 128], dtype=pl.FP32)
+        output = self.kernel_gelu(x, output)
+        return output
+
+
+@pl.program
+class SwigluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_swiglu(
+        self,
+        gate: pl.Tensor[[32, 128], pl.FP32],
+        up: pl.Tensor[[32, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        # SwiGLU(gate, up) = Swish(gate) * up = gate * sigmoid(gate) * up
+        tile_gate: pl.Tile[[32, 128], pl.FP32] = pl.load(gate, [0, 0], [32, 128])
+        tile_up: pl.Tile[[32, 128], pl.FP32] = pl.load(up, [0, 0], [32, 128])
+        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(gate_neg)
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
+        swish: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, sigmoid)
+        result: pl.Tile[[32, 128], pl.FP32] = pl.mul(swish, tile_up)
+        out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], [32, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def swiglu_orch(
+        self,
+        gate: pl.Tensor[[32, 128], pl.FP32],
+        up: pl.Tensor[[32, 128], pl.FP32],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        output: pl.Tensor[[32, 128], pl.FP32] = pl.create_tensor([32, 128], dtype=pl.FP32)
+        output = self.kernel_swiglu(gate, up, output)
+        return output
+
+
+@pl.program
+class GegluProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_geglu(
+        self,
+        gate: pl.Tensor[[32, 128], pl.FP32],
+        up: pl.Tensor[[32, 128], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        # GeGLU(gate, up) = GELU(gate) * up
+        # GELU approximation: gate * sigmoid(1.702 * gate)
+        tile_gate: pl.Tile[[32, 128], pl.FP32] = pl.load(gate, [0, 0], [32, 128])
+        tile_up: pl.Tile[[32, 128], pl.FP32] = pl.load(up, [0, 0], [32, 128])
+        gate_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, 1.702)  # type: ignore[reportArgumentType]
+        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(gate_scaled, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(gate_neg)
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
+        gelu_gate: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, sigmoid)
+        result: pl.Tile[[32, 128], pl.FP32] = pl.mul(gelu_gate, tile_up)
+        out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], [32, 128], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def geglu_orch(
+        self,
+        gate: pl.Tensor[[32, 128], pl.FP32],
+        up: pl.Tensor[[32, 128], pl.FP32],
+    ) -> pl.Tensor[[32, 128], pl.FP32]:
+        output: pl.Tensor[[32, 128], pl.FP32] = pl.create_tensor([32, 128], dtype=pl.FP32)
+        output = self.kernel_geglu(gate, up, output)
+        return output

--- a/examples/language/intermediate/ffn_activations.py
+++ b/examples/language/intermediate/ffn_activations.py
@@ -8,58 +8,101 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """
-FFN activation functions using PyPTO language DSL.
+FFN module programs using PyPTO language DSL.
 
-Programs:
-  GeluProgram    — GELU:   output = x * sigmoid(1.702 * x)        (128x128)
-  SwigluProgram  — SwiGLU: output = gate * sigmoid(gate) * up     (64x64)
-  SiluProgram    — SiLU:   output = x * sigmoid(x)                (64x64)
-  GegluProgram   — GeGLU:  output = gate * sigmoid(1.702 * gate) * up  (64x64)
+Each program implements a full FFN forward pass (gate projection → activation → down
+projection) in a single 64x64 tile:
+
+  FFNGeluProgram   — output = GELU(hidden_states @ gate_proj_weight) @ down_proj_weight
+  FFNSwigluProgram — output = SwiGLU(gate, up) @ down_proj_weight
+                     where gate = hidden_states @ gate_proj_weight
+                           up   = hidden_states @ up_proj_weight
+  FFNReluProgram   — output = ReLU(hidden_states @ gate_proj_weight) @ down_proj_weight
 """
 
 import pypto.language as pl
 
 
 @pl.program
-class GeluProgram:
+class FFNGeluProgram:
     @pl.function(type=pl.FunctionType.InCore)
-    def kernel_gelu(
+    def matmul_kernel(
         self,
-        x: pl.Tensor[[128, 128], pl.FP32],
-        output: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-    ) -> pl.Tensor[[128, 128], pl.FP32]:
-        tile_x: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
-        x_scaled: pl.Tile[[128, 128], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
-        x_neg: pl.Tile[[128, 128], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
-        exp_neg: pl.Tile[[128, 128], pl.FP32] = pl.exp(x_neg)
-        denom: pl.Tile[[128, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
-        sigmoid: pl.Tile[[128, 128], pl.FP32] = pl.recip(denom)
-        result: pl.Tile[[128, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
-        out: pl.Tensor[[128, 128], pl.FP32] = pl.store(result, [0, 0], [128, 128], output)
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Cube InCore: compute a @ b and store result to GM."""
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out = pl.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def gelu_kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Vector InCore: apply GELU activation — x * sigmoid(1.702 * x)."""
+        tile_x: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+        x_scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
+        x_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
+        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(x_neg)
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
+        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, sigmoid)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
         return out
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def gelu_orch(
+    def ffn_gelu_orch(
         self,
-        x: pl.Tensor[[128, 128], pl.FP32],
-    ) -> pl.Tensor[[128, 128], pl.FP32]:
-        output: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-        output = self.kernel_gelu(x, output)
+        hidden_states: pl.Tensor[[64, 64], pl.FP32],
+        gate_proj_weight: pl.Tensor[[64, 64], pl.FP32],
+        down_proj_weight: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # gate = hidden_states @ gate_proj_weight
+        gate: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        gate = self.matmul_kernel(hidden_states, gate_proj_weight, gate)
+        # activated = GELU(gate)
+        activated: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        activated = self.gelu_kernel(gate, activated)
+        # output = activated @ down_proj_weight
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.matmul_kernel(activated, down_proj_weight, output)
         return output
 
 
 @pl.program
-class SwigluProgram:
+class FFNSwigluProgram:
     @pl.function(type=pl.FunctionType.InCore)
-    def kernel_swiglu(
+    def matmul_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Cube InCore: compute a @ b and store result to GM."""
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out = pl.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def swiglu_kernel(
         self,
         gate: pl.Tensor[[64, 64], pl.FP32],
         up: pl.Tensor[[64, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        # Swish(gate) = gate * sigmoid(gate) = gate / (1 + exp(-gate))
-        # Note: -1.0 and 1.0 are inlined as literals; outer variables
-        # are not accessible inside the DSL kernel closure.
+        """Vector InCore: apply SwiGLU activation — gate * sigmoid(gate) * up."""
         tile_gate: pl.Tile[[64, 64], pl.FP32] = pl.load(gate, [0, 0], [64, 64])
         tile_up: pl.Tile[[64, 64], pl.FP32] = pl.load(up, [0, 0], [64, 64])
         gate_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
@@ -72,73 +115,72 @@ class SwigluProgram:
         return out
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def swiglu_orch(
+    def ffn_swiglu_orch(
         self,
-        gate: pl.Tensor[[64, 64], pl.FP32],
-        up: pl.Tensor[[64, 64], pl.FP32],
+        hidden_states: pl.Tensor[[64, 64], pl.FP32],
+        gate_proj_weight: pl.Tensor[[64, 64], pl.FP32],
+        up_proj_weight: pl.Tensor[[64, 64], pl.FP32],
+        down_proj_weight: pl.Tensor[[64, 64], pl.FP32],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # gate = hidden_states @ gate_proj_weight
+        gate: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        gate = self.matmul_kernel(hidden_states, gate_proj_weight, gate)
+        # up = hidden_states @ up_proj_weight
+        up: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        up = self.matmul_kernel(hidden_states, up_proj_weight, up)
+        # activated = SwiGLU(gate, up)
+        activated: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        activated = self.swiglu_kernel(gate, up, activated)
+        # output = activated @ down_proj_weight
         output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
-        output = self.kernel_swiglu(gate, up, output)
+        output = self.matmul_kernel(activated, down_proj_weight, output)
         return output
 
 
 @pl.program
-class SiluProgram:
+class FFNReluProgram:
     @pl.function(type=pl.FunctionType.InCore)
-    def kernel_silu(
+    def matmul_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Cube InCore: compute a @ b and store result to GM."""
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out = pl.l0c_store(tile_c_l0c, offsets=[0, 0], shapes=[64, 64], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def relu_kernel(
         self,
         x: pl.Tensor[[64, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        # SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+        """Vector InCore: apply ReLU activation — max(0, x)."""
         tile_x: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
-        x_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, -1.0)  # type: ignore[reportArgumentType]
-        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(x_neg)
-        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
-        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
-        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, sigmoid)
+        result: pl.Tile[[64, 64], pl.FP32] = pl.relu(tile_x)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
         return out
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def silu_orch(
+    def ffn_relu_orch(
         self,
-        x: pl.Tensor[[64, 64], pl.FP32],
+        hidden_states: pl.Tensor[[64, 64], pl.FP32],
+        gate_proj_weight: pl.Tensor[[64, 64], pl.FP32],
+        down_proj_weight: pl.Tensor[[64, 64], pl.FP32],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # gate = hidden_states @ gate_proj_weight
+        gate: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        gate = self.matmul_kernel(hidden_states, gate_proj_weight, gate)
+        # activated = ReLU(gate)
+        activated: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        activated = self.relu_kernel(gate, activated)
+        # output = activated @ down_proj_weight
         output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
-        output = self.kernel_silu(x, output)
-        return output
-
-
-@pl.program
-class GegluProgram:
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_geglu(
-        self,
-        gate: pl.Tensor[[64, 64], pl.FP32],
-        up: pl.Tensor[[64, 64], pl.FP32],
-        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
-    ) -> pl.Tensor[[64, 64], pl.FP32]:
-        # GeGLU(gate, up) = GELU(gate) * up
-        # GELU approximation: gate * sigmoid(1.702 * gate)
-        tile_gate: pl.Tile[[64, 64], pl.FP32] = pl.load(gate, [0, 0], [64, 64])
-        tile_up: pl.Tile[[64, 64], pl.FP32] = pl.load(up, [0, 0], [64, 64])
-        gate_scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, 1.702)  # type: ignore[reportArgumentType]
-        gate_scaled_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(gate_scaled, -1.0)  # type: ignore[reportArgumentType]
-        exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(gate_scaled_neg)
-        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
-        sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
-        gelu_gate: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, sigmoid)
-        result: pl.Tile[[64, 64], pl.FP32] = pl.mul(gelu_gate, tile_up)
-        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], [64, 64], output)
-        return out
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def geglu_orch(
-        self,
-        gate: pl.Tensor[[64, 64], pl.FP32],
-        up: pl.Tensor[[64, 64], pl.FP32],
-    ) -> pl.Tensor[[64, 64], pl.FP32]:
-        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
-        output = self.kernel_geglu(gate, up, output)
+        output = self.matmul_kernel(activated, down_proj_weight, output)
         return output

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -180,6 +180,7 @@ TypePtr DeduceBlockMoveType(const std::vector<ExprPtr>& args,
 
   TileView tile_view;
   if (space == MemorySpace::Left) {
+    tile_view.blayout = TileLayout::col_major;  // L0A requires ColMajor block layout for TMATMUL
     tile_view.slayout = TileLayout::row_major;
   } else if (space == MemorySpace::Right) {
     tile_view.slayout = TileLayout::col_major;

--- a/tests/st/examples/02_intermediate/test_activation.py
+++ b/tests/st/examples/02_intermediate/test_activation.py
@@ -1,0 +1,155 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Activation Function System Tests for PyPTO.
+
+Four activation patterns are demonstrated:
+  1. SiLU   — x * sigmoid(x)
+  2. GELU   — x * sigmoid(1.702 * x)
+  3. SwiGLU — gate * sigmoid(gate) * up
+  4. GeGLU  — gate * sigmoid(1.702 * gate) * up
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.intermediate.activation import (
+    GegluProgram,
+    GeluProgram,
+    SiluProgram,
+    SwigluProgram,
+)
+
+
+class TestSiluActivation(PTOTestCase):
+    """SiLU (Swish) activation with 32x128 input: output = x * sigmoid(x)"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "silu_activation_32x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SiluProgram
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        tensors["output"][:] = x * torch.sigmoid(x)
+
+
+class TestGeluActivation(PTOTestCase):
+    """GELU activation with 32x128 input: output = x * sigmoid(1.702 * x)"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "gelu_activation_32x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GeluProgram
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        tensors["output"][:] = x * torch.sigmoid(1.702 * x)
+
+
+class TestSwigluActivation(PTOTestCase):
+    """SwiGLU activation with 32x128 input: output = gate * sigmoid(gate) * up"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "swiglu_activation_32x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("gate", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("up", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SwigluProgram
+
+    def compute_expected(self, tensors, params=None):
+        gate = tensors["gate"]
+        up = tensors["up"]
+        tensors["output"][:] = gate * torch.sigmoid(gate) * up
+
+
+class TestGegluActivation(PTOTestCase):
+    """GeGLU activation with 32x128 input: output = gate * sigmoid(1.702 * gate) * up"""
+
+    __test__ = False  # Not a pytest test class
+
+    def get_name(self) -> str:
+        return "geglu_activation_32x128"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("gate", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("up", [32, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GegluProgram
+
+    def compute_expected(self, tensors, params=None):
+        gate = tensors["gate"]
+        up = tensors["up"]
+        tensors["output"][:] = gate * torch.sigmoid(1.702 * gate) * up
+
+
+class TestActivationOperations:
+    """Test suite for activation operations."""
+
+    def test_silu_activation_32x128(self, test_runner):
+        """Test SiLU (Swish) activation with 32x128 input."""
+        test_case = TestSiluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_gelu_activation_32x128(self, test_runner):
+        """Test GELU activation with 32x128 input."""
+        test_case = TestGeluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_swiglu_activation_32x128(self, test_runner):
+        """Test SwiGLU activation with 32x128 input."""
+        test_case = TestSwigluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_geglu_activation_32x128(self, test_runner):
+        """Test GeGLU activation with 32x128 input."""
+        test_case = TestGegluActivation()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add `activation.py` with four standalone activation programs (SiLU, GELU, SwiGLU, GeGLU) on 32x128 tiles, each implementing a single activation step
- Refactor `ffn_activations.py` into three full FFN pipeline programs (FFNGeluProgram, FFNSwigluProgram, FFNReluProgram) that chain gate projection → activation → down projection on 64x64 tiles
- Fix `DeduceBlockMoveType` in `block_ops/memory.cpp`: set `blayout = col_major` for L0A moves so TMATMUL receives the required ColMajor layout
- Add `test_activation.py` for standalone activation system tests; update `test_ffn_activations.py` to test full FFN pipelines with tolerance `TestConfig(atol=3e-3, rtol=3e-3)`