### PR TITLE
feat(pass): add ResolveTransposeLayout pass to auto-infer DN layout from transpose loads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
     src/ir/transforms/pass_context.cpp
     src/ir/transforms/passes.cpp
+    src/ir/transforms/resolve_transpose_layout_pass.cpp
     src/ir/transforms/python_printer.cpp
     src/ir/transforms/split_chunked_loops_pass.cpp
     src/ir/transforms/interchange_chunk_loops_pass.cpp

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -95,6 +95,14 @@ inline const PassProperties kInferTileMemorySpaceProperties{
     .required = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch},
     .produced = {IRProperty::SSAForm, IRProperty::TileMemoryInferred}};
 
+// -- Resolve transpose layout pass --------------------------------------------
+
+inline const PassProperties kResolveTransposeLayoutProperties{
+    .required = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch,
+                 IRProperty::TileOps2D},
+    .produced = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch,
+                 IRProperty::TileOps2D}};
+
 // -- Mixed kernel expansion pass ----------------------------------------------
 
 inline const PassProperties kExpandMixedKernelProperties{

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -267,6 +267,20 @@ Pass FlattenTileNdTo2D();
 Pass InferTileMemorySpace();
 
 /**
+ * @brief Resolve transpose layout for tile.load with transpose=True
+ *
+ * Detects tile.load(..., transpose=True) in InCore functions and transforms
+ * the source tensor parameter type from its physical shape (e.g. [N, K]) to
+ * the logical transposed shape with DN layout (e.g. [K, N] + DN).
+ * Propagates the type change to corresponding Orchestration function parameters.
+ *
+ * Requirements:
+ * - Input IR must have tile ops (run ConvertTensorToTileOps first)
+ * - Input IR must have InCore scopes outlined (run OutlineIncoreScopes first)
+ */
+Pass ResolveTransposeLayout();
+
+/**
  * @brief Expand mixed InCore functions into AIC + AIV + Group
  *
  * Splits InCore functions containing both Cube ops (tile.matmul) and Vector ops

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -231,6 +231,11 @@ void BindPass(nb::module_& m) {
              "E.g., tile [A, B, C] becomes [A*B, C]. Only converts 3D+ tiles.");
   passes.def("infer_tile_memory_space", &pass::InferTileMemorySpace,
              "Create a pass that infers memory_space for TileType variables in InCore functions");
+  passes.def("resolve_transpose_layout", &pass::ResolveTransposeLayout,
+             "Create a pass that resolves transpose layout for tile.load with transpose=True\n\n"
+             "Detects tile.load(..., transpose=True) in InCore functions and transforms\n"
+             "the source tensor parameter type to the logical transposed shape with DN layout.\n"
+             "Propagates the type change to corresponding Orchestration function parameters.");
   passes.def("expand_mixed_kernel", &pass::ExpandMixedKernel,
              "Create a pass that expands mixed InCore functions into AIC + AIV + Group");
   passes.def("flatten_call_expr", &pass::FlattenCallExpr,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -62,6 +62,7 @@ class PassManager:
                 ("ConvertTensorToTileOps", lambda: passes.convert_tensor_to_tile_ops()),
                 ("FlattenTileNdTo2D", lambda: passes.flatten_tile_nd_to_2d()),
                 ("InferTileMemorySpace", lambda: passes.infer_tile_memory_space()),
+                ("ResolveTransposeLayout", lambda: passes.resolve_transpose_layout()),
                 # TODO: Add ExpandMixedKernel here once codegen supports AIC/AIV/Group functions
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),
@@ -78,6 +79,7 @@ class PassManager:
                 ("ConvertTensorToTileOps", lambda: passes.convert_tensor_to_tile_ops()),
                 ("FlattenTileNdTo2D", lambda: passes.flatten_tile_nd_to_2d()),
                 ("InferTileMemorySpace", lambda: passes.infer_tile_memory_space()),
+                ("ResolveTransposeLayout", lambda: passes.resolve_transpose_layout()),
                 # TODO: Add ExpandMixedKernel here once codegen supports AIC/AIV/Group functions
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -252,6 +252,9 @@ def flatten_tile_nd_to_2d() -> Pass:
 def infer_tile_memory_space() -> Pass:
     """Create a pass that infers memory_space for TileType variables in InCore functions."""
 
+def resolve_transpose_layout() -> Pass:
+    """Create a pass that resolves transpose layout for tile.load with transpose=True."""
+
 def expand_mixed_kernel() -> Pass:
     """Create a pass that expands mixed InCore functions into AIC + AIV + Group."""
 

--- a/src/ir/transforms/resolve_transpose_layout_pass.cpp
+++ b/src/ir/transforms/resolve_transpose_layout_pass.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Phase 1 helpers: scan InCore functions for tile.load(..., transpose=True)
+// ---------------------------------------------------------------------------
+
+struct TransposeParamInfo {
+  size_t param_index;
+  std::vector<ExprPtr> new_shape;
+};
+
+/**
+ * Visitor that scans an InCore function body for tile.load calls with
+ * transpose=True whose source tensor is a function parameter.
+ */
+class TransposeLoadScanner : public IRVisitor {
+ public:
+  explicit TransposeLoadScanner(const std::vector<VarPtr>& params) {
+    for (size_t i = 0; i < params.size(); ++i) {
+      param_name_to_index_[params[i]->name_] = i;
+    }
+  }
+
+  const std::vector<TransposeParamInfo>& GetResults() const { return results_; }
+
+  void VisitExpr_(const CallPtr& call) override {
+    if (!call) return;
+
+    if (call->op_->name_ == "tile.load") {
+      bool transpose = call->GetKwarg<bool>("transpose", false);
+      if (transpose && !call->args_.empty()) {
+        auto src_var = As<Var>(call->args_[0]);
+        if (src_var) {
+          auto it = param_name_to_index_.find(src_var->name_);
+          if (it != param_name_to_index_.end()) {
+            size_t param_idx = it->second;
+            if (visited_params_.count(param_idx) == 0) {
+              visited_params_.insert(param_idx);
+
+              // args_[2] is the shapes tuple (MakeTuple)
+              CHECK(call->args_.size() >= 3) << "tile.load must have at least 3 positional args";
+              auto shapes_tuple = As<MakeTuple>(call->args_[2]);
+              CHECK(shapes_tuple) << "tile.load shapes arg must be a MakeTuple";
+              CHECK(shapes_tuple->elements_.size() == 2)
+                  << "transpose=true only supports 2D shapes, got " << shapes_tuple->elements_.size();
+
+              results_.push_back({param_idx, shapes_tuple->elements_});
+            }
+          }
+        }
+      }
+    }
+
+    IRVisitor::VisitExpr_(call);
+  }
+
+ private:
+  std::unordered_map<std::string, size_t> param_name_to_index_;
+  std::unordered_set<size_t> visited_params_;
+  std::vector<TransposeParamInfo> results_;
+};
+
+// ---------------------------------------------------------------------------
+// Var substitution mutator: replaces Var references by name
+// ---------------------------------------------------------------------------
+
+class VarSubstitutionMutator : public IRMutator {
+ public:
+  explicit VarSubstitutionMutator(std::unordered_map<std::string, VarPtr> substitutions)
+      : substitutions_(std::move(substitutions)) {}
+
+ protected:
+  ExprPtr VisitExpr_(const VarPtr& var) override {
+    auto it = substitutions_.find(var->name_);
+    if (it != substitutions_.end()) {
+      return it->second;
+    }
+    return var;
+  }
+
+ private:
+  std::unordered_map<std::string, VarPtr> substitutions_;
+};
+
+// ---------------------------------------------------------------------------
+// Phase 1: transform InCore function parameters
+// ---------------------------------------------------------------------------
+
+struct IncoreTransformResult {
+  FunctionPtr func;
+  // param_index -> new TensorType (for Phase 2 to propagate to callers)
+  std::unordered_map<size_t, std::shared_ptr<const TensorType>> modified_params;
+};
+
+IncoreTransformResult TransformIncoreParams(const FunctionPtr& func) {
+  TransposeLoadScanner scanner(func->params_);
+  scanner.VisitStmt(func->body_);
+
+  const auto& results = scanner.GetResults();
+  if (results.empty()) {
+    return {func, {}};
+  }
+
+  std::unordered_map<size_t, std::shared_ptr<const TensorType>> modified_params;
+  std::unordered_map<std::string, VarPtr> substitutions;
+  std::vector<VarPtr> new_params = func->params_;
+
+  for (const auto& info : results) {
+    const auto& old_param = func->params_[info.param_index];
+    auto old_tensor_type = As<TensorType>(old_param->GetType());
+    CHECK(old_tensor_type) << "transpose load source param must be TensorType";
+
+    // Skip if already has DN layout
+    if (old_tensor_type->tensor_view_.has_value() &&
+        old_tensor_type->tensor_view_->layout == TensorLayout::DN) {
+      continue;
+    }
+
+    auto new_tensor_type =
+        std::make_shared<TensorType>(info.new_shape, old_tensor_type->dtype_, old_tensor_type->memref_,
+                                     std::optional<TensorView>(TensorView({}, TensorLayout::DN)));
+
+    auto new_var = std::make_shared<Var>(old_param->name_, new_tensor_type, old_param->span_);
+    new_params[info.param_index] = new_var;
+    substitutions[old_param->name_] = new_var;
+    modified_params[info.param_index] = new_tensor_type;
+  }
+
+  if (substitutions.empty()) {
+    return {func, {}};
+  }
+
+  VarSubstitutionMutator mutator(std::move(substitutions));
+  auto new_body = mutator.VisitStmt(func->body_);
+
+  auto new_func = std::make_shared<Function>(func->name_, new_params, func->param_directions_,
+                                             func->return_types_, new_body, func->span_, func->func_type_);
+
+  return {new_func, std::move(modified_params)};
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: propagate type changes to Orchestration / Opaque function callers
+// ---------------------------------------------------------------------------
+
+/**
+ * Visitor that finds calls to modified InCore functions in the body and
+ * collects which caller variables need type updates.
+ */
+class CallerArgCollector : public IRVisitor {
+ public:
+  using ModifiedMap =
+      std::unordered_map<std::string, std::unordered_map<size_t, std::shared_ptr<const TensorType>>>;
+
+  explicit CallerArgCollector(const ModifiedMap& incore_modifications)
+      : incore_modifications_(incore_modifications) {}
+
+  // var_name -> new TensorType (for variables that need updating in the caller)
+  const std::unordered_map<std::string, std::shared_ptr<const TensorType>>& GetVarUpdates() const {
+    return var_updates_;
+  }
+
+  void VisitExpr_(const CallPtr& call) override {
+    if (!call) return;
+
+    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    if (global_var) {
+      auto it = incore_modifications_.find(global_var->name_);
+      if (it != incore_modifications_.end()) {
+        for (const auto& [param_idx, new_type] : it->second) {
+          if (param_idx < call->args_.size()) {
+            auto arg_var = As<Var>(call->args_[param_idx]);
+            if (arg_var && var_updates_.find(arg_var->name_) == var_updates_.end()) {
+              var_updates_[arg_var->name_] = new_type;
+            }
+          }
+        }
+      }
+    }
+
+    IRVisitor::VisitExpr_(call);
+  }
+
+ private:
+  const ModifiedMap& incore_modifications_;
+  std::unordered_map<std::string, std::shared_ptr<const TensorType>> var_updates_;
+};
+
+FunctionPtr UpdateCallerFunction(
+    const FunctionPtr& func,
+    const std::unordered_map<std::string, std::unordered_map<size_t, std::shared_ptr<const TensorType>>>&
+        incore_mods) {
+  CallerArgCollector collector(incore_mods);
+  collector.VisitStmt(func->body_);
+
+  const auto& var_updates = collector.GetVarUpdates();
+  if (var_updates.empty()) {
+    return func;
+  }
+
+  // Build substitution map and update params
+  std::unordered_map<std::string, VarPtr> substitutions;
+  std::vector<VarPtr> new_params = func->params_;
+
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    auto it = var_updates.find(func->params_[i]->name_);
+    if (it != var_updates.end()) {
+      auto new_var = std::make_shared<Var>(func->params_[i]->name_, it->second, func->params_[i]->span_);
+      new_params[i] = new_var;
+      substitutions[func->params_[i]->name_] = new_var;
+    }
+  }
+
+  if (substitutions.empty()) {
+    return func;
+  }
+
+  VarSubstitutionMutator mutator(std::move(substitutions));
+  auto new_body = mutator.VisitStmt(func->body_);
+
+  return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
+                                    new_body, func->span_, func->func_type_);
+}
+
+}  // namespace
+
+namespace pass {
+
+Pass ResolveTransposeLayout() {
+  auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
+    // Phase 1: Transform InCore functions -- detect tile.load transpose and update param types
+    using ModifiedMap =
+        std::unordered_map<std::string, std::unordered_map<size_t, std::shared_ptr<const TensorType>>>;
+    ModifiedMap incore_modifications;
+    std::vector<FunctionPtr> functions_phase1;
+
+    for (const auto& [gvar, func] : program->functions_) {
+      if (IsInCoreType(func->func_type_)) {
+        auto result = TransformIncoreParams(func);
+        if (!result.modified_params.empty()) {
+          incore_modifications[func->name_] = std::move(result.modified_params);
+        }
+        functions_phase1.push_back(result.func);
+      } else {
+        functions_phase1.push_back(func);
+      }
+    }
+
+    if (incore_modifications.empty()) {
+      return program;
+    }
+
+    // Phase 2: Propagate type changes to Orchestration/Opaque callers
+    std::vector<FunctionPtr> functions_phase2;
+    for (const auto& func : functions_phase1) {
+      if (!IsInCoreType(func->func_type_)) {
+        functions_phase2.push_back(UpdateCallerFunction(func, incore_modifications));
+      } else {
+        functions_phase2.push_back(func);
+      }
+    }
+
+    return std::make_shared<Program>(functions_phase2, program->name_, program->span_);
+  };
+
+  return CreateProgramPass(pass_func, "ResolveTransposeLayout", kResolveTransposeLayoutProperties);
+}
+
+}  // namespace pass
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -98,9 +98,7 @@ class TestMatmulTranspose(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [self.M, self.K], DataType.FP32, init_value=torch.randn),
-            TensorSpec(
-                "b", [self.N, self.K], DataType.FP32, init_value=torch.randn
-            ),  # [N, K] stored transposed
+            TensorSpec("b", [self.N, self.K], DataType.FP32, init_value=torch.randn),
             TensorSpec("c", [self.M, self.N], DataType.FP32, is_output=True),
         ]
 
