### PR TITLE
fix(printer): Fix TileView/TensorView syntax and roundtrip correctness

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -272,7 +272,7 @@ class ASTParser:
                 "with statements, returns, break, and continue are supported in DSL functions",
             )
 
-    def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:
+    def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:  # noqa: PLR0912
         """Parse annotated assignment: var: type = value.
 
         Args:
@@ -326,7 +326,7 @@ class ASTParser:
                 isinstance(ann, ast.Attribute)
                 and isinstance(ann.value, ast.Name)
                 and ann.value.id == "pl"
-                and ann.attr == "UnknownType"
+                and ann.attr in ("UnknownType", "MemRefType")
             )
             if is_unresolvable:
                 resolved = None
@@ -340,6 +340,18 @@ class ASTParser:
                 elif isinstance(resolved, ir.ShapedType) and resolved.memref is not None:
                     override_type = resolved
                 elif isinstance(resolved, ir.TileType) and resolved.memory_space is not None:
+                    override_type = resolved
+                elif isinstance(resolved, ir.TileType) and resolved.tile_view is not None:
+                    # Annotation specifies tile layout (blayout/slayout/fractal); preserve it
+                    override_type = resolved
+                elif isinstance(resolved, ir.TensorType) and resolved.tensor_view is not None:
+                    # Annotation specifies tensor view (stride/layout); preserve it
+                    override_type = resolved
+                elif (
+                    isinstance(resolved, ir.ScalarType)
+                    and isinstance(value_expr.type, ir.ScalarType)
+                    and value_expr.type.dtype == DataType.INDEX
+                ):
                     override_type = resolved
         var = self.builder.let(var_name, value_expr, type=override_type, span=span)
 
@@ -552,11 +564,7 @@ class ASTParser:
             iter_arg_var = loop.iter_arg(iter_arg_node.id, init_values[i])
             self.scope_manager.define_var(iter_arg_node.id, iter_arg_var, allow_redef=True)
 
-        for iter_arg_node in iter_args_node.elts:
-            assert isinstance(iter_arg_node, ast.Name)
-            loop.return_var(f"{iter_arg_node.id}_out")
-
-    def parse_for_loop(self, stmt: ast.For) -> None:
+    def parse_for_loop(self, stmt: ast.For) -> None:  # noqa: PLR0912
         """Parse for loop with pl.range(), pl.parallel(), pl.unroll(), or pl.while_().
 
         Supports patterns for range/parallel/unroll:
@@ -624,7 +632,15 @@ class ASTParser:
             self._validate_chunk_args(chunk_expr, range_args["init_values"], iter_call)
 
         kind = self._ITERATOR_TO_KIND[iterator_type]
-        loop_var = self.builder.var(loop_var_name, ir.ScalarType(DataType.INDEX))
+        # Infer loop var dtype from range bounds to preserve roundtrip fidelity.
+        # If bounds use a non-default integer dtype (e.g. INT32), use that for the loop var
+        # rather than always defaulting to INDEX. This ensures print-parse roundtrip is exact.
+        _loop_var_dtype = DataType.INDEX
+        for _bound in (range_args.get("start"), range_args.get("stop"), range_args.get("step")):
+            if isinstance(_bound, ir.ConstInt) and _bound.dtype not in (DataType.INDEX, DataType.INT64):
+                _loop_var_dtype = _bound.dtype
+                break
+        loop_var = self.builder.var(loop_var_name, ir.ScalarType(_loop_var_dtype))
         span = self.span_tracker.get_span(stmt)
         loop_output_vars: list[str] = []
 
@@ -654,6 +670,19 @@ class ASTParser:
                 assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
                 loop_output_vars = self._current_yield_vars[:]
 
+            # Create return_vars using yield LHS names (or fallback to _out names)
+            if not is_simple_for and range_args["init_values"]:
+                if loop_output_vars:
+                    for rv_name in loop_output_vars:
+                        loop.return_var(rv_name)
+                else:
+                    # Fallback: no yield vars found, use auto-generated names
+                    assert iter_args_node is not None
+                    assert isinstance(iter_args_node, ast.Tuple)
+                    for iter_arg_node in iter_args_node.elts:
+                        assert isinstance(iter_arg_node, ast.Name)
+                        loop.return_var(f"{iter_arg_node.id}_out")
+
             should_leak = is_simple_for and not loop_output_vars
             self.scope_manager.exit_scope(leak_vars=should_leak)
             self.in_for_loop = False
@@ -669,12 +698,6 @@ class ASTParser:
 
     def _validate_chunk_args(self, chunk_expr: Any, init_values: list[Any], iter_call: ast.Call) -> None:
         """Validate chunk arguments for range/parallel/unroll loops."""
-        if init_values:
-            raise ParserSyntaxError(
-                "chunk cannot be combined with init_values",
-                span=self.span_tracker.get_span(iter_call),
-                hint="Chunked loops do not support loop-carried values (init_values)",
-            )
         if not _is_const_int(chunk_expr):
             raise ParserSyntaxError(
                 "chunk must be a compile-time constant positive integer",
@@ -1093,13 +1116,18 @@ class ASTParser:
                 )
             loop.set_condition(condition)
 
-            # Add return_vars
-            for iter_arg_node in iter_args_node.elts:
-                assert isinstance(iter_arg_node, ast.Name)
-                loop.return_var(f"{iter_arg_node.id}_out")
-
-            # Parse body statements
+            # Parse body statements first to get actual output variable names
             loop_output_vars = self._parse_while_body_statements(stmt)
+
+            # Add return_vars using actual output variable names from body
+            if not loop_output_vars:
+                raise ParserSyntaxError(
+                    "pl.while_() with init_values requires a pl.yield_(...) in the body",
+                    span=self.span_tracker.get_span(stmt),
+                    hint="Yield the updated loop-carried values before the end of the body",
+                )
+            for var_name in loop_output_vars:
+                loop.return_var(var_name)
 
             self.scope_manager.exit_scope(leak_vars=False)
             self.in_while_loop = False
@@ -1328,6 +1356,18 @@ class ASTParser:
             return
         if self._is_dsl_call(stmt, "static_assert"):
             self._handle_static_assert(stmt)
+            return
+
+        # Special case: bare pl.yield_() emits a YieldStmt via parse_yield_call.
+        # Do not create an additional EvalStmt for the returned expression.
+        if (
+            isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and stmt.value.func.attr == "yield_"
+            and isinstance(stmt.value.func.value, ast.Name)
+            and stmt.value.func.value.id == "pl"
+        ):
+            self.parse_yield_call(stmt.value)
             return
 
         expr = self.parse_expression(stmt.value)
@@ -1624,6 +1664,15 @@ class ASTParser:
                 hint="Use supported unary operators: -, not",
             )
 
+        # Fold constant negation: -ConstInt(n) -> ConstInt(-n), -ConstFloat(n) -> ConstFloat(-n).
+        # Python parses negative literals (e.g. -1 in function args) as UnaryOp(USub, Constant(1)),
+        # but the IR builder creates ConstInt(-1) directly. Folding here preserves roundtrip.
+        if op_type == ast.USub:
+            if isinstance(operand, ir.ConstInt):
+                return ir.ConstInt(-operand.value, operand.dtype, span)
+            if isinstance(operand, ir.ConstFloat):
+                return ir.ConstFloat(-operand.value, operand.dtype, span)
+
         return op_map[op_type](operand, span)
 
     def parse_call(self, call: ast.Call) -> ir.Expr:
