### PR TITLE
fix(ir): report split kernel memory and avoid output name collisions

### DIFF
--- a/include/pypto/ir/reporter/report.h
+++ b/include/pypto/ir/reporter/report.h
@@ -87,10 +87,10 @@ class ReportGenerator {
 using ReportGeneratorPtr = std::shared_ptr<ReportGenerator>;
 
 /**
- * @brief Memory usage report for all InCore functions in a program.
+ * @brief Memory usage report for all compute functions in a program.
  *
- * Collects per-MemorySpace usage statistics for each InCore function
- * and compares with platform limits.
+ * Collects per-MemorySpace usage statistics for each compute function
+ * (InCore, AIC, or AIV) and compares them with platform limits.
  */
 class MemoryReport : public Report {
  public:

--- a/src/ir/reporter/memory_report_generator.cpp
+++ b/src/ir/reporter/memory_report_generator.cpp
@@ -34,6 +34,11 @@ namespace ir {
 
 namespace {
 
+bool IsReportableFunctionType(FunctionType func_type) {
+  return func_type == FunctionType::InCore || func_type == FunctionType::AIC ||
+         func_type == FunctionType::AIV;
+}
+
 // Visitor to collect MemRef objects and compute per-space high-water marks.
 // Follows the same pattern as AllocatedMemoryAddrVerifier in allocate_memory_addr_pass.cpp.
 class MemoryUsageCollector : public IRVisitor {
@@ -94,7 +99,7 @@ class MemoryReportGeneratorImpl : public ReportGenerator {
     std::vector<MemoryReport::FunctionMemoryUsage> functions;
     for (const auto& [gv, func] : program->functions_) {
       if (!func || !func->body_) continue;
-      if (func->func_type_ != FunctionType::InCore) continue;
+      if (!IsReportableFunctionType(func->func_type_)) continue;
 
       MemoryUsageCollector collector;
       collector.VisitStmt(func->body_);

--- a/src/ir/reporter/report.cpp
+++ b/src/ir/reporter/report.cpp
@@ -62,7 +62,7 @@ std::string MemoryReport::Format() const {
   os << "=== Memory Usage Report ===\n";
   os << "Pass: " << pass_name_ << "\n";
   os << "Backend: " << backend_name_ << "\n";
-  os << "Functions: " << functions_.size() << " InCore\n";
+  os << "Functions: " << functions_.size() << " compute functions\n";
 
   for (const auto& func : functions_) {
     os << "\n--- " << func.function_name << " ---\n\n";

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -845,7 +845,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
             << func->return_types_[i]->TypeName();
 
         // Add output tensor parameter
-        std::string out_name = "out_" + std::to_string(num_added_outputs);
+        std::string out_name = "outbuf" + std::to_string(num_added_outputs);
         auto out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
         new_params.push_back(out_param);
         new_param_directions.push_back(ParamDirection::Out);
@@ -1162,7 +1162,7 @@ std::vector<StmtPtr> UpdateCallSitesBody(
                                                                      {"layout", layout}};
       auto create_call = op_registry.Create("tensor.create", {shape_tuple}, create_kwargs, span);
 
-      std::string out_name = "out_" + std::to_string(i);
+      std::string out_name = "outbuf" + std::to_string(i);
       auto out_var = std::make_shared<Var>(out_name, create_call->GetType(), span);
       result.push_back(std::make_shared<AssignStmt>(out_var, create_call, span));
       extra_args.push_back(out_var);

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -447,6 +447,57 @@ class TestReportInstrument:
 
         assert not (tmp_path / "report").exists()
 
+    def test_memory_report_includes_aic_and_aiv_functions(self, tmp_path):
+        """Memory report includes post-ExpandMixedKernel compute functions."""
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.AIV)
+            def vector_kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile = pl.load(x, [0], [64])
+                y_tile = pl.add(x_tile, x_tile)
+                out_0: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                return out_0
+
+            @pl.function(type=pl.FunctionType.AIC)
+            def cube_kernel(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_1: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                out_1: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_tile, [0, 0], out_1)
+                return out_1
+
+        report_dir = str(tmp_path / "report")
+        (tmp_path / "report").mkdir()
+        instrument = passes.ReportInstrument(report_dir)
+        instrument.enable_report(passes.ReportType.Memory, "AllocateMemoryAddr")
+
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.init_mem_ref())
+        pipeline.add_pass(passes.allocate_memory_addr())
+
+        with passes.PassContext([instrument]):
+            pipeline.run(Program)
+
+        report_path = tmp_path / "report" / "memory_after_AllocateMemoryAddr.txt"
+        assert report_path.exists()
+
+        report_text = report_path.read_text()
+        assert "Functions: 2 compute functions" in report_text
+        assert "vector_kernel" in report_text
+        assert "cube_kernel" in report_text
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #579

Include AIC and AIV functions in memory reports after ExpandMixedKernel so AllocateMemoryAddr emits reports for split kernels again. Rename generated output buffers in ConvertTensorToTileOps to avoid collisions with user names, and add regression coverage for the memory report path.

Made-with: Cursor