### PR TITLE
feat(ir/passes): handle store outputs and Opaque->Orchestration in OutlineIncoreScopes

### DIFF
--- a/examples/ir_parser/paged_attention_with_incore.py
+++ b/examples/ir_parser/paged_attention_with_incore.py
@@ -1,0 +1,463 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Paged Attention: single orchestration with embedded InCore via with pl.incore()
+
+Same pipeline as paged_attention_example.py (QK matmul → softmax prepare → PV matmul
+→ online update) but all incore logic is inlined inside the orchestration using
+with pl.incore(): blocks instead of calling separate @pl.function(type=InCore) kernels.
+
+Uses chunked loop syntax (para_for.md): batch and query-tile loops are chunked for
+parallel expansion (chunk loop + in_chunk loop); the KV-block loop (bn) stays
+sequential due to online softmax recurrence.
+"""
+
+import os
+import struct
+from datetime import datetime
+
+import pypto.language as pl
+import torch  # type: ignore[import]
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+from pypto.runtime import RunConfig, RunResult, TensorSpec, run
+
+# Tile sizes used inside incore blocks (must match views created in orchestration)
+Q_TILE = 16
+BLOCK_SIZE = 128
+HEAD_DIM = 128
+
+
+def build_paged_attention_program(
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    max_num_blocks_per_req: int,
+    q_tile: int = Q_TILE,
+):
+    """Build a parameterised paged-attention @pl.program with embedded incore blocks."""
+
+    # Loop bounds and dimensions as constants (compile-time); enables chunked parallel loops
+    BATCH_CFG = batch
+    Q_LOOP_CFG = (num_heads + q_tile - 1) // q_tile
+    Q_HEAD_NUM = num_heads
+    BLOCK_NUM_CFG = max_num_blocks_per_req
+    HEAD_DIM_CFG = head_dim
+    BLOCK_SIZE_CFG = block_size
+    # Chunk sizes for chunked loops (bounds are now constants)
+    BATCH_CHUNK = 8
+    Q_CHUNK = 2
+
+    query_rows = batch * num_heads
+    key_cache_rows = batch * max_num_blocks_per_req * block_size
+    out_rows = batch * num_heads
+    block_table_flat_size = batch * max_num_blocks_per_req
+
+    @pl.program
+    class PagedAttentionProgram:
+        """Paged attention: one orchestration, incore logic embedded via with pl.incore()."""
+
+        @pl.function
+        def paged_attention(  # noqa: PLR0915
+            self,
+            query: pl.Tensor[[query_rows, head_dim], pl.BF16],
+            key_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
+            value_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
+            block_table: pl.Tensor[[block_table_flat_size], pl.INT32],
+            context_lens: pl.Tensor[[batch], pl.INT32],
+            out: pl.Tensor[[out_rows, head_dim], pl.FP32],
+            config: pl.Tensor[[7], pl.INT64],
+            size_query: pl.Tensor[[1], pl.INT64],
+            size_key_cache: pl.Tensor[[1], pl.INT64],
+            size_value_cache: pl.Tensor[[1], pl.INT64],
+        ) -> pl.Tensor[[out_rows, head_dim], pl.FP32]:
+            """Orchestration: chunked loops over batch/q_tile; sequential bn with pl.incore()."""
+            # Loop bounds and dimensions from pa.py constants (BATCH_CFG, Q_LOOP_CFG, etc.)
+
+            # Chunked loop over batch: pl.parallel, chunk → expansion (bounds are compile-time constants)
+            for b_idx in pl.parallel(0, BATCH_CFG, 1, chunk=BATCH_CHUNK):
+                cur_seq = pl.tensor.read(context_lens, [b_idx])
+                bn_this_batch = (cur_seq + BLOCK_SIZE_CFG - 1) // BLOCK_SIZE_CFG
+                # Chunked loop over query-tile groups: pl.parallel, chunk → expansion
+                for q_idx in pl.parallel(0, Q_LOOP_CFG, 1, chunk=Q_CHUNK):
+                    cur_offset = b_idx * Q_HEAD_NUM + q_idx * q_tile
+
+                    oi: pl.Tensor[[q_tile, HEAD_DIM_CFG], pl.FP32] = pl.create_tensor(
+                        [q_tile, HEAD_DIM_CFG],
+                        dtype=pl.FP32,
+                    )
+                    li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+                    mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+
+                    # ── Init: zero accumulators (embedded incore) ─────────────
+                    with pl.incore():
+                        zero_oi = pl.block.full([Q_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                        zero_li = pl.block.full([Q_TILE, 1], dtype=pl.FP32, value=0.0)
+                        zero_mi = pl.block.full([Q_TILE, 1], dtype=pl.FP32, value=0.0)
+                        pl.store(zero_oi, [0, 0], [Q_TILE, HEAD_DIM], oi)
+                        pl.store(zero_li, [0, 0], [Q_TILE, 1], li_update)
+                        pl.store(zero_mi, [0, 0], [Q_TILE, 1], mi_update)
+
+                    # Sequential loop over KV blocks (no parallel): online softmax has loop-carried
+                    # dependency (mi_update, li_update, oi depend on previous bn); order must be preserved.
+                    for bn in pl.range(bn_this_batch):
+                        qi: pl.Tensor[[q_tile, HEAD_DIM_CFG], pl.BF16] = pl.view(
+                            query, [q_tile, HEAD_DIM_CFG], [cur_offset, 0]
+                        )
+                        cur_block_idx = pl.tensor.read(block_table, [b_idx * BLOCK_NUM_CFG + bn])
+                        valid_len = pl.min(BLOCK_SIZE_CFG, cur_seq - bn * BLOCK_SIZE_CFG)
+                        kv_block_row = cur_block_idx * BLOCK_SIZE_CFG
+                        kj: pl.Tensor[[BLOCK_SIZE_CFG, HEAD_DIM_CFG], pl.BF16] = pl.view(
+                            key_cache, [BLOCK_SIZE_CFG, HEAD_DIM_CFG], [kv_block_row, 0]
+                        )
+                        vj: pl.Tensor[[BLOCK_SIZE_CFG, HEAD_DIM_CFG], pl.BF16] = pl.view(
+                            value_cache, [BLOCK_SIZE_CFG, HEAD_DIM_CFG], [kv_block_row, 0]
+                        )
+
+                        sij: pl.Tensor[[q_tile, BLOCK_SIZE_CFG], pl.FP32] = pl.create_tensor(
+                            [q_tile, BLOCK_SIZE_CFG], dtype=pl.FP32
+                        )
+
+                        # ── QK matmul (embedded incore) ─────────────────────────
+                        with pl.incore():
+                            qi_l1 = pl.load(qi, [0, 0], [Q_TILE, HEAD_DIM], target_memory=pl.MemorySpace.Mat)
+                            kj_l1 = pl.load(
+                                kj, [0, 0], [BLOCK_SIZE, HEAD_DIM], target_memory=pl.MemorySpace.Mat
+                            )
+                            qi_l0a = pl.move(qi_l1, target_memory=pl.MemorySpace.Left)
+                            kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right, transpose=True)
+                            sij_l0c = pl.matmul(qi_l0a, kj_l0b)
+                            pl.l0c_store(sij_l0c, [0, 0], [Q_TILE, BLOCK_SIZE], sij)
+
+                        sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.view(
+                            sij, [q_tile, valid_len], [0, 0]
+                        )
+
+                        pij_f16: pl.Tensor[[q_tile, BLOCK_SIZE_CFG], pl.BF16] = pl.create_tensor(
+                            [q_tile, BLOCK_SIZE_CFG], dtype=pl.BF16
+                        )
+                        mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+                        li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+
+                        # ── Softmax prepare (embedded incore) ───────────────────
+                        # Uses valid_len for the slice extent when loading/storing sij_valid.
+                        with pl.incore():
+                            scale = 1.0
+                            s_tile = pl.load(
+                                sij_valid, [0, 0], [Q_TILE, valid_len], target_memory=pl.MemorySpace.Vec
+                            )
+                            scaled = pl.mul(s_tile, scale)
+                            tmp_tile = pl.create_tile(
+                                [Q_TILE, BLOCK_SIZE], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                            )
+                            mi_tile = pl.row_max(scaled, tmp_tile)
+                            sij_centered = pl.row_expand_sub(scaled, mi_tile)
+                            exp_tile = pl.exp(sij_centered)
+                            pij_tile_bf16 = pl.cast(exp_tile, target_type=pl.BF16)
+                            pij_tile = pl.cast(pij_tile_bf16, target_type=pl.FP32)
+                            li_tile = pl.row_sum(pij_tile, tmp_tile)
+                            pl.store(pij_tile_bf16, [0, 0], [Q_TILE, valid_len], pij_f16)
+                            pl.store(mi_tile, [0, 0], [Q_TILE, 1], mi)
+                            pl.store(li_tile, [0, 0], [Q_TILE, 1], li)
+
+                        oi_tmp: pl.Tensor[[q_tile, HEAD_DIM_CFG], pl.FP32] = pl.create_tensor(
+                            [q_tile, HEAD_DIM_CFG], dtype=pl.FP32
+                        )
+
+                        # ── PV matmul (embedded incore) ─────────────────────────
+                        with pl.incore():
+                            pij_l1 = pl.load(
+                                pij_f16, [0, 0], [Q_TILE, BLOCK_SIZE], target_memory=pl.MemorySpace.Mat
+                            )
+                            vj_l1 = pl.load(
+                                vj, [0, 0], [BLOCK_SIZE, HEAD_DIM], target_memory=pl.MemorySpace.Mat
+                            )
+                            pij_l0a = pl.move(pij_l1, target_memory=pl.MemorySpace.Left)
+                            vj_l0b = pl.move(vj_l1, target_memory=pl.MemorySpace.Right)
+                            oi_l0c = pl.matmul(pij_l0a, vj_l0b)
+                            pl.l0c_store(oi_l0c, [0, 0], [Q_TILE, HEAD_DIM], oi_tmp)
+
+                        if bn == 0:
+                            is_first: pl.Scalar[pl.BOOL] = pl.yield_(1)
+                        else:
+                            is_first = pl.yield_(0)
+                        if bn == bn_this_batch - 1:
+                            is_last: pl.Scalar[pl.BOOL] = pl.yield_(1)
+                        else:
+                            is_last = pl.yield_(0)
+
+                        out_view: pl.Tensor[[q_tile, HEAD_DIM_CFG], pl.FP32] = pl.view(
+                            out, [q_tile, HEAD_DIM_CFG], [cur_offset, 0]
+                        )
+
+                        # ── Online softmax update (embedded incore) ─────────────
+                        with pl.incore():
+                            mij_tile = pl.load(mi, [0, 0], [Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+                            lij_tile = pl.load(li, [0, 0], [Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+                            oi_new_tile = pl.load(
+                                oi_tmp, [0, 0], [Q_TILE, HEAD_DIM], target_memory=pl.MemorySpace.Vec
+                            )
+                            mi_tile = pl.load(
+                                mi_update, [0, 0], [Q_TILE, 1], target_memory=pl.MemorySpace.Vec
+                            )
+                            li_tile = pl.load(
+                                li_update, [0, 0], [Q_TILE, 1], target_memory=pl.MemorySpace.Vec
+                            )
+                            oi_tile = pl.load(
+                                oi, [0, 0], [Q_TILE, HEAD_DIM], target_memory=pl.MemorySpace.Vec
+                            )
+
+                            if is_first:
+                                pl.store(mij_tile, [0, 0], [Q_TILE, 1], mi_update)
+                                pl.store(lij_tile, [0, 0], [Q_TILE, 1], li_update)
+                                pl.store(oi_new_tile, [0, 0], [Q_TILE, HEAD_DIM], oi)
+                                if is_last:
+                                    dst_tile = pl.row_expand_div(oi_new_tile, lij_tile)
+                                    pl.store(dst_tile, [0, 0], [Q_TILE, HEAD_DIM], out_view)
+                                else:
+                                    zero_tile = pl.block.full([Q_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                                    pl.store(zero_tile, [0, 0], [Q_TILE, HEAD_DIM], out_view)
+                            else:
+                                mi_tile_nd = pl.reshape(mi_tile, [1, Q_TILE])
+                                mij_tile_nd = pl.reshape(mij_tile, [1, Q_TILE])
+                                li_tile_nd = pl.reshape(li_tile, [1, Q_TILE])
+                                lij_tile_nd = pl.reshape(lij_tile, [1, Q_TILE])
+                                mi_new = pl.maximum(mi_tile_nd, mij_tile_nd)
+                                mi_diff = pl.sub(mi_tile_nd, mi_new)
+                                alpha = pl.exp(mi_diff)
+                                mij_diff = pl.sub(mij_tile_nd, mi_new)
+                                beta = pl.exp(mij_diff)
+                                li_scaled = pl.mul(alpha, li_tile_nd)
+                                lij_scaled = pl.mul(beta, lij_tile_nd)
+                                li_updated = pl.add(li_scaled, lij_scaled)
+                                alpha_dn = pl.reshape(alpha, [Q_TILE, 1])
+                                oi_scaled = pl.row_expand_mul(oi_tile, alpha_dn)
+                                beta_dn = pl.reshape(beta, [Q_TILE, 1])
+                                oi_new_scaled = pl.row_expand_mul(oi_new_tile, beta_dn)
+                                oi_updated = pl.add(oi_scaled, oi_new_scaled)
+                                mi_new_dn = pl.reshape(mi_new, [Q_TILE, 1])
+                                li_updated_dn = pl.reshape(li_updated, [Q_TILE, 1])
+                                pl.store(mi_new_dn, [0, 0], [Q_TILE, 1], mi_update)
+                                pl.store(li_updated_dn, [0, 0], [Q_TILE, 1], li_update)
+                                if is_last:
+                                    dst_tile = pl.row_expand_div(oi_updated, li_updated_dn)
+                                    pl.store(dst_tile, [0, 0], [Q_TILE, HEAD_DIM], out_view)
+                                    pl.store(oi_updated, [0, 0], [Q_TILE, HEAD_DIM], oi)
+                                else:
+                                    zero_tile = pl.block.full([Q_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                                    pl.store(zero_tile, [0, 0], [Q_TILE, HEAD_DIM], out_view)
+                                    pl.store(oi_updated, [0, 0], [Q_TILE, HEAD_DIM], oi)
+
+            return out
+
+    return PagedAttentionProgram
+
+
+def golden(tensors: dict, params: dict | None = None) -> None:
+    """Reference paged-attention (torch), matching the 4-stage pipeline."""
+    config = tensors["config"]
+    batch = int(config[0].item())
+    num_heads = int(config[1].item())
+    head_dim = int(config[3].item())
+    block_size = int(config[4].item())
+    max_num_blocks_per_req = int(config[5].item())
+    scale_bits = int(config[6].item())
+    scale = struct.unpack("f", struct.pack("I", scale_bits & 0xFFFFFFFF))[0]
+
+    query = tensors["query"].float().reshape(batch, num_heads, head_dim)
+    total_pool_blocks = batch * max_num_blocks_per_req
+    key_cache = tensors["key_cache"].float().reshape(total_pool_blocks, block_size, head_dim)
+    value_cache = tensors["value_cache"].float().reshape(total_pool_blocks, block_size, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
+
+    out = torch.zeros((batch, num_heads, head_dim), dtype=torch.float32)
+    q_tile = 16
+    max_bn = int((context_lens.max().item() + block_size - 1) // block_size)
+
+    for q_offset in range(0, num_heads, q_tile):
+        q_tile_size = min(q_tile, num_heads - q_offset)
+        qi = query[:, q_offset : q_offset + q_tile_size, :]
+        oi, li, mi = None, None, None
+
+        for bn in range(max_bn):
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            if not (valid_lens > 0).any():
+                break
+            block_indices = block_table[:, bn]
+            kj_all = key_cache[block_indices]
+            vj_all = value_cache[block_indices]
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale
+            pos = torch.arange(block_size).unsqueeze(0)
+            valid_mask = (pos < valid_lens.unsqueeze(1)).unsqueeze(1)
+            sij = sij.masked_fill(~valid_mask, float("-inf"))
+            mij = sij.max(dim=-1, keepdim=True)[0].clamp(min=-1e30)
+            pij = torch.exp(sij - mij).masked_fill(~valid_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi, li, mi = oi_new, lij, mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        assert oi is not None and li is not None
+        out[:, q_offset : q_offset + q_tile_size, :] = oi / li
+
+    tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
+
+
+def build_tensor_specs(
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    max_num_blocks_per_req: int,
+    context_len: int,
+    scale: float = 1.0,
+) -> list[TensorSpec]:
+    """Build TensorSpec list for paged_attention signature."""
+    query_rows = batch * num_heads
+    key_cache_rows = batch * max_num_blocks_per_req * block_size
+    block_table_flat_size = batch * max_num_blocks_per_req
+    scale_bits = struct.unpack("I", struct.pack("f", scale))[0]
+    config_data = torch.tensor(
+        [batch, num_heads, 1, head_dim, block_size, max_num_blocks_per_req, scale_bits],
+        dtype=torch.int64,
+    )
+    context_lens_data = torch.full((batch,), context_len, dtype=torch.int32)
+    block_table_data = torch.randint(
+        0, max(block_table_flat_size, 1), size=(batch, max_num_blocks_per_req), dtype=torch.int32
+    ).flatten()
+    size_query = torch.tensor([query_rows * head_dim * 2], dtype=torch.int64)
+    size_key_cache = torch.tensor([key_cache_rows * head_dim * 2], dtype=torch.int64)
+    size_value_cache = torch.tensor([key_cache_rows * head_dim * 2], dtype=torch.int64)
+
+    return [
+        TensorSpec("query", [query_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("key_cache", [key_cache_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("value_cache", [key_cache_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("block_table", [block_table_flat_size], torch.int32, init_value=block_table_data),
+        TensorSpec("context_lens", [batch], torch.int32, init_value=context_lens_data),
+        TensorSpec("out", [query_rows, head_dim], torch.float32, is_output=True),
+        TensorSpec("config", [7], torch.int64, init_value=config_data),
+        TensorSpec("size_query", [1], torch.int64, init_value=size_query),
+        TensorSpec("size_key_cache", [1], torch.int64, init_value=size_key_cache),
+        TensorSpec("size_value_cache", [1], torch.int64, init_value=size_value_cache),
+    ]
+
+
+def compile_and_run(
+    batch: int = 64,
+    num_heads: int = 16,
+    head_dim: int = 128,
+    block_size: int = 128,
+    context_len: int = 8192,
+    scale: float = 1.0,
+    platform: str = "a2a3",
+    device_id: int = 11,
+    work_dir: str | None = None,
+    dump_passes: bool = True,
+) -> RunResult:
+    """Compile the paged-attention program and optionally run on device.
+
+    Args:
+        batch: Batch size.
+        num_heads: Number of heads.
+        head_dim: Head dimension.
+        block_size: KV block size.
+        context_len: Context length per request.
+        scale: Attention scale.
+        platform: "a2a3" or "a2a3sim".
+        device_id: Device index (for real hardware).
+        work_dir: Output directory for generated files; None = temp dir.
+        dump_passes: Dump IR after each pass.
+
+    Returns:
+        RunResult from pypto.runtime.run (PASS/FAIL or compile-only when code_runner missing).
+    """
+    max_num_blocks_per_req = (32768 + block_size - 1) // block_size
+
+    program = build_paged_attention_program(
+        batch=batch,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        max_num_blocks_per_req=max_num_blocks_per_req,
+    )
+
+    tensor_specs = build_tensor_specs(
+        batch=batch,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        max_num_blocks_per_req=max_num_blocks_per_req,
+        context_len=context_len,
+        scale=scale,
+    )
+
+    if work_dir is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        work_dir = os.path.join("build_output", f"PagedAttentionProgram_{timestamp}")
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden,
+        config=RunConfig(
+            platform=platform,
+            device_id=device_id,
+            rtol=2e-2,
+            atol=2e-2,
+            strategy=OptimizationStrategy.PTOAS,
+            dump_passes=dump_passes,
+            backend_type=BackendType.PTO,
+            work_dir=work_dir,
+        ),
+    )
+    # Treat missing code_runner as compile-only success
+    if not result.passed and result.error and "code_runner" in result.error:
+        print("Result: COMPILE OK — device run skipped (code_runner not found).")
+        print("  Compilation and passes completed successfully.")
+        print("  Generated kernels/orchestration:", work_dir)
+        print("  To run on device, set SIMPLER_ROOT to the Simpler repo and ensure")
+        print("  code_runner is on PYTHONPATH (e.g. SIMPLER_ROOT/examples/scripts).")
+        return RunResult(passed=True, error="device run skipped (no code_runner)")
+    if result.passed:
+        print("  Generated kernels/orchestration:", work_dir)
+    return result
+
+
+def main():
+    result = compile_and_run(
+        batch=64,
+        num_heads=16,
+        head_dim=128,
+        block_size=128,
+        context_len=8192,
+        scale=1.0,
+        platform="a2a3sim",
+        device_id=11,
+        dump_passes=True,
+    )
+    # Avoid duplicate "Result:" when compile_and_run already printed COMPILE OK
+    if getattr(result, "error", None) != "device run skipped (no code_runner)":
+        print(f"Result: {result}")
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pypto/language/op/block_ops.py
+++ b/python/pypto/language/op/block_ops.py
@@ -938,7 +938,11 @@ def min(tile: Tile, axis: int, keepdim: bool = False) -> Tile: ...
 def min(tile: Scalar, axis: Scalar | int, keepdim: bool = False) -> Scalar: ...
 
 
-def min(tile: Tile | Scalar, axis: int | Scalar = 0, keepdim: bool = False) -> Tile | Scalar:
+@overload
+def min(tile: int, axis: Scalar | int, keepdim: bool = False) -> Scalar: ...
+
+
+def min(tile: Tile | Scalar | int, axis: int | Scalar = 0, keepdim: bool = False) -> Tile | Scalar:
     """Min reduction along specified axis, or scalar min of two values.
 
     Args:
@@ -949,13 +953,18 @@ def min(tile: Tile | Scalar, axis: int | Scalar = 0, keepdim: bool = False) -> T
     Returns:
         Tile or Scalar wrapping the min operation
     """
-    if isinstance(tile, Scalar):
+    if isinstance(tile, (Scalar, int)):
+        lhs: Expr = (
+            tile.unwrap()
+            if isinstance(tile, Scalar)
+            else _ir_core.ConstInt(tile, DataType.INT32, _ir_core.Span.unknown())
+        )
         rhs: Expr = (
             axis.unwrap()
             if isinstance(axis, Scalar)
             else _ir_core.ConstInt(axis, DataType.INT32, _ir_core.Span.unknown())
         )
-        return Scalar(expr=_ir_core.min_(tile.unwrap(), rhs))
+        return Scalar(expr=_ir_core.min_(lhs, rhs))
     assert isinstance(axis, int)
     call_expr = _ir_ops.min(tile.unwrap(), axis, keepdim)
     return Tile(expr=call_expr)

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -23,6 +23,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
@@ -110,6 +111,66 @@ class VarDefCollector : public IRVisitor {
     }
     IRVisitor::VisitStmt_(op);
   }
+};
+
+/**
+ * @brief Visitor to collect target tensors of block.store / block.l0c_store calls.
+ *
+ * These tensors are modified via side-effect inside InCore scopes but are not
+ * captured by VarDefCollector since they are defined externally.  The fourth
+ * argument of store/l0c_store is the output tensor.
+ */
+class StoreTargetCollector : public IRVisitor {
+ public:
+  std::unordered_set<std::string> store_targets;
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    auto opnode = std::dynamic_pointer_cast<const Op>(op->op_);
+    if (opnode && (opnode->name_ == "block.store" || opnode->name_ == "block.l0c_store")) {
+      if (op->args_.size() >= 4) {
+        if (auto var = As<Var>(op->args_[3])) {
+          store_targets.insert(var->name_);
+        }
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+};
+
+/**
+ * @brief Mutator that converts EvalStmt(Call(block.store/l0c_store, ...)) into
+ *        AssignStmt(target_var, Call(block.store/l0c_store, ...)) for specified
+ *        store targets.
+ *
+ * block.store returns the output tensor (same type as the 4th argument).  When
+ * the original IR uses EvalStmt (discarding the return value), this mutator
+ * re-writes it as an AssignStmt so the return value is captured and can be
+ * referenced in a subsequent ReturnStmt.
+ */
+class StoreEvalToAssignMutator : public IRMutator {
+ public:
+  explicit StoreEvalToAssignMutator(const std::unordered_map<std::string, VarPtr>& target_vars)
+      : target_vars_(target_vars) {}
+
+ protected:
+  StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
+    auto call = std::dynamic_pointer_cast<const Call>(op->expr_);
+    if (!call) return op;
+    auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
+    if (!opnode || (opnode->name_ != "block.store" && opnode->name_ != "block.l0c_store")) {
+      return op;
+    }
+    if (call->args_.size() < 4) return op;
+    auto var = As<Var>(call->args_[3]);
+    if (!var) return op;
+    auto it = target_vars_.find(var->name_);
+    if (it == target_vars_.end()) return op;
+    return std::make_shared<AssignStmt>(it->second, call, op->span_);
+  }
+
+ private:
+  std::unordered_map<std::string, VarPtr> target_vars_;
 };
 
 /**
@@ -245,10 +306,17 @@ class IncoreScopeOutliner : public IRMutator {
       return IRMutator::VisitStmt_(op);
     }
 
-    // Without context, treat all defined variables as outputs
+    // Without context, treat all defined variables + store targets as outputs
     VarDefCollector def_collector;
     def_collector.VisitStmt(op->body_);
     std::unordered_set<std::string> all_defs(def_collector.var_defs.begin(), def_collector.var_defs.end());
+
+    StoreTargetCollector store_collector;
+    store_collector.VisitStmt(op->body_);
+    for (const auto& t : store_collector.store_targets) {
+      all_defs.insert(t);
+    }
+
     return OutlineScope(op, all_defs);
   }
 
@@ -288,6 +356,21 @@ class IncoreScopeOutliner : public IRMutator {
         sorted_outputs.push_back(var_name);
       }
     }
+
+    // Also treat store targets as outputs: external tensors modified via
+    // block.store/l0c_store.  These represent side-effect outputs that must be
+    // returned regardless of whether they appear in used_after, because the
+    // store mutates an externally-visible buffer (e.g. loop-carried state).
+    StoreTargetCollector store_collector;
+    store_collector.VisitStmt(op->body_);
+    std::unordered_set<std::string> store_output_set;
+    for (const auto& var_name : store_collector.store_targets) {
+      if (def_collector.var_defs.find(var_name) == def_collector.var_defs.end()) {
+        sorted_outputs.push_back(var_name);
+        store_output_set.insert(var_name);
+      }
+    }
+
     std::sort(sorted_outputs.begin(), sorted_outputs.end());
 
     // Recursively transform the scope body (handles nested InCore scopes)
@@ -325,18 +408,47 @@ class IncoreScopeOutliner : public IRMutator {
     std::vector<VarPtr> outlined_output_vars;
     std::vector<TypePtr> return_types;
     for (const auto& var_name : sorted_outputs) {
-      auto var_it = scope_var_collector.var_objects.find(var_name);
-      CHECK(var_it != scope_var_collector.var_objects.end())
-          << "Variable " << var_name << " not found in scope body";
-      auto outlined_var = std::make_shared<Var>(var_name, var_it->second->GetType(), op->span_);
+      TypePtr var_type;
+      if (store_output_set.count(var_name)) {
+        // Store target: external variable, look up from outer symbol table
+        auto type_it = var_types_.find(var_name);
+        CHECK(type_it != var_types_.end()) << "Variable " << var_name << " not found in symbol table";
+        var_type = type_it->second;
+      } else {
+        // Regular output: defined in scope body
+        auto var_it = scope_var_collector.var_objects.find(var_name);
+        CHECK(var_it != scope_var_collector.var_objects.end())
+            << "Variable " << var_name << " not found in scope body";
+        var_type = var_it->second->GetType();
+      }
+      // For store targets, create a fresh variable with "_store_ret" suffix
+      // to avoid redefining the input parameter in SSA form.
+      std::string out_var_name = store_output_set.count(var_name) ? var_name + "_store_ret" : var_name;
+      auto outlined_var = std::make_shared<Var>(out_var_name, var_type, op->span_);
       outlined_output_vars.push_back(outlined_var);
-      return_types.push_back(outlined_var->GetType());
-      var_substitution_map[var_name] = outlined_var;
+      return_types.push_back(var_type);
+      if (!store_output_set.count(var_name)) {
+        var_substitution_map[var_name] = outlined_var;
+      }
     }
 
     // Apply variable substitution to the (already recursively transformed) body
     VarSubstitutor substitutor(var_substitution_map);
     auto transformed_body = substitutor.VisitStmt(recursed_body);
+
+    // Convert EvalStmt(block.store/l0c_store) to AssignStmt for store targets
+    // so the return value is captured with a fresh SSA name (e.g. oi_0_store_ret).
+    if (!store_output_set.empty()) {
+      // Map: original target name -> new _store_ret Var
+      std::unordered_map<std::string, VarPtr> store_target_vars;
+      for (size_t idx = 0; idx < sorted_outputs.size(); ++idx) {
+        if (store_output_set.count(sorted_outputs[idx])) {
+          store_target_vars[sorted_outputs[idx]] = outlined_output_vars[idx];
+        }
+      }
+      StoreEvalToAssignMutator store_mutator(store_target_vars);
+      transformed_body = store_mutator.VisitStmt(transformed_body);
+    }
 
     // Build outlined function body (transformed body + return statement)
     StmtPtr outlined_body;
@@ -389,21 +501,40 @@ class IncoreScopeOutliner : public IRMutator {
     }
 
     // Create assignments for output variables in the parent function
-    // Use the original Var objects from the scope body so they match later references
+    // Use the original Var objects from the scope body so they match later references.
+    // For store outputs (external tensors), fall back to the outer symbol table.
     if (sorted_outputs.empty()) {
       return std::make_shared<EvalStmt>(call_expr, op->span_);
     } else if (sorted_outputs.size() == 1) {
       auto var_it = scope_var_collector.var_objects.find(sorted_outputs[0]);
-      return std::make_shared<AssignStmt>(var_it->second, call_expr, op->span_);
+      VarPtr out_var;
+      if (var_it != scope_var_collector.var_objects.end() && !store_output_set.count(sorted_outputs[0])) {
+        out_var = var_it->second;
+      } else {
+        auto ext_it = var_objects_.find(sorted_outputs[0]);
+        CHECK(ext_it != var_objects_.end())
+            << "Variable " << sorted_outputs[0] << " not found in var_objects";
+        out_var = ext_it->second;
+      }
+      return std::make_shared<AssignStmt>(out_var, call_expr, op->span_);
     } else {
       // Assign call result to a temporary variable, then unpack with TupleGetItem
       auto ret_var = std::make_shared<Var>("ret", call_return_type, op->span_);
       std::vector<StmtPtr> stmts;
       stmts.push_back(std::make_shared<AssignStmt>(ret_var, call_expr, op->span_));
       for (size_t i = 0; i < sorted_outputs.size(); ++i) {
+        VarPtr out_var;
         auto var_it = scope_var_collector.var_objects.find(sorted_outputs[i]);
+        if (var_it != scope_var_collector.var_objects.end() && !store_output_set.count(sorted_outputs[i])) {
+          out_var = var_it->second;
+        } else {
+          auto ext_it = var_objects_.find(sorted_outputs[i]);
+          CHECK(ext_it != var_objects_.end())
+              << "Variable " << sorted_outputs[i] << " not found in var_objects";
+          out_var = ext_it->second;
+        }
         auto tuple_get = std::make_shared<TupleGetItemExpr>(ret_var, static_cast<int>(i), op->span_);
-        stmts.push_back(std::make_shared<AssignStmt>(var_it->second, tuple_get, op->span_));
+        stmts.push_back(std::make_shared<AssignStmt>(out_var, tuple_get, op->span_));
       }
       return std::make_shared<SeqStmts>(stmts, op->span_);
     }
@@ -437,8 +568,10 @@ namespace pass {
  *    - Analyze subsequent statements to determine which definitions are outputs
  *    - Extract body into new Function(InCore) with appropriate params/returns
  *    - Replace scope with Call to the outlined function + output assignments
+ *    - EvalStmt(store) calls on output tensors are converted to AssignStmt
  * 2. Recursively handles nested InCore scopes
  * 3. Add outlined functions to the program
+ * 4. Promote the parent function from Opaque to Orchestration
  */
 Pass OutlineIncoreScopes() {
   auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
@@ -465,14 +598,15 @@ Pass OutlineIncoreScopes() {
       IncoreScopeOutliner outliner(func->name_, type_collector.var_types, type_collector.var_objects);
       auto new_body = outliner.VisitStmt(func->body_);
 
-      // Create new function with transformed body
-      auto new_func =
-          std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                     new_body, func->span_, func->func_type_);
+      // Create new function with transformed body.
+      // If any InCore scopes were outlined, promote Opaque -> Orchestration.
+      const auto& outlined = outliner.GetOutlinedFunctions();
+      FunctionType new_func_type = outlined.empty() ? func->func_type_ : FunctionType::Orchestration;
+      auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                                 func->return_types_, new_body, func->span_, new_func_type);
       new_functions.push_back(new_func);
 
       // Collect outlined functions (prepend before parent so inner functions come first)
-      const auto& outlined = outliner.GetOutlinedFunctions();
       all_outlined_functions.insert(all_outlined_functions.end(), outlined.begin(), outlined.end());
     }
 
@@ -495,7 +629,7 @@ Pass OutlineIncoreScopes() {
 namespace {
 
 /**
- * @brief Checks no InCore ScopeStmts remain in Opaque functions.
+ * @brief Checks no InCore ScopeStmts remain in Opaque or Orchestration functions.
  */
 class SplitIncoreOrchVerifier : public IRVisitor {
  public:
@@ -505,7 +639,7 @@ class SplitIncoreOrchVerifier : public IRVisitor {
     if (!op) return;
     if (op->scope_kind_ == ScopeKind::InCore) {
       diagnostics_.emplace_back(DiagnosticSeverity::Error, "SplitIncoreOrch", 0,
-                                "InCore ScopeStmt found in Opaque function (should have been outlined)",
+                                "InCore ScopeStmt found in non-InCore function (should have been outlined)",
                                 op->span_);
     }
     IRVisitor::VisitStmt_(op);
@@ -525,8 +659,8 @@ class SplitIncoreOrchPropertyVerifierImpl : public PropertyVerifier {
     if (!program) return;
     for (const auto& [gv, func] : program->functions_) {
       if (!func || !func->body_) continue;
-      // Only check Opaque functions — InCore functions are expected to have InCore content
-      if (func->func_type_ != FunctionType::Opaque) continue;
+      // Check Opaque and Orchestration functions — InCore functions are expected to have InCore content
+      if (func->func_type_ == FunctionType::InCore) continue;
       SplitIncoreOrchVerifier verifier(diagnostics);
       verifier.VisitStmt(func->body_);
     }

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -35,7 +35,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
                 return y
@@ -75,7 +75,7 @@ class TestOutlineIncoreScopes:
                 z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
                 return z
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
                 z: pl.Tensor[[64], pl.FP32] = self.main_incore_1(y)
@@ -119,7 +119,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
                 return y
@@ -158,7 +158,7 @@ class TestOutlineIncoreScopes:
                 result: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
                 return result
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(
                 self, x: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
             ) -> pl.Tensor[[64], pl.FP32]:
@@ -199,7 +199,7 @@ class TestOutlineIncoreScopes:
                 z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
                 return (y, z)
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 ret = self.main_incore_0(x)
                 y = ret[0]
@@ -238,7 +238,7 @@ class TestOutlineIncoreScopes:
                 z: pl.Tensor[[64], pl.FP32] = self.main_incore_0_incore_0(y)
                 return z
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 z: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
                 return z
@@ -268,7 +268,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(a)
@@ -304,7 +304,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def func1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = self.func1_incore_0(x)
                 return y
@@ -314,7 +314,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def func2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = self.func2_incore_0(x)
                 return y
@@ -345,7 +345,7 @@ class TestOutlineIncoreScopes:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
                 if cond:
                     y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)  # type: ignore[no-redef]
@@ -405,7 +405,7 @@ class TestOutlineIncoreScopes:
                 d: pl.Tensor[[64], pl.FP32] = pl.mul(c, c)
                 return d
 
-            @pl.function
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
@@ -417,6 +417,66 @@ class TestOutlineIncoreScopes:
         Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_outline_scope_with_store_only_outputs(self):
+        """Test outlining scope where the only outputs are store targets.
+
+        When an InCore scope only writes to external tensors via block.store
+        (no new variable definitions used after the scope), the store targets
+        must be recognised as outputs and returned.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                with pl.incore():
+                    tile = pl.block.full([16, 128], dtype=pl.FP32, value=0.0)
+                    pl.store(tile, [0, 0], [16, 128], buf)
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf, x)
+                return result
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(Before)
+
+        printed = ir.python_print(After)
+        # The outlined InCore function should return buf (store target)
+        assert "return buf" in printed or "return buf_0" in printed
+        # The orchestration should receive the return value
+        assert "main_incore_0(" in printed
+
+    def test_outline_scope_with_multiple_store_targets(self):
+        """Test outlining scope with multiple store targets as outputs.
+
+        Multiple external tensors modified via block.store should all appear
+        as return values of the outlined function.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf_a: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                buf_b: pl.Tensor[[16, 1], pl.FP32] = pl.create_tensor([16, 1], dtype=pl.FP32)
+                with pl.incore():
+                    tile_a = pl.block.full([16, 128], dtype=pl.FP32, value=0.0)
+                    tile_b = pl.block.full([16, 1], dtype=pl.FP32, value=0.0)
+                    pl.store(tile_a, [0, 0], [16, 128], buf_a)
+                    pl.store(tile_b, [0, 0], [16, 1], buf_b)
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf_a, x)
+                return result
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(Before)
+
+        printed = ir.python_print(After)
+        # Both store targets should appear as outputs
+        assert "main_incore_0(" in printed
+        # The InCore function should have return statement
+        assert (
+            "return" in printed.split("@pl.function(type=pl.FunctionType.InCore)")[1].split("@pl.function")[0]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
OutlineIncoreScopes previously failed to recognize external tensors modified via block.store/l0c_store as function outputs, causing downstream "InCore function has no return statement" errors.

Key changes in outline_incore_scopes_pass.cpp:
- Add StoreTargetCollector to identify store target tensors
- Treat store targets (external tensors) as unconditional outputs
- Add StoreEvalToAssignMutator to convert EvalStmt(store) into AssignStmt with fresh SSA names (e.g. oi_0_store_ret)
- Promote parent function from Opaque to Orchestration after outlining
- Update verifier to check both Opaque and Orchestration functions

Also adds paged_attention_with_incore.py example using pl.incore() blocks and two new unit tests for store-only output scenarios.