### PR TITLE
feat(codegen): fix pl.transpose to work correctly with TTRANS instruction

### DIFF
--- a/examples/language/beginner/matmul_transpose.py
+++ b/examples/language/beginner/matmul_transpose.py
@@ -1,0 +1,191 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Matrix multiplication with transpose operations.
+
+This example demonstrates three transpose variants:
+1. C = A @ B^T  (MatmulTransBProgram)
+2. C = A^T @ B  (MatmulTransAProgram)
+3. C = A^T @ B^T (MatmulTransABProgram)
+
+Each variant uses:
+- Vector kernel(s) for transpose via pl.transpose
+- Cube kernel for matmul
+
+Kernels are separated because Cube and Vector operations cannot mix in one function.
+"""
+
+import pypto.language as pl
+
+
+# =============================================================================
+# C = A @ B^T
+# =============================================================================
+
+
+@pl.program
+class MatmulTransBProgram:
+    """Compute C = A @ B^T where A:[64,64], B:[64,64], C:[64,64]."""
+
+    @pl.function
+    def transpose_kernel(
+        self,
+        b: pl.Tensor[[64, 64], pl.FP32],
+        b_t: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Transpose B: b_t = b^T (Vector kernel)."""
+        tile_b: pl.Tile[[64, 64], pl.FP32] = pl.load(b, [0, 0], [64, 64])
+        tile_b_T: pl.Tile[[64, 64], pl.FP32] = pl.transpose(tile_b, axis1=0, axis2=1)
+        out_b_t: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b_T, [0, 0], [64, 64], b_t)
+        return out_b_t
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b_t: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Matmul: c = a @ b_t (Cube kernel)."""
+        tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b_t, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out_c = pl.l0c_store(tile_c_l0c, [0, 0], [64, 64], c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Orchestrate: C = A @ B^T."""
+        b_t: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        b_t = self.transpose_kernel(b, b_t)
+        out_c = self.matmul_kernel(a, b_t, out_c)
+        return out_c
+
+
+# =============================================================================
+# C = A^T @ B
+# =============================================================================
+
+
+@pl.program
+class MatmulTransAProgram:
+    """Compute C = A^T @ B where A:[64,64], B:[64,64], C:[64,64]."""
+
+    @pl.function
+    def transpose_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        a_t: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Transpose A: a_t = a^T (Vector kernel)."""
+        tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+        tile_a_T: pl.Tile[[64, 64], pl.FP32] = pl.transpose(tile_a, axis1=0, axis2=1)
+        out_a_t: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a_T, [0, 0], [64, 64], a_t)
+        return out_a_t
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_kernel(
+        self,
+        a_t: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Matmul: c = a_t @ b (Cube kernel)."""
+        tile_a_l1 = pl.load(a_t, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out_c = pl.l0c_store(tile_c_l0c, [0, 0], [64, 64], c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Orchestrate: C = A^T @ B."""
+        a_t: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        a_t = self.transpose_kernel(a, a_t)
+        out_c = self.matmul_kernel(a_t, b, out_c)
+        return out_c
+
+
+# =============================================================================
+# C = A^T @ B^T
+# =============================================================================
+
+
+@pl.program
+class MatmulTransABProgram:
+    """Compute C = A^T @ B^T where A:[64,64], B:[64,64], C:[64,64]."""
+
+    @pl.function
+    def transpose_a_kernel(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        a_t: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Transpose A: a_t = a^T (Vector kernel)."""
+        tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+        tile_a_T: pl.Tile[[64, 64], pl.FP32] = pl.transpose(tile_a, axis1=0, axis2=1)
+        out_a_t: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a_T, [0, 0], [64, 64], a_t)
+        return out_a_t
+
+    @pl.function
+    def transpose_b_kernel(
+        self,
+        b: pl.Tensor[[64, 64], pl.FP32],
+        b_t: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Transpose B: b_t = b^T (Vector kernel)."""
+        tile_b: pl.Tile[[64, 64], pl.FP32] = pl.load(b, [0, 0], [64, 64])
+        tile_b_T: pl.Tile[[64, 64], pl.FP32] = pl.transpose(tile_b, axis1=0, axis2=1)
+        out_b_t: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b_T, [0, 0], [64, 64], b_t)
+        return out_b_t
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_kernel(
+        self,
+        a_t: pl.Tensor[[64, 64], pl.FP32],
+        b_t: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Matmul: c = a_t @ b_t (Cube kernel)."""
+        tile_a_l1 = pl.load(a_t, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b_t, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        out_c = pl.l0c_store(tile_c_l0c, [0, 0], [64, 64], c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        """Orchestrate: C = A^T @ B^T."""
+        a_t: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        b_t: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        a_t = self.transpose_a_kernel(a, a_t)
+        b_t = self.transpose_b_kernel(b, b_t)
+        out_c = self.matmul_kernel(a_t, b_t, out_c)
+        return out_c

--- a/src/backend/910B_CCE/backend_910b_cce_ops.cpp
+++ b/src/backend/910B_CCE/backend_910b_cce_ops.cpp
@@ -758,7 +758,8 @@ static std::string MakeTileTransposeCodegenCCE(const ir::CallPtr& op, codegen::C
   std::string input_var = codegen.GetExprAsCode(op->args_[0]);
   auto axis1 = codegen.GetConstIntValue(op->args_[1]);
   auto axis2 = codegen.GetConstIntValue(op->args_[2]);
-  size_t ndim = ir::As<ir::TileType>(op->args_[0]->GetType())->shape_.size();
+  auto input_type = ir::As<ir::TileType>(op->args_[0]->GetType());
+  size_t ndim = input_type->shape_.size();
 
   INTERNAL_CHECK(ndim == 2) << "Codegen only supports 2D tiles, but got " << ndim << "D tile";
   INTERNAL_CHECK(axis1 != axis2) << "tile.transpose: axis1 and axis2 must be different, but got axis1=axis2="
@@ -767,7 +768,20 @@ static std::string MakeTileTransposeCodegenCCE(const ir::CallPtr& op, codegen::C
       << "tile.transpose: axis1 and axis2 must be in range [0, " << ndim << "), but got axis1=" << axis1
       << ", axis2=" << axis2;
 
-  codegen.Emit("TTRANS(" + target_var + ", " + input_var + ");");
+  // TTRANS requires a temporary tile with same type as input.
+  // Generate inline temporary tile declaration.
+  std::string tmp_var = target_var + "_ttrans_tmp";
+  auto rows = ir::As<ir::ConstInt>(input_type->shape_[0])->value_;
+  auto cols = ir::As<ir::ConstInt>(input_type->shape_[1])->value_;
+  std::string tile_type_str = codegen.GetTypeConverter().ConvertTileType(input_type, rows, cols);
+
+  // Emit temporary tile declaration (allocate after target tile)
+  codegen.Emit("using " + tmp_var + "Type = " + tile_type_str + ";");
+  codegen.Emit(tmp_var + "Type " + tmp_var + "(" + std::to_string(rows) + ", " + std::to_string(cols) + ");");
+  // Use address 0x8000 offset from target (assumes enough space)
+  codegen.Emit("TASSIGN(" + tmp_var + ", 0x8000);");
+
+  codegen.Emit("TTRANS(" + target_var + ", " + input_var + ", " + tmp_var + ");");
   return "";
 }
 
@@ -780,7 +794,7 @@ REGISTER_BACKEND_OP(Backend910B_CCE, "block.reshape")
 REGISTER_BACKEND_OP(Backend910B_CCE, "block.transpose")
     .set_pipe(ir::PipeType::V)
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-      return MakeTileReshapeCodegenCCE(op, codegen);
+      return MakeTileTransposeCodegenCCE(op, codegen);
     });
 
 REGISTER_BACKEND_OP(Backend910B_CCE, "block.view")

--- a/tests/st/examples/01_beginner/basic/test_matmul_transpose.py
+++ b/tests/st/examples/01_beginner/basic/test_matmul_transpose.py
@@ -1,0 +1,132 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Matrix multiplication with transpose system tests for PyPTO.
+
+Corresponds to examples/language/beginner/matmul_transpose.py.
+
+Tests three transpose variants:
+1. C = A @ B^T  (MatmulTransBProgram)
+2. C = A^T @ B  (MatmulTransAProgram)
+3. C = A^T @ B^T (MatmulTransABProgram)
+
+Each uses pl.transpose in Vector kernel(s) + matmul in Cube kernel.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+from examples.language.beginner.matmul_transpose import (
+    MatmulTransABProgram,
+    MatmulTransAProgram,
+    MatmulTransBProgram,
+)
+
+
+# =============================================================================
+# Test Cases
+# =============================================================================
+
+
+class MatmulTransB(PTOTestCase):
+    """C = A @ B^T (64x64)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmul_trans_b_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MatmulTransBProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"].T)
+
+
+class MatmulTransA(PTOTestCase):
+    """C = A^T @ B (64x64)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmul_trans_a_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MatmulTransAProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"].T, tensors["b"])
+
+
+class MatmulTransAB(PTOTestCase):
+    """C = A^T @ B^T (64x64)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmul_trans_ab_64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MatmulTransABProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"].T, tensors["b"].T)
+
+
+# =============================================================================
+# Test Class
+# =============================================================================
+
+
+class TestMatmulTranspose:
+    """System tests for matmul with transpose operations."""
+
+    def test_matmul_trans_b(self, test_runner):
+        """Test C = A @ B^T (64x64)"""
+        result = test_runner.run(MatmulTransB())
+        assert result.passed, f"Matmul A @ B^T failed: {result.error}"
+
+    def test_matmul_trans_a(self, test_runner):
+        """Test C = A^T @ B (64x64)"""
+        result = test_runner.run(MatmulTransA())
+        assert result.passed, f"Matmul A^T @ B failed: {result.error}"
+
+    def test_matmul_trans_ab(self, test_runner):
+        """Test C = A^T @ B^T (64x64)"""
+        result = test_runner.run(MatmulTransAB())
+        assert result.passed, f"Matmul A^T @ B^T failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fix `block.transpose` codegen which was incorrectly calling `MakeTileReshapeCodegenCCE` instead of `MakeTileTransposeCodegenCCE`
- Fix `TTRANS` instruction generation to include required temporary tile buffer
- Add matmul transpose examples and tests demonstrating `A @ B^T`, `A^T @ B`, and `A^T @ B^T` patterns

## Details

### Bug Fix 1: Wrong codegen function
`block.transpose` was registered to call `MakeTileReshapeCodegenCCE`, which is incorrect. Changed to call `MakeTileTransposeCodegenCCE`.

### Bug Fix 2: TTRANS missing temporary buffer
The `TTRANS` instruction requires a temporary tile buffer as the third argument. The fix generates:
```cpp
using target_ttrans_tmpType = LocalTensor<float, ...>;
target_ttrans_tmpType target_ttrans_tmp(rows, cols);
TASSIGN(target_ttrans_tmp, 0x8000);
TTRANS(target, input, target_ttrans_tmp);
```

## Test plan

- [x] `test_matmul_trans_b` - C = A @ B^T
- [x] `test_matmul_trans_a` - C = A^T @ B  
- [x] `test_matmul_trans_ab` - C = A^T @ B^T