### PR TITLE
docs(rules): add O(N log N) pass complexity bound rule

### DIFF
--- a/.claude/agents/code-review/AGENT.md
+++ b/.claude/agents/code-review/AGENT.md
@@ -29,7 +29,7 @@ Follow the complete review guidelines in the **code-review skill** at `.claude/s
 ## Key Focus Areas
 
 1. **Code Quality**: Style, error handling (`CHECK` vs `INTERNAL_CHECK`), PyPTO exceptions (not C++), no debug code, error messages with context
-2. **Pass Complexity**: All passes must be O(N log N) or better — no nested IR node iteration, all lookups via maps/sets (not linear scans). See `pass-complexity.md`
+2. **Pass Complexity**: All passes must be O(N log N) or better — no nested full scans over IR node collections, no linear scans for lookups (use indexed structures). See [`pass-complexity.md`](../../rules/pass-complexity.md)
 3. **Python Style**: `@overload` for multiple signatures (not `Union`), modern type syntax (`list[int]` not `List[int]`), f-strings, Google-style docstrings, type hints on public APIs
 4. **Testing Standards**: pytest only (no `unittest`), `assert` for verification (no `print`), `pytest.raises()` for exceptions, tests only in `tests/`
 5. **Documentation**: Alignment with code changes, examples still work, file lengths (≤500 for docs, ≤200 for rules/skills/agents), pass doc numbering matches pass manager execution order

--- a/.claude/rules/pass-complexity.md
+++ b/.claude/rules/pass-complexity.md
@@ -13,7 +13,7 @@ The log N factor is acceptable only when it comes from ordered map/set lookups o
 | Single IR traversal with map lookups | O(N log N) | Yes |
 | Single IR traversal, constant-time work per node | O(N) | Yes |
 | Multiple independent traversals (fixed number) | O(N) | Yes |
-| Nested iteration over IR nodes | O(N^2) | **No** |
+| Nested full scans over the same/global IR node collection | O(N^2) | **No** |
 | Repeated linear scans for lookups | O(N^2) | **No** |
 | Fixed-point iteration without convergence bound | Unbounded | **No** |
 
@@ -43,7 +43,7 @@ void GoodPass::VisitStmt_(const AssignStmtPtr& op) {
 ### Build Index First, Then Traverse
 
 ```cpp
-// ✅ O(N log N) — build map O(N log N), then traverse O(N)
+// ✅ O(N log N) — build map O(N log N), then traverse O(N log N)
 void GoodPass::Run(const ProgramPtr& prog) {
   // Phase 1: Build index — O(N log N)
   for (auto& stmt : prog->stmts_) {
@@ -52,6 +52,7 @@ void GoodPass::Run(const ProgramPtr& prog) {
   // Phase 2: Transform — O(N log N)
   for (auto& stmt : prog->stmts_) {
     auto it = index_.find(stmt->dep());  // O(log N) per lookup
+    INTERNAL_CHECK(it != index_.end()) << "missing dependency";
     Transform(stmt, it->second);
   }
 }
@@ -66,14 +67,15 @@ for stmt in program.stmts:
         if depends_on(stmt, other):
             ...
 
-# ✅ O(N log N) — build dependency map, then single traversal
+# ✅ O(N + E) — build dependency map, then single traversal
+# where E is total dependency edges (bounded by O(N) in most IR passes)
 dep_map: dict[str, list[Stmt]] = {}
 for stmt in program.stmts:
     for dep in stmt.dependencies:
         dep_map.setdefault(dep, []).append(stmt)
 
 for stmt in program.stmts:
-    for dependent in dep_map.get(stmt.name, []):  # Amortized O(N) total
+    for dependent in dep_map.get(stmt.name, []):  # O(N + E) total across both loops
         ...
 ```
 
@@ -81,8 +83,8 @@ for stmt in program.stmts:
 
 When writing or reviewing a pass:
 
-- [ ] No nested iteration over IR node collections
-- [ ] All lookups use maps/sets (not linear scans)
+- [ ] No nested full scans over the same/global IR node collection
+- [ ] All lookups use indexed structures — map, set, unordered_map, or vector (not linear scans)
 - [ ] Fixed-point loops have a proven convergence bound
 - [ ] Overall complexity is O(N log N) or better
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -37,7 +37,7 @@ When you need to perform a code review:
 - [ ] Clear, descriptive names
 - [ ] Appropriate comments for complex logic
 - [ ] Linter errors fixed (not suppressed)
-- [ ] **Pass complexity ≤ O(N log N)**: No nested IR node iteration, all lookups via maps/sets (see `pass-complexity.md`)
+- [ ] **Pass complexity ≤ O(N log N)**: No nested full scans over IR node collections, no linear scans for lookups (see [`pass-complexity.md`](../../rules/pass-complexity.md))
 
 ### 2. Python Style (see `python-style.md` for full details)
 
@@ -112,7 +112,7 @@ When APIs change, all three layers must be updated together. See [cross-layer-sy
 - **AI co-author**: `Co-Authored-By: Claude` or similar lines in commits
 - **Hardcoded paths**: Absolute paths like `/home/user/...` instead of relative paths
 - **Vague error messages**: `raise ValueError("Invalid")` without context
-- **Quadratic pass complexity**: Nested iteration over IR nodes or linear scans instead of map lookups inside a pass traversal
+- **Quadratic pass complexity**: Nested full scans over the same/global IR node collection, or linear scans instead of indexed lookups inside a pass traversal
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
- Add `.claude/rules/pass-complexity.md` requiring all IR passes to be at most O(N log N), where the log N factor comes from map/set lookups
- Update code review agent and skill to check for quadratic pass complexity during reviews
- Includes C++ and Python examples of allowed vs disallowed patterns, a review checklist, and an exception process

## Testing
- [x] All pre-commit hooks pass (markdownlint, headers, trailing whitespace)
- [x] Code review completed
- [x] No code changes — docs/rules only