### PR TITLE
refactor(ir): Differentiate gm_tensor and local_tensor in tensor-to-tile conversion

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -330,6 +330,7 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
  */
 std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
                                          std::unordered_map<std::string, VarPtr>& tensor_to_tile,
+                                         std::unordered_set<std::string>& sliced_vars,
                                          const OpConversionRegistry& conv_registry,
                                          const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
@@ -361,14 +362,16 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
     // SeqStmts: recurse into children
     if (auto seq = As<SeqStmts>(stmt)) {
-      auto inner = TransformIncoreBody(seq->stmts_, tensor_to_tile, conv_registry, op_registry, span);
+      auto inner =
+          TransformIncoreBody(seq->stmts_, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
       result.insert(result.end(), inner.begin(), inner.end());
       continue;
     }
 
     // OpStmts: recurse into children (same structure as SeqStmts)
     if (auto op_stmts = As<OpStmts>(stmt)) {
-      auto inner = TransformIncoreBody(op_stmts->stmts_, tensor_to_tile, conv_registry, op_registry, span);
+      auto inner = TransformIncoreBody(op_stmts->stmts_, tensor_to_tile, sliced_vars, conv_registry,
+                                       op_registry, span);
       result.insert(result.end(), inner.begin(), inner.end());
       continue;
     }
@@ -376,7 +379,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     // ScopeStmt: recurse into body (transparent scope, defs leak through)
     if (auto scope = As<ScopeStmt>(stmt)) {
       auto body_stmts = FlattenToStmts(scope->body_);
-      auto inner = TransformIncoreBody(body_stmts, tensor_to_tile, conv_registry, op_registry, span);
+      auto inner =
+          TransformIncoreBody(body_stmts, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
       result.push_back(std::make_shared<ScopeStmt>(scope->scope_kind_,
                                                    WrapInSeqStmts(inner, scope->body_->span_), scope->span_));
       continue;
@@ -389,7 +393,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
       // Recurse into then branch with a copy of the map
       auto then_map = tensor_to_tile;
       auto then_stmts = FlattenToStmts(if_stmt->then_body_);
-      auto new_then_stmts = TransformIncoreBody(then_stmts, then_map, conv_registry, op_registry, span);
+      auto new_then_stmts =
+          TransformIncoreBody(then_stmts, then_map, sliced_vars, conv_registry, op_registry, span);
       auto new_then_body = WrapInSeqStmts(new_then_stmts, if_stmt->then_body_->span_);
 
       // Recurse into else branch with a copy of the map
@@ -397,7 +402,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
       if (if_stmt->else_body_.has_value()) {
         auto else_map = tensor_to_tile;
         auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
-        auto new_else_stmts = TransformIncoreBody(else_stmts, else_map, conv_registry, op_registry, span);
+        auto new_else_stmts =
+            TransformIncoreBody(else_stmts, else_map, sliced_vars, conv_registry, op_registry, span);
         new_else_body = WrapInSeqStmts(new_else_stmts, (*if_stmt->else_body_)->span_);
       }
 
@@ -449,7 +455,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
       // Recurse into body
       auto body_stmts = FlattenToStmts(for_stmt->body_);
-      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
+      auto new_body_stmts =
+          TransformIncoreBody(body_stmts, body_map, sliced_vars, conv_registry, op_registry, span);
       auto new_body = WrapInSeqStmts(new_body_stmts, for_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types
@@ -496,7 +503,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
       // Recurse into body
       auto body_stmts = FlattenToStmts(while_stmt->body_);
-      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
+      auto new_body_stmts =
+          TransformIncoreBody(body_stmts, body_map, sliced_vars, conv_registry, op_registry, span);
       auto new_body = WrapInSeqStmts(new_body_stmts, while_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types
@@ -576,12 +584,22 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
       substituted_args.push_back(SubstituteExpr(arg, tensor_to_tile));
     }
 
+    // Consecutive slice detection: error if slicing a var that is already a slice result
+    if (call->op_->name_ == "tensor.slice" && !call->args_.empty()) {
+      auto input_var = As<Var>(call->args_[0]);
+      if (input_var && sliced_vars.count(input_var->name_)) {
+        throw pypto::InternalError(
+            "Consecutive tensor.slice detected: cannot slice the result of a prior slice (variable '" +
+            input_var->name_ + "')");
+      }
+    }
+
     auto conv_result = (*converter)(substituted_args, call->kwargs_, call->span_);
 
     // Prologue statements may themselves contain tensor ops (e.g. tensor.create
     // used as a scratch buffer). Run them through the same conversion pipeline.
-    auto transformed_prologue =
-        TransformIncoreBody(conv_result.prologue, tensor_to_tile, conv_registry, op_registry, span);
+    auto transformed_prologue = TransformIncoreBody(conv_result.prologue, tensor_to_tile, sliced_vars,
+                                                    conv_registry, op_registry, span);
     for (const auto& prologue_stmt : transformed_prologue) {
       result.push_back(prologue_stmt);
     }
@@ -590,6 +608,11 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     auto tile_var = std::make_shared<Var>(tile_name, conv_result.result->GetType(), assign->var_->span_);
     result.push_back(std::make_shared<AssignStmt>(tile_var, conv_result.result, assign->span_));
     tensor_to_tile[assign->var_->name_] = tile_var;
+
+    // Track slice results for consecutive slice detection
+    if (call->op_->name_ == "tensor.slice") {
+      sliced_vars.insert(assign->var_->name_);
+    }
   }
 
   return result;
@@ -656,6 +679,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   // Phase 2: Walk body and convert tensor ops to tile ops (recursive for nested control flow)
   auto body_stmts = FlattenToStmts(func->body_);
 
+  // Track variables produced by tensor.slice to detect consecutive slicing
+  std::unordered_set<std::string> sliced_vars;
+
   // Separate return statement from body (will be replaced in Phase 3)
   ReturnStmtPtr return_stmt;
   std::vector<StmtPtr> non_return_stmts;
@@ -667,7 +693,8 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     }
   }
 
-  auto transformed = TransformIncoreBody(non_return_stmts, tensor_to_tile, conv_registry, op_registry, span);
+  auto transformed =
+      TransformIncoreBody(non_return_stmts, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
   new_stmts.insert(new_stmts.end(), transformed.begin(), transformed.end());
 
   // Phase 3: Add output params + tile.store for return values
@@ -1138,6 +1165,11 @@ class IncoreTileOpsVerifier : public IRVisitor {
     const auto& entry = op_registry.GetEntry(call->op_->name_);
     if (entry.GetOpCategory() == "TensorOp" &&
         OpConversionRegistry::GetInstance().HasConversion(call->op_->name_)) {
+      // tensor.read on a gm_tensor (TensorType input) intentionally stays unconverted
+      if (call->op_->name_ == "tensor.read" && !call->args_.empty() &&
+          As<TensorType>(call->args_[0]->GetType())) {
+        return;
+      }
       diagnostics_.emplace_back(
           DiagnosticSeverity::Error, "IncoreTileOps", 0,
           "Tensor op '" + call->op_->name_ + "' found in InCore function (should have been converted)", span);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -13,11 +13,14 @@
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
@@ -142,9 +145,10 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterCustom("tensor.maximum", MakeBroadcastBinaryConv("tile.maximum", "tile.maximum"));
 
   // ────────────────────────────────────────────────────────────────────────
-  // tensor.slice → tile.load
+  // tensor.slice → tile.load (gm_tensor) or tile.slice (local_tensor)
   //
-  // tensor.slice(tensor, shape, offset) → tile.load(tensor, offset, shape, shape, target_memory=Vec)
+  // gm_tensor.slice(tensor, shape, offset) → tile.load(tensor, offset, shape, shape, target_memory=Vec)
+  // local_tensor.slice(tile, shape, offset) → tile.slice(tile, shape, offset)
   // ────────────────────────────────────────────────────────────────────────
 
   RegisterCustom(
@@ -161,36 +165,17 @@ OpConversionRegistry::OpConversionRegistry() {
         auto tile_type = As<TileType>(input->GetType());
 
         if (tensor_type) {
-          // Input is a tensor (e.g., function parameter) → direct tile.load with offset
-          std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
+          // gm_tensor: function parameter or prior gm_tensor.slice result → tile.load
+          std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
+                                                                       {"transpose", false}};
           auto load_call = op_reg.Create("tile.load", {input, offset, shape, shape}, load_kwargs, span);
           return ConversionResult{load_call};
         }
 
         if (tile_type) {
-          // Input is a tile (e.g., from a prior tensor.matmul conversion).
-          // Round-trip: store tile → temp tensor, then load the subview.
-          std::vector<StmtPtr> prologue;
-
-          // Create a temporary tensor with the tile's shape
-          auto tensor_shape = MakeShapesTuple(tile_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", tile_type->dtype_}};
-          auto create_call = op_reg.Create("tensor.create", {tensor_shape}, create_kwargs, span);
-          auto tmp_tensor_var = std::make_shared<Var>("view_tmp_tensor", create_call->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(tmp_tensor_var, create_call, span));
-
-          // Store tile to the temp tensor at offset [0,0]
-          auto store_offsets = MakeZeroOffsetsTuple(tile_type->shape_.size(), span);
-          auto store_shapes = MakeShapesTuple(tile_type->shape_, span);
-          auto store_call =
-              op_reg.Create("tile.store", {input, store_offsets, store_shapes, tmp_tensor_var}, span);
-          auto stored_var = std::make_shared<Var>("view_tmp_stored", store_call->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(stored_var, store_call, span));
-
-          // Load the subview from the stored tensor
-          std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
-          auto load_call = op_reg.Create("tile.load", {stored_var, offset, shape, shape}, load_kwargs, span);
-          return ConversionResult{std::move(prologue), load_call};
+          // local_tensor: created via tensor.create (now tile) → tile.slice
+          auto slice_call = op_reg.Create("tile.slice", {input, shape, offset}, span);
+          return ConversionResult{slice_call};
         }
 
         CHECK(false) << "tensor.slice conversion: unexpected input type: " << input->GetType()->TypeName();
@@ -390,6 +375,8 @@ OpConversionRegistry::OpConversionRegistry() {
   // tensor.create → tile.create
   //
   // tensor.create(shape, dtype=...) → tile.create(shape, dtype=..., target_memory=Vec)
+  // If all shape dimensions are static constants, validate that the tile
+  // fits within the target memory space (obtained from Backend::GetMemSize).
   // ────────────────────────────────────────────────────────────────────────
 
   RegisterCustom(
@@ -399,10 +386,78 @@ OpConversionRegistry::OpConversionRegistry() {
         CHECK(args.size() == 1) << "tensor.create conversion expects 1 arg (shape)";
         auto& op_reg = OpRegistry::GetInstance();
 
-        auto new_kwargs = kwargs;
-        new_kwargs.emplace_back("target_memory", MemorySpace::Vec);
+        MemorySpace target_mem = MemorySpace::Vec;
+        std::vector<std::pair<std::string, std::any>> new_kwargs;
+        for (const auto& [key, value] : kwargs) {
+          if (key == "dtype") {
+            new_kwargs.emplace_back(key, value);
+          }
+        }
+        new_kwargs.emplace_back("target_memory", target_mem);
+
+        // Static buffer size check when all shape dims are ConstInt
+        auto shape_tuple = As<MakeTuple>(args[0]);
+        DataType dtype = GetKwargOr<DataType>(kwargs, "dtype", DataType::FP32);
+        if (shape_tuple && backend::BackendConfig::IsConfigured()) {
+          int64_t total_elements = 1;
+          bool all_const = true;
+          for (const auto& dim : shape_tuple->elements_) {
+            if (auto c = As<ConstInt>(dim)) {
+              total_elements *= c->value_;
+            } else {
+              all_const = false;
+              break;
+            }
+          }
+          if (all_const) {
+            uint64_t tile_bytes = static_cast<uint64_t>(total_elements) * dtype.GetBit() / 8;
+            const auto* be = backend::GetBackend();
+            if (be) {
+              uint64_t mem_size = be->GetMemSize(target_mem);
+              CHECK(mem_size == 0 || tile_bytes <= mem_size)
+                  << "tensor.create: tile size (" << tile_bytes << " bytes) exceeds buffer capacity ("
+                  << mem_size << " bytes) for memory space " << static_cast<int>(target_mem);
+            }
+          }
+        }
+
         auto create_call = op_reg.Create("tile.create", args, new_kwargs, span);
         return ConversionResult{create_call};
+      });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // tensor.read → tensor.read (gm_tensor) or tile.read (local_tensor)
+  //
+  // gm_tensor.read(tensor, indices) stays as tensor.read (no conversion)
+  // local_tensor.read(tile, indices) → tile.read(tile, indices)
+  // ────────────────────────────────────────────────────────────────────────
+
+  RegisterCustom(
+      "tensor.read",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 2) << "tensor.read conversion expects 2 args (tensor, indices)";
+        auto& op_reg = OpRegistry::GetInstance();
+        const auto& input = args[0];
+
+        if (As<TensorType>(input->GetType())) {
+          // gm_tensor: keep as tensor.read
+          if (kwargs.empty()) {
+            return ConversionResult{op_reg.Create("tensor.read", args, span)};
+          }
+          return ConversionResult{op_reg.Create("tensor.read", args, kwargs, span)};
+        }
+
+        if (As<TileType>(input->GetType())) {
+          // local_tensor (now tile): convert to tile.read
+          if (kwargs.empty()) {
+            return ConversionResult{op_reg.Create("tile.read", args, span)};
+          }
+          return ConversionResult{op_reg.Create("tile.read", args, kwargs, span)};
+        }
+
+        CHECK(false) << "tensor.read conversion: unexpected input type: " << input->GetType()->TypeName();
+        return ConversionResult{nullptr};  // unreachable
       });
 }
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -461,5 +461,185 @@ class TestNestedControlFlow:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestGmLocalTensorConversion:
+    """Test gm_tensor vs local_tensor differentiated conversion."""
+
+    def test_gm_tensor_slice_to_tile_load(self):
+        """gm_tensor.slice (function param) -> tile.load."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[16, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                s: pl.Tensor[[8, 32], pl.FP32] = pl.tensor.slice(x, [8, 32], [0, 0])
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.add(s, s)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+            ) -> pl.Tensor[[8, 32], pl.FP32]:
+                s_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(x, [0, 0], [8, 32])
+                y_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.add(s_tile, s_tile)
+                out_0: pl.Tensor[[8, 32], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out_0: pl.Tensor[[8, 32], pl.FP32] = pl.create_tensor([8, 32], dtype=pl.FP32)
+                y: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_local_tensor_slice_to_tile_slice(self):
+        """local_tensor.slice (tensor.create result) -> tile.slice."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                t: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                s: pl.Tensor[[8, 32], pl.FP32] = pl.tensor.slice(t, [8, 32], [0, 0])
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.add(s, x)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[8, 32], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+            ) -> pl.Tensor[[8, 32], pl.FP32]:
+                x_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(x, [0, 0], [8, 32])
+                t_tile: pl.Tile[[16, 64], pl.FP32] = pl.tile.create([16, 64], dtype=pl.FP32)
+                s_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.slice(t_tile, [8, 32], [0, 0])
+                y_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.add(s_tile, x_tile)
+                out_0: pl.Tensor[[8, 32], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out_0: pl.Tensor[[8, 32], pl.FP32] = pl.create_tensor([8, 32], dtype=pl.FP32)
+                y: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_consecutive_slice_raises_error(self):
+        """Consecutive tensor.slice on a slice result should raise an error."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                s1: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.slice(x, [16, 32], [0, 0])
+                s2: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.slice(s1, [4, 8], [0, 0])
+                return s2
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                y: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        with pytest.raises(Exception, match="Consecutive tensor.slice"):
+            passes.convert_tensor_to_tile_ops()(Before)
+
+    def test_gm_tensor_read_stays_tensor_read(self):
+        """gm_tensor.read (function param) stays as tensor.read, no Phase 1 load."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, config: pl.Tensor[[4], pl.FP32], x: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                scale: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                y: pl.Tensor[[64], pl.FP32] = pl.mul(x, scale)
+                return y
+
+            @pl.function
+            def main(
+                self, config: pl.Tensor[[4], pl.FP32], x: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(config, x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                config: pl.Tensor[[4], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                scale_tile: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.tile.muls(x_tile, scale_tile)
+                out_0: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self, config: pl.Tensor[[4], pl.FP32], x: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(config, x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_local_tensor_read_to_tile_read(self):
+        """local_tensor.read (tile from tensor.create) -> tile.read."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                t: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                v: pl.Scalar[pl.FP32] = pl.tensor.read(t, [0])
+                return v
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                v: pl.Scalar[pl.FP32] = self.main_incore_0(x)
+                return v
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                t_tile: pl.Tile[[64], pl.FP32] = pl.tile.create([64], dtype=pl.FP32)
+                v_tile: pl.Scalar[pl.FP32] = pl.tile.read(t_tile, [0])
+                return v_tile
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                v: pl.Scalar[pl.FP32] = self.main_incore_0(x)
+                return v
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Introduce type-aware conversion for tensor.slice, tensor.read, and tensor.create based on whether the source is a global memory tensor (function parameter) or a local tensor (created via tensor.create):
- tensor.slice: gm_tensor → tile.load, local_tensor → tile.slice
- tensor.read: gm_tensor → stays tensor.read, local_tensor → tile.read
- tensor.create: add buffer size validation against Backend::GetMemSize
- Detect and reject consecutive tensor.slice operations
- Update IncoreTileOpsVerifier to allow gm_tensor.read in InCore functions
- Add 5 test cases covering all conversion paths and error conditions