### PR TITLE
fix(pass): guard tile.store reshape-back by element-count match

### DIFF
--- a/docs/en/dev/passes/09-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/09-flatten_tile_nd_to_2d.md
@@ -43,7 +43,8 @@ Per-statement handling:
 | Tile op | Transformation |
 | ------- | -------------- |
 | `tile.load` (>2D) | Keep load as-is, insert `tile.reshape` to 2D after |
-| `tile.store` (>2D) | Insert `tile.reshape` back to ND before store |
+| `tile.store` (tile covers full tensor or ND-tracked) | Insert `tile.reshape` back to ND before store |
+| `tile.store` (2D slice of larger tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |

--- a/docs/zh-cn/dev/passes/09-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/09-flatten_tile_nd_to_2d.md
@@ -43,7 +43,8 @@ program_2d = flatten_pass(program)
 | Tile 操作 | 变换方式 |
 | --------- | -------- |
 | `tile.load`（>2D） | 保持加载原样，之后插入 `tile.reshape` 为 2D |
-| `tile.store`（>2D） | 在存储前插入 `tile.reshape` 恢复为 ND |
+| `tile.store`（tile 覆盖完整 tensor 或已追踪 ND 形状） | 在存储前插入 `tile.reshape` 恢复为 ND |
+| `tile.store`（较大 tensor 的 2D 切片） | 直接透传，不插入 reshape |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -83,6 +83,26 @@ int64_t GetStaticDim(const ExprPtr& expr, const std::string& context) {
 }
 
 /**
+ * @brief Compute the product of all static ConstInt dimensions.
+ *
+ * Returns -1 if any dimension is not a ConstInt (dynamic shape).
+ * Raises pypto::ValueError if a ConstInt dimension is non-positive or
+ * if the product would overflow int64_t.
+ */
+int64_t StaticShapeProduct(const std::vector<ExprPtr>& shape) {
+  int64_t prod = 1;
+  for (const auto& dim : shape) {
+    auto ci = As<ConstInt>(dim);
+    if (!ci) return -1;
+    CHECK(ci->value_ > 0) << "StaticShapeProduct: tile dimension must be positive, got " << ci->value_;
+    CHECK(prod <= INT64_MAX / ci->value_) << "StaticShapeProduct: integer overflow computing shape product"
+                                          << " (accumulated=" << prod << ", dim=" << ci->value_ << ")";
+    prod *= ci->value_;
+  }
+  return prod;
+}
+
+/**
  * @brief Compute the merged 2D shape from an ND shape.
  *
  * [A, B, C, D] -> {A*B*C, D}
@@ -520,8 +540,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         // Determine the ND shape for reshape-back:
         // 1. Prefer tracked ND shape from ctx.nd_shapes (set by tile.load/tile.create,
         //    propagated through shape-preserving ops)
-        // 2. Fall back to output tensor shape (covers reduce ops and other cases
-        //    where the shape was not propagated)
+        // 2. Fall back to output tensor shape when tile covers the full tensor
         const std::vector<ExprPtr>* nd_shape_ptr = nullptr;
         std::string orig_tile_name;
         if (auto var = As<Var>(call->args_[0])) {
@@ -532,10 +551,16 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
           }
         }
 
-        // Fall back to tensor shape if no tracked ND shape
+        // Fall back to tensor shape only when the tile covers the full tensor
+        // (element counts match). A loop-indexed slice of a larger tensor has a
+        // smaller tile — no reshape is needed in that case.
         auto out_tensor_type = As<TensorType>(call->args_[2]->GetType());
-        if (!nd_shape_ptr && out_tensor_type) {
-          nd_shape_ptr = &out_tensor_type->shape_;
+        if (!nd_shape_ptr && out_tensor_type && tile_type) {
+          int64_t tile_sz = StaticShapeProduct(tile_type->shape_);
+          int64_t tensor_sz = StaticShapeProduct(out_tensor_type->shape_);
+          if (tile_sz >= 1 && tensor_sz >= 1 && tile_sz == tensor_sz) {
+            nd_shape_ptr = &out_tensor_type->shape_;
+          }
         }
 
         if (nd_shape_ptr && nd_shape_ptr->size() > 2 && tile_type && tile_type->shape_.size() <= 2) {

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -781,11 +781,12 @@ class TestViewOperationsMemoryReuse:
 class TestInplaceSafetyCheck:
     """Tests verifying that ops marked not_inplace_safe block producer-consumer reuse."""
 
-    def test_inplace_unsafe_op_no_producer_consumer_reuse(self):
-        """tile.recip must NOT reuse its input's buffer when last_use == def (src == dst).
+    def test_inplace_unsafe_ops_no_producer_consumer_reuse(self):
+        """Inplace-unsafe ops (recip, ands, ors, xors) must NOT reuse their input's buffer.
 
-        tile_a.last_use == tile_b.def (producer-consumer), but tile.recip does not
-        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
+        For each op: the tile's last_use == the result tile's def (producer-consumer),
+        but because the op does not support in-place execution, each result tile must
+        get a distinct MemRef from its input tile.
         """
 
         @pl.program
@@ -793,19 +794,36 @@ class TestInplaceSafetyCheck:
             @pl.function
             def main(
                 self,
-                input_a: pl.Tensor[[32, 32], pl.FP32],
-                output: pl.Tensor[[32, 32], pl.FP32],
-            ) -> pl.Tensor[[32, 32], pl.FP32]:
-                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(input_a, [0, 0], [32, 32])
-                tile_b: pl.Tile[[32, 32], pl.FP32] = pl.recip(tile_a)
-                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                input_fp: pl.Tensor[[32, 32], pl.FP32],
+                input_int1: pl.Tensor[[32, 32], pl.INT32],
+                input_int2: pl.Tensor[[32, 32], pl.INT32],
+                input_int3: pl.Tensor[[32, 32], pl.INT32],
+                input_int4: pl.Tensor[[32, 32], pl.INT32],
+                output_fp: pl.Tensor[[32, 32], pl.FP32],
+                output_int: pl.Tensor[[32, 32], pl.INT32],
+            ) -> pl.Tensor[[32, 32], pl.INT32]:
+                tile_recip_in: pl.Tile[[32, 32], pl.FP32] = pl.load(input_fp, [0, 0], [32, 32])
+                tile_recip_out: pl.Tile[[32, 32], pl.FP32] = pl.recip(tile_recip_in)
+                _s1: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_recip_out, [0, 0], output_fp)
+                tile_ands_in: pl.Tile[[32, 32], pl.INT32] = pl.load(input_int1, [0, 0], [32, 32])
+                tile_ands_out: pl.Tile[[32, 32], pl.INT32] = pl.ands(tile_ands_in, 255)
+                _s2: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_ands_out, [0, 0], output_int)
+                tile_ors_in: pl.Tile[[32, 32], pl.INT32] = pl.load(input_int2, [0, 0], [32, 32])
+                tile_ors_out: pl.Tile[[32, 32], pl.INT32] = pl.ors(tile_ors_in, 255)
+                _s3: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_ors_out, [0, 0], output_int)
+                tile_xors_in: pl.Tile[[32, 32], pl.INT32] = pl.load(input_int3, [0, 0], [32, 32])
+                tile_xors_dst: pl.Tile[[32, 32], pl.INT32] = pl.load(input_int4, [0, 0], [32, 32])
+                tile_xors_out: pl.Tile[[32, 32], pl.INT32] = pl.xors(tile_xors_in, 255, tile_xors_dst)
+                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_xors_out, [0, 0], output_int)
                 return result
 
         func = _prepare_and_run_memory_reuse(Before)
-
         _assert_all_have_memrefs(func)
-        # tile.recip does not support in-place: tile_b must have its own MemRef
-        _assert_not_shares_memref(func, "tile_a", "tile_b")
+        _assert_not_shares_memref(func, "tile_recip_in", "tile_recip_out")
+        _assert_not_shares_memref(func, "tile_ands_in", "tile_ands_out")
+        _assert_not_shares_memref(func, "tile_ors_in", "tile_ors_out")
+        _assert_not_shares_memref(func, "tile_xors_in", "tile_xors_out")
+        _assert_not_shares_memref(func, "tile_xors_dst", "tile_xors_out")
 
     def test_inplace_unsafe_op_allows_non_producer_consumer_reuse(self):
         """tile.recip output does not share a buffer with its input (tile_x) in any case.
@@ -869,87 +887,6 @@ class TestInplaceSafetyCheck:
         _assert_all_have_memrefs(func)
         # tile.add is inplace-safe: producer-consumer reuse is allowed
         _assert_shares_memref(func, "tile_a", "tile_b")
-
-    def test_ands_no_producer_consumer_reuse(self):
-        """tile.ands must NOT reuse its input's buffer when last_use == def (src == dst).
-
-        tile_a.last_use == tile_b.def (producer-consumer), but tile.ands does not
-        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
-        """
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                input_a: pl.Tensor[[32, 32], pl.INT32],
-                output: pl.Tensor[[32, 32], pl.INT32],
-            ) -> pl.Tensor[[32, 32], pl.INT32]:
-                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
-                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.ands(tile_a, 255)
-                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
-                return result
-
-        func = _prepare_and_run_memory_reuse(Before)
-
-        _assert_all_have_memrefs(func)
-        # tile.ands does not support in-place: tile_b must have its own MemRef
-        _assert_not_shares_memref(func, "tile_a", "tile_b")
-
-    def test_ors_no_producer_consumer_reuse(self):
-        """tile.ors must NOT reuse its input's buffer when last_use == def (src == dst).
-
-        tile_a.last_use == tile_b.def (producer-consumer), but tile.ors does not
-        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
-        """
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                input_a: pl.Tensor[[32, 32], pl.INT32],
-                output: pl.Tensor[[32, 32], pl.INT32],
-            ) -> pl.Tensor[[32, 32], pl.INT32]:
-                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
-                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.ors(tile_a, 255)
-                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
-                return result
-
-        func = _prepare_and_run_memory_reuse(Before)
-
-        _assert_all_have_memrefs(func)
-        # tile.ors does not support in-place: tile_b must have its own MemRef
-        _assert_not_shares_memref(func, "tile_a", "tile_b")
-
-    def test_xors_no_producer_consumer_reuse(self):
-        """tile.xors must NOT reuse its input's buffer when last_use == def (src == dst).
-
-        tile_a.last_use == tile_b.def (producer-consumer), but tile.xors does not
-        support in-place execution, so tile_b must get a distinct MemRef from tile_a.
-        tile_tmp is loaded from a separate tensor to ensure it has a MemRef assigned.
-        """
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                input_a: pl.Tensor[[32, 32], pl.INT32],
-                input_b: pl.Tensor[[32, 32], pl.INT32],
-                output: pl.Tensor[[32, 32], pl.INT32],
-            ) -> pl.Tensor[[32, 32], pl.INT32]:
-                tile_a: pl.Tile[[32, 32], pl.INT32] = pl.load(input_a, [0, 0], [32, 32])
-                tile_tmp: pl.Tile[[32, 32], pl.INT32] = pl.load(input_b, [0, 0], [32, 32])
-                tile_b: pl.Tile[[32, 32], pl.INT32] = pl.xors(tile_a, 255, tile_tmp)
-                result: pl.Tensor[[32, 32], pl.INT32] = pl.store(tile_b, [0, 0], output)
-                return result
-
-        func = _prepare_and_run_memory_reuse(Before)
-
-        _assert_all_have_memrefs(func)
-        # tile.xors does not support in-place: tile_b must have its own MemRef
-        _assert_not_shares_memref(func, "tile_a", "tile_b")
 
     def test_inplace_unsafe_two_level_transitive_chain(self):
         """tile.recip must not reuse a buffer occupied by its input via a two-level chain.

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1442,6 +1442,38 @@ class TestFlattenTileNdTo2DReduceAndCompute:
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_store_2d_tile_to_3d_tensor_no_reshape(self):
+        """Storing a 2D tile (loop-indexed slice) to a 3D tensor must not insert a reshape.
+
+        Regression test: the tile.store fallback incorrectly used the full 3D tensor
+        shape to reshape a 2D tile that was never ND-flattened, causing a size mismatch
+        (e.g., tile size 12 vs tensor size 24).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                # 2D tile loaded from 2D tensor — not tracked in nd_shapes
+                x_tile: pl.Tile[[3, 4], pl.FP32] = pl.load(x, [0, 0], [3, 4])
+                # Store 2D tile to 3D tensor at index [0, 0, 0] — no reshape needed
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(x_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        # The pass has nothing to flatten (no >2D tiles) — program should be unchanged
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Before)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Prevent FlattenTileNdTo2D from inserting a spurious reshape when storing a 2D tile (loop-indexed slice) into a 3D tensor whose element count differs from the tile.  The fallback path that uses the output tensor's ND shape now activates only when the tile fully covers the tensor (tile element count == tensor element count).

Add StaticShapeProduct helper and tighten the guard to >= 1 to make the zero-sized-tile case explicit.  Update the tile.store row in the algorithm table (EN + ZH-CN docs) to reflect the new conditional reshape behaviour, and add a regression test
test_store_2d_tile_to_3d_tensor_no_reshape.

Also consolidate the four separate inplace-unsafe op tests in test_basic_memory_reuse into a single test that covers recip, ands, ors, and xors together.