### PR TITLE
feat(flatten-nd-to-2d): Eliminate intermediate tile.reshape in flatten pass

### DIFF
--- a/docs/en/dev/passes/09-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/09-flatten_tile_nd_to_2d.md
@@ -42,8 +42,9 @@ Per-statement handling:
 
 | Tile op | Transformation |
 | ------- | -------------- |
-| `tile.load` (>2D) | Keep load as-is, insert `tile.reshape` to 2D after |
-| `tile.store` (>2D) | Insert `tile.reshape` back to ND before store |
+| `tile.load` (>2D) | Change result type to 2D directly (load produces 2D tile from ND tensor) |
+| `tile.store` (ND tensor, >2D) | Inject original ND partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged |
+| `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
@@ -73,15 +74,17 @@ class After:
     @pl.function(type=pl.FunctionType.InCore)
     def main_incore_0(self, x: pl.Tensor[[2, 3, 4], pl.FP32],
                       out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-        x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-        x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
+        x_tile: pl.Tile[[6, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
         y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-        y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-        out_0 = pl.store(y_tile_nd, [0, 0, 0], out_0)
+        out_0 = pl.store(y_tile, [0, 0, 0], out_0)
         return out_0
 ```
 
-The 3D tile `[2, 3, 4]` is flattened to `[6, 4]`. `tile.load` keeps its ND shape (interfacing with the tensor), and `tile.reshape` converts between ND and 2D. Before `tile.store`, the tile is reshaped back to ND.
+The 3D tile `[2, 3, 4]` is flattened to `[6, 4]`. `tile.load` directly produces a 2D tile —
+no `tile.reshape` is inserted. `tile.store` accepts the 2D tile and writes to the ND tensor. For ND
+tensors (>2D), the pass injects the original partition `shapes` as an extra 4th operand into the
+transformed IR (e.g. `pl.store(y_tile, [0, 0, 0], out_0, (2, 3, 4))`); this operand is only
+present in the transformed IR and is not part of the source DSL.
 
 ## Implementation
 

--- a/docs/zh-cn/dev/passes/09-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/09-flatten_tile_nd_to_2d.md
@@ -42,8 +42,9 @@ program_2d = flatten_pass(program)
 
 | Tile 操作 | 变换方式 |
 | --------- | -------- |
-| `tile.load`（>2D） | 保持加载原样，之后插入 `tile.reshape` 为 2D |
-| `tile.store`（>2D） | 在存储前插入 `tile.reshape` 恢复为 ND |
+| `tile.load`（>2D） | 直接将结果类型改为 2D（load 从 ND 张量产生 2D tile） |
+| `tile.store`（ND 张量，>2D） | 在转换后 IR 中注入原始 ND 分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变 |
+| `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
@@ -73,15 +74,13 @@ class After:
     @pl.function(type=pl.FunctionType.InCore)
     def main_incore_0(self, x: pl.Tensor[[2, 3, 4], pl.FP32],
                       out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-        x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-        x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
+        x_tile: pl.Tile[[6, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
         y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-        y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-        out_0 = pl.store(y_tile_nd, [0, 0, 0], out_0)
+        out_0 = pl.store(y_tile, [0, 0, 0], out_0)
         return out_0
 ```
 
-3D Tile `[2, 3, 4]` 被展平为 `[6, 4]`。`tile.load` 保持 ND 形状（与张量对接），`tile.reshape` 在 ND 与 2D 之间转换。`tile.store` 之前，Tile 被恢复为 ND 形状。
+3D Tile `[2, 3, 4]` 被展平为 `[6, 4]`。`tile.load` 直接产生 2D tile，无需插入 `tile.reshape`。`tile.store` 接受 2D tile 并写入 ND 张量。对于 ND 张量（>2D），Pass 会在转换后 IR 中将原始分区 `shapes` 注入为额外的第 4 个操作数（例如 `pl.store(y_tile, [0, 0, 0], out_0, (2, 3, 4))`）；该操作数仅存在于转换后的 IR 中，不属于 DSL 源码。
 
 ## 实现
 

