### PR TITLE
fix(language): Add __getitem__ to Tensor/Tile for subscript type checking

### DIFF
--- a/python/pypto/language/typing/tensor.py
+++ b/python/pypto/language/typing/tensor.py
@@ -158,7 +158,11 @@ class Tensor(metaclass=TensorMeta):
     @classmethod
     def __class_getitem__(cls, item: tuple[Sequence[int], DataType]) -> "Tensor":
         """Support static type checkers for Tensor[[shape], dtype] syntax."""
-        return cls.__getitem__(item)
+        return type(cls).__getitem__(cls, item)
+
+    def __getitem__(self, indices: Any) -> Any:
+        """Subscript syntax for tensor slicing/reading (only valid inside @pl.function)."""
+        raise NotImplementedError("Tensor subscript syntax is only available inside @pl.function")
 
     def __repr__(self) -> str:
         """String representation."""

--- a/python/pypto/language/typing/tile.py
+++ b/python/pypto/language/typing/tile.py
@@ -13,6 +13,7 @@ Tile represents a tile in unified buffer memory, used for tile-level programming
 """
 
 from collections.abc import Sequence
+from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr, MemRef
@@ -134,7 +135,11 @@ class Tile(metaclass=TileMeta):
     @classmethod
     def __class_getitem__(cls, item: tuple[Sequence[int], DataType]) -> "Tile":
         """Support static type checkers for Tile[[shape], dtype] syntax."""
-        return cls.__getitem__(item)
+        return type(cls).__getitem__(cls, item)
+
+    def __getitem__(self, indices: Any) -> Any:
+        """Subscript syntax for tile slicing (only valid inside @pl.function)."""
+        raise NotImplementedError("Tile subscript syntax is only available inside @pl.function")
 
     def __repr__(self) -> str:
         """String representation."""

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -9,10 +9,6 @@
 
 """Unit tests for subscript syntax on Tensor and Tile types."""
 
-# Subscript syntax (A[0:16, :]) is parsed at AST level by @pl.function,
-# not by Python's runtime type system, so pyright can't see __getitem__.
-# pyright: reportIndexIssue=false
-
 import pypto.language as pl
 import pytest
 from pypto import ir


### PR DESCRIPTION
## Summary
- Add instance-level `__getitem__` methods to `Tensor` and `Tile` classes so pyright no longer reports `reportIndexIssue` errors when using subscript syntax (`A[0:16, :]`, `A[i, j]`) inside `@pl.function`
- Fix `__class_getitem__` to call the metaclass `__getitem__` explicitly via `type(cls).__getitem__` to avoid resolution conflict with the new instance method
- Remove the `# pyright: reportIndexIssue=false` workaround from the subscript syntax test file

## Testing
- [x] All 12 subscript syntax tests pass
- [x] All 82 tensor/tile-related language tests pass
- [x] All pre-commit hooks pass (including pyright)
- [x] Build succeeds

Closes #392