### PR TITLE
fix(ir): exclude pure scalar assignments from InCore wrapping

### DIFF
--- a/docs/en/dev/passes/06-interchange_chunk_loops.md
+++ b/docs/en/dev/passes/06-interchange_chunk_loops.md
@@ -145,7 +145,7 @@ for i_rem, (...) in pl.parallel(2, init_values=(...)):   # ChunkRemainder
 
 When `auto_incore` is consumed, statements that were not handled by chunk interchange (standalone tensor ops, non-chunked loops, sequential chunked loops that failed the parallel guard) are wrapped in `ScopeStmt(InCore)` to ensure they get outlined into InCore functions by `OutlineIncoreScopes`.
 
-Consecutive non-InCore statements are grouped into a single `ScopeStmt(InCore)`. Control flow statements (`YieldStmt`, `ReturnStmt`) are never wrapped.
+Consecutive non-InCore statements are grouped into a single `ScopeStmt(InCore)`. Control flow statements (`YieldStmt`, `ReturnStmt`) and pure scalar assignments (e.g., index arithmetic like `offset = ob * 32`) are never wrapped — they stay in the orchestration scope.
 
 **Example** — standalone op + parallel chunk:
 

--- a/docs/zh-cn/dev/passes/06-interchange_chunk_loops.md
+++ b/docs/zh-cn/dev/passes/06-interchange_chunk_loops.md
@@ -145,7 +145,7 @@ for i_rem, (...) in pl.parallel(2, init_values=(...)):   # ChunkRemainder
 
 当 `auto_incore` 被消费时，未被分块交换处理的语句（独立张量算子、非分块循环、未通过并行守卫检查的顺序分块循环）会被包裹在 `ScopeStmt(InCore)` 中，以确保它们被 `OutlineIncoreScopes` 提取到 InCore 函数中。
 
-连续的非 InCore 语句会被分组到单个 `ScopeStmt(InCore)` 中。控制流语句（`YieldStmt`、`ReturnStmt`）不会被包裹。
+连续的非 InCore 语句会被分组到单个 `ScopeStmt(InCore)` 中。控制流语句（`YieldStmt`、`ReturnStmt`）和纯标量赋值（例如索引运算 `offset = ob * 32`）不会被包裹——它们留在编排作用域中。
 
 **示例** — 独立算子 + 并行分块：
 

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -105,6 +105,101 @@ static bool ContainsComputeTensorOp(const StmtPtr& stmt) {
   return detector.Found();
 }
 
