### PR TITLE
fix(ir): repair backend layout mismatches for tile ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
     src/ir/transforms/pass_context.cpp
     src/ir/transforms/passes.cpp
+    src/ir/transforms/resolve_backend_op_layouts_pass.cpp
     src/ir/transforms/resolve_transpose_layout_pass.cpp
     src/ir/transforms/python_printer.cpp
     src/ir/transforms/split_chunked_loops_pass.cpp

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -68,6 +68,7 @@ struct PassProperties {
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |
+| ResolveBackendOpLayouts | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | NormalizedStmtStructure |
 | ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, MixedKernelExpanded | — |
 | InitMemRef | TypeChecked, SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D | HasMemRefs | SSAForm |
 | BasicMemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
@@ -309,6 +310,26 @@ result = pm.run_passes(program)
 with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
     result = pm.run_passes(program)
 ```
+
+### Default Strategy Notes
+
+The late InCore part of the default PTO-oriented pipeline is:
+
+1. `FlattenTileNdTo2D`
+2. `InferTileMemorySpace`
+3. `ResolveTransposeLayout`
+4. `ResolveBackendOpLayouts`
+5. `ExpandMixedKernel`
+6. `InitMemRef`
+7. `BasicMemoryReuse`
+8. `AllocateMemoryAddr`
+
+`ResolveBackendOpLayouts` repairs backend-constrained elementwise tile ops using
+registered layout metadata. For the current PTO row-major elementwise ops, it
+rewrites `[N, 1]` vector operands into `[1, N] row_major` `tile.reshape`
+operations at the constrained use site, where row-major is inferred from the
+target shape. It then reshapes the result back to the original vector shape
+when needed.
 
 ### Using PassPipeline Directly
 

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -68,6 +68,7 @@ struct PassProperties {
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |
+| ResolveBackendOpLayouts | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | NormalizedStmtStructure |
 | ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, MixedKernelExpanded | — |
 | InitMemRef | TypeChecked, SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D | HasMemRefs | SSAForm |
 | BasicMemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
@@ -309,6 +310,25 @@ result = pm.run_passes(program)
 with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
     result = pm.run_passes(program)
 ```
+
+### Default 策略补充说明
+
+Default 策略中，InCore 后半段流水线顺序为：
+
+1. `FlattenTileNdTo2D`
+2. `InferTileMemorySpace`
+3. `ResolveTransposeLayout`
+4. `ResolveBackendOpLayouts`
+5. `ExpandMixedKernel`
+6. `InitMemRef`
+7. `BasicMemoryReuse`
+8. `AllocateMemoryAddr`
+
+`ResolveBackendOpLayouts` 会根据 backend 注册的 layout 元数据修复受约束
+的逐元素 tile 操作。对于当前 PTO 上要求 `row_major` 的逐元素算子，它会
+在受约束 use-site 把 `[N, 1]` 向量操作数改写成 `[1, N]` 的
+`tile.reshape`，其 layout 由目标 shape 自动推导为 `row_major`，并在需要
+时把结果 reshape 回原始向量 shape。
 
 ### 直接使用 PassPipeline
 

--- a/include/pypto/backend/common/backend.h
+++ b/include/pypto/backend/common/backend.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_BACKEND_COMMON_BACKEND_H_
 #define PYPTO_BACKEND_COMMON_BACKEND_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -25,6 +26,7 @@
 #include "pypto/core/common.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/pipe.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 
@@ -66,6 +68,11 @@ using BackendCodegenFunc = std::function<std::string(const ir::CallPtr& op, code
 // Backend per-call pipe inference function type
 using BackendPipeInferFunc = std::function<ir::PipeType(const ir::CallPtr& call)>;
 
+struct BackendTileLayoutSpec {
+  std::vector<std::optional<ir::TileLayout>> input_layouts;
+  std::optional<ir::TileLayout> output_layout;
+};
+
 /**
  * @brief Backend op registration entry for fluent interface
  *
@@ -101,6 +108,23 @@ class BackendOpRegistryEntry {
   BackendOpRegistryEntry& f_infer_pipe(BackendPipeInferFunc func);
 
   /**
+   * @brief Constrain a specific input tile layout for this backend op
+   *
+   * @param input_index Positional argument index in the op call
+   * @param layout Required tile block layout
+   * @return Reference to this entry for method chaining
+   */
+  BackendOpRegistryEntry& set_input_layout(size_t input_index, ir::TileLayout layout);
+
+  /**
+   * @brief Constrain the output tile layout for this backend op
+   *
+   * @param layout Required output tile block layout
+   * @return Reference to this entry for method chaining
+   */
+  BackendOpRegistryEntry& set_output_layout(ir::TileLayout layout);
+
+  /**
    * @brief Finalize registration in destructor
    *
    * Automatically registers the operator with the backend if
@@ -119,6 +143,7 @@ class BackendOpRegistryEntry {
   std::string op_name_;
   std::optional<BackendCodegenFunc> codegen_func_;
   std::optional<BackendPipeInferFunc> infer_pipe_func_;
+  std::optional<BackendTileLayoutSpec> tile_layout_spec_;
 };
 
 // Macro for registering backend operators with fluent interface
@@ -144,6 +169,7 @@ class Backend {
   struct BackendOpInfo {
     BackendCodegenFunc codegen_func;
     std::optional<BackendPipeInferFunc> infer_pipe_func;
+    std::optional<BackendTileLayoutSpec> tile_layout_spec;
   };
 
   virtual ~Backend() = default;
@@ -174,7 +200,8 @@ class Backend {
    * @param infer_pipe_func Optional per-call pipe inference function
    */
   void FinalizeOpRegistration(const std::string& op_name, BackendCodegenFunc func,
-                              std::optional<BackendPipeInferFunc> infer_pipe_func = std::nullopt);
+                              std::optional<BackendPipeInferFunc> infer_pipe_func = std::nullopt,
+                              std::optional<BackendTileLayoutSpec> tile_layout_spec = std::nullopt);
 
   /**
    * @brief Infer pipeline type for a specific call
@@ -195,6 +222,14 @@ class Backend {
    * @return Pointer to operator info, or nullptr if not registered
    */
   [[nodiscard]] const BackendOpInfo* GetOpInfo(const std::string& op_name) const;
+
+  /**
+   * @brief Get backend-specific tile layout constraints for an operator
+   *
+   * @param op_name Operator name
+   * @return Pointer to tile layout spec, or nullptr if none is registered
+   */
+  [[nodiscard]] const BackendTileLayoutSpec* GetTileLayoutSpec(const std::string& op_name) const;
 
   /**
    * @brief Export backend to msgpack file

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -101,7 +101,8 @@ class Op {
    * Defines that this operator accepts a kwarg with the given key and type.
    * This is used for validation when creating Call expressions.
    *
-   * Only specific types are allowed: bool, int, std::string, double, DataType, MemorySpace
+   * Only specific types are allowed: bool, int, std::string, double, DataType, MemorySpace,
+   * and TensorLayout
    * This is enforced at compile-time via static_assert.
    *
    * @tparam T Expected type of the kwarg value (must be one of the allowed types)

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -89,6 +89,15 @@ inline const PassProperties kResolveTransposeLayoutProperties{
     .produced = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch,
                  IRProperty::TileOps2D}};
 
+// -- Resolve backend op layouts pass ------------------------------------------
+
+inline const PassProperties kResolveBackendOpLayoutsProperties{
+    .required = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch,
+                 IRProperty::TileOps2D},
+    .produced = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::SplitIncoreOrch,
+                 IRProperty::TileOps2D},
+    .invalidated = {IRProperty::NormalizedStmtStructure}};
+
 // -- Mixed kernel expansion pass ----------------------------------------------
 
 inline const PassProperties kExpandMixedKernelProperties{

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -281,6 +281,16 @@ Pass InferTileMemorySpace();
 Pass ResolveTransposeLayout();
 
 /**
+ * @brief Repair backend-required layouts for constrained elementwise tile ops
+ *
+ * For current layout-constrained elementwise ops, rewrites `[N, 1]`
+ * col-major vector inputs into `[1, N]` row-major reshapes at the use-site,
+ * executes the consumer in row-major form, and reshapes the result back when
+ * the original output is a col-major column vector.
+ */
+Pass ResolveBackendOpLayouts();
+
+/**
  * @brief Expand mixed InCore functions into AIC + AIV + Group
  *
  * Splits InCore functions containing both Cube ops (tile.matmul) and Vector ops

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -239,6 +239,10 @@ void BindPass(nb::module_& m) {
              "Detects tile.load(..., transpose=True) in InCore functions and transforms\n"
              "the source tensor parameter type to the logical transposed shape with DN layout.\n"
              "Propagates the type change to corresponding Orchestration function parameters.");
+  passes.def("resolve_backend_op_layouts", &pass::ResolveBackendOpLayouts,
+             "Create a pass that repairs backend-required layouts for constrained elementwise tile ops\n\n"
+             "Repairs `[N,1]` col-major vector inputs at constrained use-sites by reshaping them\n"
+             "into `[1,N]` row-major views before the consumer and reshaping the output back when needed.");
   passes.def("expand_mixed_kernel", &pass::ExpandMixedKernel,
              "Create a pass that expands mixed InCore functions into AIC + AIV + Group");
   passes.def("flatten_call_expr", &pass::FlattenCallExpr,

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1624,7 +1624,11 @@ def slice(
     return _ir_core.create_op_call("tile.slice", args, {}, actual_span)
 
 
-def reshape(tile: Expr, shape: Sequence[int | Expr] | _ir_core.MakeTuple, span: Span | None = None) -> Call:
+def reshape(
+    tile: Expr,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
+    span: Span | None = None,
+) -> Call:
     """Reshape tile to new shape.
 
     Args:

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -63,6 +63,7 @@ class PassManager:
                 ("FlattenTileNdTo2D", lambda: passes.flatten_tile_nd_to_2d()),
                 ("InferTileMemorySpace", lambda: passes.infer_tile_memory_space()),
                 ("ResolveTransposeLayout", lambda: passes.resolve_transpose_layout()),
+                ("ResolveBackendOpLayouts", lambda: passes.resolve_backend_op_layouts()),
                 ("ExpandMixedKernel", lambda: passes.expand_mixed_kernel()),
                 ("InitMemRef", lambda: passes.init_mem_ref()),
                 ("MemoryReuse", lambda: passes.basic_memory_reuse()),

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -262,6 +262,9 @@ def infer_tile_memory_space() -> Pass:
 def resolve_transpose_layout() -> Pass:
     """Create a pass that resolves transpose layout for tile.load with transpose=True."""
 
+def resolve_backend_op_layouts() -> Pass:
+    """Create a pass that repairs backend-required layouts for constrained tile ops."""
+
 def expand_mixed_kernel() -> Pass:
     """Create a pass that expands mixed InCore functions into AIC + AIV + Group."""
 

--- a/src/backend/common/backend.cpp
+++ b/src/backend/common/backend.cpp
@@ -12,6 +12,7 @@
 #include "pypto/backend/common/backend.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <ios>
@@ -378,10 +379,12 @@ BackendOpRegistryEntry Backend::RegisterOp(const std::string& op_name) {
 }
 
 void Backend::FinalizeOpRegistration(const std::string& op_name, BackendCodegenFunc func,
-                                     std::optional<BackendPipeInferFunc> infer_pipe_func) {
+                                     std::optional<BackendPipeInferFunc> infer_pipe_func,
+                                     std::optional<BackendTileLayoutSpec> tile_layout_spec) {
   CHECK(backend_op_registry_.find(op_name) == backend_op_registry_.end())
       << "Operator '" << op_name << "' is already registered in this backend";
-  backend_op_registry_[op_name] = BackendOpInfo{std::move(func), std::move(infer_pipe_func)};
+  backend_op_registry_[op_name] =
+      BackendOpInfo{std::move(func), std::move(infer_pipe_func), std::move(tile_layout_spec)};
 }
 
 const Backend::BackendOpInfo* Backend::GetOpInfo(const std::string& op_name) const {
@@ -390,6 +393,14 @@ const Backend::BackendOpInfo* Backend::GetOpInfo(const std::string& op_name) con
     return &it->second;
   }
   return nullptr;
+}
+
+const BackendTileLayoutSpec* Backend::GetTileLayoutSpec(const std::string& op_name) const {
+  const auto* info = GetOpInfo(op_name);
+  if (!info || !info->tile_layout_spec.has_value()) {
+    return nullptr;
+  }
+  return &*info->tile_layout_spec;
 }
 
 ir::PipeType Backend::InferPipe(const ir::CallPtr& call) const {
@@ -429,9 +440,29 @@ BackendOpRegistryEntry& BackendOpRegistryEntry::f_infer_pipe(BackendPipeInferFun
   return *this;
 }
 
+BackendOpRegistryEntry& BackendOpRegistryEntry::set_input_layout(size_t input_index, ir::TileLayout layout) {
+  if (!tile_layout_spec_.has_value()) {
+    tile_layout_spec_.emplace();
+  }
+  if (tile_layout_spec_->input_layouts.size() <= input_index) {
+    tile_layout_spec_->input_layouts.resize(input_index + 1);
+  }
+  tile_layout_spec_->input_layouts[input_index] = layout;
+  return *this;
+}
+
+BackendOpRegistryEntry& BackendOpRegistryEntry::set_output_layout(ir::TileLayout layout) {
+  if (!tile_layout_spec_.has_value()) {
+    tile_layout_spec_.emplace();
+  }
+  tile_layout_spec_->output_layout = layout;
+  return *this;
+}
+
 BackendOpRegistryEntry::~BackendOpRegistryEntry() {
   if (backend_ && codegen_func_.has_value()) {
-    backend_->FinalizeOpRegistration(op_name_, std::move(*codegen_func_), std::move(infer_pipe_func_));
+    backend_->FinalizeOpRegistration(op_name_, std::move(*codegen_func_), std::move(infer_pipe_func_),
+                                     std::move(tile_layout_spec_));
   }
 }
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -47,6 +48,14 @@ using ir::AsVarLike;
 using ir::CallPtr;
 using ir::TensorType;
 using ir::Var;
+
+static bool RequiresRowMajorElementwiseLayout(std::string_view op_name) {
+  static const std::unordered_set<std::string_view> kRowMajorElementwiseOps = {
+      "tile.add", "tile.and", "tile.div", "tile.maximum", "tile.minimum", "tile.mul", "tile.or",
+      "tile.rem", "tile.sel", "tile.shl", "tile.shr",     "tile.sub",     "tile.xor",
+  };
+  return kRowMajorElementwiseOps.count(op_name) > 0;
+}
 
 // Validate that a string is a safe MLIR identifier (alphanumeric + underscores).
 // Prevents injection of arbitrary MLIR via crafted buffer/function names.
@@ -889,10 +898,16 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     if (exclude_ops.count(entry.op_name) > 0) continue;
     std::string pto_op = entry.pto_op_name;
     size_t arity = entry.arity;
-    backend.RegisterOp(entry.op_name)
-        .f_codegen([pto_op, arity](const CallPtr& op, codegen::CodegenBase& codegen) {
-          return MakeNaryCodegenPTO(pto_op, arity, op, codegen);
-        });
+    auto reg_entry = backend.RegisterOp(entry.op_name);
+    reg_entry.f_codegen([pto_op, arity](const CallPtr& op, codegen::CodegenBase& codegen) {
+      return MakeNaryCodegenPTO(pto_op, arity, op, codegen);
+    });
+    if (RequiresRowMajorElementwiseLayout(entry.op_name)) {
+      for (size_t i = 0; i < arity; ++i) {
+        reg_entry.set_input_layout(i, ir::TileLayout::row_major);
+      }
+      reg_entry.set_output_layout(ir::TileLayout::row_major);
+    }
   }
 
   // Register ops with custom codegen logic
@@ -1147,9 +1162,12 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
         }
       }
     }
-    // PTO bytecode requires distinct tile buffers for reshape input/output.
-    // When both resolve to the same buffer (shared MemRef), allocate a new result variable.
-    if (src == result_target && !result_type.empty()) {
+    // tile.reshape is a view-like op that produces a new SSA value, not an in-place write.
+    // If the target variable already has a preallocated tile buffer name, emitting
+    // `result_target = pto.treshape ...` would redefine the same SSA value after
+    // the earlier `pto.alloc_tile`. Always materialize reshape results with a fresh
+    // SSA name when codegen assigned a MemRef-backed result target.
+    if (!result_type.empty()) {
       result_target = codegen.NewNamedTemp("reshape_buf");
       codegen.SetCurrentResultBuf(result_target);
     }

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -262,6 +262,13 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
 
   // Return TileType with the static shape and dtype
   TileView tile_view;
+  if (tile_shape.size() == 2) {
+    auto rows_const = As<ConstInt>(tile_shape[0]);
+    auto cols_const = As<ConstInt>(tile_shape[1]);
+    if (rows_const && cols_const && rows_const->value_ > 1 && cols_const->value_ == 1) {
+      tile_view.blayout = TileLayout::col_major;
+    }
+  }
   tile_view.valid_shape = tile_shape;
   return std::make_shared<TileType>(tile_shape, dtype, std::nullopt, tile_view);
 }

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -86,6 +86,19 @@ bool IsIndexLikeDtype(DataType dtype) {
   return dtype == DataType::INT64 || dtype == DataType::UINT64 || dtype == DataType::INDEX;
 }
 
+TileLayout InferTileLayoutFromShape(const std::vector<ExprPtr>& shape) {
+  if (shape.size() != 2) {
+    return TileLayout::row_major;
+  }
+
+  auto rows_const = As<ConstInt>(shape[0]);
+  auto cols_const = As<ConstInt>(shape[1]);
+  if (!rows_const || !cols_const) {
+    return TileLayout::row_major;
+  }
+  return (cols_const->value_ == 1 && rows_const->value_ > 1) ? TileLayout::col_major : TileLayout::row_major;
+}
+
 /**
  * @brief Validate that all elements of a TupleType are ScalarType with an index-like dtype
  *
@@ -159,21 +172,7 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
   TileView tile_view;
   tile_view.valid_shape = new_shape;
 
-  // Infer blayout from new shape: column vectors [N, 1] use col_major
-  if (new_shape.size() == 2) {
-    auto rows_const = As<ConstInt>(new_shape[0]);
-    auto cols_const = As<ConstInt>(new_shape[1]);
-    if (rows_const && cols_const) {
-      if (cols_const->value_ == 1 && rows_const->value_ > 1) {
-        tile_view.blayout = TileLayout::col_major;
-      } else {
-        tile_view.blayout = TileLayout::row_major;
-      }
-    } else {
-      // Dynamic shape: default to row_major
-      tile_view.blayout = TileLayout::row_major;
-    }
-  }
+  tile_view.blayout = InferTileLayoutFromShape(new_shape);
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
@@ -227,21 +226,7 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
   TileView tile_view;
   tile_view.valid_shape = new_shape;
 
-  // Infer blayout from new shape: column vectors [N, 1] use col_major
-  if (new_shape.size() == 2) {
-    auto rows_const = As<ConstInt>(new_shape[0]);
-    auto cols_const = As<ConstInt>(new_shape[1]);
-    if (rows_const && cols_const) {
-      if (cols_const->value_ == 1 && rows_const->value_ > 1) {
-        tile_view.blayout = TileLayout::col_major;
-      } else {
-        tile_view.blayout = TileLayout::row_major;
-      }
-    } else {
-      // Dynamic shape: default to row_major
-      tile_view.blayout = TileLayout::row_major;
-    }
-  }
+  tile_view.blayout = InferTileLayoutFromShape(new_shape);
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+StmtPtr MakeSeqOrSingle(std::vector<StmtPtr> stmts, const Span& span) {
+  if (stmts.empty()) {
+    return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, span);
+  }
+  if (stmts.size() == 1) {
+    return stmts.front();
+  }
+  return std::make_shared<SeqStmts>(std::move(stmts), span);
+}
+
+TileLayout GetTileLayout(const TileTypePtr& tile_type) {
+  if (!tile_type || !tile_type->tile_view_.has_value()) {
+    return TileLayout::row_major;
+  }
+  return tile_type->tile_view_->blayout;
+}
+
+bool IsConstOne(const ExprPtr& expr) {
+  auto ci = As<ConstInt>(expr);
+  return ci && ci->value_ == 1;
+}
+
+bool IsColumnVectorColMajor(const TileTypePtr& tile_type) {
+  return tile_type && tile_type->shape_.size() == 2 && IsConstOne(tile_type->shape_[1]) &&
+         GetTileLayout(tile_type) == TileLayout::col_major;
+}
+
+bool IsColumnVector(const TileTypePtr& tile_type) {
+  return tile_type && tile_type->shape_.size() == 2 && IsConstOne(tile_type->shape_[1]);
+}
+
+bool IsRowVectorRowMajor(const TileTypePtr& tile_type) {
+  return tile_type && tile_type->shape_.size() == 2 && IsConstOne(tile_type->shape_[0]) &&
+         GetTileLayout(tile_type) == TileLayout::row_major;
+}
+
+ExprPtr MakeShapeTuple(const std::vector<ExprPtr>& dims, const Span& span) {
+  return std::make_shared<MakeTuple>(dims, span);
+}
+
+CallPtr CreateReshapeCall(const ExprPtr& input, const std::vector<ExprPtr>& shape, const Span& span) {
+  auto expr =
+      OpRegistry::GetInstance().Create("tile.reshape", {input, MakeShapeTuple(shape, span)}, {}, span);
+  auto call = As<Call>(expr);
+  CHECK(call) << "ResolveBackendOpLayouts: tile.reshape must produce a Call";
+  return call;
+}
+
+std::vector<ExprPtr> MakeRowVectorShape(const TileTypePtr& tile_type) {
+  CHECK(IsColumnVector(tile_type)) << "ResolveBackendOpLayouts expects a [N,1] tile for vector repair";
+  return {std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()), tile_type->shape_[0]};
+}
+
+bool IsRepairableCall(const CallPtr& call, const backend::BackendTileLayoutSpec& spec) {
+  bool has_repairable_input = false;
+  for (size_t i = 0; i < spec.input_layouts.size() && i < call->args_.size(); ++i) {
+    const auto& required_layout = spec.input_layouts[i];
+    if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+      continue;
+    }
+    auto tile_type = As<TileType>(call->args_[i]->GetType());
+    if (!tile_type) {
+      return false;
+    }
+    if (GetTileLayout(tile_type) == TileLayout::row_major) {
+      continue;
+    }
+    if (IsColumnVectorColMajor(tile_type)) {
+      has_repairable_input = true;
+      continue;
+    }
+    return false;
+  }
+  return has_repairable_input;
+}
+
+class BackendLayoutRepairMutator : public IRMutator {
+ public:
+  std::string NextTempName(const std::string& base) { return base + "_" + std::to_string(temp_var_id_++); }
+
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto call = As<Call>(op->value_);
+    if (!call) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    auto* layout_spec = backend::GetBackend()->GetTileLayoutSpec(call->op_->name_);
+    if (!layout_spec || !IsRepairableCall(call, *layout_spec)) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    auto result_tile_type = As<TileType>(op->var_->GetType());
+    CHECK(result_tile_type)
+        << "ResolveBackendOpLayouts expects constrained op assignment targets to be TileType";
+
+    std::vector<StmtPtr> rewritten;
+    std::vector<ExprPtr> new_args = call->args_;
+
+    for (size_t i = 0; i < layout_spec->input_layouts.size() && i < call->args_.size(); ++i) {
+      const auto& required_layout = layout_spec->input_layouts[i];
+      if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+        continue;
+      }
+
+      auto tile_type = As<TileType>(call->args_[i]->GetType());
+      if (!IsColumnVector(tile_type) || IsRowVectorRowMajor(tile_type)) {
+        continue;
+      }
+
+      auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
+      auto reshape_var = std::make_shared<Var>(
+          NextTempName(op->var_->name_hint_ + "_arg" + std::to_string(i) + "_row_major"),
+          reshape_call->GetType(), call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
+      new_args[i] = reshape_var;
+    }
+
+    auto repaired_expr =
+        OpRegistry::GetInstance().Create(call->op_->name_, new_args, call->kwargs_, call->span_);
+    auto repaired_call = As<Call>(repaired_expr);
+    CHECK(repaired_call) << "ResolveBackendOpLayouts: repaired consumer must remain a Call";
+
+    if (!IsRowVectorRowMajor(result_tile_type)) {
+      auto row_major_var = std::make_shared<Var>(NextTempName(op->var_->name_hint_ + "_row_major"),
+                                                 repaired_call->GetType(), call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(row_major_var, repaired_call, op->span_));
+
+      auto reshape_back = CreateReshapeCall(row_major_var, result_tile_type->shape_, call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(op->var_, reshape_back, op->span_));
+      return MakeSeqOrSingle(std::move(rewritten), op->span_);
+    }
+
+    rewritten.push_back(std::make_shared<AssignStmt>(op->var_, repaired_call, op->span_));
+    return MakeSeqOrSingle(std::move(rewritten), op->span_);
+  }
+
+  StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
+    auto call = As<Call>(op->expr_);
+    if (!call) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    auto* layout_spec = backend::GetBackend()->GetTileLayoutSpec(call->op_->name_);
+    if (!layout_spec || !IsRepairableCall(call, *layout_spec)) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    std::vector<StmtPtr> rewritten;
+    std::vector<ExprPtr> new_args = call->args_;
+
+    for (size_t i = 0; i < layout_spec->input_layouts.size() && i < call->args_.size(); ++i) {
+      const auto& required_layout = layout_spec->input_layouts[i];
+      if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+        continue;
+      }
+      auto tile_type = As<TileType>(call->args_[i]->GetType());
+      if (!IsColumnVector(tile_type) || IsRowVectorRowMajor(tile_type)) {
+        continue;
+      }
+      auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
+      auto reshape_var =
+          std::make_shared<Var>(NextTempName("layout_fix_arg" + std::to_string(i) + "_row_major"),
+                                reshape_call->GetType(), call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
+      new_args[i] = reshape_var;
+    }
+
+    auto repaired_expr =
+        OpRegistry::GetInstance().Create(call->op_->name_, new_args, call->kwargs_, call->span_);
+    rewritten.push_back(std::make_shared<EvalStmt>(repaired_expr, op->span_));
+    return MakeSeqOrSingle(std::move(rewritten), op->span_);
+  }
+
+ private:
+  size_t temp_var_id_ = 0;
+};
+
+FunctionPtr RewriteFunction(const FunctionPtr& func) {
+  if (!IsInCoreType(func->func_type_)) {
+    return func;
+  }
+  if (!backend::BackendConfig::IsConfigured()) {
+    return func;
+  }
+
+  BackendLayoutRepairMutator mutator;
+  auto new_body = mutator.VisitStmt(func->body_);
+  if (new_body.get() == func->body_.get()) {
+    return func;
+  }
+
+  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
+                                    new_body, func->span_, func->func_type_);
+}
+
+}  // namespace
+
+namespace pass {
+
+Pass ResolveBackendOpLayouts() {
+  return CreateFunctionPass(RewriteFunction, "ResolveBackendOpLayouts", kResolveBackendOpLayoutsProperties);
+}
+
+}  // namespace pass
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -948,6 +948,54 @@ def test_pto_codegen_for_loop_tile_iter_arg_no_ddr_alloc():
     )
 
 
+def test_pto_codegen_repairs_row_sum_add_layout_mismatch():
+    """`row_sum -> add` should lower through row-major reshape repair."""
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B_PTO)
+
+    @pl.program
+    class LayoutRepairProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def repro(
+            self,
+            data: pl.Tensor[[16, 256], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            acc_tile: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+            )
+            init_tile: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_tile, 0.0)
+            chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
+            tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+                [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+            )
+            partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
+            updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(init_tile, partial)
+            final: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+            return final
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    transformed_program = pm.run_passes(LayoutRepairProgram)
+
+    codegen_inst = PTOCodegen()
+    mlir_code = _get_mlir_code(codegen_inst.generate(transformed_program))
+    lines = [line.strip() for line in mlir_code.split("\n")]
+
+    reshape_lines = [line for line in lines if "pto.treshape" in line]
+    assert len(reshape_lines) == 3, f"Expected 3 reshape ops for layout repair, got: {reshape_lines}"
+    assert any("rows=16, cols=1" in line and "rows=1, cols=16" in line for line in reshape_lines), (
+        f"Expected column-vector to row-vector repair reshape, got: {reshape_lines}"
+    )
+
+    tadd_lines = [line for line in lines if "pto.tadd" in line]
+    assert len(tadd_lines) == 1, f"Expected exactly one pto.tadd, got: {tadd_lines}"
+    assert tadd_lines[0].count("blayout=row_major") >= 3, (
+        f"Expected row-major operands/results after repair, got: {tadd_lines[0]}"
+    )
+    assert "rows=1, cols=16" in tadd_lines[0], f"Expected repaired row-vector add, got: {tadd_lines[0]}"
+
+
 def test_pto_codegen_mixed_scalar_and_tile_iter_args():
     """Test that mixed iter_args (tile + scalar) emit only scalar iter_args in PTO.
 

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -181,6 +181,7 @@ class TestCrossCoreTpushTpopCodegen:
             passes.flatten_tile_nd_to_2d,
             passes.infer_tile_memory_space,
             passes.resolve_transpose_layout,
+            passes.resolve_backend_op_layouts,
             passes.init_mem_ref,
             passes.basic_memory_reuse,
             passes.allocate_memory_addr,

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -896,6 +896,16 @@ class TestTileSliceReshapeOps:
         result_type2 = call2.type
         assert isinstance(result_type2, ir.TileType)
         assert len(result_type2.shape) == 2
+        assert result_type2.tile_view is not None
+        assert result_type2.tile_view.blayout == ir.TileLayout.col_major
+
+        # Layout is inferred from target shape for vector repair
+        call3 = tile.reshape(tile_var, [1, 32])
+        result_type3 = call3.type
+        assert isinstance(result_type3, ir.TileType)
+        assert result_type3.tile_view is not None
+        assert result_type3.tile_view.blayout == ir.TileLayout.row_major
+        assert call3.kwargs == {}
 
     def test_tile_transpose(self):
         """Test tile.transpose operation."""
@@ -1727,6 +1737,29 @@ class TestTileLoadOp:
 
         # Just verifying it builds without error
         assert Prog is not None
+
+
+class TestTileCreateOp:
+    """Tests for tile.create layout inference."""
+
+    def test_create_column_vector_uses_col_major_layout(self):
+        """Static `[N, 1]` Vec tiles should infer col-major block layout."""
+        call = tile.create([32, 1], DataType.FP32, ir.MemorySpace.Vec)
+        tile_type = call.type
+
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.tile_view is not None
+        assert tile_type.tile_view.blayout == ir.TileLayout.col_major
+        assert len(tile_type.tile_view.valid_shape) == 2
+
+    def test_create_row_vector_keeps_row_major_layout(self):
+        """Non-column-vector shapes should keep the default row-major layout."""
+        call = tile.create([1, 32], DataType.FP32, ir.MemorySpace.Vec)
+        tile_type = call.type
+
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.tile_view is not None
+        assert tile_type.tile_view.blayout == ir.TileLayout.row_major
 
 
 class TestTileScalarOps:

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -41,8 +41,8 @@ class TestPassManagerBasics:
         assert pm is not None
         assert pm.strategy == ir.OptimizationStrategy.Default
 
-        assert len(pm.passes) == 15
-        assert len(pm.pass_names) == 15
+        assert len(pm.passes) == 16
+        assert len(pm.pass_names) == 16
         assert pm.pass_names[0] == "UnrollLoops"
         assert pm.pass_names[1] == "ConvertToSSA"
         assert pm.pass_names[2] == "FlattenCallExpr"
@@ -54,10 +54,11 @@ class TestPassManagerBasics:
         assert pm.pass_names[8] == "FlattenTileNdTo2D"
         assert pm.pass_names[9] == "InferTileMemorySpace"
         assert pm.pass_names[10] == "ResolveTransposeLayout"
-        assert pm.pass_names[11] == "ExpandMixedKernel"
-        assert pm.pass_names[12] == "InitMemRef"
-        assert pm.pass_names[13] == "MemoryReuse"
-        assert pm.pass_names[14] == "AllocateMemoryAddr"
+        assert pm.pass_names[11] == "ResolveBackendOpLayouts"
+        assert pm.pass_names[12] == "ExpandMixedKernel"
+        assert pm.pass_names[13] == "InitMemRef"
+        assert pm.pass_names[14] == "MemoryReuse"
+        assert pm.pass_names[15] == "AllocateMemoryAddr"
 
 
 class TestPassManagerExecution:

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ResolveBackendOpLayouts pass."""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, ir, passes
+from pypto.backend import BackendType
+
+
+class TestResolveBackendOpLayouts:
+    """Test backend-driven layout repair for constrained tile ops."""
+
+    def test_rewrites_column_vector_add_through_row_major_reshape(self):
+        """`tile.add` on `[N, 1]` vectors should be repaired through `[1, N] row_major`."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                data: pl.Tensor[[16, 256], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                acc_0: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                acc_1: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_0, 0.0)
+                chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
+                tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+                    [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
+                updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_1, partial)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+                return stored
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B_PTO)
+        try:
+            after = passes.resolve_backend_op_layouts()(Before)
+        finally:
+            backend.reset_for_testing()
+
+        printed = ir.python_print(after)
+        assert "pl.tile.reshape(acc_1, [1, 16])" in printed
+        assert "pl.tile.reshape(partial, [1, 16])" in printed
+        assert "pl.Tile[[1, 16], pl.FP32, pl.Mem.Vec] = pl.tile.add(" in printed
+        assert "updated: pl.Tile[[16, 1], pl.FP32, pl.Mem.Vec] = pl.tile.reshape(" in printed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Infer consistent vector layouts for [N,1] tiles and register PTO row-major constraints for constrained elementwise ops. Add ResolveBackendOpLayouts and regression coverage so row_sum-to-add flows are rewritten through shape-driven reshapes without exposing a reshape layout override.