### PR TITLE
fix(codegen): exclude non-scalar iter_args from PTO scf.for iter_args/yield

### DIFF
--- a/python/pypto/ir/pto_codegen.py
+++ b/python/pypto/ir/pto_codegen.py
@@ -23,6 +23,8 @@ import os
 import re
 import shutil
 import subprocess
+import textwrap
+from collections import OrderedDict
 
 from pypto.pypto_core import codegen as _codegen_core
 from pypto.pypto_core import ir as _ir_core
@@ -30,6 +32,79 @@ from pypto.pypto_core import ir as _ir_core
 logger = logging.getLogger(__name__)
 
 _PTOAS_RELEASE_URL = "https://github.com/zhangstevenunity/PTOAS/releases"
+
+
+def _get_error_summary(exc: Exception, func_name: str) -> str:
+    """Extract the first meaningful line from an exception, without the function name.
+
+    Strips the C++ Traceback tail, takes only the first line, and removes
+    occurrences of *func_name* so that identical errors across different
+    functions can be grouped together.
+    """
+    msg = str(exc)
+    traceback_marker = msg.find("\n\nC++ Traceback")
+    if traceback_marker != -1:
+        msg = msg[:traceback_marker]
+    first_line = msg.split("\n", 1)[0].strip()
+    if not first_line:
+        return type(exc).__name__
+    summary = first_line.replace(func_name, "").replace("  ", " ").strip()
+    return summary or first_line
+
+
+def _format_error_report(
+    errors: list[tuple[str, Exception]],
+    output_dir: str,
+) -> str:
+    """Build a concise error summary table and write full details to a log file.
+
+    Groups functions by their error summary so that identical errors appear on a
+    single row.  Returns the summary string for use in the ``RuntimeError`` message.
+    """
+    max_error_col = 60
+
+    grouped: OrderedDict[str, list[str]] = OrderedDict()
+    for name, exc in errors:
+        summary = _get_error_summary(exc, name)
+        grouped.setdefault(summary, []).append(name)
+
+    longest_error = max(len(s) for s in grouped)
+    error_col_width = min(longest_error, max_error_col) + 2
+    error_col_width = max(error_col_width, len("Error") + 2)
+    func_col_width = max(len(n) for n, _ in errors) + 2
+    func_col_width = max(func_col_width, len("Function") + 2)
+
+    lines: list[str] = [f"{len(errors)} function(s) failed to compile:\n"]
+    lines.append(f"  {'Error':<{error_col_width}}| {'Function'}")
+    lines.append(f"  {'-' * error_col_width}+{'-' * func_col_width}")
+
+    sep_line = f"  {'-' * error_col_width}+{'-' * func_col_width}"
+    for summary, func_names in grouped.items():
+        wrapped = textwrap.wrap(summary, width=max_error_col) or [summary]
+        lines.append(f"  {wrapped[0]:<{error_col_width}}| {func_names[0]}")
+        remaining = max(len(wrapped) - 1, len(func_names) - 1)
+        for i in range(remaining):
+            err_part = wrapped[i + 1] if i + 1 < len(wrapped) else ""
+            func_part = func_names[i + 1] if i + 1 < len(func_names) else ""
+            lines.append(f"  {err_part:<{error_col_width}}| {func_part}")
+        lines.append(sep_line)
+
+    summary_text = "\n".join(lines)
+
+    report_dir = os.path.join(output_dir, "report")
+    detail_path = os.path.join(report_dir, "codegen_errors.txt")
+    separator = "\n" + "=" * 72 + "\n"
+    detail_parts = [f"  [{name}]\n{exc}" for name, exc in errors]
+    detail_content = summary_text + "\n\n" + separator.join(detail_parts)
+    try:
+        os.makedirs(report_dir, exist_ok=True)
+        with open(detail_path, "w") as f:
+            f.write(detail_content)
+        lines.append(f"\n  Full details: {detail_path}")
+    except OSError:
+        pass
+
+    return "\n".join(lines)
 
 
 def _run_ptoas(
@@ -338,8 +413,6 @@ def generate(
             errors.append((orch_func.name, e))
 
     if errors:
-        separator = "\n" + "-" * 60 + "\n"
-        error_details = separator.join(f"  - {name}: {exc}" for name, exc in errors)
-        raise RuntimeError(f"{len(errors)} function(s) failed to compile:\n{error_details}")
+        raise RuntimeError(_format_error_report(errors, output_dir))
 
     return result_files

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -224,10 +224,10 @@ def run(
 
         return RunResult(passed=True, execution_time=time.time() - start_time)
 
-    except Exception as exc:
+    except Exception:
         return RunResult(
             passed=False,
-            error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+            error=traceback.format_exc(),
             execution_time=time.time() - start_time,
         )
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1210,72 +1210,104 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
   std::string loop_var_name = NewTemp();
   var_to_mlir_[op->loop_var_->name_] = loop_var_name;
 
-  if (op->iter_args_.empty()) {
-    // Simple scf.for (no iter_args)
+  // In PTO, only scalar types (index, f32, bool, etc.) need iter_args/yield
+  // for loop-carried value semantics. Non-scalar types (TileType, TensorType)
+  // are mutable references written in-place via outs(), so they are mapped
+  // directly to their init values and excluded from iter_args/yield.
+  std::vector<bool> is_scalar(op->iter_args_.size(), false);
+  bool has_scalar_iter_args = false;
+  for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+    if (As<ScalarType>(op->iter_args_[i]->GetType())) {
+      is_scalar[i] = true;
+      has_scalar_iter_args = true;
+    }
+  }
+
+  // Map non-scalar iter_args/return_vars directly to their init values
+  for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+    if (is_scalar[i]) continue;
+
+    const auto& iter_arg = op->iter_args_[i];
+    const auto& return_var = op->return_vars_[i];
+
+    std::string init_mlir_name;
+    auto tensor_type = As<TensorType>(iter_arg->GetType());
+    if (tensor_type) {
+      auto init_var = std::dynamic_pointer_cast<const ir::Var>(iter_arg->initValue_);
+      INTERNAL_CHECK(init_var) << "TensorType iter_arg init value must be a Var or IterArg";
+      auto tv_it = tensor_to_view_.find(init_var->name_);
+      INTERNAL_CHECK(tv_it != tensor_to_view_.end())
+          << "Tensor view not found for iter_arg init value: " << init_var->name_;
+      init_mlir_name = tv_it->second;
+    } else {
+      VisitExpr(iter_arg->initValue_);
+      init_mlir_name = current_expr_value_;
+      current_expr_value_ = "";
+    }
+
+    var_to_mlir_[iter_arg->name_] = init_mlir_name;
+    var_to_mlir_[return_var->name_] = init_mlir_name;
+
+    if (tensor_type) {
+      tensor_to_view_[iter_arg->name_] = init_mlir_name;
+      tensor_to_view_[return_var->name_] = init_mlir_name;
+    } else if (auto tile_type = As<TileType>(iter_arg->GetType())) {
+      if (tile_type->memref_.has_value()) {
+        var_to_memref_[iter_arg->name_] = tile_type->memref_.value().get();
+        var_to_memref_[return_var->name_] = tile_type->memref_.value().get();
+      }
+    }
+  }
+
+  if (!has_scalar_iter_args) {
+    // Simple scf.for (no iter_args, or all iter_args are non-scalar)
     Emit("scf.for " + loop_var_name + " = " + start + " to " + stop + " step " + step + " {");
     indent_level_++;
 
     yield_buffer_.clear();
     VisitStmt(op->body_);
+    yield_buffer_.clear();
 
     indent_level_--;
     Emit("}");
   } else {
-    // scf.for with iter_args
+    // scf.for with scalar iter_args only
     std::vector<std::string> init_values;
     std::vector<std::string> iter_arg_names;
     std::vector<std::string> iter_arg_types;
 
-    for (const auto& iter_arg : op->iter_args_) {
-      auto tensor_type = As<TensorType>(iter_arg->GetType());
-      if (tensor_type) {
-        // For TensorType iter_args, use the init value's tensor view
-        auto init_var = std::dynamic_pointer_cast<const ir::Var>(iter_arg->initValue_);
-        INTERNAL_CHECK(init_var) << "TensorType iter_arg init value must be a Var or IterArg";
-        auto tv_it = tensor_to_view_.find(init_var->name_);
-        INTERNAL_CHECK(tv_it != tensor_to_view_.end())
-            << "Tensor view not found for iter_arg init value: " << init_var->name_;
-        init_values.push_back(tv_it->second);
-      } else {
-        VisitExpr(iter_arg->initValue_);
-        init_values.push_back(current_expr_value_);
-        current_expr_value_ = "";
-      }
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      if (!is_scalar[i]) continue;
+
+      const auto& iter_arg = op->iter_args_[i];
+
+      VisitExpr(iter_arg->initValue_);
+      init_values.push_back(current_expr_value_);
+      current_expr_value_ = "";
 
       std::string iter_name = NewTemp();
       var_to_mlir_[iter_arg->name_] = iter_name;
       iter_arg_names.push_back(iter_name);
 
-      if (tensor_type) {
-        tensor_to_view_[iter_arg->name_] = iter_name;
-        iter_arg_types.push_back(GetTensorViewTypeString(tensor_type.get()));
-      } else if (auto tile_type = As<TileType>(iter_arg->GetType())) {
-        INTERNAL_CHECK(tile_type->memref_.has_value())
-            << "TileType iter_arg must have a MemRef at codegen stage for arg: " << iter_arg->name_;
-        var_to_memref_[iter_arg->name_] = tile_type->memref_.value().get();
-        iter_arg_types.push_back(GetTileBufTypeString(tile_type->memref_.value().get()));
-      } else {
-        std::string type_str = "index";
-        if (auto scalar_type = As<ScalarType>(iter_arg->GetType())) {
-          if (scalar_type->dtype_ == DataType::BOOL) {
-            type_str = "i1";
-          } else if (scalar_type->dtype_.IsFloat()) {
-            type_str = GetTypeString(scalar_type->dtype_);
-          }
+      std::string type_str = "index";
+      if (auto scalar_type = As<ScalarType>(iter_arg->GetType())) {
+        if (scalar_type->dtype_ == DataType::BOOL) {
+          type_str = "i1";
+        } else if (scalar_type->dtype_.IsFloat()) {
+          type_str = GetTypeString(scalar_type->dtype_);
         }
-        iter_arg_types.push_back(type_str);
       }
+      iter_arg_types.push_back(type_str);
     }
 
-    // Register return_vars SSA names
+    // Register return_vars SSA names (scalar only)
     std::vector<std::string> return_var_names;
-    for (const auto& return_var : op->return_vars_) {
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      if (!is_scalar[i]) continue;
+
       std::string ret_name = NewTemp();
-      var_to_mlir_[return_var->name_] = ret_name;
+      var_to_mlir_[op->return_vars_[i]->name_] = ret_name;
       return_var_names.push_back(ret_name);
-      if (auto tensor_type = As<TensorType>(return_var->GetType())) {
-        tensor_to_view_[return_var->name_] = ret_name;
-      }
     }
 
     // Emit: %ret0 = scf.for %i = %start to %stop step %step
@@ -1303,13 +1335,21 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     yield_buffer_.clear();
     VisitStmt(op->body_);
 
-    // Emit scf.yield from yield_buffer_
-    if (!yield_buffer_.empty()) {
+    // Filter yield_buffer to keep only scalar iter_arg entries
+    std::vector<std::string> scalar_yields;
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      if (is_scalar[i] && i < yield_buffer_.size()) {
+        scalar_yields.push_back(yield_buffer_[i]);
+      }
+    }
+
+    // Emit scf.yield from filtered yield values
+    if (!scalar_yields.empty()) {
       std::ostringstream yield_oss;
       yield_oss << "scf.yield ";
-      for (size_t i = 0; i < yield_buffer_.size(); ++i) {
+      for (size_t i = 0; i < scalar_yields.size(); ++i) {
         if (i > 0) yield_oss << ", ";
-        yield_oss << yield_buffer_[i];
+        yield_oss << scalar_yields[i];
       }
       yield_oss << " : ";
       for (size_t i = 0; i < iter_arg_types.size(); ++i) {
@@ -1318,8 +1358,8 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       }
       Emit(yield_oss.str());
     }
-    CHECK(yield_buffer_.size() == iter_arg_types.size())
-        << "ForStmt yield count (" << yield_buffer_.size() << ") must match iter_args ("
+    CHECK(scalar_yields.size() == iter_arg_types.size())
+        << "ForStmt scalar yield count (" << scalar_yields.size() << ") must match scalar iter_args ("
         << iter_arg_types.size() << ")";
     yield_buffer_.clear();
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -19,8 +19,6 @@ Tests verify:
 - SSA form with correct variable naming
 """
 
-import re
-
 import pypto.language as pl
 import pytest
 from pypto import DataType, backend, codegen, ir
@@ -651,12 +649,12 @@ class TestGenerateSkipPtoas:
 
 
 def test_pto_codegen_for_loop_tensor_iter_arg():
-    """Test that tensor-typed iter_args in for loops generate correct tensor_view propagation.
+    """Test that tensor-typed iter_args are excluded from PTO scf.for iter_args/yield.
 
-    Regression test: before the fix, block.store with a tensor iter_arg (loop-carried
-    output tensor) would crash with 'Tensor view not found for parameter: out_iter'.
-    The codegen now propagates tensor_to_view_ mappings through ForStmt iter_args,
-    return_vars, and IfStmt return_vars.
+    In PTO, tensor views are reference types. Only scalar types need iter_args/yield
+    for loop-carried value semantics. Tensor iter_args are mapped directly to their
+    init values (the output tensor view), and the generated scf.for should not contain
+    iter_args or scf.yield for tensor types.
     """
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.Ascend910B_PTO)
@@ -686,50 +684,39 @@ def test_pto_codegen_for_loop_tensor_iter_arg():
     # The output tensor parameter (%arg1) must have a make_tensor_view
     view_lines = [line for line in lines if "pto.make_tensor_view %arg1" in line]
     assert len(view_lines) == 1, "Expected one make_tensor_view for output tensor (%arg1)"
-    # Extract the SSA name of the output tensor view (e.g., "%2")
     output_view_name = view_lines[0].split("=")[0].strip()
 
-    # scf.for iter_args must reference the output tensor view with tensor_view type
-    for_lines = [line for line in lines if "scf.for" in line and "iter_args(" in line]
-    assert len(for_lines) == 1, "Expected exactly one scf.for with iter_args"
-    for_line = for_lines[0]
-    assert f"= {output_view_name})" in for_line, (
-        f"iter_args init value should be the output tensor view {output_view_name}"
+    # scf.for should NOT have iter_args (tensor is non-scalar, excluded)
+    for_lines = [line for line in lines if "scf.for" in line]
+    assert len(for_lines) == 1, f"Expected exactly one scf.for, got: {for_lines}"
+    assert "iter_args(" not in for_lines[0], (
+        f"scf.for should not have iter_args for tensor types: {for_lines[0]}"
     )
-    assert "!pto.tensor_view<?x?xf32>" in for_line, "iter_args type should be !pto.tensor_view<?x?xf32>"
 
-    # pto.partition_view must operate on the iter_arg (loop-carried tensor view)
+    # No scf.yield should be present (tensor yields are excluded)
+    yield_lines = [line for line in lines if "scf.yield" in line]
+    assert len(yield_lines) == 0, f"No scf.yield expected for tensor-only iter_args: {yield_lines}"
+
+    # pto.partition_view must use the output tensor view directly (mapped from iter_arg)
     partition_lines = [line for line in lines if "pto.partition_view" in line]
     assert len(partition_lines) >= 2, "Expected at least 2 partition_view ops (load + store)"
-    # The store's partition_view should use the iter_arg SSA name, not %arg1 directly
-    # Extract the iter_arg SSA name from the scf.for line (e.g., "%4" from "iter_args(%4 = %2)")
-    iter_arg_match = re.search(r"iter_args\((%\d+)\s*=", for_line)
-    assert iter_arg_match, "Could not extract iter_arg SSA name from scf.for"
-    iter_arg_name = iter_arg_match.group(1)
-    store_partitions = [line for line in partition_lines if f"pto.partition_view {iter_arg_name}," in line]
-    assert len(store_partitions) == 1, (
-        f"Expected one partition_view on iter_arg {iter_arg_name} for the store path"
+    store_partitions = [line for line in partition_lines if f"pto.partition_view {output_view_name}," in line]
+    assert len(store_partitions) >= 1, (
+        f"Expected partition_view on output tensor view {output_view_name} for store path"
     )
 
-    # pto.tstore must be present
+    # pto.tstore must still be present
     tstore_lines = [line for line in lines if line.startswith("pto.tstore")]
     assert len(tstore_lines) == 1, "Expected exactly one pto.tstore"
 
-    # scf.yield must yield a tensor_view type value
-    yield_lines = [line for line in lines if line.startswith("scf.yield")]
-    assert len(yield_lines) == 1, "Expected exactly one scf.yield"
-    assert "!pto.tensor_view<?x?xf32>" in yield_lines[0], "scf.yield type should be !pto.tensor_view<?x?xf32>"
-
 
 def test_pto_codegen_for_loop_tile_iter_arg_no_ddr_alloc():
-    """Test that tile-typed iter_args in for loops generate loc=vec, not loc=gm.
+    """Test that tile-typed iter_args are excluded from PTO scf.for iter_args/yield.
 
-    Regression test: before the fix, the body's IterArg reference could be
-    downgraded to a regular Var with a stale DDR MemRef. This caused:
-    1. A spurious `pto.alloc_tile : !pto.tile_buf<loc=gm, ...>` in the output
-    2. The IterArg operand in `pto.tadd` annotated with `loc=gm` instead of `loc=vec`
-    The fix ensures MemRefCollector skips Var nodes whose name matches a known
-    IterArg, and the codegen uses the definition's MemRef for type annotations.
+    In PTO, tile buffers are mutable references written in-place via outs().
+    Only scalar types need iter_args/yield for loop-carried value semantics.
+    Tile-typed iter_args should be mapped directly to their init values, and
+    the generated scf.for should not contain iter_args or scf.yield for tiles.
     """
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.Ascend910B_PTO)
@@ -772,18 +759,83 @@ def test_pto_codegen_for_loop_tile_iter_arg_no_ddr_alloc():
         assert "loc=vec" in alloc_line, f"Expected loc=vec in alloc_tile, got: {alloc_line}"
         assert "loc=gm" not in alloc_line, f"Unexpected loc=gm in alloc_tile: {alloc_line}"
 
-    # scf.for with iter_args must use loc=vec type
-    for_lines = [line for line in lines if "scf.for" in line and "iter_args(" in line]
-    assert len(for_lines) == 1, "Expected exactly one scf.for with iter_args"
-    assert "loc=vec" in for_lines[0], f"iter_args result type should be loc=vec: {for_lines[0]}"
+    # scf.for should NOT have iter_args (all iter_args are tile type)
+    for_lines = [line for line in lines if "scf.for" in line]
+    assert len(for_lines) == 1, f"Expected exactly one scf.for, got: {for_lines}"
+    assert "iter_args(" not in for_lines[0], (
+        f"scf.for should not have iter_args for tile types: {for_lines[0]}"
+    )
+
+    # No scf.yield should be present (tile yields are excluded)
+    yield_lines = [line for line in lines if "scf.yield" in line]
+    assert len(yield_lines) == 0, f"No scf.yield expected for tile-only iter_args: {yield_lines}"
 
     # pto.tadd (the accumulation op) must have loc=vec for all tile_buf operands
     tadd_lines = [line for line in lines if "pto.tadd" in line]
     assert len(tadd_lines) == 1, "Expected exactly one pto.tadd"
     assert "loc=gm" not in tadd_lines[0], f"pto.tadd should not have loc=gm operands: {tadd_lines[0]}"
     assert tadd_lines[0].count("loc=vec") >= 2, (
-        f"pto.tadd should have at least 2 loc=vec annotations (iter_arg + partial): {tadd_lines[0]}"
+        f"pto.tadd should have at least 2 loc=vec annotations: {tadd_lines[0]}"
     )
+
+
+def test_pto_codegen_mixed_scalar_and_tile_iter_args():
+    """Test that mixed iter_args (tile + scalar) emit only scalar iter_args in PTO.
+
+    In PTO, only scalar types need iter_args/yield for loop-carried value
+    semantics. When a for loop has both tile and scalar iter_args, the generated
+    scf.for should contain iter_args/yield only for the scalar entries, while
+    tile iter_args are mapped directly to their init values.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B_PTO)
+
+    @pl.program
+    class MixedIterArgProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def mixed(
+            self,
+            data: pl.Tensor[[16, 512], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            acc_tile: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+            )
+            init_tile: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_tile, 0.0)
+            init_offset: pl.Scalar[pl.INDEX] = 0
+            for i, (acc_iter, offset) in pl.range(2, init_values=(init_tile, init_offset)):
+                chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, offset], [16, 256])
+                tmp: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
+                updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_iter, partial)
+                new_offset: pl.Scalar[pl.INDEX] = offset + 256
+                result_tile, result_offset = pl.yield_(updated, new_offset)
+            final: pl.Tensor[[16, 1], pl.FP32] = pl.store(result_tile, [0, 0], out)
+            return final
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    transformed_program = pm.run_passes(MixedIterArgProgram)
+
+    codegen_inst = PTOCodegen()
+    mlir_code = _get_mlir_code(codegen_inst.generate(transformed_program))
+    lines = [line.strip() for line in mlir_code.split("\n")]
+
+    # scf.for should have iter_args for the scalar type only
+    for_lines = [line for line in lines if "scf.for" in line]
+    assert len(for_lines) == 1, f"Expected one scf.for, got: {for_lines}"
+    assert "iter_args(" in for_lines[0], f"Expected scalar iter_args: {for_lines[0]}"
+
+    # iter_args type should be index (scalar), not tile_buf
+    assert "tile_buf" not in for_lines[0], f"tile_buf should not appear in iter_args: {for_lines[0]}"
+    assert "index" in for_lines[0], f"Expected index type in iter_args: {for_lines[0]}"
+
+    # scf.yield should have index type only, not tile_buf
+    yield_lines = [line for line in lines if "scf.yield" in line]
+    assert len(yield_lines) == 1, f"Expected one scf.yield, got: {yield_lines}"
+    assert "tile_buf" not in yield_lines[0], f"tile_buf should not appear in scf.yield: {yield_lines[0]}"
+    assert "index" in yield_lines[0], f"Expected index type in scf.yield: {yield_lines[0]}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In PTO, tensor views and tile buffers are mutable references written
in-place via outs(). Only scalar types (index, f32, bool) need
iter_args/yield for loop-carried value semantics. Non-scalar iter_args
are now mapped directly to their init values and excluded from
scf.for iter_args and scf.yield.

Also improve codegen error reporting: group identical errors into a
summary table and write full details to report/codegen_errors.txt.