--- a/examples/ir_parser/batch_paged_attention_example.py
+++ b/examples/ir_parser/batch_paged_attention_example.py
@@ -203,9 +203,9 @@ def BuildBatchPagedAttentionProgram(
                 pij_tile = pl.cast(pij_tile_f16, target_type=pl.FP32)
                 li_tile = pl.row_sum(pij_tile, tmp_tile)
 
-                pij_batch = pl.store(pij_tile_f16, [b * q_tile, 0], [q_tile, block_size], pij_batch)
-                mij_batch = pl.store(mi_tile, [b * q_tile, 0], [q_tile, 1], mij_batch)
-                lij_batch = pl.store(li_tile, [b * q_tile, 0], [q_tile, 1], lij_batch)
+                pij_batch = pl.store(pij_tile_f16, [b * q_tile, 0], pij_batch, [q_tile, block_size])
+                mij_batch = pl.store(mi_tile, [b * q_tile, 0], mij_batch, [q_tile, 1])
+                lij_batch = pl.store(li_tile, [b * q_tile, 0], lij_batch, [q_tile, 1])
             return pij_batch, mij_batch, lij_batch
 
         # ── CUBE kernel: PV matmul ──────────────────────────────────────
@@ -303,13 +303,13 @@ def BuildBatchPagedAttentionProgram(
                         target_memory=pl.MemorySpace.Vec,
                     )
 
-                    mi_batch = pl.store(mij_tile, [b * q_tile, 0], [q_tile, 1], mi_batch)
-                    li_batch = pl.store(lij_tile, [b * q_tile, 0], [q_tile, 1], li_batch)
-                    oi_batch = pl.store(oi_new_tile, [b * q_tile, 0], [q_tile, head_dim], oi_batch)
+                    mi_batch = pl.store(mij_tile, [b * q_tile, 0], mi_batch, [q_tile, 1])
+                    li_batch = pl.store(lij_tile, [b * q_tile, 0], li_batch, [q_tile, 1])
+                    oi_batch = pl.store(oi_new_tile, [b * q_tile, 0], oi_batch, [q_tile, head_dim])
 
                     if is_last:
                         dst_tile = pl.row_expand_div(oi_new_tile, lij_tile)
-                        out_tensor = pl.store(dst_tile, [dst_row, 0], [q_tile, head_dim], out_tensor)
+                        out_tensor = pl.store(dst_tile, [dst_row, 0], out_tensor, [q_tile, head_dim])
                 else:
                     mij_tile = pl.load(
                         mij_batch,
@@ -363,8 +363,8 @@ def BuildBatchPagedAttentionProgram(
                     mi_new_dn = pl.reshape(mi_new, [q_tile, 1])
                     li_updated_dn = pl.reshape(li_updated, [q_tile, 1])
 
-                    mi_batch = pl.store(mi_new_dn, [b * q_tile, 0], [q_tile, 1], mi_batch)
-                    li_batch = pl.store(li_updated_dn, [b * q_tile, 0], [q_tile, 1], li_batch)
+                    mi_batch = pl.store(mi_new_dn, [b * q_tile, 0], mi_batch, [q_tile, 1])
+                    li_batch = pl.store(li_updated_dn, [b * q_tile, 0], li_batch, [q_tile, 1])
 
                     # Reshape ND [1,q_tile] -> DN [q_tile,1] for row_expand_mul
                     alpha_dn = pl.reshape(alpha, [q_tile, 1])
@@ -375,13 +375,13 @@ def BuildBatchPagedAttentionProgram(
 
                     if is_last:
                         dst_tile = pl.row_expand_div(oi_updated, li_updated_dn)
-                        out_tensor = pl.store(dst_tile, [dst_row, 0], [q_tile, head_dim], out_tensor)
+                        out_tensor = pl.store(dst_tile, [dst_row, 0], out_tensor, [q_tile, head_dim])
                     else:
                         oi_batch = pl.store(
                             oi_updated,
                             [b * q_tile, 0],
-                            [q_tile, head_dim],
                             oi_batch,
+                            [q_tile, head_dim],
                         )
 
             return mi_batch, li_batch, oi_batch, out_tensor

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -146,6 +146,7 @@ def store(
     tile: Expr,
     offsets: Sequence[int | Expr] | _ir_core.MakeTuple,
     output_tensor: Expr,
+    shapes: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     span: Span | None = None,
 ) -> Call:
     """Copy data from unified buffer (tile) to tensor.
@@ -154,21 +155,21 @@ def store(
         tile: Source tile (TileType)
         offsets: Offsets in each dimension (sequence of scalars), or a MakeTuple
         output_tensor: Output tensor (TensorType)
+        shapes: ND partition shape (sequence of ints), or None for 2D tiles. Normally
+            injected automatically by FlattenTileNdTo2D for ND tensors.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression that returns the output tensor
-
-    Example:
-        >>> # 2D store
-        >>> result = store(tile, offsets=[0, 0], output_tensor=tensor)
-        >>> # 3D store
-        >>> result = store(tile, offsets=[0, 0, 0], output_tensor=tensor)
     """
     actual_span = _get_span_or_capture(span)
     offsets_tuple = _to_make_tuple(offsets, actual_span)
+    if shapes is not None:
+        args: list[Expr] = [tile, offsets_tuple, output_tensor, _to_make_tuple(shapes, actual_span)]
+    else:
+        args = [tile, offsets_tuple, output_tensor]
 
-    return _ir_core.create_op_call("tile.store", [tile, offsets_tuple, output_tensor], {}, actual_span)
+    return _ir_core.create_op_call("tile.store", args, {}, actual_span)
 
 
 def assemble(

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -232,6 +232,7 @@ def store(
     tile: Tile,
     offsets: Sequence[IntLike],
     output_tensor: Tensor,
+    shapes: Sequence[IntLike] | None = None,
 ) -> Tensor:
     """Copy data from tile back to tensor.
 
@@ -239,17 +240,20 @@ def store(
         tile: Source tile
         offsets: Offsets in each dimension
         output_tensor: Output tensor
+        shapes: Optional ND partition shape. Injected by FlattenTileNdTo2D for ND tensors.
 
     Returns:
         Tensor wrapping the store operation
 
     Example:
         >>> # 2D store
-        >>> result = store(tile, offsets=[0, 0], output_tensor=tensor)
+        >>> result = store(tile, [0, 0], tensor)
         >>> # 3D store
-        >>> result = store(tile, offsets=[0, 0, 0], output_tensor=tensor)
+        >>> result = store(tile, [0, 0, 0], tensor)
     """
-    call_expr = _ir_ops.store(tile.unwrap(), _normalize_intlike(offsets), output_tensor.unwrap())
+    normalized_offsets = _normalize_intlike(offsets)
+    normalized_shapes = _normalize_intlike(shapes) if shapes is not None else None
+    call_expr = _ir_ops.store(tile.unwrap(), normalized_offsets, output_tensor.unwrap(), normalized_shapes)
     return Tensor(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -273,13 +273,11 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   auto shapes_tuple = As<ir::MakeTuple>(op->args_[2]);
   INTERNAL_CHECK(shapes_tuple) << "tile.load third argument must be a tuple (shapes)";
 
-  auto row_off = codegen.GetExprAsCode(offsets_tuple->elements_[0]);
-  auto col_off = codegen.GetExprAsCode(offsets_tuple->elements_[1]);
-  int64_t height = codegen.GetConstIntValue(shapes_tuple->elements_[0]);
-  int64_t width = codegen.GetConstIntValue(shapes_tuple->elements_[1]);
-
   auto tensor_type = As<TensorType>(tensor->GetType());
   INTERNAL_CHECK(tensor_type) << "tile.load tensor argument must have TensorType";
+
+  const size_t ndim = shapes_tuple->elements_.size();
+  INTERNAL_CHECK(ndim >= 1) << "tile.load shapes tuple must have at least one element";
 
   std::string tensor_view = codegen.GetOrCreateTensorView(tensor);
   std::string dtype_str = codegen.GetTypeString(tensor_type->dtype_);
@@ -288,15 +286,30 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
 
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
-  std::string partition_type = "!pto.partition_tensor_view<" + std::to_string(height) + "x" +
-                               std::to_string(width) + "x" + dtype_str + ">";
+  // Build partition type with all ND dimensions to match the sizes attribute.
+  std::string partition_type = "!pto.partition_tensor_view<";
+  for (size_t i = 0; i < ndim; ++i) {
+    if (i > 0) partition_type += "x";
+    partition_type += std::to_string(codegen.GetConstIntValue(shapes_tuple->elements_[i]));
+  }
+  partition_type += "x" + dtype_str + ">";
 
   std::string partition_view = codegen.NewNamedTemp(tensor->name_hint_ + "_pview");
   std::ostringstream partition_line;
   partition_line << partition_view << " = pto.partition_view " << tensor_view;
-  partition_line << ", offsets = [" << row_off << ", " << col_off << "]";
-  partition_line << ", sizes = [" << codegen.GetIndexConstant(height) << ", ";
-  partition_line << codegen.GetIndexConstant(width) << "]";
+  // Use all offsets/sizes elements to match the tensor_view rank (handles ND tensors)
+  partition_line << ", offsets = [";
+  for (size_t i = 0; i < offsets_tuple->elements_.size(); ++i) {
+    if (i > 0) partition_line << ", ";
+    partition_line << codegen.GetExprAsCode(offsets_tuple->elements_[i]);
+  }
+  partition_line << "]";
+  partition_line << ", sizes = [";
+  for (size_t i = 0; i < shapes_tuple->elements_.size(); ++i) {
+    if (i > 0) partition_line << ", ";
+    partition_line << codegen.GetIndexConstant(codegen.GetConstIntValue(shapes_tuple->elements_[i]));
+  }
+  partition_line << "]";
   partition_line << " : " << tensor_view_type << " -> " << partition_type;
   codegen.Emit(partition_line.str());
 
@@ -322,9 +335,6 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   auto& valid_shape = tile_type->tile_view_->valid_shape;
   INTERNAL_CHECK(valid_shape.size() == 2) << "tile.store tile valid_shape must be 2D";
 
-  auto row_off = codegen.GetExprAsCode(offsets_tuple->elements_[0]);
-  auto col_off = codegen.GetExprAsCode(offsets_tuple->elements_[1]);
-
   auto height_code = codegen.GetExprAsCode(valid_shape[0]);
   auto width_code = codegen.GetExprAsCode(valid_shape[1]);
 
@@ -338,20 +348,53 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   std::string tensor_view = codegen.GetOrCreateTensorView(output_tensor);
   std::string tile_buf = codegen.GetVarName(tile);
 
-  std::string height_dim = "?", width_dim = "?";
-  if (auto h = As<ir::ConstInt>(valid_shape[0])) height_dim = std::to_string(h->value_);
-  if (auto w = As<ir::ConstInt>(valid_shape[1])) width_dim = std::to_string(w->value_);
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
-  std::string partition_type =
-      "!pto.partition_tensor_view<" + height_dim + "x" + width_dim + "x" + dtype_str + ">";
-
   std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
   std::string partition_view = codegen.NewNamedTemp(output_tensor->name_hint_ + "_pview");
   std::ostringstream partition_line;
   partition_line << partition_view << " = pto.partition_view " << tensor_view;
-  partition_line << ", offsets = [" << row_off << ", " << col_off << "]";
-  partition_line << ", sizes = [" << height_code << ", " << width_code << "]";
+  // Use all offsets elements to match tensor_view rank (handles ND tensors)
+  partition_line << ", offsets = [";
+  for (size_t i = 0; i < offsets_tuple->elements_.size(); ++i) {
+    if (i > 0) partition_line << ", ";
+    partition_line << codegen.GetExprAsCode(offsets_tuple->elements_[i]);
+  }
+  partition_line << "]";
+  partition_line << ", sizes = [";
+
+  // Build partition_type and sizes to match the tensor rank so they are consistent.
+  std::string partition_type;
+  const size_t tensor_rank = tensor_type->shape_.size();
+  if (tensor_rank > 2) {
+    // Use the explicit shapes tuple (args[3]) injected by FlattenTileNdTo2D.
+    // Signature: (tile, offsets, output_tensor[, shapes]) — shapes at args[3]
+    // when 4 args total.
+    INTERNAL_CHECK(op->args_.size() > 3) << "tile.store on ND tensor requires shapes tuple (args[3])";
+    auto shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
+    INTERNAL_CHECK(shapes_tuple) << "tile.store args[3] must be a shapes MakeTuple";
+    partition_type = "!pto.partition_tensor_view<";
+    for (size_t i = 0; i < shapes_tuple->elements_.size(); ++i) {
+      if (i > 0) partition_line << ", ";
+      if (auto c = As<ir::ConstInt>(shapes_tuple->elements_[i])) {
+        partition_line << codegen.GetIndexConstant(c->value_);
+        if (i > 0) partition_type += "x";
+        partition_type += std::to_string(c->value_);
+      } else {
+        partition_line << codegen.GetExprAsCode(shapes_tuple->elements_[i]);
+        if (i > 0) partition_type += "x";
+        partition_type += "?";
+      }
+    }
+    partition_type += "x" + dtype_str + ">";
+  } else {
+    std::string height_dim = "?", width_dim = "?";
+    if (auto h = As<ir::ConstInt>(valid_shape[0])) height_dim = std::to_string(h->value_);
+    if (auto w = As<ir::ConstInt>(valid_shape[1])) width_dim = std::to_string(w->value_);
+    partition_type = "!pto.partition_tensor_view<" + height_dim + "x" + width_dim + "x" + dtype_str + ">";
+    partition_line << height_code << ", " << width_code;
+  }
+  partition_line << "]";
   partition_line << " : " << tensor_view_type << " -> " << partition_type;
   codegen.Emit(partition_line.str());
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -353,7 +353,10 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
           GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[1]));
         }
         GetOrEmitIndexConstant(1);
-      } else if (tensor_type->shape_.size() == 1) {
+      } else {
+        // 1-D and N-D (N>2): pre-emit constant 1 (innermost stride). For N>2,
+        // other strides are computed dynamically via arith.muli in
+        // EmitMakeTensorViews to support dynamic dims.
         GetOrEmitIndexConstant(1);
       }
     }
@@ -423,6 +426,28 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         }
       }
 
