### PR TITLE
feat(passes): enable ExpandMixedKernel in default pass pipeline

### DIFF
--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -63,9 +63,7 @@ class PassManager:
                 ("FlattenTileNdTo2D", lambda: passes.flatten_tile_nd_to_2d()),
                 ("InferTileMemorySpace", lambda: passes.infer_tile_memory_space()),
                 ("ResolveTransposeLayout", lambda: passes.resolve_transpose_layout()),
-                # TODO: Add ExpandMixedKernel here once downstream passes (InitMemRef,
-                # MemoryReuse, etc.) support cross-core transfer ops (tpush/tpop).
-                # Codegen already supports AIC/AIV/Group function types.
+                ("ExpandMixedKernel", lambda: passes.expand_mixed_kernel()),
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),
                 ("AllocateMemoryAddr", lambda: passes.allocate_memory_addr()),

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -163,6 +163,16 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
   // Other tile.* ops are vector
   if (name.substr(0, 5) == "tile.") return CoreAffinity::VECTOR;
 
+  // Cross-core ops: AIV-side ops are VECTOR, AIC-side ops are CUBE.
+  // reserve_buffer and import_peer_buffer are SHARED (used by both sides).
+  static const std::unordered_set<std::string> vector_cross_core_ops = {
+      "system.aiv_initialize_pipe", "system.tpush_to_aic", "system.tfree_to_aic"};
+  if (vector_cross_core_ops.count(name)) return CoreAffinity::VECTOR;
+
+  static const std::unordered_set<std::string> cube_cross_core_ops = {
+      "system.aic_initialize_pipe", "system.tfree_to_aiv", "system.tpush_to_aiv"};
+  if (cube_cross_core_ops.count(name)) return CoreAffinity::CUBE;
+
   return CoreAffinity::SHARED;
 }
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -66,7 +66,7 @@ def _get_dyn_incore_func():
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed = pm.run_passes(_DynKernel)
     for func in transformed.functions.values():
-        if func.func_type == ir.FunctionType.InCore:
+        if ir.is_incore_type(func.func_type):
             return func
     raise RuntimeError("No InCore function found in _DynKernel")
 

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -26,7 +26,6 @@ import pypto.language as pl
 import pytest
 from pypto import backend, codegen, ir, passes
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 # ============================================================================
 # Test Program: Vector Producer + Cube Consumer (V2C unidirectional)
@@ -162,14 +161,32 @@ class TestCrossCoreTpushTpopCodegen:
     def _compile_and_generate(program) -> dict[str, str]:
         """Compile program and return dict of {func_name: mlir_code}.
 
-        Runs PassManager with Default strategy (no InsertSync), then generates
-        PTO MLIR for each InCore function individually.
+        Uses a custom pipeline matching the Default strategy but without
+        ExpandMixedKernel, since these programs already have manual cross-core
+        setup with explicit AIC/AIV tpush/tpop ops.
         """
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B_PTO)
 
-        pm = PassManager.get_strategy(OptimizationStrategy.Default)
-        optimized = pm.run_passes(program)
+        pipeline = passes.PassPipeline()
+        for factory in [
+            passes.unroll_loops,
+            passes.convert_to_ssa,
+            passes.flatten_call_expr,
+            passes.split_chunked_loops,
+            passes.interchange_chunk_loops,
+            passes.outline_incore_scopes,
+            passes.outline_cluster_scopes,
+            passes.convert_tensor_to_tile_ops,
+            passes.flatten_tile_nd_to_2d,
+            passes.infer_tile_memory_space,
+            passes.resolve_transpose_layout,
+            passes.init_mem_ref,
+            passes.basic_memory_reuse,
+            passes.allocate_memory_addr,
+        ]:
+            pipeline.add_pass(factory())
+        optimized = pipeline.run(program)
 
         result = {}
         codegen_instance = codegen.PTOCodegen()

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -442,8 +442,12 @@ class BlockOperationsTest:
         output: pl.Tensor[[16, 16], pl.FP32],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Matmul: output = matmul(lhs, rhs)."""
-        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, 0], [16, 16])
-        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [0, 0], [16, 16])
+        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
         result_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul(lhs_tile, rhs_tile)
         updated_output: pl.Tensor[[16, 16], pl.FP32] = pl.store(result_tile, [0, 0], output)
         return updated_output
@@ -457,9 +461,15 @@ class BlockOperationsTest:
         output: pl.Tensor[[16, 16], pl.FP32],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Matmul_acc: output = matmul_acc(factor, lhs, rhs)."""
-        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, 0], [16, 16])
-        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [0, 0], [16, 16])
-        factor_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(factor, [0, 0], [16, 16])
+        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        factor_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            factor, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
         result_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(factor_tile, lhs_tile, rhs_tile)
         updated_output: pl.Tensor[[16, 16], pl.FP32] = pl.store(result_tile, [0, 0], output)
         return updated_output