@@ -113,7 +111,7 @@ class TestMatmulTranspose(PTOTestCase):
             def matmul_transpose(
                 self,
                 a: pl.Tensor[[M, K], pl.FP32],
-                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                b: pl.Tensor[[N, K], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat)
@@ -128,7 +126,7 @@ class TestMatmulTranspose(PTOTestCase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 out_c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
                 out_c = self.matmul_transpose(a, b, out_c)
@@ -138,6 +136,128 @@ class TestMatmulTranspose(PTOTestCase):
 
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = torch.matmul(tensors["a"].to(torch.float32), tensors["b"].to(torch.float32).T)
+
+
+class TestMatmulATranspose(PTOTestCase):
+    """Matmul with A transposed: C = A^T @ B.
+
+    A is stored as [K, M] in memory and transposed during the load to L1.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"matmul_atranspose_{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.K, self.M], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = self.M, self.K, self.N
+
+        @pl.program
+        class MatmulATransposeProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_atranspose(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a_l1 = pl.load(
+                    a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                out_c = pl.store(tile_c_l0c, offsets=[0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                out_c = self.matmul_atranspose(a, b, out_c)
+                return out_c
+
+        return MatmulATransposeProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"].to(torch.float32).T, tensors["b"].to(torch.float32))
+
+
+class TestMatmulABTranspose(PTOTestCase):
+    """Matmul with both A and B transposed: C = A^T @ B^T.
+
+    A is stored as [K, M] and B as [N, K] in memory, both transposed during load.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"matmul_abtranspose_{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.K, self.M], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.N, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = self.M, self.K, self.N
+
+        @pl.program
+        class MatmulABTransposeProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_abtranspose(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a_l1 = pl.load(
+                    a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_b_l1 = pl.load(
+                    b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                out_c = pl.store(tile_c_l0c, offsets=[0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                out_c = self.matmul_abtranspose(a, b, out_c)
+                return out_c
+
+        return MatmulABTransposeProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"].to(torch.float32).T, tensors["b"].to(torch.float32).T)
 
 
 class TestMatmulPTO(TestMatmul):
@@ -156,12 +276,42 @@ class TestMatmulPTO(TestMatmul):
 
 
 class TestMatmulTransposePTO(TestMatmulTranspose):
-    """Test matmul with PTO backend and PTOAS optimization."""
+    """Test matmul transpose with PTO backend and PTOAS optimization."""
 
     __test__ = False
 
     def get_name(self) -> str:
         return f"matmul_transpose_pto_{self.M}x{self.K}x{self.N}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
+class TestMatmulATransposePTO(TestMatmulATranspose):
+    """Test matmul A transpose with PTO backend and PTOAS optimization."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"matmul_atranspose_pto_{self.M}x{self.K}x{self.N}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
+class TestMatmulABTransposePTO(TestMatmulABTranspose):
+    """Test matmul AB transpose with PTO backend and PTOAS optimization."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"matmul_abtranspose_pto_{self.M}x{self.K}x{self.N}"
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -218,6 +368,46 @@ class TestMatmulOperations:
     def test_matmul_transpose_pto(self, test_runner, m, k, n):
         """Test matmul with B transposed (C = A @ B^T)."""
         test_case = TestMatmulTransposePTO(m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "m,k,n",
+        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
+    )
+    def test_matmul_atranspose(self, test_runner, m, k, n):
+        """Test matmul with A transposed (C = A^T @ B)."""
+        test_case = TestMatmulATranspose(m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "m,k,n",
+        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
+    )
+    def test_matmul_abtranspose(self, test_runner, m, k, n):
+        """Test matmul with both A and B transposed (C = A^T @ B^T)."""
+        test_case = TestMatmulABTranspose(m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "m,k,n",
+        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
+    )
+    def test_matmul_atranspose_pto(self, test_runner, m, k, n):
+        """Test matmul A transpose with PTO backend."""
+        test_case = TestMatmulATransposePTO(m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "m,k,n",
+        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
+    )
+    def test_matmul_abtranspose_pto(self, test_runner, m, k, n):
+        """Test matmul AB transpose with PTO backend."""
+        test_case = TestMatmulABTransposePTO(m=m, k=k, n=n)
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -41,8 +41,8 @@ class TestPassManagerBasics:
         assert pm is not None
         assert pm.strategy == ir.OptimizationStrategy.Default
 
-        assert len(pm.passes) == 13
-        assert len(pm.pass_names) == 13
+        assert len(pm.passes) == 14
+        assert len(pm.pass_names) == 14
         assert pm.pass_names[0] == "UnrollLoops"
         assert pm.pass_names[1] == "ConvertToSSA"
         assert pm.pass_names[2] == "FlattenCallExpr"
@@ -53,9 +53,10 @@ class TestPassManagerBasics:
         assert pm.pass_names[7] == "ConvertTensorToTileOps"
         assert pm.pass_names[8] == "FlattenTileNdTo2D"
         assert pm.pass_names[9] == "InferTileMemorySpace"
-        assert pm.pass_names[10] == "InitMemRef"
-        assert pm.pass_names[11] == "MemoryReuse"
-        assert pm.pass_names[12] == "AllocateMemoryAddr"
+        assert pm.pass_names[10] == "ResolveTransposeLayout"
+        assert pm.pass_names[11] == "InitMemRef"
+        assert pm.pass_names[12] == "MemoryReuse"
+        assert pm.pass_names[13] == "AllocateMemoryAddr"
 
 
 class TestPassManagerExecution:

--- a/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
@@ -1,0 +1,558 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ResolveTransposeLayout pass."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir, passes
+
+
+class TestResolveTransposeLayoutBTranspose:
+    """Test B transpose cases: C = A @ B^T."""
+
+    def test_btranspose_basic(self):
+        """B stored as [N, K], loaded with transpose=True -> param becomes [K, N] + DN."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_btranspose_non_square(self):
+        """Non-square dimensions: M=128, K=64, N=32."""
+        M, K, N = 128, 64, 32
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestResolveTransposeLayoutATranspose:
+    """Test A transpose cases: C = A^T @ B."""
+
+    def test_atranspose_basic(self):
+        """A stored as [K, M], loaded with transpose=True -> param becomes [M, K] + DN."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32, pl.DN],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32, pl.DN], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestResolveTransposeLayoutABTranspose:
+    """Test both A and B transposed: C = A^T @ B^T."""
+
+    def test_abtranspose_basic(self):
+        """Both A and B transposed -> both params get DN layout."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32, pl.DN],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32, pl.DN], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_abtranspose_non_square(self):
+        """Both transposed with non-square dimensions: M=32, K=128, N=64."""
+        M, K, N = 32, 128, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32, pl.DN],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32, pl.DN], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestResolveTransposeLayoutNoOp:
+    """Test cases where the pass should be a no-op."""
+
+    def test_no_transpose_unchanged(self):
+        """No transpose=True loads -> program unchanged."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_already_dn_layout_unchanged(self):
+        """Parameter already has DN layout -> pass is idempotent."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_elementwise_no_transpose(self):
+        """Simple elementwise with no transpose -> unchanged."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def add_incore(
+                self,
+                x: pl.Tensor[[64, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                x_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+                y_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                out_0: pl.Tensor[[64, 64], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64, 64], pl.FP32]) -> pl.Tensor[[64, 64], pl.FP32]:
+                out_0: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                y: pl.Tensor[[64, 64], pl.FP32] = self.add_incore(x, out_0)
+                return y
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_transpose_false_explicit(self):
+        """Explicit transpose=False -> no change."""
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=False)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=False)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Before)
+
+
+class TestResolveTransposeLayoutMixed:
+    """Test mixed scenarios with one transpose and one non-transpose param."""
+
+    def test_only_second_param_transposed(self):
+        """Only second param has transpose -> only second param changes."""
+        M, K, N = 64, 128, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32, pl.DN],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[K, N], pl.FP32, pl.DN]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_only_first_param_transposed(self):
+        """Only first param has transpose -> only first param changes."""
+        M, K, N = 64, 64, 128
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32, pl.DN],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c = pl.store(tile_c, [0, 0], c)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self, a: pl.Tensor[[M, K], pl.FP32, pl.DN], b: pl.Tensor[[K, N], pl.FP32]
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                c = self.matmul_incore(a, b, c)
+                return c
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Users can now write transposed matmul parameters using their physical memory shape (e.g. b: Tensor[[N, K], FP32]) instead of manually specifying the logical shape with DN layout (Tensor[[K, N], FP32, DN]). The new pass detects tile.load(..., transpose=True) in InCore functions and automatically transforms the source tensor parameter type to the transposed shape with DN layout, propagating the change to Orchestration function callers.
The pass runs after FlattenTileNdTo2D in the pipeline. Test cases cover btrans (C=A@B^T), atrans (C=A^T@B), and abtrans (C=A^T@B^T) scenarios.