### PR TITLE
feat(ir): implement VarUseVisitor and enhance IRPythonPrinter for MemRef handling

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -753,6 +753,272 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
   return result;
 }
 
+class VarUseVisitor : public IRVisitor {
+ public:
+  explicit VarUseVisitor(const Var* target) : target_(target) {}
+
+  [[nodiscard]] bool Found() const { return found_; }
+  void CheckExpr(const ExprPtr& expr) { VisitExpr(expr); }
+  void CheckStmt(const StmtPtr& stmt) { VisitStmt(stmt); }
+
+ protected:
+  void VisitExpr(const ExprPtr& expr) override {
+    if (found_ || !expr) return;
+    IRVisitor::VisitExpr(expr);
+  }
+
+  void VisitStmt(const StmtPtr& stmt) override {
+    if (found_ || !stmt) return;
+    IRVisitor::VisitStmt(stmt);
+  }
+
+  void VisitVarLike_(const VarPtr& op) override {
+    if (op.get() == target_) {
+      found_ = true;
+      return;
+    }
+  }
+
+  void VisitExpr_(const IterArgPtr& op) override { VisitVarLike_(op); }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (!op) return;
+    VisitExpr(op->value_);
+  }
+
+  void VisitStmt_(const EvalStmtPtr& op) override {
+    if (!op) return;
+    VisitExpr(op->expr_);
+  }
+
+  void VisitStmt_(const YieldStmtPtr& op) override {
+    if (!op) return;
+    for (const auto& value : op->value_) {
+      VisitExpr(value);
+      if (found_) return;
+    }
+  }
+
+  void VisitStmt_(const ReturnStmtPtr& op) override {
+    if (!op) return;
+    for (const auto& value : op->value_) {
+      VisitExpr(value);
+      if (found_) return;
+    }
+  }
+
+  void VisitStmt_(const SeqStmtsPtr& op) override {
+    if (!op) return;
+    for (const auto& stmt : op->stmts_) {
+      VisitStmt(stmt);
+      if (found_) return;
+    }
+  }
+
+  void VisitStmt_(const OpStmtsPtr& op) override {
+    if (!op) return;
+    for (const auto& stmt : op->stmts_) {
+      VisitStmt(stmt);
+      if (found_) return;
+    }
+  }
+
+  void VisitStmt_(const ScopeStmtPtr& op) override {
+    if (!op) return;
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    if (!op) return;
+    VisitExpr(op->condition_);
+    if (found_) return;
+    VisitStmt(op->then_body_);
+    if (found_ || !op->else_body_.has_value()) return;
+    VisitStmt(*op->else_body_);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (!op) return;
+    VisitExpr(op->start_);
+    if (found_) return;
+    VisitExpr(op->stop_);
+    if (found_) return;
+    VisitExpr(op->step_);
+    if (found_) return;
+    if (op->chunk_size_.has_value()) {
+      VisitExpr(*op->chunk_size_);
+      if (found_) return;
+    }
+    for (const auto& iter_arg : op->iter_args_) {
+      VisitExpr(iter_arg->initValue_);
+      if (found_) return;
+    }
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    if (!op) return;
+    VisitExpr(op->condition_);
+    if (found_) return;
+    for (const auto& iter_arg : op->iter_args_) {
+      VisitExpr(iter_arg->initValue_);
+      if (found_) return;
+    }
+    VisitStmt(op->body_);
+  }
+
+ private:
+  const Var* target_;
+  bool found_ = false;
+};
+
+bool ExprUsesVar(const ExprPtr& expr, const Var* target) {
+  if (!expr || !target) return false;
+  VarUseVisitor visitor(target);
+  visitor.CheckExpr(expr);
+  return visitor.Found();
+}
+
+bool StmtUsesVar(const StmtPtr& stmt, const Var* target) {
+  if (!stmt || !target) return false;
+  VarUseVisitor visitor(target);
+  visitor.CheckStmt(stmt);
+  return visitor.Found();
+}
+
+struct ReturnedAssembleLoopRewrite {
+  size_t stmt_index;
+  std::optional<size_t> dead_init_stmt_index;
+  ForStmtPtr new_for_stmt;
+  VarPtr new_return_var;
+};
+
+std::optional<ReturnedAssembleLoopRewrite> RewriteReturnedAssembleLoopToStore(
+    const std::vector<StmtPtr>& stmts, const ExprPtr& ret_expr, const VarPtr& out_param,
+    const TensorTypePtr& out_tensor_type, const OpRegistry& op_registry) {
+  auto ret_var = As<Var>(ret_expr);
+  if (!ret_var) return std::nullopt;
+
+  for (size_t stmt_index = 0; stmt_index < stmts.size(); ++stmt_index) {
+    auto for_stmt = As<ForStmt>(stmts[stmt_index]);
+    if (!for_stmt || for_stmt->iter_args_.size() != 1 || for_stmt->return_vars_.size() != 1 ||
+        for_stmt->return_vars_[0].get() != ret_var.get()) {
+      continue;
+    }
+
+    const auto& old_iter_arg = for_stmt->iter_args_[0];
+    auto body_stmts = FlattenToStmts(for_stmt->body_);
+
+    AssignStmtPtr assemble_assign;
+    YieldStmtPtr yield_stmt;
+    for (const auto& body_stmt : body_stmts) {
+      auto assign = As<AssignStmt>(body_stmt);
+      if (assign) {
+        auto call = As<Call>(assign->value_);
+        bool is_target_assemble = false;
+        if (call && call->op_->name_ == "tile.assemble" && call->args_.size() == 3) {
+          if (auto iter = As<IterArg>(call->args_[0])) {
+            is_target_assemble = iter.get() == old_iter_arg.get();
+          } else if (auto var = As<Var>(call->args_[0])) {
+            is_target_assemble = var.get() == old_iter_arg.get();
+          }
+        }
+        if (is_target_assemble) {
+          if (assemble_assign) return std::nullopt;
+          auto assemble_call = As<Call>(assign->value_);
+          CHECK(assemble_call) << "Internal error: expected tile.assemble call in assemble loop rewrite";
+          if (ExprUsesVar(assemble_call->args_[1], old_iter_arg.get()) ||
+              ExprUsesVar(assemble_call->args_[2], old_iter_arg.get())) {
+            return std::nullopt;
+          }
+          assemble_assign = assign;
+          continue;
+        }
+      }
+
+      if (auto yield = As<YieldStmt>(body_stmt)) {
+        if (yield->value_.size() != 1 || yield_stmt) return std::nullopt;
+        yield_stmt = yield;
+        continue;
+      }
+
+      if (StmtUsesVar(body_stmt, old_iter_arg.get())) {
+        return std::nullopt;
+      }
+    }
+
+    if (!assemble_assign || !yield_stmt) return std::nullopt;
+
+    auto yielded_var = As<Var>(yield_stmt->value_[0]);
+    if (!yielded_var || yielded_var.get() != assemble_assign->var_.get()) {
+      return std::nullopt;
+    }
+
+    auto assemble_call = As<Call>(assemble_assign->value_);
+    CHECK(assemble_call) << "Internal error: expected tile.assemble call in assemble loop rewrite";
+
+    auto new_iter_arg =
+        std::make_shared<IterArg>(old_iter_arg->name_hint_, out_tensor_type, out_param, old_iter_arg->span_);
+    auto store_call = op_registry.Create(
+        "tile.store", {assemble_call->args_[1], assemble_call->args_[2], new_iter_arg}, assemble_call->span_);
+    auto store_var = std::make_shared<Var>(assemble_assign->var_->name_hint_, store_call->GetType(),
+                                           assemble_assign->var_->span_);
+
+    std::vector<StmtPtr> new_body_stmts;
+    new_body_stmts.reserve(body_stmts.size());
+    for (const auto& body_stmt : body_stmts) {
+      if (body_stmt == assemble_assign) {
+        new_body_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, assemble_assign->span_));
+        continue;
+      }
+      if (body_stmt == yield_stmt) {
+        new_body_stmts.push_back(
+            std::make_shared<YieldStmt>(std::vector<ExprPtr>{store_var}, yield_stmt->span_));
+        continue;
+      }
+      new_body_stmts.push_back(body_stmt);
+    }
+
+    auto new_return_var = std::make_shared<Var>(for_stmt->return_vars_[0]->name_hint_, out_tensor_type,
+                                                for_stmt->return_vars_[0]->span_);
+    auto new_for_stmt = std::make_shared<ForStmt>(
+        for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
+        std::vector<IterArgPtr>{new_iter_arg}, WrapInSeqStmts(new_body_stmts, for_stmt->body_->span_),
+        std::vector<VarPtr>{new_return_var}, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
+        for_stmt->chunk_policy_, for_stmt->loop_origin_);
+
+    std::optional<size_t> dead_init_stmt_index;
+    if (auto init_var = As<Var>(old_iter_arg->initValue_)) {
+      bool has_other_uses = false;
+      for (size_t other_index = 0; other_index < stmts.size(); ++other_index) {
+        const StmtPtr& stmt_to_check = other_index == stmt_index ? new_for_stmt : stmts[other_index];
+        if (StmtUsesVar(stmt_to_check, init_var.get())) {
+          has_other_uses = true;
+          break;
+        }
+      }
+      if (!has_other_uses) {
+        for (size_t other_index = 0; other_index < stmts.size(); ++other_index) {
+          auto init_assign = As<AssignStmt>(stmts[other_index]);
+          if (init_assign && init_assign->var_.get() == init_var.get()) {
+            dead_init_stmt_index = other_index;
+            break;
+          }
+        }
+      }
+    }
+
+    return ReturnedAssembleLoopRewrite{
+        stmt_index,
+        dead_init_stmt_index,
+        new_for_stmt,
+        new_return_var,
+    };
+  }
+
+  return std::nullopt;
+}
+
 /**
  * @brief Transform an InCore function: insert loads, convert ops, insert stores
  *
@@ -853,6 +1119,19 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
         auto out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
         new_params.push_back(out_param);
         new_param_directions.push_back(ParamDirection::Out);
+
+        if (auto loop_rewrite = RewriteReturnedAssembleLoopToStore(new_stmts, ret_expr, out_param,
+                                                                   orig_tensor_type, op_registry)) {
+          new_stmts[loop_rewrite->stmt_index] = loop_rewrite->new_for_stmt;
+          if (loop_rewrite->dead_init_stmt_index.has_value()) {
+            new_stmts.erase(new_stmts.begin() +
+                            static_cast<std::ptrdiff_t>(*loop_rewrite->dead_init_stmt_index));
+          }
+          new_return_types.push_back(orig_tensor_type);
+          new_return_exprs.push_back(loop_rewrite->new_return_var);
+          ++num_added_outputs;
+          continue;
+        }
 
         // Insert tile.store(tile, zeros, out_param)
         auto offsets = MakeZeroOffsets(tile_type->shape_.size(), span);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -73,6 +73,43 @@ std::string CastModeToString(int mode) {
   }
 }
 
+template <typename DefNode>
+void BuildRenameMapForDefs(const std::vector<const DefNode*>& defs,
+                           std::unordered_map<const DefNode*, std::string>& rename_map,
+                           bool include_unique_names = false) {
+  rename_map.clear();
+
+  std::vector<const DefNode*> unique_defs;
+  unique_defs.reserve(defs.size());
+  std::unordered_set<const DefNode*> seen_defs;
+  for (const DefNode* def : defs) {
+    if (seen_defs.insert(def).second) unique_defs.push_back(def);
+  }
+
+  std::unordered_map<std::string, int> name_counts;
+  for (const DefNode* def : unique_defs) {
+    name_counts[def->name_hint_]++;
+  }
+
+  std::set<std::string> used_names;
+  for (const DefNode* def : unique_defs) {
+    const std::string& base_name = def->name_hint_;
+    if (name_counts[base_name] == 1) {
+      used_names.insert(base_name);
+      if (include_unique_names) rename_map[def] = base_name;
+      continue;
+    }
+
+    std::string candidate = base_name;
+    int suffix = 0;
+    while (!used_names.insert(candidate).second) {
+      ++suffix;
+      candidate = base_name + "_" + std::to_string(suffix);
+    }
+    rename_map[def] = candidate;
+  }
+}
+
 }  // namespace
 
 // Precedence mapping for each expression type
@@ -244,6 +281,11 @@ class IRPythonPrinter : public IRVisitor {
   // Built by BuildVarRenameMap() at the start of each function to handle SSA name shadowing.
   std::unordered_map<const Var*, std::string> var_rename_map_;
 
+  // Per-function MemRef name map: MemRef pointer → printed alloc name.
+  // Built from tile.alloc definition sites so tile/tensor annotations can refer
+  // to the same named buffers instead of re-printing inline pl.MemRef(...).
+  std::unordered_map<const MemRef*, std::string> memref_rename_map_;
+
   // Helper methods
   std::string GetIndent() const;
   void IncreaseIndent();
@@ -252,9 +294,17 @@ class IRPythonPrinter : public IRVisitor {
   // Return the printed name for a Var, using rename map if SSA name shadowing occurred.
   std::string GetVarName(const Var* var) const;
 
+  // Return the printed name for a MemRef when it is defined in the current
+  // function (for example by tile.alloc). Falls back to the original hint.
+  std::string GetMemRefName(const MemRef* memref) const;
+
   // Build var_rename_map_ for a function by scanning all Var def-sites in DFS pre-order.
   // Assigns unique suffixed names (e.g., "i", "i_1") when two distinct Vars share a name.
   void BuildVarRenameMap(const FunctionPtr& func);
+
+  // Build memref_rename_map_ for a function from MemRef definition sites
+  // (currently tile.alloc assignments).
+  void BuildMemRefRenameMap(const FunctionPtr& func);
 
   // Print a statement block at current indent level.
   // SeqStmts/OpStmts are transparent containers - recursed into without extra indent.
@@ -423,7 +473,7 @@ void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << GetVarName(op.ge
 
 void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << op->name_hint_; }
 
-void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << op->name_hint_; }
+void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << GetMemRefName(op.get()); }
 
 void IRPythonPrinter::VisitExpr_(const ConstIntPtr& op) {
   // DEFAULT_CONST_INT (= INT64) and INDEX both represent 64-bit integer constants
@@ -1120,64 +1170,55 @@ static void CollectVarDefsInOrder(const StmtPtr& stmt, std::vector<const Var*>& 
   }
 }
 
+// Collect MemRef definition sites in DFS pre-order for alloc name reuse.
+static void CollectMemRefDefsInOrder(const StmtPtr& stmt, std::vector<const MemRef*>& out) {
+  if (!stmt) return;
+  if (auto assign = As<AssignStmt>(stmt)) {
+    if (auto memref = As<MemRef>(assign->var_)) out.push_back(memref.get());
+  } else if (auto for_stmt = As<ForStmt>(stmt)) {
+    CollectMemRefDefsInOrder(for_stmt->body_, out);
+  } else if (auto if_stmt = As<IfStmt>(stmt)) {
+    CollectMemRefDefsInOrder(if_stmt->then_body_, out);
+    if (if_stmt->else_body_.has_value()) CollectMemRefDefsInOrder(*if_stmt->else_body_, out);
+  } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+    CollectMemRefDefsInOrder(while_stmt->body_, out);
+  } else if (auto seq = As<SeqStmts>(stmt)) {
+    for (auto& s : seq->stmts_) CollectMemRefDefsInOrder(s, out);
+  } else if (auto ops = As<OpStmts>(stmt)) {
+    for (auto& s : ops->stmts_) CollectMemRefDefsInOrder(s, out);
+  } else if (auto scope = As<ScopeStmt>(stmt)) {
+    CollectMemRefDefsInOrder(scope->body_, out);
+  }
+}
+
 std::string IRPythonPrinter::GetVarName(const Var* var) const {
   auto it = var_rename_map_.find(var);
   if (it != var_rename_map_.end()) return it->second;
   return var->name_hint_;
 }
 
-void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
-  var_rename_map_.clear();
+std::string IRPythonPrinter::GetMemRefName(const MemRef* memref) const {
+  auto it = memref_rename_map_.find(memref);
+  if (it != memref_rename_map_.end()) return it->second;
+  return memref->name_hint_;
+}
 
+void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
   // Collect all Var def-sites in DFS pre-order: params first, then body.
   std::vector<const Var*> defs;
   for (auto& p : func->params_) defs.push_back(p.get());
   if (func->body_) CollectVarDefsInOrder(func->body_, defs);
+  BuildRenameMapForDefs(defs, var_rename_map_);
+}
 
-  // Deduplicate by pointer (same Var object may appear as both param and assign target).
-  {
-    std::unordered_set<const Var*> seen;
-    std::vector<const Var*> unique_defs;
-    for (const Var* v : defs) {
-      if (seen.insert(v).second) unique_defs.push_back(v);
-    }
-    defs = std::move(unique_defs);
-  }
-
-  // Count occurrences of each name across distinct Var objects.
-  std::unordered_map<std::string, int> name_counts;
-  for (const Var* v : defs) name_counts[v->name_hint_]++;
-
-  // Assign printed names: unique names keep their original; duplicate names get suffixes.
-  std::set<std::string> used_names;
-  for (const Var* v : defs) {
-    if (name_counts[v->name_hint_] == 1) {
-      // No conflict — no rename map entry needed (GetVarName falls back to name_).
-      used_names.insert(v->name_hint_);
-    }
-  }
-  for (const Var* v : defs) {
-    if (name_counts[v->name_hint_] == 1) continue;  // Already handled above.
-    std::string candidate = v->name_hint_;
-    if (used_names.find(candidate) == used_names.end()) {
-      used_names.insert(candidate);
-      var_rename_map_[v] = candidate;
-    } else {
-      int suffix = 1;
-      while (true) {
-        candidate = v->name_hint_ + "_" + std::to_string(suffix);
-        if (used_names.find(candidate) == used_names.end()) {
-          used_names.insert(candidate);
-          var_rename_map_[v] = candidate;
-          break;
-        }
-        suffix++;
-      }
-    }
-  }
+void IRPythonPrinter::BuildMemRefRenameMap(const FunctionPtr& func) {
+  std::vector<const MemRef*> defs;
+  if (func->body_) CollectMemRefDefsInOrder(func->body_, defs);
+  BuildRenameMapForDefs(defs, memref_rename_map_, true);
 }
 
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
+  BuildMemRefRenameMap(func);
   // Build rename map for this function to handle SSA name shadowing.
   BuildVarRenameMap(func);
 
@@ -1499,6 +1540,9 @@ void IRPythonPrinter::PrintShapeDims(std::ostringstream& oss, const std::vector<
 
 // Helper methods for MemRef and TileView printing
 std::string IRPythonPrinter::PrintMemRef(const MemRef& memref) {
+  auto it = memref_rename_map_.find(&memref);
+  if (it != memref_rename_map_.end()) return it->second;
+
   std::ostringstream oss;
   oss << prefix_ << ".MemRef(";
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -687,6 +687,133 @@ class TestConvertTensorToTileOps:
         assert "tile.assemble" in ir_str
         assert "tile.cast" in ir_str
 
+    def test_returned_assemble_loop_rewrites_to_store_inside_loop(self):
+        """Returned chunk-assembly loops should store to the Out tensor inside the loop.
+
+        Regression test: when a returned tensor is built by a loop-carried
+        `pl.assemble`, ConvertTensorToTileOps should rewrite that loop to carry
+        the synthetic Out tensor and emit `pl.store` inside the loop body,
+        instead of materializing a full local tile and only storing once after
+        the loop.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[1, 32], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                buf: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor([1, 64], dtype=pl.FP32)
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk: pl.Tensor[[1, 32], pl.FP32] = pl.slice(x, [1, 32], [0, 0])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.assemble(acc, chunk, [0, off])
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, x: pl.Tensor[[1, 32], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(out_0,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(x, [0, 0], [1, 32])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.store(chunk_tile, [0, off], acc)
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, x: pl.Tensor[[1, 32], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                out_0: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor([1, 64], dtype=pl.FP32)
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_returned_assemble_loop_keeps_live_init_assignment(self):
+        """Keep the init assignment when the rewritten loop body still references it."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                buf: pl.Tensor[[1, 64], pl.FP32] = x
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk: pl.Tensor[[1, 32], pl.FP32] = pl.slice(buf, [1, 32], [0, off])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.assemble(acc, chunk, [0, off])
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, x: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_src = After.as_python()
+
+        assert "buf: pl.Tensor[[1, 64], pl.FP32] = x" in after_src
+        assert "init_values=(buf,)" in after_src
+        assert "pl.tile.store(" in after_src
+
+    def test_returned_assemble_loop_treats_chunk_expr_as_iter_arg_use(self):
+        """Chunk expressions must count as loop-carried uses during rewrite checks."""
+
+        span = ir.Span.unknown()
+        idx_type = ir.ScalarType(DataType.INDEX)
+        small_tensor_type = ir.TensorType([1, 32], DataType.FP32)
+        large_tensor_type = ir.TensorType([1, 64], DataType.FP32)
+
+        x = ir.Var("x", small_tensor_type, span)
+        buf_init = ir.Var("buf_init", large_tensor_type, span)
+        loop_var = ir.Var("i", idx_type, span)
+        iter_arg = ir.IterArg("acc", large_tensor_type, buf_init, span)
+        yielded_var = ir.Var("acc_next", large_tensor_type, span)
+        return_var = ir.Var("result", large_tensor_type, span)
+        inner_loop_var = ir.Var("j", idx_type, span)
+
+        inner_loop = ir.ForStmt(
+            inner_loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [],
+            ir.OpStmts([], span),
+            [],
+            span,
+            chunk_size=iter_arg,
+        )
+        assemble_stmt = ir.AssignStmt(yielded_var, ir.op.tensor.assemble(iter_arg, x, [0, 0]), span)
+        outer_loop = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(2, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [iter_arg],
+            ir.SeqStmts([inner_loop, assemble_stmt, ir.YieldStmt([yielded_var], span)], span),
+            [return_var],
+            span,
+        )
+        func = ir.Function(
+            "main_incore_0",
+            [x, buf_init],
+            [large_tensor_type],
+            ir.SeqStmts([outer_loop, ir.ReturnStmt([return_var], span)], span),
+            span,
+            ir.FunctionType.InCore,
+        )
+        with pytest.raises(ValueError, match="tensor\\.assemble"):
+            passes.convert_tensor_to_tile_ops()(ir.Program([func], "ChunkUseProg", span))
+
     def test_no_spurious_loads_for_explicit_tile_ops(self):
         """Regression test for #334: no redundant Vec loads when params are consumed by tile ops only.
 

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -200,6 +200,29 @@ class TestPythonPrinterProgram:
         except SyntaxError as e:
             pytest.fail(f"Printed code has invalid Python syntax: {e}")
 
+    def test_print_alloc_memref_names_in_tile_annotations(self):
+        """Use tile.alloc names in tile annotations when printing function bodies."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                x: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Tensor[[64, 64], pl.FP32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(x, [0, 0], [64, 64])
+                tile_b: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(tile_a, tile_a)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(tile_b, [0, 0], out)
+                return result
+
+        after = passes.allocate_memory_addr()(passes.init_mem_ref()(Before))
+        code = after.as_python()
+
+        assert "pl.MemRefType = pl.tile.alloc(" in code
+        assert "pl.Tile[[64, 64], pl.FP32, mem_vec_" in code
+        assert "pl.Tile[[64, 64], pl.FP32, pl.MemRef(" not in code
+
 
 class TestPythonPrinterConstDtypeRoundtrip:
     """Tests for round-trip of constants with non-default dtypes."""


### PR DESCRIPTION
- Introduced `VarUseVisitor` class to facilitate checking variable usage within expressions and statements, improving the ability to analyze IR constructs.
- Enhanced `IRPythonPrinter` to manage MemRef names more effectively, allowing for consistent naming in tile annotations and preventing redundant inline printing.
- Added methods to build and utilize a MemRef rename map, ensuring that printed code reflects the correct allocation names.
- Implemented tests to verify the correctness of returned assembly loop rewrites and MemRef name handling in printed output.