+      // For N-D (N > 2): pre-compute row-major strides as SSA values using arith.muli
+      // so that dynamic dimensions (ir::Var) are handled correctly. Emit any needed
+      // multiply instructions BEFORE the make_tensor_view line.
+      std::vector<std::string> nd_stride_names;
+      if (tensor_type->shape_.size() > 2) {
+        const size_t rank = tensor_type->shape_.size();
+        nd_stride_names.resize(rank);
+        nd_stride_names[rank - 1] = GetOrEmitIndexConstant(1);
+        for (int j = static_cast<int>(rank) - 2; j >= 0; j--) {
+          std::string dim_mlir;
+          if (auto var = As<ir::Var>(tensor_type->shape_[j + 1])) {
+            dim_mlir = var_to_mlir_.at(var->name_hint_);
+          } else {
+            dim_mlir = GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[j + 1]));
+          }
+          std::string mul_name = NewNamedTemp(param->name_hint_ + "_s" + std::to_string(j));
+          stream_ << GetIndent() << mul_name << " = arith.muli " << nd_stride_names[j + 1] << ", " << dim_mlir
+                  << " : index\n";
+          nd_stride_names[j] = mul_name;
+        }
+      }
+
       stream_ << GetIndent() << tensor_view << " = pto.make_tensor_view ";
       stream_ << "%arg" << i;
 
