### PR TITLE
fix(lint): resolve clang-tidy header-not-found errors in temp builds

### DIFF
--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -423,7 +423,7 @@ def _get_system_include_paths() -> list[str]:
 
     try:
         result = subprocess.run(
-            [compiler, "-E", "-x", "c++", "-v", "/dev/null"],
+            [compiler, "-E", "-x", "c++", "-v", os.devnull],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
## Summary
- Fix clang-tidy failing with `'algorithm' file not found` (and other standard headers) when running without `-B build`
- Detect the full GCC compiler name (e.g. `aarch64-openEuler-linux-g++`) via `c++ -dumpmachine` and pass it as `CMAKE_CXX_COMPILER` so clang-tidy can locate the GCC installation
- Query the compiler's built-in system include paths and append them as `-isystem` flags for header linting (which bypasses `compile_commands.json`)
- Run a full lint check (bypassing diff filter) when `clang_tidy.py` itself is among the changed files

## Root Cause
Two issues caused clang-tidy to fail in temp build directories:

1. **Source files**: CMake defaulted to `/usr/bin/c++` as the compiler. clang-tidy needs the target triple in the compiler name (e.g. `*-g++`) to locate GCC's system headers. With just `c++`, it couldn't find `<algorithm>`, `<cstdint>`, etc.

2. **Header files**: Headers are linted without `compile_commands.json` (flags passed via `--` instead). The extracted flags didn't include the compiler's implicit system include paths, so standard headers were missing.

## Testing
- [x] `python tests/lint/clang_tidy.py` (temp dir) — passes clean
- [x] `python tests/lint/clang_tidy.py -B build` (persistent dir) — passes clean
- [x] Pre-commit hooks pass (ruff, pyright, etc.)