--- a/tests/ut/codegen/test_pto_codegen_paged_attn.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn.py
@@ -63,12 +63,13 @@ class PagedAttention:
     def qk_matmul(
         self,
         qi: pl.Tensor[[16, 128], pl.BF16],
-        kj: pl.Tensor[[128, 128], pl.BF16],
+        kj: pl.Tensor[[128, 128], pl.BF16, pl.DN],
         s_ij: pl.Tensor[[16, 128], pl.FP32],
     ) -> pl.Tensor[[16, 128], pl.FP32]:
-        q_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(qi, [0, 0], [16, 128])
-        k_tile: pl.Tile[[128, 128], pl.BF16] = pl.load(kj, [0, 0], [128, 128])
-        k_tile_T: pl.Tile[[128, 128], pl.BF16] = pl.transpose(k_tile, axis1=0, axis2=1)
+        q_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(qi, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+        k_tile_T: pl.Tile[[128, 128], pl.BF16] = pl.load(
+            kj, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat, transpose=True
+        )
         s_tile: pl.Tile[[16, 128], pl.FP32] = pl.tile.matmul(q_tile, k_tile_T)
         updated_sij: pl.Tensor[[16, 128], pl.FP32] = pl.store(s_tile, [0, 0], s_ij)
         return updated_sij
@@ -80,8 +81,12 @@ class PagedAttention:
         vj: pl.Tensor[[128, 128], pl.BF16],
         oij: pl.Tensor[[16, 128], pl.FP32],
     ) -> pl.Tensor[[16, 128], pl.FP32]:
-        p_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(pij, [0, 0], [16, 128])
-        v_tile: pl.Tile[[128, 128], pl.BF16] = pl.load(vj, [0, 0], [128, 128])
+        p_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(
+            pij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+        )
+        v_tile: pl.Tile[[128, 128], pl.BF16] = pl.load(
+            vj, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat
+        )
         o_tile: pl.Tile[[16, 128], pl.FP32] = pl.tile.matmul(p_tile, v_tile)
         updated_oij: pl.Tensor[[16, 128], pl.FP32] = pl.store(o_tile, [0, 0], oij)
         return updated_oij

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -41,8 +41,8 @@ class TestPassManagerBasics:
         assert pm is not None
         assert pm.strategy == ir.OptimizationStrategy.Default
 
-        assert len(pm.passes) == 14
-        assert len(pm.pass_names) == 14
+        assert len(pm.passes) == 15
+        assert len(pm.pass_names) == 15
         assert pm.pass_names[0] == "UnrollLoops"
         assert pm.pass_names[1] == "ConvertToSSA"
         assert pm.pass_names[2] == "FlattenCallExpr"
@@ -54,9 +54,10 @@ class TestPassManagerBasics:
         assert pm.pass_names[8] == "FlattenTileNdTo2D"
         assert pm.pass_names[9] == "InferTileMemorySpace"
         assert pm.pass_names[10] == "ResolveTransposeLayout"
-        assert pm.pass_names[11] == "InitMemRef"
-        assert pm.pass_names[12] == "MemoryReuse"
-        assert pm.pass_names[13] == "AllocateMemoryAddr"
+        assert pm.pass_names[11] == "ExpandMixedKernel"
+        assert pm.pass_names[12] == "InitMemRef"
+        assert pm.pass_names[13] == "MemoryReuse"
+        assert pm.pass_names[14] == "AllocateMemoryAddr"
 
 
 class TestPassManagerExecution:


### PR DESCRIPTION
## Summary
- Enable `ExpandMixedKernel` pass in the default optimization strategy by adding it between `ResolveTransposeLayout` and `InitMemRef`
- Add cross-core op classification (tpush/tpop/initialize_pipe) to `ClassifyCallAffinity` so the pass correctly splits mixed kernels with cross-core transfer ops
- Fix unit tests to account for the new pass in the pipeline:
  - Update pass manager tests for 15 passes (was 14)
  - Cross-core codegen tests use a custom pipeline without `ExpandMixedKernel` since they have manually structured AIC/AIV functions
  - Add `target_memory=MemorySpace.Mat` for matmul load ops to satisfy `InferTileMemorySpace` requirements
  - Fix paged attention test tensor layout annotation

## Testing
- [x] Pass manager test updated for new pass count and ordering
- [x] Cross-core codegen tests use explicit pipeline to avoid double-expansion
- [x] PTO codegen and ops tests fixed for memory space inference
- [x] Paged attention test updated with correct load annotations

## Related Issues
Closes the TODO in `pass_manager.py` to enable `ExpandMixedKernel` once downstream passes support cross-core ops.