### PR TITLE
refactor(op): rename tile.create_tile to tile.create and unify create naming

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -23,7 +23,7 @@ Auto-selects between tensor and tile implementation based on input type.
 | `matmul` | `(lhs: T, rhs: T, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> T` | Matrix multiplication |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise max (tile path requires `tmp_tile`) |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise sum (tile path requires `tmp_tile`) |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace) -> Tile` | Tile-only (promoted from `pl.tile.create` / `pl.tile.create_tile`): create tile at specific memory space |
+| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace) -> Tile` | Tile-only (promoted from `pl.tile.create`): create tile at specific memory space |
 
 ## Tensor-Only (`pl.tensor.*`)
 
@@ -58,7 +58,7 @@ Transfer data between memory hierarchy levels.
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: MemorySpace = MemorySpace.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat) |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
 | `move` | `(tile: Tile, target_memory: MemorySpace) -> Tile` | Move tile between memory levels (including Vec→Vec) |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | Create tile at memory space |
+| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
 | `fillpad` | `(tile: Tile) -> Tile` | Fill tile with padding values |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -23,7 +23,7 @@
 | `matmul` | `(lhs: T, rhs: T, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> T` | 矩阵乘法 |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行最大值（tile 路径需要 `tmp_tile`） |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行求和（tile 路径需要 `tmp_tile`） |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace) -> Tile` | 在指定内存空间创建 tile（tile-only，对应 `pl.tile.create` / `pl.tile.create_tile`） |
+| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace) -> Tile` | 在指定内存空间创建 tile（tile-only，对应 `pl.tile.create`） |
 
 ## 仅 Tensor（`pl.tensor.*`）
 
