### PR TITLE
fix(pass): avoid outlining host-side tail ops into tiny incore funcs

### DIFF
--- a/python/pypto/ir/pto_codegen.py
+++ b/python/pypto/ir/pto_codegen.py
@@ -38,8 +38,8 @@ def _get_error_summary(exc: Exception, func_name: str) -> str:
     """Extract the first meaningful line from an exception, without the function name.
 
     Strips the C++ Traceback tail, takes only the first line, and removes
-    occurrences of *func_name* so that identical errors across different
-    functions can be grouped together.
+    occurrences of *func_name* so the summary column focuses on the error
+    itself instead of repeating the function name.
     """
     msg = str(exc)
     traceback_marker = msg.find("\n\nC++ Traceback")
@@ -58,35 +58,29 @@ def _format_error_report(
 ) -> str:
     """Build a concise error summary table and write full details to a log file.
 
-    Groups functions by their error summary so that identical errors appear on a
-    single row.  Returns the summary string for use in the ``RuntimeError`` message.
+    Each failed function is shown on its own row, with ``Function`` as the
+    first column and ``Error`` as the second column. Returns the summary string
+    for use in the ``RuntimeError`` message.
     """
     max_error_col = 60
 
-    grouped: OrderedDict[str, list[str]] = OrderedDict()
-    for name, exc in errors:
-        summary = _get_error_summary(exc, name)
-        grouped.setdefault(summary, []).append(name)
-
-    longest_error = max(len(s) for s in grouped)
+    summaries = OrderedDict((name, _get_error_summary(exc, name)) for name, exc in errors)
+    longest_error = max(len(summary) for summary in summaries.values())
     error_col_width = min(longest_error, max_error_col) + 2
     error_col_width = max(error_col_width, len("Error") + 2)
     func_col_width = max(len(n) for n, _ in errors) + 2
     func_col_width = max(func_col_width, len("Function") + 2)
 
     lines: list[str] = [f"{len(errors)} function(s) failed to compile:\n"]
-    lines.append(f"  {'Error':<{error_col_width}}| {'Function'}")
-    lines.append(f"  {'-' * error_col_width}+{'-' * func_col_width}")
+    lines.append(f"  {'Function':<{func_col_width}}| {'Error'}")
+    lines.append(f"  {'-' * func_col_width}+{'-' * error_col_width}")
 
-    sep_line = f"  {'-' * error_col_width}+{'-' * func_col_width}"
-    for summary, func_names in grouped.items():
+    sep_line = f"  {'-' * func_col_width}+{'-' * error_col_width}"
+    for func_name, summary in summaries.items():
         wrapped = textwrap.wrap(summary, width=max_error_col) or [summary]
-        lines.append(f"  {wrapped[0]:<{error_col_width}}| {func_names[0]}")
-        remaining = max(len(wrapped) - 1, len(func_names) - 1)
-        for i in range(remaining):
-            err_part = wrapped[i + 1] if i + 1 < len(wrapped) else ""
-            func_part = func_names[i + 1] if i + 1 < len(func_names) else ""
-            lines.append(f"  {err_part:<{error_col_width}}| {func_part}")
+        lines.append(f"  {func_name:<{func_col_width}}| {wrapped[0]}")
+        for err_part in wrapped[1:]:
+            lines.append(f"  {'':<{func_col_width}}| {err_part}")
         lines.append(sep_line)
 
     summary_text = "\n".join(lines)

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "pypto/core/logging.h"
@@ -23,6 +24,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 
@@ -68,6 +70,85 @@ static bool ContainsInCoreScope(const StmtPtr& stmt) {
   }
 }
 
