### PR TITLE
fix(pass, codegen): fix IfStmt return_vars MemorySpace and TileType codegen

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1037,6 +1037,10 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       if (auto tensor_type = As<TensorType>(return_var->GetType())) {
         tensor_to_view_[return_var->name_] = ret_name;
         return_var_types.push_back(GetTensorViewTypeString(tensor_type.get()));
+      } else if (auto tile_type = As<TileType>(return_var->GetType())) {
+        INTERNAL_CHECK(tile_type->memref_.has_value())
+            << "TileType return_var must have a MemRef at codegen stage for var: " << return_var->name_;
+        return_var_types.push_back(GetTileBufTypeString(tile_type->memref_.value().get()));
       } else {
         std::string type_str = "index";
         if (auto scalar_type = As<ScalarType>(return_var->GetType())) {
@@ -1189,6 +1193,10 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       if (tensor_type) {
         tensor_to_view_[iter_arg->name_] = iter_name;
         iter_arg_types.push_back(GetTensorViewTypeString(tensor_type.get()));
+      } else if (auto tile_type = As<TileType>(iter_arg->GetType())) {
+        INTERNAL_CHECK(tile_type->memref_.has_value())
+            << "TileType iter_arg must have a MemRef at codegen stage for arg: " << iter_arg->name_;
+        iter_arg_types.push_back(GetTileBufTypeString(tile_type->memref_.value().get()));
       } else {
         std::string type_str = "index";
         if (auto scalar_type = As<ScalarType>(iter_arg->GetType())) {

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -66,6 +66,24 @@ const std::map<std::string, std::optional<MemorySpace>> kTileOpMemoryRules = {
 // Helper to check if operation is a view operation (zero-copy metadata transform)
 bool IsViewOperation(const std::string& op_name) { return op_name == "tile.reshape"; }
 
+// Helper to find the YieldStmt inside a statement body (searches through SeqStmts/OpStmts)
+YieldStmtPtr FindYieldStmt(const StmtPtr& body) {
+  if (auto yield = As<YieldStmt>(body)) return yield;
+  if (auto seq = As<SeqStmts>(body)) {
+    for (const auto& child : seq->stmts_) {
+      auto result = FindYieldStmt(child);
+      if (result) return result;
+    }
+  }
+  if (auto ops = As<OpStmts>(body)) {
+    for (const auto& child : ops->stmts_) {
+      auto result = FindYieldStmt(child);
+      if (result) return result;
+    }
+  }
+  return nullptr;
+}
+
 // Visitor to identify memory space for each variable
 class MemRefUsageVisitor : public IRVisitor {
  public:
@@ -112,6 +130,41 @@ class MemRefUsageVisitor : public IRVisitor {
     }
     if (op->value_) {
       VisitExpr(op->value_);
+    }
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    // Visit bodies first to populate yield values' memory spaces
+    IRVisitor::VisitStmt_(op);
+
+    // Propagate memory spaces from yield values to return_vars
+    if (op->return_vars_.empty()) return;
+
+    // Collect memory spaces from both branches
+    auto then_yield = FindYieldStmt(op->then_body_);
+    auto else_yield = op->else_body_.has_value() ? FindYieldStmt(op->else_body_.value()) : nullptr;
+    if (!then_yield && !else_yield) return;
+
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      // Try then branch first
+      if (then_yield && i < then_yield->value_.size()) {
+        if (auto yield_var = As<Var>(then_yield->value_[i])) {
+          auto it = var_memory_spaces_.find(yield_var);
+          if (it != var_memory_spaces_.end()) {
+            var_memory_spaces_[op->return_vars_[i]] = it->second;
+            continue;
+          }
+        }
+      }
+      // Fall back to else branch
+      if (else_yield && i < else_yield->value_.size()) {
+        if (auto yield_var = As<Var>(else_yield->value_[i])) {
+          auto it = var_memory_spaces_.find(yield_var);
+          if (it != var_memory_spaces_.end()) {
+            var_memory_spaces_[op->return_vars_[i]] = it->second;
+          }
+        }
+      }
     }
   }
 

--- a/tests/st/runtime/test_ctrl_flow.py
+++ b/tests/st/runtime/test_ctrl_flow.py
@@ -331,6 +331,85 @@ class TestIfYieldTensor(PTOTestCase):
         tensors["c"][:] = tensors["a"] * 2.0
 
 
+class TestForIfElseNested(PTOTestCase):
+    """Test if-else nested inside a for loop.
+
+    Iterates 4 chunks of 64 rows. In each iteration, if condition is 1,
+    performs add(a, b); otherwise performs mul(a, b). With condition=1,
+    expected result: c = a + b = 5.0.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "for_if_else_nested"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [256, 64], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [256, 64], DataType.FP32, init_value=3.0),
+            TensorSpec("condition", [1], DataType.INT32, init_value=1),
+            TensorSpec("c", [256, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class ForIfElseNestedProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_for_if_else(
+                self,
+                a: pl.Tensor[[256, 64], pl.FP32],
+                b: pl.Tensor[[256, 64], pl.FP32],
+                cond: pl.Scalar[pl.INT32],
+                c: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                for i in pl.range(4):
+                    offset_i = i * 64
+                    tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [offset_i, 0], [64, 64])
+                    tile_b: pl.Tile[[64, 64], pl.FP32] = pl.load(b, [offset_i, 0], [64, 64])
+                    tile_c: pl.Tile[[64, 64], pl.FP32] = pl.create_tile([64, 64], dtype=pl.FP32)
+
+                    if cond == 1:
+                        tile_c = pl.add(tile_a, tile_b)
+                    else:
+                        tile_c = pl.mul(tile_a, tile_b)
+
+                    out: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile_c, [offset_i, 0], c)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[256, 64], pl.FP32],
+                b: pl.Tensor[[256, 64], pl.FP32],
+                cond_tensor: pl.Tensor[[1], pl.INT32],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                c: pl.Tensor[[256, 64], pl.FP32] = pl.create_tensor([256, 64], dtype=pl.FP32)
+                cond: pl.Scalar[pl.INT32] = pl.tensor.read(cond_tensor, [0])
+                c = self.kernel_for_if_else(a, b, cond, c)
+                return c
+
+        return ForIfElseNestedProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = tensors["a"] + tensors["b"]
+
+
+class TestForIfElseNestedPTO(TestForIfElseNested):
+    """Test if-else nested inside a for loop with PTO backend and PTOAS."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "for_if_else_nested_pto"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
 class TestCtrlFlowOperations:
     """Test suite for control flow operations."""
 
@@ -364,17 +443,31 @@ class TestCtrlFlowOperations:
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="sync error")
+    @pytest.mark.xfail(reason="InsertSync BUG")
     def test_for_loop_yield_tile_accum(self, test_runner):
         """Test for loop with yield carrying tile accumulator across iterations."""
         test_case = TestForLoopYieldTileAccum()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="init_memref error")
+    @pytest.mark.xfail(reason="InsertSync BUG")
     def test_if_yield_tensor(self, test_runner):
         """Test if-else with yield carrying tensors."""
         test_case = TestIfYieldTensor()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.xfail(reason="MemRef and InsertSync BUG")
+    def test_for_if_else_nested(self, test_runner):
+        """Test if-else nested inside a for loop."""
+        test_case = TestForIfElseNested()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.skip(reason="PTOAS BUG")
+    def test_for_if_else_nested_pto(self, test_runner):
+        """Test if-else nested inside a for loop with PTO backend and PTOAS."""
+        test_case = TestForIfElseNestedPTO()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 


### PR DESCRIPTION
fix(pass, codegen): fix IfStmt return_vars MemorySpace and TileType codegen

- InitMemRef: MemRefUsageVisitor did not track variable uses inside IfStmt
branches, causing return_vars to default to DDR instead of inheriting the
correct MemorySpace (Vec/Acc) from yield values. Add IfStmt override that
propagates memory space from yield values to return_vars.

- PTO codegen: IfStmt/ForStmt type inference only handled TensorType and
ScalarType for return_vars/iter_args, falling through to "index" for
TileType. Add TileType handling to emit correct tile_buf type strings
for scf.if and scf.for yield types.

- Also add TestForIfElseNested runtime test case covering if-else nested
inside a for loop.