### PR TITLE
feat(ir): Add valid_shape field to TensorView and tensor op interfaces

### DIFF
--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -145,9 +145,11 @@ enum class TensorLayout {
 struct TensorView {
   std::vector<ExprPtr> stride;  ///< Stride for each dimension
   TensorLayout layout;          ///< Tensor layout type
+  std::vector<ExprPtr>
+      valid_shape;  ///< Valid shape for each dimension (optional, empty means use full shape)
 
   /**
-   * @brief Default constructor for aggregate initialization
+   * @brief Default constructor with ND layout and empty stride/valid_shape
    */
   TensorView() : layout(TensorLayout::ND) {}
 
@@ -156,8 +158,10 @@ struct TensorView {
    *
    * @param stride Stride for each dimension
    * @param layout Tensor layout type
+   * @param valid_shape Valid shape for each dimension (optional, defaults to empty)
    */
-  TensorView(std::vector<ExprPtr> stride, TensorLayout layout) : stride(std::move(stride)), layout(layout) {}
+  TensorView(std::vector<ExprPtr> stride, TensorLayout layout, std::vector<ExprPtr> valid_shape = {})
+      : stride(std::move(stride)), layout(layout), valid_shape(std::move(valid_shape)) {}
 
   /**
    * @brief Get field descriptors for reflection-based visitation
@@ -166,7 +170,8 @@ struct TensorView {
    */
   static constexpr auto GetFieldDescriptors() {
     return std::make_tuple(reflection::UsualField(&TensorView::stride, "stride"),
-                           reflection::UsualField(&TensorView::layout, "layout"));
+                           reflection::UsualField(&TensorView::layout, "layout"),
+                           reflection::UsualField(&TensorView::valid_shape, "valid_shape"));
   }
 };
 
@@ -443,9 +448,7 @@ class TileType : public ShapedType {
    * @param memref Optional memory reference (shared pointer)
    */
   TileType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRefPtr> memref)
-      : ShapedType(dtype, std::move(shape), std::move(memref)), tile_view_(std::nullopt) {
-    // No dimension limit at type level; code generation may have constraints
-  }
+      : ShapedType(dtype, std::move(shape), std::move(memref)), tile_view_(std::nullopt) {}
 
   /**
    * @brief Create a tile type with constant shape

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -233,12 +233,14 @@ void BindIR(nb::module_& m) {
       .export_values();
 
   // TensorView - struct for tensor view information - must be before TensorType
-  nb::class_<TensorView>(ir, "TensorView", "Tensor view representation with stride and layout")
+  nb::class_<TensorView>(ir, "TensorView", "Tensor view representation with stride, layout and valid shape")
       .def(nb::init<>(), "Create an empty tensor view")
-      .def(nb::init<const std::vector<ExprPtr>&, TensorLayout>(), nb::arg("stride"), nb::arg("layout"),
-           "Create a tensor view with stride and layout")
+      .def(nb::init<const std::vector<ExprPtr>&, TensorLayout, const std::vector<ExprPtr>&>(),
+           nb::arg("stride"), nb::arg("layout"), nb::arg("valid_shape") = std::vector<ExprPtr>{},
+           "Create a tensor view with stride, layout and optional valid shape")
       .def_rw("stride", &TensorView::stride, "Stride for each dimension")
-      .def_rw("layout", &TensorView::layout, "Tensor layout type");
+      .def_rw("layout", &TensorView::layout, "Tensor layout type")
+      .def_rw("valid_shape", &TensorView::valid_shape, "Valid shape for each dimension");
 
   // TensorType - const shared_ptr
   auto tensor_type_class = nb::class_<TensorType, ShapedType>(ir, "TensorType", "Tensor type representation");

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -82,6 +82,7 @@ def slice(
     tensor: Expr,
     shape: list[int | Expr] | _ir_core.MakeTuple,
     offset: list[int | Expr] | _ir_core.MakeTuple,
+    valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
     span: Span | None = None,
 ) -> Call:
     """Create a slice of a tensor with new shape and offset.
@@ -90,6 +91,7 @@ def slice(
         tensor: Input tensor expression
         shape: New shape dimensions, or a MakeTuple
         offset: Offset dimensions for the slice, or a MakeTuple
+        valid_shape: Valid shape dimensions (optional, defaults to empty)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -101,6 +103,8 @@ def slice(
     offset_tuple = _to_make_tuple(offset, actual_span)
 
     args = [tensor, shape_tuple, offset_tuple]
+    if valid_shape is not None:
+        args.append(_to_make_tuple(valid_shape, actual_span))
     return _ir_core.create_op_call("tensor.slice", args, {}, actual_span)
 
 
@@ -443,12 +447,18 @@ def assemble(
     return _ir_core.create_op_call("tensor.assemble", args, {}, actual_span)
 
 
-def reshape(tensor: Expr, shape: list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None) -> Call:
+def reshape(
+    tensor: Expr,
+    shape: list[int | Expr] | _ir_core.MakeTuple,
+    valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
+    span: Span | None = None,
+) -> Call:
     """Reshape tensor to new shape.
 
     Args:
         tensor: Input tensor expression
         shape: New shape dimensions, or a MakeTuple
+        valid_shape: Valid shape dimensions (optional, defaults to empty)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -459,16 +469,25 @@ def reshape(tensor: Expr, shape: list[int | Expr] | _ir_core.MakeTuple, span: Sp
     shape_tuple = _to_make_tuple(shape, actual_span)
 
     args = [tensor, shape_tuple]
+    if valid_shape is not None:
+        args.append(_to_make_tuple(valid_shape, actual_span))
     return _ir_core.create_op_call("tensor.reshape", args, {}, actual_span)
 
 
-def transpose(tensor: Expr, axis1: int, axis2: int, span: Span | None = None) -> Call:
+def transpose(
+    tensor: Expr,
+    axis1: int,
+    axis2: int,
+    valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
+    span: Span | None = None,
+) -> Call:
     """Transpose tensor by swapping two axes.
 
     Args:
         tensor: Input tensor expression
         axis1: First axis to swap (supports negative indexing)
         axis2: Second axis to swap (supports negative indexing)
+        valid_shape: Valid shape dimensions (optional, defaults to empty)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -479,7 +498,8 @@ def transpose(tensor: Expr, axis1: int, axis2: int, span: Span | None = None) ->
     axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
 
     args = [tensor, axis1_expr, axis2_expr]
-
+    if valid_shape is not None:
+        args.append(_to_make_tuple(valid_shape, actual_span))
     return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)
 
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -346,7 +346,7 @@ class TilePad(enum.Enum):
     """Min value padding."""
 
 class TensorView:
-    """Tensor view representation with stride and layout."""
+    """Tensor view representation with stride, layout and valid shape."""
 
     stride: Sequence[Expr]
     """Stride for each dimension."""
@@ -354,17 +354,26 @@ class TensorView:
     layout: TensorLayout
     """Tensor layout type."""
 
+    valid_shape: Sequence[Expr]
+    """Valid shape for each dimension (empty means use full shape)."""
+
     @overload
     def __init__(self) -> None:
         """Create an empty tensor view with default ND layout."""
 
     @overload
-    def __init__(self, stride: Sequence[Expr], layout: TensorLayout) -> None:
-        """Create a tensor view with stride and layout.
+    def __init__(
+        self,
+        stride: Sequence[Expr],
+        layout: TensorLayout,
+        valid_shape: Sequence[Expr] = ...,
+    ) -> None:
+        """Create a tensor view with stride, layout and optional valid shape.
 
         Args:
             stride: Stride for each dimension
             layout: Tensor layout type (ND, DN, or NZ)
+            valid_shape: Valid shape for each dimension (optional, defaults to empty)
         """
 
 class TensorType(ShapedType):

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -128,9 +129,10 @@ TypePtr DeduceTensorCreateType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.slice requires exactly 3 arguments: input tensor, shape tuple, and offset tuple
-  CHECK(args.size() == 3) << "tensor.slice requires exactly 3 arguments (input, shape, offset), but got "
-                          << args.size();
+  // tensor.slice requires 3 arguments (input, shape, offset) with optional 4th (valid_shape)
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tensor.slice requires 3 or 4 arguments (input, shape, offset[, valid_shape]), but got "
+      << args.size();
 
   // First argument must be TensorType
   auto tensor_type = As<TensorType>(args[0]->GetType());
@@ -185,6 +187,14 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
   }
 
   // View preserves dtype but has new shape (which can have different rank than input)
+  // If valid_shape is provided as 4th argument, store it in TensorView
+  if (args.size() == 4) {
+    auto valid_shape_tuple = As<MakeTuple>(args[3]);
+    CHECK(valid_shape_tuple) << "tensor.slice valid_shape (4th argument) must be a MakeTuple";
+    TensorView tensor_view({}, TensorLayout::ND, valid_shape_tuple->elements_);
+    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
+                                        std::make_optional(std::move(tensor_view)));
+  }
   return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
 }
 

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -83,9 +84,9 @@ int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
 
 TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.reshape requires exactly 2 arguments: input tensor and shape tuple
-  CHECK(args.size() == 2) << "tensor.reshape requires exactly 2 arguments (input, shape), but got "
-                          << args.size();
+  // tensor.reshape requires 2 arguments (input, shape) with optional 3rd (valid_shape)
+  CHECK(args.size() == 2 || args.size() == 3)
+      << "tensor.reshape requires 2 or 3 arguments (input, shape[, valid_shape]), but got " << args.size();
 
   // First argument must be TensorType
   auto tensor_type = As<TensorType>(args[0]->GetType());
@@ -134,14 +135,23 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   }
 
   // Return new TensorType with reshaped dimensions and same dtype
+  // If valid_shape is provided as 3rd argument, store it in TensorView
+  if (args.size() == 3) {
+    auto valid_shape_tuple = As<MakeTuple>(args[2]);
+    CHECK(valid_shape_tuple) << "tensor.reshape valid_shape (3rd argument) must be a MakeTuple";
+    TensorView tensor_view({}, TensorLayout::ND, valid_shape_tuple->elements_);
+    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
+                                        std::make_optional(std::move(tensor_view)));
+  }
   return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
 }
 
 TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
                                   const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.transpose requires exactly 3 arguments: input tensor, axis1, axis2
-  CHECK(args.size() == 3) << "tensor.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
-                          << args.size();
+  // tensor.transpose requires 3 arguments (input, axis1, axis2) with optional 4th (valid_shape)
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tensor.transpose requires 3 or 4 arguments (input, axis1, axis2[, valid_shape]), but got "
+      << args.size();
 
   // First argument must be TensorType
   auto tensor_type = As<TensorType>(args[0]->GetType());
@@ -173,6 +183,14 @@ TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
   std::swap(new_shape[axis1], new_shape[axis2]);
 
   // Return new TensorType with transposed shape and same dtype
+  // If valid_shape is provided as 4th argument, store it in TensorView
+  if (args.size() == 4) {
+    auto valid_shape_tuple = As<MakeTuple>(args[3]);
+    CHECK(valid_shape_tuple) << "tensor.transpose valid_shape (4th argument) must be a MakeTuple";
+    TensorView tensor_view({}, TensorLayout::ND, valid_shape_tuple->elements_);
+    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
+                                        std::make_optional(std::move(tensor_view)));
+  }
   return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
 }
 

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -95,7 +95,7 @@ void ShadowIterArgInBodyMap(std::unordered_map<std::string, VarPtr>& body_map,
  * non-converted ops (e.g. tile.load, tile.move) already manage their own tile
  * representation and must NOT get an extra load inserted.
  *
- * Also excludes parameters used by tensor.view and tensor.matmul since those conversions
+ * Also excludes parameters used by tensor.slice and tensor.matmul since those conversions
  * create their own block.load with proper offsets/memory spaces.
  */
 class TensorArgsInConvertedOpsCollector : public IRVisitor {
@@ -114,7 +114,7 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // Skip ops that manage their own data loading (they create block.load
       // with specific offsets/memory-spaces during conversion, so an extra
       // Phase-1 default Vec load would be redundant or wrong).
-      static const std::unordered_set<std::string> kSelfLoadingOps = {"tensor.view", "tensor.matmul",
+      static const std::unordered_set<std::string> kSelfLoadingOps = {"tensor.slice", "tensor.matmul",
                                                                       "tensor.assemble", "tensor.read"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -145,16 +145,16 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterCustom("tensor.maximum", MakeBroadcastBinaryConv("tile.maximum", "tile.maximum"));
 
   // ────────────────────────────────────────────────────────────────────────
-  // tensor.view → tile.load
+  // tensor.slice → tile.load
   //
-  // tensor.view(tensor, shape, offset) → tile.load(tensor, offset, shape, shape, target_memory=Vec)
+  // tensor.slice(tensor, shape, offset) → tile.load(tensor, offset, shape, shape, target_memory=Vec)
   // ────────────────────────────────────────────────────────────────────────
 
   RegisterCustom(
-      "tensor.view",
+      "tensor.slice",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3) << "tensor.view conversion expects 3 args (tensor, shape, offset)";
+        CHECK(args.size() == 3) << "tensor.slice conversion expects 3 args (tensor, shape, offset)";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
         const auto& shape = args[1];
@@ -196,7 +196,7 @@ OpConversionRegistry::OpConversionRegistry() {
           return ConversionResult{std::move(prologue), load_call};
         }
 
-        CHECK(false) << "tensor.view conversion: unexpected input type: " << input->GetType()->TypeName();
+        CHECK(false) << "tensor.slice conversion: unexpected input type: " << input->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
       });
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -261,7 +261,7 @@ class IRPythonPrinter : public IRVisitor {
   // MemRef and TileView printing helpers
   std::string PrintMemRef(const MemRef& memref);
   std::string PrintTileView(const TileView& tile_view, const std::vector<ExprPtr>& tile_shape);
-  std::string PrintTensorView(const TensorView& tensor_view);
+  std::string PrintTensorView(const TensorView& tensor_view, const std::vector<ExprPtr>& tensor_shape);
 };
 
 // Helper function to format float literals with decimal point
@@ -318,9 +318,12 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
     PrintShapeDims(oss, tensor_type->shape_);
     oss << "], " << prefix_ << "." << DataTypeToString(tensor_type->dtype_);
 
-    // Add optional tensor_view parameter if present (before memref for positional ordering)
+    // Add optional tensor_view parameter if present and has non-default fields
     if (tensor_type->tensor_view_.has_value()) {
-      oss << ", tensor_view=" << PrintTensorView(tensor_type->tensor_view_.value());
+      auto tv_str = PrintTensorView(tensor_type->tensor_view_.value(), tensor_type->shape_);
+      if (!tv_str.empty()) {
+        oss << ", tensor_view=" << tv_str;
+      }
     }
 
     // Add optional memref as positional arg
@@ -1357,31 +1360,74 @@ std::string IRPythonPrinter::PrintTileView(const TileView& tile_view,
   return oss.str();
 }
 
-std::string IRPythonPrinter::PrintTensorView(const TensorView& tensor_view) {
+std::string IRPythonPrinter::PrintTensorView(const TensorView& tensor_view,
+                                             const std::vector<ExprPtr>& tensor_shape) {
   std::ostringstream oss;
-  oss << prefix_ << ".TensorView(stride=[";
+  oss << prefix_ << ".TensorView(";
 
-  // Print stride
-  for (size_t i = 0; i < tensor_view.stride.size(); ++i) {
-    if (i > 0) oss << ", ";
-    IRPythonPrinter temp_printer(prefix_);
-    oss << temp_printer.Print(tensor_view.stride[i]);
+  bool first = true;
+  auto maybe_comma = [&]() {
+    if (!first) oss << ", ";
+    first = false;
+  };
+
+  // valid_shape — omit if it matches the parent tensor's shape
+  bool valid_shape_matches = (tensor_view.valid_shape.size() == tensor_shape.size());
+  if (valid_shape_matches) {
+    for (size_t i = 0; i < tensor_shape.size(); ++i) {
+      const auto& vs_expr = tensor_view.valid_shape[i];
+      const auto& ts_expr = tensor_shape[i];
+      if (vs_expr == ts_expr) continue;
+      auto vs = As<ConstInt>(vs_expr);
+      auto ts = As<ConstInt>(ts_expr);
+      if (!vs || !ts || vs->value_ != ts->value_) {
+        valid_shape_matches = false;
+        break;
+      }
+    }
+  }
+  if (!valid_shape_matches && !tensor_view.valid_shape.empty()) {
+    maybe_comma();
+    oss << "valid_shape=[";
+    for (size_t i = 0; i < tensor_view.valid_shape.size(); ++i) {
+      if (i > 0) oss << ", ";
+      IRPythonPrinter temp_printer(prefix_);
+      oss << temp_printer.Print(tensor_view.valid_shape[i]);
+    }
+    oss << "]";
   }
 
-  oss << "], layout=" << prefix_ << ".TensorLayout.";
-
-  // Print layout enum value
-  switch (tensor_view.layout) {
-    case TensorLayout::ND:
-      oss << "ND";
-      break;
-    case TensorLayout::DN:
-      oss << "DN";
-      break;
-    case TensorLayout::NZ:
-      oss << "NZ";
-      break;
+  // stride — omit if empty
+  if (!tensor_view.stride.empty()) {
+    maybe_comma();
+    oss << "stride=[";
+    for (size_t i = 0; i < tensor_view.stride.size(); ++i) {
+      if (i > 0) oss << ", ";
+      IRPythonPrinter temp_printer(prefix_);
+      oss << temp_printer.Print(tensor_view.stride[i]);
+    }
+    oss << "]";
   }
+
+  // layout — omit if ND (default)
+  if (tensor_view.layout != TensorLayout::ND) {
+    maybe_comma();
+    oss << "layout=" << prefix_ << ".TensorLayout.";
+    switch (tensor_view.layout) {
+      case TensorLayout::ND:
+        oss << "ND";
+        break;
+      case TensorLayout::DN:
+        oss << "DN";
+        break;
+      case TensorLayout::NZ:
+        oss << "NZ";
+        break;
+    }
+  }
+
+  // If all fields were at defaults, return empty string to skip tensor_view entirely
+  if (first) return "";
 
   oss << ")";
   return oss.str();

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -747,6 +747,50 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
     for (size_t i = 0; i < lhs_tensor->shape_.size(); ++i) {
       if (!Equal(lhs_tensor->shape_[i], rhs_tensor->shape_[i])) return false;
     }
+    // Compare tensor_view
+    if (lhs_tensor->tensor_view_.has_value() != rhs_tensor->tensor_view_.has_value()) {
+      if constexpr (AssertMode) {
+        ThrowMismatch("TensorType tensor_view presence mismatch", IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    if (lhs_tensor->tensor_view_.has_value()) {
+      const auto& lhs_tv = lhs_tensor->tensor_view_.value();
+      const auto& rhs_tv = rhs_tensor->tensor_view_.value();
+      // Compare valid_shape
+      if (lhs_tv.valid_shape.size() != rhs_tv.valid_shape.size()) {
+        if constexpr (AssertMode) {
+          std::ostringstream msg;
+          msg << "TensorView valid_shape size mismatch (" << lhs_tv.valid_shape.size()
+              << " != " << rhs_tv.valid_shape.size() << ")";
+          ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+      for (size_t i = 0; i < lhs_tv.valid_shape.size(); ++i) {
+        if (!Equal(lhs_tv.valid_shape[i], rhs_tv.valid_shape[i])) return false;
+      }
+      // Compare stride
+      if (lhs_tv.stride.size() != rhs_tv.stride.size()) {
+        if constexpr (AssertMode) {
+          std::ostringstream msg;
+          msg << "TensorView stride size mismatch (" << lhs_tv.stride.size() << " != " << rhs_tv.stride.size()
+              << ")";
+          ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+      for (size_t i = 0; i < lhs_tv.stride.size(); ++i) {
+        if (!Equal(lhs_tv.stride[i], rhs_tv.stride[i])) return false;
+      }
+      // Compare layout
+      if (lhs_tv.layout != rhs_tv.layout) {
+        if constexpr (AssertMode) {
+          ThrowMismatch("TensorView layout mismatch", IRNodePtr(), IRNodePtr(), "", "");
+        }
+        return false;
+      }
+    }
     return true;
   } else if (auto lhs_tile = As<TileType>(lhs)) {
     auto rhs_tile = As<TileType>(rhs);

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -282,6 +282,27 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       INTERNAL_CHECK(dim) << "structural_hash encountered null shape dimension in TypePtr";
       h = hash_combine(h, HashNode(dim));
     }
+    // Hash tensor_view if present
+    if (tensor_type->tensor_view_.has_value()) {
+      const auto& tv = tensor_type->tensor_view_.value();
+      h = hash_combine(h, static_cast<result_type>(1));  // indicate presence
+      // Hash valid_shape
+      h = hash_combine(h, static_cast<result_type>(tv.valid_shape.size()));
+      for (const auto& dim : tv.valid_shape) {
+        INTERNAL_CHECK(dim) << "structural_hash encountered null valid_shape dimension in TensorView";
+        h = hash_combine(h, HashNode(dim));
+      }
+      // Hash stride
+      h = hash_combine(h, static_cast<result_type>(tv.stride.size()));
+      for (const auto& dim : tv.stride) {
+        INTERNAL_CHECK(dim) << "structural_hash encountered null stride dimension in TensorView";
+        h = hash_combine(h, HashNode(dim));
+      }
+      // Hash layout
+      h = hash_combine(h, static_cast<result_type>(tv.layout));
+    } else {
+      h = hash_combine(h, static_cast<result_type>(0));  // indicate absence
+    }
   } else if (auto tile_type = As<TileType>(type)) {
     // Hash dtype
     h = hash_combine(h, static_cast<result_type>(std::hash<uint8_t>{}(tile_type->dtype_.Code())));

--- a/tests/ut/ir/expressions/test_tensor_expr.py
+++ b/tests/ut/ir/expressions/test_tensor_expr.py
@@ -222,5 +222,120 @@ class TestTensorVarStructuralHash:
         assert hash_a != hash_b
 
 
+class TestTensorView:
+    """Test cases for TensorView struct construction and fields."""
+
+    def test_tensor_view_with_valid_shape(self):
+        """Test TensorView construction with valid_shape field."""
+        span = ir.Span.unknown()
+        stride = [ir.ConstInt(32, DataType.INT32, span), ir.ConstInt(1, DataType.INT32, span)]
+        valid_shape = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        tv = ir.TensorView(stride=stride, layout=ir.TensorLayout.ND, valid_shape=valid_shape)
+
+        assert len(tv.valid_shape) == 2
+        assert tv.layout == ir.TensorLayout.ND
+
+        # Attach to TensorType
+        shape = [ir.ConstInt(16, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)]
+        t = ir.TensorType(shape, DataType.FP16, None, tv)
+        assert t.tensor_view is not None
+        assert len(t.tensor_view.valid_shape) == 2
+
+    def test_tensor_view_default_valid_shape_is_empty(self):
+        """Test that TensorView valid_shape defaults to empty when not provided."""
+        span = ir.Span.unknown()
+        stride = [ir.ConstInt(16, DataType.INT32, span)]
+        tv = ir.TensorView(stride=stride, layout=ir.TensorLayout.ND)
+
+        assert len(tv.valid_shape) == 0
+
+    def test_tensor_view_empty_default_constructor(self):
+        """Test that TensorView default constructor has empty valid_shape."""
+        tv = ir.TensorView()
+        assert len(tv.valid_shape) == 0
+
+    def test_tensor_type_with_valid_shape_structural_equal(self):
+        """Test that TensorType with same valid_shape are structurally equal."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        vs1 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        vs2 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        tv1 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs1)
+        tv2 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs2)
+        t1 = ir.TensorType(shape1, DataType.FP32, None, tv1)
+        t2 = ir.TensorType(shape2, DataType.FP32, None, tv2)
+        A = ir.Var("A", t1, span)
+        B = ir.Var("A", t2, span)
+
+        ir.assert_structural_equal(A, B, enable_auto_mapping=True)
+
+    def test_tensor_type_different_valid_shape_not_equal(self):
+        """Test that TensorType with different valid_shape are not structurally equal."""
+        span = ir.Span.unknown()
+        vs1 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        vs2 = [ir.ConstInt(2, DataType.INT32, span), ir.ConstInt(4, DataType.INT32, span)]
+        tv1 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs1)
+        tv2 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs2)
+        shape1 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        t1 = ir.TensorType(shape1, DataType.FP32, None, tv1)
+        t2 = ir.TensorType(shape2, DataType.FP32, None, tv2)
+        A = ir.Var("A", t1, span)
+        B = ir.Var("A", t2, span)
+
+        assert not ir.structural_equal(A, B, enable_auto_mapping=True)
+
+    def test_tensor_type_valid_shape_presence_not_equal(self):
+        """Test that TensorType with and without valid_shape are not structurally equal."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        vs = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        tv = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs)
+        t1 = ir.TensorType(shape1, DataType.FP32, None, tv)
+        t2 = ir.TensorType(shape2, DataType.FP32)
+        A = ir.Var("A", t1, span)
+        B = ir.Var("A", t2, span)
+
+        assert not ir.structural_equal(A, B, enable_auto_mapping=True)
+
+    def test_tensor_type_with_valid_shape_structural_hash(self):
+        """Test that TensorType with same valid_shape produce same structural hash."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        vs1 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        vs2 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        tv1 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs1)
+        tv2 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs2)
+        t1 = ir.TensorType(shape1, DataType.FP32, None, tv1)
+        t2 = ir.TensorType(shape2, DataType.FP32, None, tv2)
+        A = ir.Var("A", t1, span)
+        B = ir.Var("A", t2, span)
+
+        assert ir.structural_hash(A, enable_auto_mapping=True) == ir.structural_hash(
+            B, enable_auto_mapping=True
+        )
+
+    def test_tensor_type_different_valid_shape_different_hash(self):
+        """Test that TensorType with different valid_shape produce different structural hash."""
+        span = ir.Span.unknown()
+        shape1 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        shape2 = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        vs1 = [ir.ConstInt(4, DataType.INT32, span), ir.ConstInt(8, DataType.INT32, span)]
+        vs2 = [ir.ConstInt(2, DataType.INT32, span), ir.ConstInt(4, DataType.INT32, span)]
+        tv1 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs1)
+        tv2 = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=vs2)
+        t1 = ir.TensorType(shape1, DataType.FP32, None, tv1)
+        t2 = ir.TensorType(shape2, DataType.FP32, None, tv2)
+        A = ir.Var("A", t1, span)
+        B = ir.Var("A", t2, span)
+
+        assert ir.structural_hash(A, enable_auto_mapping=True) != ir.structural_hash(
+            B, enable_auto_mapping=True
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -564,6 +564,66 @@ def test_get_new_ops():
     assert cast_op.name == "tensor.cast"
 
 
+def test_tensor_slice_with_valid_shape():
+    """Test tensor.slice with valid_shape parameter."""
+    span = ir.Span.unknown()
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim16, dim32], DataType.FP16)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.slice(tensor_var, [8, 16], [0, 0], valid_shape=[4, 8])
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.slice"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert len(call.args) == 4
+    assert result_type.tensor_view is not None
+    assert len(result_type.tensor_view.valid_shape) == 2
+
+
+def test_tensor_reshape_with_valid_shape():
+    """Test tensor.reshape with valid_shape parameter."""
+    span = ir.Span.unknown()
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim4, dim8], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.reshape(tensor_var, [32], valid_shape=[16])
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.reshape"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(call.args) == 3
+    assert result_type.tensor_view is not None
+    assert len(result_type.tensor_view.valid_shape) == 1
+
+
+def test_tensor_transpose_with_valid_shape():
+    """Test tensor.transpose with valid_shape parameter."""
+    span = ir.Span.unknown()
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim8, dim16], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.transpose(tensor_var, 0, 1, valid_shape=[16, 8])
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.transpose"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(call.args) == 4
+    assert result_type.tensor_view is not None
+    assert len(result_type.tensor_view.valid_shape) == 2
+
+
 class TestTensorScalarMemoryOps:
     """Test suite for tensor-level scalar memory operations (load_scalar, store_scalar)."""
 


### PR DESCRIPTION
Add std::vector<ExprPtr> valid_shape field to TensorView struct with reflection support. Update tensor.slice, tensor.reshape, tensor.transpose type deduction to accept optional valid_shape argument and store it in the result TensorType's tensor_view. Add corresponding Python API parameters and test coverage.