@@ -1712,6 +1761,9 @@ class ASTParser:
 
         # Return first expression as the "value" of the yield
         # This handles: var = pl.yield_(expr)
+        if len(yield_exprs) == 0:
+            # Bare pl.yield_() with no arguments — return None (used as bare stmt)
+            return None  # type: ignore[return-value]
         if len(yield_exprs) == 1:
             return yield_exprs[0]
 
@@ -2346,6 +2398,13 @@ class ASTParser:
         Returns:
             IR expression
         """
+        # Try to evaluate as a Python enum value (e.g., pl.MemorySpace.Vec -> ConstInt)
+        try:
+            value = self.expr_evaluator.eval_expr(attr)
+            if isinstance(value, ir.MemorySpace):
+                return ir.ConstInt(value.value, DataType.INDEX, self.span_tracker.get_span(attr))
+        except Exception:
+            pass
         # This might be accessing a DataType enum or similar
         # For now, this is primarily used in calls, not standalone
         raise UnsupportedFeatureError(

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -18,6 +18,23 @@ from pypto.pypto_core import ir
 from .diagnostics.exceptions import ParserError
 
 
+class _AutoDynVar(dict):
+    """Dict subclass that auto-creates DynVar for undefined identifiers during exec.
+
+    When re-parsing roundtrip-printed IR, dynamic shape variables like
+    ``M = pl.dynamic("M")`` may not be in scope. This dict's ``__missing__``
+    hook intercepts undefined name lookups and creates a DynVar automatically.
+    """
+
+    def __missing__(self, key: str) -> object:
+        pl_mod = self.get("pl")
+        if pl_mod is not None and isinstance(key, str):
+            dvar = pl_mod.dynamic(key)
+            self[key] = dvar
+            return dvar
+        raise KeyError(key)
+
+
 def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
     """Parse a DSL function or program from a string.
 
@@ -97,9 +114,11 @@ def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
     # Add module to sys.modules so inspect can find it
     sys.modules[module_name] = temp_module
 
-    # Execute the code in the module's namespace
+    # Execute the code in the module's namespace, using _AutoDynVar to handle
+    # dynamic shape variable references that may not be in scope during re-parse
+    exec_ns = _AutoDynVar(temp_module.__dict__)
     try:
-        exec(compiled_code, temp_module.__dict__)
+        exec(compiled_code, exec_ns)
     except ParserError as e:
         # Re-raise ParserError as-is, it already has source lines
         raise e
@@ -115,7 +134,7 @@ def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
             del sys.modules[module_name]
 
     # Get namespace from executed module
-    namespace = temp_module.__dict__
+    namespace = exec_ns
 
     # Scan namespace for ir.Function and ir.Program instances
     functions = []

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -10,7 +10,7 @@
 """Type annotation resolution for IR parsing."""
 
 import ast
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from pypto.language.typing.dynamic import DynVar
@@ -117,6 +117,7 @@ class TypeResolver:
         self.expr_evaluator = expr_evaluator
         self.scope_lookup = scope_lookup
         self.span_tracker = span_tracker
+        self._dyn_var_cache: dict[str, ir.Var] = {}
 
     def resolve_param_type(self, type_node: ast.expr) -> "tuple[ir.Type, ir.ParamDirection]":
         """Resolve AST type annotation to (ir.Type, ParamDirection) for function parameters.
@@ -184,9 +185,9 @@ class TypeResolver:
         Returns:
             Type name string if recognized, None otherwise
         """
-        if isinstance(node, ast.Attribute) and node.attr in ("Tensor", "Tile", "Scalar"):
+        if isinstance(node, ast.Attribute) and node.attr in ("Tensor", "Tile", "Scalar", "Tuple"):
             return node.attr
-        if isinstance(node, ast.Name) and node.id in ("Tensor", "Tile", "Scalar"):
+        if isinstance(node, ast.Name) and node.id in ("Tensor", "Tile", "Scalar", "Tuple"):
             return node.id
         return None
 
@@ -226,7 +227,7 @@ class TypeResolver:
             hint="Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]",
         )
 
-    def _resolve_subscript_type(self, subscript_node: ast.Subscript) -> ir.Type:
+    def _resolve_subscript_type(self, subscript_node: ast.Subscript) -> ir.Type:  # noqa: PLR0912
         """Resolve subscript type annotation.
 
         Supports:
@@ -262,8 +263,8 @@ class TypeResolver:
             return ir.ScalarType(dtype)
 
         # Tensor: [shape, dtype], [shape, dtype, layout_or_memref], [shape, dtype, layout, memref]
-        # Tile: [shape, dtype], [shape, dtype, memref_or_memory_space],
-        #       [shape, dtype, memref, memory_space]
+        # Tile: [shape, dtype], [shape, dtype, tileview_or_memref_or_memory_space],
+        #       [shape, dtype, tileview, memref] or [shape, dtype, memref, memory_space]
         valid_counts = (2, 3, 4)
         if not isinstance(slice_value, ast.Tuple) or len(slice_value.elts) not in valid_counts:
             if type_name == "Tensor":
@@ -278,13 +279,15 @@ class TypeResolver:
             else:
                 message = (
                     f"{type_name} subscript requires [shape, dtype], "
-                    f"[shape, dtype, memref_or_memory_space], or [shape, dtype, memref, memory_space], "
+                    f"[shape, dtype, tileview_or_memref_or_memory_space], "
+                    f"or [shape, dtype, tileview_or_memref, memref_or_memory_space], "
                     f"got: {ast.unparse(slice_value)}"
                 )
                 hint = (
                     f"Use pl.{type_name}[[shape], dtype], "
                     f"pl.{type_name}[[shape], dtype, pl.MemRef(...)], "
-                    f"or pl.{type_name}[[shape], dtype, pl.MemorySpace.Vec]"
+                    f"pl.{type_name}[[shape], dtype, pl.TileView(...)], "
+                    f"or pl.{type_name}[[shape], dtype, pl.TileView(...), pl.MemRef(...)]"
                 )
             raise ParserTypeError(message, hint=hint)
 
@@ -303,27 +306,48 @@ class TypeResolver:
             return ir.TensorType(shape, dtype)
 
         # 3 args: [shape, dtype, layout_or_memref] for Tensor,
-        #         [shape, dtype, memref_or_memory_space] for Tile
+        #         [shape, dtype, tileview_or_memref_or_memory_space] for Tile
         if n_elts == 3:
             third = slice_value.elts[2]
             if type_name == "Tile":
+                if self._is_tileview_node(third):
+                    tile_view = self._resolve_tileview(third, shape)
+                    return ir.TileType(shape, dtype, None, tile_view)
                 return self._resolve_tile_third_arg(shape, dtype, third)
             # Tensor: disambiguate 3rd arg
             if self._is_memref_node(third):
                 memref = self.resolve_memref(third)
                 return ir.TensorType(shape, dtype, memref)
+            if self._is_tensorview_node(third):
+                tensor_view = self._resolve_tensorview(third)
+                return ir.TensorType(shape, dtype, None, tensor_view)
             layout = self.resolve_layout(third)
             tensor_view = ir.TensorView([], layout)
             return ir.TensorType(shape, dtype, None, tensor_view)
 
         # 4 args: [shape, dtype, layout, memref] for Tensor,
-        #         [shape, dtype, memref, memory_space] for Tile
+        #         [shape, dtype, tileview_or_memref, memref_or_memory_space] for Tile
         if type_name == "Tile":
+            tileview_node = slice_value.elts[2]
+            if self._is_tileview_node(tileview_node):
+                tile_view = self._resolve_tileview(tileview_node, shape)
+                memref_node = slice_value.elts[3]
+                if not self._is_memref_node(memref_node):
+                    raise ParserTypeError(
+                        "Tile 4th argument must be pl.MemRef(...)",
+                        hint="Use pl.Tile[[shape], dtype, pl.TileView(...), pl.MemRef(...)]",
+                    )
+                memref = self.resolve_memref(memref_node)
+                return ir.TileType(shape, dtype, memref, tile_view)
             return self._resolve_tile_four_args(shape, dtype, slice_value.elts[2], slice_value.elts[3])
 
-        # Tensor 4 args: [shape, dtype, layout, memref]
-        layout = self.resolve_layout(slice_value.elts[2])
-        tensor_view = ir.TensorView([], layout)
+        # Tensor 4 args: [shape, dtype, layout_or_tensorview, memref]
+        third = slice_value.elts[2]
+        if self._is_tensorview_node(third):
+            tensor_view = self._resolve_tensorview(third)
+        else:
+            layout = self.resolve_layout(third)
+            tensor_view = ir.TensorView([], layout)
         memref_node = slice_value.elts[3]
         if not self._is_memref_node(memref_node):
             raise ParserTypeError(
@@ -375,6 +399,7 @@ class TypeResolver:
             "Tensor": self._resolve_tensor_type,
             "Tile": self._resolve_tile_type,
             "Scalar": self._resolve_scalar_type,
+            "Tuple": self._resolve_tuple_call_type,
         }
         resolver = resolvers.get(type_name) if type_name is not None else None
         if resolver is not None:
@@ -451,6 +476,24 @@ class TypeResolver:
         # Create ScalarType
         return ir.ScalarType(dtype)
 
+    def _resolve_tuple_call_type(self, call_node: ast.Call) -> ir.TupleType:
+        """Resolve pl.Tuple([type1, type2, ...]) annotation to ir.TupleType."""
+        if len(call_node.args) != 1 or not isinstance(call_node.args[0], ast.List):
+            raise ParserTypeError(
+                f"Tuple type requires a list of types, got: {ast.unparse(call_node)}",
+                hint="Use pl.Tuple([pl.Tensor[...], pl.Tile[...], ...]) format",
+            )
+        types = []
+        for elt in call_node.args[0].elts:
+            resolved = self.resolve_type(elt)
+            if isinstance(resolved, list):
+                raise ParserTypeError(
+                    "Nested tuple types are not supported",
+                    hint="Use a flat list of types in pl.Tuple([...])",
+                )
+            types.append(resolved)
+        return ir.TupleType(types)
+
     def _parse_shape(self, shape_node: ast.expr) -> list[int | ir.Expr]:
         """Parse shape from AST node.
 
