### PR TITLE
fix(transforms): Preserve loop kind for outer loop in SplitChunkedLoops

### DIFF
--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -306,8 +306,8 @@ class ChunkedLoopSplitter : public IRMutator {
       // Outer loop
       auto outer_for = std::make_shared<ForStmt>(
           out_var, MakeConstIndex(0, op->span_), MakeConstIndex(num_full_chunks, op->span_),
-          MakeConstIndex(1, op->span_), outer_iter_args, outer_body, outer_return_vars, op->span_,
-          ForKind::Sequential, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+          MakeConstIndex(1, op->span_), outer_iter_args, outer_body, outer_return_vars, op->span_, op->kind_,
+          std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
 
       result_stmts.push_back(outer_for);
       final_return_vars = outer_return_vars;
@@ -471,7 +471,7 @@ class ChunkedLoopSplitter : public IRMutator {
       auto outer_for = std::make_shared<ForStmt>(
           out_var, MakeConstIndex(0, op->span_), MakeConstIndex(num_full_chunks, op->span_),
           MakeConstIndex(1, op->span_), std::vector<IterArgPtr>{}, inner_for, std::vector<VarPtr>{},
-          op->span_, ForKind::Sequential, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+          op->span_, op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
 
       result_stmts.push_back(outer_for);
     }

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -181,7 +181,7 @@ class TestChunkingWithKind:
     """Tests for chunking with different loop kinds."""
 
     def test_parallel_chunk(self):
-        """Chunk a parallel loop: inner loop should be Parallel, outer Sequential."""
+        """Chunk a parallel loop: both inner and outer loops should be Parallel."""
 
         @pl.program
         class Input:
@@ -200,7 +200,7 @@ class TestChunkingWithKind:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.auto_incore():
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 2, 1, init_values=(x_0,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.parallel(0, 2, 1, init_values=(x_0,)):
                         for i_0_in, (x_iter_1_inner,) in pl.parallel(0, 4, 1, init_values=(x_iter_1_outer,)):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
@@ -210,7 +210,7 @@ class TestChunkingWithKind:
         ir.assert_structural_equal(After, Expected)
 
     def test_unroll_chunk(self):
-        """Chunk an unroll loop: inner loop is Unroll, outer is Sequential.
+        """Chunk an unroll loop: both inner and outer loops are Unroll.
 
         Since the DSL does not support pl.unroll() with init_values,
         we verify the IR structure properties directly instead of
@@ -244,7 +244,7 @@ class TestChunkingWithKind:
 
         # Inside the scope is the outer for loop
         outer_for = scope.body
-        assert outer_for.kind == ir.ForKind.Sequential
+        assert outer_for.kind == ir.ForKind.Unroll
         assert len(outer_for.iter_args) == 1
         assert len(outer_for.return_vars) == 1
 


### PR DESCRIPTION
## Summary
- The outer loop created by `SplitChunkedLoops` was hardcoded to `ForKind::Sequential`, even when the original chunked loop was `Parallel` or `Unroll`
- Changed both the iter_args path and the simple (no iter_args) path to use `op->kind_` so the original loop kind is preserved for outer, inner, and remainder loops
- Updated tests to expect matching loop kinds on both outer and inner loops

## Testing
- [x] All 17 `test_split_chunked_loops` tests pass
- [x] All 13 `test_interchange_chunk_loops` tests pass
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)