### PR TITLE
feat(ir): fix ForStmt loop-carry MemRef handling in InitMemRef and BasicMemoryReuse

### DIFF
--- a/docs/en/dev/passes/12-init_memref.md
+++ b/docs/en/dev/passes/12-init_memref.md
@@ -93,6 +93,24 @@ Key observations:
 - `tile.store` result shares MemRef with the output tensor parameter
 - Alloc statements are placed at the beginning of the first OpStmts
 
+## ForStmt Loop-Carry Variables
+
+ForStmt has four loop-carry related variables with specific MemRef sharing rules:
+
+| Role | Description | MemRef Source |
+| ---- | ----------- | ------------- |
+| initValue | Initial value before first iteration | From producing operation |
+| iter_arg | Loop body variable | Inherited from initValue |
+| yield value | Produced at end of each iteration | From producing operation (independent) |
+| return_var | Captures final yield value after loop | Inherited from yield value |
+
+**Sharing groups**:
+
+- Group A: initValue + iter_arg (same MemRef)
+- Group B: yield value + return_var (same MemRef)
+
+Group A and B may have different MemRefs. The yield-to-iter_arg mismatch is resolved later by BasicMemoryReuse (which inserts `tile.move` if needed).
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`
@@ -122,3 +140,4 @@ passes.def("init_mem_ref", &pass::InitMemRef, "Initialize MemRef for variables")
 - Tests tile.alloc statements are created for non-DDR MemRefs
 - Tests normalized SeqStmts/OpStmts structure
 - Tests tile.store result shares MemRef with output param
+- Tests ForStmt loop-carry MemRef relationships (initValue/iter_arg sharing, yield/return_var sharing)

--- a/docs/en/dev/passes/13-basic_memory_reuse.md
+++ b/docs/en/dev/passes/13-basic_memory_reuse.md
@@ -44,7 +44,8 @@ program_optimized = reuse_pass(program)
 2. **Lifetime Analysis**: Compute def-use chains and live ranges for each variable
 3. **Interference Check**: Identify variables with overlapping lifetimes
 4. **MemRef Sharing**: Assign same MemRef pointer to non-interfering variables in the same memory space
-5. **Remove redundant allocs**: Collect all MemRefs still referenced by TileType variables, then remove `tile.alloc` statements whose MemRef is no longer in use
+5. **ForStmt yield fixup**: Ensure all 4 loop-carry variables (initValue, iter_arg, yield value, return_var) share the same MemRef. InitMemRef guarantees initValue==iter_arg and yield==return_var. This step ensures iter_arg==yield by inserting `tile.move` before yield if their MemRefs differ, then patches all 4 variables to use the same MemRef (initValue's)
+6. **Remove redundant allocs**: Collect all MemRefs still referenced by TileType variables, then remove `tile.alloc` statements whose MemRef is no longer in use
 
 **Reuse conditions**:
 
@@ -136,6 +137,7 @@ Pass BasicMemoryReuse();
 - `ComputeLifetimesFromDependencies` calculates live ranges
 - `IdentifyReuseOpportunities` finds reuse candidates
 - `ApplyMemRefSharing` updates MemRef pointers via `MemRefSharingMutator`
+- `ForStmtYieldFixupMutator` inserts `tile.move` when yield/iter_arg MemRefs diverge after reuse
 - `UsedMemRefCollector` gathers still-referenced MemRef pointers after sharing
 - `RemoveUnusedAllocStatements` filters out redundant `tile.alloc` statements from OpStmts
 

--- a/docs/zh-cn/dev/passes/12-init_memref.md
+++ b/docs/zh-cn/dev/passes/12-init_memref.md
@@ -93,6 +93,24 @@ def main(
 - `tile.store` 结果与输出张量参数共享 MemRef
 - Alloc 语句放置在第一个 OpStmts 的开头
 
+## ForStmt 循环携带变量
+
+ForStmt 有四个循环携带相关变量，遵循特定的 MemRef 共享规则：
+
+| 角色 | 描述 | MemRef 来源 |
+| ---- | ---- | ----------- |
+| initValue | 首次迭代前的初始值 | 来自产生该值的操作 |
+| iter_arg | 循环体内变量 | 继承自 initValue |
+| yield value | 每次迭代结束时产出的值 | 来自产生该值的操作（独立分配） |
+| return_var | 循环结束后接收最终 yield 值 | 继承自 yield value |
+
+**共享组**：
+
+- 组 A：initValue + iter_arg（共享同一 MemRef）
+- 组 B：yield value + return_var（共享同一 MemRef）
+
+组 A 和组 B 可能有不同的 MemRef。yield 与 iter_arg 之间的 MemRef 不一致由后续的 BasicMemoryReuse 解决（必要时插入 `tile.move`）。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`
@@ -122,3 +140,4 @@ passes.def("init_mem_ref", &pass::InitMemRef, "Initialize MemRef for variables")
 - 测试为非 DDR MemRef 创建 tile.alloc 语句
 - 测试规范化的 SeqStmts/OpStmts 结构
 - 测试 tile.store 结果与输出参数共享 MemRef
