### PR TITLE
fix(passes/codegen): Add memory reuse shape check and col_major layout for unit-dim tile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.2
-          PTOAS_SHA256=2d0a89b6790e6dc5b76b13b005ce75942b91f36dc11009460bed270dd3646887
+          PTOAS_VERSION=v0.3
+          PTOAS_SHA256=203727d744cd437325e3b22c599ca90f642e51e735ede2ac3a22636b36aa89d9
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/src/ir/op/block_ops/memory.cpp
+++ b/src/ir/op/block_ops/memory.cpp
@@ -109,6 +109,10 @@ TypePtr DeduceBlockLoadType(const std::vector<ExprPtr>& args,
     tile_shape.push_back(shape_expr);
   }
 
+  if (auto last_dim = As<ConstInt>(tile_shape.back()); last_dim && last_dim->value_ == 1) {
+    tile_view.blayout = TileLayout::col_major;
+  }
+
   // Return TileType with same dtype as tensor
   return std::make_shared<TileType>(tile_shape, tensor_type->dtype_, std::nullopt, tile_view);
 }

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -313,6 +313,27 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
           continue;  // Cannot reuse due to overlap with source or insufficient size
         }
 
+        // Check shape compatibility: PTO codegen binds the alloc_tile type (shape,
+        // blayout, etc.) to the buffer and uses it for ALL operations referencing
+        // that buffer.  Reuse between tiles with different shapes would cause
+        // attribute mismatches in the generated PTO IR.
+        auto curr_tile = As<TileType>(curr_var->GetType());
+        auto prev_tile = As<TileType>(prev_var->GetType());
+        if (curr_tile && prev_tile) {
+          const auto& shape1 = curr_tile->shape_;
+          const auto& shape2 = prev_tile->shape_;
+          bool shape_match =
+              (shape1.size() == shape2.size()) && std::equal(shape1.begin(), shape1.end(), shape2.begin(),
+                                                             [](const ExprPtr& e1, const ExprPtr& e2) {
+                                                               auto c1 = As<ConstInt>(e1);
+                                                               auto c2 = As<ConstInt>(e2);
+                                                               return c1 && c2 && c1->value_ == c2->value_;
+                                                             });
+          if (!shape_match) {
+            continue;  // Cannot reuse due to shape mismatch
+          }
+        }
+
         // CRITICAL: Check if current variable's lifetime overlaps with ANY variable
         // that is already reusing the same MemRef (transitive reuse check)
         bool overlaps_with_users = false;

--- a/tests/st/codegen/test_paged_attention.py
+++ b/tests/st/codegen/test_paged_attention.py
@@ -36,6 +36,8 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.ir_parser.paged_attention_example import build_paged_attention_program
 
@@ -659,6 +661,39 @@ class PagedAttentionTestCase(PTOTestCase):
         tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
 
 
