### PR TITLE
fix(printer): Print BF16 dtype as pl.BF16 to match parser

### DIFF
--- a/include/pypto/core/dtype.h
+++ b/include/pypto/core/dtype.h
@@ -353,7 +353,7 @@ inline constexpr DataType DataType::DEFAULT_CONST_FLOAT = DataType(kFp32Code);  
  * @brief Convert DataType to its canonical enum name string
  *
  * Returns the uppercase enum-style name for a DataType, suitable for use
- * as a suffix in code generation (e.g., "FP32", "BFLOAT16", "INT32").
+ * as a suffix in code generation (e.g., "FP32", "BF16", "INT32").
  *
  * Callers compose the full qualified name:
  *   - Python printer: prefix + "." + DataTypeToString(dtype)
@@ -380,7 +380,7 @@ inline std::string DataTypeToString(const DataType& dtype) {
   if (dtype == DataType::FP8E5M2) return "FP8E5M2";
   if (dtype == DataType::FP16) return "FP16";
   if (dtype == DataType::FP32) return "FP32";
-  if (dtype == DataType::BF16) return "BFLOAT16";
+  if (dtype == DataType::BF16) return "BF16";
   if (dtype == DataType::HF4) return "HF4";
   if (dtype == DataType::HF8) return "HF8";
   return "UnknownType";

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -379,7 +379,7 @@ def test_python_print_all_scalar_types():
         (DataType.UINT64, "pl.UINT64"),
         (DataType.FP16, "pl.FP16"),
         (DataType.FP32, "pl.FP32"),
-        (DataType.BF16, "pl.BFLOAT16"),
+        (DataType.BF16, "pl.BF16"),
     ]
 
     for dtype, expected_str in type_map:


### PR DESCRIPTION
## Summary
- `DataTypeToString` returned `"BFLOAT16"` for `BF16`, but the parser and Python language module expect `"BF16"`
- This caused round-trip failure when printing and re-parsing programs using BF16 tensors
- Updates docstring comment to reflect the correct output

## Testing
- [x] All 38 printer tests pass
- [x] Code review completed
- [x] Clang-tidy passed
- [x] All pre-commit hooks passed (clang-format, cpplint, ruff, pyright)