### PR TITLE
fix(dsl): type loop variables as Scalar instead of int

### DIFF
--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -71,38 +71,38 @@ class RangeIterator(Generic[T]):
         return self
 
     @overload
-    def __next__(self: RangeIterator[int]) -> int: ...
+    def __next__(self: RangeIterator[Scalar]) -> Scalar: ...
 
     @overload
     def __next__(
-        self: RangeIterator[tuple[int, tuple[T1]]],
-    ) -> tuple[int, tuple[T1]]: ...
+        self: RangeIterator[tuple[Scalar, tuple[T1]]],
+    ) -> tuple[Scalar, tuple[T1]]: ...
 
     @overload
     def __next__(
-        self: RangeIterator[tuple[int, tuple[T1, T2]]],
-    ) -> tuple[int, tuple[T1, T2]]: ...
+        self: RangeIterator[tuple[Scalar, tuple[T1, T2]]],
+    ) -> tuple[Scalar, tuple[T1, T2]]: ...
 
     @overload
     def __next__(
-        self: RangeIterator[tuple[int, tuple[T1, T2, T3]]],
-    ) -> tuple[int, tuple[T1, T2, T3]]: ...
+        self: RangeIterator[tuple[Scalar, tuple[T1, T2, T3]]],
+    ) -> tuple[Scalar, tuple[T1, T2, T3]]: ...
 
     @overload
     def __next__(
-        self: RangeIterator[tuple[int, tuple[T1, T2, T3, T4]]],
-    ) -> tuple[int, tuple[T1, T2, T3, T4]]: ...
+        self: RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4]]],
+    ) -> tuple[Scalar, tuple[T1, T2, T3, T4]]: ...
 
     @overload
     def __next__(
-        self: RangeIterator[tuple[int, tuple[T1, T2, T3, T4, T5]]],
-    ) -> tuple[int, tuple[T1, T2, T3, T4, T5]]: ...
+        self: RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4, T5]]],
+    ) -> tuple[Scalar, tuple[T1, T2, T3, T4, T5]]: ...
 
-    def __next__(self) -> int | tuple[int, tuple[Any, ...]]:
+    def __next__(self) -> Scalar | tuple[Scalar, tuple[Any, ...]]:
         """Get next iteration value.
 
         Returns:
-            If no init_values: just the loop variable (int)
+            If no init_values: just the loop variable (Scalar)
             If init_values provided: Tuple of (loop_var, (iter_arg_values...))
         """
         if self.current >= self.stop:  # type: ignore[operator]
@@ -123,7 +123,7 @@ def _make_range_iterator(
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
     func_name: str = "range",
-) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
+) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Shared implementation for range(), parallel(), and unroll()."""
     if chunk is not None and (not isinstance(chunk, int) or isinstance(chunk, bool) or chunk <= 0):
         raise ValueError(f"{func_name}() chunk must be a positive integer, got {chunk!r}")
@@ -144,19 +144,19 @@ def _make_range_iterator(
 @overload
 def range(
     *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[int]: ...
+) -> RangeIterator[Scalar]: ...
 
 
 @overload
 def range(
     *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[tuple[int, tuple[T1]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1]]]: ...
 
 
 @overload
 def range(
     *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[tuple[int, tuple[T1, T2]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2]]]: ...
 
 
 @overload
@@ -165,7 +165,7 @@ def range(
     init_values: tuple[T1, T2, T3],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3]]]: ...
 
 
 @overload
@@ -174,7 +174,7 @@ def range(
     init_values: tuple[T1, T2, T3, T4],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3, T4]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4]]]: ...
 
 
 @overload
@@ -183,7 +183,7 @@ def range(
     init_values: tuple[T1, T2, T3, T4, T5],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3, T4, T5]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4, T5]]]: ...
 
 
 def range(
@@ -191,7 +191,7 @@ def range(
     init_values: tuple[Any, ...] | None = None,
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
+) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Create a range iterator for for loops.
 
     Supports two patterns:
@@ -212,7 +212,7 @@ def range(
         chunk_policy: Chunk distribution policy (default: "leading_full")
 
     Returns:
-        If no init_values: RangeIterator yielding loop variable (int)
+        If no init_values: RangeIterator yielding loop variable (Scalar)
         If init_values: RangeIterator yielding (loop_var, (iter_args...))
     """
     return _make_range_iterator(
@@ -223,19 +223,19 @@ def range(
 @overload
 def parallel(
     *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[int]: ...
+) -> RangeIterator[Scalar]: ...
 
 
 @overload
 def parallel(
     *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[tuple[int, tuple[T1]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1]]]: ...
 
 
 @overload
 def parallel(
     *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "leading_full"
-) -> RangeIterator[tuple[int, tuple[T1, T2]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2]]]: ...
 
 
 @overload
@@ -244,7 +244,7 @@ def parallel(
     init_values: tuple[T1, T2, T3],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3]]]: ...
 
 
 @overload
