### PR TITLE
fix(pass): use SeqStmts::Flatten in ConvertToSSA to avoid single-child blocks

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -264,12 +264,14 @@ class ASTParser:
             self.parse_break(stmt)
         elif isinstance(stmt, ast.Continue):
             self.parse_continue(stmt)
+        elif isinstance(stmt, ast.Pass):
+            pass  # No-op: pass statements produce no IR
         else:
             raise UnsupportedFeatureError(
                 f"Unsupported statement type: {type(stmt).__name__}",
                 span=self.span_tracker.get_span(stmt),
                 hint="Only assignments, for loops, while loops, if statements, "
-                "with statements, returns, break, and continue are supported in DSL functions",
+                "with statements, returns, break, continue, and pass are supported in DSL functions",
             )
 
     def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:  # noqa: PLR0912

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -683,16 +683,16 @@ class SSAConverter : public IRMutator {
         // Replace last yield
         std::vector<StmtPtr> new_stmts(seq->stmts_.begin(), seq->stmts_.end() - 1);
         new_stmts.push_back(yield);
-        return std::make_shared<SeqStmts>(new_stmts, seq->span_);
+        return SeqStmts::Flatten(std::move(new_stmts), seq->span_);
       }
       // Append yield
       std::vector<StmtPtr> new_stmts = seq->stmts_;
       new_stmts.push_back(yield);
-      return std::make_shared<SeqStmts>(new_stmts, seq->span_);
+      return SeqStmts::Flatten(std::move(new_stmts), seq->span_);
     }
 
     // Wrap single statement and yield in SeqStmts
-    return std::make_shared<SeqStmts>(std::vector<StmtPtr>{stmt, yield}, span);
+    return SeqStmts::Flatten(std::vector<StmtPtr>{stmt, yield}, span);
   }
 
   /**
@@ -721,12 +721,12 @@ class SSAConverter : public IRMutator {
         // Replace last yield
         std::vector<StmtPtr> new_stmts(seq->stmts_.begin(), seq->stmts_.end() - 1);
         new_stmts.push_back(new_yield);
-        return std::make_shared<SeqStmts>(new_stmts, seq->span_);
+        return SeqStmts::Flatten(std::move(new_stmts), seq->span_);
       }
       // Append yield
       std::vector<StmtPtr> new_stmts = seq->stmts_;
       new_stmts.push_back(new_yield);
-      return std::make_shared<SeqStmts>(new_stmts, seq->span_);
+      return SeqStmts::Flatten(std::move(new_stmts), seq->span_);
     }
 
     if (As<YieldStmt>(stmt)) {
@@ -734,7 +734,7 @@ class SSAConverter : public IRMutator {
     }
 
     // Wrap single statement and yield in SeqStmts
-    return std::make_shared<SeqStmts>(std::vector<StmtPtr>{stmt, new_yield}, span);
+    return SeqStmts::Flatten(std::vector<StmtPtr>{stmt, new_yield}, span);
   }
 };
 

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1195,6 +1195,42 @@ class TestPlainSyntax:
         After = passes.convert_to_ssa()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_if_with_empty_then_branch_plain(self):
+        """Empty then-branch (e.g. from continue elimination) should not create single-child SeqStmts.
+
+        Regression test for issue #561: ConvertToSSA was wrapping a single yield
+        in a SeqStmts when inserting into an empty branch, violating NoRedundantBlocks.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = x
+                for i in pl.range(10):
+                    if i > 5:
+                        pass
+                    else:
+                        result = pl.add(result, 1.0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                for i_0, (result_iter_1,) in pl.range(0, 10, 1, init_values=(result_0,)):
+                    if i_0 > 5:
+                        result_4 = pl.yield_(result_iter_1)
+                    else:
+                        result_3: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                        result_4 = pl.yield_(result_3)
+                    result_2 = pl.yield_(result_4)
+                return result_2
+
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Replace `std::make_shared<SeqStmts>(...)` with `SeqStmts::Flatten(...)` in `AppendYield` and `ReplaceOrAppendYield` helpers in `convert_to_ssa_pass.cpp`, so that single-child SeqStmts are automatically unwrapped — fixing the `NoRedundantBlocks` structural property violation
- Add `pass` statement support in the DSL parser (`ast_parser.py`) — a no-op that produces no IR, enabling empty branches in the frontend
- Add regression test `test_if_with_empty_then_branch_plain` covering the exact scenario from the issue

## Related Issues
Fixes #561

## Testing
- [x] All 2,360 unit tests pass
- [x] Code review completed
- [x] clang-tidy: no new warnings (pre-existing issues on unrelated lines only)
- [x] All pre-commit hooks pass (ruff, clang-format, cpplint, pyright)