### PR TITLE
fix(codegen): Usa SSA format for pto.treshape and infer tile blayout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.3
-          PTOAS_SHA256=203727d744cd437325e3b22c599ca90f642e51e735ede2ac3a22636b36aa89d9
+          PTOAS_VERSION=v0.4
+          PTOAS_SHA256=07abef173c026ae2168606b4522941bd23a72ce03f762fc2056a5a7309a9b45d
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -163,6 +163,7 @@ class PTOCodegen : public CodegenBase {
    * @param buf New result buffer SSA name
    */
   void SetCurrentResultBuf(const std::string& buf);
+  void RegisterTileBufType(const std::string& ssa_name, const std::string& type_string);
 
  protected:
   // Override visitor methods for code generation - Statements

--- a/src/backend/910B_PTO/backend_910b_pto_ops.cpp
+++ b/src/backend/910B_PTO/backend_910b_pto_ops.cpp
@@ -609,17 +609,21 @@ REGISTER_BACKEND_OP(Backend910B_PTO, "block.reshape")
         }
       }
       // PTO bytecode requires distinct tile buffers for reshape input/output.
-      // When both resolve to the same buffer (shared MemRef), allocate a new output buffer.
+      // When both resolve to the same buffer (shared MemRef), allocate a new result variable.
       if (src == result_target && !result_type.empty()) {
-        result_target = codegen.AllocNewTileBuf(result_type);
+        result_target = codegen.NewTemp();
         codegen.SetCurrentResultBuf(result_target);
       }
+      // Register the result variable's type so GetExprTypeAnnotation can find it
+      if (!result_type.empty()) {
+        codegen.RegisterTileBufType(result_target, result_type);
+      }
+      // New format: %result = pto.treshape %src : input_type -> output_type
       std::ostringstream oss;
-      oss << "pto.treshape ins(" << src;
-      if (!src_type.empty()) oss << " : " << src_type;
-      oss << ") outs(" << result_target;
-      if (!result_type.empty()) oss << " : " << result_type;
-      oss << ")";
+      oss << result_target << " = pto.treshape " << src;
+      if (!src_type.empty() && !result_type.empty()) {
+        oss << " : " << src_type << " -> " << result_type;
+      }
       codegen.Emit(oss.str());
       return std::string("");
     });

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -352,7 +352,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
           stream_ << GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[j]));
         }
       }
-      stream_ << "]";
+      stream_ << "],";
 
       stream_ << " strides = [";
       if (tensor_type->shape_.size() == 2) {
@@ -441,6 +441,10 @@ std::string PTOCodegen::AllocNewTileBuf(const std::string& tile_buf_type_string)
 }
 
 void PTOCodegen::SetCurrentResultBuf(const std::string& buf) { current_result_buf_ = buf; }
+
+void PTOCodegen::RegisterTileBufType(const std::string& ssa_name, const std::string& type_string) {
+  extra_tile_buf_types_[ssa_name] = type_string;
+}
 
 void PTOCodegen::EmitExtraAllocTiles() {
   for (const auto& [name, type_str] : extra_alloc_tiles_) {

--- a/src/ir/op/block_ops/transform.cpp
+++ b/src/ir/op/block_ops/transform.cpp
@@ -158,6 +158,23 @@ TypePtr DeduceTileViewType(const std::vector<ExprPtr>& args,
   // View preserves dtype but has new shape (which can have different rank than input)
   TileView tile_view;
   tile_view.valid_shape = new_shape;
+
+  // Infer blayout from new shape: column vectors [N, 1] use col_major
+  if (new_shape.size() == 2) {
+    auto rows_const = As<ConstInt>(new_shape[0]);
+    auto cols_const = As<ConstInt>(new_shape[1]);
+    if (rows_const && cols_const) {
+      if (cols_const->value_ == 1 && rows_const->value_ > 1) {
+        tile_view.blayout = TileLayout::col_major;
+      } else {
+        tile_view.blayout = TileLayout::row_major;
+      }
+    } else {
+      // Dynamic shape: default to row_major
+      tile_view.blayout = TileLayout::row_major;
+    }
+  }
+
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -209,6 +226,23 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
   // Return new TileType with reshaped dimensions and same dtype
   TileView tile_view;
   tile_view.valid_shape = new_shape;
+
+  // Infer blayout from new shape: column vectors [N, 1] use col_major
+  if (new_shape.size() == 2) {
+    auto rows_const = As<ConstInt>(new_shape[0]);
+    auto cols_const = As<ConstInt>(new_shape[1]);
+    if (rows_const && cols_const) {
+      if (cols_const->value_ == 1 && rows_const->value_ > 1) {
+        tile_view.blayout = TileLayout::col_major;
+      } else {
+        tile_view.blayout = TileLayout::row_major;
+      }
+    } else {
+      // Dynamic shape: default to row_major
+      tile_view.blayout = TileLayout::row_major;
+    }
+  }
+
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
 


### PR DESCRIPTION
  fix(codegen): Usa SSA format for pto.treshape and infer tile blayout

- Change pto.treshape bytecode from DPS format `ins(...) outs(...)` to
    SSA format `%result = pto.treshape %src : input_type -> output_type`
    to match PTOAS expected input format

  - Add RegisterTileBufType to track dynamically allocated tile buffer
    types for proper type annotation lookup

  - Infer blayout from shape in DeduceTileViewType and
  DeduceTileReshapeType:
    column vectors [N, 1] use col_major, others use row_major

  - Fix missing comma between shape and strides in EmitMakeTensorViews

  This enables PTOAS to correctly generate TRESHAPE macro instead of
  invalid pointer cast when lowering pto.treshape operations.

- Update PTOAS to v0.4