### PR TITLE
feat(ir): add tile.assemble op and refactor matmul transpose to load-time

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -171,6 +171,29 @@ def store(
     return _ir_core.create_op_call("tile.store", [tile, offsets_tuple, output_tensor], {}, actual_span)
 
 
+def assemble(
+    target: Expr,
+    source: Expr,
+    offset: Sequence[int | Expr] | _ir_core.MakeTuple,
+    span: Span | None = None,
+) -> Call:
+    """Write source tile data into target tile at specified offset.
+
+    Args:
+        target: Target tile (TileType)
+        source: Source tile to write (TileType)
+        offset: Offset dimensions for where to write, or a MakeTuple
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns a TileType with the same shape/dtype as target
+    """
+    actual_span = _get_span_or_capture(span)
+    offset_tuple = _to_make_tuple(offset, actual_span)
+
+    return _ir_core.create_op_call("tile.assemble", [target, source, offset_tuple], {}, actual_span)
+
+
 def move(
     tile: Expr,
     target_memory: MemorySpace,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -67,9 +67,8 @@ class RunConfig:
         save_kernels: If ``True``, retain generated artefacts after execution.
             When ``False`` (default), a temporary directory is used and cleaned up.
         save_kernels_dir: Directory to save generated artefacts when *save_kernels*
-            is ``True``.  If ``None``, the harness auto-generates a timestamped
-            directory under ``build/tests/st/outputs/``; direct :func:`run` calls
-            create a temporary directory instead.
+            is ``True``.  If ``None``, a timestamped directory is created under
+            ``build_output/<program_name>_<timestamp>``.
         codegen_only: If ``True``, stop after code generation without executing
             on device.  Useful for validating compilation output.
     """

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -323,5 +323,42 @@ REGISTER_OP("tile.transpose")
       return DeduceTileTransposeType(args, kwargs);
     });
 
+TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3) << "tile.assemble requires exactly 3 arguments (target, source, offset), but got "
+                          << args.size();
+
+  auto target_type = As<TileType>(args[0]->GetType());
+  CHECK(target_type) << "tile.assemble requires first argument (target) to be a TileType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  auto source_type = As<TileType>(args[1]->GetType());
+  CHECK(source_type) << "tile.assemble requires second argument (source) to be a TileType, but got "
+                     << args[1]->GetType()->TypeName();
+
+  auto offset_tuple_type = As<TupleType>(args[2]->GetType());
+  CHECK(offset_tuple_type) << "tile.assemble requires offset to be TupleType, but got "
+                           << args[2]->GetType()->TypeName();
+
+  ValidateIndexTupleElements(offset_tuple_type, "tile.assemble", "offset");
+
+  CHECK(target_type->dtype_ == source_type->dtype_)
+      << "tile.assemble requires target and source to have the same dtype, but got "
+      << target_type->dtype_.ToString() << " and " << source_type->dtype_.ToString();
+
+  return std::make_shared<TileType>(target_type->shape_, target_type->dtype_);
+}
+
+REGISTER_OP("tile.assemble")
+    .set_op_category("TileOp")
+    .set_description("Write source tile data into target tile at specified offset")
+    .add_argument("target", "Target tile (TileType)")
+    .add_argument("source", "Source tile to write (TileType)")
+    .add_argument("offset", "Offset dimensions (TupleType of ScalarType(INT64/UINT64/INDEX))")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileAssembleType(args, kwargs);
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op_registry.cpp
+++ b/src/ir/op_registry.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/op_registry.h"
 
 #include <any>
+#include <exception>
 #include <memory>
 #include <string>
 #include <typeindex>
@@ -107,7 +108,13 @@ CallPtr OpRegistry::Create(const std::string& op_name, const std::vector<ExprPtr
   const auto& deduce_type_fn = entry.GetDeduceType();
 
   // Deduce result type (pass args and kwargs separately)
-  TypePtr result_type = deduce_type_fn(args, kwargs);
+  TypePtr result_type;
+  try {
+    result_type = deduce_type_fn(args, kwargs);
+  } catch (const std::exception& e) {
+    std::string location = span.is_valid() ? " at " + span.to_string() : "";
+    throw ValueError(std::string(e.what()) + location);
+  }
   INTERNAL_CHECK(result_type) << "Type deduction failed for '" + op_name + "'";
 
   // Create Call with deduced type

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -322,6 +322,74 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
 }
 
 /**
+ * @brief Info about a tensor.slice result that feeds into a tensor.matmul operand.
+ *
+ * When a tensor.slice result is consumed by tensor.matmul, the slice conversion
+ * should produce tile.load(Mat, transpose=...) instead of tile.load(Vec) so that
+ * the matmul conversion can skip the load and directly use the Mat-space tile.
+ */
+struct MatmulSliceInfo {
+  bool is_rhs;     ///< true if the slice result is the rhs operand of matmul
+  bool transpose;  ///< transpose flag from matmul (b_trans for rhs, a_trans for lhs)
+};
+
+/**
+ * @brief Pre-scan statements to find tensor.slice results consumed by tensor.matmul.
+ *
+ * Scans a flat list of statements to build a map from slice result variable names
+ * to their matmul usage info (which side and transpose flag).
+ */
+std::unordered_map<std::string, MatmulSliceInfo> PreScanSliceMatmulPatterns(
+    const std::vector<StmtPtr>& stmts) {
+  // Collect variable names assigned from tensor.slice
+  std::unordered_set<std::string> slice_results;
+  for (const auto& stmt : stmts) {
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) continue;
+    auto call = As<Call>(assign->value_);
+    if (!call) continue;
+    if (call->op_->name_ == "tensor.slice") {
+      slice_results.insert(assign->var_->name_);
+    }
+  }
+  if (slice_results.empty()) return {};
+
+  std::unordered_map<std::string, MatmulSliceInfo> result;
+
+  // Find tensor.matmul calls that consume slice results
+  for (const auto& stmt : stmts) {
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) continue;
+    auto call = As<Call>(assign->value_);
+    if (!call || call->op_->name_ != "tensor.matmul") continue;
+    if (call->args_.size() < 2) continue;
+
+    bool a_trans = false;
+    bool b_trans = false;
+    for (const auto& [k, v] : call->kwargs_) {
+      if (k == "a_trans") a_trans = std::any_cast<bool>(v);
+      if (k == "b_trans") b_trans = std::any_cast<bool>(v);
+    }
+
+    // Check lhs (args[0])
+    if (auto lhs_var = As<Var>(call->args_[0])) {
+      if (slice_results.count(lhs_var->name_)) {
+        result[lhs_var->name_] = MatmulSliceInfo{false, a_trans};
+      }
+    }
+
+    // Check rhs (args[1])
+    if (auto rhs_var = As<Var>(call->args_[1])) {
+      if (slice_results.count(rhs_var->name_)) {
+        result[rhs_var->name_] = MatmulSliceInfo{true, b_trans};
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * @brief Recursively transform statements in an InCore function body.
  *
  * Converts tensor ops to tile ops, handling nested control flow (IfStmt, ForStmt,
@@ -333,6 +401,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
                                          const OpConversionRegistry& conv_registry,
                                          const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
+
+  auto matmul_slice_targets = PreScanSliceMatmulPatterns(stmts);
 
   for (const auto& stmt : stmts) {
     // ReturnStmt: pass through (handled by Phase 3 in TransformIncoreFunction)
@@ -431,7 +501,6 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
     // ForStmt: recurse into body
     if (auto for_stmt = As<ForStmt>(stmt)) {
-      LOG_WARN << "[ConvertTensorToBlockOps] Entering ForStmt";
       auto new_start = SubstituteExpr(for_stmt->start_, tensor_to_tile);
       auto new_stop = SubstituteExpr(for_stmt->stop_, tensor_to_tile);
       auto new_step = SubstituteExpr(for_stmt->step_, tensor_to_tile);
@@ -602,7 +671,6 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
             << "TensorOp \"" << call->op_->name_ << "\" has no registered tile conversion. "
             << "Add a conversion in src/ir/transforms/op_conversion_registry.cpp.";
       }
-      LOG_WARN << "[ConvertTensorToBlockOps] No converter for op: " << call->op_->name_;
       auto new_value = SubstituteExpr(assign->value_, tensor_to_tile);
       if (new_value != assign->value_) {
         auto new_var = std::make_shared<Var>(assign->var_->name_, new_value->GetType(), assign->var_->span_);
@@ -615,7 +683,6 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     }
 
     // Substitute args and call the converter
-    LOG_WARN << "[ConvertTensorToBlockOps] Converting op: " << call->op_->name_;
     std::vector<ExprPtr> substituted_args;
     substituted_args.reserve(call->args_.size());
     for (const auto& arg : call->args_) {
@@ -626,9 +693,52 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     if (call->op_->name_ == "tensor.slice" && !call->args_.empty()) {
       auto input_var = As<Var>(call->args_[0]);
       if (input_var && sliced_vars.count(input_var->name_)) {
+        std::string location = call->span_.is_valid() ? " at " + call->span_.to_string() : "";
         throw pypto::InternalError(
             "Consecutive tensor.slice detected: cannot slice the result of a prior slice (variable '" +
-            input_var->name_ + "')");
+            input_var->name_ + "')" + location);
+      }
+    }
+
+    // Special handling: tensor.slice feeding into tensor.matmul
+    // Generate tile.load(Mat, transpose=xx) instead of the default tile.load(Vec)
+    if (call->op_->name_ == "tensor.slice" && matmul_slice_targets.count(assign->var_->name_)) {
+      const auto& info = matmul_slice_targets.at(assign->var_->name_);
+      const auto& input = substituted_args[0];
+      auto tensor_type = As<TensorType>(input->GetType());
+      if (tensor_type) {
+        // Use the slice's offset and shape args (args[1]=shape, args[2]=offset)
+        const auto& shape_arg = substituted_args[1];
+        const auto& offset_arg = substituted_args[2];
+
+        // For transpose, swap shape dims: [N,K] → [K,N]
+        ExprPtr load_shapes = shape_arg;
+        ExprPtr valid_shapes_base = (substituted_args.size() == 4) ? substituted_args[3] : shape_arg;
+        if (info.transpose) {
+          auto shape_tuple = As<MakeTuple>(shape_arg);
+          if (shape_tuple && shape_tuple->elements_.size() == 2) {
+            std::vector<ExprPtr> swapped = {shape_tuple->elements_[1], shape_tuple->elements_[0]};
+            load_shapes = std::make_shared<MakeTuple>(swapped, shape_arg->span_);
+          }
+          auto valid_tuple = As<MakeTuple>(valid_shapes_base);
+          if (valid_tuple && valid_tuple->elements_.size() == 2) {
+            std::vector<ExprPtr> swapped = {valid_tuple->elements_[1], valid_tuple->elements_[0]};
+            valid_shapes_base = std::make_shared<MakeTuple>(swapped, valid_shapes_base->span_);
+          }
+        }
+
+        auto valid_shapes = valid_shapes_base;
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Mat},
+                                                                     {"transpose", info.transpose}};
+        auto load_call = op_registry.Create("tile.load", {input, offset_arg, load_shapes, valid_shapes},
+                                            load_kwargs, span);
+
+        std::string tile_name = assign->var_->name_ + "_tile";
+        auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(tile_var, load_call, assign->span_));
+        tensor_to_tile[assign->var_->name_] = tile_var;
+        sliced_vars.insert(assign->var_->name_);
+        continue;
       }
     }
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -170,7 +170,8 @@ OpConversionRegistry::OpConversionRegistry() {
       "tensor.slice",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3) << "tensor.slice conversion expects 3 args (tensor, shape, offset)";
+        CHECK(args.size() == 3 || args.size() == 4)
+            << "tensor.slice conversion expects 3 or 4 args (tensor, shape, offset[, valid_shape])";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
         const auto& shape = args[1];
@@ -181,9 +182,11 @@ OpConversionRegistry::OpConversionRegistry() {
 
         if (tensor_type) {
           // gm_tensor: function parameter or prior gm_tensor.slice result → tile.load
+          auto valid_shapes = (args.size() == 4) ? args[3] : shape;
           std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
                                                                        {"transpose", false}};
-          auto load_call = op_reg.Create("tile.load", {input, offset, shape, shape}, load_kwargs, span);
+          auto load_call =
+              op_reg.Create("tile.load", {input, offset, shape, valid_shapes}, load_kwargs, span);
           return ConversionResult{load_call};
         }
 
@@ -198,7 +201,7 @@ OpConversionRegistry::OpConversionRegistry() {
       });
 
   // ────────────────────────────────────────────────────────────────────────
-  // tensor.matmul → tile.load(Mat) + tile.move(L0A/L0B) + tile.matmul + tile.l0c_store
+  // tensor.matmul → tile.load(Mat) + tile.move(L0A/L0B) + tile.matmul + tile.store
   //
   // tensor.matmul(lhs, rhs, a_trans=False, b_trans=True, c_matrix_nz=False)
   // ────────────────────────────────────────────────────────────────────────
@@ -210,6 +213,7 @@ OpConversionRegistry::OpConversionRegistry() {
         CHECK(args.size() == 2) << "tensor.matmul conversion expects 2 args (lhs, rhs)";
         auto& op_reg = OpRegistry::GetInstance();
 
+        bool a_trans = GetKwargOr<bool>(kwargs, "a_trans", false);
         bool b_trans = GetKwargOr<bool>(kwargs, "b_trans", false);
 
         const auto& lhs = args[0];
@@ -224,59 +228,56 @@ OpConversionRegistry::OpConversionRegistry() {
 
         ExprPtr lhs_mat, rhs_mat;
 
-        // Load lhs to Mat if it's a tensor, or move from Vec if it's a tile
         if (lhs_tensor_type) {
           auto offsets = MakeZeroOffsetsTuple(lhs_tensor_type->shape_.size(), span);
-          auto shapes = MakeShapesTuple(lhs_tensor_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat}};
+          auto lhs_shape = lhs_tensor_type->shape_;
+          if (a_trans && lhs_shape.size() == 2) {
+            std::swap(lhs_shape[0], lhs_shape[1]);
+          }
+          auto shapes = MakeShapesTuple(lhs_shape, span);
+          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat},
+                                                              {"transpose", a_trans}};
           auto load = op_reg.Create("tile.load", {lhs, offsets, shapes, shapes}, kw, span);
           auto load_var = std::make_shared<Var>("lhs_mat", load->GetType(), span);
           prologue.push_back(std::make_shared<AssignStmt>(load_var, load, span));
           lhs_mat = load_var;
         } else if (lhs_tile_type) {
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat},
-                                                              {"transpose", false}};
-          auto move = op_reg.Create("tile.move", {lhs}, kw, span);
-          auto move_var = std::make_shared<Var>("lhs_mat", move->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(move_var, move, span));
-          lhs_mat = move_var;
+          lhs_mat = lhs;
         } else {
           CHECK(false) << "tensor.matmul: unexpected lhs type: " << lhs->GetType()->TypeName();
         }
 
         if (rhs_tensor_type) {
           auto offsets = MakeZeroOffsetsTuple(rhs_tensor_type->shape_.size(), span);
-          auto shapes = MakeShapesTuple(rhs_tensor_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat}};
+          auto rhs_shape = rhs_tensor_type->shape_;
+          if (b_trans && rhs_shape.size() == 2) {
+            std::swap(rhs_shape[0], rhs_shape[1]);
+          }
+          auto shapes = MakeShapesTuple(rhs_shape, span);
+          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat},
+                                                              {"transpose", b_trans}};
           auto load = op_reg.Create("tile.load", {rhs, offsets, shapes, shapes}, kw, span);
           auto load_var = std::make_shared<Var>("rhs_mat", load->GetType(), span);
           prologue.push_back(std::make_shared<AssignStmt>(load_var, load, span));
           rhs_mat = load_var;
         } else if (rhs_tile_type) {
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat},
-                                                              {"transpose", false}};
-          auto move = op_reg.Create("tile.move", {rhs}, kw, span);
-          auto move_var = std::make_shared<Var>("rhs_mat", move->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(move_var, move, span));
-          rhs_mat = move_var;
+          rhs_mat = rhs;
         } else {
           CHECK(false) << "tensor.matmul: unexpected rhs type: " << rhs->GetType()->TypeName();
         }
 
         // Move lhs to L0A (Left)
         {
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Left},
-                                                              {"transpose", false}};
+          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Left}};
           auto move = op_reg.Create("tile.move", {lhs_mat}, kw, span);
           auto var = std::make_shared<Var>("lhs_l0a", move->GetType(), span);
           prologue.push_back(std::make_shared<AssignStmt>(var, move, span));
           lhs_mat = var;
         }
 
-        // Move rhs to L0B (Right) with optional transpose
+        // Move rhs to L0B (Right)
         {
-          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Right},
-                                                              {"transpose", b_trans}};
+          std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Right}};
           auto move = op_reg.Create("tile.move", {rhs_mat}, kw, span);
           auto var = std::make_shared<Var>("rhs_l0b", move->GetType(), span);
           prologue.push_back(std::make_shared<AssignStmt>(var, move, span));
@@ -364,20 +365,27 @@ OpConversionRegistry::OpConversionRegistry() {
         }
 
         if (source_tile_type && target_tile_type) {
-          // Both are tiles (e.g. target from tile.create, source from conversion).
-          // Store source into a temp tensor, then return the tensor.
+          // Both are tiles → tile.assemble(target, source, offset)
+          auto assemble_call = op_reg.Create("tile.assemble", {target, source, offset}, span);
+          return ConversionResult{assemble_call};
+        }
+
+        if (target_tile_type && !source_tile_type) {
+          // Target is tile, source is still tensor → load source to Vec, then tile.assemble
+          auto source_tensor_type = As<TensorType>(source->GetType());
+          CHECK(source_tensor_type) << "tensor.assemble: source must be TensorType or TileType, but got "
+                                    << source->GetType()->TypeName();
           std::vector<StmtPtr> prologue;
+          auto offsets_load = MakeZeroOffsetsTuple(source_tensor_type->shape_.size(), span);
+          auto shapes = MakeShapesTuple(source_tensor_type->shape_, span);
+          std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", MemorySpace::Vec},
+                                                                   {"transpose", false}};
+          auto load_call = op_reg.Create("tile.load", {source, offsets_load, shapes, shapes}, load_kw, span);
+          auto source_tile_var = std::make_shared<Var>("assemble_src", load_call->GetType(), span);
+          prologue.push_back(std::make_shared<AssignStmt>(source_tile_var, load_call, span));
 
-          // Create a temporary tensor for the target
-          auto target_shape = MakeShapesTuple(target_tile_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", target_tile_type->dtype_}};
-          auto create_call = op_reg.Create("tensor.create", {target_shape}, create_kwargs, span);
-          auto tmp_tensor = std::make_shared<Var>("assemble_tmp", create_call->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(tmp_tensor, create_call, span));
-
-          // Store source tile into the tensor at the given offset
-          auto store_call = op_reg.Create("tile.store", {source, offset, tmp_tensor}, span);
-          return ConversionResult{std::move(prologue), store_call};
+          auto assemble_call = op_reg.Create("tile.assemble", {target, source_tile_var, offset}, span);
+          return ConversionResult{std::move(prologue), assemble_call};
         }
 
         // Both still tensors — keep as tensor.assemble

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -78,7 +78,7 @@ class TestMatmul(PTOTestCase):
         tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
 
 
-class TestMatmulTranspose(PTOTestCase):
+class TestMatmulBTranspose(PTOTestCase):
     """Matmul with B transposed: C = A @ B^T.
 
     B is stored as [N, K] in memory and transposed during the load to L1.
@@ -93,7 +93,7 @@ class TestMatmulTranspose(PTOTestCase):
         self.N = n
 
     def get_name(self) -> str:
-        return f"matmul_transpose_{self.M}x{self.K}x{self.N}"
+        return f"matmul_btranspose_{self.M}x{self.K}x{self.N}"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -106,9 +106,9 @@ class TestMatmulTranspose(PTOTestCase):
         M, K, N = self.M, self.K, self.N
 
         @pl.program
-        class MatmulTransposeProgram:
+        class MatmulBTransposeProgram:
             @pl.function(type=pl.FunctionType.InCore)
-            def matmul_transpose(
+            def matmul_btranspose(
                 self,
                 a: pl.Tensor[[M, K], pl.FP32],
                 b: pl.Tensor[[N, K], pl.FP32],
@@ -129,10 +129,10 @@ class TestMatmulTranspose(PTOTestCase):
                 self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 out_c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
-                out_c = self.matmul_transpose(a, b, out_c)
+                out_c = self.matmul_btranspose(a, b, out_c)
                 return out_c
 
-        return MatmulTransposeProgram
+        return MatmulBTransposeProgram
 
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = torch.matmul(tensors["a"].to(torch.float32), tensors["b"].to(torch.float32).T)
@@ -275,13 +275,13 @@ class TestMatmulPTO(TestMatmul):
         return BackendType.Ascend910B_PTO
 
 
-class TestMatmulTransposePTO(TestMatmulTranspose):
-    """Test matmul transpose with PTO backend and PTOAS optimization."""
+class TestMatmulBTransposePTO(TestMatmulBTranspose):
+    """Test matmul B transpose with PTO backend and PTOAS optimization."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return f"matmul_transpose_pto_{self.M}x{self.K}x{self.N}"
+        return f"matmul_btranspose_pto_{self.M}x{self.K}x{self.N}"
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -343,7 +343,7 @@ class TestMatmulOperations:
     )
     def test_matmul_transpose(self, test_runner, m, k, n):
         """Test matmul with B transposed (C = A @ B^T)."""
-        test_case = TestMatmulTranspose(m=m, k=k, n=n)
+        test_case = TestMatmulBTranspose(m=m, k=k, n=n)
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
@@ -367,7 +367,7 @@ class TestMatmulOperations:
     )
     def test_matmul_transpose_pto(self, test_runner, m, k, n):
         """Test matmul with B transposed (C = A @ B^T)."""
-        test_case = TestMatmulTransposePTO(m=m, k=k, n=n)
+        test_case = TestMatmulBTransposePTO(m=m, k=k, n=n)
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1774,5 +1774,46 @@ class TestTileScalarOps:
         assert "tile.write" in ir_str
 
 
+class TestTileAssembleOp:
+    """Tests for tile.assemble operator."""
+
+    def test_tile_assemble_basic(self):
+        """Test tile.assemble type deduction returns target TileType."""
+        span = ir.Span.unknown()
+
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim128 = ir.ConstInt(128, DataType.INT32, span)
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+
+        target_type = ir.TileType([dim16, dim128], DataType.FP32)
+        target_var = ir.Var("target", target_type, span)
+
+        source_type = ir.TileType([dim16, dim64], DataType.FP32)
+        source_var = ir.Var("source", source_type, span)
+
+        call = tile.assemble(target_var, source_var, [0, 0])
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.assemble"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP32
+        assert len(result_type.shape) == 2
+
+    def test_tile_assemble_dtype_mismatch(self):
+        """tile.assemble requires matching dtypes for target and source."""
+        span = ir.Span.unknown()
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+        target_type = ir.TileType([dim16, dim16], DataType.FP32)
+        target_var = ir.Var("target", target_type, span)
+
+        source_type = ir.TileType([dim16, dim16], DataType.FP16)
+        source_var = ir.Var("source", source_type, span)
+
+        with pytest.raises(ValueError, match="same dtype"):
+            tile.assemble(target_var, source_var, [0, 0])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -532,6 +532,165 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_matmul_conversion(self):
+        """tensor.matmul -> tile.load(Mat) + tile.move(Left/Right) + tile.matmul.
+
+        Verifies that tile.move calls do NOT contain transpose kwargs,
+        and rhs tile.load carries transpose=False when b_trans is not set.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP16],
+                rhs: pl.Tensor[[128, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                y: pl.Tensor[[16, 64], pl.FP16] = pl.matmul(lhs, rhs)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP16],
+                rhs: pl.Tensor[[128, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                y: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP16],
+                rhs: pl.Tensor[[128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP16]],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                lhs_mat: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_mat: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                lhs_l0a: pl.Tile[[16, 128], pl.FP16] = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_l0b: pl.Tile[[128, 64], pl.FP16] = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                y_tile: pl.Tile[[16, 64], pl.FP32] = pl.matmul(lhs_l0a, rhs_l0b)
+                out_0: pl.Tensor[[16, 64], pl.FP16] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP16],
+                rhs: pl.Tensor[[128, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                out_0: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
+                y: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_matmul_b_trans_conversion(self):
+        """tensor.matmul(b_trans=True) -> tile.load(Mat, transpose=True) + tile.move + tile.matmul.
+
+        Verifies that b_trans is moved from tile.move to tile.load for rhs,
+        and tile.move calls have no transpose kwarg.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[16, 128], pl.BF16]:
+                y: pl.Tensor[[16, 128], pl.BF16] = pl.matmul(lhs, rhs, b_trans=True)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[16, 128], pl.BF16]:
+                y: pl.Tensor[[16, 128], pl.BF16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+            ) -> pl.Tensor[[16, 128], pl.BF16]:
+                lhs_mat: pl.Tile[[16, 128], pl.BF16] = pl.load(
+                    lhs, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_mat: pl.Tile[[128, 128], pl.BF16] = pl.load(
+                    rhs, [0, 0], [128, 128], [128, 128], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                lhs_l0a: pl.Tile[[16, 128], pl.BF16] = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_l0b: pl.Tile[[128, 128], pl.BF16] = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                y_tile: pl.Tile[[16, 128], pl.FP32] = pl.matmul(lhs_l0a, rhs_l0b)
+                out_0: pl.Tensor[[16, 128], pl.BF16] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[16, 128], pl.BF16]:
+                out_0: pl.Tensor[[16, 128], pl.BF16] = pl.create_tensor([16, 128], dtype=pl.BF16)
+                y: pl.Tensor[[16, 128], pl.BF16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_assemble_tile_tile_then_cast_conversion(self):
+        """tensor.create + tensor.assemble(tile,tile) + tensor.cast must not crash.
+
+        Regression test: tensor.create → tile.create, so the subsequent
+        tensor.assemble sees both args as tiles → tile.assemble (stays TileType).
+        The following tensor.cast then sees a tile input and converts to tile.cast
+        without error.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[1, 32], pl.FP32],
+                b: pl.Tensor[[1, 32], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.BF16]:
+                t: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor([1, 64], dtype=pl.FP32)
+                t = pl.assemble(t, a, [0, 0])
+                t = pl.assemble(t, b, [0, 32])
+                out: pl.Tensor[[1, 64], pl.BF16] = pl.cast(t, target_type=pl.BF16)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[1, 32], pl.FP32],
+                b: pl.Tensor[[1, 32], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.BF16]:
+                out: pl.Tensor[[1, 64], pl.BF16] = self.main_incore_0(a, b)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir_str = str(After)
+        assert "tile.assemble" in ir_str
+        assert "tile.cast" in ir_str
+
     def test_no_spurious_loads_for_explicit_tile_ops(self):
         """Regression test for #334: no redundant Vec loads when params are consumed by tile ops only.
 
@@ -1310,6 +1469,215 @@ class TestGmLocalTensorConversion:
             def main(self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]) -> pl.Scalar[pl.FP32]:
                 v: pl.Scalar[pl.FP32] = self.main_incore_0(a, b)
                 return v
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestSliceMatmulConversion:
+    """Test tensor.slice + tensor.matmul conversion patterns.
+
+    When a tensor.slice result feeds into tensor.matmul, the slice should produce
+    tile.load(Mat, transpose=...) instead of tile.load(Vec), and the matmul should
+    skip its own load for that operand (using the tile directly for move + matmul).
+    """
+
+    def test_slice_then_matmul_no_trans(self):
+        """slice + matmul (no trans) -> tile.load(Mat, transpose=False) + move + matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                b_slice: pl.Tensor[[128, 64], pl.BF16] = pl.slice(b, [128, 64], [0, 0])
+                result: pl.Tensor[[16, 64], pl.BF16] = pl.matmul(a, b_slice)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(a, b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.BF16]],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                b_slice_tile: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                    b, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                lhs_mat: pl.Tile[[16, 128], pl.BF16] = pl.load(
+                    a, [0, 0], [16, 128], [16, 128], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                lhs_l0a: pl.Tile[[16, 128], pl.BF16] = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_l0b: pl.Tile[[128, 64], pl.BF16] = pl.move(
+                    b_slice_tile, target_memory=pl.MemorySpace.Right
+                )
+                result_tile: pl.Tile[[16, 64], pl.FP32] = pl.matmul(lhs_l0a, rhs_l0b)
+                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.store(result_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.create_tensor([16, 64], dtype=pl.BF16)
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(a, b, out_0)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_slice_then_matmul_btrans(self):
+        """slice + matmul(b_trans=True) -> tile.load(Mat, transpose=True) with swapped shapes."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                q: pl.Tensor[[1, 128], pl.BF16],
+                k_cache: pl.Tensor[[120, 128], pl.BF16],
+            ) -> pl.Tensor[[1, 120], pl.BF16]:
+                k_slice: pl.Tensor[[120, 128], pl.BF16] = pl.slice(k_cache, [120, 128], [0, 0])
+                result: pl.Tensor[[1, 120], pl.BF16] = pl.matmul(q, k_slice, b_trans=True)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                q: pl.Tensor[[1, 128], pl.BF16],
+                k_cache: pl.Tensor[[120, 128], pl.BF16],
+            ) -> pl.Tensor[[1, 120], pl.BF16]:
+                result: pl.Tensor[[1, 120], pl.BF16] = self.main_incore_0(q, k_cache)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                q: pl.Tensor[[1, 128], pl.BF16],
+                k_cache: pl.Tensor[[120, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[1, 120], pl.BF16]],
+            ) -> pl.Tensor[[1, 120], pl.BF16]:
+                k_slice_tile: pl.Tile[[128, 120], pl.BF16] = pl.load(
+                    k_cache,
+                    [0, 0],
+                    [128, 120],
+                    [128, 120],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=True,
+                )
+                lhs_mat: pl.Tile[[1, 128], pl.BF16] = pl.load(
+                    q,
+                    [0, 0],
+                    [1, 128],
+                    [1, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=False,
+                )
+                lhs_l0a: pl.Tile[[1, 128], pl.BF16] = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_l0b: pl.Tile[[128, 120], pl.BF16] = pl.move(
+                    k_slice_tile, target_memory=pl.MemorySpace.Right
+                )
+                result_tile: pl.Tile[[1, 120], pl.FP32] = pl.matmul(lhs_l0a, rhs_l0b)
+                out_0: pl.Tensor[[1, 120], pl.BF16] = pl.store(result_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                q: pl.Tensor[[1, 128], pl.BF16],
+                k_cache: pl.Tensor[[120, 128], pl.BF16],
+            ) -> pl.Tensor[[1, 120], pl.BF16]:
+                out_0: pl.Tensor[[1, 120], pl.BF16] = pl.create_tensor([1, 120], dtype=pl.BF16)
+                result: pl.Tensor[[1, 120], pl.BF16] = self.main_incore_0(q, k_cache, out_0)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_slice_then_matmul_atrans(self):
+        """slice + matmul(a_trans=True) -> tile.load(Mat, transpose=True) for lhs with swapped shapes."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, 16], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                a_slice: pl.Tensor[[128, 16], pl.BF16] = pl.slice(a, [128, 16], [0, 0])
+                result: pl.Tensor[[16, 64], pl.BF16] = pl.matmul(a_slice, b, a_trans=True)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 16], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(a, b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, 16], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.BF16]],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                a_slice_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(
+                    a,
+                    [0, 0],
+                    [16, 128],
+                    [16, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=True,
+                )
+                rhs_mat: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                    b,
+                    [0, 0],
+                    [128, 64],
+                    [128, 64],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=False,
+                )
+                lhs_l0a: pl.Tile[[16, 128], pl.BF16] = pl.move(
+                    a_slice_tile, target_memory=pl.MemorySpace.Left
+                )
+                rhs_l0b: pl.Tile[[128, 64], pl.BF16] = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                result_tile: pl.Tile[[16, 64], pl.FP32] = pl.matmul(lhs_l0a, rhs_l0b)
+                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.store(result_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 16], pl.BF16],
+                b: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.create_tensor([16, 64], dtype=pl.BF16)
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(a, b, out_0)
+                return result
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)


### PR DESCRIPTION
- Add tile.assemble op for writing source tile into target tile at offset
- Move transpose from tile.move to tile.load in matmul conversion, supporting both a_trans and b_trans
- Pre-scan slice→matmul patterns to emit tile.load(Mat) directly from tensor.slice, skipping redundant Vec→Mat loads
- Update tensor.assemble tile-tile conversion to use tile.assemble
- Support optional valid_shape arg in tensor.slice conversion
- Append span location to type deduction errors in OpRegistry
- Auto-generate timestamped save_kernels directory in runner