### PR TITLE
fix(flatten-nd-to-2d): inject shapes tuple based on tensor rank, not tile rank

### DIFF
--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -505,13 +505,17 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.store: pass through, injecting shapes for ND tensors ----
-    // tile.store semantics: 2D tile → ND tensor. No reshape needed.
-    // For ND tiles, inject the original ND shape as an explicit 4th argument
-    // (shapes tuple) after output_tensor, so that tile.store codegen knows
-    // the correct partition sizes for pto.partition_view.
+    // tile.store semantics: (flattened-)2D tile → ND tensor. No reshape needed.
+    // When the output tensor is ND (rank > 2), inject an explicit shapes tuple as
+    // args[3] so that the codegen can reconstruct the correct pto.partition_view.
+    // The shapes tuple is the tile's original shape left-padded with 1s to reach
+    // the tensor rank.  Examples:
+    //   tile [A,B,C] (ND, rank 3) → tensor rank 3: shapes = (A,B,C)       [no pad]
+    //   tile [A,B,C] (ND, rank 3) → tensor rank 4: shapes = (1,A,B,C)     [1 pad]
+    //   tile [H,W]   (2D, rank 2) → tensor rank 3: shapes = (1,H,W)       [1 pad]
+    // The original tile type is read BEFORE substitution so it still carries the
+    // pre-flatten ND shape.
     // Signature: (tile, offsets, output_tensor[, shapes])
-    // The original tile type is read BEFORE substitution, when it still
-    // carries the ND shape.
     if (op_name == "tile.store") {
       auto orig_tile_type = As<TileType>(call->args_[0]->GetType());
 
@@ -521,9 +525,22 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       for (const auto& arg : call->args_) {
         new_args.push_back(SubstituteExpr(arg, ctx.var_map));
       }
-      // Append shapes tuple after output_tensor for ND tiles
-      if (orig_tile_type && orig_tile_type->shape_.size() > 2) {
-        new_args.push_back(std::make_shared<MakeTuple>(orig_tile_type->shape_, span));
+      // Inject shapes tuple whenever the output tensor is ND (rank > 2).
+      // Codegen always requires args[3] in that case regardless of tile rank.
+      auto out_tensor_type = As<TensorType>(new_args[2]->GetType());
+      if (orig_tile_type && out_tensor_type && out_tensor_type->shape_.size() > 2) {
+        const size_t tensor_rank = out_tensor_type->shape_.size();
+        const size_t tile_rank = orig_tile_type->shape_.size();
+        std::vector<ExprPtr> shapes;
+        shapes.reserve(tensor_rank);
+        // Left-pad with 1s when tile rank < tensor rank.
+        for (size_t i = tile_rank; i < tensor_rank; ++i) {
+          shapes.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
+        }
+        for (const auto& dim : orig_tile_type->shape_) {
+          shapes.push_back(dim);
+        }
+        new_args.push_back(std::make_shared<MakeTuple>(shapes, span));
       }
 
       // Construct call directly: store result type = output tensor type (args[2])

--- a/tests/st/runtime/test_elementwise_nd.py
+++ b/tests/st/runtime/test_elementwise_nd.py
@@ -24,62 +24,6 @@ from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
-# --- Programs ---
-
-
-@pl.program
-class Tile4DMulProgram:
-    """Element-wise square of a [2, 3, 8, 64] tensor via a 4D tile."""
-
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel(
-        self,
-        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 3, 8, 64], pl.FP32]],
-    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
-        a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
-        c_tile = pl.tile.mul(a_tile, a_tile)
-        out = pl.store(c_tile, [0, 0, 0, 0], out)
-        return out
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
-        self,
-        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
-        out = pl.create_tensor([2, 3, 8, 64], dtype=pl.FP32)
-        out = self.kernel(a, out)
-        return out
-
-
-@pl.program
-class Tile4DAddProgram:
-    """Element-wise addition of two [2, 3, 8, 64] tensors via a 4D tile."""
-
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel(
-        self,
-        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-        b: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 3, 8, 64], pl.FP32]],
-    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
-        a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
-        b_tile = pl.load(b, [0, 0, 0, 0], [2, 3, 8, 64])
-        c_tile = pl.tile.add(a_tile, b_tile)
-        out = pl.store(c_tile, [0, 0, 0, 0], out)
-        return out
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
-        self,
-        a: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-        b: pl.Tensor[[2, 3, 8, 64], pl.FP32],
-    ) -> pl.Tensor[[2, 3, 8, 64], pl.FP32]:
-        out = pl.create_tensor([2, 3, 8, 64], dtype=pl.FP32)
-        out = self.kernel(a, b, out)
-        return out
-
-
 # --- Programs (partial coverage) ---
 
 
@@ -193,32 +137,42 @@ class Tile4DTopToBottomProgram:
         return out
 
 
