### PR TITLE
feat(ir): add operator==/!= to TileView and centralize ExprPtr comparison

### DIFF
--- a/docs/en/dev/passes/12-basic_memory_reuse.md
+++ b/docs/en/dev/passes/12-basic_memory_reuse.md
@@ -54,7 +54,7 @@ program_optimized = reuse_pass(program)
 - Full TileType compatibility — checked by `AreTileTypesCompatible`:
   - Same shape (all dimensions must match exactly)
   - Same dtype (e.g., FP32 vs BF16 prevents reuse, handling `tile.cast` automatically)
-  - Same TileView attributes when present: `valid_shape`, `pad`, `blayout`, `slayout`, `fractal` (e.g., `tile.fillpad` changes `valid_shape` and `pad`, so its output cannot reuse its input)
+  - Same TileView attributes when present: all fields (`valid_shape`, `stride`, `start_offset`, `blayout`, `slayout`, `fractal`, `pad`) are compared via `TileView::operator==` (e.g., `tile.fillpad` changes `valid_shape` and `pad`, so its output cannot reuse its input)
 
 **Alloc cleanup**:
 

--- a/docs/zh-cn/dev/passes/12-basic_memory_reuse.md
+++ b/docs/zh-cn/dev/passes/12-basic_memory_reuse.md
@@ -48,9 +48,13 @@ program_optimized = reuse_pass(program)
 
 **复用条件**：
 
-- 生命周期不重叠（无干涉）
+- 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）
 - 相同内存空间
 - 大小兼容（复用目标必须足够大）
+- 完整的 TileType 兼容性 — 由 `AreTileTypesCompatible` 检查：
+  - 相同 shape（所有维度必须精确匹配）
+  - 相同 dtype（例如 FP32 与 BF16 阻止复用，自动处理 `tile.cast`）
+  - 相同 TileView 属性：所有字段（`valid_shape`、`stride`、`start_offset`、`blayout`、`slayout`、`fractal`、`pad`）通过 `TileView::operator==` 比较（例如 `tile.fillpad` 改变 `valid_shape` 和 `pad`，因此其输出不能复用其输入）
 
 **Alloc 清理**：
 

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -503,6 +503,16 @@ class TupleGetItemExpr : public Expr {
 
 using TupleGetItemExprPtr = std::shared_ptr<const TupleGetItemExpr>;
 
+/**
+ * @brief Compare two ExprPtr values: ConstInt by value, otherwise by pointer identity
+ */
+bool AreExprsEqual(const ExprPtr& e1, const ExprPtr& e2);
+
+/**
+ * @brief Compare two ExprPtr vectors element-wise
+ */
+bool AreExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2);
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -283,6 +283,9 @@ struct TileView {
   }
 };
 
+bool operator==(const TileView& lhs, const TileView& rhs);
+bool operator!=(const TileView& lhs, const TileView& rhs);
+
 /**
  * @brief Base class for shaped types (tensors and tiles)
  *

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -358,7 +358,13 @@ void BindIR(nb::module_& m) {
       .def_rw("blayout", &TileView::blayout, "Block layout")
       .def_rw("slayout", &TileView::slayout, "Scatter layout")
       .def_rw("fractal", &TileView::fractal, "Fractal size")
-      .def_rw("pad", &TileView::pad, "Pad mode");
+      .def_rw("pad", &TileView::pad, "Pad mode")
+      .def(
+          "__eq__", [](const TileView& self, const TileView& other) { return self == other; },
+          nb::arg("other"), "Structural equality comparison")
+      .def(
+          "__ne__", [](const TileView& self, const TileView& other) { return self != other; },
+          nb::arg("other"), "Structural inequality comparison");
 
   // Dynamic dimension constant
   ir.attr("DYNAMIC_DIM") = kDynamicDim;

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -521,6 +521,12 @@ class TileView:
             pad: Pad mode (default: null)
         """
 
+    def __eq__(self, other: object) -> bool:
+        """Structural equality comparison."""
+
+    def __ne__(self, other: object) -> bool:
+        """Structural inequality comparison."""
+
 class TileType(ShapedType):
     """Tile type representation (multi-dimensional tensor)."""
 

--- a/src/ir/expr.cpp
+++ b/src/ir/expr.cpp
@@ -10,12 +10,14 @@
  */
 #include "pypto/ir/expr.h"
 
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
 
@@ -49,6 +51,23 @@ TupleGetItemExpr::TupleGetItemExpr(ExprPtr tuple, int index, Span span)
 
   // Set result type to the accessed element's type
   type_ = tuple_type->types_[index];
