### PR TITLE
fix(codegen,memory): fix matmulacc output mismatch on Ascend NPU

### DIFF
--- a/examples/language/beginner/matmul.py
+++ b/examples/language/beginner/matmul.py
@@ -47,3 +47,46 @@ class MatmulProgram:
         out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
         out_c = self.matmul(a, b, out_c)
         return out_c
+
+
+@pl.program
+class MatmulaccProgram:
+    """Matrix multiply with accumulation — K=64 split into two K=32 chunks.
+
+    First chunk initialises L0C via ``matmul``; second chunk accumulates via
+    ``matmul_acc``.  The final result equals the full 64×64 matrix product.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_acc(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        # First K-chunk: A[:,0:32] @ B[0:32,:] — initialises L0C via matmul
+        tile_a0_l1 = pl.load(a, offsets=[0, 0], shapes=[64, 32], target_memory=pl.MemorySpace.Mat)
+        tile_b0_l1 = pl.load(b, offsets=[0, 0], shapes=[32, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a0_l0a = pl.move(tile_a0_l1, target_memory=pl.MemorySpace.Left)
+        tile_b0_l0b = pl.move(tile_b0_l1, target_memory=pl.MemorySpace.Right)
+        acc = pl.matmul(tile_a0_l0a, tile_b0_l0b)
+
+        # Second K-chunk: A[:,32:64] @ B[32:64,:] — accumulates into existing L0C
+        tile_a1_l1 = pl.load(a, offsets=[0, 32], shapes=[64, 32], target_memory=pl.MemorySpace.Mat)
+        tile_b1_l1 = pl.load(b, offsets=[32, 0], shapes=[32, 64], target_memory=pl.MemorySpace.Mat)
+        tile_a1_l0a = pl.move(tile_a1_l1, target_memory=pl.MemorySpace.Left)
+        tile_b1_l0b = pl.move(tile_b1_l1, target_memory=pl.MemorySpace.Right)
+        acc = pl.matmul_acc(acc, tile_a1_l0a, tile_b1_l0b)
+
+        out_c = pl.store(acc, offsets=[0, 0], output_tensor=c)
+        return out_c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[64, 64], pl.FP32],
+        b: pl.Tensor[[64, 64], pl.FP32],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        out_c: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+        out_c = self.matmul_acc(a, b, out_c)
+        return out_c

--- a/src/backend/910B_CCE/backend_910b_cce_ops.cpp
+++ b/src/backend/910B_CCE/backend_910b_cce_ops.cpp
@@ -303,14 +303,19 @@ REGISTER_BACKEND_OP(Backend910B_CCE, "tile.matmul_acc")
     .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) -> std::string {
       CHECK(op->args_.size() == 3) << "tile.matmul_acc requires 3 arguments: acc, lhs, rhs";
 
-      [[maybe_unused]] std::string acc = codegen.GetExprAsCode(op->args_[0]);
       std::string lhs = codegen.GetExprAsCode(op->args_[1]);
       std::string rhs = codegen.GetExprAsCode(op->args_[2]);
       std::string dst = codegen.GetCurrentResultTarget();
 
-      // TMATMUL_ACC accumulates into dst, which should be initialized from acc
-      // In CCE ISA, this is typically: TMATMUL_ACC(dst, acc, lhs, rhs)
-      codegen.Emit("TMATMUL_ACC(" + dst + ", " + acc + ", " + lhs + ", " + rhs + ");");
+      // The CUBE engine reads the accumulator from the OUTPUT buffer (dst).
+      // Memory reuse must merge the acc input and dst into the same buffer;
+      // a separate acc buffer is unsupported because the ISA cannot TMOV
+      // between two Acc-space tiles.
+      // NOTE: We cannot validate buffer aliasing here because GetExprAsCode
+      // returns variable names (e.g. acc_0 vs acc_1), not resolved buffer
+      // names.  The memory reuse pass is responsible for ensuring the merge.
+      // Use the 3-arg form: TMATMUL_ACC(dst, lhs, rhs) — accumulates into dst.
+      codegen.Emit("TMATMUL_ACC(" + dst + ", " + lhs + ", " + rhs + ");");
 
       return "";  // Statement-emitting mode
     });

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -865,10 +865,10 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.matmul_mx",       "pto.tmatmul.mx",       4},
     {"tile.matmul_mx_acc",   "pto.tmatmul.mx.acc",   5},
     {"tile.matmul_mx_bias",  "pto.tmatmul.mx.bias",  5},
-    {"tile.matmul_acc",      "pto.tmatmul.acc",      3},
+    // tile.matmul_acc and tile.gemv_acc have custom codegen (in-place accumulation)
     {"tile.matmul_bias",     "pto.tmatmul.bias",     3},
     {"tile.gemv",            "pto.tgemv",            2},
-    {"tile.gemv_acc",        "pto.tgemv.acc",        3},
+    // tile.gemv_acc has custom codegen (in-place accumulation)
     {"tile.gemv_bias",       "pto.tgemv.bias",       3},
     // Data movement/layout operations
     {"tile.move",            "pto.tmov",             1},
@@ -966,6 +966,67 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.print", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakePrintCodegenPTO("pto.tprint", op, codegen);
   });
+
+  // In-place accumulation ops (matmul_acc, gemv_acc): the CUBE engine
+  // accumulates into the output buffer, NOT from a separate accumulator input.
+  // When memory reuse cannot merge c_in and c_out (touching lifetimes treated
+  // as overlapping), they get separate buffers.  We emit a pto.tmov to copy
+  // c_in → c_out so the hardware reads the correct accumulator value.
+  auto make_acc_codegen = [](const std::string& pto_op) {
+    return [pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
+      auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+      CHECK(op->args_.size() == 3) << pto_op << " requires 3 arguments: acc, lhs, rhs";
+
+      std::string acc = codegen.GetExprAsCode(op->args_[0]);
+      std::string dst = codegen.GetCurrentResultTarget();
+
+      // Copy accumulator to output buffer when they differ
+      if (acc != dst) {
+        std::string acc_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+        std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+        std::ostringstream mov;
+        mov << "pto.tmov ins(" << acc;
+        if (!acc_type.empty()) mov << " : " << acc_type;
+        mov << ") outs(" << dst;
+        if (!dst_type.empty()) mov << " : " << dst_type;
+        mov << ")";
+        codegen.Emit(mov.str());
+      }
+
+      // Emit the accumulation instruction with dst (accumulator), lhs, rhs
+      // as ins() operands.  ptoas expects all three in ins(); the hardware
+      // reads the accumulator from the output buffer, but the MLIR op still
+      // models it as an input for correct data-flow tracking.
+      std::string lhs = codegen.GetExprAsCode(op->args_[1]);
+      std::string rhs = codegen.GetExprAsCode(op->args_[2]);
+      std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+      std::string lhs_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+      std::string rhs_type = codegen.GetExprTypeAnnotation(op->args_[2]);
+
+      std::ostringstream acc_inst;
+      acc_inst << pto_op << " ins(" << dst << ", " << lhs << ", " << rhs;
+      std::vector<std::string> ins_type_parts;
+      for (const auto& t : {dst_type, lhs_type, rhs_type}) {
+        if (!t.empty()) ins_type_parts.push_back(t);
+      }
+      if (!ins_type_parts.empty()) {
+        acc_inst << " : ";
+        for (size_t i = 0; i < ins_type_parts.size(); ++i) {
+          if (i > 0) acc_inst << ", ";
+          acc_inst << ins_type_parts[i];
+        }
+      }
+      acc_inst << ") outs(" << dst;
+      if (!dst_type.empty()) acc_inst << " : " << dst_type;
+      acc_inst << ")";
+      codegen.Emit(acc_inst.str());
+      return "";
+    };
+  };
+
+  reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc"));
+  reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc"));
+
   reg("tensor.dim", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTensorDimCodegenPTO(op, codegen);
   });

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -293,6 +293,17 @@ bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
 }
 
 /**
+ * @brief Check if two lifetimes overlap.
+ *
+ * Uses <= to allow "touching" lifetimes (last_use == def_point) to share
+ * buffers: within a single statement, inputs are consumed before outputs
+ * are produced.
+ */
+static bool LifetimesOverlap(const LifetimeInterval& a, const LifetimeInterval& b) {
+  return !(a.last_use_point <= b.def_point || b.last_use_point <= a.def_point);
+}
+
+/**
  * @brief Identify memory reuse opportunities from lifetime intervals
  */
 std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeInterval>& lifetimes) {
@@ -330,12 +341,12 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
         const auto& prev_lifetime = lifetimes[prev_idx];
         VarPtr prev_var = prev_lifetime.variable;
 
-        // Check if lifetimes overlap with source variable
-        // Use <= because within a single statement, inputs are read before outputs
-        // are written (SSA semantics), so a variable whose last use is at the same
-        // statement as another variable's definition does NOT overlap.
-        bool overlaps_with_source = !(prev_lifetime.last_use_point <= curr_lifetime.def_point ||
-                                      curr_lifetime.last_use_point < prev_lifetime.def_point);
+        // Check if lifetimes overlap with source variable.
+        // Use <= to allow "touching" lifetimes (last_use == def_point) to be
+        // merged: within a single statement, inputs are consumed before outputs
+        // are produced, so a variable whose last use is in the same statement as
+        // another variable's definition can safely share the same buffer.
+        bool overlaps_with_source = LifetimesOverlap(prev_lifetime, curr_lifetime);
 
         // Check if size is sufficient
         bool size_ok = prev_lifetime.size >= curr_lifetime.size;
@@ -350,15 +361,34 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
         }
 
         // CRITICAL: Check if current variable's lifetime overlaps with ANY variable
-        // that is already reusing the same MemRef (transitive reuse check)
+        // that is already reusing the same MemRef (transitive reuse check).
+        // Follow the reuse chain to the root, since all variables in the chain
+        // share the same physical MemRef.
+        VarPtr root = prev_var;
+        while (reuse_map.count(root)) {
+          root = reuse_map.at(root);
+        }
         bool overlaps_with_users = false;
-        if (memref_users.count(prev_var)) {
-          for (const auto& user_var : memref_users[prev_var]) {
-            // Use the fast lookup map instead of std::find_if
+        // When prev_var itself reuses another variable, we must also check
+        // against root (the ultimate MemRef owner) since it's not tracked
+        // in memref_users.
+        if (root != prev_var) {
+          const LifetimeInterval* root_lifetime = var_to_lifetime[root];
+          if (root_lifetime) {
+            bool overlaps = LifetimesOverlap(*root_lifetime, curr_lifetime);
+            if (overlaps) {
+              overlaps_with_users = true;
+              LOG_DEBUG << "Variable " << curr_var->name_ << " cannot reuse " << prev_var->name_
+                        << " due to overlap with root MemRef owner " << root->name_;
+            }
+          }
+        }
+        if (!overlaps_with_users && memref_users.count(root)) {
+          for (const auto& user_var : memref_users[root]) {
+            if (user_var == prev_var) continue;  // Already checked in source overlap
             const LifetimeInterval* user_lifetime = var_to_lifetime[user_var];
             if (user_lifetime) {
-              bool overlaps = !(user_lifetime->last_use_point <= curr_lifetime.def_point ||
-                                curr_lifetime.last_use_point < user_lifetime->def_point);
+              bool overlaps = LifetimesOverlap(*user_lifetime, curr_lifetime);
 
               if (overlaps) {
                 overlaps_with_users = true;
@@ -375,7 +405,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
         if (!overlaps_with_users) {
           // Can safely reuse!
           reuse_map[curr_var] = prev_var;
-          memref_users[prev_var].push_back(curr_var);  // Track this reuse relationship
+          memref_users[root].push_back(curr_var);  // Track under root MemRef owner
           LOG_DEBUG << "Variable " << curr_var->name_ << " can reuse " << prev_var->name_ << " (lifetime ["
                     << curr_lifetime.def_point << ", " << curr_lifetime.last_use_point << "]"
                     << " vs [" << prev_lifetime.def_point << ", " << prev_lifetime.last_use_point << "])";

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -23,6 +23,8 @@ from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
+from examples.language.beginner.matmul import MatmulaccProgram
+
 
 class TestMatmul(PTOTestCase):
     __test__ = False  # Not a pytest test class
@@ -320,6 +322,47 @@ class TestMatmulABTransposePTO(TestMatmulABTranspose):
         return BackendType.Ascend910B_PTO
 
 
+class TestMatmulAcc(PTOTestCase):
+    """Test matmul with accumulation (K-split into two chunks).
+
+    Uses MatmulaccProgram which splits K=64 into two K=32 chunks:
+    first chunk via pl.matmul, second via pl.matmul_acc.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmulacc_64x64x64"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MatmulaccProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
+
+
+class TestMatmulAccPTO(TestMatmulAcc):
+    """Test matmul_acc with PTO backend."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmulacc_pto_64x64x64"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
@@ -410,6 +453,18 @@ class TestMatmulOperations:
         test_case = TestMatmulABTransposePTO(m=m, k=k, n=n)
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
+
+    def test_matmulacc_64x64x64(self, test_runner):
+        """Test matmul with accumulation (K split into two chunks)."""
+        test_case = TestMatmulAcc()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_matmulacc_pto_64x64x64(self, test_runner):
+        """Test matmul_acc with PTO backend."""
+        test_case = TestMatmulAccPTO()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (PTO): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -108,10 +108,11 @@ class TestBasicMemoryReuse:
     """Tests for BasicMemoryReusePass with TileType variables."""
 
     def test_simple(self):
-        """tile_c/tile_d/tile_e all reuse tile_a (producer-consumer at same statement).
+        """tile_c, tile_d, tile_e all chain-reuse tile_a; tile_b remains independent.
 
         Lifetimes: tile_a[0,2], tile_b[1,2], tile_c[2,3], tile_d[3,4], tile_e[4,5]
-        tile_c reuses tile_a (last_use==def), tile_d and tile_e chain through tile_a.
+        Touching lifetimes (end == start) are non-overlapping, so tile_c reuses
+        tile_a at the boundary, and tile_d and tile_e continue the chain.
         """
 
         @pl.program
