### PR TITLE
feat(st): Add minimal single-head LLaMA 7B complete system tests

### DIFF
--- a/examples/language/llm_models/llama_7b_mini.py
+++ b/examples/language/llm_models/llama_7b_mini.py
@@ -394,7 +394,7 @@ def build_llama_mini_program(
         # =========================================================================
 
         @pl.function(type=pl.FunctionType.Orchestration)
-        def llama_mini_orch(
+        def llama_mini_orch(  # noqa: PLR0913
             self,
             # Input hidden states
             hidden: pl.Tensor[[seq_len, head_dim], pl.FP32],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ ignore = [
 ]
 fixable = ["ALL"]
 
-[tool.ruff.lint.per-file-ignores]
-# Hardware DSL programs in examples/ have fixed I/O interfaces determined by the
-# model architecture — the max-args limit does not apply to hardware entry points.
-"examples/**/*.py" = ["PLR0913"]
-
 [tool.ruff.lint.pylint]
 max-statements = 100
 max-args = 10

--- a/tests/st/examples/03_llm_models/test_llama_7b_mini_1h.py
+++ b/tests/st/examples/03_llm_models/test_llama_7b_mini_1h.py
@@ -39,7 +39,7 @@ import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 
-from examples.language.intermediate.llama_7b_mini import build_llama_mini_program
+from examples.language.llm_models.llama_7b_mini import build_llama_mini_program
 
 
 class TestLlamaMini(PTOTestCase):


### PR DESCRIPTION
- Test decoder layer with pre-norm, single-head RoPE-QKV attention, SwiGLU MLP
- Test final RMSNorm and LM head projection ([16, 64] logits)
- Minimal config: hidden_size=64, num_heads=1, head_dim=64, seq_len=16
- Simplified from test_llama_7b_full.py: no head splitting/concatenation