+}
+
+bool AreExprsEqual(const ExprPtr& e1, const ExprPtr& e2) {
+  if (e1 == e2) return true;
+  if (!e1 || !e2) return false;
+  auto c1 = As<ConstInt>(e1);
+  auto c2 = As<ConstInt>(e2);
+  if (c1 && c2) return c1->value_ == c2->value_;
+  return false;
+}
+
+bool AreExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2) {
+  if (v1.size() != v2.size()) return false;
+  for (size_t i = 0; i < v1.size(); ++i) {
+    if (!AreExprsEqual(v1[i], v2[i])) return false;
+  }
+  return true;
 }
 
 }  // namespace ir

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -26,7 +26,6 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/op_registry.h"
-#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -258,19 +257,6 @@ LifetimeAnalysisResult ComputeLifetimesFromDependencies(const std::vector<BasicB
 }
 
 /**
- * @brief Compare two ExprPtr vectors element-wise by ConstInt value
- */
-bool AreExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2) {
-  if (v1.size() != v2.size()) return false;
-  for (size_t i = 0; i < v1.size(); i++) {
-    auto c1 = As<ConstInt>(v1[i]);
-    auto c2 = As<ConstInt>(v2[i]);
-    if (!c1 || !c2 || c1->value_ != c2->value_) return false;
-  }
-  return true;
-}
-
-/**
  * @brief Check if two TileType variables have fully compatible tile attributes
  *
  * PTO codegen binds a single alloc_tile declaration (shape, dtype, blayout, pad, etc.)
@@ -278,7 +264,7 @@ bool AreExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprP
  * Reuse between tiles with different attributes would cause attribute mismatches in
  * the generated PTO IR, leading to incorrect codegen or hardware behaviour.
  *
- * Checked attributes: shape, dtype, and TileView (valid_shape, pad, blayout, slayout, fractal).
+ * Checked attributes: shape, dtype, and TileView (all fields via TileView::operator==).
  */
 bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   auto t1 = As<TileType>(var1->GetType());
@@ -291,16 +277,7 @@ bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   bool has_view1 = t1->tile_view_.has_value();
   bool has_view2 = t2->tile_view_.has_value();
   if (has_view1 != has_view2) return false;
-
-  if (has_view1) {
-    const auto& v1 = t1->tile_view_.value();
-    const auto& v2 = t2->tile_view_.value();
-    if (!AreExprVectorsEqual(v1.valid_shape, v2.valid_shape)) return false;
-    if (v1.pad != v2.pad) return false;
-    if (v1.blayout != v2.blayout) return false;
-    if (v1.slayout != v2.slayout) return false;
-    if (v1.fractal != v2.fractal) return false;
-  }
+  if (has_view1 && t1->tile_view_.value() != t2->tile_view_.value()) return false;
   return true;
 }
 

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -21,6 +21,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/scalar_expr.h"
@@ -45,6 +46,15 @@ std::optional<MemorySpace> ValidateTileMemorySpaceConsistency(const std::optiona
 }
 
 }  // namespace