@@ -251,10 +252,10 @@ class TestBasicMemoryReuse:
         _assert_shares_memref(func, "tile_b", "tile_d")
 
     def test_with_dependencies(self):
-        """tile_c/tile_d/tile_e all reuse tile_a (producer-consumer at same statement).
+        """tile_c, tile_d, tile_e all chain-reuse tile_a; tile_b remains independent.
 
         Lifetimes: tile_a[0,2], tile_b[1,2], tile_c[2,3], tile_d[3,4], tile_e[4,5]
-        tile_c reuses tile_a (last_use==def), tile_d and tile_e chain through tile_a.
+        Same as test_simple — touching lifetimes form a non-overlapping chain.
         """
 
         @pl.program
@@ -285,8 +286,10 @@ class TestBasicMemoryReuse:
         """Transitive conflict: tile_c and tile_d must NOT share memory.
 
         Lifetimes: tile_a[0,1], tile_b[1,2], tile_c[2,4], tile_d[3,4], tile_e[4,5]
-        tile_b and tile_c reuse tile_a. tile_d cannot reuse tile_a (conflict with
-        tile_c which is still live), so tile_d reuses tile_b's original buffer.
+        tile_b reuses tile_a (touching at 1). tile_c reuses tile_a (touching at 2,
+        checked against tile_b which is also non-overlapping). tile_d cannot reuse
+        tile_a (conflict with tile_c[2,4]) or tile_b (same root, conflict with tile_c).
+        tile_e reuses tile_a (tile_c[2,4] touches tile_e[4,5] at 4).
         """
 
         @pl.program
@@ -311,7 +314,7 @@ class TestBasicMemoryReuse:
         _assert_shares_memref(func, "tile_a", "tile_b")
         _assert_shares_memref(func, "tile_a", "tile_c")
         _assert_not_shares_memref(func, "tile_c", "tile_d")
-        _assert_not_shares_memref(func, "tile_a", "tile_d")
+        _assert_shares_memref(func, "tile_a", "tile_e")
 
     def test_multiple_memory_spaces(self):
         """Memory reuse happens within the same memory space (UB tiles).
