### PR TITLE
fix(pass): erase stale var_map entries for unconverted assignments

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1124,6 +1124,8 @@ std::vector<StmtPtr> UpdateCallSitesBody(
         changed = true;
       } else {
         result.push_back(stmt);
+        // Erase any stale mapping: this assignment redefines the variable
+        var_map.erase(assign->var_->name_);
       }
       continue;
     }
@@ -1137,6 +1139,7 @@ std::vector<StmtPtr> UpdateCallSitesBody(
         changed = true;
       } else {
         result.push_back(stmt);
+        var_map.erase(assign->var_->name_);
       }
       continue;
     }
@@ -1150,6 +1153,7 @@ std::vector<StmtPtr> UpdateCallSitesBody(
         changed = true;
       } else {
         result.push_back(stmt);
+        var_map.erase(assign->var_->name_);
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- Fix a bug in `UpdateCallSitesBody` within the `ConvertTensorToTileOps` pass where stale variable mappings were not erased when assignments fell through to the unconverted (else) branches
- When a variable was previously mapped due to a transformed assignment, a subsequent untransformed assignment to the same variable left the old mapping intact, causing incorrect substitutions in downstream statements
- Added `var_map.erase(assign->var_->name_)` in all three early-exit branches (non-Call value, non-GlobalVar target, no added outputs)

## Testing
- [x] All 2229 unit tests pass
- [x] Code review completed (PASS)
- [x] Clang-tidy passed
- [x] Pre-commit hooks passed (clang-format, cpplint, headers)