### PR TITLE
feat(parser): enforce chunked loop validation within auto_incore scope

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -244,7 +244,7 @@ for i in pl.unroll(12, chunk=4):
     body_statements
 ```
 
-**Key points:** `chunk=C` splits the loop into an outer sequential loop and an inner loop of `C` iterations. The inner loop preserves the original kind (Sequential/Parallel/Unroll). `chunk` cannot be combined with `init_values`. See [SplitChunkedLoops Pass](../passes/04-split_chunked_loops.md).
+**Key points:** `chunk=C` splits the loop into an outer sequential loop and an inner loop of `C` iterations. The inner loop preserves the original kind (Sequential/Parallel/Unroll). `chunk` cannot be combined with `init_values`, and `chunk=` loops are only valid inside `with pl.auto_incore():` outside that scope the parser rejects them with an error. See [SplitChunkedLoops Pass](../passes/04-split_chunked_loops.md).
 
 ### Yield Statement
 

--- a/docs/en/dev/passes/04-split_chunked_loops.md
+++ b/docs/en/dev/passes/04-split_chunked_loops.md
@@ -43,7 +43,7 @@ with pl.auto_incore():
         x = pl.add(x, 1.0)
 ```
 
-Chunked loops outside `auto_incore` are left as-is (not split).
+Chunked loops outside `auto_incore` are rejected earlier by the DSL parser, so this pass only sees valid chunked loops that are already inside `auto_incore`.
 
 ## Constraints
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -244,7 +244,7 @@ for i in pl.unroll(12, chunk=4):
     body_statements
 ```
 
-**要点:** `chunk=C` 将循环拆分为外层顺序循环和 `C` 次迭代的内层循环。内层循环保留原始类型 (Sequential/Parallel/Unroll)。`chunk` 不能与 `init_values` 一起使用。参见 [SplitChunkedLoops Pass](../passes/04-split_chunked_loops.md)。
+**要点:** `chunk=C` 将循环拆分为外层顺序循环和 `C` 次迭代的内层循环。内层循环保留原始类型 (Sequential/Parallel/Unroll)。`chunk` 不能与 `init_values` 一起使用，且 `chunk=` 循环只能出现在 `with pl.auto_incore():` 内；在该作用域外，parser 会直接报错。参见 [SplitChunkedLoops Pass](../passes/04-split_chunked_loops.md)。
 
 ### Yield 语句
 

--- a/docs/zh-cn/dev/passes/04-split_chunked_loops.md
+++ b/docs/zh-cn/dev/passes/04-split_chunked_loops.md
@@ -43,7 +43,7 @@ with pl.auto_incore():
         x = pl.add(x, 1.0)
 ```
 
-`auto_incore` 之外的分块循环保持原样（不被拆分）。
+`auto_incore` 之外的分块循环会在 DSL parser 阶段被提前拒绝，因此该 Pass 只会看到已经位于 `auto_incore` 内的合法分块循环。
 
 ## 约束
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -123,6 +123,7 @@ class ASTParser:
 
         # Track loop kinds for break/continue validation
         self._loop_kind_stack: list[str] = []
+        self._scope_kind_stack: list[ir.ScopeKind] = []
 
         # Inline function expansion state
         self._inline_mode = False
@@ -177,6 +178,19 @@ class ASTParser:
         if self._current_yield_types is not None:
             if len(yield_exprs) == 1:
                 self._current_yield_types.setdefault(var_name, yield_exprs[0].type)
