### PR TITLE
refactor(ir): extract shared memref utilities

### DIFF
--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_MEMREF_UTILS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_MEMREF_UTILS_H_
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/type.h"
+
+namespace pypto::ir {
+
+inline std::optional<MemRefPtr> GetTypeMemRef(const TypePtr& type) {
+  if (auto shaped_type = std::dynamic_pointer_cast<const ShapedType>(type)) {
+    return shaped_type->memref_;
+  }
+  return std::nullopt;
+}
+
+inline TypePtr CloneTypeWithMemRef(const TypePtr& type, const std::optional<MemRefPtr>& memref,
+                                   std::optional<MemorySpace> tile_memory_space_override = std::nullopt) {
+  if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
+    return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, memref,
+                                        tensor_type->tensor_view_);
+  }
+
+  if (auto tile_type = std::dynamic_pointer_cast<const TileType>(type)) {
+    auto memory_space =
+        tile_memory_space_override.has_value() ? tile_memory_space_override : tile_type->memory_space_;
+    return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, memref, tile_type->tile_view_,
+                                      memory_space);
+  }
+
+  return type;
+}
+
+inline std::shared_ptr<const TileType> GetTileTypeWithMemRef(const TypePtr& type) {
+  auto tile_type = std::dynamic_pointer_cast<const TileType>(type);
+  if (!tile_type || !tile_type->memref_.has_value()) {
+    return nullptr;
+  }
+  return tile_type;
+}
+
+inline MemRefPtr GetDefinedMemRef(const std::shared_ptr<const TileType>& tile_type) {
+  CHECK(tile_type != nullptr) << "TileType must not be null";
+  CHECK(tile_type->memref_.has_value()) << "TileType must carry MemRef";
+  return *tile_type->memref_;
+}
+
+inline bool TryRegisterUniqueMemRef(const MemRefPtr& memref, std::set<const MemRef*>& seen_ptrs) {
+  CHECK(memref != nullptr) << "MemRef must not be null";
+  return seen_ptrs.insert(memref.get()).second;
+}
+
+inline bool TryRegisterUniqueMemRef(const MemRefPtr& memref, MemorySpace memory_space,
+                                    std::map<const MemRef*, MemorySpace>& seen_ptrs) {
+  CHECK(memref != nullptr) << "MemRef must not be null";
+  auto [it, inserted] = seen_ptrs.emplace(memref.get(), memory_space);
+  CHECK(inserted || it->second == memory_space)
+      << "Conflicting TileType.memory_space values found for the same MemRef";
+  return inserted;
+}
+
+}  // namespace pypto::ir
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_MEMREF_UTILS_H_

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -532,6 +532,8 @@ void BindIR(nb::module_& m) {
             result[key.c_str()] = AnyCast<MemorySpace>(value, "converting to Python: " + key);
           } else if (value.type() == typeid(TensorLayout)) {
             result[key.c_str()] = AnyCast<TensorLayout>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(TilePad)) {
+            result[key.c_str()] = AnyCast<TilePad>(value, "converting to Python: " + key);
           }
         }
         return result;

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -910,7 +910,7 @@ class Call(Expr):
     args: Final[Sequence[Expr]]
     """Positional arguments."""
 
-    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace]]
+    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | TilePad]]
     """Keyword arguments (metadata)."""
 
     @overload