@@ -453,6 +478,12 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         }
       } else if (tensor_type->shape_.size() == 1) {
         stream_ << GetOrEmitIndexConstant(1);
+      } else {
+        // Use pre-computed SSA stride names (built above via arith.muli)
+        for (size_t j = 0; j < nd_stride_names.size(); j++) {
+          if (j > 0) stream_ << ", ";
+          stream_ << nd_stride_names[j];
+        }
       }
       stream_ << "]";
 

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -147,9 +147,12 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
 TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs,
                             const std::string& op_name) {
-  // store signature: (tile, offsets_tuple, output_tensor)
-  CHECK(args.size() == 3) << "The operator " << op_name
-                          << " requires 3 arguments (tile, offsets, output_tensor), but got " << args.size();
+  // store signature: (tile, offsets_tuple, output_tensor[, shapes_tuple])
+  // shapes_tuple is an optional 4th argument injected by FlattenTileNdTo2D
+  // for ND tensors to carry the original partition shape for codegen.
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "The operator " << op_name
+      << " requires 3 or 4 arguments (tile, offsets, output_tensor[, shapes]), but got " << args.size();
 
   // First argument must be TileType
   auto tile_type = As<TileType>(args[0]->GetType());
@@ -167,6 +170,19 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
   CHECK(output_tensor_type) << "The operator " << op_name
                             << " requires third argument to be a TensorType, but got "
                             << args[2]->GetType()->TypeName();
+
+  // Optional fourth argument (when 4 args total) must be a shapes tuple
+  if (args.size() == 4) {
+    auto shapes_tuple = As<MakeTuple>(args[3]);
+    CHECK(shapes_tuple) << "The operator " << op_name
+                        << " requires optional 4th argument to be a shapes tuple (MakeTuple)";
+    CHECK(!shapes_tuple->elements_.empty())
+        << "The operator " << op_name << " requires non-empty shapes tuple when provided";
+    CHECK(shapes_tuple->elements_.size() == offsets_tuple->elements_.size())
+        << "The operator " << op_name
+        << " requires shapes and offsets to have the same number of dimensions, but got "
+        << shapes_tuple->elements_.size() << " shapes and " << offsets_tuple->elements_.size() << " offsets";
+  }
 
   // store returns the output tensor (same type)
   return output_tensor_type;
@@ -467,6 +483,9 @@ REGISTER_OP("tile.store")
     .add_argument("tile", "Source tile (TileType)")
     .add_argument("offsets", "Offsets in each dimension (TupleType of ScalarType)")
     .add_argument("output_tensor", "Output tensor (TensorType)")
+    .add_argument("shapes",
+                  "Optional ND partition shape (TupleType). "
+                  "Injected by FlattenTileNdTo2D for ND tensors.")
     .set_input_memory(0, {MemorySpace::Vec, MemorySpace::Acc})
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -250,12 +250,8 @@ class PreconditionChecker : public IRVisitor {
 // Main transformation
 // ============================================================================
 
-/**
- * @brief Track original ND shapes for reshape-back before tile.store.
- */
 struct FlattenContext {
-  std::unordered_map<std::string, VarPtr> var_map;                  // old var name -> new 2D var
-  std::unordered_map<std::string, std::vector<ExprPtr>> nd_shapes;  // var name -> original ND shape
+  std::unordered_map<std::string, VarPtr> var_map;  // old var name -> new 2D var
 };
 
 /**
@@ -474,110 +470,65 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     const auto& op_name = call->op_->name_;
 
-    // ---- tile.load on >2D tile: keep load, insert reshape ----
-    // TODO(pypto): Fuse tile.load + tile.reshape into a single tile.load that
-    //       directly produces the 2D tile, instead of emitting two separate
-    //       instructions.  This requires extending tile.load to accept a
-    //       target shape that differs from the tensor shape.
+    // ---- tile.load on >2D tile: produce 2D tile directly ----
+    // tile.load semantics: ND tensor → 2D tile. No reshape needed.
     if (op_name == "tile.load") {
+      // Substitute args via ctx.var_map so all operand Vars reference the latest SSA values.
+      std::vector<ExprPtr> sub_args;
+      sub_args.reserve(call->args_.size());
+      for (const auto& arg : call->args_) {
+        sub_args.push_back(SubstituteExpr(arg, ctx.var_map));
+      }
+
       auto result_tile = As<TileType>(call->GetType());
       if (result_tile && result_tile->shape_.size() > 2) {
         auto [merged, last] = ComputeMergedShape(result_tile->shape_, "tile.load result");
 
-        // Keep the original load as-is (interfaces with ND tensor)
-        std::string nd_name = assign->var_->name_hint_ + "_nd";
-        auto nd_var = std::make_shared<Var>(nd_name, call->GetType(), assign->var_->span_);
-        result.push_back(std::make_shared<AssignStmt>(nd_var, call, assign->span_));
-
-        // Record original ND shape
-        ctx.nd_shapes[assign->var_->name_hint_] = result_tile->shape_;
-
-        // Insert tile.reshape(nd_var, (merged, last))
-        auto shape_tuple = MakeShapeTupleFromInts({merged, last}, span);
-        auto reshape_call = op_registry.Create("tile.reshape", {nd_var, shape_tuple}, span);
-
-        auto flat_var =
-            std::make_shared<Var>(assign->var_->name_hint_, reshape_call->GetType(), assign->var_->span_);
-        result.push_back(std::make_shared<AssignStmt>(flat_var, reshape_call, assign->span_));
+        // Construct call with explicit 2D TileType (bypasses ND type inference).
+        auto flat_tile_type =
+            std::make_shared<TileType>(Make2DShapeExprs(merged, last, span), result_tile->dtype_,
+                                       std::nullopt, std::nullopt, std::nullopt);
+        auto flat_call =
+            std::make_shared<Call>(call->op_, sub_args, call->kwargs_, flat_tile_type, call->span_);
+        auto flat_var = std::make_shared<Var>(assign->var_->name_hint_, flat_tile_type, assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(flat_var, flat_call, assign->span_));
         ctx.var_map[assign->var_->name_hint_] = flat_var;
         continue;
       }
-      // ≤2D tile.load: pass through
-      result.push_back(stmt);
+      // ≤2D tile.load: honor any pending var_map substitutions
+      auto new_call = op_registry.Create(op_name, sub_args, call->kwargs_, span);
+      auto new_var =
+          std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
+      result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
+      ctx.var_map[assign->var_->name_hint_] = new_var;
       continue;
     }
 
-    // ---- tile.store: reshape back to ND before storing ----
-    // TODO(pypto): Fuse tile.reshape + tile.store into a single tile.store that
-    //       accepts a 2D tile and writes it directly to the ND tensor,
-    //       instead of emitting a reshape followed by a store.
+    // ---- tile.store: pass through, injecting shapes for ND tensors ----
+    // tile.store semantics: 2D tile → ND tensor. No reshape needed.
+    // For ND tiles, inject the original ND shape as an explicit 4th argument
+    // (shapes tuple) after output_tensor, so that tile.store codegen knows
+    // the correct partition sizes for pto.partition_view.
+    // Signature: (tile, offsets, output_tensor[, shapes])
+    // The original tile type is read BEFORE substitution, when it still
+    // carries the ND shape.
     if (op_name == "tile.store") {
-      // tile.store args: (tile, offsets, tensor)
-      if (call->args_.size() >= 3) {
-        auto subst_tile = SubstituteExpr(call->args_[0], ctx.var_map);
-        auto tile_type = As<TileType>(subst_tile->GetType());
+      auto orig_tile_type = As<TileType>(call->args_[0]->GetType());
 
-        // Determine the ND shape for reshape-back:
-        // 1. Prefer tracked ND shape from ctx.nd_shapes (set by tile.load/tile.create,
-        //    propagated through shape-preserving ops)
-        // 2. Fall back to output tensor shape (covers reduce ops and other cases
-        //    where the shape was not propagated)
-        const std::vector<ExprPtr>* nd_shape_ptr = nullptr;
-        std::string orig_tile_name;
-        if (auto var = As<Var>(call->args_[0])) {
-          orig_tile_name = var->name_hint_;
-          auto nd_it = ctx.nd_shapes.find(orig_tile_name);
-          if (nd_it != ctx.nd_shapes.end()) {
-            nd_shape_ptr = &nd_it->second;
-          }
-        }
-
-        // Fall back to tensor shape if no tracked ND shape
-        auto out_tensor_type = As<TensorType>(call->args_[2]->GetType());
-        if (!nd_shape_ptr && out_tensor_type) {
-          nd_shape_ptr = &out_tensor_type->shape_;
-        }
-
-        if (nd_shape_ptr && nd_shape_ptr->size() > 2 && tile_type && tile_type->shape_.size() <= 2) {
-          const auto& orig_shape = *nd_shape_ptr;
-
-          // Build ND shape values
-          std::vector<int64_t> nd_dims;
-          nd_dims.reserve(orig_shape.size());
-          for (const auto& dim_expr : orig_shape) {
-            nd_dims.push_back(GetStaticDim(dim_expr, "tile.store reshape-back"));
-          }
-
-          // Insert tile.reshape to restore ND shape
-          auto nd_shape_tuple = MakeShapeTupleFromInts(nd_dims, span);
-          auto reshape_back = op_registry.Create("tile.reshape", {subst_tile, nd_shape_tuple}, span);
-
-          std::string nd_name = (orig_tile_name.empty() ? assign->var_->name_hint_ : orig_tile_name) + "_nd";
-          auto nd_var = std::make_shared<Var>(nd_name, reshape_back->GetType(), assign->var_->span_);
-          result.push_back(std::make_shared<AssignStmt>(nd_var, reshape_back, assign->span_));
-
-          // Rebuild tile.store with the ND tile
-          std::vector<ExprPtr> new_store_args;
-          new_store_args.push_back(nd_var);
-          for (size_t i = 1; i < call->args_.size(); ++i) {
-            new_store_args.push_back(SubstituteExpr(call->args_[i], ctx.var_map));
-          }
-          auto new_store = op_registry.Create("tile.store", new_store_args, call->kwargs_, span);
-          auto store_var =
-              std::make_shared<Var>(assign->var_->name_hint_, new_store->GetType(), assign->var_->span_);
-          result.push_back(std::make_shared<AssignStmt>(store_var, new_store, assign->span_));
-          ctx.var_map[assign->var_->name_hint_] = store_var;
-          continue;
-        }
-      }
-
-      // No reshape needed — just substitute and pass through
       std::vector<ExprPtr> new_args;
-      new_args.reserve(call->args_.size());
+      new_args.reserve(call->args_.size() + 1);
+      // Push all original args (tile, offsets, output_tensor) with substitution
       for (const auto& arg : call->args_) {
         new_args.push_back(SubstituteExpr(arg, ctx.var_map));
       }
-      auto new_call = op_registry.Create("tile.store", new_args, call->kwargs_, span);
+      // Append shapes tuple after output_tensor for ND tiles
+      if (orig_tile_type && orig_tile_type->shape_.size() > 2) {
+        new_args.push_back(std::make_shared<MakeTuple>(orig_tile_type->shape_, span));
+      }
+
+      // Construct call directly: store result type = output tensor type (args[2])
+      auto out_type = new_args[2]->GetType();
+      auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, out_type, call->span_);
       auto new_var =
           std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
       result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
@@ -606,9 +557,6 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
             std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
         result.push_back(std::make_shared<AssignStmt>(flat_var, new_call, assign->span_));
         ctx.var_map[assign->var_->name_hint_] = flat_var;
-
-        // Record original ND shape for potential store
-        ctx.nd_shapes[assign->var_->name_hint_] = result_tile->shape_;
         continue;
       }
       // ≤2D: pass through
@@ -668,28 +616,11 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
             (op_name.substr(0, 5) == "tile.")
                 ? op_registry.Create(op_name, new_args, call->kwargs_, span)
                 : std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->GetType(), call->span_);
+
         auto new_var =
             std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
         result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
         ctx.var_map[assign->var_->name_hint_] = new_var;
-
-        // Propagate ND shape for shape-preserving ops (so tile.store can reshape-back).
-        // Only propagate when the output shape matches the substituted input shape
-        // (element-wise ops). Reduce ops change shape and must NOT propagate.
-        // Note: we compare against new_args[0] (the substituted/flattened type), not
-        // input_var->GetType() (the original pre-flatten type).
-        if (!new_args.empty()) {
-          if (auto input_var = As<Var>(call->args_[0])) {
-            auto shape_it = ctx.nd_shapes.find(input_var->name_hint_);
-            if (shape_it != ctx.nd_shapes.end()) {
-              auto out_tile = As<TileType>(new_call->GetType());
-              auto in_tile = As<TileType>(new_args[0]->GetType());
-              if (out_tile && in_tile && out_tile->shape_.size() == in_tile->shape_.size()) {
-                ctx.nd_shapes[assign->var_->name_hint_] = shape_it->second;
-              }
-            }
-          }
-        }
       }
     }
   }
@@ -761,7 +692,8 @@ class TileOps2DVerifier : public IRVisitor {
     const auto& name = call->op_->name_;
     if (name.substr(0, 5) != "tile.") return;
 
-    // Skip ops that are expected to work with ND tiles (load/store interface with ND tensors)
+    // tile.load/tile.store are permitted to have any tile rank:
+    // load produces 2D tiles from ND tensors; store accepts 2D tiles and writes to ND tensors.
     if (name == "tile.load" || name == "tile.store" || name == "tile.reshape") return;
 
     // Check result type

--- a/tests/st/runtime/test_elementwise_4d.py
+++ b/tests/st/runtime/test_elementwise_4d.py
@@ -1,0 +1,385 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for elementwise operations on 4D tiles.
+
+These tests exercise the FlattenTileNdTo2D pass end-to-end: programs are
+written with 4D tile shapes which the pass flattens to 2D before code
+generation.  Shape [2, 3, 8, 64] flattens to [48, 64].
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# --- Programs ---
+
+
+@pl.program
+class Tile4DMulProgram:
+    """Element-wise square of a [2, 3, 8, 64] tensor via a 4D tile."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 3, 8, 64], pl.FP32]],
+    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
+        a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
+        c_tile = pl.tile.mul(a_tile, a_tile)
+        out = pl.store(c_tile, [0, 0, 0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
+        out = pl.create_tensor([2, 3, 8, 64], dtype=pl.FP32)
+        out = self.kernel(a, out)
+        return out
+
+
+@pl.program
+class Tile4DAddProgram:
+    """Element-wise addition of two [2, 3, 8, 64] tensors via a 4D tile."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+        b: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 3, 8, 64], pl.FP32]],
+    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
+        a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
+        b_tile = pl.load(b, [0, 0, 0, 0], [2, 3, 8, 64])
+        c_tile = pl.tile.add(a_tile, b_tile)
+        out = pl.store(c_tile, [0, 0, 0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+        b: pl.Tensor[[2, 3, 8, 64], pl.FP32],
+    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
+        out = pl.create_tensor([2, 3, 8, 64], dtype=pl.FP32)
+        out = self.kernel(a, b, out)
+        return out
+
+
+# --- Programs (partial coverage) ---
+
+
+@pl.program
+class Tile4DMulPartialProgram:
+    """Partial-coverage 4D tile: load first half of dim-0, store to second half.
+
+    Tensor shape [4, 3, 8, 64]; tile shape [2, 3, 8, 64] (half of dim-0).
+    Exercises the case where tile.store offset is non-zero: the partition_view
+    sizes must reflect the tile shape [2,3,8,64], NOT the full tensor [4,3,8,64].
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[4, 3, 8, 64], pl.FP32],
+        out: pl.Out[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
+    ) -> pl.Tensor[[4, 3, 8, 64], pl.FP32]:
+        # Load first half of outer dim: [0:2, 0:3, 0:8, 0:64]
+        a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
+        c_tile = pl.tile.mul(a_tile, a_tile)
+        # Store to second half: offset [2,0,0,0], tile covers [2,3,8,64] elements
+        out = pl.store(c_tile, [2, 0, 0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[4, 3, 8, 64], pl.FP32],
+    ) -> pl.Tensor[[4, 3, 8, 64], pl.FP32]:
+        out = pl.create_tensor([4, 3, 8, 64], dtype=pl.FP32)
+        out = self.kernel(a, out)
+        return out
+
+
+@pl.program
+class Tile4DQuadrantProgram:
+    """4D tensor [2,2,8,16] divided into 4 blocks of [1,1,8,16].
+
+    Loads the top-right block (offset [0,1,0,0]), squares it, then stores
+    the result into the bottom-left block (offset [1,0,0,0]).
+
+    This is the key partial-coverage test: the tile [1,1,8,16] flattens to
+    [8,16], but the store offset [1,0,0,0] is non-zero in dim-0.  The
+    partition_view sizes for the store must be [1,1,8,16] (tile shape), NOT
+    [2,2,8,16] (full tensor shape).  With the wrong sizes, offset[0]+size[0]
+    = 1+2 = 3 > 2, which is out-of-bounds and produces incorrect results.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+    ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
+        # Load top-right quadrant: a[0, 1, :, :]
+        tile = pl.load(a, [0, 1, 0, 0], [1, 1, 8, 16])
+        result_tile = pl.tile.mul(tile, tile)
+        # Store to bottom-left quadrant: out[1, 0, :, :]
+        out = pl.store(result_tile, [1, 0, 0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+    ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
+        out = pl.create_tensor([2, 2, 8, 16], dtype=pl.FP32)
+        out = self.kernel(a, out)
+        return out
+
+
+@pl.program
+class Tile4DTopToBottomProgram:
+    """4D tensor [2,2,8,16] divided into 4 blocks of [1,1,8,16].
+
+    Computes a*b for the entire top row via a single [1,2,8,16] tile and
+    stores the result into the bottom row:
+      a[0,:,:,:] * b[0,:,:,:] -> out[1,:,:,:]
+
+    Uses a single [1,2,8,16] tile (load offset [0,0,0,0], store offset
+    [1,0,0,0]).  The mul op lets ResolveBackendOpLayouts infer TileView;
+    the store offset is non-zero in dim-0 so partition_view sizes must be
+    [1,2,8,16] (tile shape), not [2,2,8,16] (full tensor shape).
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+        b: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+    ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
+        # Load entire top row as one tile: a[0, :, :, :] and b[0, :, :, :]
+        a_tile = pl.load(a, [0, 0, 0, 0], [1, 2, 8, 16])
+        b_tile = pl.load(b, [0, 0, 0, 0], [1, 2, 8, 16])
+        # Multiply element-wise so ResolveBackendOpLayouts can infer TileView
+        result_tile = pl.tile.mul(a_tile, b_tile)
+        # Store to bottom row in one shot: out[1, :, :, :]
+        out = pl.store(result_tile, [1, 0, 0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+        b: pl.Tensor[[2, 2, 8, 16], pl.FP32],
+    ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
+        out = pl.create_tensor([2, 2, 8, 16], dtype=pl.FP32)
+        out = self.kernel(a, b, out)
+        return out
+
+
+# --- Test Cases ---
+
+
+class Tile4DMulTestCase(PTOTestCase):
+    """4D tile [2,3,8,64] element-wise mul (self-square); flattens to [48,64]."""
+
+    def get_name(self) -> str:
+        return "tile_4d_mul"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [2, 3, 8, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Tile4DMulProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["a"] * tensors["a"]
+
+
+class Tile4DMulPartialTestCase(PTOTestCase):
+    """4D tile partial coverage: tile [2,3,8,64] stores to offset [2,0,0,0] of a [4,3,8,64] tensor."""
+
+    def get_name(self) -> str:
+        return "tile_4d_mul_partial"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [4, 3, 8, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [4, 3, 8, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Tile4DMulPartialProgram
+
+    def compute_expected(self, tensors, params=None):
+        # First half of dim-0 is unsquared (out[:2] unchanged / zero-initialized)
+        # Second half of dim-0 = a[:2, ...] ** 2
+        tensors["out"][2:, ...] = tensors["a"][:2, ...] * tensors["a"][:2, ...]
+
+
+class Tile4DTopToBottomTestCase(PTOTestCase):
+    """4D tensor [2,2,8,16]; mul top row a*b via one [1,2,8,16] tile, store to bottom row."""
+
+    def get_name(self) -> str:
+        return "tile_4d_top_to_bottom"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Tile4DTopToBottomProgram
+
+    def compute_expected(self, tensors, params=None):
+        # Only bottom row is written; top row stays zero-initialized.
+        tensors["out"][1] = tensors["a"][0] * tensors["b"][0]
+
+
+class Tile4DQuadrantTestCase(PTOTestCase):
+    """4D tensor [2,2,8,16] split into 4 blocks; load top-right, store squared to bottom-left."""
+
+    def get_name(self) -> str:
+        return "tile_4d_quadrant"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Tile4DQuadrantProgram
+
+    def compute_expected(self, tensors, params=None):
+        # Only bottom-left quadrant is written; the rest stays zero-initialized.
+        tensors["out"][1, 0] = tensors["a"][0, 1] ** 2
+
+
+class Tile4DAddTestCase(PTOTestCase):
+    """4D tile [2,3,8,64] element-wise add; flattens to [48,64]."""
+
+    def get_name(self) -> str:
+        return "tile_4d_add"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [2, 3, 8, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Tile4DAddProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["a"] + tensors["b"]
+
+
+# --- Tests ---
+
+
+class TestElementwise4D:
+    """End-to-end tests for elementwise ops on 4D tiles (exercises FlattenTileNdTo2D pass)."""
+
+    def test_tile_4d_top_to_bottom(self, test_runner):
+        """4D tensor [2,2,8,16]; a*b on top row via a single [1,2,8,16] tile, store to bottom row.
+
+        Loads a[0,:,:,:] and b[0,:,:,:] with tile shape [1,2,8,16] from offset
+        [0,0,0,0], multiplies them, and stores to out[1,:,:,:] at offset
+        [1,0,0,0].  Partition_view sizes for the store must be [1,2,8,16]
+        (tile shape), not [2,2,8,16] (full tensor shape).
+        """
+        test_case = Tile4DTopToBottomTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_4d_quadrant(self, test_runner):
+        """4D tensor [2,2,8,16] divided into 4 blocks of [1,1,8,16].
+
+        Loads top-right block a[0,1,:,:], squares it, stores to bottom-left
+        block out[1,0,:,:].  Partition_view sizes for the store must be
+        [1,1,8,16] (tile shape).  With the current bug, sizes=[2,2,8,16] and
+        offset[0]=1 gives offset+size=3 > tensor_dim=2 (out of bounds).
+        """
+        test_case = Tile4DQuadrantTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_4d_mul_partial(self, test_runner):
+        """Partial-coverage 4D tile store: tile [2,3,8,64] at offset [2,0,0,0] of [4,3,8,64] tensor.
+
+        Verifies that partition_view sizes match the tile shape [2,3,8,64] (not the full
+        tensor [4,3,8,64]). With the bug, sizes=[4,3,8,64] and offset=[2,0,0,0] would
+        produce offset+size=[6,...] > tensor_dim[4,...], causing ptoas to reject the IR.
+        """
+        test_case = Tile4DMulPartialTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_4d_mul(self, test_runner):
+        """4D tile mul: [2,3,8,64] flattened to [48,64] by FlattenTileNdTo2D."""
+        test_case = Tile4DMulTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_4d_add(self, test_runner):
+        """4D tile add: [2,3,8,64] flattened to [48,64] by FlattenTileNdTo2D."""
+        test_case = Tile4DAddTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -12,13 +12,33 @@
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
+from pypto.ir import IRBuilder
+from pypto.ir.op import tensor as tensor_ops
+from pypto.ir.op import tile as tile_ops
+
+
+def _load2d(
+    tensor: ir.Expr,
+    offsets: list,
+    shapes: list,
+    flat_shape: list,
+    dtype: DataType,
+) -> ir.Call:
+    """Create tile.load Call with explicit 2D TileType (bypasses op registry type inference).
+
+    tile.load hardware semantics: ND tensor -> 2D tile. The pass changes the result type
+    directly to 2D without inserting a tile.reshape.
+    """
+    nd_call = tile_ops.load(tensor, offsets, shapes, span=ir.Span.unknown())
+    flat_type = ir.TileType(flat_shape, dtype)
+    return ir.Call(nd_call.op, list(nd_call.args), nd_call.kwargs, flat_type, nd_call.span)
 
 
 class TestFlattenTileNdTo2D:
     """Test FlattenTileNdTo2D pass."""
 
     def test_3d_tile_element_wise(self):
-        """3D tile [2, 3, 4] with tile.add -> reshaped to [6, 4]."""
+        """3D tile [2, 3, 4] with tile.add -> flattened to [6, 4]."""
 
         @pl.program
         class Before:
@@ -39,32 +59,37 @@ class TestFlattenTileNdTo2D:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
 
     def test_4d_tile(self):
-        """4D tile [2, 3, 4, 5] with tile.mul -> reshaped to [24, 5]."""
+        """4D tile [2, 3, 4, 5] with tile.mul -> flattened to [24, 5]."""
 
         @pl.program
         class Before:
@@ -85,26 +110,31 @@ class TestFlattenTileNdTo2D:
                 y: pl.Tensor[[2, 3, 4, 5], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4, 5], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4, 5], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4, 5], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4, 5], pl.FP32] = pl.load(x, [0, 0, 0, 0], [2, 3, 4, 5])
-                x_tile: pl.Tile[[24, 5], pl.FP32] = pl.tile.reshape(x_tile_nd, [24, 5])
-                y_tile: pl.Tile[[24, 5], pl.FP32] = pl.tile.mul(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4, 5], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4, 5])
-                out_0: pl.Tensor[[2, 3, 4, 5], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4, 5], pl.FP32]) -> pl.Tensor[[2, 3, 4, 5], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4, 5], pl.FP32] = pl.create_tensor([2, 3, 4, 5], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4, 5], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4, 5], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4, 5], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4, 5], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0, 0], [2, 3, 4, 5], [24, 5], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.mul(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0, 0], out_0, [2, 3, 4, 5]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4, 5], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4, 5], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4, 5], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -160,7 +190,7 @@ class TestFlattenTileNdTo2D:
         ir.assert_structural_equal(After, Before)
 
     def test_tile_load_store_reshape(self):
-        """tile.load 3D -> reshape -> ops -> reshape -> tile.store."""
+        """Two 3D loads -> tile.add -> tile.store."""
 
         @pl.program
         class Before:
@@ -187,33 +217,34 @@ class TestFlattenTileNdTo2D:
                 z: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, y, out_0)
                 return z
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                y: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(y, [0, 0, 0], [2, 3, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(y_tile_nd, [6, 4])
-                z_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, y_tile)
-                z_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(z_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(z_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                y: pl.Tensor[[2, 3, 4], pl.FP32],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                z: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, y, out_0)
-                return z
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                y = f.param("y", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", _load2d(y, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                z_tile = ib.let("z_tile", tile_ops.add(x_tile, y_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(z_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                y = f.param("y", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                z = ib.let("z", ir.Call(incore_gvar, [x, y, out_0], ir.Span.unknown()))
+                ib.return_stmt(z)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -241,27 +272,32 @@ class TestFlattenTileNdTo2D:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                tmp: pl.Tile[[6, 4], pl.FP32] = pl.tile.create([6, 4], dtype=pl.FP32)
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, tmp)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                tmp = ib.let("tmp", tile_ops.create([6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, tmp))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -288,26 +324,31 @@ class TestFlattenTileNdTo2D:
                 y: pl.Tensor[[2, 3, 1], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 1], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 1], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 1], pl.FP32] = pl.tile.sum(x_tile, axis=1, keepdim=True)
-                y_tile_nd: pl.Tile[[2, 3, 1], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 1])
-                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 1], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.create_tensor([2, 3, 1], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 1], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 1], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 1], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.sum(x_tile, axis=1, keepdim=True))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 1]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 1], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 1], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -423,26 +464,31 @@ class TestFlattenTileNdTo2DUnaryOps:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.exp(x_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.exp(x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -469,26 +515,31 @@ class TestFlattenTileNdTo2DUnaryOps:
                 y: pl.Tensor[[4, 2, 8], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[4, 2, 8], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[4, 2, 8], pl.FP32]],
-            ) -> pl.Tensor[[4, 2, 8], pl.FP32]:
-                x_tile_nd: pl.Tile[[4, 2, 8], pl.FP32] = pl.load(x, [0, 0, 0], [4, 2, 8])
-                x_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.reshape(x_tile_nd, [8, 8])
-                y_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.neg(x_tile)
-                y_tile_nd: pl.Tile[[4, 2, 8], pl.FP32] = pl.tile.reshape(y_tile, [4, 2, 8])
-                out_0: pl.Tensor[[4, 2, 8], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[4, 2, 8], pl.FP32]) -> pl.Tensor[[4, 2, 8], pl.FP32]:
-                out_0: pl.Tensor[[4, 2, 8], pl.FP32] = pl.create_tensor([4, 2, 8], dtype=pl.FP32)
-                y: pl.Tensor[[4, 2, 8], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([4, 2, 8], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([4, 2, 8], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([4, 2, 8], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [4, 2, 8], [8, 8], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.neg(x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [4, 2, 8]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([4, 2, 8], DataType.FP32))
+                f.return_type(ir.TensorType([4, 2, 8], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([4, 2, 8], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -519,26 +570,31 @@ class TestFlattenTileNdTo2DScalarOps:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.muls(x_tile, 2.0)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.muls(x_tile, 2.0))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -565,26 +621,31 @@ class TestFlattenTileNdTo2DScalarOps:
                 y: pl.Tensor[[2, 4, 8], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 4, 8], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 4, 8], pl.FP32]],
-            ) -> pl.Tensor[[2, 4, 8], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 4, 8], pl.FP32] = pl.load(x, [0, 0, 0], [2, 4, 8])
-                x_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.reshape(x_tile_nd, [8, 8])
-                y_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.adds(x_tile, 1.0)
-                y_tile_nd: pl.Tile[[2, 4, 8], pl.FP32] = pl.tile.reshape(y_tile, [2, 4, 8])
-                out_0: pl.Tensor[[2, 4, 8], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 4, 8], pl.FP32]) -> pl.Tensor[[2, 4, 8], pl.FP32]:
-                out_0: pl.Tensor[[2, 4, 8], pl.FP32] = pl.create_tensor([2, 4, 8], dtype=pl.FP32)
-                y: pl.Tensor[[2, 4, 8], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 4, 8], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 4, 8], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 4, 8], [8, 8], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.adds(x_tile, 1.0))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 4, 8]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP32))
+                f.return_type(ir.TensorType([2, 4, 8], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 4, 8], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -615,26 +676,31 @@ class TestFlattenTileNdTo2DReduceOps:
                 y: pl.Tensor[[2, 4, 1], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 4, 8], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 4, 1], pl.FP32]],
-            ) -> pl.Tensor[[2, 4, 1], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 4, 8], pl.FP32] = pl.load(x, [0, 0, 0], [2, 4, 8])
-                x_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.reshape(x_tile_nd, [8, 8])
-                y_tile: pl.Tile[[8, 1], pl.FP32] = pl.tile.max(x_tile, axis=1, keepdim=True)
-                y_tile_nd: pl.Tile[[2, 4, 1], pl.FP32] = pl.tile.reshape(y_tile, [2, 4, 1])
-                out_0: pl.Tensor[[2, 4, 1], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 4, 8], pl.FP32]) -> pl.Tensor[[2, 4, 1], pl.FP32]:
-                out_0: pl.Tensor[[2, 4, 1], pl.FP32] = pl.create_tensor([2, 4, 1], dtype=pl.FP32)
-                y: pl.Tensor[[2, 4, 1], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 4, 1], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 4, 1], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 4, 8], [8, 8], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.max(x_tile, axis=1, keepdim=True))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 4, 1]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP32))
+                f.return_type(ir.TensorType([2, 4, 1], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 4, 1], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -692,28 +758,33 @@ class TestFlattenTileNdTo2DChainedOps:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.exp(x_tile)
-                b_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(a_tile, x_tile)
-                c_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.muls(b_tile, 0.5)
-                c_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(c_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(c_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                a_tile = ib.let("a_tile", tile_ops.exp(x_tile))
+                b_tile = ib.let("b_tile", tile_ops.add(a_tile, x_tile))
+                c_tile = ib.let("c_tile", tile_ops.muls(b_tile, 0.5))
+                out_0_r = ib.let("out_0", tile_ops.store(c_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -746,33 +817,34 @@ class TestFlattenTileNdTo2DChainedOps:
                 z: pl.Tensor[[3, 4, 5], pl.FP32] = self.main_incore_0(x, y, out_0)
                 return z
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[3, 4, 5], pl.FP32],
-                y: pl.Tensor[[3, 4, 5], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[3, 4, 5], pl.FP32]],
-            ) -> pl.Tensor[[3, 4, 5], pl.FP32]:
-                x_tile_nd: pl.Tile[[3, 4, 5], pl.FP32] = pl.load(x, [0, 0, 0], [3, 4, 5])
-                x_tile: pl.Tile[[12, 5], pl.FP32] = pl.tile.reshape(x_tile_nd, [12, 5])
-                y_tile_nd: pl.Tile[[3, 4, 5], pl.FP32] = pl.load(y, [0, 0, 0], [3, 4, 5])
-                y_tile: pl.Tile[[12, 5], pl.FP32] = pl.tile.reshape(y_tile_nd, [12, 5])
-                z_tile: pl.Tile[[12, 5], pl.FP32] = pl.tile.sub(x_tile, y_tile)
-                z_tile_nd: pl.Tile[[3, 4, 5], pl.FP32] = pl.tile.reshape(z_tile, [3, 4, 5])
-                out_0: pl.Tensor[[3, 4, 5], pl.FP32] = pl.store(z_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[3, 4, 5], pl.FP32],
-                y: pl.Tensor[[3, 4, 5], pl.FP32],
-            ) -> pl.Tensor[[3, 4, 5], pl.FP32]:
-                out_0: pl.Tensor[[3, 4, 5], pl.FP32] = pl.create_tensor([3, 4, 5], dtype=pl.FP32)
-                z: pl.Tensor[[3, 4, 5], pl.FP32] = self.main_incore_0(x, y, out_0)
-                return z
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([3, 4, 5], DataType.FP32))
+                y = f.param("y", ir.TensorType([3, 4, 5], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([3, 4, 5], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([3, 4, 5], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [3, 4, 5], [12, 5], DataType.FP32))
+                y_tile = ib.let("y_tile", _load2d(y, [0, 0, 0], [3, 4, 5], [12, 5], DataType.FP32))
+                z_tile = ib.let("z_tile", tile_ops.sub(x_tile, y_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(z_tile, [0, 0, 0], out_0, [3, 4, 5]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([3, 4, 5], DataType.FP32))
+                y = f.param("y", ir.TensorType([3, 4, 5], DataType.FP32))
+                f.return_type(ir.TensorType([3, 4, 5], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([3, 4, 5], DataType.FP32))
+                z = ib.let("z", ir.Call(incore_gvar, [x, y, out_0], ir.Span.unknown()))
+                ib.return_stmt(z)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -803,26 +875,33 @@ class TestFlattenTileNdTo2DHigherDims:
                 y: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 2, 2, 2, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 2, 2, 2, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 2, 2, 2, 4], pl.FP32] = pl.load(x, [0, 0, 0, 0, 0], [2, 2, 2, 2, 4])
-                x_tile: pl.Tile[[16, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [16, 4])
-                y_tile: pl.Tile[[16, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 2, 2, 2, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 2, 2, 2, 4])
-                out_0: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32]) -> pl.Tensor[[2, 2, 2, 2, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32] = pl.create_tensor([2, 2, 2, 2, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 2, 2, 2, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 2, 2, 2, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 2, 2, 2, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 2, 2, 2, 4], DataType.FP32))
+                x_tile = ib.let(
+                    "x_tile", _load2d(x, [0, 0, 0, 0, 0], [2, 2, 2, 2, 4], [16, 4], DataType.FP32)
+                )
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0, 0, 0], out_0, [2, 2, 2, 2, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 2, 2, 2, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 2, 2, 2, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 2, 2, 2, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -865,38 +944,42 @@ class TestFlattenTileNdTo2DMixedDims:
                 r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, y, out_0, out_1)
                 return r
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                y: pl.Tensor[[32, 64], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-                out_1: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                # 3D -> flattened
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.exp(x_tile)
-                a_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(a_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(a_tile_nd, [0, 0, 0], out_0)
-                # 2D -> unchanged
-                y_tile: pl.Tile[[32, 64], pl.FP32] = pl.load(y, [0, 0], [32, 64])
-                b_tile: pl.Tile[[32, 64], pl.FP32] = pl.tile.add(y_tile, y_tile)
-                out_1: pl.Tensor[[32, 64], pl.FP32] = pl.store(b_tile, [0, 0], out_1)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                y: pl.Tensor[[32, 64], pl.FP32],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                out_1: pl.Tensor[[32, 64], pl.FP32] = pl.create_tensor([32, 64], dtype=pl.FP32)
-                r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, y, out_0, out_1)
-                return r
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                y = f.param("y", ir.TensorType([32, 64], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                out_1 = f.param(
+                    "out_1", ir.TensorType([32, 64], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                # 3D -> flattened
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                a_tile = ib.let("a_tile", tile_ops.exp(x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(a_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                # 2D -> unchanged
+                y_tile = ib.let("y_tile", tile_ops.load(y, [0, 0], [32, 64]))
+                b_tile = ib.let("b_tile", tile_ops.add(y_tile, y_tile))
+                ib.let("out_1", tile_ops.store(b_tile, [0, 0], out_1))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                y = f.param("y", ir.TensorType([32, 64], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                out_1 = ib.let("out_1", tensor_ops.create([32, 64], DataType.FP32))
+                r = ib.let("r", ir.Call(incore_gvar, [x, y, out_0, out_1], ir.Span.unknown()))
+                ib.return_stmt(r)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -931,31 +1014,37 @@ class TestFlattenTileNdTo2DMultipleStores:
                 r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0, out_1)
                 return r
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-                out_1: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-                a_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(a_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(a_tile_nd, [0, 0, 0], out_0)
-                b_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.mul(x_tile, x_tile)
-                b_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(b_tile, [2, 3, 4])
-                out_1: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(b_tile_nd, [0, 0, 0], out_1)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                out_1: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0, out_1)
-                return r
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                out_1 = f.param(
+                    "out_1", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                a_tile = ib.let("a_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(a_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                b_tile = ib.let("b_tile", tile_ops.mul(x_tile, x_tile))
+                ib.let("out_1", tile_ops.store(b_tile, [0, 0, 0], out_1, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                out_1 = ib.let("out_1", tensor_ops.create([2, 3, 4], DataType.FP32))
+                r = ib.let("r", ir.Call(incore_gvar, [x, out_0, out_1], ir.Span.unknown()))
+                ib.return_stmt(r)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1003,45 +1092,47 @@ class TestFlattenTileNdTo2DMultipleFunctions:
                 _rb: pl.Tensor[[3, 4, 5], pl.FP32] = self.incore_b(y, out_b)
                 return ra
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def incore_a(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_a_gvar = prog.declare_function("incore_a")
+            incore_b_gvar = prog.declare_function("incore_b")
+            prog.declare_function("main")
 
-            @pl.function(type=pl.FunctionType.InCore)
-            def incore_b(
-                self,
-                x: pl.Tensor[[3, 4, 5], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[3, 4, 5], pl.FP32]],
-            ) -> pl.Tensor[[3, 4, 5], pl.FP32]:
-                x_tile_nd: pl.Tile[[3, 4, 5], pl.FP32] = pl.load(x, [0, 0, 0], [3, 4, 5])
-                x_tile: pl.Tile[[12, 5], pl.FP32] = pl.tile.reshape(x_tile_nd, [12, 5])
-                y_tile: pl.Tile[[12, 5], pl.FP32] = pl.tile.mul(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[3, 4, 5], pl.FP32] = pl.tile.reshape(y_tile, [3, 4, 5])
-                out_0: pl.Tensor[[3, 4, 5], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+            with ib.function("incore_a", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
 
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                y: pl.Tensor[[3, 4, 5], pl.FP32],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_a: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                out_b: pl.Tensor[[3, 4, 5], pl.FP32] = pl.create_tensor([3, 4, 5], dtype=pl.FP32)
-                ra: pl.Tensor[[2, 3, 4], pl.FP32] = self.incore_a(x, out_a)
-                _rb: pl.Tensor[[3, 4, 5], pl.FP32] = self.incore_b(y, out_b)
-                return ra
+            with ib.function("incore_b", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([3, 4, 5], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([3, 4, 5], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([3, 4, 5], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [3, 4, 5], [12, 5], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.mul(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [3, 4, 5]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                y = f.param("y", ir.TensorType([3, 4, 5], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_a = ib.let("out_a", tensor_ops.create([2, 3, 4], DataType.FP32))
+                out_b = ib.let("out_b", tensor_ops.create([3, 4, 5], DataType.FP32))
+                ra = ib.let("ra", ir.Call(incore_a_gvar, [x, out_a], ir.Span.unknown()))
+                _rb = ib.let("_rb", ir.Call(incore_b_gvar, [y, out_b], ir.Span.unknown()))
+                ib.return_stmt(ra)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1073,27 +1164,32 @@ class TestFlattenTileNdTo2DFull:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                z_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.full([6, 4], dtype=pl.FP32, value=0.0)
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, z_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                z_tile = ib.let("z_tile", tile_ops.full([6, 4], DataType.FP32, 0.0))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, z_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1124,26 +1220,31 @@ class TestFlattenTileNdTo2DFunctionTypes:
                 y: pl.Tensor[[2, 3, 4], pl.FP32] = self.aic_func(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.AIC)
-            def aic_func(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                y_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(y_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            aic_gvar = prog.declare_function("aic_func")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.aic_func(x, out_0)
-                return y
+            with ib.function("aic_func", type=ir.FunctionType.AIC) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 3, 4]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
+                y = ib.let("y", ir.Call(aic_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1170,26 +1271,31 @@ class TestFlattenTileNdTo2DFunctionTypes:
                 y: pl.Tensor[[4, 2, 8], pl.FP32] = self.aiv_func(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.AIV)
-            def aiv_func(
-                self,
-                x: pl.Tensor[[4, 2, 8], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[4, 2, 8], pl.FP32]],
-            ) -> pl.Tensor[[4, 2, 8], pl.FP32]:
-                x_tile_nd: pl.Tile[[4, 2, 8], pl.FP32] = pl.load(x, [0, 0, 0], [4, 2, 8])
-                x_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.reshape(x_tile_nd, [8, 8])
-                y_tile: pl.Tile[[8, 8], pl.FP32] = pl.tile.exp(x_tile)
-                y_tile_nd: pl.Tile[[4, 2, 8], pl.FP32] = pl.tile.reshape(y_tile, [4, 2, 8])
-                out_0: pl.Tensor[[4, 2, 8], pl.FP32] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            aiv_gvar = prog.declare_function("aiv_func")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[4, 2, 8], pl.FP32]) -> pl.Tensor[[4, 2, 8], pl.FP32]:
-                out_0: pl.Tensor[[4, 2, 8], pl.FP32] = pl.create_tensor([4, 2, 8], dtype=pl.FP32)
-                y: pl.Tensor[[4, 2, 8], pl.FP32] = self.aiv_func(x, out_0)
-                return y
+            with ib.function("aiv_func", type=ir.FunctionType.AIV) as f:
+                x = f.param("x", ir.TensorType([4, 2, 8], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([4, 2, 8], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([4, 2, 8], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [4, 2, 8], [8, 8], DataType.FP32))
+                y_tile = ib.let("y_tile", tile_ops.exp(x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [4, 2, 8]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([4, 2, 8], DataType.FP32))
+                f.return_type(ir.TensorType([4, 2, 8], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([4, 2, 8], DataType.FP32))
+                y = ib.let("y", ir.Call(aiv_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1237,26 +1343,31 @@ class TestFlattenTileNdTo2DDataTypes:
                 y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 4, 8], pl.FP16],
-                out_0: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
-            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                x_tile_nd: pl.Tile[[2, 4, 8], pl.FP16] = pl.load(x, [0, 0, 0], [2, 4, 8])
-                x_tile: pl.Tile[[8, 8], pl.FP16] = pl.tile.reshape(x_tile_nd, [8, 8])
-                y_tile: pl.Tile[[8, 8], pl.FP16] = pl.tile.add(x_tile, x_tile)
-                y_tile_nd: pl.Tile[[2, 4, 8], pl.FP16] = pl.tile.reshape(y_tile, [2, 4, 8])
-                out_0: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(y_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 4, 8], pl.FP16]) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                out_0: pl.Tensor[[2, 4, 8], pl.FP16] = pl.create_tensor([2, 4, 8], dtype=pl.FP16)
-                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP16))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 4, 8], DataType.FP16), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 4, 8], DataType.FP16))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 4, 8], [8, 8], DataType.FP16))
+                y_tile = ib.let("y_tile", tile_ops.add(x_tile, x_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0, 0, 0], out_0, [2, 4, 8]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 4, 8], DataType.FP16))
+                f.return_type(ir.TensorType([2, 4, 8], DataType.FP16))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 4, 8], DataType.FP16))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1370,27 +1481,32 @@ class TestFlattenTileNdTo2DReduceAndCompute:
                 y: pl.Tensor[[2, 3, 1], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                x: pl.Tensor[[2, 3, 4], pl.FP32],
-                out_0: pl.Out[pl.Tensor[[2, 3, 1], pl.FP32]],
-            ) -> pl.Tensor[[2, 3, 1], pl.FP32]:
-                x_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.load(x, [0, 0, 0], [2, 3, 4])
-                x_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.reshape(x_tile_nd, [6, 4])
-                s_tile: pl.Tile[[6, 1], pl.FP32] = pl.tile.sum(x_tile, axis=1, keepdim=True)
-                r_tile: pl.Tile[[6, 1], pl.FP32] = pl.tile.add(s_tile, s_tile)
-                r_tile_nd: pl.Tile[[2, 3, 1], pl.FP32] = pl.tile.reshape(r_tile, [2, 3, 1])
-                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.store(r_tile_nd, [0, 0, 0], out_0)
-                return out_0
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
 
-            @pl.function
-            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 1], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.create_tensor([2, 3, 1], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 1], pl.FP32] = self.main_incore_0(x, out_0)
-                return y
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([2, 3, 1], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([2, 3, 1], DataType.FP32))
+                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
+                s_tile = ib.let("s_tile", tile_ops.sum(x_tile, axis=1, keepdim=True))
+                r_tile = ib.let("r_tile", tile_ops.add(s_tile, s_tile))
+                out_0_r = ib.let("out_0", tile_ops.store(r_tile, [0, 0, 0], out_0, [2, 3, 1]))
+                ib.return_stmt(out_0_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
+                f.return_type(ir.TensorType([2, 3, 1], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 1], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -1429,8 +1545,7 @@ class TestFlattenTileNdTo2DReduceAndCompute:
                 a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.create([6, 4], dtype=pl.FP32)
                 b_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.full([6, 4], dtype=pl.FP32, value=1.0)
                 c_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(a_tile, b_tile)
-                c_tile_nd: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.reshape(c_tile, [2, 3, 4])
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(c_tile_nd, [0, 0, 0], out_0)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(c_tile, [0, 0, 0], out_0, [2, 3, 4])
                 return out_0
 
             @pl.function


### PR DESCRIPTION
tile.load now produces a 2D tile directly by overriding the result type (bypassing ND type inference), removing the need for an inserted reshape. tile.store accepts the 2D tile directly; an optional shapes tuple (3rd arg) is injected by FlattenTileNdTo2D to carry the ND partition shape for codegen.

Backend codegen updated: tile.load flattens ND shapes to 2D height×width and uses all offsets for ND partition_view; tile.store reads output tensor from args.back() and uses the injected shapes for ND partition_view. PTO codegen adds row-major stride constant emission for ND tensors.

Resolves the TODO items for fusing tile.load+reshape and reshape+tile.store.