@@ -516,7 +559,10 @@ class TypeResolver:
             if isinstance(elem, int):
                 dims.append(elem)
             elif isinstance(elem, DynVar):
-                dims.append(self.expr_evaluator.get_or_create_dynvar(elem, span))
+                name = elem.name
+                if name not in self._dyn_var_cache:
+                    self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
+                dims.append(self._dyn_var_cache[name])
             else:
                 raise ParserTypeError(
                     f"Shape '{source_name}' element {i} must be int or pl.dynamic(), "
@@ -539,7 +585,10 @@ class TypeResolver:
         if isinstance(value, int):
             return value
         if isinstance(value, DynVar):
-            return self.expr_evaluator.get_or_create_dynvar(value, span)
+            name = value.name
+            if name not in self._dyn_var_cache:
+                self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
+            return self._dyn_var_cache[name]
         raise ParserTypeError(
             f"Shape variable '{source_name}' must be int or pl.dynamic(), got {type(value).__name__}",
             span=span,
@@ -854,20 +903,225 @@ class TypeResolver:
         third: ast.expr,
         fourth: ast.expr,
     ) -> "ir.TileType":
-        """Resolve a 4-arg Tile: [shape, dtype, memref, memory_space]."""
+        """Resolve a 4-arg Tile: [shape, dtype, memref, memory_space] or [shape, dtype, memref, tileview]."""
         if not self._is_memref_node(third):
             raise ParserTypeError(
                 "Tile 3rd argument must be pl.MemRef(...) when 4 arguments are provided",
                 hint="Use pl.Tile[[shape], dtype, pl.MemRef(...), pl.MemorySpace.Vec]",
             )
+        memref = self.resolve_memref(third)
+        # Support [shape, dtype, memref, tileview] format from printer
+        if self._is_tileview_node(fourth):
+            tile_view = self._resolve_tileview(fourth, shape)
+            return ir.TileType(shape, dtype, memref, tile_view)
         if not self._is_memory_space_node(fourth):
             raise ParserTypeError(
-                "Tile 4th argument must be pl.MemorySpace.<space>",
+                "Tile 4th argument must be pl.MemorySpace.<space> or pl.TileView(...)",
                 hint="Use pl.Tile[[shape], dtype, pl.MemRef(...), pl.MemorySpace.Vec]",
             )
-        memref = self.resolve_memref(third)
         target_memory = self._resolve_memory_space(fourth)
         return ir.TileType(shape, dtype, memref, None, target_memory)
+
+    def _is_tensorview_node(self, node: ast.expr) -> bool:
+        """Check if an AST node is a pl.TensorView(...) call."""
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        return (isinstance(func, ast.Attribute) and func.attr == "TensorView") or (
+            isinstance(func, ast.Name) and func.id == "TensorView"
+        )
+
+    def _resolve_tensorview(self, node: ast.expr) -> "ir.TensorView":
+        """Resolve a pl.TensorView(...) AST call to ir.TensorView.
+
+        Args:
+            node: AST Call node for pl.TensorView(...)
+
+        Returns:
+            ir.TensorView instance
+
+        Raises:
+            ParserTypeError: If the TensorView call is malformed
+        """
+        if not isinstance(node, ast.Call):
+            raise ParserTypeError(
+                f"Expected pl.TensorView(...) call, got: {ast.unparse(node)}",
+                hint="Use pl.TensorView(valid_shape=[...], stride=[...], layout=pl.TensorLayout.NZ)",
+            )
+        if node.args:
+            raise ParserTypeError(
+                f"pl.TensorView() does not accept positional arguments, got: {ast.unparse(node)}",
+                hint="Use keyword arguments: pl.TensorView(stride=[...], layout=pl.TensorLayout.NZ)",
+            )
+        tv = ir.TensorView()
+        for kw in node.keywords:
+            if kw.arg == "valid_shape":
+                tv.valid_shape = self._parse_tileview_expr_list(kw.value)
+            elif kw.arg == "stride":
+                tv.stride = self._parse_tileview_expr_list(kw.value)
+            elif kw.arg == "layout":
+                tv.layout = self.resolve_layout(kw.value)
+            else:
+                raise ParserTypeError(
+                    f"Unknown TensorView keyword argument: {kw.arg!r}",
+                    hint="Supported: valid_shape, stride, layout",
+                )
+        return tv
+
+    def _is_tileview_node(self, node: ast.expr) -> bool:
+        """Check if an AST node is a pl.TileView(...) call."""
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        return (isinstance(func, ast.Attribute) and func.attr == "TileView") or (
+            isinstance(func, ast.Name) and func.id == "TileView"
+        )
+
+    def _resolve_tileview(  # noqa: PLR0912
+        self, node: ast.expr, tile_shape: "Sequence[int | ir.Expr] | None" = None
+    ) -> "ir.TileView":
+        """Resolve a pl.TileView(...) AST call to ir.TileView.
+
+        Args:
+            node: AST Call node for pl.TileView(...)
+            tile_shape: Optional tile shape to use as default valid_shape when not explicit.
+
+        Returns:
+            ir.TileView instance
+
+        Raises:
+            ParserTypeError: If the TileView call is malformed
+        """
+        if not isinstance(node, ast.Call):
+            raise ParserTypeError(
+                f"Expected pl.TileView(...) call, got: {ast.unparse(node)}",
+                hint="Use pl.TileView(valid_shape=[...], stride=[...], ...)",
+            )
+        if node.args:
+            raise ParserTypeError(
+                f"pl.TileView() does not accept positional arguments, got: {ast.unparse(node)}",
+                hint="Use keyword arguments: pl.TileView(valid_shape=[...], stride=[...], ...)",
+            )
+        tv = ir.TileView()
+        has_explicit_valid_shape = False
+        for kw in node.keywords:
+            if kw.arg == "valid_shape":
+                tv.valid_shape = self._parse_tileview_expr_list(kw.value)
+                has_explicit_valid_shape = True
+            elif kw.arg == "stride":
+                tv.stride = self._parse_tileview_expr_list(kw.value)
+            elif kw.arg == "start_offset":
+                tv.start_offset = self._parse_tileview_expr(kw.value)
+            elif kw.arg == "blayout":
+                tv.blayout = self._resolve_tilelayout(kw.value)
+            elif kw.arg == "slayout":
+                tv.slayout = self._resolve_tilelayout(kw.value)
+            elif kw.arg == "fractal":
+                val = self._try_resolve_int(kw.value)
+                if val is None:
+                    raise ParserTypeError(
+                        f"TileView fractal must be an integer, got: {ast.unparse(kw.value)}",
+                    )
+                tv.fractal = val
+            elif kw.arg == "pad":
+                tv.pad = self._resolve_tilepad(kw.value)
+            else:
+                raise ParserTypeError(
+                    f"Unknown TileView keyword argument: {kw.arg!r}",
+                    hint="Supported: valid_shape, stride, start_offset, blayout, slayout, fractal, pad",
+                )
+        # If valid_shape was not explicitly given, inherit from tile_shape so roundtrip is stable
+        if not has_explicit_valid_shape and tile_shape is not None:
+            tv.valid_shape = self._tile_shape_to_expr_list(tile_shape)
+        return tv
+
+    def _tile_shape_to_expr_list(self, shape: "Sequence[int | ir.Expr]") -> "list[ir.Expr]":
+        """Convert a tile shape (list of int or Expr) to a list of Expr for TileView.valid_shape."""
+        result = []
+        for dim in shape:
+            if isinstance(dim, int):
+                result.append(ir.ConstInt(dim, DataType.INDEX, ir.Span.unknown()))
+            else:
+                result.append(dim)
+        return result
+
+    def _parse_tileview_expr_list(self, node: ast.expr) -> list["ir.Expr"]:
+        """Parse a list literal of integer expressions for TileView fields."""
+        if not isinstance(node, ast.List):
+            raise ParserTypeError(
+                f"Expected a list, got: {ast.unparse(node)}",
+                hint="Use a list like [64, 32]",
+            )
+        return [self._parse_tileview_expr(elt) for elt in node.elts]
+
+    def _parse_tileview_expr(self, node: ast.expr) -> "ir.Expr":
+        """Parse a single expression for a TileView field."""
+        val = self._try_resolve_int(node)
+        if val is not None:
+            return ir.ConstInt(val, DataType.INDEX, self._get_span(node))
+        if isinstance(node, ast.Name):
+            name = node.id
+            # 1. Check parser scope first (IR variables from function body)
+            if self.scope_lookup:
+                var = self.scope_lookup(name)
+                if var is not None:
+                    return var
+            # 2. Check closure variables (DynVar or int from Python scope)
+            if name in self.expr_evaluator.closure_vars:
+                value = self.expr_evaluator.closure_vars[name]
+                if isinstance(value, DynVar):
+                    if value.name not in self._dyn_var_cache:
+                        self._dyn_var_cache[value.name] = ir.Var(
+                            value.name, ir.ScalarType(DataType.INDEX), self._get_span(node)
+                        )
+                    return self._dyn_var_cache[value.name]
+                if isinstance(value, int):
+                    return ir.ConstInt(value, DataType.INDEX, self._get_span(node))
+                raise ParserTypeError(
+                    f"TileView dimension {name!r} is bound to {type(value).__name__}, expected DynVar or int",
+                    hint="Use pl.dynamic() or an integer for TileView dimension variables",
+                )
+            # Auto-create a dynamic variable for unknown names to support roundtrip with dynamic shapes.
+            # When re-parsing printed IR, dynamic vars like M, N are defined as pl.dynamic() at module
+            # scope but may not be captured in closure_vars from the decorator frame.
+            if name not in self._dyn_var_cache:
+                self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), self._get_span(node))
+            return self._dyn_var_cache[name]
+        raise ParserTypeError(
+            f"TileView expression must be an integer constant, got: {ast.unparse(node)}",
+            hint="Use an integer literal for TileView fields",
+        )
+
+    def _resolve_tilelayout(self, node: ast.expr) -> "ir.TileLayout":
+        """Resolve pl.TileLayout.xxx to ir.TileLayout."""
+        _TILELAYOUT_MAP = {
+            "none_box": ir.TileLayout.none_box,
+            "row_major": ir.TileLayout.row_major,
+            "col_major": ir.TileLayout.col_major,
+        }
+        if isinstance(node, ast.Attribute):
+            if node.attr in _TILELAYOUT_MAP:
+                return _TILELAYOUT_MAP[node.attr]
+        raise ParserTypeError(
+            f"Unknown TileLayout value: {ast.unparse(node)}",
+            hint="Use pl.TileLayout.none_box, pl.TileLayout.row_major, or pl.TileLayout.col_major",
+        )
+
+    def _resolve_tilepad(self, node: ast.expr) -> "ir.TilePad":
+        """Resolve pl.TilePad.xxx to ir.TilePad."""
+        _TILEPAD_MAP = {
+            "null": ir.TilePad.null,
+            "zero": ir.TilePad.zero,
+            "max": ir.TilePad.max,
+            "min": ir.TilePad.min,
+        }
+        if isinstance(node, ast.Attribute):
+            if node.attr in _TILEPAD_MAP:
+                return _TILEPAD_MAP[node.attr]
+        raise ParserTypeError(
+            f"Unknown TilePad value: {ast.unparse(node)}",
+            hint="Use pl.TilePad.null, pl.TilePad.zero, pl.TilePad.max, or pl.TilePad.min",
+        )
 
     def _is_memref_node(self, node: ast.expr) -> bool:
         """Check if an AST node is a pl.MemRef(...) call."""

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -23,6 +23,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -239,10 +240,21 @@ class IRPythonPrinter : public IRVisitor {
   bool concise_;                          // When true, omit intermediate type annotations
   ProgramPtr current_program_ = nullptr;  // Track when printing within Program (for self.method() calls)
 
+  // Per-function rename map: Var pointer → unique printed name.
+  // Built by BuildVarRenameMap() at the start of each function to handle SSA name shadowing.
+  std::unordered_map<const Var*, std::string> var_rename_map_;
+
   // Helper methods
   std::string GetIndent() const;
   void IncreaseIndent();
   void DecreaseIndent();
+
+  // Return the printed name for a Var, using rename map if SSA name shadowing occurred.
+  std::string GetVarName(const Var* var) const;
+
+  // Build var_rename_map_ for a function by scanning all Var def-sites in DFS pre-order.
+  // Assigns unique suffixed names (e.g., "i", "i_1") when two distinct Vars share a name.
+  void BuildVarRenameMap(const FunctionPtr& func);
 
   // Print a statement block at current indent level.
   // SeqStmts/OpStmts are transparent containers - recursed into without extra indent.
@@ -250,7 +262,8 @@ class IRPythonPrinter : public IRVisitor {
 
   // Statement body visitor with SSA-style handling
   void VisitStmtBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars = {});
-  void PrintYieldAssignmentVars(const std::vector<VarPtr>& return_vars);
+  void PrintYieldAssignmentVars(const std::vector<VarPtr>& return_vars,
+                                const TypePtr& override_type = nullptr);
 
   // Binary/unary operator helpers (reuse precedence logic)
   void PrintBinaryOp(const BinaryExprPtr& op, const char* op_symbol);
@@ -321,11 +334,15 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
     PrintShapeDims(oss, tensor_type->shape_);
     oss << "], " << prefix_ << "." << DataTypeToString(tensor_type->dtype_);
 
-    // Add optional tensor_view parameter if present and has non-default fields
+    // Add optional tensor_view parameter if present.
+    // Always emit something when tensor_view is set so that print->parse roundtrip
+    // preserves presence: structural equality distinguishes present vs absent.
     if (tensor_type->tensor_view_.has_value()) {
       auto tv_str = PrintTensorView(tensor_type->tensor_view_.value(), tensor_type->shape_);
       if (!tv_str.empty()) {
-        oss << ", tensor_view=" << tv_str;
+        oss << ", " << tv_str;
+      } else {
+        oss << ", " << prefix_ << ".TensorView()";
       }
     }
 
@@ -356,12 +373,15 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
       oss << ", " << prefix_ << ".MemorySpace." << mem_str;
     }
 
