### PR TITLE
fix(pass): remove overly aggressive consecutive tensor.slice check

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -397,7 +397,6 @@ std::unordered_map<std::string, MatmulSliceInfo> PreScanSliceMatmulPatterns(
  */
 std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
                                          std::unordered_map<std::string, VarPtr>& tensor_to_tile,
-                                         std::unordered_set<std::string>& sliced_vars,
                                          const OpConversionRegistry& conv_registry,
                                          const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
@@ -431,16 +430,14 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
     // SeqStmts: recurse into children
     if (auto seq = As<SeqStmts>(stmt)) {
-      auto inner =
-          TransformIncoreBody(seq->stmts_, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
+      auto inner = TransformIncoreBody(seq->stmts_, tensor_to_tile, conv_registry, op_registry, span);
       result.insert(result.end(), inner.begin(), inner.end());
       continue;
     }
 
     // OpStmts: recurse into children (same structure as SeqStmts)
     if (auto op_stmts = As<OpStmts>(stmt)) {
-      auto inner = TransformIncoreBody(op_stmts->stmts_, tensor_to_tile, sliced_vars, conv_registry,
-                                       op_registry, span);
+      auto inner = TransformIncoreBody(op_stmts->stmts_, tensor_to_tile, conv_registry, op_registry, span);
       result.insert(result.end(), inner.begin(), inner.end());
       continue;
     }
@@ -448,8 +445,7 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     // ScopeStmt: recurse into body (transparent scope, defs leak through)
     if (auto scope = As<ScopeStmt>(stmt)) {
       auto body_stmts = FlattenToStmts(scope->body_);
-      auto inner =
-          TransformIncoreBody(body_stmts, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
+      auto inner = TransformIncoreBody(body_stmts, tensor_to_tile, conv_registry, op_registry, span);
       result.push_back(std::make_shared<ScopeStmt>(scope->scope_kind_,
                                                    WrapInSeqStmts(inner, scope->body_->span_), scope->span_));
       continue;
@@ -462,8 +458,7 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
       // Recurse into then branch with a copy of the map
       auto then_map = tensor_to_tile;
       auto then_stmts = FlattenToStmts(if_stmt->then_body_);
-      auto new_then_stmts =
-          TransformIncoreBody(then_stmts, then_map, sliced_vars, conv_registry, op_registry, span);
+      auto new_then_stmts = TransformIncoreBody(then_stmts, then_map, conv_registry, op_registry, span);
       auto new_then_body = WrapInSeqStmts(new_then_stmts, if_stmt->then_body_->span_);
 
       // Recurse into else branch with a copy of the map
@@ -471,8 +466,7 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
       if (if_stmt->else_body_.has_value()) {
         auto else_map = tensor_to_tile;
         auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
-        auto new_else_stmts =
-            TransformIncoreBody(else_stmts, else_map, sliced_vars, conv_registry, op_registry, span);
+        auto new_else_stmts = TransformIncoreBody(else_stmts, else_map, conv_registry, op_registry, span);
         new_else_body = WrapInSeqStmts(new_else_stmts, (*if_stmt->else_body_)->span_);
       }
 
@@ -523,8 +517,7 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
       // Recurse into body
       auto body_stmts = FlattenToStmts(for_stmt->body_);
-      auto new_body_stmts =
-          TransformIncoreBody(body_stmts, body_map, sliced_vars, conv_registry, op_registry, span);
+      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
       auto new_body = WrapInSeqStmts(new_body_stmts, for_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types
@@ -571,8 +564,7 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
       // Recurse into body
       auto body_stmts = FlattenToStmts(while_stmt->body_);
-      auto new_body_stmts =
-          TransformIncoreBody(body_stmts, body_map, sliced_vars, conv_registry, op_registry, span);
+      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
       auto new_body = WrapInSeqStmts(new_body_stmts, while_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types
@@ -610,8 +602,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
               substituted_args.push_back(SubstituteExpr(arg, tensor_to_tile));
             }
             auto conv_result = (*converter)(substituted_args, call->kwargs_, call->span_);
-            auto transformed_prologue = TransformIncoreBody(conv_result.prologue, tensor_to_tile, sliced_vars,
-                                                            conv_registry, op_registry, span);
+            auto transformed_prologue =
+                TransformIncoreBody(conv_result.prologue, tensor_to_tile, conv_registry, op_registry, span);
             for (const auto& prologue_stmt : transformed_prologue) {
               result.push_back(prologue_stmt);
             }
@@ -726,7 +718,6 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
         auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), assign->var_->span_);
         result.push_back(std::make_shared<AssignStmt>(tile_var, load_call, assign->span_));
         tensor_to_tile[assign->var_->name_] = tile_var;
-        sliced_vars.insert(assign->var_->name_);
         continue;
       }
     }
@@ -735,8 +726,8 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
 
     // Prologue statements may themselves contain tensor ops (e.g. tensor.create
     // used as a scratch buffer). Run them through the same conversion pipeline.
-    auto transformed_prologue = TransformIncoreBody(conv_result.prologue, tensor_to_tile, sliced_vars,
-                                                    conv_registry, op_registry, span);
+    auto transformed_prologue =
+        TransformIncoreBody(conv_result.prologue, tensor_to_tile, conv_registry, op_registry, span);
     for (const auto& prologue_stmt : transformed_prologue) {
       result.push_back(prologue_stmt);
     }
@@ -745,11 +736,6 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
     auto tile_var = std::make_shared<Var>(tile_name, conv_result.result->GetType(), assign->var_->span_);
     result.push_back(std::make_shared<AssignStmt>(tile_var, conv_result.result, assign->span_));
     tensor_to_tile[assign->var_->name_] = tile_var;
-
-    // Track slice results for consecutive slice detection
-    if (call->op_->name_ == "tensor.slice") {
-      sliced_vars.insert(assign->var_->name_);
-    }
   }
 
   return result;