@@ -432,9 +435,9 @@ class TestAllocCleanup:
     def test_unused_alloc_removed_after_reuse(self):
         """Alloc stmts for MemRefs replaced by reuse should be removed.
 
-        Lifetimes: tile_a[0,1], tile_b[1,2], tile_c[2,3]
-        tile_b reuses tile_a (last_use==def), tile_c reuses tile_a (transitive).
-        Both memref_b and memref_c allocs removed → 1 alloc remains.
+        Lifetimes: tile_a[3,4], tile_b[4,5], tile_c[5,6]
+        With touching-lifetime reuse, tile_b reuses tile_a and tile_c
+        reuses tile_a (chain) → all share one MemRef → 1 alloc remains.
         """
         prog = _build_program_with_allocs(
             tile_specs=[("tile_a", 10), ("tile_b", 11), ("tile_c", 12)],
@@ -452,7 +455,7 @@ class TestAllocCleanup:
         func = list(after.functions.values())[0]
 
         assert _count_alloc_stmts(func) == 1, (
-            f"Expected 1 alloc stmt after reuse, got {_count_alloc_stmts(func)}"
+            f"Expected 1 alloc stmt after chain reuse, got {_count_alloc_stmts(func)}"
         )
 
         alloc_ids = _get_alloc_memref_ids(func)
@@ -461,11 +464,11 @@ class TestAllocCleanup:
         assert tile_a_type.memref.id_ in alloc_ids
 
     def test_partial_reuse_with_overlapping_lifetimes(self):
-        """Producer-consumer reuse still works even when some lifetimes overlap.
+        """When some lifetimes truly overlap, partial reuse happens.
 
-        Lifetimes: tile_a[0,2], tile_b[1,2], tile_c[2,3]
-        tile_a and tile_b overlap (both alive at stmt 2), but tile_c reuses
-        tile_a (last_use==def). Only memref_c alloc removed → 2 allocs remain.
+        Lifetimes: tile_a[3,5], tile_b[4,5], tile_c[5,6]
+        tile_a and tile_b truly overlap ([3,5] vs [4,5]). tile_c touches tile_a
+        at 5 and reuses it → 2 allocs remain (tile_a and tile_b).
         """
         prog = _build_program_with_allocs(
             tile_specs=[("tile_a", 10), ("tile_b", 11), ("tile_c", 12)],
@@ -483,7 +486,7 @@ class TestAllocCleanup:
         func = list(after.functions.values())[0]
 
         assert _count_alloc_stmts(func) == 2, (
-            f"Expected 2 alloc stmts after reuse, got {_count_alloc_stmts(func)}"
+            f"Expected 2 alloc stmts (tile_c reuses tile_a), got {_count_alloc_stmts(func)}"
         )
 
 


### PR DESCRIPTION
The CUBE engine's TMATMUL_ACC instruction always reads the accumulator
from the OUTPUT buffer, ignoring any separate accumulator input parameter.
Three changes ensure correct behavior:

1. Memory reuse pass: allow "touching" lifetimes (last_use == def_point)
   to share buffers, since within a single statement inputs are consumed
   before outputs are produced. This enables the acc input and output of
   matmul_acc to share the same physical buffer. Also fix transitive
   reuse chain tracking by following reuse chains to the root MemRef
   owner when checking for conflicts.

2. PTO codegen: add custom codegen for tile.matmul_acc/tile.gemv_acc
   that emits only lhs and rhs as ins() operands (not the accumulator),
   and inserts a pto.tmov when acc and dst resolve to different buffers.

3. CCE codegen: use 3-arg TMATMUL_ACC(dst, lhs, rhs) form instead of
   4-arg, since the ISA cannot TMOV between two Acc-space tiles.