+/// Returns true if op_name is a compute tensor op, not a host-side memory op.
+static bool IsComputeTensorOp(const std::string& op_name) {
+  if (op_name.compare(0, 7, "tensor.") != 0) return false;
+  static const std::unordered_set<std::string> kHostSideOps = {
+      "tensor.create",   "tensor.read", "tensor.write",   "tensor.slice",
+      "tensor.assemble", "tensor.dim",  "tensor.reshape", "tensor.transpose",
+  };
+  return kHostSideOps.count(op_name) == 0;
+}
+
+class ComputeTensorOpDetector : public IRVisitor {
+ public:
+  [[nodiscard]] bool Found() const { return found_; }
+
+  void VisitExpr_(const CallPtr& op) override {
+    if (!op || found_) return;
+    if (op->op_ && IsComputeTensorOp(op->op_->name_)) {
+      found_ = true;
+      return;
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  bool found_ = false;
+};
+
+static bool ContainsComputeTensorOp(const StmtPtr& stmt) {
+  if (!stmt) return false;
+  ComputeTensorOpDetector detector;
+  detector.VisitStmt(stmt);
+  return detector.Found();
+}
+
+static bool ContainsChunkLoop(const StmtPtr& stmt) {
+  if (!stmt) return false;
+
+  auto kind = stmt->GetKind();
+  switch (kind) {
+    case ObjectKind::ForStmt: {
+      auto for_stmt = std::static_pointer_cast<const ForStmt>(stmt);
+      return for_stmt->loop_origin_ != LoopOrigin::Original || ContainsChunkLoop(for_stmt->body_);
+    }
+    case ObjectKind::SeqStmts: {
+      auto seq = std::static_pointer_cast<const SeqStmts>(stmt);
+      for (const auto& s : seq->stmts_) {
+        if (ContainsChunkLoop(s)) return true;
+      }
+      return false;
+    }
+    case ObjectKind::ScopeStmt: {
+      auto scope = std::static_pointer_cast<const ScopeStmt>(stmt);
+      return ContainsChunkLoop(scope->body_);
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Check whether a statement needs an InCore wrapper after auto_incore is consumed.
+ *
+ * We only wrap statements that still need outlining:
+ * - compute tensor ops
+ * - chunk loops that failed interchange or remain sequential
+ *
+ * Pure host-side groups such as a lone tensor.assemble/create/slice should stay
+ * in orchestration rather than becoming tiny outlined InCore functions.
+ */
+static bool NeedsInCoreWrapping(const StmtPtr& stmt) {
+  if (!stmt) return false;
+
+  auto kind = stmt->GetKind();
+  if (kind == ObjectKind::YieldStmt || kind == ObjectKind::ReturnStmt) return false;
+  if (ContainsInCoreScope(stmt)) return false;
+
+  return ContainsChunkLoop(stmt) || ContainsComputeTensorOp(stmt);
+}
+
 /**
  * @brief Wrap statements that lack InCore coverage in ScopeStmt(InCore).
  *
@@ -79,13 +160,6 @@ static bool ContainsInCoreScope(const StmtPtr& stmt) {
  * Control flow statements (YieldStmt, ReturnStmt) are never wrapped.
  */
 static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& span) {
-  auto needs_wrapping = [](const StmtPtr& s) -> bool {
-    if (!s) return false;
-    auto kind = s->GetKind();
-    if (kind == ObjectKind::YieldStmt || kind == ObjectKind::ReturnStmt) return false;
-    return !ContainsInCoreScope(s);
-  };
-
   // When a ForStmt contains InCore scopes in its body (e.g. a pl.range loop
   // wrapping interchanged parallel chunks), recurse into it so that non-InCore
   // statements *inside* the loop body also get wrapped.
@@ -104,7 +178,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
 
   auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
   if (!seq) {
-    if (needs_wrapping(body)) {
+    if (NeedsInCoreWrapping(body)) {
       return std::make_shared<ScopeStmt>(ScopeKind::InCore, body, span);
     }
     return maybe_recurse_into_compound(body);
@@ -113,7 +187,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
   // Check if any wrapping or recursion is needed (fast path)
   bool has_work = false;
   for (const auto& s : seq->stmts_) {
-    if (needs_wrapping(s)) {
+    if (NeedsInCoreWrapping(s)) {
       has_work = true;
       break;
     }
@@ -137,7 +211,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
   };
 
   for (const auto& s : seq->stmts_) {
-    if (needs_wrapping(s)) {
+    if (NeedsInCoreWrapping(s)) {
       pending.push_back(s);
     } else {
       flush();

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -27,6 +27,7 @@ from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.builder import IRBuilder
 from pypto.ir.op import tile
 from pypto.ir.pto_codegen import (
+    _format_error_report,
     _generate_arg_unpacking,
     _generate_kernel_wrapper,
     _preprocess_ptoas_output,
@@ -646,6 +647,44 @@ class TestGenerateSkipPtoas:
         for key in kernel_keys:
             assert key.endswith(".pto"), f"Expected .pto extension, got: {key}"
             assert not key.endswith(".cpp"), f"Unexpected .cpp extension: {key}"
+
+
+class TestFormatErrorReport:
+    """Tests for codegen error summary formatting."""
+
+    def test_summary_lists_function_name_first(self, tmp_path):
+        report = _format_error_report(
+            [
+                ("vector_func", RuntimeError("vector_func invalid tile shape\n\nC++ Traceback:\n...")),
+                ("cube_func", ValueError("cube_func unsupported memory space")),
+            ],
+            str(tmp_path),
+        )
+
+        assert "2 function(s) failed to compile:" in report
+        assert "  Function" in report
+        assert "| Error" in report
+        assert "  vector_func" in report
+        assert "  cube_func" in report
+        assert "| vector_func" not in report
+        assert "| cube_func" not in report
+        assert "invalid tile shape | vector_func" not in report
+        assert "unsupported memory space | cube_func" not in report
+        assert "| invalid tile shape" in report
+        assert "| unsupported memory space" in report
+
+    def test_summary_does_not_group_same_error(self, tmp_path):
+        report = _format_error_report(
+            [
+                ("func_a", RuntimeError("func_a same failure")),
+                ("func_b", RuntimeError("func_b same failure")),
+            ],
+            str(tmp_path),
+        )
+
+        assert report.count("| same failure") == 2
+        assert "  func_a" in report
+        assert "  func_b" in report
 
 
 def test_pto_codegen_for_loop_tensor_iter_arg():

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -587,6 +587,30 @@ class TestNonChunkStatementsWrapping:
         incore_count = after_str.count("pl.incore()")
         assert incore_count >= 2
 
+    def test_host_side_assemble_after_parallel_chunk_not_wrapped(self):
+        """Host-side tail assemble after a chunk should stay outside InCore."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[4], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                out_0: pl.Tensor[[8], pl.FP32] = pl.tensor.create(
+                    [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                with pl.auto_incore():
+                    for i in pl.parallel(0, 4, 1, chunk=2):
+                        x = pl.tensor.adds(x, 1.0)
+                    out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])
+                return out_1
+
+        Before = _prepare_for_interchange(Input)
+        After = passes.interchange_chunk_loops()(Before)
+
+        after_str = python_print(After)
+        # Only the interchanged chunk body should be in InCore.
+        assert after_str.count("pl.incore()") == 1
+        assert "pl.tensor.assemble(" in after_str
+
     def test_multiple_parallel_chunks_no_regression(self):
         """Multiple parallel chunks with no standalone ops: all interchanged, no extra wrapping."""
 

--- a/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
+++ b/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
@@ -321,5 +321,39 @@ class TestNestedForStmtRecursion:
         assert "tensor.muls" not in orch_str
 
 
+class TestHostSideTailOps:
+    """Host-side tensor ops may stay in Orchestration after outline."""
+
+    def test_tail_assemble_after_parallel_chunk_stays_in_orchestration(self):
+        """A trailing tensor.assemble should not become its own InCore function."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[4], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                out_0: pl.Tensor[[8], pl.FP32] = pl.tensor.create(
+                    [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                with pl.auto_incore():
+                    for i in pl.parallel(0, 4, 1, chunk=2):
+                        x = pl.tensor.adds(x, 1.0)
+                    out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])
+                return out_1
+
+        program = _prepare_for_interchange(Input)
+        program = passes.interchange_chunk_loops()(program)
+        program = passes.outline_incore_scopes()(program)
+
+        orch_funcs = [f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration]
+        assert len(orch_funcs) == 1
+        orch_str = orch_funcs[0].as_python()
+
+        assert "tensor.adds" not in orch_str
+        assert "tensor.assemble" in orch_str
+
+        incore_funcs = [f for f in program.functions.values() if f.func_type == ir.FunctionType.InCore]
+        assert len(incore_funcs) == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Only wrap auto_incore leftovers that still contain compute tensor ops or chunk loops. Keep trailing host-side tensor.assemble in orchestration and add regressions for interchange and outline behavior.