### PR TITLE
ix(transforms): Collect IterArg initValue_ variables in OutlineIncoreScopes

### DIFF
--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -265,12 +265,26 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     // Wrap standalone parallel ChunkRemainder sub-loops in InCore
     new_body = WrapSubRemainderLoopsInInCore(new_body, op->span_);
 
-    if (new_body.get() == op->body_.get()) {
+    // Visit iter_args to apply substitutions to initValue_
+    std::vector<IterArgPtr> new_iter_args;
+    bool iter_args_changed = false;
+    new_iter_args.reserve(op->iter_args_.size());
+    for (const auto& ia : op->iter_args_) {
+      auto new_init = VisitExpr(ia->initValue_);
+      if (new_init.get() != ia->initValue_.get()) {
+        new_iter_args.push_back(std::make_shared<IterArg>(ia->name_, ia->GetType(), new_init, ia->span_));
+        iter_args_changed = true;
+      } else {
+        new_iter_args.push_back(ia);
+      }
+    }
+
+    if (new_body.get() == op->body_.get() && !iter_args_changed) {
       return op;
     }
 
-    return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                     new_body, op->return_vars_, op->span_, op->kind_, op->chunk_size_,
+    return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, new_iter_args, new_body,
+                                     op->return_vars_, op->span_, op->kind_, op->chunk_size_,
                                      op->chunk_policy_, op->loop_origin_);
   }
 
@@ -337,8 +351,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
    */
   StmtPtr RebuildSimple(const std::vector<ForStmtPtr>& outers, const std::vector<ForStmtPtr>& inners,
                         const std::vector<ChainEntry>& chain, const Span& span) {
-    // Get the innermost body
-    const auto& innermost = chain.back().for_stmt;
+    // Get the body from the last loop in inners (not chain.back(), which may be a remainder)
+    const auto& innermost = inners.back();
     auto body = VisitStmt(innermost->body_);
 
     // Build inners inside-out
@@ -418,29 +432,13 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       }
     }
 
-    // Set up substitutions: map original iter_args of the innermost loop to the
-    // innermost new iter_args
-    // We need to find the original chain order and map each loop's iter_args
-    // to the corresponding new iter_args
-
-    // Map each original loop's iter_args to the new iter_args at their new position
-    // Original chain: O1, I1, O2, I2 (positions 0,1,2,3)
-    // Reordered:      O1, O2, I1, I2 (positions 0,1,2,3)
-    // So O1's iter_args (used by I1's body) should map to reordered position 0's iter_args
-    // I1's iter_args (used by O2's body/init) should map to reordered position 2's iter_args
-    // etc.
-
-    // Build a mapping: for each original chain entry, find its position in reordered
-    std::unordered_map<const ForStmt*, size_t> reordered_pos;
-    for (size_t i = 0; i < total_loops; ++i) {
-      reordered_pos[reordered[i].get()] = i;
-    }
-
     // Now set up substitutions for the body:
-    // The innermost loop in the reordered chain (last inner) passes its iter_args to the body.
-    // We need to remap the original innermost loop's iter_args to the new innermost iter_args.
-    const auto& orig_innermost = chain.back().for_stmt;
-    size_t innermost_reordered_idx = reordered_pos[orig_innermost.get()];
+    // The last loop in reordered (last inner) passes its iter_args to the body.
+    // We remap its original iter_args to the new innermost iter_args.
+    // Note: chain.back() may be a ChunkRemainder that is NOT in reordered,
+    // so we must use reordered.back() to get the actual innermost interchange loop.
+    const auto& orig_innermost = reordered.back();
+    size_t innermost_reordered_idx = total_loops - 1;
 
     for (size_t ia_idx = 0; ia_idx < num_iter_args; ++ia_idx) {
       substitution_map_[orig_innermost->iter_args_[ia_idx].get()] =

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -68,7 +68,21 @@ class VarRefCollector : public IRVisitor {
  protected:
   void VisitExpr_(const VarPtr& op) override { var_refs.insert(op->name_); }
 
-  void VisitExpr_(const IterArgPtr& op) override { var_refs.insert(op->name_); }
+  void VisitExpr_(const IterArgPtr& op) override {
+    var_refs.insert(op->name_);
+    // Collect variables from initValue_ using dynamic_pointer_cast (not kind-based
+    // As<Var>) to match both Var and IterArg via C++ inheritance, while avoiding
+    // recursive IterArg.initValue_ chain traversal that would pull in outer-scope
+    // variables beyond the current scope boundary.
+    if (op->initValue_) {
+      auto as_var = std::dynamic_pointer_cast<const Var>(op->initValue_);
+      if (as_var) {
+        var_refs.insert(as_var->name_);
+      } else {
+        VisitExpr(op->initValue_);
+      }
+    }
+  }
 };
 
 /**

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -155,6 +155,68 @@ class TestNestedParallelChunks:
         assert len(j_in.return_vars) == 1
 
 
+class TestChunkWithRemainderInChain:
+    """Tests for chunk chains that include remainder loops (non-divisible inner)."""
+
+    def test_chunk_outer_inner_with_remainder_preserves_iter_args(self):
+        """Chunk chain with trailing remainder: iter_args thread through inner, remainder preserved."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.parallel(0, 8, 1, chunk=4):
+                        for j in pl.parallel(0, 1, 1, chunk=2):
+                            x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_interchange(Input)
+        After = passes.interchange_chunk_loops()(Before)
+
+        func = list(After.functions.values())[0]
+        stmts = list(func.body.stmts)  # type: ignore[attr-defined]
+
+        # i_out (ChunkOuter, Sequential)
+        i_out = stmts[0]
+        assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert i_out.kind == ir.ForKind.Sequential
+        assert len(i_out.iter_args) == 1
+
+        # InCore { i_in → body with remainder }
+        i_out_body = list(i_out.body.stmts)
+        scope = i_out_body[0]
+        assert scope.scope_kind == ir.ScopeKind.InCore
+
+        i_in = scope.body
+        assert i_in.loop_origin == ir.LoopOrigin.ChunkInner
+        assert len(i_in.iter_args) == 1
+
+        # i_in's iter_arg should chain from i_out's iter_arg (not from original init)
+        assert i_in.iter_args[0].initValue.name == i_out.iter_args[0].name
+
+    def test_chunk_with_remainder_body_contains_remainder_loop(self):
+        """Remainder loop inside chain body must be preserved after interchange."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.parallel(0, 8, 1, chunk=4):
+                        for j in pl.parallel(0, 1, 1, chunk=2):
+                            x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_interchange(Input)
+        After = passes.interchange_chunk_loops()(Before)
+        after_str = python_print(After)
+
+        # The remainder loop variable should still appear in the output
+        # (it must not be dropped during interchange)
+        assert "rem" in after_str or "j_" in after_str or "parallel(1" in after_str
+
+
 class TestRemainderLoops:
     """Tests for non-divisible cases with remainder loops."""
 

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -478,6 +478,45 @@ class TestOutlineIncoreScopes:
             "return" in printed.split("@pl.function(type=pl.FunctionType.InCore)")[1].split("@pl.function")[0]
         )
 
+    def test_outline_scope_with_loop_carried_init_values(self):
+        """Test outlining scope where inner loop references outer loop-carried variable via init_values.
+
+        Regression test for issue #369: OutlineIncoreScopes failed to include
+        outer loop-carried variables as incore function parameters when they
+        appeared only inside IterArg.initValue_ expressions.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for i, (acc,) in pl.range(3, init_values=(x,)):
+                    with pl.incore():
+                        for j, (inner,) in pl.range(2, init_values=(acc,)):
+                            updated: pl.Tensor[[64], pl.FP32] = pl.add(inner, y)
+                            inner_rv = pl.yield_(updated)
+                    acc_rv = pl.yield_(inner_rv)
+                return acc_rv
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(Before)
+
+        printed = ir.python_print(After)
+        incore_section = printed.split("@pl.function(type=pl.FunctionType.InCore)")[1].split("@pl.function")[
+            0
+        ]
+        incore_params = incore_section.split("(self,")[1].split(")")[0]
+        orch_section = printed.split("@pl.function(type=pl.FunctionType.Orchestration)")[1]
+
+        assert "acc" in incore_params, (
+            "outer loop-carried variable 'acc' must be a parameter of the outlined function"
+        )
+        assert "main_incore_0(acc" in orch_section.replace(" ", ""), (
+            "orchestration must pass 'acc' to the outlined function"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #369
VarRefCollector::VisitExpr_(IterArgPtr) only collected the iter arg's own name but never visited its initValue_ expression. When an incore scope contained loops whose init_values referenced outer loop-carried variables, those variables were not recognized as free variables and were omitted from the outlined function's parameter list and call site. Use dynamic_pointer_cast<const Var> to collect the direct variable name from initValue_ without chasing IterArg.initValue_ chains into outer scopes. For non-Var initValue_ expressions, fall back to full recursive VisitExpr traversal.

Fix InterchangeChunkLoops body source and iter_arg substitution InterchangeChunkLoops had two bugs when processing chains containing ChunkRemainder loops:
1. RebuildSimple used chain.back() to get the innermost body, but chain.back() could be a remainder loop not present in inners. Use inners.back() instead.
2. RebuildInterleaved used chain.back() and reordered_pos lookup for the innermost loop, but remainder loops are not in the reordered array. Use reordered.back() directly.
3. VisitStmt_ for ForStmt did not apply substitutions to iter_arg initValue_ expressions, causing stale references after interchange.