+- 测试 ForStmt 循环携带变量的 MemRef 关系（initValue/iter_arg 共享，yield/return_var 共享）

--- a/docs/zh-cn/dev/passes/13-basic_memory_reuse.md
+++ b/docs/zh-cn/dev/passes/13-basic_memory_reuse.md
@@ -44,7 +44,8 @@ program_optimized = reuse_pass(program)
 2. **生命周期分析**：计算每个变量的 def-use 链和活跃区间
 3. **干涉检查**：识别生命周期重叠的变量
 4. **MemRef 共享**：为同一内存空间中不干涉的变量分配相同的 MemRef 指针
-5. **移除冗余 alloc**：收集仍被 TileType 变量引用的所有 MemRef，然后移除不再使用的 `tile.alloc` 语句
+5. **ForStmt yield 修复**：确保 4 个循环携带变量（initValue、iter_arg、yield value、return_var）共享同一个 MemRef。InitMemRef 已保证 initValue==iter_arg 且 yield==return_var。此步骤确保 iter_arg==yield：若两者 MemRef 不同则在 yield 前插入 `tile.move`，然后将 4 个变量统一到同一个 MemRef（initValue 的）
+6. **移除冗余 alloc**：收集仍被 TileType 变量引用的所有 MemRef，然后移除不再使用的 `tile.alloc` 语句
 
 **复用条件**：
 
@@ -121,6 +122,7 @@ Pass BasicMemoryReuse();
 - `ComputeLifetimesFromDependencies` 计算活跃区间
 - `IdentifyReuseOpportunities` 查找复用候选
 - `ApplyMemRefSharing` 通过 `MemRefSharingMutator` 更新 MemRef 指针
