### PR TITLE
fix(codegen): adapt to simplified PTO2 runtime API

### DIFF
--- a/python/pypto/ir/pto_codegen.py
+++ b/python/pypto/ir/pto_codegen.py
@@ -141,8 +141,7 @@ def _generate_arg_unpacking(func: _ir_core.Function) -> tuple[str, list[str]]:
             c_type = param_type.dtype.to_c_type_string()
             lines.append(f"    // Unpack tensor: {param_name}")
             lines.append(
-                f"    __gm__ TensorData* {param_name}_tensor = "
-                f"reinterpret_cast<__gm__ TensorData*>(args[{i}]);"
+                f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);"
             )
             lines.append(
                 f"    __gm__ {c_type}* {param_name} = "

--- a/src/codegen/cce/cce_codegen.cpp
+++ b/src/codegen/cce/cce_codegen.cpp
@@ -89,7 +89,7 @@ std::map<std::string, std::string> CCECodegen::Generate(const ir::ProgramPtr& pr
     // Add compute_stride helper function
     oss << "// Helper function to compute stride from raw_shapes\n";
     oss << "__aicore__ __attribute__((always_inline)) inline int64_t compute_stride(\n";
-    oss << "    __gm__ TensorData* tensor, int dim) {\n";
+    oss << "    __gm__ Tensor* tensor, int dim) {\n";
     oss << "  int64_t stride = 1;\n";
     oss << "  for (int j = dim + 1; j < static_cast<int>(tensor->ndims); j++) {\n";
     oss << "    stride *= static_cast<int64_t>(tensor->raw_shapes[j]);\n";
@@ -198,9 +198,9 @@ void CCECodegen::GeneratePrologue(const ir::FunctionPtr& func) {
       // Extract element type
       std::string element_type = tensor_type->dtype_.ToCTypeString();
 
-      // Emit argument unpacking via TensorData* indirection
+      // Emit argument unpacking via Tensor* indirection
       std::string tensor_var = param_name + "_tensor";
-      emitter_.EmitLine("__gm__ TensorData* " + tensor_var + " = reinterpret_cast<__gm__ TensorData*>(args[" +
+      emitter_.EmitLine("__gm__ Tensor* " + tensor_var + " = reinterpret_cast<__gm__ Tensor*>(args[" +
                         std::to_string(i) + "]);");
       emitter_.EmitLine("__gm__ " + element_type + "* " + param_name + " = reinterpret_cast<__gm__ " +
                         element_type + "*>(" + tensor_var + "->buffer.addr) + " + tensor_var +

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -442,8 +442,8 @@ std::string GenerateConfigFunction(int expected_arg_count) {
   return oss.str();
 }
 
-std::string CoreTypeToWorker(CoreType core_type) {
-  return core_type == CoreType::CUBE ? "PTO2_WORKER_CUBE" : "PTO2_WORKER_VECTOR";
+std::string CoreTypeToSubmitFunc(CoreType core_type) {
+  return core_type == CoreType::CUBE ? "pto2_rt_submit_aic_task" : "pto2_rt_submit_aiv_task";
 }
 
 // Removed DataTypeToPTO2Enum — now uses DataTypeToString from dtype.h
@@ -823,8 +823,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << "    " << p.kind << "(" << p.value << "),\n";
     }
     code_ << ind << "};\n";
-    code_ << ind << "pto2_rt_submit_task(rt, " << func_id << ", " << CoreTypeToWorker(core_type) << ", "
-          << task_var << ", " << params.size() << ");\n";
+    code_ << ind << CoreTypeToSubmitFunc(core_type) << "(rt, " << func_id << ", " << task_var << ", "
+          << params.size() << ");\n";
 
     task_counter_++;
   }
@@ -904,8 +904,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   // 6. Entry function
   oss << "__attribute__((visibility(\"default\")))\n";
   oss << "void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {\n";
-  oss << "    (void)arg_count;\n";
-  oss << "    pto2_rt_init_tensor_pool(rt);  // Initialize TensorPool singleton\n\n";
+  oss << "    (void)arg_count;\n\n";
 
   // 7. Extract arguments
   oss << "    // Extract device pointers\n";

--- a/tests/ut/codegen/test_cce_codegen.py
+++ b/tests/ut/codegen/test_cce_codegen.py
@@ -69,7 +69,7 @@ class TestCCECodegenBasics:
 
         # Verify function parameters unpacking and declarations are generated
         assert "GlobalTensor<float" in code
-        assert "__gm__ TensorData*" in code
+        assert "__gm__ Tensor*" in code
         assert "->buffer.addr" in code
         assert "union { uint64_t u64; float val; }" in code
         assert "float input_b_0 =" in code

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -39,7 +39,7 @@ class TestOrchestration:
     """Test orchestration codegen format."""
 
     def test_basic_structure(self):
-        """Test codegen produces PTO2 format: make_tensor_external, PTOParam, pto2_rt_submit_task."""
+        """Test codegen produces PTO2 format: make_tensor_external, PTOParam, pto2_rt_submit_aiv_task."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B_CCE)
 
@@ -146,7 +146,6 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                 (void)arg_count;
-                pto2_rt_init_tensor_pool(rt);  // Initialize TensorPool singleton
 
                 // Extract device pointers
                 void* arg_a_ptr = reinterpret_cast<void*>(args[ARG_PTR_A]);
@@ -170,7 +169,7 @@ class TestOrchestration:
                     make_input_param(ext_b),
                     make_output_param(c),
                 };
-                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t0, 3);
+                pto2_rt_submit_aiv_task(rt, 0, params_t0, 3);
 
                 // Task 1: kernel_add
                 PTOParam params_t1[] = {
@@ -178,7 +177,7 @@ class TestOrchestration:
                     make_input_param(ext_b),
                     make_output_param(ext_d),
                 };
-                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t1, 3);
+                pto2_rt_submit_aiv_task(rt, 0, params_t1, 3);
             }
 
             }  // extern "C"
@@ -306,7 +305,7 @@ class TestOrchestration:
         assert "make_tensor_external" in code
 
         # Two tasks submitted
-        assert code.count("pto2_rt_submit_task") == 2
+        assert code.count("pto2_rt_submit_aiv_task") == 2
 
         # No PTO2_SCOPE needed: all tasks use only external tensors
         assert "PTO2_SCOPE" not in code
@@ -459,7 +458,6 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                 (void)arg_count;
-                pto2_rt_init_tensor_pool(rt);  // Initialize TensorPool singleton
 
                 // Extract device pointers
                 void* arg_a_ptr = reinterpret_cast<void*>(args[ARG_PTR_A]);
@@ -483,7 +481,7 @@ class TestOrchestration:
                     make_input_param(ext_b),
                     make_output_param(c),
                 };
-                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t0, 3);
+                pto2_rt_submit_aiv_task(rt, 0, params_t0, 3);
                 uint64_t d_shapes[2] = {16, 16};
                 Tensor d = make_tensor(d_shapes, 2, DataType::FLOAT32);
 
@@ -493,7 +491,7 @@ class TestOrchestration:
                     make_scalar_param(float_to_u64(1.000000f)),
                     make_output_param(d),
                 };
-                pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, params_t1, 3);
+                pto2_rt_submit_aiv_task(rt, 1, params_t1, 3);
                 uint64_t e_shapes[2] = {16, 16};
                 Tensor e = make_tensor(e_shapes, 2, DataType::FLOAT32);
 
@@ -503,7 +501,7 @@ class TestOrchestration:
                     make_scalar_param(float_to_u64(2.000000f)),
                     make_output_param(e),
                 };
-                pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, params_t2, 3);
+                pto2_rt_submit_aiv_task(rt, 1, params_t2, 3);
                 uint64_t g_shapes[2] = {16, 16};
                 Tensor g = make_tensor(g_shapes, 2, DataType::FLOAT32);
 
@@ -513,7 +511,7 @@ class TestOrchestration:
                     make_input_param(e),
                     make_output_param(g),
                 };
-                pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, params_t3, 3);
+                pto2_rt_submit_aiv_task(rt, 2, params_t3, 3);
 
                 // Task 4: kernel_add
                 PTOParam params_t4[] = {
@@ -521,7 +519,7 @@ class TestOrchestration:
                     make_input_param(c),
                     make_output_param(ext_f),
                 };
-                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t4, 3);
+                pto2_rt_submit_aiv_task(rt, 0, params_t4, 3);
             }
 
             }  // extern "C"
@@ -590,7 +588,7 @@ class TestOrchestration:
         assert "make_tensor_external(arg_result_ptr" in code
 
         # Two tasks: kernel_pair + kernel_add
-        assert code.count("pto2_rt_submit_task") == 2
+        assert code.count("pto2_rt_submit_aiv_task") == 2
 
         # No PTO2_SCOPE: no control flow
         assert "PTO2_SCOPE" not in code
@@ -640,7 +638,7 @@ class TestOrchestration:
         assert "make_tensor_external(arg_y_ptr" in code
 
         # Only one task: kernel_pair
-        assert code.count("pto2_rt_submit_task") == 1
+        assert code.count("pto2_rt_submit_aiv_task") == 1
 
         # No PTO2_SCOPE needed: single task, all external
         assert "PTO2_SCOPE" not in code
@@ -722,7 +720,7 @@ class TestOrchestration:
         assert "make_tensor_external(arg_final_ptr" in code
 
         # Two tasks: online_update + kernel_add
-        assert code.count("pto2_rt_submit_task") == 2
+        assert code.count("pto2_rt_submit_aiv_task") == 2
 
         # online_update: 3 In + 3 InOut + 1 Out = 7 params
         assert "make_input_param(ext_mij)" in code
@@ -909,7 +907,6 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                 (void)arg_count;
-                pto2_rt_init_tensor_pool(rt);  // Initialize TensorPool singleton
 
                 // Extract device pointers
                 void* arg_mij_ptr = reinterpret_cast<void*>(args[ARG_PTR_MIJ]);
@@ -947,7 +944,7 @@ class TestOrchestration:
                     make_inout_param(ext_oi),
                     make_output_param(ext_dst),
                 };
-                pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t0, 7);
+                pto2_rt_submit_aiv_task(rt, 0, params_t0, 7);
             }
 
             }  // extern "C"
@@ -1050,7 +1047,7 @@ class TestOrchestration:
         assert "static_cast<int64_t*>(arg_config_ptr)" in code
 
         # kernel_add task submitted inside loop
-        assert "pto2_rt_submit_task" in code
+        assert "pto2_rt_submit_aiv_task" in code
 
     def test_if_statement(self):
         """Test if/else codegen with conditional scalar values."""
@@ -1277,7 +1274,7 @@ class TestOrchestration:
         # Both tasks submitted
         assert "kernel_init" in code
         assert "kernel_update" in code
-        assert code.count("pto2_rt_submit_task") == 2
+        assert code.count("pto2_rt_submit_aiv_task") == 2
 
 
 class TestTensorReadWriteOffsetCodegen:

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -534,18 +534,18 @@ class TestGenerateArgUnpacking:
     def test_tensor_only(self):
         func = _make_func("test_fn", [("a", "tensor"), ("b", "tensor"), ("out", "tensor")])
         code, names = _generate_arg_unpacking(func)
-        assert "reinterpret_cast<__gm__ TensorData*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[1])" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[2])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[2])" in code
         assert names == ["a", "b", "out"]
 
     def test_mixed_tensor_scalar(self):
         func = _make_func("test_fn", [("input", "tensor"), ("scale", "scalar"), ("output", "tensor")])
         code, names = _generate_arg_unpacking(func)
-        assert "reinterpret_cast<__gm__ TensorData*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
         assert "scale_conv.u64 = args[1];" in code
         assert "float scale = scale_conv.val;" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[2])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[2])" in code
         assert names == ["input", "scale", "output"]
 
     def test_scalar_only(self):


### PR DESCRIPTION
- Rename TensorData* to Tensor* in CCE and PTO codegen argument unpacking
- Replace pto2_rt_submit_task(rt, id, PTO2_WORKER_*, params, n) with core-type-specific pto2_rt_submit_aiv_task / pto2_rt_submit_aic_task
- Remove pto2_rt_init_tensor_pool call from orchestration entry function