@@ -948,7 +948,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | TilePad],
         span: Span,
     ) -> None:
         """Create a function call expression with kwargs.
@@ -966,7 +966,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | TilePad],
         type: Type,
         span: Span,
     ) -> None:

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -141,9 +142,8 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
 
   void VisitExpr_(const VarPtr& op) override {
     if (iter_arg_names_.count(op->name_)) return;
-    auto tile_type = As<TileType>(op->GetType());
-    if (tile_type && tile_type->memref_.has_value()) {
-      AddMemRefIfUnique(tile_type->memref_.value(), tile_type);
+    if (auto tile_type = ir::GetTileTypeWithMemRef(op->GetType())) {
+      AddMemRefIfUnique(ir::GetDefinedMemRef(tile_type), tile_type);
     }
   }
 
@@ -160,9 +160,8 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
 
   void AddMemRefIfUnique(const MemRefPtr& memref, const std::shared_ptr<const TileType>& tile_type) {
     const ir::MemRef* raw_ptr = memref.get();
-    if (seen_ptrs_.find(raw_ptr) == seen_ptrs_.end()) {
+    if (ir::TryRegisterUniqueMemRef(memref, seen_ptrs_)) {
       memrefs_.push_back(memref);
-      seen_ptrs_.insert(raw_ptr);
       memref_tile_types_[raw_ptr] = tile_type;
     } else {
       // Merge TileView properties when multiple tiles share the same MemRef:
@@ -392,14 +391,13 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
         : var_to_memref(mapping), memref_to_var_name(reverse_mapping) {}
 
     void VisitStmt_(const AssignStmtPtr& op) override {
-      if (auto tile_type = As<TileType>(op->var_->GetType())) {
-        if (tile_type->memref_.has_value()) {
-          const ir::MemRef* ptr = tile_type->memref_.value().get();
-          var_to_memref[op->var_->name_] = ptr;
-          // Record first variable name per MemRef (program order)
-          if (memref_to_var_name.find(ptr) == memref_to_var_name.end()) {
-            memref_to_var_name[ptr] = op->var_->name_;
-          }
+      if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
+        const auto memref = ir::GetDefinedMemRef(tile_type);
+        const ir::MemRef* ptr = memref.get();
+        var_to_memref[op->var_->name_] = ptr;
+        // Record first variable name per MemRef (program order)
+        if (memref_to_var_name.find(ptr) == memref_to_var_name.end()) {
+          memref_to_var_name[ptr] = op->var_->name_;
         }
       }
       ir::IRVisitor::VisitStmt_(op);
@@ -562,10 +560,10 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
     if (backend_ != nullptr && backend_->GetOpInfo(call->op_->name_) != nullptr) {
       std::string result_buf = op->var_->name_;  // use for var_name to mlir name mapping for non-tile op
       std::shared_ptr<const TileType> result_tile_type;
-      if (auto tile_type = As<TileType>(op->var_->GetType())) {
-        if (tile_type->memref_.has_value()) {
-          result_buf = GetTileBufForMemRef(tile_type->memref_.value());
-        }
+      if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
+        result_buf = GetTileBufForMemRef(ir::GetDefinedMemRef(tile_type));
+        result_tile_type = tile_type;
+      } else if (auto tile_type = As<TileType>(op->var_->GetType())) {
         result_tile_type = tile_type;
       } else if (As<ScalarType>(op->var_->GetType())) {
         // Pre-allocate an SSA name for scalar-result backend ops (e.g., tile.getval).
@@ -926,10 +924,8 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
       return GetTypeString(scalar_type->dtype_);
     }
     // Check if variable has TileType with memref
-    if (auto tile_type = As<TileType>(var->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        return GetTileBufTypeString(tile_type->memref_.value().get());
-      }
+    if (auto tile_type = ir::GetTileTypeWithMemRef(var->GetType())) {
+      return GetTileBufTypeString(ir::GetDefinedMemRef(tile_type).get());
     }
   }
   if (auto iter_arg = As<ir::IterArg>(expr)) {
@@ -937,10 +933,8 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
     if (memref_it != var_to_memref_.end()) {
       return GetTileBufTypeString(memref_it->second);
     }
-    if (auto tile_type = As<TileType>(iter_arg->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        return GetTileBufTypeString(tile_type->memref_.value().get());
-      }
+    if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
+      return GetTileBufTypeString(ir::GetDefinedMemRef(tile_type).get());
     }
     if (auto scalar_type = As<ScalarType>(iter_arg->GetType())) {
       return GetTypeString(scalar_type->dtype_);
@@ -1330,11 +1324,10 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     if (tensor_type) {
       tensor_to_view_[iter_arg->name_] = init_mlir_name;
       tensor_to_view_[return_var->name_] = init_mlir_name;
-    } else if (auto tile_type = As<TileType>(iter_arg->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        var_to_memref_[iter_arg->name_] = tile_type->memref_.value().get();
-        var_to_memref_[return_var->name_] = tile_type->memref_.value().get();
-      }
+    } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
+      const auto memref = ir::GetDefinedMemRef(tile_type);
+      var_to_memref_[iter_arg->name_] = memref.get();
+      var_to_memref_[return_var->name_] = memref.get();
     }
   }
 
@@ -1473,11 +1466,10 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     if (tensor_type) {
       tensor_to_view_[iter_arg->name_] = init_mlir_name;
       tensor_to_view_[return_var->name_] = init_mlir_name;
-    } else if (auto tile_type = As<TileType>(iter_arg->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        var_to_memref_[iter_arg->name_] = tile_type->memref_.value().get();
-        var_to_memref_[return_var->name_] = tile_type->memref_.value().get();
-      }
+    } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
+      const auto memref = ir::GetDefinedMemRef(tile_type);
+      var_to_memref_[iter_arg->name_] = memref.get();
+      var_to_memref_[return_var->name_] = memref.get();
     }
   }
 

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -58,8 +59,7 @@ class MemRefCollectorVisitor : public IRVisitor {
   [[nodiscard]] const std::vector<MemRefWithSpace>& GetMemRefs() const { return memrefs_; }
 
   void VisitVarLike_(const VarPtr& op) override {
-    auto tile_type = As<TileType>(op->GetType());
-    if (tile_type && tile_type->memref_.has_value()) {
+    if (auto tile_type = GetTileTypeWithMemRef(op->GetType())) {
       AddMemRefIfUnique(tile_type);
     }
   }
@@ -76,12 +76,7 @@ class MemRefCollectorVisitor : public IRVisitor {
     const MemorySpace canonical_space = memory_space.value();
 
     const auto& memref = tile_type->memref_.value();
-    // Use raw pointer address to check uniqueness (same shared_ptr)
-    const MemRef* raw_ptr = memref.get();
-    auto [it, inserted] = seen_ptrs_.emplace(raw_ptr, canonical_space);
-    CHECK(inserted || it->second == canonical_space)
-        << "Conflicting TileType.memory_space values found for the same MemRef";
-    if (inserted) {
+    if (TryRegisterUniqueMemRef(memref, canonical_space, seen_ptrs_)) {
       memrefs_.emplace_back(memref, canonical_space);
     }
   }
@@ -140,21 +135,13 @@ class MemRefUpdateMutator : public IRMutator {
   std::unordered_map<const MemRef*, MemRefPtr> memref_map_;
 
   TypePtr UpdateTypeMemRef(const TypePtr& type) {
-    if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
-      if (tensor_type->memref_.has_value()) {
-        auto it = memref_map_.find(tensor_type->memref_.value().get());
-        if (it != memref_map_.end()) {
-          return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, it->second);
-        }
-      }
-    } else if (auto tile_type = std::dynamic_pointer_cast<const TileType>(type)) {
-      if (tile_type->memref_.has_value()) {
-        auto it = memref_map_.find(tile_type->memref_.value().get());
-        if (it != memref_map_.end()) {
-          return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, it->second,
-                                            tile_type->tile_view_, tile_type->memory_space_);
-        }
-      }
+    auto memref = GetTypeMemRef(type);
+    if (!memref.has_value()) {
+      return type;
+    }
+    auto it = memref_map_.find(memref.value().get());
+    if (it != memref_map_.end()) {
+      return CloneTypeWithMemRef(type, it->second);
     }
     return type;
   }

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/dependency_graph.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -455,9 +456,7 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
 
         // Create new TileType with shared MemRef
         auto new_tile_type =
-            std::make_shared<const TileType>(curr_tile_type->shape_, curr_tile_type->dtype_,
-                                             source_memref,  // Share MemRef!
-                                             curr_tile_type->tile_view_, curr_tile_type->memory_space_);
+            std::dynamic_pointer_cast<const TileType>(CloneTypeWithMemRef(curr_tile_type, source_memref));
 
         // Create new Var
         auto new_var = std::make_shared<const Var>(op->var_->name_, new_tile_type, op->var_->span_);
@@ -475,10 +474,8 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
               // Create new Var for shared variable with same reused MemRef
               auto shared_tile_type = As<TileType>(shared_var->GetType());
               if (shared_tile_type) {
-                auto new_shared_tile_type = std::make_shared<const TileType>(
-                    shared_tile_type->shape_, shared_tile_type->dtype_,
-                    source_memref,  // Same reused MemRef!
-                    shared_tile_type->tile_view_, shared_tile_type->memory_space_);
+                auto new_shared_tile_type = std::dynamic_pointer_cast<const TileType>(
+                    CloneTypeWithMemRef(shared_tile_type, source_memref));
                 auto new_shared_var =
                     std::make_shared<const Var>(shared_var->name_, new_shared_tile_type, shared_var->span_);
                 var_substitution_map_[shared_var] = new_shared_var;
@@ -528,10 +525,8 @@ class UsedMemRefCollector : public IRVisitor {
   [[nodiscard]] const std::set<const MemRef*>& GetUsedPtrs() const { return used_ptrs_; }
 
   void VisitVarLike_(const VarPtr& op) override {
-    if (auto tile_type = As<TileType>(op->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        used_ptrs_.insert(tile_type->memref_.value().get());
-      }
+    if (auto tile_type = GetTileTypeWithMemRef(op->GetType())) {
+      used_ptrs_.insert(GetDefinedMemRef(tile_type).get());
     }
   }
 

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/normalize_stmt_structure.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -251,38 +252,6 @@ class InitMemRefMutator : public IRMutator {
     return std::make_shared<MemRef>(space, addr, size_bytes, id);
   }
 
-  // Clone a type with specified MemRef (handles TensorType and TileType)
-  TypePtr CloneTypeWithMemRef(const TypePtr& original_type, const std::optional<MemRefPtr>& memref,
-                              std::optional<MemorySpace> memory_space_override = std::nullopt) {
-    if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(original_type)) {
-      return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, memref,
-                                          tensor_type->tensor_view_);
-    }
-
-    if (auto tile_type = std::dynamic_pointer_cast<const TileType>(original_type)) {
-      auto tile_memory_space =
-          memory_space_override.has_value() ? memory_space_override : tile_type->memory_space_;
-      return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, memref, tile_type->tile_view_,
-                                        tile_memory_space);
-    }
-
-    // For non-ShapedTypes, return as-is
-    return original_type;
-  }
-
-  // Extract MemRef from ShapedType (TensorType or TileType)
-  std::optional<MemRefPtr> ExtractMemRefFromType(const TypePtr& type) {
-    if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
-      return tensor_type->memref_;
-    }
-
-    if (auto tile_type = std::dynamic_pointer_cast<const TileType>(type)) {
-      return tile_type->memref_;
-    }
-
-    return std::nullopt;
-  }
-
   std::optional<MemorySpace> ExtractMemorySpaceFromType(const TypePtr& type) {
     auto shaped_type = std::dynamic_pointer_cast<const ShapedType>(type);
     if (!shaped_type) {
@@ -299,7 +268,7 @@ class InitMemRefMutator : public IRMutator {
     auto new_init = VisitExpr(iter_arg->initValue_);
 
     // Extract MemRef from initValue and create new type
-    auto memref = ExtractMemRefFromType(new_init->GetType());
+    auto memref = GetTypeMemRef(new_init->GetType());
     auto old_var_expr = std::static_pointer_cast<const Expr>(old_var);
     auto source_memory_space = ExtractMemorySpaceFromType(new_init->GetType());
     TypePtr new_type = CloneTypeWithMemRef(old_var_expr->GetType(), memref, source_memory_space);
@@ -372,7 +341,7 @@ class InitMemRefMutator : public IRMutator {
           auto input_tile_arg = new_call->args_[0];
 
           // Extract MemRef from input tile
-          auto shared_memref = ExtractMemRefFromType(input_tile_arg->GetType());
+          auto shared_memref = GetTypeMemRef(input_tile_arg->GetType());
 
           // Create new variable with shared MemRef
           if (shared_memref.has_value()) {
@@ -397,7 +366,7 @@ class InitMemRefMutator : public IRMutator {
           auto output_tensor_arg = new_call->args_[2];
 
           // Extract MemRef from the output tensor
-          auto shared_memref = ExtractMemRefFromType(output_tensor_arg->GetType());
+          auto shared_memref = GetTypeMemRef(output_tensor_arg->GetType());
 
           // Create new variable with the shared MemRef
           if (shared_memref.has_value()) {
@@ -476,10 +445,8 @@ class NonDDRMemRefCollector : public IRVisitor {
   [[nodiscard]] const std::vector<MemRefAlloc>& GetMemRefs() const { return memrefs_; }
 
   void VisitVarLike_(const VarPtr& op) override {
-    if (auto tile_type = As<TileType>(op->GetType())) {
-      if (tile_type->memref_.has_value()) {
-        AddMemRefIfUnique(tile_type);
-      }
+    if (auto tile_type = GetTileTypeWithMemRef(op->GetType())) {
+      AddMemRefIfUnique(tile_type);
     }
   }
 
@@ -496,11 +463,7 @@ class NonDDRMemRefCollector : public IRVisitor {
     if (canonical_space == MemorySpace::DDR) return;
 
     const auto& memref = tile_type->memref_.value();
-    const MemRef* raw_ptr = memref.get();
-    auto [it, inserted] = seen_ptrs_.emplace(raw_ptr, canonical_space);
-    CHECK(inserted || it->second == canonical_space)
-        << "Conflicting TileType.memory_space values found for the same MemRef";
-    if (inserted) {
+    if (TryRegisterUniqueMemRef(memref, canonical_space, seen_ptrs_)) {
       memrefs_.emplace_back(memref, canonical_space);
     }
   }

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -230,6 +230,87 @@ def test_pto_codegen_alloc_tile():
     assert "rows=32, cols=32" in mlir_code
 
 
+def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
+    """Test that shared MemRef tiles emit one alloc_tile and preserve merged TileView info."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B_PTO)
+    span = ir.Span.unknown()
+    zero = ir.ConstInt(0, DataType.INDEX, span)
+    size = ir.ConstInt(128, DataType.INDEX, span)
+
+    input_tensor = ir.Var("a", ir.TensorType([128, 128], DataType.FP32), span)
+    output_tensor = ir.Var("output", ir.TensorType([128, 128], DataType.FP32), span)
+    m_var = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
+    n_var = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+    shared_memref = ir.MemRef(ir.MemorySpace.Vec, zero, 128 * 128 * 4, 0)
+
+    load_view = ir.TileView()
+    load_view.valid_shape = [m_var, n_var]
+    load_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, load_view, ir.MemorySpace.Vec)
+    load_tile = ir.Var("tile_a", load_tile_type, span)
+
+    padded_view = ir.TileView()
+    padded_view.valid_shape = [size, size]
+    padded_view.pad = ir.TilePad.max
+    padded_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, padded_view, ir.MemorySpace.Vec)
+    padded_tile = ir.Var("padded", padded_tile_type, span)
+
+    result_var = ir.Var("result", ir.TensorType([128, 128], DataType.FP32), span)
+    offsets = ir.MakeTuple([zero, zero], span)
+    shapes = ir.MakeTuple([size, size], span)
+
+    load_call = ir.Call(ir.Op("tile.load"), [input_tensor, offsets, shapes], {}, load_tile_type, span)
+    fillpad_call = ir.Call(
+        ir.Op("tile.fillpad"),
+        [load_tile],
+        {"pad_value": ir.TilePad.max},
+        padded_tile_type,
+        span,
+    )
+    assert fillpad_call.kwargs["pad_value"] == ir.TilePad.max
+    store_call = ir.Call(ir.Op("tile.store"), [padded_tile, offsets, output_tensor], result_var.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.OpStmts(
+                [
+                    ir.AssignStmt(load_tile, load_call, span),
+                    ir.AssignStmt(padded_tile, fillpad_call, span),
+                    ir.AssignStmt(result_var, store_call, span),
+                ],
+                span,
+            ),
+            ir.ReturnStmt([result_var], span),
+        ],
+        span,
+    )
+    func = ir.Function(
+        "fillpad_test",
+        [
+            (input_tensor, ir.ParamDirection.In),
+            (output_tensor, ir.ParamDirection.Out),
+            (m_var, ir.ParamDirection.In),
+            (n_var, ir.ParamDirection.In),
+        ],
+        [ir.TensorType([128, 128], DataType.FP32)],
+        body,
+        span,
+        ir.FunctionType.InCore,
+    )
+    program = ir.Program([func], "fillpad_test_program", span)
+
+    codegen = PTOCodegen()
+    mlir_code = _get_mlir_code(codegen.generate(program))
+    alloc_lines = [line.strip() for line in mlir_code.splitlines() if "pto.alloc_tile" in line]
+
+    assert len(alloc_lines) == 1, f"Expected one alloc_tile for shared MemRef, got: {alloc_lines}"
+    assert "valid_row = %arg2 valid_col = %arg3" in alloc_lines[0]
+    assert "v_row=?" in alloc_lines[0]
+    assert "v_col=?" in alloc_lines[0]
+    assert "pad=" in alloc_lines[0]
+    assert "pad=0>" not in alloc_lines[0], f"Expected fillpad pad metadata to be preserved: {alloc_lines[0]}"
+
+
 def test_pto_codegen_tile_load_lowering():
     """Test that tile.load generates partition_view + tload."""
     backend.reset_for_testing()


### PR DESCRIPTION
Fixes #550

Extract shared helpers for MemRef-aware type cloning, MemRef lookup, and raw-pointer deduplication across IR transforms and PTO codegen. This keeps pass-specific collector behavior intact while removing duplicated TensorType/TileType MemRef handling and adds a regression test for shared-MemRef PTO alloc_tile emission.