### PR TITLE
fix(ir): handle partial code generation failures in compile()

### DIFF
--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -113,9 +113,13 @@ def compile(
         transformed_program = pm.run_passes(program, dump_ir=dump_passes, output_dir=passes_dump_dir)
 
     if backend_type in (BackendType.Ascend910B_PTO, BackendType.Ascend950):
-        from .pto_codegen import generate  # noqa: PLC0415
+        from .pto_codegen import PartialCodegenError, generate  # noqa: PLC0415
 
-        files = generate(transformed_program, output_dir, skip_ptoas=skip_ptoas)
+        try:
+            files = generate(transformed_program, output_dir, skip_ptoas=skip_ptoas)
+        except PartialCodegenError as exc:
+            _write_files(exc.files, output_dir)
+            raise
         _write_files(files, output_dir)
     elif backend_type == BackendType.Ascend910B_CCE:
         codegen_instance = _codegen_core.CCECodegen()

--- a/python/pypto/ir/pto_codegen.py
+++ b/python/pypto/ir/pto_codegen.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 _PTOAS_RELEASE_URL = "https://github.com/zhangstevenunity/PTOAS/releases"
 
 
+class PartialCodegenError(RuntimeError):
+    """Codegen failed after producing some output files."""
+
+    def __init__(self, message: str, files: dict[str, str]) -> None:
+        super().__init__(message)
+        self.files = files
+
+
 def _get_error_summary(exc: Exception, func_name: str) -> str:
     """Extract the first meaningful line from an exception, without the function name.
 
@@ -408,6 +416,9 @@ def generate(
             errors.append((orch_func.name, e))
 
     if errors:
-        raise RuntimeError(_format_error_report(errors, output_dir))
+        report = _format_error_report(errors, output_dir)
+        if result_files:
+            raise PartialCodegenError(report, result_files)
+        raise RuntimeError(report)
 
     return result_files

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -731,6 +731,54 @@ class TestGenerateSkipPtoas:
             assert not key.endswith(".cpp"), f"Unexpected .cpp extension: {key}"
 
 
+def test_compile_writes_orchestration_on_partial_codegen_failure(tmp_path):
+    """compile() should preserve generated files when some InCore functions fail."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B_PTO)
+
+    @pl.program
+    class PartialFailureProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def good_kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            tile = pl.load(a, offsets=[0, 0], shapes=[16, 16])
+            out = pl.store(tile, offsets=[0, 0], output_tensor=output)
+            return out
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def bad_kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            source = pl.slice(a, [16, 16], [0, 0])
+            result = pl.create_tensor([16, 16], dtype=pl.FP32)
+            result = pl.assemble(result, source, [0, 0])
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            out = pl.create_tensor([16, 16], dtype=pl.FP32)
+            out = self.good_kernel(a, out)
+            return out
+
+    output_dir = tmp_path / "partial_codegen"
+    with pytest.raises(RuntimeError, match="bad_kernel"):
+        ir.compile(
+            PartialFailureProgram,
+            output_dir=str(output_dir),
+            strategy=OptimizationStrategy.Default,
+            dump_passes=False,
+            backend_type=BackendType.Ascend910B_PTO,
+            skip_ptoas=True,
+        )
+
+    assert (output_dir / "orchestration" / "orch.cpp").exists()
+    assert (output_dir / "kernels" / "aiv" / "good_kernel.pto").exists()
+
+
 class TestFormatErrorReport:
     """Tests for codegen error summary formatting."""
 


### PR DESCRIPTION
Introduce PartialCodegenError to manage scenarios where code generation fails after producing some output files. Update the compile function to catch this error, ensuring that generated files are preserved even when some functions fail. Add a test to verify that orchestration files are correctly written during partial failures.