### PR TITLE
fix(pass): Preserve ChunkOuter ForKind after interchange instead of forcing Sequential

### DIFF
--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -431,13 +431,13 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     // Wrap in InCore
     current = std::make_shared<ScopeStmt>(ScopeKind::InCore, current, span);
 
-    // Build outers inside-out
+    // Build outers inside-out, preserving the original ForKind.
     for (int i = static_cast<int>(outers.size()) - 1; i >= 0; --i) {
       const auto& outer = outers[i];
       current = std::make_shared<ForStmt>(outer->loop_var_, outer->start_, outer->stop_, outer->step_,
                                           std::vector<IterArgPtr>{}, current, std::vector<VarPtr>{},
-                                          outer->span_, ForKind::Sequential, std::nullopt,
-                                          ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+                                          outer->span_, outer->kind_, std::nullopt, ChunkPolicy::LeadingFull,
+                                          LoopOrigin::ChunkOuter);
     }
 
     return current;
@@ -540,8 +540,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
 
       current = std::make_shared<ForStmt>(
           orig_loop->loop_var_, orig_loop->start_, orig_loop->stop_, orig_loop->step_, new_iter_args[i],
-          current, new_return_vars[i], orig_loop->span_, is_inner ? orig_loop->kind_ : ForKind::Sequential,
-          std::nullopt, ChunkPolicy::LeadingFull, is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter);
+          current, new_return_vars[i], orig_loop->span_, orig_loop->kind_, std::nullopt,
+          ChunkPolicy::LeadingFull, is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter);
 
       // Insert InCore scope right after building all inners (at the boundary)
       if (!is_inner && i + 1 < static_cast<int>(total_loops) &&

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -50,7 +50,7 @@ class TestSingleParallelChunk:
 
         outer_for = stmts[0]
         assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
-        assert outer_for.kind == ir.ForKind.Sequential
+        assert outer_for.kind == ir.ForKind.Parallel
 
         # Outer body = SeqStmts [InCore, yield]
         outer_body_stmts = list(outer_for.body.stmts)
@@ -89,13 +89,13 @@ class TestNestedParallelChunks:
         # i_out
         i_out = stmts[0]
         assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
-        assert i_out.kind == ir.ForKind.Sequential
+        assert i_out.kind == ir.ForKind.Parallel
 
         # j_out inside i_out body
         i_out_body = list(i_out.body.stmts)
         j_out = i_out_body[0]
         assert j_out.loop_origin == ir.LoopOrigin.ChunkOuter
-        assert j_out.kind == ir.ForKind.Sequential
+        assert j_out.kind == ir.ForKind.Parallel
 
         # InCore inside j_out body
         j_out_body = list(j_out.body.stmts)
@@ -179,10 +179,10 @@ class TestChunkWithRemainderInChain:
         func = list(After.functions.values())[0]
         stmts = list(func.body.stmts)  # type: ignore[attr-defined]
 
-        # i_out (ChunkOuter, Sequential)
+        # i_out (ChunkOuter, Parallel — preserves original kind from pl.parallel)
         i_out = stmts[0]
         assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
-        assert i_out.kind == ir.ForKind.Sequential
+        assert i_out.kind == ir.ForKind.Parallel
         assert len(i_out.iter_args) == 1
 
         # InCore { i_in → body with remainder }


### PR DESCRIPTION
InterchangeChunkLoops was hardcoding ForKind::Sequential for ChunkOuter loops
after interchange, discarding the original ForKind set by the user. This is
incorrect: ForKind is an IR-level semantic annotation (representing the
programmer's parallelism intent) that is independent of runtime scheduling or
hardware capabilities. The original ForKind should be preserved just as
ChunkInner's kind is already preserved.

## Summary

- Fix `RebuildSimple`: use `outer->kind_` instead of `ForKind::Sequential`
- Fix `RebuildWithIterArgs`: use `orig_loop->kind_` instead of
  `ForKind::Sequential` (removing the `is_inner ? ... : ForKind::Sequential`
  ternary — now simply `orig_loop->kind_` for all loops)
- Update test assertions in `test_interchange_chunk_loops.py`: ChunkOuter
  loops originating from `pl.parallel` now correctly assert `ForKind::Parallel`
  instead of `ForKind::Sequential`
- Remove incorrect "ChunkOuter ForKind always forced to Sequential" row from
  the Constraints table in both English and Chinese pass documentation

## Testing

- [x] Updated affected test assertions to match correct behavior
- [x] Pre-commit hooks pass

Fixes #427
