### PR TITLE
fix(serialization): preserve TileType memory_space in serialize/deserialize(#522)

### DIFF
--- a/docs/en/dev/ir/04-serialization.md
+++ b/docs/en/dev/ir/04-serialization.md
@@ -127,7 +127,7 @@ assert len(restored.type.tile_view.valid_shape) == 2
 | **Span** | Map | `filename`, `begin_line`, `begin_column`, `end_line`, `end_column` |
 | **ScalarType** | Map | `type_kind: "ScalarType"`, `dtype: 19` |
 | **TensorType** | Map | `type_kind`, `dtype`, `shape`, optional `memref` |
-| **TileType** | Map | `type_kind`, `dtype`, `shape`, optional `memref`, optional `tile_view` |
+| **TileType** | Map | `type_kind`, `dtype`, `shape`, optional `memref`, optional `tile_view`, optional `memory_space` |
 | **Op/GlobalVar** | Map | `name`, `is_global_var` |
 
 ### MemRef and TileView Format

--- a/docs/zh-cn/dev/ir/04-serialization.md
+++ b/docs/zh-cn/dev/ir/04-serialization.md
@@ -127,7 +127,7 @@ assert len(restored.type.tile_view.valid_shape) == 2
 | **Span** | Map | `filename`, `begin_line`, `begin_column`, `end_line`, `end_column` |
 | **ScalarType** | Map | `type_kind: "ScalarType"`, `dtype: 19` |
 | **TensorType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref` |
-| **TileType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref`, 可选 `tile_view` |
+| **TileType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref`, 可选 `tile_view`, 可选 `memory_space` |
 | **Op/GlobalVar** | Map | `name`, `is_global_var` |
 
 ### MemRef 和 TileView 格式

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -311,6 +311,8 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
     bool has_memref = false;
     bool has_tile_view = false;
     bool has_tensor_view = false;
+    uint8_t memory_space_code = 0;
+    bool has_memory_space = false;
 
     msgpack::object_kv* p = obj.via.map.ptr;
     msgpack::object_kv* const pend = obj.via.map.ptr + obj.via.map.size;
@@ -343,6 +345,9 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
       } else if (key == "tensor_view") {
         tensor_view_obj = p->val;
         has_tensor_view = true;
+      } else if (key == "memory_space") {
+        p->val.convert(memory_space_code);
+        has_memory_space = true;
       }
     }
 
@@ -363,6 +368,7 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
     } else if (type_kind == "TileType") {
       std::optional<MemRefPtr> memref;
       std::optional<TileView> tile_view;
+      std::optional<MemorySpace> memory_space;
 
       if (has_memref) {
         memref = DeserializeMemRef(memref_obj, zone);
@@ -370,13 +376,10 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
       if (has_tile_view) {
         tile_view = DeserializeTileView(tile_view_obj, zone);
       }
-
-      if (has_memref && has_tile_view) {
-        return std::make_shared<TileType>(shape, DataType(dtype_code), memref, tile_view);
-      } else if (has_memref) {
-        return std::make_shared<TileType>(shape, DataType(dtype_code), memref);
+      if (has_memory_space) {
+        memory_space = static_cast<MemorySpace>(memory_space_code);
       }
-      return std::make_shared<TileType>(shape, DataType(dtype_code));
+      return std::make_shared<TileType>(shape, DataType(dtype_code), memref, tile_view, memory_space);
     } else if (type_kind == "TupleType") {
       return std::make_shared<TupleType>(types);
     } else if (type_kind == "MemRefType") {

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -390,6 +390,12 @@ class IRSerializer::Impl {
       if (tile_type->tile_view_.has_value()) {
         type_map["tile_view"] = SerializeTileView(tile_type->tile_view_, zone);
       }
+
+      // Serialize memory_space if present
+      if (tile_type->memory_space_.has_value()) {
+        type_map["memory_space"] =
+            msgpack::object(static_cast<uint8_t>(*tile_type->memory_space_), zone);
+      }
     } else if (auto tuple_type = As<TupleType>(type)) {
       std::vector<msgpack::object> types_vec;
       for (const auto& t : tuple_type->types_) {

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -699,5 +699,85 @@ class TestRobustness:
             ir.deserialize_from_file("/nonexistent/path/file.msgpack")
 
 
+class TestTypeSerialization:
+    """Tests for type serialization, especially optional fields."""
+
+    def test_tiletype_memory_space_survives_round_trip(self):
+        """TileType memory_space is preserved through serialize/deserialize."""
+        # Create a Var with TileType that has memory_space set
+        shape = [ir.ConstInt(16, DataType.INT64, ir.Span.unknown()),
+                 ir.ConstInt(16, DataType.INT64, ir.Span.unknown())]
+        memory_space = ir.MemorySpace.Mat
+        tile_type = ir.TileType(shape, DataType.FP32, None, None, memory_space)
+
+        # Create a Var with this TileType
+        var = ir.Var("tile_var", tile_type, ir.Span.unknown())
+
+        # Serialize and deserialize
+        serialized = ir.serialize(var)
+        restored = ir.deserialize(serialized)
+        restored_var = cast(ir.Var, restored)
+
+        # Verify memory_space is preserved in the TileType
+        restored_tile_type = restored_var.type
+        assert isinstance(restored_tile_type, ir.TileType)
+        assert restored_tile_type.memory_space == memory_space
+
+        # Verify structural equality
+        ir.assert_structural_equal(var, restored_var, enable_auto_mapping=True)
+
+    def test_tiletype_without_memory_space_survives_round_trip(self):
+        """TileType without memory_space (nullopt) survives round-trip."""
+        # Create a Var with TileType without memory_space
+        shape = [ir.ConstInt(16, DataType.INT64, ir.Span.unknown()),
+                 ir.ConstInt(16, DataType.INT64, ir.Span.unknown())]
+        tile_type = ir.TileType(shape, DataType.FP32)
+
+        # Create a Var with this TileType
+        var = ir.Var("tile_var", tile_type, ir.Span.unknown())
+
+        # Serialize and deserialize
+        serialized = ir.serialize(var)
+        restored = ir.deserialize(serialized)
+        restored_var = cast(ir.Var, restored)
+
+        # Verify memory_space is still nullopt
+        restored_tile_type = restored_var.type
+        assert isinstance(restored_tile_type, ir.TileType)
+        assert restored_tile_type.memory_space is None
+
+        # Verify structural equality
+        ir.assert_structural_equal(var, restored_var, enable_auto_mapping=True)
+
+    def test_tiletype_with_memref_and_memory_space(self):
+        """TileType with both memref and memory_space preserves both."""
+        # Create MemRef
+        addr = ir.ConstInt(0, DataType.INT64, ir.Span.unknown())
+        memref = ir.MemRef(ir.MemorySpace.Vec, addr, 256, 1)
+
+        # Create TileType with both memref and memory_space
+        shape = [ir.ConstInt(16, DataType.INT64, ir.Span.unknown()),
+                 ir.ConstInt(16, DataType.INT64, ir.Span.unknown())]
+        memory_space = ir.MemorySpace.Acc
+        tile_type = ir.TileType(shape, DataType.FP32, memref, None, memory_space)
+
+        # Create a Var with this TileType
+        var = ir.Var("tile_var", tile_type, ir.Span.unknown())
+
+        # Serialize and deserialize
+        serialized = ir.serialize(var)
+        restored = ir.deserialize(serialized)
+        restored_var = cast(ir.Var, restored)
+
+        # Verify both memref and memory_space are preserved
+        restored_tile_type = restored_var.type
+        assert isinstance(restored_tile_type, ir.TileType)
+        assert restored_tile_type.memref is not None
+        assert restored_tile_type.memory_space == memory_space
+
+        # Verify structural equality
+        ir.assert_structural_equal(var, restored_var, enable_auto_mapping=True)
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary
  - Fix `TileType.memory_space_` being silently dropped during serialization
  - Add deserialization support for the optional `memory_space` field
  - Use the same `uint8` pattern as `MemRef.memory_space_` for consistency
  - Update serialization format documentation (English and Chinese)

  ## Testing
  - [x] All unit tests pass (2325 passed)
  - [x] clang-tidy passed
  - [x] 3 new regression tests added for `TileType` memory_space round-trip

  ## Related Issues
  Fixes #522