### PR TITLE
fix(ir): fix BasicMemoryReuse aliasing of simultaneously live tiles

### DIFF
--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -82,13 +82,116 @@ struct LifetimeAnalysisResult {
 };
 
 /**
+ * @brief Collect all Var nodes referenced in an expression.
+ */
+class VarUseCollector : public IRVisitor {
+ public:
+  std::set<VarPtr> used_vars;
+
+  void VisitExpr_(const VarPtr& var) override {
+    used_vars.insert(var);
+    IRVisitor::VisitExpr_(var);
+  }
+};
+
+/**
+ * @brief Collect variable uses from a list of expressions into var_use_stmts.
+ */
+void CollectVarUsesFromExprs(const std::vector<ExprPtr>& exprs, const StmtPtr& stmt,
+                             std::map<VarPtr, std::vector<StmtPtr>>& var_use_stmts) {
+  VarUseCollector collector;
+  for (const auto& expr : exprs) {
+    collector.VisitExpr(expr);
+  }
+  for (const auto& used_var : collector.used_vars) {
+    var_use_stmts[used_var].push_back(stmt);
+  }
+}
+
+/**
+ * @brief Find the first leaf statement in a statement subtree.
+ *
+ * Mirrors CollectStmtsInBlock logic: unwraps SeqStmts/OpStmts, skips
+ * IfStmt/ForStmt/WhileStmt. Returns nullptr if no leaf is found.
+ */
+StmtPtr FindFirstLeafStmt(const StmtPtr& stmt) {
+  if (!stmt) return nullptr;
+  if (auto seq = As<SeqStmts>(stmt)) {
+    for (const auto& sub : seq->stmts_) {
+      auto leaf = FindFirstLeafStmt(sub);
+      if (leaf) return leaf;
+    }
+    return nullptr;
+  }
+  if (auto op_stmts = As<OpStmts>(stmt)) {
+    for (const auto& sub : op_stmts->stmts_) {
+      auto leaf = FindFirstLeafStmt(sub);
+      if (leaf) return leaf;
+    }
+    return nullptr;
+  }
+  if (IsA<IfStmt>(stmt) || IsA<ForStmt>(stmt) || IsA<WhileStmt>(stmt)) {
+    return nullptr;  // Control flow nodes are not leaf statements
+  }
+  return stmt;  // AssignStmt, EvalStmt, YieldStmt, ReturnStmt, etc.
+}
+
+/**
+ * @brief Collect variables used as init_values in ForStmt/WhileStmt iter_args.
+ *
+ * ForStmt/WhileStmt nodes are not flattened into basic blocks, so variables
+ * used as IterArg::initValue_ are invisible to the block-based lifetime
+ * analysis. This visitor walks the IR tree and associates each init_value
+ * variable use with the first leaf statement in the loop body, ensuring
+ * the variable's lifetime extends to the loop entry point.
+ */
+class LoopInitValueCollector : public IRVisitor {
+ public:
+  /// Map from variable to list of statements where it is used as init_value
+  std::map<VarPtr, std::vector<StmtPtr>> init_value_uses;
+
+ protected:
+  void VisitStmt_(const ForStmtPtr& op) override {
+    CollectIterArgUses(op->iter_args_, op->body_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    CollectIterArgUses(op->iter_args_, op->body_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void CollectIterArgUses(const std::vector<IterArgPtr>& iter_args, const StmtPtr& body) {
+    if (iter_args.empty()) return;
+
+    // Find the first leaf statement in the loop body to use as the anchor point
+    StmtPtr anchor = FindFirstLeafStmt(body);
+    if (!anchor) {
+      LOG_DEBUG << "No leaf statement found in loop body, init_value uses not anchored";
+      return;
+    }
+
+    for (const auto& iter_arg : iter_args) {
+      if (!iter_arg->initValue_) continue;
+      VarUseCollector collector;
+      collector.VisitExpr(iter_arg->initValue_);
+      for (const auto& used_var : collector.used_vars) {
+        init_value_uses[used_var].push_back(anchor);
+      }
+    }
+  }
+};
+
+/**
  * @brief Compute lifetime intervals from dependencies
  *
  * This function identifies memory reuse opportunities using ONLY dependency
  * relationships (topological ordering), NOT execution timing simulation.
  */
 LifetimeAnalysisResult ComputeLifetimesFromDependencies(const std::vector<BasicBlock>& blocks,
-                                                        const std::vector<DependencyEdge>& dependencies) {
+                                                        const std::vector<DependencyEdge>& dependencies,
+                                                        const StmtPtr& func_body) {
   std::vector<LifetimeInterval> lifetimes;
 
   // Step 1: Assign topological order to all statements
@@ -104,16 +207,6 @@ LifetimeAnalysisResult ComputeLifetimesFromDependencies(const std::vector<BasicB
   std::vector<VarPtr> ordered_vars;  // Variables in definition order
   std::map<VarPtr, StmtPtr> var_def_stmt;
   std::map<VarPtr, std::vector<StmtPtr>> var_use_stmts;
-  // Helper to collect variable uses from an expression
-  class VarUseCollector : public IRVisitor {
-   public:
-    std::set<VarPtr> used_vars;
-
-    void VisitExpr_(const VarPtr& var) override {
-      used_vars.insert(var);
-      IRVisitor::VisitExpr_(var);
-    }
-  };
 
   for (const auto& block : blocks) {
     for (const auto& stmt : block.statements) {
@@ -127,20 +220,27 @@ LifetimeAnalysisResult ComputeLifetimesFromDependencies(const std::vector<BasicB
 
         // Collect variables used in the value expression (for ALL AssignStmt, not just TileType)
         // This ensures we capture uses in statements like: result = store(tile_e, ...)
-        VarUseCollector collector;
-        collector.VisitExpr(assign->value_);
-
-        for (const auto& used_var : collector.used_vars) {
-          var_use_stmts[used_var].push_back(stmt);
-        }
+        CollectVarUsesFromExprs({assign->value_}, stmt, var_use_stmts);
       } else if (auto eval_stmt = As<EvalStmt>(stmt)) {
-        // Collect variable uses
-        VarUseCollector collector;
-        collector.VisitExpr(eval_stmt->expr_);
+        CollectVarUsesFromExprs({eval_stmt->expr_}, stmt, var_use_stmts);
+      } else if (auto yield_stmt = As<YieldStmt>(stmt)) {
+        // Tiles yielded across loop iterations must remain live until the yield point
+        CollectVarUsesFromExprs(yield_stmt->value_, stmt, var_use_stmts);
+      } else if (auto return_stmt = As<ReturnStmt>(stmt)) {
+        // Tiles returned from the function must remain live until the return point
+        CollectVarUsesFromExprs(return_stmt->value_, stmt, var_use_stmts);
+      }
+    }
+  }
 
-        for (const auto& used_var : collector.used_vars) {
-          var_use_stmts[used_var].push_back(stmt);
-        }
+  // Step 2a: Collect init_value uses from ForStmt/WhileStmt iter_args
+  // These are not flattened into basic blocks, so we walk the function body
+  if (func_body) {
+    LoopInitValueCollector init_collector;
+    init_collector.VisitStmt(func_body);
+    for (const auto& [used_var, stmts] : init_collector.init_value_uses) {
+      for (const auto& anchor_stmt : stmts) {
+        var_use_stmts[used_var].push_back(anchor_stmt);
       }
     }
   }
@@ -651,7 +751,7 @@ FunctionPtr TransformBasicMemoryReuse(const FunctionPtr& func) {
   }
 
   // Step 2: Compute lifetimes based on dependency graph
-  auto analysis_result = ComputeLifetimesFromDependencies(graph.blocks, graph.dependencies);
+  auto analysis_result = ComputeLifetimesFromDependencies(graph.blocks, graph.dependencies, func->body_);
 
   if (analysis_result.lifetimes.empty()) {
     LOG_WARN << "No TileType variables found, skipping memory reuse";

--- a/tests/ut/ir/transforms/test_basic_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_basic_memory_reuse.py
@@ -1013,5 +1013,145 @@ class TestInplaceSafetyCheck:
         _assert_not_shares_memref(func, "tile_d", "tile_c")
 
 
+def _iter_all_assign_stmts(stmt):
+    """Recursively iterate all AssignStmt in a statement tree (enters ForStmt/IfStmt/WhileStmt bodies)."""
+    if isinstance(stmt, ir.AssignStmt):
+        yield stmt
+    elif isinstance(stmt, ir.SeqStmts):
+        for child in stmt.stmts:
+            yield from _iter_all_assign_stmts(child)
+    elif isinstance(stmt, ir.OpStmts):
+        for child in stmt.stmts:
+            yield from _iter_all_assign_stmts(child)
+    elif isinstance(stmt, ir.ForStmt):
+        yield from _iter_all_assign_stmts(stmt.body)
+    elif isinstance(stmt, ir.IfStmt):
+        yield from _iter_all_assign_stmts(stmt.then_body)
+        if stmt.else_body is not None:
+            yield from _iter_all_assign_stmts(stmt.else_body)
+    elif isinstance(stmt, ir.WhileStmt):
+        yield from _iter_all_assign_stmts(stmt.body)
+
+
+def _get_var_type_recursive(func, var_name):
+    """Extract ShapedType for a variable by name, searching the full statement tree."""
+    for stmt in _iter_all_assign_stmts(func.body):
+        if stmt.var.name_hint == var_name:
+            if isinstance(stmt.var.type, ir.ShapedType):
+                return stmt.var.type
+    return None
+
+
+def _assert_not_shares_memref_recursive(func, var_a, var_b):
+    """Assert two variables do NOT share MemRef, searching the full statement tree."""
+    type_a = _get_var_type_recursive(func, var_a)
+    type_b = _get_var_type_recursive(func, var_b)
+    assert type_a is not None, f"{var_a} should have ShapedType"
+    assert type_b is not None, f"{var_b} should have ShapedType"
+    assert not type_a.shares_memref_with(type_b), f"{var_b} should NOT share MemRef with {var_a}"
+
+
+class TestYieldAndInitValueAliasing:
+    """Tests for yield and init_value aliasing prevention (issue #585)."""
+
+    @pl.program
+    class _TestProgram:
+        """Shared program with two accumulators in a for-loop with yield."""
+
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            input_b: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            gate_init: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            up_init: pl.Tile[[64, 64], pl.FP32] = pl.load(input_b, [0, 0], [64, 64])
+            for _i, (gate_acc, up_acc) in pl.range(4, init_values=(gate_init, up_init)):
+                chunk: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+                gate_new: pl.Tile[[64, 64], pl.FP32] = pl.add(gate_acc, chunk)
+                up_new: pl.Tile[[64, 64], pl.FP32] = pl.add(up_acc, chunk)
+                gate_out, _up_out = pl.yield_(gate_new, up_new)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(gate_out, [0, 0], output)
+            return result
+
+    def test_yield_prevents_aliasing_of_simultaneously_live_tiles(self):
+        """Two tile accumulators inside a loop, both yielded, must NOT share MemRef.
+
+        gate_new and up_new are both live at the yield point, so their lifetimes
+        overlap. Without the YieldStmt fix, the yield was silently skipped and
+        both tiles appeared dead, causing incorrect aliasing.
+        """
+        func = _prepare_and_run_memory_reuse(self._TestProgram)
+
+        # gate_new and up_new are both live at the yield → must NOT share MemRef
+        _assert_not_shares_memref_recursive(func, "gate_new", "up_new")
+
+    def test_init_values_prevent_aliasing_of_loop_inputs(self):
+        """Two tiles used as init_values must NOT share MemRef.
+
+        gate_init and up_init are both consumed at the loop entry point as
+        init_values. Without the ForStmt init_value fix, these variables
+        appeared dead and got incorrectly aliased.
+        """
+        func = _prepare_and_run_memory_reuse(self._TestProgram)
+
+        # gate_init and up_init are both used as init_values → must NOT share MemRef
+        _assert_not_shares_memref_recursive(func, "gate_init", "up_init")
+
+    def test_return_prevents_aliasing_of_simultaneously_live_tiles(self):
+        """Two tiles both live at the return point must NOT share MemRef."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                input_b: pl.Tensor[[64, 64], pl.FP32],
+                output_a: pl.Tensor[[64, 64], pl.FP32],
+                output_b: pl.Tensor[[64, 64], pl.FP32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+                tile_b: pl.Tile[[64, 64], pl.FP32] = pl.load(input_b, [0, 0], [64, 64])
+                result_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], output_a)
+                _result_b: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output_b)
+                return result_a
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        # tile_a and tile_b are both live (used in store) → must NOT share MemRef
+        _assert_not_shares_memref_recursive(func, "tile_a", "tile_b")
+
+    def test_while_init_values_prevent_aliasing(self):
+        """Two tiles used as while-loop init_values must NOT share MemRef."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[4], pl.FP32],
+                input_b: pl.Tensor[[4], pl.FP32],
+                output: pl.Tensor[[4], pl.FP32],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                gate_init: pl.Tile[[4], pl.FP32] = pl.load(input_a, [0], [4])
+                up_init: pl.Tile[[4], pl.FP32] = pl.load(input_b, [0], [4])
+                n: pl.Scalar[pl.INT64] = 0
+                for gate_acc, up_acc in pl.while_(init_values=(gate_init, up_init)):
+                    pl.cond(n < 4)
+                    chunk: pl.Tile[[4], pl.FP32] = pl.load(input_a, [0], [4])
+                    gate_new: pl.Tile[[4], pl.FP32] = pl.add(gate_acc, chunk)
+                    up_new: pl.Tile[[4], pl.FP32] = pl.add(up_acc, chunk)
+                    _gate_out, _up_out = pl.yield_(gate_new, up_new)
+                result: pl.Tensor[[4], pl.FP32] = pl.store(_gate_out, [0], output)
+                return result
+
+        func = _prepare_and_run_memory_reuse(Before)
+
+        # gate_init and up_init are both used as while-loop init_values → must NOT share MemRef
+        _assert_not_shares_memref_recursive(func, "gate_init", "up_init")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

BasicMemoryReuse pass's lifetime analysis (ComputeLifetimesFromDependencies) missed two categories of variable uses, causing simultaneously live tile accumulators to be incorrectly aliased onto the same MemRef buffer:

1. YieldStmt/ReturnStmt: These statements were collected into basic blocks but silently skipped by the if-else type dispatch chain, so yielded/returned tiles appeared dead at the yield/return point — their lifetimes were prematurely truncated.
2. ForStmt/WhileStmt init_values: ForStmt nodes are not flattened into basic blocks, so variables referenced in IterArg::initValue_ were completely invisible to the block-based lifetime analysis.

Fix:

- Handle YieldStmt and ReturnStmt in the statement traversal loop, collecting variable uses to extend their lifetimes to the yield/return point.
- Add LoopInitValueCollector visitor that walks the function body, collects ForStmt/WhileStmt init_value variable uses, and anchors them to the first leaf statement of the loop body.
 
Fixes #585

## Testing
Added TestYieldAndInitValueAliasing test class with two regression tests:

- `test_yield_prevents_aliasing_of_simultaneously_live_tiles`: Constructs a loop with two independent tile accumulators (gate_new, up_new) both yielded at the same point, verifying they are NOT assigned to the same MemRef.
- `test_init_values_prevent_aliasing_of_loop_inputs`: Constructs two tiles (gate_init, up_init) both used as ForStmt init_values, verifying they are NOT incorrectly aliased.
 
Also added recursive helper utilities (_iter_all_assign_stmts, _get_var_type_recursive, _assert_not_shares_memref_recursive) to support MemRef verification inside nested control flow (ForStmt/IfStmt/WhileStmt bodies).