### PR TITLE
fix(codegen): remove unsafe name-based extra_tile_buf_types_ fallback in GetExprTypeAnnotation

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1010,14 +1010,6 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
         return extra_it->second;
       }
     }
-    // Compatibility fallback for passes that rebuild equivalent Vars by name.
-    auto name_mlir_it = var_name_to_mlir_.find(var->name_hint_);
-    if (name_mlir_it != var_name_to_mlir_.end()) {
-      auto extra_it = extra_tile_buf_types_.find(name_mlir_it->second);
-      if (extra_it != extra_tile_buf_types_.end()) {
-        return extra_it->second;
-      }
-    }
     // Check if this variable maps to a tile buffer via memref
     auto memref_it = var_to_memref_.find(key);
     if (memref_it != var_to_memref_.end()) {


### PR DESCRIPTION
## Summary

Remove the `var_name_to_mlir_` → `extra_tile_buf_types_` name-based fallback in `GetExprTypeAnnotation`, which produced incorrect type annotations when multiple variables shared the same `name_hint_`.

## Bug Analysis

After the auto-naming refactor (#619), the `ConvertToSSA` pass generates variables with a `base__qualifier_vN` naming scheme. When a program has both a `tile.reshape` result and a `tile.row_expand_mul` result derived from the same source variable, they can both receive `name_hint_ = "t__tile"` despite having completely different shapes (`[1, 64]` vs `[64, 64]`).

The lookup chain in `GetExprTypeAnnotation` was:

1. `var_to_mlir_[ptr]` → `extra_tile_buf_types_[mlir_name]` (pointer-based, correct)
2. **`var_name_to_mlir_[name_hint_]` → `extra_tile_buf_types_[mlir_name]` (name-based, BUGGY)**
3. `var_to_memref_[ptr]` → `GetTileBufTypeString(memref)` (pointer-based, correct)
4. `var_name_to_memref_[name_hint_]` → `GetTileBufTypeString(memref)` (name-based, safe — MemRef carries its own shape)

When the `row_expand_mul` result `t__tile` (shape `[64, 64]`) was looked up:
- Step 1 missed (different Var pointer, not in `var_to_mlir_`)
- Step 2 hit: `var_name_to_mlir_["t__tile"]` returned `%reshape_buf`, and `extra_tile_buf_types_["%reshape_buf"]` returned the reshape output type `[1, 64]`

This caused `tcolexpandmul` to be emitted with a `[1, 64]` type annotation for its `[64, 64]` input, which ptoas rejected as a type mismatch.

The fix removes step 2. The remaining fallback paths (steps 3 and 4) are sufficient and correct — they resolve through MemRef which carries its own shape information.

## Testing

- All 2577 unit tests pass
- `examples/rms_norm.py --sim` passes (previously failed with type mismatch)
- `examples/softmax.py --sim` passes