+- `ForStmtYieldFixupMutator` 在复用后 yield/iter_arg MemRef 不一致时插入 `tile.move`
 - `UsedMemRefCollector` 收集共享后仍被引用的 MemRef 指针
 - `RemoveUnusedAllocStatements` 从 OpStmts 中过滤掉冗余的 `tile.alloc` 语句
 

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -18,10 +18,30 @@
 #include <set>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/type.h"
 
 namespace pypto::ir {
+
+/// Find the YieldStmt inside a statement body (searches through SeqStmts/OpStmts).
+inline YieldStmtPtr FindYieldStmt(const StmtPtr& body) {
+  if (auto yield = As<YieldStmt>(body)) return yield;
+  if (auto seq = As<SeqStmts>(body)) {
+    for (const auto& child : seq->stmts_) {
+      auto result = FindYieldStmt(child);
+      if (result) return result;
+    }
+  }
+  if (auto ops = As<OpStmts>(body)) {
+    for (const auto& child : ops->stmts_) {
+      auto result = FindYieldStmt(child);
+      if (result) return result;
+    }
+  }
+  return nullptr;
+}
 
 inline std::optional<MemRefPtr> GetTypeMemRef(const TypePtr& type) {
   if (auto shaped_type = std::dynamic_pointer_cast<const ShapedType>(type)) {

--- a/src/ir/transforms/basic_memory_reuse_pass.cpp
+++ b/src/ir/transforms/basic_memory_reuse_pass.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <algorithm>
+#include <any>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
@@ -18,6 +19,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/logging.h"
@@ -644,6 +646,181 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
   return mutator.VisitStmt(stmt);
 }
 
+/**
+ * @brief Fix ForStmt yield/iter_arg MemRef mismatch after MemoryReuse.
+ *
+ * MemoryReuse may assign different MemRefs to iter_arg and yield value.
+ * Since yield value becomes the next iteration's iter_arg, they must use the
+ * same buffer. When they differ, insert a tile.move before yield to copy the
+ * yield value into the iter_arg's MemRef, and update return_var accordingly.
+ */
+class ForStmtYieldFixupMutator : public IRMutator {
+ public:
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    // First recurse into nested ForStmts
+    auto result = IRMutator::VisitStmt_(op);
+    auto for_stmt = As<ForStmt>(result);
+    if (!for_stmt || for_stmt->iter_args_.empty()) return result;
+
+    auto yield_stmt = FindYieldStmt(for_stmt->body_);
+    if (!yield_stmt) return result;
+
+    // Check each (iter_arg, yield_value) pair for MemRef mismatch.
+    // Use initValue's MemRef as the target because codegen maps iter_arg to initValue's buffer,
+    // and MemoryReuse may have updated initValue's MemRef without updating iter_arg's.
+    std::vector<std::pair<size_t, VarPtr>> moves_to_insert;  // (index, new_moved_var)
+    std::vector<StmtPtr> move_stmts;
+    for (size_t i = 0; i < yield_stmt->value_.size() && i < for_stmt->iter_args_.size(); ++i) {
+      auto yield_var = As<Var>(yield_stmt->value_[i]);
+      if (!yield_var) continue;
+
+      auto yield_tile = GetTileTypeWithMemRef(yield_var->GetType());
+      if (!yield_tile) continue;
+      auto yield_memref = GetDefinedMemRef(yield_tile);
+
+      // Get the initValue's MemRef (the actual buffer used at runtime)
+      auto init_var = As<Var>(for_stmt->iter_args_[i]->initValue_);
+      if (!init_var) continue;
+      auto init_tile = GetTileTypeWithMemRef(init_var->GetType());
+      if (!init_tile) continue;
+      auto init_memref = GetDefinedMemRef(init_tile);
+
+      if (yield_memref.get() == init_memref.get()) continue;
+
+      // MemRef mismatch — create tile.move to copy yield value into initValue's buffer
+      auto target_memory = init_tile->GetMemorySpace();
+      INTERNAL_CHECK(target_memory.has_value())
+          << "Internal error: initValue TileType must have memory_space";
+
+      auto& op_reg = OpRegistry::GetInstance();
+      std::vector<std::pair<std::string, std::any>> kwargs = {
+          {"target_memory", std::any(target_memory.value())}};
+      auto move_call = op_reg.Create("tile.move", {yield_var}, kwargs, yield_var->span_);
+
+      // Create moved var with initValue's MemRef
+      auto moved_type = CloneTypeWithMemRef(yield_var->GetType(), init_memref, target_memory);
+      auto moved_var = std::make_shared<Var>(yield_var->name_hint_ + "_mv", moved_type, yield_var->span_);
+
+      move_stmts.emplace_back(std::make_shared<AssignStmt>(moved_var, move_call, yield_var->span_));
+      moves_to_insert.emplace_back(i, moved_var);
+    }
+
+    if (moves_to_insert.empty()) {
+      // Even without tile.move insertion, iter_arg and return_var may have stale MemRefs
+      // (MemoryReuse updates initValue/yield but not iter_arg/return_var types).
+      // Ensure all 4 loop-carry variables share the same MemRef (= initValue's).
+      return PatchIterArgsAndReturnVars(for_stmt, yield_stmt);
+    }
+
+    // Build new yield values with moved vars substituted
+    std::vector<ExprPtr> new_yield_values = yield_stmt->value_;
+    for (const auto& [idx, moved_var] : moves_to_insert) {
+      new_yield_values[idx] = moved_var;
+    }
+    auto new_yield = std::make_shared<YieldStmt>(new_yield_values, yield_stmt->span_);
+
+    // Insert tile.move stmts before yield and replace yield in body
+    auto new_body = InsertMovesAndReplaceYield(for_stmt->body_, new_yield, move_stmts);
+
+    // Build intermediate ForStmt with new body, then patch iter_args/return_vars
+    auto intermediate_for = std::make_shared<ForStmt>(
+        for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
+        new_body, for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
+        for_stmt->chunk_policy_, for_stmt->loop_origin_);
+
+    return PatchIterArgsAndReturnVars(intermediate_for, new_yield);
+  }
+
+ private:
+  // Patch iter_args and return_vars to share initValue's MemRef.
+  // Returns the original ForStmt if no patching is needed.
+  StmtPtr PatchIterArgsAndReturnVars(const ForStmtPtr& for_stmt, const YieldStmtPtr& yield_stmt) {
+    bool changed = false;
+    std::vector<IterArgPtr> new_iter_args = for_stmt->iter_args_;
+    std::vector<VarPtr> new_return_vars = for_stmt->return_vars_;
+
+    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+      auto init_var = As<Var>(for_stmt->iter_args_[i]->initValue_);
+      if (!init_var) continue;
+      auto init_tile = GetTileTypeWithMemRef(init_var->GetType());
+      if (!init_tile) continue;
+      auto init_memref = GetDefinedMemRef(init_tile);
+
+      // Patch iter_arg if its MemRef differs from initValue's
+      auto ia_tile = As<TileType>(for_stmt->iter_args_[i]->GetType());
+      if (ia_tile && ia_tile->memref_.has_value()) {
+        auto ia_memref = GetDefinedMemRef(ia_tile);
+        if (ia_memref.get() != init_memref.get()) {
+          auto new_ia_type = CloneTypeWithMemRef(ia_tile, init_memref, init_tile->GetMemorySpace());
+          new_iter_args[i] =
+              std::make_shared<IterArg>(for_stmt->iter_args_[i]->name_hint_, new_ia_type,
+                                        for_stmt->iter_args_[i]->initValue_, for_stmt->iter_args_[i]->span_);
+          var_remap_[for_stmt->iter_args_[i].get()] = new_iter_args[i];
+          changed = true;
+        }
+      }
+
+      // Patch return_var to share yield value's MemRef (which should == initValue's after fixup)
+      if (i >= new_return_vars.size() || !yield_stmt || i >= yield_stmt->value_.size()) continue;
+      auto yield_var = As<Var>(yield_stmt->value_[i]);
+      if (!yield_var) continue;
+      auto yield_tile = GetTileTypeWithMemRef(yield_var->GetType());
+      if (!yield_tile) continue;
+      auto yield_memref = GetDefinedMemRef(yield_tile);
+      auto rv_tile = As<TileType>(new_return_vars[i]->GetType());
+      if (!rv_tile || !rv_tile->memref_.has_value()) continue;
+      auto rv_memref = GetDefinedMemRef(rv_tile);
+      if (rv_memref.get() != yield_memref.get()) {
+        auto new_rv_type = CloneTypeWithMemRef(rv_tile, yield_memref, yield_tile->GetMemorySpace());
+        new_return_vars[i] =
+            std::make_shared<Var>(new_return_vars[i]->name_hint_, new_rv_type, new_return_vars[i]->span_);
+        // Register old→new so downstream references (e.g., ReturnStmt) are updated
+        var_remap_[for_stmt->return_vars_[i].get()] = new_return_vars[i];
+        changed = true;
+      }
+    }
+
+    if (!changed) return for_stmt;
+
+    return std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
+                                     new_iter_args, for_stmt->body_, std::move(new_return_vars),
+                                     for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
+                                     for_stmt->chunk_policy_, for_stmt->loop_origin_);
+  }
+
+  // Replace YieldStmt in body and insert move AssignStmts before it.
+  // Body structure is typically SeqStmts([OpStmts([...assigns...]), YieldStmt]).
+  // Move stmts go into the OpStmts (they are AssignStmts), yield is replaced at SeqStmts level.
+  static StmtPtr InsertMovesAndReplaceYield(const StmtPtr& body, const YieldStmtPtr& new_yield,
+                                            const std::vector<StmtPtr>& move_stmts) {
+    if (As<YieldStmt>(body)) {
+      // Body is just a yield — wrap moves + yield in SeqStmts
+      std::vector<StmtPtr> stmts;
+      if (!move_stmts.empty()) {
+        stmts.push_back(std::make_shared<OpStmts>(move_stmts, body->span_));
+      }
+      stmts.push_back(new_yield);
+      return std::make_shared<SeqStmts>(stmts, body->span_);
+    }
+    if (auto seq = As<SeqStmts>(body)) {
+      std::vector<StmtPtr> new_children;
+      for (const auto& child : seq->stmts_) {
+        if (As<YieldStmt>(child)) {
+          // Insert move stmts as OpStmts before the new yield
+          if (!move_stmts.empty()) {
+            new_children.push_back(std::make_shared<OpStmts>(move_stmts, child->span_));
+          }
+          new_children.push_back(new_yield);
+        } else {
+          new_children.push_back(child);
+        }
+      }
+      return std::make_shared<SeqStmts>(new_children, body->span_);
+    }
+    return body;
+  }
+};
+
 // Collect all MemRef raw pointers currently referenced by TileType variables
 class UsedMemRefCollector : public IRVisitor {
  public:
@@ -738,14 +915,17 @@ FunctionPtr TransformBasicMemoryReuse(const FunctionPtr& func) {
   // Step 3: Identify reuse opportunities
   auto reuse_map = IdentifyReuseOpportunities(analysis_result.lifetimes);
 
-  if (reuse_map.empty()) {
-    return func;
+  // Step 4: Apply MemRef sharing (skip if no reuse candidates)
+  StmtPtr new_body = func->body_;
+  if (!reuse_map.empty()) {
+    new_body = ApplyMemRefSharing(func->body_, reuse_map, analysis_result.var_sharing_groups);
   }
 
-  // Step 4: Apply MemRef sharing
-  StmtPtr new_body = ApplyMemRefSharing(func->body_, reuse_map, analysis_result.var_sharing_groups);
+  // Step 5: Fix ForStmt yield/iter_arg MemRef mismatches by inserting tile.move
+  ForStmtYieldFixupMutator yield_fixup;
+  new_body = yield_fixup.VisitStmt(new_body);
 
-  // Step 5: Remove alloc statements for MemRefs no longer in use
+  // Step 6: Remove alloc statements for MemRefs no longer in use
   UsedMemRefCollector used_collector;
   used_collector.VisitStmt(new_body);
   new_body = RemoveUnusedAllocStatements(new_body, used_collector.GetUsedPtrs());

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -20,6 +20,7 @@
 
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -77,24 +78,6 @@ bool IsViewOperation(const std::string& op_name) {
   if (!spec_opt.has_value() || !spec_opt->deduce_output_memory) return false;
 
   return !spec_opt->deduce_output_memory({}).has_value();
-}
-
-// Helper to find the YieldStmt inside a statement body (searches through SeqStmts/OpStmts)
-YieldStmtPtr FindYieldStmt(const StmtPtr& body) {
-  if (auto yield = As<YieldStmt>(body)) return yield;
-  if (auto seq = As<SeqStmts>(body)) {
-    for (const auto& child : seq->stmts_) {
-      auto result = FindYieldStmt(child);
-      if (result) return result;
-    }
-  }
-  if (auto ops = As<OpStmts>(body)) {
-    for (const auto& child : ops->stmts_) {
-      auto result = FindYieldStmt(child);
-      if (result) return result;
-    }
-  }
-  return nullptr;
 }
 
 // Visitor to identify memory space for each variable
@@ -406,33 +389,89 @@ class InitMemRefMutator : public IRMutator {
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    // Let the default mutator process iter_args, body, and return_vars
-    auto result = IRMutator::VisitStmt_(op);
-    auto new_for = As<ForStmt>(result);
-    if (!new_for || new_for->iter_args_.empty() || new_for->return_vars_.empty()) {
-      return result;
+    // Manual traversal of ForStmt fields to ensure correct MemRef assignment:
+    // - iter_args inherit MemRef from initValue (via ProcessIterArg)
+    // - return_vars share MemRef with corresponding yield values
+
+    // Step 1: Visit loop bounds and loop_var
+    auto new_loop_var_expr = VisitExpr(op->loop_var_);
+    auto new_loop_var = As<Var>(new_loop_var_expr);
+    INTERNAL_CHECK(new_loop_var) << "Internal error: ForStmt loop_var is not a Var after mutation";
+    auto new_start = VisitExpr(op->start_);
+    auto new_stop = VisitExpr(op->stop_);
+    auto new_step = VisitExpr(op->step_);
+
+    // Step 2: Process iter_args (inherits MemRef from initValue via ProcessIterArg)
+    std::vector<IterArgPtr> new_iter_args;
+    new_iter_args.reserve(op->iter_args_.size());
+    for (const auto& ia : op->iter_args_) {
+      auto new_ia_expr = VisitExpr(ia);
+      auto new_ia =
+          std::dynamic_pointer_cast<const IterArg>(std::static_pointer_cast<const IRNode>(new_ia_expr));
+      INTERNAL_CHECK(new_ia) << "Internal error: ForStmt iter_arg is not an IterArg after mutation";
+      new_iter_args.push_back(new_ia);
     }
 
-    // Make each return_var share the same MemRef as the corresponding iter_arg
-    // (MLIR scf.for requires result types to match iter_arg types)
+    // Register old->new IterArg mappings so body references are substituted
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      if (new_iter_args[i].get() != op->iter_args_[i].get()) {
+        var_remap_[op->iter_args_[i].get()] = new_iter_args[i];
+      }
+    }
+
+    // Step 3: Visit body
+    auto new_body = VisitStmt(op->body_);
+
+    // Clean up IterArg remappings
+    for (const auto& old_iter_arg : op->iter_args_) {
+      var_remap_.erase(old_iter_arg.get());
+    }
+
+    // Step 4: Visit return_vars
+    std::vector<VarPtr> new_return_vars;
+    new_return_vars.reserve(op->return_vars_.size());
+    for (const auto& rv : op->return_vars_) {
+      auto new_rv_expr = VisitExpr(rv);
+      auto new_rv = As<Var>(new_rv_expr);
+      INTERNAL_CHECK(new_rv) << "Internal error: ForStmt return_var is not a Var after mutation";
+      new_return_vars.push_back(new_rv);
+    }
+
+    // Visit chunk_size if present
+    std::optional<ExprPtr> new_chunk_size = op->chunk_size_;
+    if (op->chunk_size_.has_value()) {
+      new_chunk_size = VisitExpr(*op->chunk_size_);
+    }
+
+    auto new_for = std::make_shared<ForStmt>(new_loop_var, new_start, new_stop, new_step, new_iter_args,
+                                             new_body, new_return_vars, op->span_, op->kind_, new_chunk_size,
+                                             op->chunk_policy_, op->loop_origin_);
+
+    // Step 5: Patch return_vars to share yield value MemRefs.
+    // return_var receives the last yield value, so they must share the same MemRef.
+    auto yield_stmt = FindYieldStmt(new_body);
+    if (!yield_stmt || new_for->iter_args_.empty() || new_for->return_vars_.empty()) {
+      return new_for;
+    }
+
     bool changed = false;
     std::vector<VarPtr> patched_return_vars;
     patched_return_vars.reserve(new_for->return_vars_.size());
 
     for (size_t i = 0; i < new_for->return_vars_.size(); ++i) {
-      if (i >= new_for->iter_args_.size()) {
+      if (i >= yield_stmt->value_.size()) {
         patched_return_vars.push_back(new_for->return_vars_[i]);
         continue;
       }
 
       auto rv_tile = As<TileType>(new_for->return_vars_[i]->GetType());
-      auto ia_tile = As<TileType>(new_for->iter_args_[i]->GetType());
-      if (rv_tile && ia_tile && ia_tile->memref_.has_value()) {
-        auto new_type = CloneTypeWithMemRef(new_for->return_vars_[i]->GetType(), ia_tile->memref_,
-                                            ia_tile->GetMemorySpace());
+      auto yield_var = As<Var>(yield_stmt->value_[i]);
+      auto yield_tile = yield_var ? As<TileType>(yield_var->GetType()) : nullptr;
+      if (rv_tile && yield_tile && yield_tile->memref_.has_value()) {
+        auto new_type = CloneTypeWithMemRef(new_for->return_vars_[i]->GetType(), yield_tile->memref_,
+                                            yield_tile->GetMemorySpace());
         auto new_rv = std::make_shared<Var>(new_for->return_vars_[i]->name_hint_, new_type,
                                             new_for->return_vars_[i]->span_);
-        // Update the cache so downstream references use the patched var
         var_map_[op->return_vars_[i]] = new_rv;
         patched_return_vars.push_back(new_rv);
         changed = true;
@@ -441,7 +480,7 @@ class InitMemRefMutator : public IRMutator {
       }
     }
 
-    if (!changed) return result;
+    if (!changed) return new_for;
 
     return std::make_shared<ForStmt>(new_for->loop_var_, new_for->start_, new_for->stop_, new_for->step_,
                                      new_for->iter_args_, new_for->body_, std::move(patched_return_vars),

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -400,8 +400,27 @@ def test_init_memref_untracked_tile_defaults_to_ddr():
     assert cast(ir.ConstInt, external_tile_type.memref.addr_).value == -1
 
 
-def test_init_memref_for_return_var_inherits_iter_arg_memory_space():
-    """Regression: ForStmt return vars must override stale DDR with iter_arg memory space."""
+def _find_yield_stmt(stmt):
+    """Recursively find YieldStmt in a statement tree."""
+    if isinstance(stmt, ir.YieldStmt):
+        return stmt
+    if isinstance(stmt, (ir.SeqStmts, ir.OpStmts)):
+        for child in stmt.stmts:
+            result = _find_yield_stmt(child)
+            if result:
+                return result
+    return None
+
+
+def test_init_memref_for_stmt_loop_carry_memref_relationships():
+    """ForStmt loop-carry variables have two MemRef sharing groups after InitMemRef.
+
+    Group A: initValue + iter_arg (iter_arg inherits from initValue)
+    Group B: yield value + return_var (return_var inherits from yield value)
+
+    Group A and B may have different MemRefs — the yield-to-iter_arg mismatch
+    is resolved later by MemoryReuse (which inserts tile.move if needed).
+    """
     span = ir.Span.unknown()
 
     input_tensor = ir.Var("input_tensor", ir.TensorType([64, 64], ir.DataType.FP32), span)
@@ -412,11 +431,18 @@ def test_init_memref_for_return_var_inherits_iter_arg_memory_space():
         init_tile, ir.Call(ir.Op("tile.load"), [input_tensor, _ci(0), _ci(0), _ci(64), _ci(64)], span), span
     )
 
+    other_tile = ir.Var(
+        "other_tile", ir.TileType([64, 64], ir.DataType.FP32, memory_space=MemorySpace.Vec), span
+    )
+    other_stmt = ir.AssignStmt(
+        other_tile, ir.Call(ir.Op("tile.load"), [input_tensor, _ci(0), _ci(0), _ci(64), _ci(64)], span), span
+    )
+
     iter_arg = ir.IterArg("acc_iter", ir.TileType([64, 64], ir.DataType.FP32), init_tile, span)
     next_tile = ir.Var(
         "acc_next", ir.TileType([64, 64], ir.DataType.FP32, memory_space=MemorySpace.Vec), span
     )
-    next_stmt = ir.AssignStmt(next_tile, ir.Call(ir.Op("tile.add"), [iter_arg, init_tile], span), span)
+    next_stmt = ir.AssignStmt(next_tile, ir.Call(ir.Op("tile.add"), [iter_arg, other_tile], span), span)
     return_var = ir.Var("acc_out", ir.TileType([64, 64], ir.DataType.FP32), span)
 
     loop_body = ir.SeqStmts([ir.OpStmts([next_stmt], span), ir.YieldStmt([next_tile], span)], span)
@@ -430,7 +456,9 @@ def test_init_memref_for_return_var_inherits_iter_arg_memory_space():
         [return_var],
         span,
     )
-    body = ir.SeqStmts([ir.OpStmts([init_stmt], span), loop_stmt, ir.ReturnStmt([return_var], span)], span)
+    body = ir.SeqStmts(
+        [ir.OpStmts([init_stmt, other_stmt], span), loop_stmt, ir.ReturnStmt([return_var], span)], span
+    )
     func = ir.Function(
         "test_func",
         [(input_tensor, ir.ParamDirection.In)],
@@ -443,18 +471,46 @@ def test_init_memref_for_return_var_inherits_iter_arg_memory_space():
     after = passes.init_mem_ref()(program)
     result_func = list(after.functions.values())[0]
 
-    assert isinstance(result_func.body, ir.SeqStmts)
     loop_after = cast(
-        ir.ForStmt, next(stmt for stmt in result_func.body.stmts if isinstance(stmt, ir.ForStmt))
+        ir.ForStmt,
+        next(stmt for stmt in cast(ir.SeqStmts, result_func.body).stmts if isinstance(stmt, ir.ForStmt)),
     )
     loop_iter_arg = loop_after.iter_args[0]
     loop_return_var = loop_after.return_vars[0]
+    yield_stmt = _find_yield_stmt(loop_after.body)
+    assert yield_stmt is not None
+    yield_var = yield_stmt.value[0]
 
-    assert isinstance(loop_iter_arg.type, ir.TileType)
-    assert isinstance(loop_return_var.type, ir.TileType)
-    assert loop_iter_arg.type.memory_space == MemorySpace.Vec
-    assert loop_return_var.type.memory_space == MemorySpace.Vec
-    assert loop_iter_arg.type.shares_memref_with(loop_return_var.type)
+    # Find initValue after transformation (iter_arg.init_value)
+    init_value = loop_iter_arg.initValue
+    assert isinstance(init_value, ir.Var)
+
+    # All 4 variables must have TileType with MemRef in Vec space
+    for name, var_type in [
+        ("initValue", init_value.type),
+        ("iter_arg", loop_iter_arg.type),
+        ("yield_value", yield_var.type),
+        ("return_var", loop_return_var.type),
+    ]:
+        assert isinstance(var_type, ir.TileType), f"{name} should be TileType"
+        assert var_type.memref is not None, f"{name} should have MemRef"
+        assert var_type.memory_space == MemorySpace.Vec, f"{name} should be Vec"
+
+    # Group A: initValue and iter_arg share the same MemRef
+    init_tile = cast(ir.TileType, init_value.type)
+    iter_arg_tile = cast(ir.TileType, loop_iter_arg.type)
+    yield_tile = cast(ir.TileType, yield_var.type)
+    return_var_tile = cast(ir.TileType, loop_return_var.type)
+
+    assert init_tile.shares_memref_with(iter_arg_tile), "initValue and iter_arg must share MemRef"
+
+    # Group B: yield value and return_var share the same MemRef
+    assert yield_tile.shares_memref_with(return_var_tile), "yield value and return_var must share MemRef"
+
+    # Group A and B have different MemRefs (yield gets independent MemRef from tile.add)
+    assert not yield_tile.shares_memref_with(iter_arg_tile), (
+        "yield value should get its own MemRef from tile.add, not share with iter_arg"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix ForStmt loop-carry variable MemRef assignment in InitMemRef and BasicMemoryReuse passes.

### InitMemRef changes
- Refactored `VisitStmt_(ForStmtPtr)` to manually traverse ForStmt fields, ensuring correct MemRef inheritance order:
  - **Group A**: `initValue` + `iter_arg` share the same MemRef (iter_arg inherits from initValue)
  - **Group B**: `yield value` + `return_var` share the same MemRef (return_var inherits from yield value)
- Previously, return_var incorrectly inherited from iter_arg instead of yield value

### BasicMemoryReuse changes
- Added `ForStmtYieldFixupMutator` (Step 4.5) to reconcile Group A and Group B after memory reuse:
  - When yield and iter_arg MemRefs diverge, inserts `tile.move` before yield to copy into initValue's buffer
  - Patches all 4 loop-carry variables to use the same MemRef (initValue's)

### Shared utilities
- Extracted `FindYieldStmt` from both passes into `memref_utils.h` to eliminate duplication

## Testing
- [x] All 735 transform tests pass
- [x] All 6 init_memref tests pass (including new `test_init_memref_for_stmt_loop_carry_memref_relationships`)
- [x] All 30 basic_memory_reuse tests pass
- [x] Code review completed
- [x] clang-tidy clean
- [x] pyright clean
- [x] Documentation updated (EN + ZH-CN)

## Files Changed
- `include/pypto/ir/transforms/utils/memref_utils.h` — Added shared `FindYieldStmt`
- `src/ir/transforms/init_memref.cpp` — Refactored ForStmt MemRef assignment
- `src/ir/transforms/basic_memory_reuse_pass.cpp` — Added `ForStmtYieldFixupMutator`
- `tests/ut/ir/transforms/test_init_memref.py` — Updated test for two-group MemRef model
- `docs/en/dev/passes/12-init_memref.md` — Added ForStmt loop-carry section
- `docs/en/dev/passes/13-basic_memory_reuse.md` — Added yield fixup step
- `docs/zh-cn/dev/passes/12-init_memref.md` — Chinese translation
- `docs/zh-cn/dev/passes/13-basic_memory_reuse.md` — Chinese translation