### PR TITLE
fix(ir): Fix TensorView not exported problem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# PyPTO Codex Instructions
+
+This repository keeps AI project policy in `.claude/`. Treat `.claude/` as the
+authoritative source of truth; this file is only the Codex entrypoint.
+
+## Read First
+
+Before making code changes, reviewing code, committing changes, or working
+across layers:
+
+- Read `.claude/CLAUDE.md`
+- Read all relevant files in `.claude/rules/`
+- Follow `.claude/skills/*/SKILL.md` when the task matches a documented workflow
+
+Task mapping:
+
+- Testing: `.claude/skills/testing/SKILL.md`
+- Code review: `.claude/skills/code-review/SKILL.md`
+- Commit workflow: `.claude/skills/git-commit/SKILL.md`
+- PR workflow: `.claude/skills/github-pr/SKILL.md`
+- Issue workflows: `.claude/skills/create-issue/SKILL.md`,
+  `.claude/skills/fix-issue/SKILL.md`, `.claude/skills/fix-pr/SKILL.md`
+- Branch cleanup: `.claude/skills/clean-branches/SKILL.md`
+
+When a Claude skill or agent refers to `Task`, a subagent, or Claude-only
+plugins:
+
+- Execute the workflow directly in Codex
+- Use parallel tool calls when safe
+- Treat `.claude/agents/*/AGENT.md` as checklists, not as a separate runtime
+
+## Working Agreements
+
+- Use modern language standards: Python 3.10+ and C++17+
+- Keep public API changes synchronized across `include/pypto/`, `src/`,
+  `python/bindings/`, and `python/pypto/pypto_core/*.pyi`
+- Update docs when behavior changes. English docs in `docs/en/dev/` are the
+  ground truth; keep `docs/zh-cn/dev/` aligned when English docs change
+- Follow `.claude/rules/documentation.md` for markdown file placement; do not
+  create markdown files outside `docs/` unless that rule explicitly allows it
+- Do not create temporary test scripts or examples outside `tests/` and
+  `examples/`
+- Build and test from the current worktree. Never copy `.so` files or other
+  build artifacts from another checkout
+- Treat `.env`, `secrets/`, credentials, and machine-specific absolute paths as
+  off-limits unless the user explicitly requires them
+- Never add AI co-author lines to commits or PR text
+
+## Preferred Commands
+
+For full testing details, follow `.claude/skills/testing/SKILL.md`.
+
+```bash
+# Install dev dependencies
+pip install -e ".[dev]"
+
+# Optional test env
+[ -f .claude/skills/testing/testing.env ] && . .claude/skills/testing/testing.env
+
+# Configure and build
+[ ! -f build/CMakeCache.txt ] && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --parallel
+
+# Test
+export PYTHONPATH=$(pwd)/python:$PYTHONPATH
+python -m pytest tests/ut/ -v
+python -m pytest tests/ut/path/to/test_file.py -v
+
+# Lint and type check
+ruff check .
+ruff format --check .
+pyright
+pre-commit run --all-files
+```
+
+Run system tests in `tests/st/` only when the task requires them and the
+necessary hardware or environment is available.
+
+## Repository Map
+
+- `include/pypto/`: public C++ headers
+- `src/`: C++ implementation, passes, codegen, runtime internals
+- `python/bindings/`: nanobind extension bindings
+- `python/pypto/`: Python API, DSL, pass manager, and type stubs
+- `tests/ut/`: unit tests
+- `tests/st/`: system and hardware-dependent tests
+- `tests/lint/`: repo-specific lint and validation scripts
+- `docs/en/dev/`, `docs/zh-cn/dev/`: developer documentation
+- `examples/`: user-facing examples only

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -48,6 +48,7 @@ from pypto.pypto_core.ir import (
     TileLayout,
     TilePad,
     TileView,
+    TensorView
 )
 
 from . import parser


### PR DESCRIPTION
## Summary
- Fix `TensorView` not exported: add `TensorView` to `pypto.language.__init__` so it is accessible as `pl.TensorView`; `resolve_transpose_layout_pass` emits `TensorView(stride=[], layout=TensorLayout.DN)` into tensor parameter types when it detects `tile.load(..., transpose=True)`, the printer then serializes this as `pl.TensorView(...)` — without the export the parser cannot reconstruct the IR, breaking the print-parse round-trip for all transpose-layout tests

## Testing
- [x] All existing tests pass
- [x] Pre-commit hooks pass (ruff, pyright)
- [x] Fix `TensorView` not exported — 8 tests in `test_resolve_transpose_layout_pass.py` now pass:
  - `TestResolveTransposeLayoutBTranspose::test_btranspose_basic`
  - `TestResolveTransposeLayoutBTranspose::test_btranspose_non_square`
  - `TestResolveTransposeLayoutATranspose::test_atranspose_basic`
  - `TestResolveTransposeLayoutABTranspose::test_abtranspose_basic`
  - `TestResolveTransposeLayoutABTranspose::test_abtranspose_non_square`
  - `TestResolveTransposeLayoutNoOp::test_already_dn_layout_unchanged`
  - `TestResolveTransposeLayoutMixed::test_only_second_param_transposed`
  - `TestResolveTransposeLayoutMixed::test_only_first_param_transposed`