+class PTOASTestCaseMixin:
+    """Mixin for test cases using PTO backend and PTOAS optimization strategy."""
+
+    __test__ = False
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.PTOAS
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.PTO
+
+
+class QKMatmulPTOASTestCase(PTOASTestCaseMixin, QKMatmulTestCase):
+    """Test QK matmul with PTO backend and PTOAS optimization strategy."""
+
+    def get_name(self) -> str:
+        return f"qk_matmul_ptoas_{self.num_heads}h_{self.head_dim}d_b{self.block_size}"
+
+
+class SoftmaxPreparePTOASTestCase(PTOASTestCaseMixin, SoftmaxPrepareTestCase):
+    """Test softmax prepare with PTO backend and PTOAS optimization strategy."""
+
+    def get_name(self) -> str:
+        return f"softmax_prepare_ptoas_{self.num_heads}h_{self.block_size}b"
+
+
+class PVMatmulPTOASTestCase(PTOASTestCaseMixin, PVMatmulTestCase):
+    """Test PV matmul with PTO backend and PTOAS optimization strategy."""
+
+    def get_name(self) -> str:
+        return f"pv_matmul_ptoas_{self.num_heads}h_{self.head_dim}d"
+
+
 class TestPagedAttentionKernels:
     """Integration tests for the four Paged Attention kernels.
 
@@ -722,3 +757,30 @@ class TestPagedAttentionKernels:
         )
         result = test_runner.run(test_case)
         assert result.passed, f"Paged attention test failed: {result.error}"
+
+    # ── PTOAS variants ────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("num_heads,head_dim,block_size", [(16, 128, 128)])
+    def test_qk_matmul_ptoas(self, test_runner, num_heads, head_dim, block_size):
+        """Test QK matmul with PTO backend and PTOAS optimization."""
+        test_case = QKMatmulPTOASTestCase(num_heads=num_heads, head_dim=head_dim, block_size=block_size)
+        result = test_runner.run(test_case)
+        assert result.passed, f"QK matmul PTOAS test failed: {result.error}"
+
+    @pytest.mark.parametrize("num_heads,block_size", [(16, 128)])
+    def test_softmax_prepare_ptoas(self, test_runner, num_heads, block_size):
+        """Test softmax prepare with PTO backend and PTOAS optimization."""
+        test_case = SoftmaxPreparePTOASTestCase(num_heads=num_heads, block_size=block_size)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Softmax prepare PTOAS test failed: {result.error}"
+
+    @pytest.mark.parametrize("num_heads,block_size,head_dim", [(16, 128, 128)])
+    def test_pv_matmul_ptoas(self, test_runner, num_heads, block_size, head_dim):
+        """Test PV matmul with PTO backend and PTOAS optimization."""
+        test_case = PVMatmulPTOASTestCase(num_heads=num_heads, block_size=block_size, head_dim=head_dim)
+        result = test_runner.run(test_case)
+        assert result.passed, f"PV matmul PTOAS test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -156,9 +156,11 @@ class TestBasicMemoryReuse:
         _assert_shares_memref(func, "tile_c", "tile_e")
 
     def test_different_sizes(self):
-        """Small tile (32x32) can reuse large tile (64x64) buffer, not vice versa.
+        """Different-shaped tiles cannot reuse each other's buffer.
 
-        tile_d (32x32) reuses tile_a (64x64) since 64x64 >= 32x32.
+        PTO codegen binds alloc_tile type to the buffer, so shape must match
+        exactly. tile_e (64x64) reuses tile_a (64x64); tile_f (32x32) reuses
+        tile_b (32x32); cross-shape reuse is forbidden despite sufficient size.
         """
 
         @pl.program
@@ -172,17 +174,26 @@ class TestBasicMemoryReuse:
                 output_b: pl.Tensor[[32, 32], pl.FP32],
             ) -> pl.Tensor[[32, 32], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+                _result_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], [64, 64], output_a)
                 tile_b: pl.Tile[[32, 32], pl.FP32] = pl.load(input_b, [0, 0], [32, 32])
-                tile_c: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
-                _result_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_c, [0, 0], [64, 64], output_a)
-                tile_d: pl.Tile[[32, 32], pl.FP32] = pl.add(tile_b, tile_b)
-                result_b: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_d, [0, 0], [32, 32], output_b)
-                return result_b
+                _result_b: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], [32, 32], output_b)
+                # tile_a and tile_b are dead
+                tile_e: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+                tile_f: pl.Tile[[32, 32], pl.FP32] = pl.load(input_b, [0, 0], [32, 32])
+                _result_e: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], [64, 64], output_a)
+                result_f: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_f, [0, 0], [32, 32], output_b)
+                return result_f
 
         func = _prepare_and_run_memory_reuse(Before)
 
         _assert_all_have_memrefs(func)
-        _assert_shares_memref(func, "tile_a", "tile_d")
+        # Same shape reuses: tile_e (64x64) reuses tile_a (64x64)
+        _assert_shares_memref(func, "tile_a", "tile_e")
+        # Same shape reuses: tile_f (32x32) reuses tile_b (32x32)
+        _assert_shares_memref(func, "tile_b", "tile_f")
+        # Different shapes cannot reuse despite sufficient size
+        _assert_not_shares_memref(func, "tile_a", "tile_f")
+        _assert_not_shares_memref(func, "tile_b", "tile_e")
 
     def test_empty_function(self):
         """Empty function should not crash."""


### PR DESCRIPTION
fix(passes/codegen): Add memory reuse shape check and col_major layout for unit-dim tile

- Add shape compatibility check in BasicMemoryReusePass to prevent reuse
  between tiles with different shapes (PTO codegen requires matching types)
- Exclude block.reshape outputs from memory reuse alongside block.cast
- Set col_major tile layout when block.load last dimension is 1
- Add PTOAS optimization strategy test variants for paged attention kernels (matmul & softmax)
- Updated PTOAS to v0.3 in ci.yaml