### PR TITLE
fix(ir): use original tensor shape in ResolveTransposeLayout pass

### DIFF
--- a/src/ir/transforms/resolve_transpose_layout_pass.cpp
+++ b/src/ir/transforms/resolve_transpose_layout_pass.cpp
@@ -41,7 +41,6 @@ namespace {
 
 struct TransposeParamInfo {
   size_t param_index;
-  std::vector<ExprPtr> new_shape;
 };
 
 /**
@@ -71,15 +70,7 @@ class TransposeLoadScanner : public IRVisitor {
             size_t param_idx = it->second;
             if (visited_params_.count(param_idx) == 0) {
               visited_params_.insert(param_idx);
-
-              // args_[2] is the shapes tuple (MakeTuple)
-              CHECK(call->args_.size() >= 3) << "tile.load must have at least 3 positional args";
-              auto shapes_tuple = As<MakeTuple>(call->args_[2]);
-              CHECK(shapes_tuple) << "tile.load shapes arg must be a MakeTuple";
-              CHECK(shapes_tuple->elements_.size() == 2)
-                  << "transpose=true only supports 2D shapes, got " << shapes_tuple->elements_.size();
-
-              results_.push_back({param_idx, shapes_tuple->elements_});
+              results_.push_back({param_idx});
             }
           }
         }
@@ -151,9 +142,12 @@ IncoreTransformResult TransformIncoreParams(const FunctionPtr& func) {
       continue;
     }
 
-    auto new_tensor_type =
-        std::make_shared<TensorType>(info.new_shape, old_tensor_type->dtype_, old_tensor_type->memref_,
-                                     std::optional<TensorView>(TensorView({}, TensorLayout::DN)));
+    CHECK(old_tensor_type->shape_.size() == 2) << "transpose layout resolution only supports 2D tensors, got "
+                                               << old_tensor_type->shape_.size() << "D";
+
+    auto new_tensor_type = std::make_shared<TensorType>(
+        std::vector<ExprPtr>{old_tensor_type->shape_[1], old_tensor_type->shape_[0]}, old_tensor_type->dtype_,
+        old_tensor_type->memref_, std::optional<TensorView>(TensorView({}, TensorLayout::DN)));
 
     auto new_var = std::make_shared<Var>(old_param->name_hint_, new_tensor_type, old_param->span_);
     new_params[info.param_index] = new_var;

--- a/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
@@ -554,5 +554,78 @@ class TestResolveTransposeLayoutMixed:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestResolveTransposeLayoutPartialLoad:
+    """Test cases where tile.load reads a subset of the tensor (partial load)."""
+
+    def test_partial_load_square_tensor(self):
+        """Tensor [128, 128] with partial tile.load [128, 64] transpose -> shape stays [128, 128] + DN.
+
+        Regression test for #606: paged attention key_cache tensor shape was incorrectly
+        changed from [128, 128] to [128, 64] because the pass used the tile load shape
+        instead of transposing the original tensor shape.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_k = pl.load(
+                    key_cache, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_a_l0 = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_k_l0 = pl.move(tile_k, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0, tile_k_l0)
+                out = pl.store(tile_c, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                out: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                out = self.kernel(a, key_cache, out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16, pl.DN],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_k = pl.load(
+                    key_cache, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_a_l0 = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_k_l0 = pl.move(tile_k, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0, tile_k_l0)
+                out = pl.store(tile_c, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16, pl.DN],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                out: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                out = self.kernel(a, key_cache, out)
+                return out
+
+        After = passes.resolve_transpose_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fix `ResolveTransposeLayout` pass incorrectly using tile.load shape as the new tensor parameter shape. The pass now transposes the original tensor shape instead, which correctly handles partial tile loads (e.g., paged attention where tensor is `[128, 128]` but tile.load reads `[128, 64]`).

## Changes

- **`src/ir/transforms/resolve_transpose_layout_pass.cpp`**: Remove tile load shape extraction from scanner; transpose original tensor shape instead of using tile load shape; add 2D shape CHECK
- **`tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py`**: Add regression test for partial tile.load scenario (square tensor with smaller load)

## Testing

- [x] All 12 ResolveTransposeLayout tests pass (including new regression test)
- [x] Full UT suite passes (2488/2488)
- [x] Code review completed
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

Fixes #606