### PR TITLE
fix(codegen): Guard all paged attention examples with v0.6 PTOAS update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.4
-          PTOAS_SHA256=07abef173c026ae2168606b4522941bd23a72ce03f762fc2056a5a7309a9b45d
+          PTOAS_VERSION=v0.6
+          PTOAS_SHA256=b2082034faf20a2eae9e0355c9c3587353f4a20b39dc68d59bd02a8eb341ca33
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/tests/st/codegen/test_paged_attention.py
+++ b/tests/st/codegen/test_paged_attention.py
@@ -643,7 +643,6 @@ class TestPagedAttentionKernels:
         result = test_runner.run(test_case)
         assert result.passed, f"PV matmul PTOAS test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="Online update with PTO backend has precision bug", strict=False)
     @pytest.mark.parametrize(
         "num_heads,head_dim,is_first,is_last",
         [
@@ -663,7 +662,6 @@ class TestPagedAttentionKernels:
             f"Online update PTOAS test failed (is_first={is_first}, is_last={is_last}): {result.error}"
         )
 
-    @pytest.mark.xfail(reason="Online update with PTO backend has precision bug", strict=False)
     @pytest.mark.parametrize(
         "batch,num_heads,head_dim,block_size,context_len,max_model_len",
         [


### PR DESCRIPTION
fix(codegen): Guard all paged attention examples with v0.6 PTOAS update

- Update to PTOAS v0.6
- Add CI guard for all paged attention kernels, including online_update & integrated example with PTOAS backend