### PR TITLE
feat(ir): handle EvalStmt ops and add tensor.write conversion in ConvertTensorToTileOps

### DIFF
--- a/src/ir/op/testing.cpp
+++ b/src/ir/op/testing.cpp
@@ -46,5 +46,15 @@ REGISTER_OP("test.op")
       return args[0]->GetType();
     });
 
+// Used exclusively to test the "missing conversion" error path in ConvertTensorToTileOps.
+REGISTER_OP("test.tensor_op_no_conv")
+    .set_op_category("TensorOp")
+    .set_description("Test-only op: TensorOp with no registered tile conversion")
+    .add_argument("x", "Input tensor")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return args[0]->GetType();
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -529,8 +529,36 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     // AssignStmt: convert tensor ops to tile ops
     auto assign = As<AssignStmt>(stmt);
     if (!assign) {
-      // Non-assign, non-control-flow statements pass through
-      result.push_back(stmt);
+      // EvalStmt: apply op conversion and var substitution (same logic as AssignStmt path)
+      auto eval_stmt = As<EvalStmt>(stmt);
+      if (eval_stmt) {
+        auto call = As<Call>(eval_stmt->expr_);
+        if (call && !std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
+          const auto* converter = conv_registry.Lookup(call->op_->name_);
+          if (converter) {
+            std::vector<ExprPtr> substituted_args;
+            substituted_args.reserve(call->args_.size());
+            for (const auto& arg : call->args_) {
+              substituted_args.push_back(SubstituteExpr(arg, tensor_to_tile));
+            }
+            auto conv_result = (*converter)(substituted_args, call->kwargs_, call->span_);
+            auto transformed_prologue = TransformIncoreBody(conv_result.prologue, tensor_to_tile, sliced_vars,
+                                                            conv_registry, op_registry, span);
+            for (const auto& prologue_stmt : transformed_prologue) {
+              result.push_back(prologue_stmt);
+            }
+            result.push_back(std::make_shared<EvalStmt>(conv_result.result, eval_stmt->span_));
+            continue;
+          }
+        }
+        // No converter (or non-call): substitute renamed vars in args
+        auto new_expr = SubstituteExpr(eval_stmt->expr_, tensor_to_tile);
+        result.push_back(new_expr != eval_stmt->expr_ ? std::make_shared<EvalStmt>(new_expr, eval_stmt->span_)
+                                                      : stmt);
+      } else {
+        // Non-assign, non-EvalStmt statements pass through unchanged
+        result.push_back(stmt);
+      }
       continue;
     }
 
@@ -564,6 +592,17 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
     const auto* converter = conv_registry.Lookup(call->op_->name_);
     if (!converter) {
+      // TensorOps must always have a registered conversion, except for ops that are
+      // handled directly by backend codegen and never need conversion in InCore bodies.
+      if (op_registry.IsRegistered(call->op_->name_)) {
+        const auto& entry = op_registry.GetEntry(call->op_->name_);
+        static const std::unordered_set<std::string> kPassthroughTensorOps = {
+            "tensor.dim",  // queries gm_tensor dimensions; backend codegen handles it directly
+        };
+        INTERNAL_CHECK(entry.GetOpCategory() != "TensorOp" || kPassthroughTensorOps.count(call->op_->name_))
+            << "TensorOp \"" << call->op_->name_ << "\" has no registered tile conversion. "
+            << "Add a conversion in src/ir/transforms/op_conversion_registry.cpp.";
+      }
       LOG_WARN << "[ConvertTensorToBlockOps] No converter for op: " << call->op_->name_;
       auto new_value = SubstituteExpr(assign->value_, tensor_to_tile);
       if (new_value != assign->value_) {
@@ -1172,11 +1211,12 @@ class IncoreTileOpsVerifier : public IRVisitor {
     const auto& entry = op_registry.GetEntry(call->op_->name_);
     if (entry.GetOpCategory() == "TensorOp" &&
         OpConversionRegistry::GetInstance().HasConversion(call->op_->name_)) {
-      // tensor.read on a gm_tensor (TensorType input) intentionally stays unconverted
-      if (call->op_->name_ == "tensor.read" && !call->args_.empty() &&
+      // tensor.read/tensor.write on a gm_tensor (TensorType input) intentionally stays unconverted
+      if ((call->op_->name_ == "tensor.read" || call->op_->name_ == "tensor.write") && !call->args_.empty() &&
           As<TensorType>(call->args_[0]->GetType())) {
         return;
       }
+
       diagnostics_.emplace_back(
           DiagnosticSeverity::Error, "IncoreTileOps", 0,
           "Tensor op '" + call->op_->name_ + "' found in InCore function (should have been converted)", span);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -459,6 +459,40 @@ OpConversionRegistry::OpConversionRegistry() {
         CHECK(false) << "tensor.read conversion: unexpected input type: " << input->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
       });
+
+  // ────────────────────────────────────────────────────────────────────────
+  //
+  // gm_tensor.write(tensor, indices, value) stays as tensor.write (no conversion)
+  // local_tensor.write(tile, indices, value) → tile.write(tile, indices, value)
+  // ────────────────────────────────────────────────────────────────────────
+
+  RegisterCustom(
+      "tensor.write",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 3) << "tensor.write conversion expects 3 args (tensor, indices, value)";
+        auto& op_reg = OpRegistry::GetInstance();
+        const auto& dest = args[0];
+
+        if (As<TensorType>(dest->GetType())) {
+          // gm_tensor: keep as tensor.write
+          if (kwargs.empty()) {
+            return ConversionResult{op_reg.Create("tensor.write", args, span)};
+          }
+          return ConversionResult{op_reg.Create("tensor.write", args, kwargs, span)};
+        }
+
+        if (As<TileType>(dest->GetType())) {
+          // local_tensor (now tile): convert to tile.write
+          if (kwargs.empty()) {
+            return ConversionResult{op_reg.Create("tile.write", args, span)};
+          }
+          return ConversionResult{op_reg.Create("tile.write", args, kwargs, span)};
+        }
+
+        CHECK(false) << "tensor.write conversion: unexpected input type: " << dest->GetType()->TypeName();
+        return ConversionResult{nullptr};  // unreachable
+      });
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op) {

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -11,7 +11,7 @@
 
 import pypto.language as pl
 import pytest
-from pypto import ir, passes
+from pypto import DataType, ir, passes
 
 
 class TestConvertTensorToTileOps:
@@ -460,6 +460,27 @@ class TestNestedControlFlow:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_missing_conversion_raises_error(self):
+        """TensorOp with no registered converter raises an error when encountered in InCore body."""
+        span = ir.Span.unknown()
+        tensor_type = ir.TensorType([4], DataType.FP32)
+
+        x_param = ir.Var("x", tensor_type, span)
+        call = ir.create_op_call("test.tensor_op_no_conv", [x_param], {}, span)
+        y_var = ir.Var("y", tensor_type, span)
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(y_var, call, span),
+                ir.ReturnStmt([y_var], span),
+            ],
+            span,
+        )
+        func = ir.Function("incore", [x_param], [tensor_type], body, span, ir.FunctionType.InCore)
+        prog = ir.Program([func], "test_program", span)
+
+        with pytest.raises(Exception, match="has no registered tile conversion"):
+            passes.convert_tensor_to_tile_ops()(prog)
+
 
 class TestGmLocalTensorConversion:
     """Test gm_tensor vs local_tensor differentiated conversion."""