-    // Add optional tile_view parameter if present and has non-default fields
+    // Add optional tile_view parameter if present and non-trivial.
+    // A trivial tile_view (valid_shape==shape, all other defaults) is omitted since
+    // structural_equal treats it as equivalent to no tile_view.
     if (tile_type->tile_view_.has_value()) {
       auto tv_str = PrintTileView(tile_type->tile_view_.value(), tile_type->shape_);
       if (!tv_str.empty()) {
-        oss << ", tile_view=" << tv_str;
+        oss << ", " << tv_str;
       }
+      // When all TileView fields are at defaults, omit entirely.
     }
 
     oss << "]";
@@ -399,7 +419,7 @@ void IRPythonPrinter::DecreaseIndent() {
 }
 
 // Expression visitors - reuse precedence logic from base printer
-void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << op->name_; }
+void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << GetVarName(op.get()); }
 
 void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << op->name_; }
 
@@ -453,6 +473,14 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   // and are printed in parseable format like "pl.tensor.adds"
   std::string op_name = op->op_->name_;
 
+  // Normalize tensor.add with scalar rhs to tensor.adds (matches Python API dispatch)
+  if (op_name == "tensor.add" && op->args_.size() == 2) {
+    if (std::dynamic_pointer_cast<const ConstFloat>(op->args_[1]) ||
+        std::dynamic_pointer_cast<const ConstInt>(op->args_[1])) {
+      op_name = "tensor.adds";
+    }
+  }
+
   // Check if this is a registered operation (contains a dot)
   if (op_name.find('.') != std::string::npos) {
     // Print with pl. prefix
@@ -460,6 +488,41 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   } else {
     // Not a registered operation, print as-is
     stream_ << op_name << "(";
+  }
+
+  // Special handling for tile.full: print as keyword args to match Python API
+  // IR stores: args_=[shape, value_expr], kwargs_={"dtype": dtype}
+  // Python API: full(shape, dtype, value) — print as full(shape, dtype=.., value=..)
+  // because pl.FP32 as positional is rejected by the parser (standalone attribute access)
+  if (op->op_->name_ == "tile.full" && op->args_.size() >= 2) {
+    VisitExpr(op->args_[0]);  // shape (positional)
+    for (const auto& [key, val] : op->kwargs_) {
+      if (key == "dtype") {
+        stream_ << ", dtype=" << prefix_ << "."
+                << DataTypeToString(AnyCast<DataType>(val, "tile.full dtype"));
+        break;
+      }
+    }
+    stream_ << ", value=";
+    VisitExpr(op->args_[1]);  // value (as keyword)
+    stream_ << ")";
+    return;
+  }
+
+  // Special handling for tile.load: always print full form to ensure roundtrip stability.
+  // IR built directly via ir.Call may have only 3 positional args (tensor, offsets, shapes)
+  // but the Python API pl.tile.load() defaults valid_shapes=shapes, target_memory=Vec,
+  // transpose=False — after reparsing those defaults are filled in, causing mismatch.
+  if (op->op_->name_ == "tile.load" && op->args_.size() == 3 && op->kwargs_.empty()) {
+    VisitExpr(op->args_[0]);  // source tensor
+    stream_ << ", ";
+    VisitExpr(op->args_[1]);  // offsets
+    stream_ << ", ";
+    VisitExpr(op->args_[2]);  // shapes
+    stream_ << ", ";
+    VisitExpr(op->args_[2]);  // valid_shapes = shapes (default)
+    stream_ << ", target_memory=" << prefix_ << ".MemorySpace.Vec, transpose=False)";
+    return;
   }
 
   // Print positional arguments
