### PR TITLE
fix(language): add Scalar.__bool__ to raise TypeError for type checker correctness

### DIFF
--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -127,6 +127,21 @@ class Scalar(metaclass=ScalarMeta):
             return f"Scalar[{self.dtype}]"
         return f"Scalar(expr={self.expr})"
 
+    def __bool__(self) -> bool:
+        """Prevent implicit boolean conversion of symbolic Scalar values.
+
+        Defined so that type checkers (pyright, mypy) do not infer that
+        ``if scalar:`` is always truthy.  At runtime, a symbolic IR
+        wrapper has no concrete truth value.
+
+        Raises:
+            TypeError: Always — Scalar cannot be converted to bool.
+        """
+        raise TypeError(
+            "Cannot convert Scalar to bool. "
+            "Scalar wraps a symbolic IR expression and has no concrete truth value."
+        )
+
     @classmethod
     def __class_getitem__(cls, item: DataType) -> "Scalar":
         """Support static type checkers for Scalar[dtype] syntax."""


### PR DESCRIPTION
## Summary
- Add `Scalar.__bool__` that raises `TypeError` to prevent type checkers (pyright, mypy) from inferring `if scalar:` is always truthy
- Uses `TypeError` following Python convention for unsupported boolean conversion (matching NumPy behavior)
- Includes docstring explaining the type-checker purpose

## Testing
- [x] All 2012 tests pass, no regressions
- [x] Code review completed
- [x] All pre-commit hooks pass (ruff, pyright, etc.)