### PR TITLE
fix(codegen): register tile.slice in PTO backend

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1033,6 +1033,46 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
 
     return std::string("");
   });
+  reg("tile.slice", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 3)
+        << "Operation:[tile.slice] requires 3 arguments (tile, shape, offset), but got " << op->args_.size();
+
+    std::string src = codegen.GetExprAsCode(op->args_[0]);
+    std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+
+    auto offset_tuple = ir::As<ir::MakeTuple>(op->args_[2]);
+    INTERNAL_CHECK(offset_tuple) << "tile.slice third argument must be a tuple (offset)";
+    INTERNAL_CHECK(offset_tuple->elements_.size() >= 2)
+        << "tile.slice offset tuple must have at least 2 elements (row, col), got "
+        << offset_tuple->elements_.size();
+    std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
+    std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
+
+    std::string result_target = codegen.GetCurrentResultTarget();
+    std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
+
+    if (src == result_target && !result_type.empty()) {
+      result_target = codegen.NewTemp();
+      codegen.SetCurrentResultBuf(result_target);
+    }
+    if (!result_type.empty()) {
+      codegen.RegisterTileBufType(result_target, result_type);
+    }
+
+    std::ostringstream oss;
+    oss << "pto.textract ins(" << src << ", " << row_off << ", " << col_off;
+    if (!src_type.empty()) {
+      oss << " : " << src_type << ", index, index";
+    }
+    oss << ") outs(" << result_target;
+    if (!result_type.empty()) {
+      oss << " : " << result_type;
+    }
+    oss << ")";
+    codegen.Emit(oss.str());
+    return std::string("");
+  });
   reg("tile.reshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     CHECK(op->args_.size() == 2) << "Operation:[tile.reshape] requires 2 arguments (tile, shape), but got "

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -645,5 +645,40 @@ class TestBroadcastOpsCodegen:
         assert "pto.tcolexpandmul" in mlir, f"col_expand_mul should generate pto.tcolexpandmul, got:\n{mlir}"
 
 
+class TestTileSliceCodegen:
+    """Tests for tile.slice PTO code generation (pto.textract)."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B_PTO)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_slice_codegen(self):
+        """tile.slice(tile[32,32], [16,16], [0,0]) should generate pto.textract."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[32, 32], pl.FP32],
+                dst: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(src, [0, 0], [32, 32])
+                sliced: pl.Tile[[16, 16], pl.FP32] = pl.tile.slice(src_tile, [16, 16], [0, 0])
+                return pl.store(sliced, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.textract" in mlir, f"tile.slice should generate pto.textract, got:\n{mlir}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #508

Add custom codegen handler for tile.slice that emits pto.textract with the correct ins/outs format. The handler extracts row/col offsets from the offset tuple and handles memory inheritance when input and output share the same MemRef, following the same pattern as tile.reshape.

Made-with: Cursor