@@ -726,7 +789,7 @@ void IRPythonPrinter::VisitStmt_(const ReturnStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
   // SSA-style for with pl.range() or pl.parallel() - no inline type annotations in unpacking
-  stream_ << "for " << op->loop_var_->name_;
+  stream_ << "for " << GetVarName(op->loop_var_.get());
 
   // If we have iter_args, add tuple unpacking without type annotations
   if (!op->iter_args_.empty()) {
@@ -933,19 +996,21 @@ void IRPythonPrinter::VisitStmt_(const ContinueStmtPtr& op) { stream_ << "contin
 
 void IRPythonPrinter::VisitStmt_(const StmtPtr& op) { stream_ << op->TypeName(); }
 
-void IRPythonPrinter::PrintYieldAssignmentVars(const std::vector<VarPtr>& return_vars) {
+void IRPythonPrinter::PrintYieldAssignmentVars(const std::vector<VarPtr>& return_vars,
+                                               const TypePtr& override_type) {
   // Helper to print left-hand side of yield assignment
   // For single variable: print with type annotation (var: type)
   // For multiple variables: print without type annotations (var1, var2)
   if (return_vars.size() == 1) {
-    stream_ << return_vars[0]->name_;
+    stream_ << GetVarName(return_vars[0].get());
     if (!concise_) {
-      stream_ << ": " << Print(return_vars[0]->GetType());
+      auto type = override_type ? override_type : return_vars[0]->GetType();
+      stream_ << ": " << Print(type);
     }
   } else {
     for (size_t i = 0; i < return_vars.size(); ++i) {
       if (i > 0) stream_ << ", ";
-      stream_ << return_vars[i]->name_;
+      stream_ << GetVarName(return_vars[i].get());
     }
   }
 }
@@ -956,7 +1021,8 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
     // If parent has return_vars, wrap yield as assignment
     if (!yield_stmt->value_.empty() && !return_vars.empty()) {
       stream_ << GetIndent();
-      PrintYieldAssignmentVars(return_vars);
+      PrintYieldAssignmentVars(return_vars,
+                               yield_stmt->value_.size() == 1 ? yield_stmt->value_[0]->GetType() : nullptr);
       stream_ << " = " << prefix_ << ".yield_(";
       for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {
         if (i > 0) stream_ << ", ";
@@ -978,7 +1044,8 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
         if (is_last && !yield_stmt->value_.empty() && !return_vars.empty()) {
           // Wrap as assignment
           stream_ << GetIndent();
-          PrintYieldAssignmentVars(return_vars);
+          PrintYieldAssignmentVars(
+              return_vars, yield_stmt->value_.size() == 1 ? yield_stmt->value_[0]->GetType() : nullptr);
           stream_ << " = " << prefix_ << ".yield_(";
           for (size_t j = 0; j < yield_stmt->value_.size(); ++j) {
             if (j > 0) stream_ << ", ";
@@ -1002,7 +1069,93 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
   }
 }
 
+// Collect all Var definition sites in DFS pre-order for SSA rename map construction.
+static void CollectVarDefsInOrder(const StmtPtr& stmt, std::vector<const Var*>& out) {
+  if (!stmt) return;
+  if (auto assign = As<AssignStmt>(stmt)) {
+    out.push_back(assign->var_.get());
+  } else if (auto for_stmt = As<ForStmt>(stmt)) {
+    out.push_back(for_stmt->loop_var_.get());
+    for (auto& rv : for_stmt->return_vars_) out.push_back(rv.get());
+    for (auto& ia : for_stmt->iter_args_) out.push_back(ia.get());
+    CollectVarDefsInOrder(for_stmt->body_, out);
+  } else if (auto if_stmt = As<IfStmt>(stmt)) {
+    for (auto& rv : if_stmt->return_vars_) out.push_back(rv.get());
+    CollectVarDefsInOrder(if_stmt->then_body_, out);
+    if (if_stmt->else_body_.has_value()) CollectVarDefsInOrder(*if_stmt->else_body_, out);
+  } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+    for (auto& rv : while_stmt->return_vars_) out.push_back(rv.get());
+    CollectVarDefsInOrder(while_stmt->body_, out);
+  } else if (auto seq = As<SeqStmts>(stmt)) {
+    for (auto& s : seq->stmts_) CollectVarDefsInOrder(s, out);
+  } else if (auto ops = As<OpStmts>(stmt)) {
+    for (auto& s : ops->stmts_) CollectVarDefsInOrder(s, out);
+  } else if (auto scope = As<ScopeStmt>(stmt)) {
+    CollectVarDefsInOrder(scope->body_, out);
+  }
+}
+
+std::string IRPythonPrinter::GetVarName(const Var* var) const {
+  auto it = var_rename_map_.find(var);
+  if (it != var_rename_map_.end()) return it->second;
+  return var->name_;
+}
+
+void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
+  var_rename_map_.clear();
+
+  // Collect all Var def-sites in DFS pre-order: params first, then body.
+  std::vector<const Var*> defs;
+  for (auto& p : func->params_) defs.push_back(p.get());
+  if (func->body_) CollectVarDefsInOrder(func->body_, defs);
+
+  // Deduplicate by pointer (same Var object may appear as both param and assign target).
+  {
+    std::unordered_set<const Var*> seen;
+    std::vector<const Var*> unique_defs;
+    for (const Var* v : defs) {
+      if (seen.insert(v).second) unique_defs.push_back(v);
+    }
+    defs = std::move(unique_defs);
+  }
+
+  // Count occurrences of each name across distinct Var objects.
+  std::unordered_map<std::string, int> name_counts;
+  for (const Var* v : defs) name_counts[v->name_]++;
+
+  // Assign printed names: unique names keep their original; duplicate names get suffixes.
+  std::set<std::string> used_names;
+  for (const Var* v : defs) {
+    if (name_counts[v->name_] == 1) {
+      // No conflict — no rename map entry needed (GetVarName falls back to name_).
+      used_names.insert(v->name_);
+    }
+  }
+  for (const Var* v : defs) {
+    if (name_counts[v->name_] == 1) continue;  // Already handled above.
+    std::string candidate = v->name_;
+    if (used_names.find(candidate) == used_names.end()) {
+      used_names.insert(candidate);
+      var_rename_map_[v] = candidate;
+    } else {
+      int suffix = 1;
+      while (true) {
+        candidate = v->name_ + "_" + std::to_string(suffix);
+        if (used_names.find(candidate) == used_names.end()) {
+          used_names.insert(candidate);
+          var_rename_map_[v] = candidate;
+          break;
+        }
+        suffix++;
+      }
+    }
+  }
+}
+
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
+  // Build rename map for this function to handle SSA name shadowing.
+  BuildVarRenameMap(func);
+
   // Print decorator
   stream_ << GetIndent() << "@" << prefix_ << ".function";
   if (func->func_type_ != FunctionType::Opaque) {
@@ -1023,7 +1176,7 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
     if (i > 0 || current_program_) stream_ << ", ";
     const auto& var = func->params_[i];
     const auto& dir = func->param_directions_[i];
-    stream_ << var->name_ << ": ";
+    stream_ << GetVarName(var.get()) << ": ";
     if (dir == ParamDirection::InOut) {
       stream_ << prefix_ << ".InOut[" << Print(var->GetType()) << "]";
     } else if (dir == ParamDirection::Out) {
@@ -1169,6 +1322,75 @@ static std::vector<std::pair<GlobalVarPtr, FunctionPtr>> TopologicalSortFunction
   return sorted;
 }
 
+static std::set<std::string> CollectDynVarNames(const ProgramPtr& program) {
+  std::set<std::string> dyn_vars;
+  std::function<void(const TypePtr&)> collect_from_type = [&](const TypePtr& type) {
+    if (auto tensor_type = As<TensorType>(type)) {
+      for (const auto& dim : tensor_type->shape_) {
+        if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+      }
+      if (tensor_type->tensor_view_.has_value()) {
+        for (const auto& dim : tensor_type->tensor_view_->valid_shape) {
+          if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+        }
+        for (const auto& dim : tensor_type->tensor_view_->stride) {
+          if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+        }
+      }
+    } else if (auto tile_type = As<TileType>(type)) {
+      for (const auto& dim : tile_type->shape_) {
+        if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+      }
+      if (tile_type->tile_view_.has_value()) {
+        for (const auto& dim : tile_type->tile_view_->valid_shape) {
+          if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+        }
+        for (const auto& dim : tile_type->tile_view_->stride) {
+          if (auto var = As<Var>(dim)) dyn_vars.insert(var->name_);
+        }
+        if (tile_type->tile_view_->start_offset) {
+          if (auto var = As<Var>(tile_type->tile_view_->start_offset)) {
+            dyn_vars.insert(var->name_);
+          }
+        }
+      }
+    }
+  };
+  // Use a full IRVisitor so that dynamic-dimension Var names are found in every
+  // expression context: loop bounds (ForStmt start/stop/step/chunk_size),
+  // if/while conditions, EvalStmt expressions, AssignStmt values, etc.
+  // The ad-hoc collect_from_stmt only inspected AssignStmt variable types and
+  // missed all those other locations.
+  class DynVarCollector : public IRVisitor {
+   public:
+    explicit DynVarCollector(const std::function<void(const TypePtr&)>& collect_from_type)
+        : collect_from_type_(collect_from_type) {}
+
+    void VisitExpr_(const VarPtr& op) override {
+      // Collect dynamic dimension names from the variable's type annotation.
+      // Handles TensorType/TileType shapes and their tensor_view_/tile_view_ fields.
+      collect_from_type_(op->GetType());
+    }
+
+   private:
+    const std::function<void(const TypePtr&)>& collect_from_type_;
+  };
+
+  DynVarCollector collector(collect_from_type);
+  for (const auto& [gvar, func] : program->functions_) {
+    for (const auto& param : func->params_) {
+      collector.VisitExpr(param);
+    }
+    for (const auto& ret_type : func->return_types_) {
+      collect_from_type(ret_type);
+    }
+    if (func->body_) {
+      collector.VisitStmt(func->body_);
+    }
+  }
+  return dyn_vars;
+}
+
 void IRPythonPrinter::VisitProgram(const ProgramPtr& program) {
   // Print program header comment
   stream_ << "# pypto.program: " << (program->name_.empty() ? "Program" : program->name_) << "\n";
@@ -1178,6 +1400,15 @@ void IRPythonPrinter::VisitProgram(const ProgramPtr& program) {
     stream_ << "import pypto.language as pl\n\n";
   } else {
     stream_ << "from pypto import language as " << prefix_ << "\n\n";
+  }
+
+  // Emit pl.dynamic() declarations for dynamic shape variables used in function signatures
+  auto dyn_vars = CollectDynVarNames(program);
+  if (!dyn_vars.empty()) {
+    for (const auto& name : dyn_vars) {
+      stream_ << name << " = " << prefix_ << ".dynamic(\"" << name << "\")\n";
+    }
+    stream_ << "\n";
   }
 
   // Print as @pl.program class with @pl.function methods
@@ -1400,26 +1631,27 @@ std::string IRPythonPrinter::PrintTensorView(const TensorView& tensor_view,
     oss << "]";
   }
 
-  // stride — omit if empty
-  if (!tensor_view.stride.empty()) {
-    maybe_comma();
-    oss << "stride=[";
-    for (size_t i = 0; i < tensor_view.stride.size(); ++i) {
-      if (i > 0) oss << ", ";
-      IRPythonPrinter temp_printer(prefix_);
-      oss << temp_printer.Print(tensor_view.stride[i]);
-    }
-    oss << "]";
-  }
+  bool has_stride = !tensor_view.stride.empty();
+  bool has_non_default_layout = (tensor_view.layout != TensorLayout::ND);
 
-  // layout — omit if ND (default)
-  if (tensor_view.layout != TensorLayout::ND) {
-    maybe_comma();
-    oss << "layout=" << prefix_ << ".TensorLayout." << TensorLayoutToString(tensor_view.layout);
-  }
+  // If valid_shape matched and stride/layout are at defaults, skip TensorView entirely
+  if (first && !has_stride && !has_non_default_layout) return "";
 
-  // If all fields were at defaults, return empty string to skip tensor_view entirely
-  if (first) return "";
+  // When TensorView is non-trivial, always emit both stride and layout to satisfy
+  // the C++ constructor signature TensorView(stride, layout, valid_shape=[]).
+  // Omitting either required arg causes TypeError when Python eagerly evaluates
+  // function parameter annotations during exec() in the text parser.
+  maybe_comma();
+  oss << "stride=[";
+  for (size_t i = 0; i < tensor_view.stride.size(); ++i) {
+    if (i > 0) oss << ", ";
+    IRPythonPrinter temp_printer(prefix_);
+    oss << temp_printer.Print(tensor_view.stride[i]);
+  }
+  oss << "]";
+
+  maybe_comma();
+  oss << "layout=" << prefix_ << ".TensorLayout." << TensorLayoutToString(tensor_view.layout);
 
   oss << ")";
   return oss.str();

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -1111,7 +1111,7 @@ class TestPythonSyntaxPrinting:
         assert "pl.MemorySpace.Left" in printed
         assert "8192" in printed  # 0x2000 in decimal
         assert "512" in printed  # size
-        assert "tile_view=" in printed
+        # TileView is now a positional arg in subscript (fixes #323), not keyword
         assert "pl.TileView" in printed
         # valid_shape matches tile shape [16, 16] — should be omitted
         assert "valid_shape=" not in printed
@@ -1274,10 +1274,10 @@ class TestPythonSyntaxPrinting:
 
         assert "pl.Tensor" in printed
         assert "pl.FP16" in printed
-        # MemRef prints as positional (no keyword), tensor_view as keyword
+        # MemRef and TensorView both print as positional args (fixes #323)
         assert "memref=" not in printed
         assert "pl.MemRef" in printed
-        assert "tensor_view=" in printed
+        # tensor_view is now positional, not keyword in subscript
         assert "pl.TensorView" in printed
         assert "pl.TensorLayout.NZ" in printed
 
@@ -1380,7 +1380,7 @@ class TestIRBuilderHelpers:
         assert "memref=" not in printed
         assert "pl.MemRef" in printed
         assert "pl.MemorySpace.Right" in printed
-        assert "tile_view=pl.TileView" in printed
+        assert "pl.TileView" in printed  # positional arg (fixes #323)
 
 
 class TestTensorLayout:
@@ -1693,8 +1693,8 @@ class TestMemRefRoundTrip:
         printed = program.as_python()
         assert "pl.MemRef" in printed
         assert "pl.MemorySpace.DDR" in printed
-        # Layout should appear as tensor_view
-        assert "tensor_view=" in printed
+        # Layout appears as positional TensorView arg (fixes #323)
+        assert "pl.TensorView" in printed
 
     def test_roundtrip_tile_memref(self):
         """Parse → print → parse → assert_structural_equal for tile with memref."""

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -9,9 +9,14 @@
 
 """Unit tests for Python IR printer."""
 
+import ast
+
 import pypto.language as pl
 import pytest
-from pypto import DataType, ir
+from pypto import DataType, ir, passes
+from pypto.ir.printer import python_print
+from pypto.language.parser.expr_evaluator import ExprEvaluator
+from pypto.language.parser.type_resolver import TypeResolver
 
 
 class TestPythonPrinterProgram:
@@ -267,3 +272,110 @@ class TestPythonPrinterConstDtypeRoundtrip:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestTileViewTensorViewPrinting:
+    """Printer output fix for Python 3.10 keyword subscript syntax (Fix #323)."""
+
+    def test_tiletype_with_tileview_no_keyword_subscript(self):
+        span = ir.Span.unknown()
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(32, DataType.INT64, span)]
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        tile_type = ir.TileType([64], DataType.FP32, memref=memref, tile_view=tile_view)
+
+        printed = ir.python_print_type(tile_type)
+
+        assert "tile_view=" not in printed  # must not use keyword subscript syntax
+        assert "pl.TileView(" in printed  # must be emitted as a positional call
+
+    def test_printed_type_is_valid_python_syntax(self):
+        span = ir.Span.unknown()
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(32, DataType.INT64, span)]
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        tile_type = ir.TileType([64], DataType.FP32, memref=memref, tile_view=tile_view)
+
+        printed = "import pypto.language as pl\nresult = " + ir.python_print_type(tile_type)
+        compile(printed, "<string>", "exec")  # must not raise SyntaxError
+
+    def test_tensorview_always_emitted_when_present(self):
+        tensor_view = ir.TensorView()  # all-default fields
+        tensor_type = ir.TensorType([64], DataType.FP32, tensor_view=tensor_view)
+
+        printed = ir.python_print_type(tensor_type)
+        assert "pl.TensorView()" in printed  # all-default fields must still be emitted
+
+    def test_tileview_tensorview_parseable_by_type_resolver(self):
+        span = ir.Span.unknown()
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(32, DataType.INT64, span)]
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        original = ir.TileType([64], DataType.FP32, memref=memref, tile_view=tile_view)
+
+        printed = ir.python_print_type(original)
+        node = ast.parse(printed, mode="eval").body
+        resolver = TypeResolver(expr_evaluator=ExprEvaluator(closure_vars={}))
+        reparsed = resolver.resolve_type(node)
+
+        assert isinstance(reparsed, ir.TileType)
+        assert reparsed.tile_view is not None
+
+
+class TestDynVarAndSSARename:
+    """dyn var collection and SSA var deduplication in printer."""
+
+    def test_dyn_var_declared_in_header(self):
+        N = pl.dynamic("N")
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(self, x: pl.Tensor[[N], pl.FP32]) -> pl.Tensor[[N], pl.FP32]:
+                return x
+
+        src = Prog.as_python()
+        assert 'N = pl.dynamic("N")' in src
+
+    def test_ssa_shadowed_vars_get_unique_names(self):
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.range(4):
+                    x = pl.add(x, 1.0)
+                return x
+
+        after_ssa = passes.convert_to_ssa()(Prog)
+        src = python_print(after_ssa)
+        lhs_names = [
+            line.split(":")[0].strip() for line in src.splitlines() if ": pl." in line and "=" in line
+        ]
+        assert len(lhs_names) == len(set(lhs_names))
+
+
+class TestOpOutputNormalization:
+    """Op-specific printer output normalization."""
+
+    def test_tensor_add_scalar_prints_as_adds(self):
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return pl.add(x, 1.0)
+
+        src = python_print(Prog)
+        assert "pl.tensor.adds(" in src
+        assert "pl.tensor.add(" not in src
+
+    def test_tile_full_dtype_as_keyword(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tile[[64], pl.FP32]) -> pl.Tile[[64], pl.FP32]:
+                y: pl.Tile[[64], pl.FP32] = pl.tile.full([64], dtype=pl.FP32, value=0.0)
+                return y
+
+        src = python_print(Prog)
+        assert "dtype=pl.FP32" in src
+        assert "value=" in src

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -304,18 +304,17 @@ class TestPrinterRoundTrip:
 class TestParserErrors:
     """Tests for parser validation of chunk arguments."""
 
-    def test_chunk_with_init_values_error(self):
-        """chunk + init_values should raise parser error."""
-        with pytest.raises(Exception, match="chunk cannot be combined with init_values"):
+    def test_chunk_with_init_values_allowed(self):
+        """chunk + init_values should be allowed (not raise parser error)."""
 
-            @pl.program
-            class Bad:
-                @pl.function
-                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
-                        s = pl.add(s, 1.0)  # noqa: PLW2901
-                        s = pl.yield_(s)  # noqa: PLW2901
-                    return x
+        @pl.program
+        class Good:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
+                    s = pl.add(s, 1.0)  # noqa: PLW2901
+                    s = pl.yield_(s)  # noqa: PLW2901
+                return x
 
     def test_chunk_zero_error(self):
         """chunk=0 should raise parser error."""


### PR DESCRIPTION
## Summary

### Printer (`src/ir/transforms/python_printer.cpp`)
- Switch `TileView`/`TensorView` output from keyword-subscript form
  (`Tile[..., tile_view=...]`) to positional-call form (`pl.TileView(...)`)
  — PEP 637 keyword subscripts are invalid Python syntax on 3.10/3.11
- Always emit `pl.TensorView()` even for all-default fields so that
  structural presence is preserved through print-parse roundtrip
- Add `BuildVarRenameMap` to deduplicate SSA-shadowed `Var` names in
  DFS pre-order (e.g. two `Var`s both named `i` → `i` and `i_1`)
- Extend `CollectDynVarNames` to scan `TensorView.valid_shape`/`stride`
  and all function body statements so `pl.dynamic()` declarations are
  always emitted in the printed program header
- Normalize `tensor.add` with scalar RHS to `tensor.adds` to match
  Python API dispatch
- Print `tile.full` with `dtype=`/`value=` keyword args to avoid
  ambiguity between dtype enum and positional expression
- Always print `tile.load` in full 5-arg form to prevent default-filling
  mismatch on re-parse
- Use yield expression type for LHS annotation in
  `PrintYieldAssignmentVars` instead of `return_var` type

### Parser (`python/pypto/language/parser/`)
- `type_resolver.py`: Add `_is_tileview_node`, `_is_tensorview_node`,
  `_resolve_tileview`, `_resolve_tensorview` helpers to parse the new
  positional-call `TileView`/`TensorView` format; support
  `[shape, dtype, tileview]` and `[shape, dtype, tileview, memref]`
  subscript forms for roundtrip; add `_resolve_tuple_call_type` for
  `pl.Tuple([...])` annotations; add `_dyn_var_cache` to avoid creating
  duplicate `Var` objects for the same dynamic-shape name
- `text_parser.py`: Add `_AutoDynVar` dict subclass to exec namespace so
  body-level dyn vars referenced before declaration do not raise `NameError`
- `ast_parser.py`: Infer loop-var dtype from range bounds to preserve
  roundtrip fidelity; allow chunk loops to carry `init_values` (remove
  incorrect validation); defer `return_var` registration until after body
  parse to use actual yield LHS names; fold constant negation
  (`-ConstInt`/`-ConstFloat`) for roundtrip stability; handle bare
  `pl.yield_()` as `EvalStmt` without creating duplicate `YieldStmt`;
  parse `MemorySpace` enum attrs as `ConstInt`; preserve `TileType`/
  `TensorType` annotation with `tile_view`/`tensor_view` as override type

## Testing
- [x] Add `TestTileViewTensorViewPrinting`: verify no keyword subscript in
  output, printed type is valid Python syntax, `TensorView` always emitted,
  and `type_resolver` can re-parse the new format
- [x] Add `TestDynVarAndSSARename`: verify dyn var header declaration and
  SSA-shadowed vars get unique printed names
- [x] Add `TestOpOutputNormalization`: verify `tensor.add` with scalar RHS
  prints as `tensor.adds`, and `tile.full` emits `dtype=` keyword
- [x] All existing tests pass
- [x] Pre-commit hooks pass (clang-format, ruff, pyright)

Closes #323