+/// Detects whether an expression tree contains any sub-expression with TensorType or TileType.
+class TensorOrTileTypedExprDetector : public IRVisitor {
+ public:
+  [[nodiscard]] bool Found() const { return found_; }
+
+  void VisitExpr(const ExprPtr& expr) override {
+    if (!expr || found_) return;
+    auto type = expr->GetType();
+    if (type) {
+      auto kind = type->GetKind();
+      if (kind == ObjectKind::TensorType || kind == ObjectKind::TileType) {
+        found_ = true;
+        return;
+      }
+    }
+    IRVisitor::VisitExpr(expr);
+  }
+
+ private:
+  bool found_ = false;
+};
+
+/// Returns true if stmt is an AssignStmt with a scalar-typed target variable
+/// and a value expression that involves no tensor/tile data.
+static bool IsPureScalarAssignment(const StmtPtr& stmt) {
+  if (!stmt) return false;
+
+  auto kind = stmt->GetKind();
+  if (kind == ObjectKind::AssignStmt) {
+    auto assign = std::static_pointer_cast<const AssignStmt>(stmt);
+    auto var_type = assign->var_->GetType();
+    if (!var_type || var_type->GetKind() != ObjectKind::ScalarType) return false;
+    TensorOrTileTypedExprDetector detector;
+    detector.VisitExpr(assign->value_);
+    return !detector.Found();
+  }
+
+  // An OpStmts is pure scalar only if every sub-statement is a pure scalar assignment.
+  if (kind == ObjectKind::OpStmts) {
+    auto op_stmts = std::static_pointer_cast<const OpStmts>(stmt);
+    for (const auto& s : op_stmts->stmts_) {
+      if (!IsPureScalarAssignment(s)) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/// Expand an OpStmts that contains a mix of pure scalar and non-scalar assignments
+/// into individual sub-statements. Returns the original list if no expansion needed.
+static std::vector<StmtPtr> ExpandMixedOpStmts(const std::vector<StmtPtr>& stmts) {
+  bool needs_expansion = false;
+  for (const auto& s : stmts) {
+    if (s && s->GetKind() == ObjectKind::OpStmts && !IsPureScalarAssignment(s)) {
+      auto op_stmts = std::static_pointer_cast<const OpStmts>(s);
+      // Check if any sub-statement is a pure scalar assignment
+      for (const auto& sub : op_stmts->stmts_) {
+        if (IsPureScalarAssignment(sub)) {
+          needs_expansion = true;
+          break;
+        }
+      }
+      if (needs_expansion) break;
+    }
+  }
+  if (!needs_expansion) return stmts;
+
+  std::vector<StmtPtr> expanded;
+  expanded.reserve(stmts.size() * 2);
+  for (const auto& s : stmts) {
+    if (s && s->GetKind() == ObjectKind::OpStmts && !IsPureScalarAssignment(s)) {
+      auto op_stmts = std::static_pointer_cast<const OpStmts>(s);
+      bool has_scalar = false;
+      for (const auto& sub : op_stmts->stmts_) {
+        if (IsPureScalarAssignment(sub)) {
+          has_scalar = true;
+          break;
+        }
+      }
+      if (has_scalar) {
+        // Expand: push sub-statements individually
+        for (const auto& sub : op_stmts->stmts_) {
+          expanded.push_back(sub);
+        }
+      } else {
+        expanded.push_back(s);
+      }
+    } else {
+      expanded.push_back(s);
+    }
+  }
+  return expanded;
+}
+
 static bool ContainsChunkLoop(const StmtPtr& stmt) {
   if (!stmt) return false;
 
@@ -137,8 +232,10 @@ static bool ContainsChunkLoop(const StmtPtr& stmt) {
  * - compute tensor ops
  * - chunk loops that failed interchange or remain sequential
  *
- * Pure host-side groups such as a lone tensor.assemble/create/slice should stay
- * in orchestration rather than becoming tiny outlined InCore functions.
+ * The following stay in orchestration (not wrapped):
+ * - Pure host-side groups (tensor.assemble/create/slice)
+ * - Pure scalar assignments (e.g., index arithmetic like `offset = ob * 32`)
+ *   whose value expression contains no tensor/tile-typed sub-expressions
  */
 static bool NeedsInCoreWrapping(const StmtPtr& stmt) {
   if (!stmt) return false;
@@ -146,6 +243,7 @@ static bool NeedsInCoreWrapping(const StmtPtr& stmt) {
   auto kind = stmt->GetKind();
   if (kind == ObjectKind::YieldStmt || kind == ObjectKind::ReturnStmt) return false;
   if (ContainsInCoreScope(stmt)) return false;
+  if (IsPureScalarAssignment(stmt)) return false;
 
   return ContainsChunkLoop(stmt) || ContainsComputeTensorOp(stmt);
 }
@@ -200,6 +298,11 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
   }
   if (!has_work) return body;
 
+  // Expand mixed OpStmts so scalar assignments can be classified individually.
+  // An OpStmts containing both scalar and tensor assignments would otherwise be
+  // wrapped as a unit, sweeping the scalar into InCore.
+  auto flat_stmts = ExpandMixedOpStmts(seq->stmts_);
+
   // Group consecutive wrappable statements and wrap each group in InCore
   std::vector<StmtPtr> result;
   std::vector<StmtPtr> pending;
@@ -211,7 +314,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
     pending.clear();
   };
 
-  for (const auto& s : seq->stmts_) {
+  for (const auto& s : flat_stmts) {
     if (NeedsInCoreWrapping(s)) {
       pending.push_back(s);
     } else {

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -666,6 +666,69 @@ class TestNonChunkStatementsWrapping:
         assert after_str.count("pl.incore()") >= 2
 
 
+class TestScalarAssignmentNotWrapped:
+    """Tests that pure scalar assignments stay outside InCore scopes."""
+
+    def test_scalar_assign_adjacent_to_compute_not_wrapped(self):
+        """Scalar assignment adjacent to tensor compute ops should stay in orchestration."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for ob in pl.range(0, 8):
+                        offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
+                        x = pl.add(x, 1.0)
+                        for i in pl.parallel(0, 8, 1, chunk=4):
+                            x = pl.add(x, 2.0)
+                return x
+
+        Before = _prepare_for_interchange(Input)
+        After = passes.interchange_chunk_loops()(Before)
+        after_str = python_print(After)
+
+        # The scalar assignment should NOT be inside any pl.incore() scope.
+        scalar_assign_re = re.compile(r"offset\S*\s*:.*=.*\*\s*4")
+        lines = after_str.split("\n")
+        in_incore = False
+        incore_depth = 0
+        for line in lines:
+            stripped = line.strip()
+            if "pl.incore()" in stripped:
+                in_incore = True
+                incore_depth = len(line) - len(line.lstrip())
+            elif in_incore and stripped and (len(line) - len(line.lstrip())) <= incore_depth:
+                if not stripped.startswith("#"):
+                    in_incore = False
+            if in_incore:
+                assert not scalar_assign_re.search(stripped), (
+                    f"Pure scalar assignment found inside InCore scope: {stripped}"
+                )
+
+    def test_scalar_assign_not_wrapped_outline_no_crash(self):
+        """Scalar assignment stays in orchestration after outline — no undefined variable."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for ob in pl.range(0, 8):
+                        offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
+                        for i in pl.parallel(0, 8, 1, chunk=4):
+                            x = pl.add(x, 2.0)
+                return x
+
+        program = _prepare_for_interchange(Input)
+        program = passes.interchange_chunk_loops()(program)
+        # This should not crash with undefined variable references
+        program = passes.outline_incore_scopes()(program)
+
+        incore_funcs = [f for f in program.functions.values() if f.func_type == ir.FunctionType.InCore]
+        assert len(incore_funcs) >= 1
+
+
 class TestEndToEndNoComputeLeaks:
     """End-to-end tests verifying no compute tensor ops leak into Orchestration."""
 


### PR DESCRIPTION
## Summary
- Add `IsPureScalarAssignment` check to `NeedsInCoreWrapping` so that scalar index arithmetic (e.g. `offset = ob * 32`) stays in the orchestration scope instead of being swept into InCore
- Detection is type-based: an `AssignStmt` is pure scalar when its target variable has `ScalarType` and its value expression tree contains no `TensorType`/`TileType` sub-expressions
- Update pass documentation (EN + ZH-CN) to document the new exclusion

## Testing
- [x] 2 new tests in `TestScalarAssignmentNotWrapped`: one verifies scalar stays outside InCore, one end-to-end through `OutlineIncoreScopes`
- [x] All 2583 existing tests pass
- [x] clang-tidy clean

Fixes #639