### PR TITLE
fix(parser): remove rsqrt from tile-only op list in ast_parser

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1905,7 +1905,6 @@ class ASTParser:
         "store",
         "move",
         "neg",
-        "rsqrt",
         "recip",
         "log",
         "relu",


### PR DESCRIPTION
rsqrt is now a unified dispatch op (supporting both Tensor and Tile), so it should no longer be listed as a tile-only op in the parser whitelist.