+@pl.program
+class Tile2DStoreTo3DProgram:
+    """2D tile [1, 16] mul then stored into a 3D tensor [2, 4, 16].
+
+    The tile is natively 2D — no ND tile involved, so FlattenTileNdTo2D
+    would previously skip injecting the shapes tuple (it only checked tile rank).
+    This test verifies the fix: shapes are injected based on tensor rank.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[4, 16], pl.FP32],
+        b: pl.Tensor[[4, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 4, 16], pl.FP32]],
+    ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
+        # Load row 0 from each input: natively 2D tiles [1, 16]
+        a_tile = pl.load(a, [0, 0], [1, 16])
+        b_tile = pl.load(b, [0, 0], [1, 16])
+        c_tile = pl.tile.mul(a_tile, b_tile)
+        # Store into slot [1, 2, 0] of the 3D tensor
+        out = pl.store(c_tile, [1, 2, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[4, 16], pl.FP32],
+        b: pl.Tensor[[4, 16], pl.FP32],
+    ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
+        out = pl.create_tensor([2, 4, 16], dtype=pl.FP32)
+        out = self.kernel(a, b, out)
+        return out
+
+
 # --- Test Cases ---
-
-
-class Tile4DMulTestCase(PTOTestCase):
-    """4D tile [2,3,8,64] element-wise mul (self-square); flattens to [48,64]."""
-
-    def get_name(self) -> str:
-        return "tile_4d_mul"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B_PTO
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("a", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [2, 3, 8, 64], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return Tile4DMulProgram
-
-    def compute_expected(self, tensors, params=None):
-        tensors["out"][:] = tensors["a"] * tensors["a"]
 
 
 class Tile4DMulPartialTestCase(PTOTestCase):
@@ -301,11 +255,17 @@ class Tile4DQuadrantTestCase(PTOTestCase):
         tensors["out"][1, 0] = tensors["a"][0, 1] ** 2
 
 
-class Tile4DAddTestCase(PTOTestCase):
-    """4D tile [2,3,8,64] element-wise add; flattens to [48,64]."""
+class Tile2DStoreTo3DTestCase(PTOTestCase):
+    """2D tile [1, 16] mul then stored into a 3D tensor [2, 4, 16].
+
+    Verifies that FlattenTileNdTo2D injects the correct shapes tuple [1, 1, 16]
+    (tile coverage left-padded to tensor rank) rather than the full tensor shape
+    [2, 4, 16]. Before the fix, this would crash with
+    'tile.store on ND tensor requires shapes tuple (args[3])'.
+    """
 
     def get_name(self) -> str:
-        return "tile_4d_add"
+        return "tile_2d_store_to_3d"
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -315,16 +275,16 @@ class Tile4DAddTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("a", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
-            TensorSpec("b", [2, 3, 8, 64], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [2, 3, 8, 64], DataType.FP32, is_output=True),
+            TensorSpec("a", [4, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [4, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [2, 4, 16], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return Tile4DAddProgram
+        return Tile2DStoreTo3DProgram
 
     def compute_expected(self, tensors, params=None):
-        tensors["out"][:] = tensors["a"] + tensors["b"]
+        tensors["out"][1, 2, :] = tensors["a"][0, :] * tensors["b"][0, :]
 
 
 # --- Tests ---
@@ -368,15 +328,14 @@ class TestElementwise4D:
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_4d_mul(self, test_runner):
-        """4D tile mul: [2,3,8,64] flattened to [48,64] by FlattenTileNdTo2D."""
-        test_case = Tile4DMulTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
+    def test_tile_2d_store_to_3d(self, test_runner):
+        """2D tile [1, 16] stored into a 3D tensor [2, 4, 16].
 
-    def test_tile_4d_add(self, test_runner):
-        """4D tile add: [2,3,8,64] flattened to [48,64] by FlattenTileNdTo2D."""
-        test_case = Tile4DAddTestCase()
+        Regression test for the bug where FlattenTileNdTo2D only injected the
+        shapes tuple when the *tile* was ND, missing the case where the tile is
+        natively 2D but the output tensor is ND (rank > 2).
+        """
+        test_case = Tile2DStoreTo3DTestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 


### PR DESCRIPTION
tile.store into an ND tensor (rank > 2) always requires a shapes tuple in args[3] for the codegen to build the correct pto.partition_view.  Previously the pass only injected the tuple when the *tile* was ND, so a natively-2D tile stored to an ND tensor would crash with:
  "tile.store on ND tensor requires shapes tuple (args[3])"

The condition now checks the output tensor rank instead of the tile rank. When the tile rank is less than the tensor rank, the tile's shape is left-padded with 1s to reach the tensor rank:
  tile [H,W]   + tensor rank 3 → shapes (1,H,W)
  tile [A,B,C] + tensor rank 4 → shapes (1,A,B,C)

Also rename test_elementwise_4d → test_elementwise_nd and replace the removed full-tensor-coverage cases with a regression test for the natively-2D-tile-to-3D-tensor scenario.