@@ -58,7 +58,7 @@
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: MemorySpace = MemorySpace.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat） |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
 | `move` | `(tile: Tile, target_memory: MemorySpace) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | 在指定内存空间创建 tile |
+| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: MemorySpace = MemorySpace.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
 | `fillpad` | `(tile: Tile) -> Tile` | 用填充值填充 tile |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -46,6 +46,9 @@ def create(
     return _ir_core.create_op_call("tensor.create", args, kwargs, actual_span)
 
 
+create_tensor = create
+
+
 def read(
     tensor: Expr, indices: Expr | list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None
 ) -> Call:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -48,7 +48,7 @@ def _validate_offsets_shapes(offsets_tuple: _ir_core.MakeTuple, shapes_tuple: _i
 # ============================================================================
 
 
-def create_tile(
+def create(
     shape: Sequence[int] | _ir_core.MakeTuple,
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
@@ -68,10 +68,10 @@ def create_tile(
     actual_span = _get_span_or_capture(span)
     shape_tuple = _to_make_tuple(shape, actual_span)
     kwargs: dict[str, Any] = {"dtype": dtype, "target_memory": target_memory}
-    return _ir_core.create_op_call("tile.create_tile", [shape_tuple], kwargs, actual_span)
+    return _ir_core.create_op_call("tile.create", [shape_tuple], kwargs, actual_span)
 
 
-create = create_tile
+create_tile = create
 
 
 def load(

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -27,7 +27,8 @@ from . import tensor_ops as tensor
 from . import tile_ops as tile
 
 # Promoted tensor-only ops (accessible as pl.create_tensor, etc.)
-from .tensor_ops import assemble, create_tensor, dim
+from .tensor_ops import assemble, dim
+from .tensor_ops import create as create_tensor
 
 # Promoted tile-only ops (accessible as pl.load, etc.)
 from .tile_ops import (
@@ -42,7 +43,6 @@ from .tile_ops import (
     col_expand_div,
     col_expand_mul,
     col_expand_sub,
-    create_tile,
     expands,
     gemv,
     gemv_acc,
@@ -87,6 +87,9 @@ from .tile_ops import (
     sum,
     xor,
     xors,
+)
+from .tile_ops import (
+    create as create_tile,
 )
 
 # Unified dispatch (overlapping ops)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -60,9 +60,7 @@ def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
 
 
-def create_tensor(
-    shape: Sequence[IntLike], dtype: DataType, layout: TensorLayout = TensorLayout.ND
-) -> Tensor:
+def create(shape: Sequence[IntLike], dtype: DataType, layout: TensorLayout = TensorLayout.ND) -> Tensor:
     """Create a new tensor with specified shape and dtype.
 
     Args:
@@ -77,7 +75,7 @@ def create_tensor(
     return Tensor(expr=call_expr)
 
 
-create = create_tensor
+create_tensor = create
 
 
 def read(tensor: Tensor, indices: IntLike | Sequence[IntLike]) -> Scalar:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -113,7 +113,7 @@ def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
 
 
-def create_tile(
+def create(
     shape: Sequence[IntLike],
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
@@ -126,11 +126,11 @@ def create_tile(
         target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right)
 
     Returns:
-        Tile wrapping the create_tile operation
+        Tile wrapping the create operation
     """
-    # create_tile C++ binding accepts Sequence[int]; Expr elements from Scalar
+    # create C++ binding accepts Sequence[int]; Expr elements from Scalar
     # unwrapping are valid at DSL parse time (parser reads the AST).
-    call_expr = _ir_ops.create_tile(
+    call_expr = _ir_ops.create(
         _normalize_intlike(shape),  # type: ignore[reportArgumentType]
         dtype,
         target_memory,
@@ -138,7 +138,7 @@ def create_tile(
     return Tile(expr=call_expr)
 
 
-create = create_tile
+create_tile = create
 
 
 def read(tile: Tile, indices: IntLike | Sequence[IntLike]) -> Scalar:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -280,7 +280,7 @@ def cast(
 
 def create_tile(shape: list[int], dtype: DataType, target_memory: MemorySpace) -> Tile:
     """Create a tile at specific memory space."""
-    return _tile.create_tile(shape, dtype, target_memory)
+    return _tile.create(shape, dtype, target_memory)
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1782,13 +1782,11 @@ class ASTParser:
 
     def _parse_tensor_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tensor operation."""
-        ir_op_name = self._TENSOR_OP_NAME_MAP.get(op_name, op_name)
-        return self._dispatch_op(ir_op.tensor, "tensor", ir_op_name, call)
+        return self._dispatch_op(ir_op.tensor, "tensor", op_name, call)
 
     def _parse_tile_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tile operation."""
-        ir_op_name = self._TILE_OP_NAME_MAP.get(op_name, op_name)
-        return self._dispatch_op(ir_op.tile, "tile", ir_op_name, call)
+        return self._dispatch_op(ir_op.tile, "tile", op_name, call)
 
     def _parse_system_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse system operation."""
@@ -1821,16 +1819,6 @@ class ASTParser:
     # Maps unified op names to ir scalar functions that take (expr, dtype, span).
     _SCALAR_DTYPE_OPS: dict[str, str] = {
         "cast": "cast",
-    }
-
-    # Maps language-level tensor operation names to IR-level names.
-    _TENSOR_OP_NAME_MAP: dict[str, str] = {
-        "create_tensor": "create",
-    }
-
-    # Maps language-level tile operation names to IR-level names.
-    _TILE_OP_NAME_MAP: dict[str, str] = {
-        "create_tile": "create",
     }
 
     # Ops that exist only in one module (no dispatch needed).

--- a/src/backend/910B_CCE/backend_910b_cce_ops.cpp
+++ b/src/backend/910B_CCE/backend_910b_cce_ops.cpp
@@ -265,7 +265,7 @@ static std::string MakeTileGetBlockIdxCodegenCCE(const ir::CallPtr& op, codegen:
   return "";
 }
 
-// Helper function for tile.create_tile (no-op: allocation handled elsewhere)
+// Helper function for tile.create (no-op: allocation handled elsewhere)
 static std::string MakeTileCreateTileCodegenCCE(const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
   (void)op;
   (void)codegen_base;
@@ -438,7 +438,7 @@ REGISTER_BACKEND_OP(Backend910B_CCE, "tile.alloc")
       return MakeTileAllocCodegenCCE(op, codegen);
     });
 
-REGISTER_BACKEND_OP(Backend910B_CCE, "tile.create_tile")
+REGISTER_BACKEND_OP(Backend910B_CCE, "tile.create")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
       return MakeTileCreateTileCodegenCCE(op, codegen);
     });

--- a/src/backend/910B_PTO/backend_910b_pto_ops.cpp
+++ b/src/backend/910B_PTO/backend_910b_pto_ops.cpp
@@ -760,7 +760,7 @@ REGISTER_BACKEND_OP(Backend910B_PTO, "tile.alloc")
       return MakeTileAllocCodegenPTO(op, codegen);
     });
 
-REGISTER_BACKEND_OP(Backend910B_PTO, "tile.create_tile")
+REGISTER_BACKEND_OP(Backend910B_PTO, "tile.create")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
       (void)op;
       (void)codegen_base;

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -418,7 +418,7 @@ REGISTER_OP("tile.read")
       return DeduceTileReadType(args, kwargs, "tile.read");
     });
 
-REGISTER_OP("tile.create_tile")
+REGISTER_OP("tile.create")
     .set_op_category("TileOp")
     .set_description("Create a tile")
     .add_argument("shape", "Shape dimensions (TupleType of ScalarType(INT64))")
@@ -426,7 +426,7 @@ REGISTER_OP("tile.create_tile")
     .set_attr<MemorySpace>("target_memory")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileCreateTileType(args, kwargs, "tile.create_tile");
+      return DeduceTileCreateTileType(args, kwargs, "tile.create");
     });
 
 REGISTER_OP("tile.load")

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -55,7 +55,7 @@ MemorySpace ExtractTargetMemory(const CallPtr& call) {
 
 // Return value memory space rules for tile operators
 const std::map<std::string, std::optional<MemorySpace>> kTileOpMemoryRules = {
-    {"tile.create_tile", std::nullopt},     // Extract from target_memory
+    {"tile.create", std::nullopt},          // Extract from target_memory
     {"tile.load", std::nullopt},            // Extract from target_memory
     {"tile.move", std::nullopt},            // Extract from target_memory
     {"tile.store", MemorySpace::DDR},       // Fixed DDR

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -320,7 +320,7 @@ OpConversionRegistry::OpConversionRegistry() {
       auto shape_tuple = std::make_shared<MakeTuple>(tmp_shape, span);
       std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", tile_type->dtype_},
                                                                      {"target_memory", MemorySpace::Vec}};
-      auto create_call = op_reg.Create("tile.create_tile", {shape_tuple}, create_kwargs, span);
+      auto create_call = op_reg.Create("tile.create", {shape_tuple}, create_kwargs, span);
 
       auto tmp_var = std::make_shared<Var>("tmp_tile", create_call->GetType(), span);
       std::vector<StmtPtr> prologue;
@@ -363,7 +363,7 @@ OpConversionRegistry::OpConversionRegistry() {
         }
 
         if (source_tile_type && target_tile_type) {
-          // Both are tiles (e.g. target from tile.create_tile, source from conversion).
+          // Both are tiles (e.g. target from tile.create, source from conversion).
           // Store source into a temp tensor, then return the tensor.
           std::vector<StmtPtr> prologue;
 
@@ -387,9 +387,9 @@ OpConversionRegistry::OpConversionRegistry() {
       });
 
   // ────────────────────────────────────────────────────────────────────────
-  // tensor.create → tile.create_tile
+  // tensor.create → tile.create
   //
-  // tensor.create(shape, dtype=...) → tile.create_tile(shape, dtype=..., target_memory=Vec)
+  // tensor.create(shape, dtype=...) → tile.create(shape, dtype=..., target_memory=Vec)
   // ────────────────────────────────────────────────────────────────────────
 
   RegisterCustom(
@@ -401,7 +401,7 @@ OpConversionRegistry::OpConversionRegistry() {
 
         auto new_kwargs = kwargs;
         new_kwargs.emplace_back("target_memory", MemorySpace::Vec);
-        auto create_call = op_reg.Create("tile.create_tile", args, new_kwargs, span);
+        auto create_call = op_reg.Create("tile.create", args, new_kwargs, span);
         return ConversionResult{create_call};
       });
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -458,10 +458,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       }
       return false;
     };
-    // "_scalar" and "_tile" are mutually exclusive; try in order.
-    if (!strip_suffix(op_name, "_scalar")) {
-      strip_suffix(op_name, "_tile");
-    }
+    strip_suffix(op_name, "_scalar");
 
     // Print with pl. prefix
     stream_ << prefix_ << "." << op_name << "(";


### PR DESCRIPTION
Rename the IR op from "tile.create_tile" to "tile.create" to eliminate the redundant _tile suffix. Align both tile and tensor Python APIs so that `create` is the primary function name and `create_tile`/`create_tensor` become backward-compatible aliases. Remove the now-unnecessary _TILE_OP_NAME_MAP and _TENSOR_OP_NAME_MAP in the parser, and drop the _tile suffix stripping logic in the printer.