### PR TITLE
fix(ir): Preserve tile dtype in scalar tile ops instead of promoting

### DIFF
--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -132,14 +132,12 @@ TypePtr DeduceTileOpScalarBinaryType(const std::vector<ExprPtr>& args,
   CHECK(scalar_type) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
                      << args[1]->GetType()->TypeName();
 
-  // Result has same shape as tile, with promoted dtype
-  auto result_dtype = PromoteDataTypes(tile_type->dtype_, scalar_type->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                      << tile_type->dtype_.ToString() << " and " << scalar_type->dtype_.ToString();
-
+  // Result preserves the tile's element type. The hardware scalar instructions
+  // (e.g. pto.tmuls) require src and dst to share the same element type; the
+  // scalar operand is implicitly narrowed to match the tile dtype at runtime.
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type);
-  return std::make_shared<TileType>(tile_type->shape_, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
 TypePtr DeduceTileOpIntScalarBinaryType(const std::vector<ExprPtr>& args,

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -123,6 +123,33 @@ class TestTileElementwiseOps:
         ir_str = str(Program)
         assert "tile.muls" in ir_str
 
+    def test_tile_muls_preserves_tile_dtype(self):
+        """tile.muls result must keep the tile's element dtype, not promote to the scalar's dtype.
+
+        pto.tmuls requires src and dst to share the same element type, so multiplying a BF16
+        tile by an FP32 scalar must produce a BF16 result (the scalar is narrowed at runtime).
+        """
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.BF16],
+                output: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[128, 128], pl.BF16]:
+                tile_a: pl.Tile[[32, 32], pl.BF16] = pl.load(a, [0, 0], [32, 32])
+                # Scalar 0.0 is typed FP32 by default; result must still be BF16.
+                tile_c: pl.Tile[[32, 32], pl.BF16] = pl.mul(tile_a, 0.0)
+                result: pl.Tensor[[128, 128], pl.BF16] = pl.store(tile_c, [0, 0], output)
+                return result
+
+        ir_str = str(Program)
+        assert "tile.muls" in ir_str
+        # Confirm the result tile carries BF16 (pl.BF16 in the Python printer),
+        # not a promoted FP32.  The hardware narrowing happens at runtime.
+        assert "tile_c: pl.Tile[[32, 32], pl.BF16" in ir_str
+
     def test_tile_cmp(self):
         """Test tile.cmp operator - element-wise comparison of two tiles."""
 


### PR DESCRIPTION
DeduceTileOpScalarBinaryType was calling PromoteDataTypes(tile_dtype, scalar_dtype), which could widen the result to the scalar's type (e.g. BF16 tile × FP32 scalar → FP32 result tile). The hardware scalar instructions (pto.tmuls, pto.tadds, etc.) require src and dst to share the same element type, so this promotion caused ptoas to reject the generated assembly.

Fix: return the tile's own dtype as the result type unconditionally. The scalar operand is implicitly narrowed to the tile element type at runtime, matching the semantics already followed by DeduceTileOpIntScalarBinaryType for integer scalar ops.

Add test_tile_muls_preserves_tile_dtype to verify that BF16 tile × FP32 scalar yields a BF16 result in the IR.