@@ -816,9 +802,6 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   // Phase 2: Walk body and convert tensor ops to tile ops (recursive for nested control flow)
   auto body_stmts = FlattenToStmts(func->body_);
 
-  // Track variables produced by tensor.slice to detect consecutive slicing
-  std::unordered_set<std::string> sliced_vars;
-
   // Separate return statement from body (will be replaced in Phase 3)
   ReturnStmtPtr return_stmt;
   std::vector<StmtPtr> non_return_stmts;
@@ -830,8 +813,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     }
   }
 
-  auto transformed =
-      TransformIncoreBody(non_return_stmts, tensor_to_tile, sliced_vars, conv_registry, op_registry, span);
+  auto transformed = TransformIncoreBody(non_return_stmts, tensor_to_tile, conv_registry, op_registry, span);
   new_stmts.insert(new_stmts.end(), transformed.begin(), transformed.end());
 
   // Phase 3: Add output params + tile.store for return values

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1289,7 +1289,7 @@ class TestGmLocalTensorConversion:
         ir.assert_structural_equal(After, Expected)
 
     def test_consecutive_slice_converts_to_tile_slice(self):
-        """Consecutive tensor.slice on a slice result should produce tile.slice."""
+        """Consecutive tensor.slice: first becomes tile.load, second becomes tile.slice."""
 
         @pl.program
         class Before:
@@ -1304,12 +1304,107 @@ class TestGmLocalTensorConversion:
                 y: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(x)
                 return y
 
-        # Consecutive slices should now succeed — the second slice converts to tile.slice
-        result = passes.convert_tensor_to_tile_ops()(Before)
-        incore_funcs = [f for f in result.functions.values() if f.func_type == ir.FunctionType.InCore]
-        assert len(incore_funcs) == 1
-        incore_str = incore_funcs[0].as_python()
-        assert "tile.slice" in incore_str, "Expected tile.slice for consecutive slice"
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[32, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                s1_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(x, [0, 0], [16, 32])
+                s2_tile: pl.Tile[[4, 8], pl.FP32] = pl.tile.slice(s1_tile, [4, 8], [0, 0])
+                out_0: pl.Tensor[[4, 8], pl.FP32] = pl.store(s2_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                out_0: pl.Tensor[[4, 8], pl.FP32] = pl.create_tensor([4, 8], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_triple_consecutive_slice(self):
+        """Three consecutive tensor.slice: first becomes tile.load, rest become tile.slice."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[2, 4], pl.FP32]:
+                s1: pl.Tensor[[32, 64], pl.FP32] = pl.tensor.slice(x, [32, 64], [0, 0])
+                s2: pl.Tensor[[8, 16], pl.FP32] = pl.tensor.slice(s1, [8, 16], [0, 0])
+                s3: pl.Tensor[[2, 4], pl.FP32] = pl.tensor.slice(s2, [2, 4], [0, 0])
+                return s3
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[2, 4], pl.FP32]:
+                y: pl.Tensor[[2, 4], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[64, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 4], pl.FP32]:
+                s1_tile: pl.Tile[[32, 64], pl.FP32] = pl.load(x, [0, 0], [32, 64])
+                s2_tile: pl.Tile[[8, 16], pl.FP32] = pl.tile.slice(s1_tile, [8, 16], [0, 0])
+                s3_tile: pl.Tile[[2, 4], pl.FP32] = pl.tile.slice(s2_tile, [2, 4], [0, 0])
+                out_0: pl.Tensor[[2, 4], pl.FP32] = pl.store(s3_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[2, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 4], pl.FP32] = pl.create_tensor([2, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_consecutive_slice_with_computation(self):
+        """Consecutive slice result used in computation (tile.add)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                s1: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.slice(x, [16, 32], [0, 0])
+                s2: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.slice(s1, [4, 8], [0, 0])
+                y: pl.Tensor[[4, 8], pl.FP32] = pl.add(s2, s2)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                y: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[32, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                s1_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(x, [0, 0], [16, 32])
+                s2_tile: pl.Tile[[4, 8], pl.FP32] = pl.tile.slice(s1_tile, [4, 8], [0, 0])
+                y_tile: pl.Tile[[4, 8], pl.FP32] = pl.tile.add(s2_tile, s2_tile)
+                out_0: pl.Tensor[[4, 8], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 64], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                out_0: pl.Tensor[[4, 8], pl.FP32] = pl.create_tensor([4, 8], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_gm_tensor_read_stays_tensor_read(self):
         """gm_tensor.read (function param) stays as tensor.read, no Phase 1 load."""


### PR DESCRIPTION
## Summary

- Remove the hard error in `ConvertTensorToTileOps` that rejected consecutive `tensor.slice` operations (slicing the result of a prior slice)
- The `op_conversion_registry` already handles tile-type inputs correctly via `tile.slice` conversion, making this check unnecessary
- Remove the now-dead `sliced_vars` parameter from `TransformIncoreBody` — after removing the check, it was only written to but never read (dead code threaded through every recursive call)
- Replace the weak string-matching test with three proper `Before`/`Expected` tests using `ir.assert_structural_equal`

## Test plan

- [x] `test_consecutive_slice_converts_to_tile_slice` — verifies first slice → `tile.load`, second slice → `tile.slice`
- [x] `test_triple_consecutive_slice` — three chained slices: load + slice + slice + store
- [x] `test_consecutive_slice_with_computation` — consecutive slice result fed into `tile.add`
- [x] Full `tests/ut/ir/transforms/` suite passes (602 tests)