### PR TITLE
refactor(op): rename scalar read/write IR ops to use multi-dimensional indices

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -42,12 +42,15 @@ def create(
     return _ir_core.create_op_call("tensor.create", args, kwargs, actual_span)
 
 
-def read(tensor: Expr, indices: list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None) -> Call:
+def read(
+    tensor: Expr, indices: Expr | list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None
+) -> Call:
     """Read a scalar value from a tensor at given indices.
 
     Args:
         tensor: Input tensor expression
-        indices: List of index expressions (one per tensor dimension), or a MakeTuple
+        indices: A single index expression (for 1-D flat access), a list of index
+            expressions (one per tensor dimension), or a MakeTuple
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -55,10 +58,44 @@ def read(tensor: Expr, indices: list[int | Expr] | _ir_core.MakeTuple, span: Spa
     """
     actual_span = _get_span_or_capture(span)
 
+    # Allow a bare Expr as a flat 1-D index for backwards compatibility
+    if isinstance(indices, Expr) and not isinstance(indices, _ir_core.MakeTuple):
+        indices = [indices]
+
     indices_tuple = _to_make_tuple(indices, actual_span)
 
     args = [tensor, indices_tuple]
     return _ir_core.create_op_call("tensor.read", args, {}, actual_span)
+
+
+def write(
+    tensor: Expr,
+    indices: Expr | list[int | Expr] | _ir_core.MakeTuple,
+    value: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Write a scalar value into a tensor at given indices.
+
+    Args:
+        tensor: Destination tensor expression (TensorType)
+        indices: A single index expression (for 1-D flat access), a list of index
+            expressions (one per tensor dimension), or a MakeTuple
+        value: Scalar value to write (ScalarType, must match tensor dtype)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the tensor (for chaining)
+    """
+    actual_span = _get_span_or_capture(span)
+
+    # Allow a bare Expr as a flat 1-D index for backwards compatibility
+    if isinstance(indices, Expr) and not isinstance(indices, _ir_core.MakeTuple):
+        indices = [indices]
+
+    indices_tuple = _to_make_tuple(indices, actual_span)
+
+    args = [tensor, indices_tuple, value]
+    return _ir_core.create_op_call("tensor.write", args, {}, actual_span)
 
 
 def dim(tensor: Expr, axis: int | Expr, span: Span | None = None) -> Call:
@@ -501,45 +538,3 @@ def transpose(
     if valid_shape is not None:
         args.append(_to_make_tuple(valid_shape, actual_span))
     return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)
-
-
-def load_scalar(
-    tensor: Expr,
-    offset: int | Expr,
-    span: Span | None = None,
-) -> Call:
-    """Load a scalar value from a tensor at a flat offset.
-
-    Args:
-        tensor: Source tensor expression (TensorType)
-        offset: Flat offset into the tensor (int or ScalarType expression)
-        span: Optional source span for debugging (auto-captured if not provided)
-
-    Returns:
-        Call expression returning a scalar with the same dtype as the tensor
-    """
-    actual_span = _get_span_or_capture(span)
-    offset_expr = _normalize_expr(offset, actual_span) if not isinstance(offset, Expr) else offset
-    return _ir_core.create_op_call("tensor.load_scalar", [tensor, offset_expr], {}, actual_span)
-
-
-def store_scalar(
-    tensor: Expr,
-    offset: int | Expr,
-    value: Expr,
-    span: Span | None = None,
-) -> Call:
-    """Store a scalar value to a tensor at a flat offset.
-
-    Args:
-        tensor: Destination tensor expression (TensorType)
-        offset: Flat offset into the tensor (int or ScalarType expression)
-        value: Value to store (ScalarType expression)
-        span: Optional source span for debugging (auto-captured if not provided)
-
-    Returns:
-        Call expression returning the tensor (for chaining)
-    """
-    actual_span = _get_span_or_capture(span)
-    offset_expr = _normalize_expr(offset, actual_span) if not isinstance(offset, Expr) else offset
-    return _ir_core.create_op_call("tensor.store_scalar", [tensor, offset_expr, value], {}, actual_span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -213,48 +213,6 @@ def get_block_idx(span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.get_block_idx", [], {}, actual_span)
 
 
-def getval(
-    tile: Expr,
-    offset: int | Expr,
-    span: Span | None = None,
-) -> Call:
-    """Get a scalar value from a tile at a flat offset.
-
-    Args:
-        tile: Source tile expression (TileType)
-        offset: Flat offset into the tile (int or ScalarType expression)
-        span: Optional source span for debugging (auto-captured if not provided)
-
-    Returns:
-        Call expression returning a scalar with the same dtype as the tile
-    """
-    actual_span = _get_span_or_capture(span)
-    offset_expr = _normalize_expr(offset, actual_span) if not isinstance(offset, Expr) else offset
-    return _ir_core.create_op_call("tile.getval", [tile, offset_expr], {}, actual_span)
-
-
-def setval(
-    tile: Expr,
-    offset: int | Expr,
-    value: Expr,
-    span: Span | None = None,
-) -> Call:
-    """Write a scalar value into a tile at a flat offset.
-
-    Args:
-        tile: Destination tile expression (TileType)
-        offset: Flat offset into the tile (int or ScalarType expression)
-        value: Scalar value to write (ScalarType expression)
-        span: Optional source span for debugging (auto-captured if not provided)
-
-    Returns:
-        Call expression returning the tile (for chaining)
-    """
-    actual_span = _get_span_or_capture(span)
-    offset_expr = _normalize_expr(offset, actual_span) if not isinstance(offset, Expr) else offset
-    return _ir_core.create_op_call("tile.setval", [tile, offset_expr, value], {}, actual_span)
-
-
 def full(
     shape: Sequence[int] | _ir_core.MakeTuple,
     dtype: DataType,
@@ -1552,12 +1510,13 @@ def row_min(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.row_min", [tile, tmp_tile], {}, actual_span)
 
 
-def read(tile: Expr, indices: list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None) -> Call:
+def read(tile: Expr, indices: Expr | list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None) -> Call:
     """Read a scalar value from a tile at given indices.
 
     Args:
         tile: Input tile expression
-        indices: List of index expressions (one per tile dimension), or a MakeTuple
+        indices: A single index expression (for 1-D flat access), a list of index
+            expressions (one per tile dimension), or a MakeTuple
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1565,10 +1524,44 @@ def read(tile: Expr, indices: list[int | Expr] | _ir_core.MakeTuple, span: Span 
     """
     actual_span = _get_span_or_capture(span)
 
+    # Allow a bare Expr as a flat 1-D index for backwards compatibility
+    if isinstance(indices, Expr) and not isinstance(indices, _ir_core.MakeTuple):
+        indices = [indices]
+
     indices_tuple = _to_make_tuple(indices, actual_span)
 
     args = [tile, indices_tuple]
     return _ir_core.create_op_call("tile.read", args, {}, actual_span)
+
+
+def write(
+    tile: Expr,
+    indices: Expr | list[int | Expr] | _ir_core.MakeTuple,
+    value: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Write a scalar value into a tile at given indices.
+
+    Args:
+        tile: Destination tile expression (TileType)
+        indices: A single index expression (for 1-D flat access), a list of index
+            expressions (one per tile dimension), or a MakeTuple
+        value: Scalar value to write (ScalarType, must match tile dtype)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the tile (for chaining)
+    """
+    actual_span = _get_span_or_capture(span)
+
+    # Allow a bare Expr as a flat 1-D index for backwards compatibility
+    if isinstance(indices, Expr) and not isinstance(indices, _ir_core.MakeTuple):
+        indices = [indices]
+
+    indices_tuple = _to_make_tuple(indices, actual_span)
+
+    args = [tile, indices_tuple, value]
+    return _ir_core.create_op_call("tile.write", args, {}, actual_span)
 
 
 # ============================================================================

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -19,6 +19,7 @@ __all__ = [
     "create_tensor",
     "create",
     "read",
+    "write",
     "dim",
     "slice",
     "matmul",
@@ -38,8 +39,6 @@ __all__ = [
     "assemble",
     "reshape",
     "transpose",
-    "load_scalar",
-    "store_scalar",
 ]
 
 from pypto.ir.op import tensor_ops as _ir_ops
@@ -78,19 +77,37 @@ def create_tensor(shape: Sequence[IntLike], dtype: DataType) -> Tensor:
 create = create_tensor
 
 
-def read(tensor: Tensor, indices: Sequence[IntLike]) -> Scalar:
+def read(tensor: Tensor, indices: IntLike | Sequence[IntLike]) -> Scalar:
     """Read a scalar value from a tensor at given indices.
 
     Args:
         tensor: Input tensor
-        indices: List of index expressions (one per tensor dimension)
+        indices: A single index expression (for 1-D flat access) or a list of
+            index expressions (one per tensor dimension)
 
     Returns:
         Scalar wrapping the read operation
     """
     tensor_expr = tensor.unwrap()
-    call_expr = _ir_ops.read(tensor_expr, _normalize_intlike(indices))
+    # Allow a bare IntLike as a flat 1-D index for backwards compatibility
+    indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
+    call_expr = _ir_ops.read(tensor_expr, _normalize_intlike(indices_seq))
     return Scalar(expr=call_expr)
+
+
+def write(tensor: Tensor, indices: IntLike | Sequence[IntLike], value: Scalar) -> None:
+    """Write a scalar value into a tensor at given indices.
+
+    Args:
+        tensor: Destination tensor
+        indices: A single index expression (for 1-D flat access) or a list of
+            index expressions (one per tensor dimension)
+        value: Scalar value to write
+    """
+    # Allow a bare IntLike as a flat 1-D index for backwards compatibility
+    indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
+    call_expr = _ir_ops.write(tensor.unwrap(), _normalize_intlike(indices_seq), value.unwrap())
+    _ = call_expr  # result is the tensor itself; discarded here
 
 
 def dim(tensor: Tensor, axis: int) -> Scalar:
@@ -413,30 +430,3 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.transpose(tensor_expr, axis1, axis2)
     return Tensor(expr=call_expr)
-
-
-def load_scalar(tensor: Tensor, offset: IntLike) -> Scalar:
-    """Load a scalar value from a tensor at a flat offset.
-
-    Args:
-        tensor: Source tensor (TensorType)
-        offset: Flat offset into the tensor
-
-    Returns:
-        Scalar wrapping the load_scalar operation
-    """
-    offset_expr = offset.unwrap() if isinstance(offset, Scalar) else offset
-    call_expr = _ir_ops.load_scalar(tensor.unwrap(), offset_expr)
-    return Scalar(expr=call_expr)
-
-
-def store_scalar(tensor: Tensor, offset: IntLike, value: Scalar) -> None:
-    """Store a scalar value to a tensor at a flat offset.
-
-    Args:
-        tensor: Destination tensor (TensorType)
-        offset: Flat offset into the tensor
-        value: Value to store
-    """
-    offset_expr = offset.unwrap() if isinstance(offset, Scalar) else offset
-    _ir_ops.store_scalar(tensor.unwrap(), offset_expr, value.unwrap())

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -22,14 +22,13 @@ __all__ = [
     "create_tile",
     "create",
     "read",
+    "write",
     "load",
     "store",
     "move",
     "full",
     "fillpad",
     "get_block_idx",
-    "getval",
-    "setval",
     "add",
     "sub",
     "mul",
@@ -142,18 +141,36 @@ def create_tile(
 create = create_tile
 
 
-def read(tile: Tile, indices: Sequence[IntLike]) -> Scalar:
+def read(tile: Tile, indices: IntLike | Sequence[IntLike]) -> Scalar:
     """Read a scalar value from a tile at given indices.
 
     Args:
         tile: Input tile
-        indices: List of index expressions (one per tile dimension)
+        indices: A single index expression (for 1-D flat access) or a list of
+            index expressions (one per tile dimension)
 
     Returns:
         Scalar wrapping the read operation
     """
-    call_expr = _ir_ops.read(tile.unwrap(), _normalize_intlike(indices))
+    # Allow a bare IntLike as a flat 1-D index for backwards compatibility
+    indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
+    call_expr = _ir_ops.read(tile.unwrap(), _normalize_intlike(indices_seq))
     return Scalar(expr=call_expr)
+
+
+def write(tile: Tile, indices: IntLike | Sequence[IntLike], value: Scalar) -> None:
+    """Write a scalar value into a tile at given indices.
+
+    Args:
+        tile: Destination tile
+        indices: A single index expression (for 1-D flat access) or a list of
+            index expressions (one per tile dimension)
+        value: Scalar value to write
+    """
+    # Allow a bare IntLike as a flat 1-D index for backwards compatibility
+    indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
+    call_expr = _ir_ops.write(tile.unwrap(), _normalize_intlike(indices_seq), value.unwrap())
+    _ = call_expr  # result is the tile itself; discarded here
 
 
 def load(
@@ -283,33 +300,6 @@ def get_block_idx() -> Scalar:
     """
     call_expr = _ir_ops.get_block_idx()
     return Scalar(expr=call_expr)
-
-
-def getval(tile: Tile, offset: IntLike) -> Scalar:
-    """Get a scalar value from a tile at a flat offset.
-
-    Args:
-        tile: Source tile
-        offset: Flat offset into the tile
-
-    Returns:
-        Scalar wrapping the getval operation
-    """
-    offset_expr = offset.unwrap() if isinstance(offset, Scalar) else offset
-    call_expr = _ir_ops.getval(tile.unwrap(), offset_expr)
-    return Scalar(expr=call_expr)
-
-
-def setval(tile: Tile, offset: IntLike, value: Scalar) -> None:
-    """Write a scalar value into a tile at a flat offset.
-
-    Args:
-        tile: Destination tile
-        offset: Flat offset into the tile
-        value: Scalar value to write
-    """
-    offset_expr = offset.unwrap() if isinstance(offset, Scalar) else offset
-    _ir_ops.setval(tile.unwrap(), offset_expr, value.unwrap())
 
 
 def add(lhs: Tile, rhs: Tile) -> Tile:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -288,33 +288,35 @@ def create_tile(shape: list[int], dtype: DataType, target_memory: MemorySpace) -
 # ---------------------------------------------------------------------------
 
 
-def read(src: Tensor | Tile, offset: IntLike) -> Scalar:
-    """Read a scalar value at a flat offset, dispatched by source type.
+def read(src: Tensor | Tile, offset: IntLike | Sequence[IntLike]) -> Scalar:
+    """Read a scalar value at given indices, dispatched by source type.
 
     Args:
         src: Source tensor (global memory) or tile (unified buffer)
-        offset: Flat offset into the source
+        offset: A single index expression (for 1-D flat access) or index list
+            (one per dimension) into the source
 
     Returns:
         Scalar wrapping the read value
     """
     if isinstance(src, Tensor):
-        return _tensor.load_scalar(src, offset)
+        return _tensor.read(src, offset)
     if isinstance(src, Tile):
-        return _tile.getval(src, offset)
+        return _tile.read(src, offset)
     raise TypeError(f"read: expected Tensor or Tile, got {type(src).__name__}")
 
 
-def write(dst: Tensor | Tile, offset: IntLike, value: Scalar) -> None:
-    """Write a scalar value to a tensor or tile at a flat offset.
+def write(dst: Tensor | Tile, offset: IntLike | Sequence[IntLike], value: Scalar) -> None:
+    """Write a scalar value to a tensor or tile at given indices.
 
     Args:
         dst: Destination tensor (global memory) or tile (unified buffer)
-        offset: Flat offset into the destination
+        offset: A single index expression (for 1-D flat access) or index list
+            (one per dimension) into the destination
         value: Scalar value to write
     """
     if isinstance(dst, Tensor):
-        return _tensor.store_scalar(dst, offset, value)
+        return _tensor.write(dst, offset, value)
     if isinstance(dst, Tile):
-        return _tile.setval(dst, offset, value)
+        return _tile.write(dst, offset, value)
     raise TypeError(f"write: expected Tensor or Tile, got {type(dst).__name__}")

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1833,13 +1833,6 @@ class ASTParser:
         "create_tile": "create",
     }
 
-    # Unified ops that dispatch to different IR names per type (tensor_name, tile_name).
-    # Dispatch is always on the first argument.
-    _RENAMED_DISPATCH_OPS: dict[str, tuple[str, str]] = {
-        "read": ("load_scalar", "getval"),
-        "write": ("store_scalar", "setval"),
-    }
-
     # Ops that exist only in one module (no dispatch needed).
     _TENSOR_ONLY_OPS = {
         "create_tensor",
@@ -1930,19 +1923,6 @@ class ASTParser:
         # Parse only the first arg to determine dispatch target
         first_arg = self.parse_expression(call.args[0])
         first_type = first_arg.type
-
-        # Ops that map to different IR names per type — dispatch on first arg
-        if op_name in self._RENAMED_DISPATCH_OPS:
-            tensor_op, tile_op = self._RENAMED_DISPATCH_OPS[op_name]
-            if isinstance(first_type, ir.TensorType):
-                return self._parse_tensor_op(tensor_op, call)
-            if isinstance(first_type, ir.TileType):
-                return self._parse_tile_op(tile_op, call)
-            raise InvalidOperationError(
-                f"{op_name}: expected Tensor or Tile as first argument, got {type(first_type).__name__}",
-                span=call_span,
-                hint=f"Use pl.{op_name}(tensor, ...) or pl.{op_name}(tile, ...)",
-            )
 
         if isinstance(first_type, ir.TensorType):
             return self._parse_tensor_op(op_name, call)

--- a/src/backend/910B_PTO/backend_910b_pto_ops.cpp
+++ b/src/backend/910B_PTO/backend_910b_pto_ops.cpp
@@ -372,97 +372,159 @@ static std::string MakeTileAllocCodegenPTO(const CallPtr& op, codegen::CodegenBa
   return "";  // No MLIR emission - pto.alloc_tile generated from MemRefs in TileTypes
 }
 
-// Helper function for tile.getval (scalar result with SSA assignment prefix)
-static std::string MakeGetValCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
-                                        codegen::CodegenBase& codegen_base) {
+// Compute a row-major flat offset string from a MakeTuple of indices and the shape of the container.
+// Returns the flat offset as a string (either a constant or a computed expression).
+// If all indices are constants, returns a single integer literal.
+// Otherwise returns an expression like "i0 * s1 * s2 + i1 * s2 + i2".
+static std::string ComputeFlatOffsetPTO(const ir::MakeTuplePtr& indices_tuple,
+                                        const std::vector<ir::ExprPtr>& shape, codegen::PTOCodegen& codegen) {
+  const auto& indices = indices_tuple->elements_;
+  INTERNAL_CHECK(indices.size() == shape.size())
+      << "Index count (" << indices.size() << ") must match shape rank (" << shape.size() << ")";
+
+  // Build linear index expression
+  std::ostringstream idx_oss;
+  for (size_t i = 0; i < indices.size(); ++i) {
+    if (i > 0) idx_oss << " + ";
+    idx_oss << codegen.GetExprAsCode(indices[i]);
+    for (size_t j = i + 1; j < shape.size(); ++j) {
+      idx_oss << " * " << codegen.GetExprAsCode(shape[j]);
+    }
+  }
+  return idx_oss.str();
+}
+
+// Get or emit a flat offset SSA value for a MakeTuple of indices and shape.
+// If all indices and shape dims are ConstInt, compute the flat offset at codegen time and return an index
+// constant. Otherwise, emit arith operations and return the final SSA name.
+static std::string GetFlatOffsetSSA(const ir::MakeTuplePtr& indices_tuple,
+                                    const std::vector<ir::ExprPtr>& shape, codegen::PTOCodegen& codegen) {
+  const auto& indices = indices_tuple->elements_;
+
+  // Try to compute a fully-constant flat offset
+  int64_t flat_offset = 0;
+  bool all_constant = true;
+  for (size_t i = 0; i < indices.size() && all_constant; ++i) {
+    auto idx_val = As<ir::ConstInt>(indices[i]);
+    if (!idx_val) {
+      all_constant = false;
+      break;
+    }
+
+    int64_t stride = 1;
+    for (size_t j = i + 1; j < shape.size(); ++j) {
+      auto dim_val = As<ir::ConstInt>(shape[j]);
+      if (!dim_val) {
+        all_constant = false;
+        break;
+      }
+      stride *= dim_val->value_;
+    }
+    if (!all_constant) break;
+    flat_offset += idx_val->value_ * stride;
+  }
+
+  if (all_constant) {
+    return codegen.GetIndexConstant(flat_offset);
+  }
+
+  // For variable expressions, emit arith operations via GetExprAsCode.
+  // GetExprAsCode already emits index-typed arith ops, so the result SSA name
+  // is already of type 'index' and no cast is needed.
+  return ComputeFlatOffsetPTO(indices_tuple, shape, codegen);
+}
+
+// Helper function for tile.read (indices -> flat offset -> pto.tgetval)
+static std::string MakeTileReadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments, but got "
-                               << op->args_.size();
-  std::string off = codegen.GetExprAsCode(op->args_[1]);
-  std::string off_type = codegen.GetExprTypeAnnotation(op->args_[1]);
-  if (off_type.empty()) off_type = "index";
-  std::string result = codegen.GetCurrentResultTarget();
+  CHECK(op->args_.size() == 2) << "tile.read requires 2 arguments, but got " << op->args_.size();
 
   auto tile_type = As<ir::TileType>(op->args_[0]->GetType());
-  INTERNAL_CHECK(tile_type) << "tile.getval first argument must be TileType";
-  std::string scalar_type = codegen.GetTypeString(tile_type->dtype_);
+  INTERNAL_CHECK(tile_type) << "tile.read first argument must be TileType";
+
+  auto indices_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK(indices_tuple) << "tile.read second argument must be MakeTuple (indices)";
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string result = codegen.GetCurrentResultTarget();
+  std::string scalar_type = codegen.GetTypeString(tile_type->dtype_);
+
+  std::string off = GetFlatOffsetSSA(indices_tuple, tile_type->shape_, codegen);
 
   std::ostringstream oss;
-  oss << result << " = " << pto_op_name << " ins(" << src << ", " << off;
-  if (!src_type.empty() || !off_type.empty()) {
-    oss << " : ";
-    if (!src_type.empty()) oss << src_type;
-    if (!src_type.empty() && !off_type.empty()) oss << ", ";
-    if (!off_type.empty()) oss << off_type;
+  oss << result << " = pto.tgetval ins(" << src << ", " << off;
+  if (!src_type.empty()) {
+    oss << " : " << src_type << ", index";
+  } else {
+    oss << " : , index";
   }
   oss << ") outs : " << scalar_type;
   codegen.Emit(oss.str());
   return "";
 }
 
-// Helper function for tile.setval (DPS: ins(offset, val) outs(dst))
-static std::string MakeSetValCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
-                                        codegen::CodegenBase& codegen_base) {
+// Helper function for tile.write (indices -> flat offset -> pto.tsetval)
+static std::string MakeTileWriteCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 3) << "Operation:[" << pto_op_name << "] requires 3 arguments, but got "
-                               << op->args_.size();
-  // args: (tile, offset, value)
+  CHECK(op->args_.size() == 3) << "tile.write requires 3 arguments, but got " << op->args_.size();
+
+  auto tile_type = As<ir::TileType>(op->args_[0]->GetType());
+  INTERNAL_CHECK(tile_type) << "tile.write first argument must be TileType";
+
+  auto indices_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK(indices_tuple) << "tile.write second argument must be MakeTuple (indices)";
+
   std::string tile = codegen.GetExprAsCode(op->args_[0]);
-  std::string off = codegen.GetExprAsCode(op->args_[1]);
+  std::string tile_type_str = codegen.GetExprTypeAnnotation(op->args_[0]);
   std::string value = codegen.GetExprAsCode(op->args_[2]);
-  std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
-  std::string off_type = codegen.GetExprTypeAnnotation(op->args_[1]);
   std::string value_type = codegen.GetExprTypeAnnotation(op->args_[2]);
-  if (off_type.empty()) off_type = "index";
+
+  std::string off = GetFlatOffsetSSA(indices_tuple, tile_type->shape_, codegen);
 
   std::ostringstream oss;
-  // pto.tsetval ins(%off, %val : index, dtype) outs(%dst : tile_buf_type)
-  oss << pto_op_name << " ins(" << off << ", " << value;
-  if (!off_type.empty() || !value_type.empty()) {
-    oss << " : ";
-    if (!off_type.empty()) oss << off_type;
-    if (!off_type.empty() && !value_type.empty()) oss << ", ";
-    if (!value_type.empty()) oss << value_type;
-  }
+  oss << "pto.tsetval ins(" << off << ", " << value;
+  oss << " : index";
+  if (!value_type.empty()) oss << ", " << value_type;
   oss << ") outs(" << tile;
-  if (!tile_type.empty()) oss << " : " << tile_type;
+  if (!tile_type_str.empty()) oss << " : " << tile_type_str;
   oss << ")";
   codegen.Emit(oss.str());
+
+  // Register result target as alias of the destination tile so chained writes resolve correctly.
+  std::string result_var = codegen.GetCurrentResultTarget();
+  if (!result_var.empty()) {
+    codegen.RegisterVarToMlir(result_var, tile);
+  }
   return "";
 }
 
-static std::string MakeLoadScalarCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
-                                            codegen::CodegenBase& codegen_base) {
+static std::string MakeTensorReadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments, but got "
-                               << op->args_.size();
-  std::string off = codegen.GetExprAsCode(op->args_[1]);
-  std::string off_type = codegen.GetExprTypeAnnotation(op->args_[1]);
-  if (off_type.empty()) off_type = "index";
-  std::string result = codegen.GetCurrentResultTarget();
+  CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments, but got " << op->args_.size();
 
-  // Get dtype from the result type
+  auto tensor_type_ptr = As<ir::TensorType>(op->args_[0]->GetType());
+  INTERNAL_CHECK(tensor_type_ptr) << "tensor.read first argument must be TensorType";
+
+  auto indices_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK(indices_tuple) << "tensor.read second argument must be MakeTuple (indices)";
+
   auto scalar_type_ptr = As<ir::ScalarType>(op->GetType());
-  INTERNAL_CHECK(scalar_type_ptr) << "tensor.load_scalar result must be ScalarType";
+  INTERNAL_CHECK(scalar_type_ptr) << "tensor.read result must be ScalarType";
   std::string scalar_type = codegen.GetTypeString(scalar_type_ptr->dtype_);
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string result = codegen.GetCurrentResultTarget();
 
-  // If src_type is empty, construct it from the tensor type
   if (src_type.empty()) {
-    auto tensor_type = As<ir::TensorType>(op->args_[0]->GetType());
-    if (tensor_type) {
-      // For function parameters, tensors are represented as !pto.ptr<dtype>
-      src_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type->dtype_) + ">";
-    }
+    src_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type_ptr->dtype_) + ">";
   }
 
+  std::string off = GetFlatOffsetSSA(indices_tuple, tensor_type_ptr->shape_, codegen);
+
   std::ostringstream oss;
-  oss << result << " = " << pto_op_name << " " << src << "[" << off << "]";
+  oss << result << " = pto.load_scalar " << src << "[" << off << "]";
   if (!src_type.empty()) {
     oss << " : " << src_type;
   }
@@ -471,36 +533,43 @@ static std::string MakeLoadScalarCodegenPTO(const std::string& pto_op_name, cons
   return "";
 }
 
-static std::string MakeStoreScalarCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
-                                             codegen::CodegenBase& codegen_base) {
+static std::string MakeTensorWriteCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 3) << "Operation:[" << pto_op_name << "] requires 3 arguments, but got "
-                               << op->args_.size();
+  CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments, but got " << op->args_.size();
+
+  auto tensor_type_ptr = As<ir::TensorType>(op->args_[0]->GetType());
+  INTERNAL_CHECK(tensor_type_ptr) << "tensor.write first argument must be TensorType";
+
+  auto indices_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK(indices_tuple) << "tensor.write second argument must be MakeTuple (indices)";
 
   std::string tensor = codegen.GetExprAsCode(op->args_[0]);
-  std::string off = codegen.GetExprAsCode(op->args_[1]);
+  std::string tensor_type_str = codegen.GetExprTypeAnnotation(op->args_[0]);
   std::string value = codegen.GetExprAsCode(op->args_[2]);
-  std::string tensor_type = codegen.GetExprTypeAnnotation(op->args_[0]);
   std::string value_type = codegen.GetExprTypeAnnotation(op->args_[2]);
 
-  // If tensor_type is empty, construct it from the tensor type
-  if (tensor_type.empty()) {
-    auto tensor_type_ptr = As<ir::TensorType>(op->args_[0]->GetType());
-    if (tensor_type_ptr) {
-      // For function parameters, tensors are represented as !pto.ptr<dtype>
-      tensor_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type_ptr->dtype_) + ">";
-    }
+  if (tensor_type_str.empty()) {
+    tensor_type_str = "!pto.ptr<" + codegen.GetTypeString(tensor_type_ptr->dtype_) + ">";
   }
 
+  std::string off = GetFlatOffsetSSA(indices_tuple, tensor_type_ptr->shape_, codegen);
+
   std::ostringstream oss;
-  oss << pto_op_name << " " << value << ", " << tensor << "[" << off << "]";
-  if (!tensor_type.empty() || !value_type.empty()) {
+  oss << "pto.store_scalar " << value << ", " << tensor << "[" << off << "]";
+  if (!tensor_type_str.empty() || !value_type.empty()) {
     oss << " : ";
-    if (!tensor_type.empty()) oss << tensor_type;
-    if (!tensor_type.empty() && !value_type.empty()) oss << ", ";
+    if (!tensor_type_str.empty()) oss << tensor_type_str;
+    if (!tensor_type_str.empty() && !value_type.empty()) oss << ", ";
     if (!value_type.empty()) oss << value_type;
   }
   codegen.Emit(oss.str());
+
+  // Register result target as alias of the destination tensor so chained writes resolve correctly.
+  std::string result_var = codegen.GetCurrentResultTarget();
+  if (!result_var.empty()) {
+    codegen.RegisterTensorView(result_var, tensor);
+    codegen.RegisterVarToMlir(result_var, tensor);
+  }
   return "";
 }
 
@@ -656,24 +725,24 @@ static const bool kSimpleOpsRegistered = [] {
 // Operations with custom codegen logic
 // ============================================================================
 
-REGISTER_BACKEND_OP(Backend910B_PTO, "tile.getval")
+REGISTER_BACKEND_OP(Backend910B_PTO, "tile.read")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-      return MakeGetValCodegenPTO("pto.tgetval", op, codegen);
+      return MakeTileReadCodegenPTO(op, codegen);
     });
 
-REGISTER_BACKEND_OP(Backend910B_PTO, "tile.setval")
+REGISTER_BACKEND_OP(Backend910B_PTO, "tile.write")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-      return MakeSetValCodegenPTO("pto.tsetval", op, codegen);
+      return MakeTileWriteCodegenPTO(op, codegen);
     });
 
-REGISTER_BACKEND_OP(Backend910B_PTO, "tensor.load_scalar")
+REGISTER_BACKEND_OP(Backend910B_PTO, "tensor.read")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-      return MakeLoadScalarCodegenPTO("pto.load_scalar", op, codegen);
+      return MakeTensorReadCodegenPTO(op, codegen);
     });
 
-REGISTER_BACKEND_OP(Backend910B_PTO, "tensor.store_scalar")
+REGISTER_BACKEND_OP(Backend910B_PTO, "tensor.write")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-      return MakeStoreScalarCodegenPTO("pto.store_scalar", op, codegen);
+      return MakeTensorWriteCodegenPTO(op, codegen);
     });
 
 REGISTER_BACKEND_OP(Backend910B_PTO, "tile.load")

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -111,10 +111,11 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
       idx_oss << " * " << codegen.GenerateExprString(shape[j]);
     }
   }
-  std::string idx_expr = idx_oss.str();
+  // Default to "0" for rank-0 tensors (scalar tensor with empty shape/indices)
+  std::string idx_expr = idx_oss.str().empty() ? "0" : idx_oss.str();
 
   // Check if the index expression is a simple constant (all digits)
-  bool is_simple = !idx_expr.empty() && std::all_of(idx_expr.begin(), idx_expr.end(), ::isdigit);
+  bool is_simple = std::all_of(idx_expr.begin(), idx_expr.end(), ::isdigit);
 
   std::ostringstream oss;
   if (is_simple) {
@@ -126,6 +127,56 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
     oss << "size_t idx_" << result_var << " = " << idx_expr << ";\n";
     oss << cpp_type << " " << result_var << " = static_cast<" << cpp_type << "*>(" << ptr_expr << ")[idx_"
         << result_var << "];";
+  }
+
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
+  // tensor.write(tensor, indices_tuple, value) -> write scalar value to tensor at indices
+  CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments";
+
+  std::string input_name = codegen.TryGetVarName(op->args_[0]);
+  CHECK(!input_name.empty()) << "tensor.write input must be a variable";
+
+  auto input_type = As<TensorType>(op->args_[0]->GetType());
+  CHECK(input_type) << "tensor.write input must be TensorType";
+
+  std::string ptr_expr = codegen.GetTensorDataPtr(input_name);
+
+  auto indices_tuple = As<MakeTuple>(op->args_[1]);
+  CHECK(indices_tuple) << "tensor.write indices must be MakeTuple";
+
+  std::string value_expr = codegen.GenerateExprString(op->args_[2]);
+  auto value_type = As<ScalarType>(op->args_[2]->GetType());
+  CHECK(value_type) << "tensor.write value must be ScalarType";
+  std::string cpp_type = value_type->dtype_.ToCTypeString();
+
+  // Compute linear index
+  const auto& indices = indices_tuple->elements_;
+  const auto& shape = input_type->shape_;
+
+  std::ostringstream idx_oss;
+  for (size_t i = 0; i < indices.size(); ++i) {
+    if (i > 0) idx_oss << " + ";
+    idx_oss << codegen.GenerateExprString(indices[i]);
+    for (size_t j = i + 1; j < shape.size(); ++j) {
+      idx_oss << " * " << codegen.GenerateExprString(shape[j]);
+    }
+  }
+  // Default to "0" for rank-0 tensors (scalar tensor with empty shape/indices)
+  std::string idx_expr = idx_oss.str().empty() ? "0" : idx_oss.str();
+
+  bool is_simple = std::all_of(idx_expr.begin(), idx_expr.end(), ::isdigit);
+
+  std::ostringstream oss;
+  if (is_simple) {
+    oss << "static_cast<" << cpp_type << "*>(" << ptr_expr << ")[" << idx_expr << "] = " << value_expr << ";";
+  } else {
+    std::string result_var = codegen.GetCurrentResultTarget();
+    oss << "size_t idx_" << result_var << " = " << idx_expr << ";\n";
+    oss << "static_cast<" << cpp_type << "*>(" << ptr_expr << ")[idx_" << result_var << "] = " << value_expr
+        << ";";
   }
 
   return oss.str();

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -316,73 +316,56 @@ REGISTER_OP("tensor.dim")
       return DeduceTensorDimType(args, kwargs);
     });
 
-TypePtr DeduceTensorLoadScalarType(const std::vector<ExprPtr>& args,
-                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                   const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (tensor, offset), but got "
+TypePtr DeduceTensorWriteType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.write: Write a scalar value into a tensor at given indices
+  // Args: (tensor, indices_tuple, value)
+  // Returns: TensorType (the destination tensor, for chaining)
+  CHECK(args.size() == 3) << "tensor.write requires exactly 3 arguments (tensor, indices, value), but got "
                           << args.size();
 
   auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  CHECK(tensor_type) << "tensor.write requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
-  auto offset_type = As<ScalarType>(args[1]->GetType());
-  CHECK(offset_type) << "The operator " << op_name
-                     << " requires second argument (offset) to be a ScalarType, but got "
-                     << args[1]->GetType()->TypeName();
+  auto indices_type = As<TupleType>(args[1]->GetType());
+  CHECK(indices_type) << "tensor.write requires indices to be TupleType, but got "
+                      << args[1]->GetType()->TypeName();
 
-  // Return scalar with same dtype as tensor
-  return std::make_shared<ScalarType>(tensor_type->dtype_);
-}
+  CHECK(indices_type->types_.size() == tensor_type->shape_.size())
+      << "tensor.write indices count (" << indices_type->types_.size() << ") must match tensor rank ("
+      << tensor_type->shape_.size() << ")";
 
-TypePtr DeduceTensorStoreScalarType(const std::vector<ExprPtr>& args,
-                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                    const std::string& op_name) {
-  CHECK(args.size() == 3) << "The operator " << op_name
-                          << " requires 3 arguments (tensor, offset, value), but got " << args.size();
-
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
-
-  auto offset_type = As<ScalarType>(args[1]->GetType());
-  CHECK(offset_type) << "The operator " << op_name
-                     << " requires second argument (offset) to be a ScalarType, but got "
-                     << args[1]->GetType()->TypeName();
+  for (size_t i = 0; i < indices_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(indices_type->types_[i]);
+    CHECK(scalar_type) << "tensor.write index element " << i << " must be ScalarType, but got "
+                       << indices_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_.IsInt())
+        << "tensor.write index element " << i << " must have integer dtype, but got "
+        << scalar_type->dtype_.ToString();
+  }
 
   auto value_type = As<ScalarType>(args[2]->GetType());
-  CHECK(value_type) << "The operator " << op_name
-                    << " requires third argument (value) to be a ScalarType, but got "
+  CHECK(value_type) << "tensor.write requires third argument (value) to be a ScalarType, but got "
                     << args[2]->GetType()->TypeName();
 
-  // Check value dtype matches tensor dtype
   CHECK(value_type->dtype_ == tensor_type->dtype_)
-      << "The operator " << op_name << " requires value dtype to match tensor dtype, but got value dtype "
+      << "tensor.write requires value dtype to match tensor dtype, but got value dtype "
       << value_type->dtype_.ToString() << " and tensor dtype " << tensor_type->dtype_.ToString();
 
-  // store_scalar returns the tensor (for chaining)
+  // tensor.write returns the tensor (for chaining)
   return args[0]->GetType();
 }
 
-REGISTER_OP("tensor.load_scalar")
+REGISTER_OP("tensor.write")
     .set_op_category("TensorOp")
-    .set_description("Load a scalar value from a tensor at a flat offset")
-    .add_argument("tensor", "Source tensor (TensorType)")
-    .add_argument("offset", "Flat offset into the tensor (ScalarType index)")
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorLoadScalarType(args, kwargs, "tensor.load_scalar");
-    });
-
-REGISTER_OP("tensor.store_scalar")
-    .set_op_category("TensorOp")
-    .set_description("Store a scalar value to a tensor at a flat offset")
+    .set_description("Write a scalar value into a tensor at given indices")
     .add_argument("tensor", "Destination tensor (TensorType)")
-    .add_argument("offset", "Flat offset into the tensor (ScalarType index)")
-    .add_argument("value", "Value to store (ScalarType)")
+    .add_argument("indices", "Index dimensions (TupleType of ScalarType)")
+    .add_argument("value", "Value to write (ScalarType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorStoreScalarType(args, kwargs, "tensor.store_scalar");
+      return DeduceTensorWriteType(args, kwargs);
     });
 
 }  // namespace ir

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -350,50 +350,57 @@ TypePtr DeduceTileReadType(const std::vector<ExprPtr>& args,
   return std::make_shared<ScalarType>(tile_type->dtype_);
 }
 
-TypePtr DeduceTileGetValType(const std::vector<ExprPtr>& args,
-                             const std::vector<std::pair<std::string, std::any>>& kwargs,
-                             const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (tile, offset), but got "
+TypePtr DeduceTileWriteType(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs,
+                            const std::string& op_name) {
+  // tile.write: Write a scalar value into a tile at given indices
+  // Args: (tile, indices_tuple, value)
+  // Returns: TileType (the destination tile, for chaining)
+  CHECK(args.size() == 3) << "tile.write requires exactly 3 arguments (tile, indices, value), but got "
                           << args.size();
 
   auto tile_type = As<TileType>(args[0]->GetType());
-  CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+  CHECK(tile_type) << "tile.write requires first argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
-  auto offset_type = As<ScalarType>(args[1]->GetType());
-  CHECK(offset_type) << "The operator " << op_name
-                     << " requires second argument (offset) to be a ScalarType, but got "
-                     << args[1]->GetType()->TypeName();
+  auto indices_type = As<TupleType>(args[1]->GetType());
+  CHECK(indices_type) << "tile.write requires indices to be TupleType, but got "
+                      << args[1]->GetType()->TypeName();
 
-  return std::make_shared<ScalarType>(tile_type->dtype_);
-}
+  CHECK(indices_type->types_.size() == tile_type->shape_.size())
+      << "tile.write indices count (" << indices_type->types_.size() << ") must match tile rank ("
+      << tile_type->shape_.size() << ")";
 
-TypePtr DeduceTileSetValType(const std::vector<ExprPtr>& args,
-                             const std::vector<std::pair<std::string, std::any>>& kwargs,
-                             const std::string& op_name) {
-  CHECK(args.size() == 3) << "The operator " << op_name
-                          << " requires 3 arguments (tile, offset, value), but got " << args.size();
-
-  auto tile_type = As<TileType>(args[0]->GetType());
-  CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
-                   << args[0]->GetType()->TypeName();
-
-  auto offset_type = As<ScalarType>(args[1]->GetType());
-  CHECK(offset_type) << "The operator " << op_name
-                     << " requires second argument (offset) to be a ScalarType, but got "
-                     << args[1]->GetType()->TypeName();
+  for (size_t i = 0; i < indices_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(indices_type->types_[i]);
+    CHECK(scalar_type) << "tile.write index element " << i << " must be ScalarType, but got "
+                       << indices_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_.IsInt())
+        << "tile.write index element " << i << " must have integer dtype, but got "
+        << scalar_type->dtype_.ToString();
+  }
 
   auto value_type = As<ScalarType>(args[2]->GetType());
-  CHECK(value_type) << "The operator " << op_name
-                    << " requires third argument (value) to be a ScalarType, but got "
+  CHECK(value_type) << "tile.write requires third argument (value) to be a ScalarType, but got "
                     << args[2]->GetType()->TypeName();
 
   CHECK(value_type->dtype_ == tile_type->dtype_)
-      << "The operator " << op_name << " requires value dtype to match tile dtype, but got value dtype "
+      << "tile.write requires value dtype to match tile dtype, but got value dtype "
       << value_type->dtype_.ToString() << " and tile dtype " << tile_type->dtype_.ToString();
 
   return args[0]->GetType();
 }
+
+REGISTER_OP("tile.write")
+    .set_op_category("TileOp")
+    .set_description("Write a scalar value into a tile at given indices")
+    .add_argument("tile", "Destination tile (TileType)")
+    .add_argument("indices", "Index dimensions (TupleType of ScalarType)")
+    .add_argument("value", "Scalar value to write (ScalarType)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileWriteType(args, kwargs, "tile.write");
+    });
 
 // ============================================================================
 // Registration Function for Block Memory Operations
@@ -485,27 +492,6 @@ REGISTER_OP("tile.full")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileFullType(args, kwargs, "tile.full");
-    });
-
-REGISTER_OP("tile.getval")
-    .set_op_category("TileOp")
-    .set_description("Get a scalar value from a tile at a flat offset")
-    .add_argument("tile", "Source tile (TileType)")
-    .add_argument("offset", "Flat offset into the tile (ScalarType index)")
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileGetValType(args, kwargs, "tile.getval");
-    });
-
-REGISTER_OP("tile.setval")
-    .set_op_category("TileOp")
-    .set_description("Write a scalar value into a tile at a flat offset")
-    .add_argument("tile", "Destination tile (TileType)")
-    .add_argument("offset", "Flat offset into the tile (ScalarType index)")
-    .add_argument("value", "Scalar value to write (ScalarType)")
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileSetValType(args, kwargs, "tile.setval");
     });
 
 }  // namespace ir

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -114,8 +114,8 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // Skip ops that manage their own data loading (they create block.load
       // with specific offsets/memory-spaces during conversion, so an extra
       // Phase-1 default Vec load would be redundant or wrong).
-      static const std::unordered_set<std::string> kSelfLoadingOps = {"tensor.slice", "tensor.matmul",
-                                                                      "tensor.assemble", "tensor.read"};
+      static const std::unordered_set<std::string> kSelfLoadingOps = {
+          "tensor.slice", "tensor.matmul", "tensor.assemble", "tensor.read", "tensor.write"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);
         return;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -103,9 +103,6 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterSimple("tensor.mul_scalar", "tile.muls");
   RegisterSimple("tensor.div_scalar", "tile.divs");
 
-  // Memory ops (scalar read from GM tensor)
-  RegisterSimple("tensor.read", "tile.getval");
-
   // Unary ops
   RegisterSimple("tensor.exp", "tile.exp");
   RegisterSimple("tensor.cast", "tile.cast");

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1181,5 +1181,108 @@ class TestOrchestration:
         assert code.count("pto2_rt_submit_task") == 2
 
 
+class TestTensorReadWriteOffsetCodegen:
+    """Tests verifying that multi-dimensional indices are correctly converted to flat offsets in codegen."""
+
+    def test_tensor_read_constant_1d(self):
+        """1D tensor [8], read(t, [3]) -> flat offset 3 (inlined constant)."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(self, t: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [3])  # noqa: F841
+                return t
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(Prog)
+        code = files["orchestration/orch.cpp"]
+        assert "static_cast<float*>(arg_t_ptr)[3]" in code
+
+    def test_tensor_read_constant_2d(self):
+        """2D tensor [4, 8], read(t, [1, 3]) -> flat offset 1*8+3=11 (computed correctly)."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(self, t: pl.Tensor[[4, 8], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [1, 3])  # noqa: F841
+                return t
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(Prog)
+        code = files["orchestration/orch.cpp"]
+        # The flat offset expression 1*8+3=11 is generated (either inlined or via idx_val)
+        assert ("arg_t_ptr)[11]" in code) or ("1 * 8 + 3" in code)
+        assert "arg_t_ptr)" in code
+
+    def test_tensor_read_constant_3d(self):
+        """3D tensor [2, 4, 8], read(t, [1, 2, 3]) -> flat offset 1*32+2*8+3=51."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(self, t: pl.Tensor[[2, 4, 8], pl.FP32]) -> pl.Tensor[[2, 4, 8], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [1, 2, 3])  # noqa: F841
+                return t
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(Prog)
+        code = files["orchestration/orch.cpp"]
+        # The flat offset expression is generated (either inlined as 51 or as computed expression)
+        assert ("arg_t_ptr)[51]" in code) or ("1 * 4 * 8" in code and "2 * 8" in code)
+        assert "arg_t_ptr)" in code
+
+    def test_tensor_read_variable_index(self):
+        """2D tensor [4, 8], read(t, [i, j]) -> generates idx_val = i * 8 + j."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                t: pl.Tensor[[4, 8], pl.FP32],
+                config: pl.Tensor[[2], pl.INT64],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                row: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                col: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [row, col])  # noqa: F841
+                return t
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(Prog)
+        code = files["orchestration/orch.cpp"]
+        assert "idx_val" in code
+        assert "* 8" in code
+
+    def test_tensor_write_constant_2d(self):
+        """2D tensor [4, 8], write(t, [1, 3], val) -> flat offset 11."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.CCE)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(self, t: pl.Tensor[[4, 8], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(t, [0, 0])
+                pl.tensor.write(t, [1, 3], val)
+                return t
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(Prog)
+        code = files["orchestration/orch.cpp"]
+        # Write generates flat offset 11 or the expression 1*8+3
+        assert ("arg_t_ptr)[11]" in code) or ("1 * 8 + 3" in code)
+        assert "arg_t_ptr)" in code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -532,5 +532,82 @@ class Test910BBlockOpsCodegen:
             validate_kernel_codegen(func_name, mlir_code)
 
 
+class TestTileReadWriteOffsetCodegen:
+    """Tests verifying tile.read/write multi-dimensional indices generate correct flat offsets."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.PTO)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.PTOAS)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_read_constant_1d(self):
+        """1D-like slice of 2D tile [1, 16], tile.read(t, [0, 3]) -> flat offset 3 -> pto.tgetval."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP32],
+                dst: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(src, [0, 0], [16, 16])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 3])
+                pl.tile.write(t, [0, 0], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tgetval" in mlir
+        assert "3" in mlir
+
+    def test_tile_read_constant_2d(self):
+        """2D tile [4, 8], tile.read(t, [1, 3]) -> flat offset 11 -> pto.tgetval."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[4, 8], pl.FP32],
+                dst: pl.Tensor[[4, 8], pl.FP32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                t: pl.Tile[[4, 8], pl.FP32] = pl.load(src, [0, 0], [4, 8])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [1, 3])
+                pl.tile.write(t, [0, 0], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tgetval" in mlir
+        assert "11" in mlir
+
+    def test_tile_write_constant_2d(self):
+        """2D tile [4, 8], tile.write(t, [1, 3], val) -> flat offset 11 -> pto.tsetval."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[4, 8], pl.FP32],
+                dst: pl.Tensor[[4, 8], pl.FP32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                t: pl.Tile[[4, 8], pl.FP32] = pl.load(src, [0, 0], [4, 8])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])
+                pl.tile.write(t, [1, 3], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tsetval" in mlir
+        assert "11" in mlir
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -449,6 +449,7 @@ def test_operator_registration():
     # Check that our new operators are registered
     assert ir.is_op_registered("tensor.create")
     assert ir.is_op_registered("tensor.read")
+    assert ir.is_op_registered("tensor.write")
     assert ir.is_op_registered("tensor.slice")
     assert ir.is_op_registered("tensor.matmul")
     assert ir.is_op_registered("tensor.row_max")
@@ -625,51 +626,83 @@ def test_tensor_transpose_with_valid_shape():
 
 
 class TestTensorScalarMemoryOps:
-    """Test suite for tensor-level scalar memory operations (load_scalar, store_scalar)."""
+    """Test suite for tensor-level scalar memory operations (tensor.read / tensor.write)."""
 
-    def test_load_scalar_basic(self):
-        """Test tensor.load_scalar and store_scalar are exported from tensor_ops."""
-        assert hasattr(tensor, "load_scalar")
-        assert hasattr(tensor, "store_scalar")
+    def test_read_write_exported(self):
+        """Test tensor.read and tensor.write are exported from tensor_ops."""
+        assert hasattr(tensor, "read")
+        assert hasattr(tensor, "write")
 
-    def test_load_scalar_return_type(self):
-        """Test tensor.load_scalar returns a Call with ScalarType matching tensor dtype."""
+    def test_read_return_type(self):
+        """Test tensor.read returns a Call with ScalarType matching tensor dtype."""
         span = ir.Span.unknown()
         dim = ir.ConstInt(64, DataType.INT32, span)
         tensor_type = ir.TensorType([dim], DataType.FP32)
         tensor_var = ir.Var("t", tensor_type, span)
-        offset = ir.ConstInt(0, DataType.INT64, span)
+        idx = ir.ConstInt(0, DataType.INT64, span)
 
-        call = tensor.load_scalar(tensor_var, offset)
+        call = tensor.read(tensor_var, [idx])
 
         assert isinstance(call, ir.Call)
+        assert call.op.name == "tensor.read"
         assert isinstance(call.type, ir.ScalarType)
         assert call.type.dtype == DataType.FP32
 
-    def test_store_scalar_basic(self):
-        """Test tensor.store_scalar returns a Call with correct op name."""
+    def test_read_2d(self):
+        """Test tensor.read with 2D indices."""
+        span = ir.Span.unknown()
+        d0 = ir.ConstInt(4, DataType.INT32, span)
+        d1 = ir.ConstInt(8, DataType.INT32, span)
+        tensor_type = ir.TensorType([d0, d1], DataType.FP32)
+        tensor_var = ir.Var("t", tensor_type, span)
+        i = ir.ConstInt(1, DataType.INT64, span)
+        j = ir.ConstInt(3, DataType.INT64, span)
+
+        call = tensor.read(tensor_var, [i, j])
+
+        assert call.op.name == "tensor.read"
+        assert isinstance(call.type, ir.ScalarType)
+        assert call.type.dtype == DataType.FP32
+
+    def test_write_basic(self):
+        """Test tensor.write returns a Call with correct op name."""
         span = ir.Span.unknown()
         dim = ir.ConstInt(64, DataType.INT32, span)
         tensor_type = ir.TensorType([dim], DataType.FP32)
         tensor_var = ir.Var("t", tensor_type, span)
         value = ir.Var("v", ir.ScalarType(DataType.FP32), span)
-        offset = ir.ConstInt(0, DataType.INT64, span)
+        idx = ir.ConstInt(0, DataType.INT64, span)
 
-        call = tensor.store_scalar(tensor_var, offset, value)
+        call = tensor.write(tensor_var, [idx], value)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.store_scalar"
+        assert call.op.name == "tensor.write"
 
-    def test_load_scalar_type_mismatch(self):
-        """Test tensor.load_scalar with wrong argument types raises error."""
+    def test_write_2d(self):
+        """Test tensor.write with 2D indices."""
+        span = ir.Span.unknown()
+        d0 = ir.ConstInt(4, DataType.INT32, span)
+        d1 = ir.ConstInt(8, DataType.INT32, span)
+        tensor_type = ir.TensorType([d0, d1], DataType.FP32)
+        tensor_var = ir.Var("t", tensor_type, span)
+        value = ir.Var("v", ir.ScalarType(DataType.FP32), span)
+        i = ir.ConstInt(1, DataType.INT64, span)
+        j = ir.ConstInt(3, DataType.INT64, span)
+
+        call = tensor.write(tensor_var, [i, j], value)
+
+        assert call.op.name == "tensor.write"
+
+    def test_read_type_mismatch(self):
+        """Test tensor.read with wrong argument types raises error."""
         span = ir.Span.unknown()
         # First arg must be TensorType, not TileType
         tile_type = ir.TileType([32, 32], DataType.FP32)
         tile_var = ir.Var("tile", tile_type, span)
-        offset = ir.ConstInt(0, DataType.INT64, span)
+        idx = ir.ConstInt(0, DataType.INT64, span)
 
-        with pytest.raises(Exception):  # Should raise ValueError from C++
-            tensor.load_scalar(tile_var, offset)
+        with pytest.raises(ValueError, match="TensorType"):
+            tensor.read(tile_var, [idx])
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1730,30 +1730,10 @@ class TestTileLoadOp:
 
 
 class TestTileScalarOps:
-    """Tests for tile scalar read/write ops (getval/setval)."""
+    """Tests for tile scalar read/write ops (tile.read / tile.write)."""
 
-    def test_tile_setval(self):
-        """Test tile.setval: write scalar into tile via pl.write."""
-
-        @pl.program
-        class Program:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main(
-                self,
-                src: pl.Tensor[[16, 16], pl.FP16],
-                dst: pl.Tensor[[16, 16], pl.FP16],
-            ) -> pl.Tensor[[16, 16], pl.FP16]:
-                t: pl.Tile[[16, 16], pl.FP16] = pl.load(src, [0, 0], [16, 16])
-                val: pl.Scalar[pl.FP16] = pl.read(t, 0)
-                pl.write(t, 1, val)
-                result: pl.Tensor[[16, 16], pl.FP16] = pl.store(t, [0, 0], dst)
-                return result
-
-        ir_str = str(Program)
-        assert "tile.setval" in ir_str
-
-    def test_tile_setval_direct(self):
-        """Test tile.setval via pl.tile.setval directly."""
+    def test_tile_write_via_pl_write(self):
+        """Test tile.write: write scalar into tile via pl.write with indices."""
 
         @pl.program
         class Program:
@@ -1764,13 +1744,34 @@ class TestTileScalarOps:
                 dst: pl.Tensor[[16, 16], pl.FP16],
             ) -> pl.Tensor[[16, 16], pl.FP16]:
                 t: pl.Tile[[16, 16], pl.FP16] = pl.load(src, [0, 0], [16, 16])
-                val: pl.Scalar[pl.FP16] = pl.tile.getval(t, 0)
-                pl.tile.setval(t, 1, val)
+                val: pl.Scalar[pl.FP16] = pl.read(t, [0, 0])
+                pl.write(t, [0, 1], val)
                 result: pl.Tensor[[16, 16], pl.FP16] = pl.store(t, [0, 0], dst)
                 return result
 
         ir_str = str(Program)
-        assert "tile.setval" in ir_str
+        assert "tile.write" in ir_str
+
+    def test_tile_read_write_direct(self):
+        """Test tile.read/write via pl.tile.read/pl.tile.write directly."""
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP16],
+                dst: pl.Tensor[[16, 16], pl.FP16],
+            ) -> pl.Tensor[[16, 16], pl.FP16]:
+                t: pl.Tile[[16, 16], pl.FP16] = pl.load(src, [0, 0], [16, 16])
+                val: pl.Scalar[pl.FP16] = pl.tile.read(t, [0, 0])
+                pl.tile.write(t, [0, 1], val)
+                result: pl.Tensor[[16, 16], pl.FP16] = pl.store(t, [0, 0], dst)
+                return result
+
+        ir_str = str(Program)
+        assert "tile.read" in ir_str
+        assert "tile.write" in ir_str
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace tensor.load_scalar/store_scalar and tile.getval/setval with tensor.read/write and tile.read/write respectively. The new interface accepts a sequence of indices (TupleType) instead of a flat scalar offset; codegen computes the row-major flat offset at compile time.

- IR op layer: add tensor.write and tile.write registrations; remove tensor.load_scalar, tensor.store_scalar, tile.getval, tile.setval
- Codegen: add MakeTensorRead/Write and MakeTileRead/Write helpers that fold constant indices to a single offset or emit arith.index_cast for variable indices; add tensor.write orchestration codegen
- Pass: remove RegisterSimple("tensor.read", "tile.getval"); add tensor.write to kSelfLoadingOps whitelist
- Python ir/op: add write() to tensor_ops and tile_ops; drop old flat- offset functions
- Python language/op: update tensor_ops, tile_ops, unified_ops to use multi-dimensional index API; remove _RENAMED_DISPATCH_OPS mechanism from ast_parser (read/write now follow the standard dispatch path)
- Tests: update existing scalar op tests; add TestTensorReadWriteOffsetCodegen and TestTileReadWriteOffsetCodegen to verify 1D/2D/3D constant folding and variable-index code generation