### PR TITLE
feat(language): Export fillpad to top-level namespace

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -69,7 +69,7 @@ Transfer data between memory hierarchy levels.
 | `move` | `(tile: Tile, target_memory: MemorySpace) -> Tile` | Move tile between memory levels (including Vec→Vec) |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
-| `fillpad` | `(tile: Tile) -> Tile` | Fill tile with padding values |
+| `fillpad` | `(tile: Tile, pad_value: TilePad = TilePad.zero) -> Tile` | Fill remaining tile elements with zeros |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -64,7 +64,7 @@
 | `move` | `(tile: Tile, target_memory: MemorySpace) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
-| `fillpad` | `(tile: Tile) -> Tile` | 用填充值填充 tile |
+| `fillpad` | `(tile: Tile, pad_value: TilePad = TilePad.zero) -> Tile` | 用零填充 tile 剩余元素 |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
 
 ## Tile 算术（`pl.tile.*`）

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -100,7 +100,7 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     std::string key = nb::cast<std::string>(item.first);
 
     // Try to cast to common types
-    // NOTE: Check DataType/MemorySpace/PipeType/CoreType BEFORE int, and bool BEFORE int
+    // NOTE: Check DataType/MemorySpace/PipeType/CoreType/TilePad BEFORE int, and bool BEFORE int
     if (nb::isinstance<DataType>(item.second)) {
       kwargs.emplace_back(key, nb::cast<DataType>(item.second));
     } else if (nb::isinstance<MemorySpace>(item.second)) {
@@ -113,6 +113,8 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<CoreType>(item.second)) {
       // Cast enum to int for storage
       kwargs.emplace_back(key, static_cast<int>(nb::cast<CoreType>(item.second)));
+    } else if (nb::isinstance<TilePad>(item.second)) {
+      kwargs.emplace_back(key, nb::cast<TilePad>(item.second));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<bool>(item.second));
     } else if (nb::isinstance<nb::int_>(item.second)) {

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, ConstFloat, ConstInt, Expr, MemorySpace, Span
+from pypto.pypto_core.ir import Call, ConstFloat, ConstInt, Expr, MemorySpace, Span, TilePad
 
 from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
 
@@ -268,18 +268,19 @@ def full(
     return _ir_core.create_op_call("tile.full", [shape_tuple, value_expr], kwargs, actual_span)
 
 
-def fillpad(tile: Expr, span: Span | None = None) -> Call:
-    """Fill tile with padding for remaining elements.
+def fillpad(tile: Expr, pad_value: TilePad = TilePad.zero, span: Span | None = None) -> Call:
+    """Fill remaining tile elements with specified padding value.
 
     Args:
         tile: Input tile (TileType)
+        pad_value: Padding mode (TilePad.zero, TilePad.max, or TilePad.min). Default is zero.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression that returns the filled and padded tile
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.fillpad", [tile], {}, actual_span)
+    return _ir_core.create_op_call("tile.fillpad", [tile], {"pad_value": pad_value}, actual_span)
 
 
 # ============================================================================

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -38,7 +38,7 @@ Typical usage:
 """
 
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import ForKind, FunctionType, MemorySpace, MemRef, PipeType, TensorLayout
+from pypto.pypto_core.ir import ForKind, FunctionType, MemorySpace, MemRef, PipeType, TensorLayout, TilePad
 
 from . import parser
 from .dsl_api import (
@@ -83,6 +83,7 @@ from .op.tile_ops import (
     cmp,
     cmps,
     create_tile,
+    fillpad,
     gemv,
     gemv_acc,
     gemv_bias,
@@ -244,6 +245,7 @@ __all__ = [
     "write",
     # Promoted tile-only
     "create_tile",
+    "fillpad",
     "load",
     "store",
     "move",
@@ -310,6 +312,7 @@ __all__ = [
     "MemorySpace",
     "PipeType",
     "TensorLayout",
+    "TilePad",
     "ND",
     "DN",
     "NZ",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -39,6 +39,7 @@ from .tile_ops import (
     ands,
     cmp,
     cmps,
+    fillpad,
     gemv,
     gemv_acc,
     gemv_bias,
@@ -147,6 +148,7 @@ __all__ = [
     "recip",
     # Promoted tile-only
     "create_tile",
+    "fillpad",
     "load",
     "store",
     "move",

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -103,7 +103,7 @@ __all__ = [
 from pypto.ir.op import tile_ops as _ir_ops
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Expr, MemorySpace
+from pypto.pypto_core.ir import Expr, MemorySpace, TilePad
 
 from ..typing import IntLike, Scalar, Tensor, Tile
 
@@ -271,16 +271,17 @@ def full(shape: list[int], dtype: DataType, value: int | float) -> Tile:
     return Tile(expr=call_expr)
 
 
-def fillpad(tile: Tile) -> Tile:
-    """Fill tile with padding for remaining elements.
+def fillpad(tile: Tile, pad_value: TilePad = TilePad.zero) -> Tile:
+    """Fill remaining tile elements with specified padding value.
 
     Args:
         tile: Input tile
+        pad_value: Padding mode (TilePad.zero, TilePad.max, or TilePad.min). Default is zero.
 
     Returns:
         Tile wrapping the fillpad operation
     """
-    call_expr = _ir_ops.fillpad(tile.unwrap())
+    call_expr = _ir_ops.fillpad(tile.unwrap(), pad_value=pad_value)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2103,7 +2103,7 @@ def create_op_call(op_name: str, args: Sequence[Expr], span: Span) -> Call:
 def create_op_call(
     op_name: str,
     args: Sequence[Expr],
-    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
+    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | TilePad],
     span: Span,
 ) -> Call:
     """Create a Call expression with args and kwargs.

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -140,6 +140,23 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
       memrefs_.push_back(memref);
       seen_ptrs_.insert(raw_ptr);
       memref_tile_types_[raw_ptr] = tile_type;
+    } else {
+      // Merge TileView properties when multiple tiles share the same MemRef:
+      // - Keep valid_shape from the original tile (e.g., from load)
+      // - Take pad from the new tile if it has a non-null pad (e.g., from fillpad)
+      // This ensures fillpad's pad_value is used while preserving the original valid_shape
+      auto existing = memref_tile_types_[raw_ptr];
+      if (tile_type->tile_view_.has_value() && tile_type->tile_view_->pad != ir::TilePad::null) {
+        // Merge: keep valid_shape from existing, take pad from new tile
+        ir::TileView merged_view;
+        if (existing->tile_view_.has_value()) {
+          merged_view = existing->tile_view_.value();
+        }
+        merged_view.pad = tile_type->tile_view_->pad;
+        auto merged_tile_type =
+            std::make_shared<TileType>(existing->shape_, existing->dtype_, existing->memref_, merged_view);
+        memref_tile_types_[raw_ptr] = merged_tile_type;
+      }
     }
   }
 };
@@ -669,15 +686,16 @@ static const char* TileLayoutToStr(ir::TileLayout layout) {
 }
 
 // Helper to format tile_buf type string from components
+// v_row/v_col are the valid shape dimensions (may differ from rows/cols when valid_shapes is specified)
 static std::string FormatTileBufTypeString(const std::string& loc, const std::string& dtype_str, int64_t rows,
                                            int64_t cols, ir::TileLayout blayout, ir::TileLayout slayout,
-                                           uint64_t fractal, ir::TilePad pad, bool v_row_dynamic = false,
-                                           bool v_col_dynamic = false) {
+                                           uint64_t fractal, ir::TilePad pad, int64_t v_row, int64_t v_col,
+                                           bool v_row_dynamic = false, bool v_col_dynamic = false) {
   std::ostringstream oss;
   oss << "!pto.tile_buf<loc=" << loc << ", dtype=" << dtype_str;
   oss << ", rows=" << rows << ", cols=" << cols;
-  oss << ", v_row=" << (v_row_dynamic ? "?" : std::to_string(rows));
-  oss << ", v_col=" << (v_col_dynamic ? "?" : std::to_string(cols));
+  oss << ", v_row=" << (v_row_dynamic ? "?" : std::to_string(v_row));
+  oss << ", v_col=" << (v_col_dynamic ? "?" : std::to_string(v_col));
   oss << ", blayout=" << TileLayoutToStr(blayout);
   oss << ", slayout=" << TileLayoutToStr(slayout);
   oss << ", fractal=" << fractal;
@@ -686,10 +704,11 @@ static std::string FormatTileBufTypeString(const std::string& loc, const std::st
 }
 
 // Extract dtype, shape and layout from a TileType into output parameters
+// v_row/v_col are set to valid_shape values if available, otherwise to rows/cols
 static void ExtractTileTypeInfo(const TileType& tile_type, const PTOCodegen& codegen, std::string& dtype_str,
                                 int64_t& rows, int64_t& cols, ir::TileLayout& blayout,
-                                ir::TileLayout& slayout, uint64_t& fractal, ir::TilePad& pad,
-                                bool& v_row_dynamic, bool& v_col_dynamic) {
+                                ir::TileLayout& slayout, uint64_t& fractal, ir::TilePad& pad, int64_t& v_row,
+                                int64_t& v_col, bool& v_row_dynamic, bool& v_col_dynamic) {
   dtype_str = codegen.GetTypeString(tile_type.dtype_);
   if (tile_type.shape_.size() >= 2) {
     if (auto c0 = As<ir::ConstInt>(tile_type.shape_[0])) rows = c0->value_;
@@ -700,17 +719,29 @@ static void ExtractTileTypeInfo(const TileType& tile_type, const PTOCodegen& cod
       cols = c0->value_;
     }
   }
+  // Default v_row/v_col to physical shape
+  v_row = rows;
+  v_col = cols;
   if (tile_type.tile_view_.has_value()) {
     const auto& tv = *tile_type.tile_view_;
     blayout = tv.blayout;
     slayout = tv.slayout;
     fractal = tv.fractal;
     pad = tv.pad;
-    if (tv.valid_shape.size() >= 1 && As<ir::Var>(tv.valid_shape[0])) {
-      v_row_dynamic = true;
+    // Extract valid_shape values
+    if (tv.valid_shape.size() >= 1) {
+      if (auto c0 = As<ir::ConstInt>(tv.valid_shape[0])) {
+        v_row = c0->value_;
+      } else if (As<ir::Var>(tv.valid_shape[0])) {
+        v_row_dynamic = true;
+      }
     }
-    if (tv.valid_shape.size() >= 2 && As<ir::Var>(tv.valid_shape[1])) {
-      v_col_dynamic = true;
+    if (tv.valid_shape.size() >= 2) {
+      if (auto c1 = As<ir::ConstInt>(tv.valid_shape[1])) {
+        v_col = c1->value_;
+      } else if (As<ir::Var>(tv.valid_shape[1])) {
+        v_col_dynamic = true;
+      }
     }
   } else if (cols == 1 && rows > 1) {
     // Infer blayout from shape: column vectors [N, 1] use col_major (DN format convention)
@@ -728,16 +759,18 @@ std::string PTOCodegen::GetTileBufTypeString(const ir::MemRef* memref) const {
   uint64_t fractal = 512;
   ir::TilePad pad = ir::TilePad::null;
 
+  int64_t v_row = rows;
+  int64_t v_col = cols;
   bool v_row_dynamic = false;
   bool v_col_dynamic = false;
   auto tile_it = memref_to_tile_type_.find(memref);
   if (tile_it != memref_to_tile_type_.end()) {
-    ExtractTileTypeInfo(*tile_it->second, *this, dtype_str, rows, cols, blayout, slayout, fractal, pad,
-                        v_row_dynamic, v_col_dynamic);
+    ExtractTileTypeInfo(*tile_it->second, *this, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row,
+                        v_col, v_row_dynamic, v_col_dynamic);
   }
 
-  return FormatTileBufTypeString(loc, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row_dynamic,
-                                 v_col_dynamic);
+  return FormatTileBufTypeString(loc, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row, v_col,
+                                 v_row_dynamic, v_col_dynamic);
 }
 
 std::string PTOCodegen::GetTileBufTypeStringFromTileType(
@@ -753,14 +786,16 @@ std::string PTOCodegen::GetTileBufTypeStringFromTileType(
   ir::TileLayout slayout = ir::TileLayout::none_box;
   uint64_t fractal = 512;
   ir::TilePad pad = ir::TilePad::null;
+  int64_t v_row = rows;
+  int64_t v_col = cols;
   bool v_row_dynamic = false;
   bool v_col_dynamic = false;
 
-  ExtractTileTypeInfo(*tile_type, *this, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row_dynamic,
-                      v_col_dynamic);
+  ExtractTileTypeInfo(*tile_type, *this, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row, v_col,
+                      v_row_dynamic, v_col_dynamic);
 
-  return FormatTileBufTypeString(loc, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row_dynamic,
-                                 v_col_dynamic);
+  return FormatTileBufTypeString(loc, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row, v_col,
+                                 v_row_dynamic, v_col_dynamic);
 }
 
 std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
@@ -800,6 +835,28 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
 
 std::string PTOCodegen::GetCurrentResultTileBufTypeString() const {
   if (current_result_tile_type_ && current_result_tile_type_->memref_.has_value()) {
+    // Check if the MemRef has an updated pad value from fillpad.
+    // Only take the pad value — NOT the shape, because memory reuse can make
+    // different-shaped tiles share the same MemRef.
+    auto memref = current_result_tile_type_->memref_.value().get();
+    auto it = memref_to_tile_type_.find(memref);
+    if (it != memref_to_tile_type_.end()) {
+      if (it->second->tile_view_.has_value()) {
+        const auto& tv = it->second->tile_view_.value();
+        if (tv.pad != ir::TilePad::null) {
+          // Merge: use current tile's shape but take pad from memref mapping
+          auto current = current_result_tile_type_;
+          ir::TileView merged_view;
+          if (current->tile_view_.has_value()) {
+            merged_view = current->tile_view_.value();
+          }
+          merged_view.pad = tv.pad;
+          auto merged =
+              std::make_shared<TileType>(current->shape_, current->dtype_, current->memref_, merged_view);
+          return GetTileBufTypeStringFromTileType(merged);
+        }
+      }
+    }
     return GetTileBufTypeStringFromTileType(current_result_tile_type_);
   }
   return "";

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -815,10 +815,21 @@ REGISTER_OP("tile.fillpad")
       CHECK(tile_type) << "The operator tile.fillpad requires first argument to be a TileType, but got "
                        << args[0]->GetType()->TypeName();
 
-      // Return same TileType
+      // Get pad_value from kwargs, default to TilePad::zero
+      TilePad pad_value = TilePad::zero;
+      for (const auto& kv : kwargs) {
+        if (kv.first == "pad_value") {
+          pad_value = std::any_cast<TilePad>(kv.second);
+          CHECK(pad_value != TilePad::null) << "tile.fillpad requires pad_value to be zero/max/min, not null";
+        }
+      }
+
+      // Return TileType with pad value set in tile_view
+      // After fillpad, the entire tile is valid (padding region is now filled with pad_value)
       TileView tile_view;
-      tile_view.valid_shape = GetValidShape(tile_type);
-      return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
+      tile_view.valid_shape = tile_type->shape_;  // Expand valid_shape to full shape
+      tile_view.pad = pad_value;
+      return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, tile_type->memref_, tile_view);
     });
 
 }  // namespace ir

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -204,6 +204,11 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
                                : input_shape;
   tile_view.valid_shape = input_valid_shape;
 
+  // Preserve pad value from input tile
+  if (tile_type->tile_view_ && tile_type->tile_view_->pad != TilePad::null) {
+    tile_view.pad = tile_type->tile_view_->pad;
+  }
+
   // Return TileType with computed shape and same dtype (no explicit MemRef)
   return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -579,10 +579,27 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     } else if (value.type() == typeid(TensorLayout)) {
       stream_ << prefix_ << ".TensorLayout."
               << TensorLayoutToString(AnyCast<TensorLayout>(value, "printing kwarg: " + key));
+    } else if (value.type() == typeid(TilePad)) {
+      auto pad = AnyCast<TilePad>(value, "printing kwarg: " + key);
+      stream_ << prefix_ << ".TilePad.";
+      switch (pad) {
+        case TilePad::null:
+          stream_ << "null";
+          break;
+        case TilePad::zero:
+          stream_ << "zero";
+          break;
+        case TilePad::max:
+          stream_ << "max";
+          break;
+        case TilePad::min:
+          stream_ << "min";
+          break;
+      }
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
                       ", expected int, bool, std::string, double, float, DataType, MemorySpace, "
-                      "or TensorLayout, but got " +
+                      "TensorLayout, or TilePad, but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/tests/st/runtime/test_fillpad.py
+++ b/tests/st/runtime/test_fillpad.py
@@ -1,0 +1,226 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Test fillpad operation with different pad values (zero, max, min).
+
+Each test verifies that fillpad correctly fills the padding region:
+1. Load 48x64 data into 64x64 tile (rows 48-63 are padding region)
+2. fillpad with specified pad_value fills rows 48-63 AND expands valid_shape to 64x64
+3. Store the full 64x64 tile to output
+4. Verify: rows 0-47 = input data, rows 48-63 = expected fill value
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# --- Programs ---
+
+
+@pl.program
+class FillpadZeroProgram:
+    """Verify fillpad by storing the full tile including padding region."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_zero_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.TilePad.zero)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.fillpad_zero_kernel(input_tensor, output)
+        return output
+
+
+@pl.program
+class FillpadMaxProgram:
+    """Verify fillpad with max by storing the full tile including padding region."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_max_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.TilePad.max)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.fillpad_max_kernel(input_tensor, output)
+        return output
+
+
+@pl.program
+class FillpadMinProgram:
+    """Verify fillpad with min by storing the full tile including padding region."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_min_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.TilePad.min)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        output = self.fillpad_min_kernel(input_tensor, output)
+        return output
+
+
+# --- Test Cases ---
+
+
+class FillpadZeroTestCase(PTOTestCase):
+    """Test fillpad - padding region should be filled with 0.0."""
+
+    def get_name(self) -> str:
+        return "fillpad_zero"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadZeroProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = 0.0"""
+        expected = torch.zeros(64, 64, dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+class FillpadMaxTestCase(PTOTestCase):
+    """Test fillpad - padding region should be filled with FP32 max."""
+
+    def get_name(self) -> str:
+        return "fillpad_max"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadMaxProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = FP32 max"""
+        expected = torch.full((64, 64), float("inf"), dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+class FillpadMinTestCase(PTOTestCase):
+    """Test fillpad - padding region should be filled with FP32 min (-inf)."""
+
+    def get_name(self) -> str:
+        return "fillpad_min"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadMinProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = -inf"""
+        expected = torch.full((64, 64), float("-inf"), dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+# --- Tests ---
+
+
+class TestFillpad:
+    """Test suite to verify fillpad fills padding region with different pad values."""
+
+    def test_fillpad_zero(self, test_runner):
+        """Verify fillpad fills the padding region with 0.0."""
+        test_case = FillpadZeroTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_fillpad_max(self, test_runner):
+        """Verify fillpad fills the padding region with FP32 max value."""
+        test_case = FillpadMaxTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_fillpad_min(self, test_runner):
+        """Verify fillpad fills the padding region with FP32 min value (-inf)."""
+        test_case = FillpadMinTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                      
Export fillpad operation to top-level namespace (pl.fillpad), add pad_value parameter supporting TilePad.zero/max/min, and fix PTO codegen bug where valid_shape was not correctly propagated to v_row/v_col, causing fillpad to have no effect.                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                        
## Changes                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                    
### Python API
- Export fillpad to pl.fillpad and pl.tile.fillpad
- Export TilePad enum to language module
- Add pad_value parameter to fillpad API (TilePad.zero, TilePad.max, TilePad.min; default is zero)
- Add TilePad type support in ConvertKwargsDict (Python bindings) and create_op_call type stub

### PTO Codegen Fix
- ExtractTileTypeInfo: Extract constant valid_shape values for v_row/v_col instead of using physical rows/cols
- MemRefCollectorVisitor: Merge TileView properties when multiple tiles share the same MemRef
  - Keep valid_shape from load (e.g., [48, 64])
  - Take pad value from fillpad
- FormatTileBufTypeString: Add separate v_row/v_col parameters
- GetCurrentResultTileBufTypeString: Look up memref_to_tile_type_ mapping to ensure fillpad's pad_value is reflected in codegen output

### Other
- Update tile.fillpad type deduction to read pad_value from kwargs, expand valid_shape to full shape, and preserve memref_ reference
- Preserve pad value propagation through tile.move
- Add TilePad enum printing support in IR Python printer
- Update English and Chinese documentation

## Testing

- Add system test tests/st/runtime/test_fillpad.py with three test cases:
  - test_fillpad_zero: fillpad with TilePad.zero fills padding region (rows 48-63) with 0.0
  - test_fillpad_max: fillpad with TilePad.max fills padding region with +inf
  - test_fillpad_min: fillpad with TilePad.min fills padding region with -inf
- Test scenario: Load 48x64 data into 64x64 tile, fillpad fills rows 48-63, store full 64x64 tile, verify data region preserves original values and padding region matches expected fill value

## Note: PTOAS uses v7.0.