### PR TITLE
fix(codegen): use memref-based type lookup for SSA value consistency

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -140,8 +140,20 @@ class PTOCodegen : public CodegenBase {
 
   /**
    * @brief Get tile_buf type string for the current assignment result target
+   *
+   * Uses the memref-based lookup (same as alloc_tile) to ensure the emitted
+   * type is consistent with the SSA value's definition.
    */
   std::string GetCurrentResultTileBufTypeString() const;
+
+  /**
+   * @brief Get tile_buf type string from the current result's own TileType
+   *
+   * Unlike GetCurrentResultTileBufTypeString(), this bypasses the memref lookup
+   * and uses current_result_tile_type_ directly. Needed for operations like
+   * reshape where the output shape differs from the memref's alloc_tile shape.
+   */
+  std::string GetCurrentResultTileBufTypeStringFromTileType() const;
 
   /**
    * @brief Get tile_buf type string directly from a TileType

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1038,7 +1038,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
                                  << op->args_.size();
     std::string src = codegen.GetExprAsCode(op->args_[0]);
     std::string result_target = codegen.GetCurrentResultTarget();
-    std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+    // Use the TileType-based method to get the correct reshaped output type,
+    // bypassing the memref lookup which would return the pre-reshape shape.
+    std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
     // Get the correct input type directly from the source variable's TileType,
     // bypassing the memref_to_tile_type_ lookup which may return the wrong shape
     // when input and output share the same MemRef.

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -849,28 +849,13 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
 
 std::string PTOCodegen::GetCurrentResultTileBufTypeString() const {
   if (current_result_tile_type_ && current_result_tile_type_->memref_.has_value()) {
-    // Check if the MemRef has an updated pad value from fillpad.
-    // Only take the pad value — NOT the shape, because memory reuse can make
-    // different-shaped tiles share the same MemRef.
-    auto memref = current_result_tile_type_->memref_.value().get();
-    auto it = memref_to_tile_type_.find(memref);
-    if (it != memref_to_tile_type_.end()) {
-      if (it->second->tile_view_.has_value()) {
-        const auto& tv = it->second->tile_view_.value();
-        if (tv.pad != ir::TilePad::null) {
-          // Merge: use current tile's shape but take pad from memref mapping
-          auto current = current_result_tile_type_;
-          ir::TileView merged_view;
-          if (current->tile_view_.has_value()) {
-            merged_view = current->tile_view_.value();
-          }
-          merged_view.pad = tv.pad;
-          auto merged =
-              std::make_shared<TileType>(current->shape_, current->dtype_, current->memref_, merged_view);
-          return GetTileBufTypeStringFromTileType(merged);
-        }
-      }
-    }
+    return GetTileBufTypeString(current_result_tile_type_->memref_.value().get());
+  }
+  return "";
+}
+
+std::string PTOCodegen::GetCurrentResultTileBufTypeStringFromTileType() const {
+  if (current_result_tile_type_ && current_result_tile_type_->memref_.has_value()) {
     return GetTileBufTypeStringFromTileType(current_result_tile_type_);
   }
   return "";


### PR DESCRIPTION
GetCurrentResultTileBufTypeString used current_result_tile_type_ directly, which could produce a different blayout than the alloc_tile definition for the same SSA value (e.g., shape heuristic infers col_major for [N,1] tiles while memref_to_tile_type_ has row_major).

Delegate to GetTileBufTypeString(memref) so the emitted type always matches the alloc_tile definition. Add a separate
GetCurrentResultTileBufTypeStringFromTileType method for reshape, which intentionally needs a type that differs from the alloc_tile.