### PR TITLE
fix(ir): replace name-based with identity-based var matching in FlattenTileNdTo2D

### DIFF
--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -531,10 +531,15 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         auto [merged, last] = ComputeMergedShape(result_tile->shape_, "tile.load result");
 
         // Construct call with explicit 2D TileType (bypasses ND type inference).
-        // Preserve tile_view and memory_space from the original ND tile type.
-        auto flat_tile_type =
-            std::make_shared<TileType>(Make2DShapeExprs(merged, last, span), result_tile->dtype_,
-                                       std::nullopt, result_tile->tile_view_, result_tile->memory_space_);
+        // Create a 2D tile_view and preserve memory_space for type consistency
+        // with downstream ops (op_registry always adds tile_view + memory_space).
+        auto flat_shape_exprs = Make2DShapeExprs(merged, last, span);
+        std::optional<TileView> flat_tile_view;
+        if (result_tile->tile_view_.has_value()) {
+          flat_tile_view = TileView(flat_shape_exprs, /*stride=*/{}, /*start_offset=*/nullptr);
+        }
+        auto flat_tile_type = std::make_shared<TileType>(flat_shape_exprs, result_tile->dtype_, std::nullopt,
+                                                         flat_tile_view, result_tile->memory_space_);
         auto flat_call =
             std::make_shared<Call>(call->op_, sub_args, call->kwargs_, flat_tile_type, call->span_);
         auto flat_var = std::make_shared<Var>(assign->var_->name_hint_, flat_tile_type, assign->var_->span_);

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -31,8 +31,11 @@ def _load2d(
     from the original ND type.
     """
     nd_call = tile_ops.load(tensor, offsets, shapes, span=ir.Span.unknown())
-    nd_type: ir.TileType = nd_call.type  # type: ignore[assignment]
-    flat_type = ir.TileType(flat_shape, dtype, tile_view=nd_type.tile_view, memory_space=nd_type.memory_space)
+    # Create a reference 2D tile.load to get the correct type (with proper tile_view + memory_space)
+    ref_tensor = ir.Var("_ref", ir.TensorType(flat_shape, dtype), ir.Span.unknown())
+    ref_offsets = [0] * len(flat_shape)
+    ref_call = tile_ops.load(ref_tensor, ref_offsets, flat_shape, span=ir.Span.unknown())
+    flat_type: ir.TileType = ref_call.type  # type: ignore[assignment]
     return ir.Call(nd_call.op, list(nd_call.args), nd_call.kwargs, flat_type, nd_call.span)
 
 


### PR DESCRIPTION
## Summary

- Replace `name_to_new_var` (string-keyed) map with pointer-based `var_map` for control-flow return_var matching in `FlattenTileNdTo2D`, fixing the IR contract violation where `Var::name_hint_` was used as a semantic key
- Add `FindYieldTypes` helper for IfStmt positional return_var matching; ForStmt/WhileStmt use iter_arg type positional matching
- Fix `SubstituteExpr` to handle `IterArg` before `Var` — `As<Var>()` uses exact `ObjectKind` matching and silently skips `IterArg` nodes
- Preserve `tile_view` and `memory_space` in tile.load flat type creation for type consistency
- Add 4 regression tests covering ForStmt, IfStmt, and WhileStmt control-flow with 3D tile iter_args/return_vars

## Testing

- [x] All 2589 unit tests pass
- [x] Code review passed
- [x] clang-tidy clean
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

Fixes #648