### PR TITLE
chore(skill): improve fix-pr skill with shell pitfalls

### DIFF
--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -49,7 +49,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }' > /tmp/threads.json
 
 # Count unresolved threads (use whitespace-tolerant pattern)
-grep -c '"isResolved":\s*false' /tmp/threads.json
+grep -Ec '"isResolved":[[:space:]]*false' /tmp/threads.json
 
 # Paginate: if hasNextPage is true, re-run with -F cursor="<endCursor>" until done
 
@@ -87,7 +87,7 @@ gh pr checks <NUMBER> --json name,state,link
 
 # Extract run ID from a failed check's link
 # Link format: https://github.com/<owner>/<repo>/actions/runs/<RUN_ID>/job/<JOB_ID>
-RUN_ID=$(echo "$LINK" | sed -n 's|.*/runs/\([0-9]\+\)/.*|\1|p')
+RUN_ID=$(echo "$LINK" | sed -En 's|.*/runs/([0-9]+)/.*|\1|p')
 gh run view "$RUN_ID" --log-failed
 ```
 


### PR DESCRIPTION
## Summary
- Condensed `.claude/skills/fix-pr/SKILL.md` from 250→154 lines (under 200-line limit)
- Added shell pitfalls section documenting `gh api graphql` parsing issues (`JSONDecodeError`, `Expected VAR_SIGN` with `--jq`)
- Added `--log-failed` run completion caveat (requires all jobs complete, not just failed one)
- Added pagination guidance for review thread fetching
- Restored checklist and external checks tip

## Testing
- [ ] Skill file is under 200-line limit (154 lines)
- [ ] Markdown passes markdownlint
- [ ] All pre-commit hooks pass