### PR TITLE
feat(ir): implement alias tracking for buffer access in IR transformations

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -350,39 +350,110 @@ std::optional<size_t> GetWriteOnlyArgIndex(const std::string& op_name) {
   return std::nullopt;
 }
 
-class AliasReferenceVisitor : public IRVisitor {
+std::optional<std::vector<ExprPtr>> FindYieldValues(const std::vector<StmtPtr>& stmts) {
+  for (const auto& stmt : stmts) {
+    if (auto yield = As<YieldStmt>(stmt)) {
+      return yield->value_;
+    }
+    if (auto if_stmt = As<IfStmt>(stmt)) {
+      auto found = FindYieldValues(FlattenToStmts(if_stmt->then_body_));
+      if (found.has_value()) return found;
+      if (if_stmt->else_body_.has_value()) {
+        found = FindYieldValues(FlattenToStmts(*if_stmt->else_body_));
+        if (found.has_value()) return found;
+      }
+    }
+    if (auto for_stmt = As<ForStmt>(stmt)) {
+      auto found = FindYieldValues(FlattenToStmts(for_stmt->body_));
+      if (found.has_value()) return found;
+    }
+    if (auto while_stmt = As<WhileStmt>(stmt)) {
+      auto found = FindYieldValues(FlattenToStmts(while_stmt->body_));
+      if (found.has_value()) return found;
+    }
+    if (auto seq = As<SeqStmts>(stmt)) {
+      auto found = FindYieldValues(seq->stmts_);
+      if (found.has_value()) return found;
+    }
+    if (auto op_stmts = As<OpStmts>(stmt)) {
+      auto found = FindYieldValues(op_stmts->stmts_);
+      if (found.has_value()) return found;
+    }
+    if (auto scope = As<ScopeStmt>(stmt)) {
+      auto found = FindYieldValues(FlattenToStmts(scope->body_));
+      if (found.has_value()) return found;
+    }
+  }
+  return std::nullopt;
+}
+
+void MergeAliases(std::unordered_set<const Var*>& aliases,
+                  const std::unordered_set<const Var*>& branch_aliases) {
+  aliases.insert(branch_aliases.begin(), branch_aliases.end());
+}
+
+void MergeAliasParamMapping(std::unordered_map<const Var*, const Var*>& alias_to_param, const Var* alias,
+                            const Var* source_param) {
+  if (!alias) {
+    return;
+  }
+
+  auto [it, inserted] = alias_to_param.emplace(alias, source_param);
+  if (!inserted && it->second != source_param) {
+    it->second = nullptr;
+  }
+}
+
+void MergeAliasParamMappings(std::unordered_map<const Var*, const Var*>& alias_to_param,
+                             const std::unordered_map<const Var*, const Var*>& branch_alias_to_param) {
+  for (const auto& [alias, source_param] : branch_alias_to_param) {
+    MergeAliasParamMapping(alias_to_param, alias, source_param);
+  }
+}
+
+class AliasVisitorBase : public IRVisitor {
  public:
-  explicit AliasReferenceVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
+  explicit AliasVisitorBase(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
 
   [[nodiscard]] bool Found() const { return found_; }
+
+  void VisitExpr(const ExprPtr& expr) override {
+    if (found_ || !expr) {
+      return;
+    }
+    IRVisitor::VisitExpr(expr);
+  }
+
+  void VisitStmt(const StmtPtr& stmt) override {
+    if (found_ || !stmt) {
+      return;
+    }
+    IRVisitor::VisitStmt(stmt);
+  }
 
  protected:
   void VisitVarLike_(const VarPtr& op) override {
     if (op && aliases_.count(op.get())) {
       found_ = true;
     }
-    IRVisitor::VisitVarLike_(op);
   }
 
- private:
   const std::unordered_set<const Var*>& aliases_;
   bool found_ = false;
+
+ private:
 };
 
-class AliasReadVisitor : public IRVisitor {
+class AliasReferenceVisitor : public AliasVisitorBase {
  public:
-  explicit AliasReadVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
+  using AliasVisitorBase::AliasVisitorBase;
+};
 
-  [[nodiscard]] bool Found() const { return found_; }
+class AliasReadVisitor : public AliasReferenceVisitor {
+ public:
+  using AliasReferenceVisitor::AliasReferenceVisitor;
 
  protected:
-  void VisitVarLike_(const VarPtr& op) override {
-    if (op && aliases_.count(op.get())) {
-      found_ = true;
-    }
-    IRVisitor::VisitVarLike_(op);
-  }
-
   void VisitExpr_(const CallPtr& op) override {
     if (!op) return;
 
@@ -394,17 +465,11 @@ class AliasReadVisitor : public IRVisitor {
       VisitExpr(op->args_[i]);
     }
   }
-
- private:
-  const std::unordered_set<const Var*>& aliases_;
-  bool found_ = false;
 };
 
-class AliasWriteVisitor : public IRVisitor {
+class AliasWriteVisitor : public AliasVisitorBase {
  public:
-  explicit AliasWriteVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
-
-  [[nodiscard]] bool Found() const { return found_; }
+  using AliasVisitorBase::AliasVisitorBase;
 
  protected:
   void VisitExpr_(const CallPtr& op) override {
@@ -416,6 +481,7 @@ class AliasWriteVisitor : public IRVisitor {
       ref_visitor.VisitExpr(op->args_[*write_only_arg]);
       if (ref_visitor.Found()) {
         found_ = true;
+        return;
       }
     }
 
@@ -428,8 +494,6 @@ class AliasWriteVisitor : public IRVisitor {
   }
 
  private:
-  const std::unordered_set<const Var*>& aliases_;
-  bool found_ = false;
 };
 
 bool ExprReferencesAlias(const ExprPtr& expr, const std::unordered_set<const Var*>& aliases) {
@@ -513,11 +577,31 @@ void CollectBufferAccessInStmt(const StmtPtr& stmt, std::unordered_set<const Var
     access.reads = access.reads || ExprReadsAlias(if_stmt->condition_, aliases);
     access.writes = access.writes || ExprWritesAlias(if_stmt->condition_, aliases);
 
-    auto then_aliases = aliases;
-    CollectBufferAccessInStmts(FlattenToStmts(if_stmt->then_body_), then_aliases, access);
+    const auto incoming_aliases = aliases;
+    auto then_stmts = FlattenToStmts(if_stmt->then_body_);
+    auto then_aliases = incoming_aliases;
+    CollectBufferAccessInStmts(then_stmts, then_aliases, access);
+    if (auto then_yields = FindYieldValues(then_stmts)) {
+      for (size_t i = 0; i < if_stmt->return_vars_.size() && i < then_yields->size(); ++i) {
+        if (ExprAliasesTrackedBuffer((*then_yields)[i], then_aliases)) {
+          aliases.insert(if_stmt->return_vars_[i].get());
+        }
+      }
+    }
+    MergeAliases(aliases, then_aliases);
+
     if (if_stmt->else_body_.has_value()) {
-      auto else_aliases = aliases;
-      CollectBufferAccessInStmts(FlattenToStmts(*if_stmt->else_body_), else_aliases, access);
+      auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
+      auto else_aliases = incoming_aliases;
+      CollectBufferAccessInStmts(else_stmts, else_aliases, access);
+      if (auto else_yields = FindYieldValues(else_stmts)) {
+        for (size_t i = 0; i < if_stmt->return_vars_.size() && i < else_yields->size(); ++i) {
+          if (ExprAliasesTrackedBuffer((*else_yields)[i], else_aliases)) {
+            aliases.insert(if_stmt->return_vars_[i].get());
+          }
+        }
+      }
+      MergeAliases(aliases, else_aliases);
     }
     return;
   }
@@ -619,13 +703,29 @@ void CollectLoopCarriedTensorParamDirections(
     }
 
     if (auto if_stmt = As<IfStmt>(stmt)) {
-      auto then_alias_to_param = alias_to_param;
-      CollectLoopCarriedTensorParamDirections(FlattenToStmts(if_stmt->then_body_), then_alias_to_param,
-                                              inferred_param_directions);
+      const auto incoming_alias_to_param = alias_to_param;
+      auto then_stmts = FlattenToStmts(if_stmt->then_body_);
+      auto then_alias_to_param = incoming_alias_to_param;
+      CollectLoopCarriedTensorParamDirections(then_stmts, then_alias_to_param, inferred_param_directions);
+      if (auto then_yields = FindYieldValues(then_stmts)) {
+        for (size_t i = 0; i < if_stmt->return_vars_.size() && i < then_yields->size(); ++i) {
+          MergeAliasParamMapping(alias_to_param, if_stmt->return_vars_[i].get(),
+                                 ResolveAliasedParamFromExpr((*then_yields)[i], then_alias_to_param));
+        }
+      }
+      MergeAliasParamMappings(alias_to_param, then_alias_to_param);
+
       if (if_stmt->else_body_.has_value()) {
-        auto else_alias_to_param = alias_to_param;
-        CollectLoopCarriedTensorParamDirections(FlattenToStmts(*if_stmt->else_body_), else_alias_to_param,
-                                                inferred_param_directions);
+        auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
+        auto else_alias_to_param = incoming_alias_to_param;
+        CollectLoopCarriedTensorParamDirections(else_stmts, else_alias_to_param, inferred_param_directions);
+        if (auto else_yields = FindYieldValues(else_stmts)) {
+          for (size_t i = 0; i < if_stmt->return_vars_.size() && i < else_yields->size(); ++i) {
+            MergeAliasParamMapping(alias_to_param, if_stmt->return_vars_[i].get(),
+                                   ResolveAliasedParamFromExpr((*else_yields)[i], else_alias_to_param));
+          }
+        }
+        MergeAliasParamMappings(alias_to_param, else_alias_to_param);
       }
       continue;
     }

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -330,6 +330,389 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
   return {};
 }
 
+ParamDirection MergeParamDirections(ParamDirection lhs, ParamDirection rhs) {
+  if (lhs == ParamDirection::InOut || rhs == ParamDirection::InOut) {
+    return ParamDirection::InOut;
+  }
+  if (lhs == ParamDirection::Out || rhs == ParamDirection::Out) {
+    return ParamDirection::Out;
+  }
+  return ParamDirection::In;
+}
+
+std::optional<size_t> GetWriteOnlyArgIndex(const std::string& op_name) {
+  if (op_name == "tile.store") {
+    return 2;
+  }
+  if (op_name == "tensor.assemble" || op_name == "tensor.write") {
+    return 0;
+  }
+  return std::nullopt;
+}
+
+class AliasReferenceVisitor : public IRVisitor {
+ public:
+  explicit AliasReferenceVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
+
+  [[nodiscard]] bool Found() const { return found_; }
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override {
+    if (op && aliases_.count(op.get())) {
+      found_ = true;
+    }
+    IRVisitor::VisitVarLike_(op);
+  }
+
+ private:
+  const std::unordered_set<const Var*>& aliases_;
+  bool found_ = false;
+};
+
+class AliasReadVisitor : public IRVisitor {
+ public:
+  explicit AliasReadVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
+
+  [[nodiscard]] bool Found() const { return found_; }
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override {
+    if (op && aliases_.count(op.get())) {
+      found_ = true;
+    }
+    IRVisitor::VisitVarLike_(op);
+  }
+
+  void VisitExpr_(const CallPtr& op) override {
+    if (!op) return;
+
+    auto write_only_arg = GetWriteOnlyArgIndex(op->op_->name_);
+    for (size_t i = 0; i < op->args_.size(); ++i) {
+      if (write_only_arg.has_value() && i == *write_only_arg) {
+        continue;
+      }
+      VisitExpr(op->args_[i]);
+    }
+  }
+
+ private:
+  const std::unordered_set<const Var*>& aliases_;
+  bool found_ = false;
+};
+
+class AliasWriteVisitor : public IRVisitor {
+ public:
+  explicit AliasWriteVisitor(const std::unordered_set<const Var*>& aliases) : aliases_(aliases) {}
+
+  [[nodiscard]] bool Found() const { return found_; }
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    if (!op) return;
+
+    auto write_only_arg = GetWriteOnlyArgIndex(op->op_->name_);
+    if (write_only_arg.has_value() && *write_only_arg < op->args_.size()) {
+      AliasReferenceVisitor ref_visitor(aliases_);
+      ref_visitor.VisitExpr(op->args_[*write_only_arg]);
+      if (ref_visitor.Found()) {
+        found_ = true;
+      }
+    }
+
+    for (size_t i = 0; i < op->args_.size(); ++i) {
+      if (write_only_arg.has_value() && i == *write_only_arg) {
+        continue;
+      }
+      VisitExpr(op->args_[i]);
+    }
+  }
+
+ private:
+  const std::unordered_set<const Var*>& aliases_;
+  bool found_ = false;
+};
+
+bool ExprReferencesAlias(const ExprPtr& expr, const std::unordered_set<const Var*>& aliases) {
+  AliasReferenceVisitor visitor(aliases);
+  visitor.VisitExpr(expr);
+  return visitor.Found();
+}
+
+bool ExprReadsAlias(const ExprPtr& expr, const std::unordered_set<const Var*>& aliases) {
+  AliasReadVisitor visitor(aliases);
+  visitor.VisitExpr(expr);
+  return visitor.Found();
+}
+
+bool ExprWritesAlias(const ExprPtr& expr, const std::unordered_set<const Var*>& aliases) {
+  AliasWriteVisitor visitor(aliases);
+  visitor.VisitExpr(expr);
+  return visitor.Found();
+}
+
+bool ExprAliasesTrackedBuffer(const ExprPtr& expr, const std::unordered_set<const Var*>& aliases) {
+  if (auto iter_arg = As<IterArg>(expr)) {
+    return aliases.count(iter_arg.get()) > 0;
+  }
+  if (auto var = As<Var>(expr)) {
+    return aliases.count(var.get()) > 0;
+  }
+
+  auto call = As<Call>(expr);
+  if (!call) {
+    return false;
+  }
+
+  auto write_only_arg = GetWriteOnlyArgIndex(call->op_->name_);
+  return write_only_arg.has_value() && *write_only_arg < call->args_.size() &&
+         ExprReferencesAlias(call->args_[*write_only_arg], aliases);
+}
+
+struct BufferAccessInfo {
+  bool reads = false;
+  bool writes = false;
+};
+
+void CollectBufferAccessInStmts(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& aliases,
+                                BufferAccessInfo& access);
+
+void CollectBufferAccessInStmt(const StmtPtr& stmt, std::unordered_set<const Var*>& aliases,
+                               BufferAccessInfo& access) {
+  if (auto assign = As<AssignStmt>(stmt)) {
+    access.reads = access.reads || ExprReadsAlias(assign->value_, aliases);
+    access.writes = access.writes || ExprWritesAlias(assign->value_, aliases);
+    if (ExprAliasesTrackedBuffer(assign->value_, aliases)) {
+      aliases.insert(assign->var_.get());
+    }
+    return;
+  }
+
+  if (auto eval_stmt = As<EvalStmt>(stmt)) {
+    access.reads = access.reads || ExprReadsAlias(eval_stmt->expr_, aliases);
+    access.writes = access.writes || ExprWritesAlias(eval_stmt->expr_, aliases);
+    return;
+  }
+
+  if (auto seq = As<SeqStmts>(stmt)) {
+    CollectBufferAccessInStmts(seq->stmts_, aliases, access);
+    return;
+  }
+
+  if (auto op_stmts = As<OpStmts>(stmt)) {
+    CollectBufferAccessInStmts(op_stmts->stmts_, aliases, access);
+    return;
+  }
+
+  if (auto scope = As<ScopeStmt>(stmt)) {
+    auto body_stmts = FlattenToStmts(scope->body_);
+    CollectBufferAccessInStmts(body_stmts, aliases, access);
+    return;
+  }
+
+  if (auto if_stmt = As<IfStmt>(stmt)) {
+    access.reads = access.reads || ExprReadsAlias(if_stmt->condition_, aliases);
+    access.writes = access.writes || ExprWritesAlias(if_stmt->condition_, aliases);
+
+    auto then_aliases = aliases;
+    CollectBufferAccessInStmts(FlattenToStmts(if_stmt->then_body_), then_aliases, access);
+    if (if_stmt->else_body_.has_value()) {
+      auto else_aliases = aliases;
+      CollectBufferAccessInStmts(FlattenToStmts(*if_stmt->else_body_), else_aliases, access);
+    }
+    return;
+  }
+
+  if (auto for_stmt = As<ForStmt>(stmt)) {
+    access.reads = access.reads || ExprReadsAlias(for_stmt->start_, aliases);
+    access.reads = access.reads || ExprReadsAlias(for_stmt->stop_, aliases);
+    access.reads = access.reads || ExprReadsAlias(for_stmt->step_, aliases);
+
+    auto loop_aliases = aliases;
+    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+      if (ExprAliasesTrackedBuffer(for_stmt->iter_args_[i]->initValue_, aliases)) {
+        loop_aliases.insert(for_stmt->iter_args_[i].get());
+        if (i < for_stmt->return_vars_.size()) {
+          aliases.insert(for_stmt->return_vars_[i].get());
+        }
+      }
+    }
+    CollectBufferAccessInStmts(FlattenToStmts(for_stmt->body_), loop_aliases, access);
+    return;
+  }
+
+  if (auto while_stmt = As<WhileStmt>(stmt)) {
+    auto loop_aliases = aliases;
+    for (size_t i = 0; i < while_stmt->iter_args_.size(); ++i) {
+      if (ExprAliasesTrackedBuffer(while_stmt->iter_args_[i]->initValue_, aliases)) {
+        loop_aliases.insert(while_stmt->iter_args_[i].get());
+        if (i < while_stmt->return_vars_.size()) {
+          aliases.insert(while_stmt->return_vars_[i].get());
+        }
+      }
+    }
+    access.reads = access.reads || ExprReadsAlias(while_stmt->condition_, loop_aliases);
+    access.writes = access.writes || ExprWritesAlias(while_stmt->condition_, loop_aliases);
+    CollectBufferAccessInStmts(FlattenToStmts(while_stmt->body_), loop_aliases, access);
+    return;
+  }
+}
+
+void CollectBufferAccessInStmts(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& aliases,
+                                BufferAccessInfo& access) {
+  for (const auto& stmt : stmts) {
+    CollectBufferAccessInStmt(stmt, aliases, access);
+  }
+}
+
+ParamDirection InferLoopCarriedDirection(const std::vector<StmtPtr>& body_stmts, const IterArgPtr& iter_arg) {
+  std::unordered_set<const Var*> aliases = {iter_arg.get()};
+  BufferAccessInfo access;
+  CollectBufferAccessInStmts(body_stmts, aliases, access);
+
+  if (!access.writes) {
+    return ParamDirection::In;
+  }
+  return access.reads ? ParamDirection::InOut : ParamDirection::Out;
+}
+
+const Var* ResolveAliasedParamFromExpr(const ExprPtr& expr,
+                                       const std::unordered_map<const Var*, const Var*>& alias_to_param) {
+  if (auto iter_arg = As<IterArg>(expr)) {
+    auto it = alias_to_param.find(iter_arg.get());
+    return it == alias_to_param.end() ? nullptr : it->second;
+  }
+  if (auto var = As<Var>(expr)) {
+    auto it = alias_to_param.find(var.get());
+    return it == alias_to_param.end() ? nullptr : it->second;
+  }
+
+  auto call = As<Call>(expr);
+  if (!call) {
+    return nullptr;
+  }
+
+  auto write_only_arg = GetWriteOnlyArgIndex(call->op_->name_);
+  if (!write_only_arg.has_value() || *write_only_arg >= call->args_.size()) {
+    return nullptr;
+  }
+  return ResolveAliasedParamFromExpr(call->args_[*write_only_arg], alias_to_param);
+}
+
+void CollectLoopCarriedTensorParamDirections(
+    const std::vector<StmtPtr>& stmts, std::unordered_map<const Var*, const Var*>& alias_to_param,
+    std::unordered_map<const Var*, ParamDirection>& inferred_param_directions) {
+  for (const auto& stmt : stmts) {
+    if (auto seq = As<SeqStmts>(stmt)) {
+      CollectLoopCarriedTensorParamDirections(seq->stmts_, alias_to_param, inferred_param_directions);
+      continue;
+    }
+
+    if (auto op_stmts = As<OpStmts>(stmt)) {
+      CollectLoopCarriedTensorParamDirections(op_stmts->stmts_, alias_to_param, inferred_param_directions);
+      continue;
+    }
+
+    if (auto scope = As<ScopeStmt>(stmt)) {
+      CollectLoopCarriedTensorParamDirections(FlattenToStmts(scope->body_), alias_to_param,
+                                              inferred_param_directions);
+      continue;
+    }
+
+    if (auto if_stmt = As<IfStmt>(stmt)) {
+      auto then_alias_to_param = alias_to_param;
+      CollectLoopCarriedTensorParamDirections(FlattenToStmts(if_stmt->then_body_), then_alias_to_param,
+                                              inferred_param_directions);
+      if (if_stmt->else_body_.has_value()) {
+        auto else_alias_to_param = alias_to_param;
+        CollectLoopCarriedTensorParamDirections(FlattenToStmts(*if_stmt->else_body_), else_alias_to_param,
+                                                inferred_param_directions);
+      }
+      continue;
+    }
+
+    if (auto assign = As<AssignStmt>(stmt)) {
+      if (const Var* source_param = ResolveAliasedParamFromExpr(assign->value_, alias_to_param)) {
+        alias_to_param[assign->var_.get()] = source_param;
+      }
+      continue;
+    }
+
+    if (auto for_stmt = As<ForStmt>(stmt)) {
+      auto body_alias_to_param = alias_to_param;
+      std::vector<const Var*> iter_source_params(for_stmt->iter_args_.size(), nullptr);
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        const auto& iter_arg = for_stmt->iter_args_[i];
+        if (!As<TensorType>(iter_arg->GetType())) {
+          continue;
+        }
+
+        const Var* source_param = ResolveAliasedParamFromExpr(iter_arg->initValue_, alias_to_param);
+        if (!source_param) {
+          continue;
+        }
+
+        iter_source_params[i] = source_param;
+        body_alias_to_param[iter_arg.get()] = source_param;
+
+        auto inferred_direction = InferLoopCarriedDirection(FlattenToStmts(for_stmt->body_), iter_arg);
+        if (inferred_direction != ParamDirection::In) {
+          auto [it, inserted] = inferred_param_directions.emplace(source_param, inferred_direction);
+          if (!inserted) {
+            it->second = MergeParamDirections(it->second, inferred_direction);
+          }
+        }
+      }
+
+      CollectLoopCarriedTensorParamDirections(FlattenToStmts(for_stmt->body_), body_alias_to_param,
+                                              inferred_param_directions);
+
+      for (size_t i = 0; i < for_stmt->return_vars_.size() && i < iter_source_params.size(); ++i) {
+        if (iter_source_params[i]) {
+          alias_to_param[for_stmt->return_vars_[i].get()] = iter_source_params[i];
+        }
+      }
+      continue;
+    }
+
+    if (auto while_stmt = As<WhileStmt>(stmt)) {
+      auto body_alias_to_param = alias_to_param;
+      std::vector<const Var*> iter_source_params(while_stmt->iter_args_.size(), nullptr);
+      for (size_t i = 0; i < while_stmt->iter_args_.size(); ++i) {
+        const auto& iter_arg = while_stmt->iter_args_[i];
+        if (!As<TensorType>(iter_arg->GetType())) {
+          continue;
+        }
+
+        const Var* source_param = ResolveAliasedParamFromExpr(iter_arg->initValue_, alias_to_param);
+        if (!source_param) {
+          continue;
+        }
+
+        iter_source_params[i] = source_param;
+        body_alias_to_param[iter_arg.get()] = source_param;
+
+        auto inferred_direction = InferLoopCarriedDirection(FlattenToStmts(while_stmt->body_), iter_arg);
+        if (inferred_direction != ParamDirection::In) {
+          auto [it, inserted] = inferred_param_directions.emplace(source_param, inferred_direction);
+          if (!inserted) {
+            it->second = MergeParamDirections(it->second, inferred_direction);
+          }
+        }
+      }
+
+      CollectLoopCarriedTensorParamDirections(FlattenToStmts(while_stmt->body_), body_alias_to_param,
+                                              inferred_param_directions);
+
+      for (size_t i = 0; i < while_stmt->return_vars_.size() && i < iter_source_params.size(); ++i) {
+        if (iter_source_params[i]) {
+          alias_to_param[while_stmt->return_vars_[i].get()] = iter_source_params[i];
+        }
+      }
+      continue;
+    }
+  }
+}
+
 /**
  * @brief Info about a tensor.slice result that feeds into a tensor.matmul operand.
  *
@@ -1098,6 +1481,27 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   std::vector<ParamDirection> new_param_directions = func->param_directions_;
   std::vector<TypePtr> new_return_types;
   size_t num_added_outputs = 0;
+
+  // Loop-carried tensor params can become write-only/read-write buffers after
+  // tensor.assemble lowers to tile.store, even when the function still returns
+  // a TensorType. Infer those directions before processing returned values.
+  std::unordered_map<const Var*, const Var*> alias_to_param;
+  alias_to_param.reserve(func->params_.size());
+  for (const auto& param : func->params_) {
+    if (As<TensorType>(param->GetType())) {
+      alias_to_param[param.get()] = param.get();
+    }
+  }
+
+  std::unordered_map<const Var*, ParamDirection> inferred_param_directions;
+  CollectLoopCarriedTensorParamDirections(new_stmts, alias_to_param, inferred_param_directions);
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    auto it = inferred_param_directions.find(func->params_[i].get());
+    if (it == inferred_param_directions.end()) {
+      continue;
+    }
+    new_param_directions[i] = MergeParamDirections(new_param_directions[i], it->second);
+  }
 
   if (return_stmt) {
     std::vector<ExprPtr> new_return_exprs;

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1985,6 +1985,100 @@ class TestSliceMatmulConversion:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_loop_carried_tensor_param_marked_out(self):
+        """Loop-carried tensor output buffers should become pl.Out."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                buf: pl.Tensor[[1, 64], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk: pl.Tensor[[1, 32], pl.FP32] = pl.slice(x, [1, 32], [0, 0])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.assemble(acc, chunk, [0, off])
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                buf: pl.Tensor[[1, 64], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, buf)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                buf: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(x, [0, 0], [1, 32])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.store(chunk_tile, [0, off], acc)
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                buf: pl.Tensor[[1, 64], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, buf)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_loop_carried_tensor_param_marked_inout(self):
+        """Loop-carried tensor buffers that are read before write should become pl.InOut."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, buf: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk: pl.Tensor[[1, 32], pl.FP32] = pl.slice(acc, [1, 32], [0, off])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.assemble(acc, chunk, [0, off])
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, buf: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(buf)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, buf: pl.InOut[pl.Tensor[[1, 64], pl.FP32]]
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(acc, [0, off], [1, 32])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.store(chunk_tile, [0, off], acc)
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, buf: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(buf)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2079,6 +2079,33 @@ class TestSliceMatmulConversion:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_loop_carried_tensor_param_marked_inout_through_if_alias(self):
+        """Aliases yielded from IfStmt branches should still contribute to InOut inference."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, buf: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    if i == 0:
+                        branch_acc: pl.Tensor[[1, 64], pl.FP32] = acc
+                        acc_alias = pl.yield_(branch_acc)
+                    else:
+                        branch_acc: pl.Tensor[[1, 64], pl.FP32] = acc
+                        acc_alias = pl.yield_(branch_acc)
+                    chunk: pl.Tensor[[1, 32], pl.FP32] = pl.slice(acc_alias, [1, 32], [0, 0])
+                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.assemble(acc_alias, chunk, [0, 0])
+                    result = pl.yield_(acc_next)
+                return result
+
+            @pl.function
+            def main(self, buf: pl.Tensor[[1, 64], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(buf)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        assert "buf: pl.InOut[pl.Tensor[[1, 64], pl.FP32]]" in After.as_python()
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Added new visitors (`AliasReferenceVisitor`, `AliasReadVisitor`, `AliasWriteVisitor`) to track variable aliasing during buffer access in IR transformations.
- Introduced functions to determine parameter directions (`MergeParamDirections`, `GetWriteOnlyArgIndex`) and to check if expressions reference or read/write aliases.
- Enhanced `CollectBufferAccessInStmt` to analyze buffer access patterns in various statement types, including loops and conditionals.
- Added tests to validate the handling of loop-carried tensor parameters, ensuring correct marking as `pl.Out` or `pl.InOut` based on usage.
- This update improves the robustness of buffer management in the IR layer, aligning with recent refactoring efforts.