+
+    @contextmanager
+    def _scope_kind_context(self, scope_kind: ir.ScopeKind) -> Iterator[None]:
+        """Track scope nesting during parsing for context-sensitive validation."""
+        self._scope_kind_stack.append(scope_kind)
+        try:
+            yield
+        finally:
+            self._scope_kind_stack.pop()
+
+    def _is_inside_scope(self, scope_kind: ir.ScopeKind) -> bool:
+        """Return whether parsing is currently nested inside the given scope kind."""
+        return scope_kind in self._scope_kind_stack
 
     def parse_function(
         self,
@@ -725,6 +739,12 @@ class ASTParser:
 
     def _validate_chunk_args(self, chunk_expr: Any, init_values: list[Any], iter_call: ast.Call) -> None:
         """Validate chunk arguments for range/parallel/unroll loops."""
+        if not self._is_inside_scope(ir.ScopeKind.AutoInCore):
+            raise ParserSyntaxError(
+                "chunk=... loops are only valid inside with pl.auto_incore():",
+                span=self.span_tracker.get_span(iter_call),
+                hint="Wrap the loop in 'with pl.auto_incore():' or remove the chunk= argument.",
+            )
         if not _is_const_int(chunk_expr):
             raise ParserSyntaxError(
                 "chunk must be a compile-time constant positive integer",
@@ -1379,10 +1399,11 @@ class ASTParser:
                     span = self.span_tracker.get_span(stmt)
 
                     with self.builder.scope(scope_kind, span):
-                        self.scope_manager.enter_scope("scope")
-                        for body_stmt in stmt.body:
-                            self.parse_statement(body_stmt)
-                        self.scope_manager.exit_scope(leak_vars=True)
+                        with self._scope_kind_context(scope_kind):
+                            self.scope_manager.enter_scope("scope")
+                            for body_stmt in stmt.body:
+                                self.parse_statement(body_stmt)
+                            self.scope_manager.exit_scope(leak_vars=True)
                     return
 
                 # NEW: pl.at(level=..., role=...)
@@ -1391,10 +1412,11 @@ class ASTParser:
                     span = self.span_tracker.get_span(stmt)
 
                     with self.builder.scope(ir.ScopeKind.Hierarchy, span, level=level, role=role):
-                        self.scope_manager.enter_scope("scope")
-                        for body_stmt in stmt.body:
-                            self.parse_statement(body_stmt)
-                        self.scope_manager.exit_scope(leak_vars=True)
+                        with self._scope_kind_context(ir.ScopeKind.Hierarchy):
+                            self.scope_manager.enter_scope("scope")
+                            for body_stmt in stmt.body:
+                                self.parse_statement(body_stmt)
+                            self.scope_manager.exit_scope(leak_vars=True)
                     return
 
         # Unsupported context manager

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -467,26 +467,6 @@ class TestAutoIncoreConsumed:
 
         assert "auto_incore" not in after_str
 
-    def test_loops_outside_auto_incore_not_interchanged(self):
-        """Loops outside auto_incore are not interchanged."""
-
-        @pl.program
-        class Input:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.parallel(0, 8, 1, chunk=4):
-                    x = pl.add(x, 1.0)
-                return x
-
-        # Without auto_incore, split_chunked_loops won't split, so
-        # interchange also has nothing to do
-        Before = _prepare_for_interchange(Input)
-        before_str = python_print(Before)
-        After = passes.interchange_chunk_loops()(Before)
-        after_str = python_print(After)
-
-        assert before_str == after_str
-
 
 class TestPassProperties:
     """Tests for pass properties and factory."""

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -321,9 +321,10 @@ class TestParserErrors:
         class Good:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
-                    s = pl.add(s, 1.0)  # noqa: PLW2901
-                    s = pl.yield_(s)  # noqa: PLW2901
+                with pl.auto_incore():
+                    for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
+                        s = pl.add(s, 1.0)  # noqa: PLW2901
+                        s = pl.yield_(s)  # noqa: PLW2901
                 return x
 
     def test_chunk_zero_error(self):
@@ -334,8 +335,9 @@ class TestParserErrors:
             class Bad:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    for i in pl.range(0, 10, 1, chunk=0):
-                        x = pl.add(x, 1.0)
+                    with pl.auto_incore():
+                        for i in pl.range(0, 10, 1, chunk=0):
+                            x = pl.add(x, 1.0)
                     return x
 
     def test_chunk_negative_error(self):
@@ -346,8 +348,9 @@ class TestParserErrors:
             class Bad:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    for i in pl.range(0, 10, 1, chunk=-1):
-                        x = pl.add(x, 1.0)
+                    with pl.auto_incore():
+                        for i in pl.range(0, 10, 1, chunk=-1):
+                            x = pl.add(x, 1.0)
                     return x
 
 
@@ -571,29 +574,6 @@ class TestNestedChunking:
             assert ref != "x_iter_3", (
                 "Found bare 'x_iter_3' in init_values; should be x_iter_3_inner or x_iter_3_rem etc."
             )
-
-
-class TestAutoIncoreGating:
-    """Tests for auto_incore scope gating behavior."""
-
-    def test_chunked_loop_without_auto_incore_not_split(self):
-        """Chunked loop outside auto_incore scope is NOT split."""
-
-        @pl.program
-        class Input:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(0, 10, 1, chunk=5):
-                    x = pl.add(x, 1.0)
-                return x
-
-        Before = _prepare_for_split(Input)
-        before_str = python_print(Before)
-        After = passes.split_chunked_loops()(Before)
-        after_str = python_print(After)
-
-        # Should be unchanged — no splitting without auto_incore
-        assert before_str == after_str
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -122,6 +122,26 @@ class TestErrorCases:
 
                 return result
 
+    def test_chunked_loop_requires_auto_incore(self):
+        """Test that chunked loops are rejected outside auto_incore scope."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class ChunkedLoopProgram:
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        x: pl.Tensor[[16, 4], pl.FP32],
+        seq_lens: pl.Tensor[[16], pl.INT32],
+    ) -> pl.Tensor[[16, 4], pl.FP32]:
+        for b in pl.parallel(0, 16, 1, chunk=4):
+            _ctx_len = pl.tensor.read(seq_lens, [b])
+        return x
+"""
+        with pytest.raises(ParserSyntaxError, match="only valid inside with pl.auto_incore"):
+            pl.parse_program(code)
+
     def test_unknown_tensor_operation(self):
         """Test error on unknown tensor operation."""
 


### PR DESCRIPTION
- Updated the parser to reject chunked loops defined outside the `with pl.auto_incore():` context, ensuring proper validation and error handling.
- Enhanced documentation to clarify the scope requirements for chunked loops in both English and Chinese.
- Adjusted related tests to verify that chunked loops are correctly processed only within the appropriate scope, improving robustness and user guidance.