@@ -635,6 +656,94 @@ class TestGmLocalTensorConversion:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
                 v: pl.Scalar[pl.FP32] = self.main_incore_0(x)
+                return v
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_gm_tensor_write_stays_tensor_write(self):
+        """tensor.write to a gm_tensor (function parameter) stays as tensor.write."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                dst: pl.Tensor[[4], pl.FP32],
+                val: pl.Scalar[pl.FP32],
+            ) -> pl.Scalar[pl.FP32]:
+                pl.tensor.write(dst, [0], val)
+                return val
+
+            @pl.function
+            def main(
+                self,
+                dst: pl.Tensor[[4], pl.FP32],
+                val: pl.Scalar[pl.FP32],
+            ) -> pl.Scalar[pl.FP32]:
+                result: pl.Scalar[pl.FP32] = self.main_incore_0(dst, val)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                dst: pl.Tensor[[4], pl.FP32],
+                val: pl.Scalar[pl.FP32],
+            ) -> pl.Scalar[pl.FP32]:
+                pl.tensor.write(dst, [0], val)
+                return val
+
+            @pl.function
+            def main(
+                self,
+                dst: pl.Tensor[[4], pl.FP32],
+                val: pl.Scalar[pl.FP32],
+            ) -> pl.Scalar[pl.FP32]:
+                result: pl.Scalar[pl.FP32] = self.main_incore_0(dst, val)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_local_tensor_write_to_tile_write(self):
+        """tensor.write to a local_tensor (result of tensor.add) converts to tile.write."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]
+            ) -> pl.Scalar[pl.FP32]:
+                t: pl.Tensor[[4], pl.FP32] = pl.add(a, b)
+                val: pl.Scalar[pl.FP32] = pl.tensor.read(a, [0])
+                pl.tensor.write(t, [0], val)
+                v: pl.Scalar[pl.FP32] = pl.tensor.read(t, [0])
+                return v
+
+            @pl.function
+            def main(self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                v: pl.Scalar[pl.FP32] = self.main_incore_0(a, b)
+                return v
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]
+            ) -> pl.Scalar[pl.FP32]:
+                a_tile: pl.Tile[[4], pl.FP32] = pl.load(a, [0], [4])
+                b_tile: pl.Tile[[4], pl.FP32] = pl.load(b, [0], [4])
+                t_tile: pl.Tile[[4], pl.FP32] = pl.tile.add(a_tile, b_tile)
+                val: pl.Scalar[pl.FP32] = pl.tile.read(a_tile, [0])
+                pl.tile.write(t_tile, [0], val)
+                v: pl.Scalar[pl.FP32] = pl.tile.read(t_tile, [0])
+                return v
+
+            @pl.function
+            def main(self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]) -> pl.Scalar[pl.FP32]:
+                v: pl.Scalar[pl.FP32] = self.main_incore_0(a, b)
                 return v
 
         After = passes.convert_tensor_to_tile_ops()(Before)


### PR DESCRIPTION

- Handle EvalStmt in TransformIncoreBody: previously only AssignStmt was converted; now EvalStmt with call expressions also goes through op conversion and var substitution
- Add tensor.write smart conversion: gm_tensor keeps tensor.write, local_tensor (tile) converts to tile.write
- Add INTERNAL_CHECK for unregistered TensorOps in InCore bodies: any TensorOp without a registered converter must be in the explicit passthrough allowlist (currently only tensor.dim); add test-only op test.tensor_op_no_conv to cover this error path
- Fix IncoreTileOpsVerifier to skip tensor.write on gm_tensor, consistent with existing tensor.read handling

closes #403