@@ -253,7 +253,7 @@ def parallel(
     init_values: tuple[T1, T2, T3, T4],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3, T4]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4]]]: ...
 
 
 @overload
@@ -262,7 +262,7 @@ def parallel(
     init_values: tuple[T1, T2, T3, T4, T5],
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[tuple[int, tuple[T1, T2, T3, T4, T5]]]: ...
+) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4, T5]]]: ...
 
 
 def parallel(
@@ -270,7 +270,7 @@ def parallel(
     init_values: tuple[Any, ...] | None = None,
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[int] | RangeIterator[tuple[int, tuple[Any, ...]]]:
+) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Create a parallel range iterator for parallel for loops.
 
     Behaves identically to range() at runtime. The distinction is used by the
@@ -284,7 +284,7 @@ def parallel(
         chunk_policy: Chunk distribution policy (default: "leading_full")
 
     Returns:
-        If no init_values: RangeIterator yielding loop variable (int)
+        If no init_values: RangeIterator yielding loop variable (Scalar)
         If init_values: RangeIterator yielding (loop_var, (iter_args...))
     """
     return _make_range_iterator(
@@ -296,7 +296,7 @@ def unroll(
     *args: RangeArg,
     chunk: int | None = None,
     chunk_policy: str = "leading_full",
-) -> RangeIterator[int]:
+) -> RangeIterator[Scalar]:
     """Create an unroll range iterator for compile-time loop unrolling.
 
     Behaves identically to range() at runtime. The distinction is used by the
@@ -311,7 +311,7 @@ def unroll(
         chunk_policy: Chunk distribution policy (default: "leading_full")
 
     Returns:
-        RangeIterator yielding loop variable (int)
+        RangeIterator yielding loop variable (Scalar)
 
     Examples:
         >>> for i in pl.unroll(4):

--- a/tests/ut/language/test_loop_var_type.py
+++ b/tests/ut/language/test_loop_var_type.py
@@ -1,0 +1,52 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+# pyright: reportCallIssue=true
+# pyright: reportArgumentType=true
+
+"""Pyright regression test: loop variables from pl.range/parallel/unroll must be Scalar.
+
+If the loop variable type regresses to ``int``, pyright will report:
+  "Argument of type 'int' cannot be assigned to parameter of type 'Scalar'"
+on every ``accept_scalar()`` call below.
+"""
+
+import pypto.language as pl
+import pytest
+
+
+def accept_scalar(x: pl.Scalar) -> None: ...
+
+
+class TestLoopVarType:
+    """Verify loop variables from pl.range/parallel/unroll are typed as Scalar."""
+
+    def test_range_loop_var(self):
+        for i in pl.range(10):
+            accept_scalar(i)
+
+    def test_range_loop_var_with_init_values(self):
+        for j, (t,) in pl.range(0, 8, 1, init_values=(pl.Scalar[pl.INDEX],)):
+            accept_scalar(j)
+
+    def test_parallel_loop_var(self):
+        for k in pl.parallel(4):
+            accept_scalar(k)
+
+    def test_parallel_loop_var_with_init_values(self):
+        for m, (t,) in pl.parallel(0, 4, 1, init_values=(pl.Scalar[pl.INDEX],)):
+            accept_scalar(m)
+
+    def test_unroll_loop_var(self):
+        for n in pl.unroll(3):
+            accept_scalar(n)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Loop variables from `pl.range()`, `pl.parallel()`, and `pl.unroll()` are `Scalar[INDEX]` IR expressions, not Python `int`s
- The old `int` type annotation caused pyright errors when passing loop variables to functions expecting `Scalar` parameters (e.g., InCore function signatures)
- Updated all `RangeIterator` overloads, `__next__` signatures, and `range`/`parallel`/`unroll` return types from `int` to `Scalar`

## Testing
- [x] All 2063 tests pass (including 5 new regression tests)
- [x] Pre-commit hooks pass (pyright, ruff, headers)
- [x] Code review completed