### PR TITLE
fix(ir): prevent in-place memory reuse for ops that do not support src==dst

### DIFF
--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -361,6 +361,18 @@ class OpRegistryEntry {
   /// Get memory spec (nullopt if not annotated)
   [[nodiscard]] const std::optional<OpMemorySpaceSpec>& GetMemorySpec() const { return memory_spec_; }
 
+  /// Mark this operation as NOT safe for in-place execution (src buffer == dst buffer).
+  /// BasicMemoryReuse will skip producer-consumer reuse for such operations.
+  inline OpRegistryEntry& not_inplace_safe() {
+    is_inplace_safe_ = false;
+    return *this;
+  }
+
+  /// Returns true if this operation supports in-place execution (src == dst buffer).
+  /// Defaults to true (backward compatible). Ops that do not support src == dst must
+  /// explicitly call not_inplace_safe() during registration.
+  [[nodiscard]] bool IsInplaceSafe() const { return is_inplace_safe_; }
+
  private:
   void EnsureMemorySpec() {
     if (!memory_spec_.has_value()) {
@@ -393,6 +405,7 @@ class OpRegistryEntry {
                                       const std::vector<std::pair<std::string, std::any>>&)>>
       deduce_type_;                               ///< Type deduction function
   std::optional<OpMemorySpaceSpec> memory_spec_;  ///< Memory space specification
+  bool is_inplace_safe_{true};  ///< Whether the op supports in-place execution (src == dst buffer)
 };
 
 /**

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -420,6 +420,7 @@ REGISTER_OP("tile.ands")
     .add_argument("rhs", "Scalar (ScalarType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpIntScalarBinaryType(args, kwargs, "tile.ands");
@@ -445,6 +446,7 @@ REGISTER_OP("tile.ors")
     .add_argument("rhs", "Scalar (ScalarType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpIntScalarBinaryType(args, kwargs, "tile.ors");
@@ -613,6 +615,7 @@ REGISTER_OP("tile.xors")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpXorScalarType(args, kwargs, "tile.xors");

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -121,6 +121,7 @@ REGISTER_OP("tile.recip")
     .add_argument("tile", "Input tile (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileUnaryType(args, kwargs, "tile.recip");

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
@@ -48,6 +49,7 @@ struct LifetimeInterval {
   int last_use_point;        ///< Last use point (topological order)
   MemorySpace memory_space;  ///< Memory space
   uint64_t size;             ///< Size in bytes
+  std::string def_op_name;   ///< Op name that defines this variable (empty if unknown)
 };
 
 namespace {
@@ -231,6 +233,15 @@ LifetimeAnalysisResult ComputeLifetimesFromDependencies(const std::vector<BasicB
     interval.memory_space = *memory_space;
     interval.size = memref->size_;
 
+    // Extract the defining op name for use in the in-place safety check
+    if (var_def_stmt.count(sharing_group[0])) {
+      if (auto assign = As<AssignStmt>(var_def_stmt.at(sharing_group[0]))) {
+        if (auto call = As<Call>(assign->value_)) {
+          interval.def_op_name = call->op_->name_;
+        }
+      }
+    }
+
     lifetimes.push_back(interval);
 
     // Mark all variables in the group as processed
@@ -404,6 +415,42 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
         }
 
         if (!overlaps_with_users) {
+          // For inplace-unsafe ops (src buffer == dst buffer not supported), block reuse
+          // whenever the buffer is still occupied at curr_var's definition statement.
+          // A conflict exists if root or any variable sharing root's buffer has
+          // last_use == curr_var.def — meaning it is still being read as an input
+          // to the inplace-unsafe op that defines curr_var (src == dst).
+          if (!curr_lifetime.def_op_name.empty()) {
+            auto& registry = OpRegistry::GetInstance();
+            if (registry.IsRegistered(curr_lifetime.def_op_name) &&
+                !registry.GetEntry(curr_lifetime.def_op_name).IsInplaceSafe()) {
+              // Check root (the ultimate buffer owner)
+              const LifetimeInterval* root_lifetime =
+                  var_to_lifetime.count(root) ? var_to_lifetime.at(root) : nullptr;
+              bool inplace_conflict =
+                  root_lifetime && root_lifetime->last_use_point == curr_lifetime.def_point;
+
+              // Check all variables sharing root's buffer
+              if (!inplace_conflict && memref_users.count(root)) {
+                for (const auto& user_var : memref_users.at(root)) {
+                  const LifetimeInterval* user_lifetime =
+                      var_to_lifetime.count(user_var) ? var_to_lifetime.at(user_var) : nullptr;
+                  if (user_lifetime && user_lifetime->last_use_point == curr_lifetime.def_point) {
+                    inplace_conflict = true;
+                    break;
+                  }
+                }
+              }
+
+              if (inplace_conflict) {
+                LOG_DEBUG << "Variable " << curr_var->name_hint_ << " cannot reuse " << prev_var->name_hint_
+                          << " (op=" << curr_lifetime.def_op_name
+                          << " does not support in-place execution, buffer still occupied at def)";
+                continue;
+              }
+            }
+          }
+
           // Can safely reuse!
           reuse_map[curr_var] = prev_var;
           memref_users[root].push_back(curr_var);  // Track under root MemRef owner

--- a/tests/st/examples/02_intermediate/test_activation.py
+++ b/tests/st/examples/02_intermediate/test_activation.py
@@ -22,6 +22,8 @@ from typing import Any
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.language.intermediate.activation import (
     GegluProgram,
@@ -31,7 +33,19 @@ from examples.language.intermediate.activation import (
 )
 
 
-class TestSiluActivation(PTOTestCase):
+class BaseActivationTest(PTOTestCase):
+    """Base class for activation tests providing common backend configuration."""
+
+    __test__ = False  # Prevent pytest from collecting this as a test
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
+class TestSiluActivation(BaseActivationTest):
     """SiLU (Swish) activation with 32x128 input: output = x * sigmoid(x)"""
 
     __test__ = False  # Not a pytest test class
@@ -53,7 +67,7 @@ class TestSiluActivation(PTOTestCase):
         tensors["output"][:] = x * torch.sigmoid(x)
 
 
-class TestGeluActivation(PTOTestCase):
+class TestGeluActivation(BaseActivationTest):
     """GELU activation with 32x128 input: output = x * sigmoid(1.702 * x)"""
 
     __test__ = False  # Not a pytest test class
@@ -75,7 +89,7 @@ class TestGeluActivation(PTOTestCase):
         tensors["output"][:] = x * torch.sigmoid(1.702 * x)
 
 
-class TestSwigluActivation(PTOTestCase):
+class TestSwigluActivation(BaseActivationTest):
     """SwiGLU activation with 32x128 input: output = gate * sigmoid(gate) * up"""
 
     __test__ = False  # Not a pytest test class
@@ -99,7 +113,7 @@ class TestSwigluActivation(PTOTestCase):
         tensors["output"][:] = gate * torch.sigmoid(gate) * up
 
 
-class TestGegluActivation(PTOTestCase):
+class TestGegluActivation(BaseActivationTest):
     """GeGLU activation with 32x128 input: output = gate * sigmoid(1.702 * gate) * up"""
 
     __test__ = False  # Not a pytest test class
@@ -126,28 +140,24 @@ class TestGegluActivation(PTOTestCase):
 class TestActivationOperations:
     """Test suite for activation operations."""
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_silu_activation_32x128(self, test_runner):
         """Test SiLU (Swish) activation with 32x128 input."""
         test_case = TestSiluActivation()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_gelu_activation_32x128(self, test_runner):
         """Test GELU activation with 32x128 input."""
         test_case = TestGeluActivation()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_swiglu_activation_32x128(self, test_runner):
         """Test SwiGLU activation with 32x128 input."""
         test_case = TestSwigluActivation()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_geglu_activation_32x128(self, test_runner):
         """Test GeGLU activation with 32x128 input."""
         test_case = TestGegluActivation()

--- a/tests/st/examples/02_intermediate/test_ffn_activations.py
+++ b/tests/st/examples/02_intermediate/test_ffn_activations.py
@@ -21,6 +21,8 @@ from typing import Any
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime.runner import RunConfig
 
 from examples.language.intermediate.ffn_activations import (
@@ -30,7 +32,19 @@ from examples.language.intermediate.ffn_activations import (
 )
 
 
-class TestFFNGelu(PTOTestCase):
+class BaseFFNTest(PTOTestCase):
+    """Base class for FFN tests providing common backend configuration."""
+
+    __test__ = False  # Prevent pytest from collecting this as a test
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+
+class TestFFNGelu(BaseFFNTest):
     """FFN with GELU activation on 64x64 tiles.
 
     Pipeline: output = GELU(hidden_states @ gate_proj_weight) @ down_proj_weight
@@ -62,7 +76,7 @@ class TestFFNGelu(PTOTestCase):
         tensors["output"][:] = activated @ down_proj_weight
 
 
-class TestFFNSwiglu(PTOTestCase):
+class TestFFNSwiglu(BaseFFNTest):
     """FFN with SwiGLU activation on 64x64 tiles.
 
     Pipeline: output = SwiGLU(gate, up) @ down_proj_weight
@@ -98,7 +112,7 @@ class TestFFNSwiglu(PTOTestCase):
         tensors["output"][:] = activated @ down_proj_weight
 
 
-class TestFFNRelu(PTOTestCase):
+class TestFFNRelu(BaseFFNTest):
     """FFN with ReLU activation on 64x64 tiles.
 
     Pipeline: output = ReLU(hidden_states @ gate_proj_weight) @ down_proj_weight
@@ -132,14 +146,12 @@ class TestFFNRelu(PTOTestCase):
 class TestFFNActivationOperations:
     """Test suite for FFN module operations."""
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_ffn_gelu_64x64(self, test_runner):
         """Test FFN with GELU activation: GELU(hidden @ gate_proj) @ down_proj."""
         test_case = TestFFNGelu(RunConfig(atol=3e-3, rtol=3e-3))
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.xfail(reason="producer-consumer reuse (last_use==def) causes in-place src==dst conflict")
     def test_ffn_swiglu_64x64(self, test_runner):
         """Test FFN with SwiGLU activation: SwiGLU(gate, up) @ down_proj."""
         test_case = TestFFNSwiglu(RunConfig(atol=3e-3, rtol=3e-3))

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -778,5 +778,240 @@ class TestViewOperationsMemoryReuse:
         _assert_shares_memref(func, "tile_d", "tile_a")
 
 
+class TestInplaceSafetyCheck:
+    """Tests verifying that ops marked not_inplace_safe block producer-consumer reuse."""
+
+    def test_inplace_unsafe_op_no_producer_consumer_reuse(self):
+        """tile.recip must NOT reuse its input's buffer when last_use == def (src == dst).
+
+        tile_a.last_use == tile_b.def (producer-consumer), but tile.recip does not
+        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP32],
+                output: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(input_a, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.FP32] = pl.recip(tile_a)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.recip does not support in-place: tile_b must have its own MemRef
+        _assert_not_shares_memref(func, "tile_a", "tile_b")
+
+    def test_inplace_unsafe_op_allows_non_producer_consumer_reuse(self):
+        """tile.recip output does not share a buffer with its input (tile_x) in any case.
+
+        tile_c is freed strictly before tile_b's definition and tile_x occupies
+        tile_a's buffer.  The key correctness property is that tile_b (result of
+        recip(tile_x)) must never end up in the same buffer as tile_x regardless of
+        how many dead buffers are available for reuse.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP32],
+                input_c: pl.Tensor[[32, 32], pl.FP32],
+                input_x: pl.Tensor[[32, 32], pl.FP32],
+                output: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                # Two separate dead buffers before recip is called
+                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(input_a, [0, 0], [32, 32])
+                _s1: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_a, [0, 0], output)
+                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.load(input_c, [0, 0], [32, 32])
+                _s2: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                # tile_x reuses one of the dead buffers
+                tile_x: pl.Tile[[32, 32], pl.FP32] = pl.load(input_x, [0, 0], [32, 32])
+                # tile_b = recip(tile_x): inplace-unsafe, must not share buffer with tile_x
+                tile_b: pl.Tile[[32, 32], pl.FP32] = pl.recip(tile_x)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # Core correctness: tile.recip output must never share a buffer with its input
+        _assert_not_shares_memref(func, "tile_x", "tile_b")
+
+    def test_inplace_safe_op_allows_producer_consumer_reuse(self):
+        """tile.add (inplace-safe by default) CAN reuse its input's buffer.
+
+        tile_a.last_use == tile_b.def (producer-consumer), but tile.add supports
+        in-place execution, so tile_b is allowed to reuse tile_a's MemRef.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP32],
+                output: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(input_a, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.FP32] = pl.add(tile_a, tile_a)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.add is inplace-safe: producer-consumer reuse is allowed
+        _assert_shares_memref(func, "tile_a", "tile_b")
+
+    def test_ands_no_producer_consumer_reuse(self):
+        """tile.ands must NOT reuse its input's buffer when last_use == def (src == dst).
+
+        tile_a.last_use == tile_b.def (producer-consumer), but tile.ands does not
+        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.INT32],
+                output: pl.Tensor[[32, 32], pl.INT32],
+            ) -> pl.Tensor[[32, 32], pl.INT32]:
+                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.ands(tile_a, 255)
+                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.ands does not support in-place: tile_b must have its own MemRef
+        _assert_not_shares_memref(func, "tile_a", "tile_b")
+
+    def test_ors_no_producer_consumer_reuse(self):
+        """tile.ors must NOT reuse its input's buffer when last_use == def (src == dst).
+
+        tile_a.last_use == tile_b.def (producer-consumer), but tile.ors does not
+        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.INT32],
+                output: pl.Tensor[[32, 32], pl.INT32],
+            ) -> pl.Tensor[[32, 32], pl.INT32]:
+                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.ors(tile_a, 255)
+                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.ors does not support in-place: tile_b must have its own MemRef
+        _assert_not_shares_memref(func, "tile_a", "tile_b")
+
+    def test_xors_no_producer_consumer_reuse(self):
+        """tile.xors must NOT reuse its input's buffer when last_use == def (src == dst).
+
+        tile_a.last_use == tile_b.def (producer-consumer), but tile.xors does not
+        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
+        tile_tmp is loaded from a separate tensor to ensure it has a MemRef assigned.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.INT32],
+                input_b: pl.Tensor[[32, 32], pl.INT32],
+                output: pl.Tensor[[32, 32], pl.INT32],
+            ) -> pl.Tensor[[32, 32], pl.INT32]:
+                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
+                tile_tmp: pl.Tile[[32, 32], pl.INT32] = pl.load(input_b, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.xors(tile_a, 255, tile_tmp)
+                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.xors does not support in-place: tile_b must have its own MemRef
+        _assert_not_shares_memref(func, "tile_a", "tile_b")
+
+    def test_inplace_unsafe_two_level_transitive_chain(self):
+        """tile.recip must not reuse a buffer occupied by its input via a two-level chain.
+
+        Timeline (statement order):
+          stmt 0: tile_a = load(input_a)              tile_a.def=0, last_use=1
+          stmt 1: tile_b = add(tile_a, tile_a)        tile_b.def=1, last_use=2
+          stmt 2: _s1   = store(tile_b, output)       tile_b last use
+          stmt 3: tile_u = load(input_u)              tile_u.def=3, last_use=5
+          stmt 4: tile_d = add(tile_u, tile_u)        tile_d.def=4, last_use=6
+          stmt 5: _s2   = store(tile_u, output)       tile_u last use (> tile_d.def)
+          stmt 6: tile_c = recip(tile_d)              tile_c.def=6, recip is inplace-unsafe
+          stmt 7: result = store(tile_c, output)
+
+        Greedy reuse chain (without fix):
+          tile_b reuses tile_a  →  memref_users[tile_a] = [tile_b]
+          tile_u reuses tile_a  →  memref_users[tile_a] = [tile_b, tile_u]
+          tile_d cannot reuse tile_a (tile_u.last_use=5 > tile_d.def=4 → overlap)
+          tile_d reuses tile_b  →  memref_users[tile_b] = [tile_d]
+          tile_c tries tile_a: direct conflict (tile_a.last_use=1 != 6) and indirect
+          (tile_b.last_use=2!=6, tile_u.last_use=5!=6) both miss tile_d
+          BUG: tile_c reuses tile_a even though tile_d (= tile_a's physical buffer)
+          has last_use=6 == tile_c.def=6 → recip(tile_d) executes with src == dst.
+
+        After fix: tile_d is propagated into memref_users[tile_a] when it reuses
+        tile_b, so tile_d.last_use(6) == tile_c.def(6) is detected → reuse blocked.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP32],
+                input_u: pl.Tensor[[32, 32], pl.FP32],
+                output: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                # tile_a: last use at stmt 1 (tile_b definition)
+                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(input_a, [0, 0], [32, 32])
+                # tile_b reuses tile_a (add is inplace-safe, producer-consumer OK)
+                tile_b: pl.Tile[[32, 32], pl.FP32] = pl.add(tile_a, tile_a)
+                # tile_b last use at stmt 2
+                _s1: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                # tile_u reuses tile_a (tile_b is done before stmt 3)
+                tile_u: pl.Tile[[32, 32], pl.FP32] = pl.load(input_u, [0, 0], [32, 32])
+                # tile_d reuses tile_b (tile_u overlap at stmt 5 blocks tile_a for tile_d)
+                tile_d: pl.Tile[[32, 32], pl.FP32] = pl.add(tile_u, tile_u)
+                # tile_u last use at stmt 5, which is AFTER tile_d.def (stmt 4)
+                _s2: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_u, [0, 0], output)
+                # tile_c = recip(tile_d): inplace-unsafe, must NOT share buffer with tile_d
+                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.recip(tile_d)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        _assert_all_have_memrefs(func)
+        # tile.recip is inplace-unsafe: tile_c must not share a buffer with its input tile_d.
+        # tile_d physically occupies tile_a's buffer (via chain tile_d→tile_b→tile_a),
+        # so this also verifies that the two-level transitive chain is detected.
+        _assert_not_shares_memref(func, "tile_d", "tile_c")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add `not_inplace_safe()` / `IsInplaceSafe()` API to `OpRegistryEntry` so individual ops can declare they cannot execute with src buffer == dst buffer.

Mark `tile.recip`, `tile.ands`, `tile.ors`, and `tile.xors` as not-inplace-safe.

Update `BasicMemoryReuse` pass to skip producer-consumer reuse when the defining op is not inplace-safe and the source buffer is still live at the definition point. Simplify user tracking to maintain all users under the root MemRef owner directly, removing the per-hop ancestor propagation.

Add unit tests covering ands/ors/xors inplace-unsafe blocking and remove the duplicate recip test. Remove `xfail` markers from activation and FFN system tests that were tracking this bug.