+
+bool operator==(const TileView& lhs, const TileView& rhs) {
+  return AreExprVectorsEqual(lhs.valid_shape, rhs.valid_shape) &&
+         AreExprVectorsEqual(lhs.stride, rhs.stride) && AreExprsEqual(lhs.start_offset, rhs.start_offset) &&
+         lhs.blayout == rhs.blayout && lhs.slayout == rhs.slayout && lhs.fractal == rhs.fractal &&
+         lhs.pad == rhs.pad;
+}
+
+bool operator!=(const TileView& lhs, const TileView& rhs) { return !(lhs == rhs); }
 
 std::string TensorLayoutToString(TensorLayout layout) {
   switch (layout) {

--- a/tests/ut/ir/core/test_tile_view_equality.py
+++ b/tests/ut/ir/core/test_tile_view_equality.py
@@ -1,0 +1,133 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for TileView equality operators."""
+
+import pytest
+from pypto import DataType, ir
+
+
+def _make_span():
+    return ir.Span.unknown()
+
+
+def _make_const(value, span=None):
+    if span is None:
+        span = _make_span()
+    return ir.ConstInt(value, DataType.INT64, span)
+
+
+def _make_view(
+    valid_shape=None,
+    stride=None,
+    start_offset=None,
+    blayout=ir.TileLayout.row_major,
+    slayout=ir.TileLayout.none_box,
+    fractal=512,
+    pad=ir.PadValue.null,
+):
+    """Create a TileView with given parameters, using sensible defaults."""
+    span = _make_span()
+    if valid_shape is None:
+        valid_shape = [_make_const(16, span), _make_const(16, span)]
+    if stride is None:
+        stride = [_make_const(1, span), _make_const(16, span)]
+    if start_offset is None:
+        start_offset = _make_const(0, span)
+    return ir.TileView(valid_shape, stride, start_offset, blayout, slayout, fractal, pad)
+
+
+class TestTileViewEquality:
+    """Tests for TileView.__eq__ and __ne__."""
+
+    def test_default_views_equal(self):
+        """Two default-constructed TileViews are equal."""
+        v1 = ir.TileView()
+        v2 = ir.TileView()
+        assert v1 == v2
+        assert not (v1 != v2)
+
+    def test_identical_views_equal(self):
+        """TileViews constructed with the same parameters are equal."""
+        v1 = _make_view()
+        v2 = _make_view()
+        assert v1 == v2
+
+    def test_different_valid_shape(self):
+        """Views with different valid_shape are not equal."""
+        span = _make_span()
+        v1 = _make_view(valid_shape=[_make_const(16, span), _make_const(16, span)])
+        v2 = _make_view(valid_shape=[_make_const(32, span), _make_const(16, span)])
+        assert v1 != v2
+        assert not (v1 == v2)
+
+    def test_different_valid_shape_length(self):
+        """Views with different-length valid_shape are not equal."""
+        span = _make_span()
+        v1 = _make_view(valid_shape=[_make_const(16, span)])
+        v2 = _make_view(valid_shape=[_make_const(16, span), _make_const(16, span)])
+        assert v1 != v2
+
+    def test_different_stride(self):
+        """Views with different stride are not equal."""
+        span = _make_span()
+        v1 = _make_view(stride=[_make_const(1, span), _make_const(16, span)])
+        v2 = _make_view(stride=[_make_const(1, span), _make_const(32, span)])
+        assert v1 != v2
+
+    def test_different_start_offset(self):
+        """Views with different start_offset are not equal."""
+        v1 = _make_view(start_offset=_make_const(0))
+        v2 = _make_view(start_offset=_make_const(8))
+        assert v1 != v2
+
+    def test_different_blayout(self):
+        """Views with different blayout are not equal."""
+        v1 = _make_view(blayout=ir.TileLayout.row_major)
+        v2 = _make_view(blayout=ir.TileLayout.none_box)
+        assert v1 != v2
+
+    def test_different_slayout(self):
+        """Views with different slayout are not equal."""
+        v1 = _make_view(slayout=ir.TileLayout.none_box)
+        v2 = _make_view(slayout=ir.TileLayout.row_major)
+        assert v1 != v2
+
+    def test_different_fractal(self):
+        """Views with different fractal are not equal."""
+        v1 = _make_view(fractal=512)
+        v2 = _make_view(fractal=256)
+        assert v1 != v2
+
+    def test_different_pad(self):
+        """Views with different pad are not equal."""
+        v1 = _make_view(pad=ir.PadValue.null)
+        v2 = _make_view(pad=ir.PadValue.zero)
+        assert v1 != v2
+
+    def test_symbolic_same_object_equal(self):
+        """Symbolic exprs that are the same object compare equal."""
+        span = _make_span()
+        sym = ir.Var("M", ir.ScalarType(DataType.INT64), span)
+        v1 = _make_view(valid_shape=[sym], stride=[_make_const(1, span)])
+        v2 = _make_view(valid_shape=[sym], stride=[_make_const(1, span)])
+        assert v1 == v2
+
+    def test_symbolic_different_objects_not_equal(self):
+        """Different symbolic expr objects compare not-equal (conservative)."""
+        span = _make_span()
+        sym1 = ir.Var("M", ir.ScalarType(DataType.INT64), span)
+        sym2 = ir.Var("M", ir.ScalarType(DataType.INT64), span)
+        v1 = _make_view(valid_shape=[sym1], stride=[_make_const(1, span)])
+        v2 = _make_view(valid_shape=[sym2], stride=[_make_const(1, span)])
+        assert v1 != v2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `operator==`/`operator!=` to `TileView`, comparing all 7 fields (`valid_shape`, `stride`, `start_offset`, `blayout`, `slayout`, `fractal`, `pad`)
- Extract `AreExprsEqual`/`AreExprVectorsEqual` into `expr.h`/`expr.cpp` as reusable helpers (ConstInt by value, non-ConstInt by pointer identity)
- Refactor `AreTileTypesCompatible` in `BasicMemoryReuse` pass to delegate TileView comparison to the new `operator==`, fixing a bug where `stride` and `start_offset` fields were silently skipped
- Add Python bindings (`__eq__`/`__ne__`) and type stubs for `TileView`
- Update EN and ZH-CN documentation for the memory reuse pass

## Testing

- [x] 12 new tests in `test_tile_view_equality.py` covering all fields, default views, symbolic exprs
- [x] All 26 existing `test_basic_memory_reuse.py` tests pass
- [x] Full suite: 2491 passed
- [x] clang-tidy clean on new lines
- [x] All pre-commit hooks pass

## Related Issues

Fixes #551