### PR TITLE
style(lint): remove unnecessary lint suppression annotations

### DIFF
--- a/examples/ir_parser/batch_paged_attention_example.py
+++ b/examples/ir_parser/batch_paged_attention_example.py
@@ -422,7 +422,7 @@ def BuildBatchPagedAttentionProgram(
             q_loop_cfg = (num_heads_cfg + q_tile - 1) // q_tile
 
             # Compute max_bn across all batches (mirrors C++ max_bn loop)
-            max_bn: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+            max_bn: pl.Scalar[pl.INT64] = pl.yield_(0)
             for b in pl.range(batch_cfg):
                 cur_seq_b = pl.tensor.read(context_lens, [b])
                 bn_b = (cur_seq_b + block_size_cfg - 1) // block_size_cfg
@@ -432,16 +432,16 @@ def BuildBatchPagedAttentionProgram(
                 q_offset = q_idx * q_tile
 
                 # Batch-sized accumulators (mirrors C++ oi_batch/li_batch/mi_batch)
-                oi_batch: pl.Tensor[[batch_cfg * q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                    [batch_cfg * q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                oi_batch: pl.Tensor[[batch_cfg * q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                    [batch_cfg * q_tile, head_dim_cfg],
                     dtype=pl.FP32,
                 )
-                li_batch: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                    [batch_cfg * q_tile, 1],  # type: ignore[reportArgumentType]
+                li_batch: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(
+                    [batch_cfg * q_tile, 1],
                     dtype=pl.FP32,
                 )
-                mi_batch: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                    [batch_cfg * q_tile, 1],  # type: ignore[reportArgumentType]
+                mi_batch: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(
+                    [batch_cfg * q_tile, 1],
                     dtype=pl.FP32,
                 )
 
@@ -450,24 +450,24 @@ def BuildBatchPagedAttentionProgram(
 
                 for bn in pl.range(max_bn):
                     # Batch-sized intermediate tensors (mirrors C++ sij_b/pij_b/etc.)
-                    sij_b: pl.Tensor[[batch_cfg * q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                        [batch_cfg * q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                    sij_b: pl.Tensor[[batch_cfg * q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
+                        [batch_cfg * q_tile, block_size_cfg],
                         dtype=pl.FP32,
                     )
-                    pij_b: pl.Tensor[[batch_cfg * q_tile, block_size_cfg], pl.FP16] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                        [batch_cfg * q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                    pij_b: pl.Tensor[[batch_cfg * q_tile, block_size_cfg], pl.FP16] = pl.create_tensor(
+                        [batch_cfg * q_tile, block_size_cfg],
                         dtype=pl.FP16,
                     )
-                    mij_b: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                        [batch_cfg * q_tile, 1],  # type: ignore[reportArgumentType]
+                    mij_b: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(
+                        [batch_cfg * q_tile, 1],
                         dtype=pl.FP32,
                     )
-                    lij_b: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                        [batch_cfg * q_tile, 1],  # type: ignore[reportArgumentType]
+                    lij_b: pl.Tensor[[batch_cfg * q_tile, 1], pl.FP32] = pl.create_tensor(
+                        [batch_cfg * q_tile, 1],
                         dtype=pl.FP32,
                     )
-                    oi_new_b: pl.Tensor[[batch_cfg * q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(  # type: ignore[reportArgumentType]
-                        [batch_cfg * q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                    oi_new_b: pl.Tensor[[batch_cfg * q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                        [batch_cfg * q_tile, head_dim_cfg],
                         dtype=pl.FP32,
                     )
 
@@ -478,10 +478,10 @@ def BuildBatchPagedAttentionProgram(
                         sij_b,
                         block_table,
                         batch_cfg,
-                        bn,  # type: ignore[reportArgumentType]
-                        q_offset,  # type: ignore[reportArgumentType]
+                        bn,
+                        q_offset,
                         block_num_cfg,
-                        num_heads_cfg,  # type: ignore[reportArgumentType]
+                        num_heads_cfg,
                     )
 
                     # Stage 2: Softmax prepare (FUNC_SOFTMAX_PREPARE, AIV / VECTOR)
@@ -493,7 +493,7 @@ def BuildBatchPagedAttentionProgram(
                         1.0,  # type: ignore[reportArgumentType]
                         context_lens,
                         batch_cfg,
-                        bn,  # type: ignore[reportArgumentType]
+                        bn,
                     )
 
                     # Stage 3: PV matmul (FUNC_PV_MATMUL, AIC / CUBE)
@@ -503,19 +503,19 @@ def BuildBatchPagedAttentionProgram(
                         oi_new_b,
                         block_table,
                         batch_cfg,
-                        bn,  # type: ignore[reportArgumentType]
-                        block_num_cfg,  # type: ignore[reportArgumentType]
+                        bn,
+                        block_num_cfg,
                     )
 
                     # Conditional flags (mirrors C++ is_first/is_last)
                     if bn == 0:
-                        is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        is_first: pl.Scalar[pl.INT64] = pl.yield_(1)
                     else:
-                        is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                        is_first: pl.Scalar[pl.INT64] = pl.yield_(0)
                     if bn == max_bn - 1:
-                        is_last: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        is_last: pl.Scalar[pl.INT64] = pl.yield_(1)
                     else:
-                        is_last: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                        is_last: pl.Scalar[pl.INT64] = pl.yield_(0)
 
                     # Stage 4: Online update (FUNC_ONLINE_UPDATE, AIV / VECTOR)
                     mi_batch, li_batch, oi_batch, out = self.KernelOnlineUpdate(
@@ -529,8 +529,8 @@ def BuildBatchPagedAttentionProgram(
                         is_first,
                         is_last,
                         batch_cfg,
-                        q_offset,  # type: ignore[reportArgumentType]
-                        num_heads_cfg,  # type: ignore[reportArgumentType]
+                        q_offset,
+                        num_heads_cfg,
                     )
 
             return out

--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -273,11 +273,11 @@ def build_paged_attention_program(
 
                     # Create inplace accumulators for this q_tile group
                     oi: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
-                        [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                        [q_tile, head_dim_cfg],
                         dtype=pl.FP32,
                     )
-                    li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
-                    mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                    li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+                    mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
 
                     # Initialize accumulators via shared module-level InCore kernel
                     oi, li_update, mi_update = kernel_init_inplace(oi, li_update, mi_update)
@@ -286,7 +286,7 @@ def build_paged_attention_program(
                         # Query view: row offset = b_idx * num_heads + q_idx * q_tile
                         qi: pl.Tensor[[q_tile, head_dim_cfg], pl.BF16] = pl.slice(
                             query,
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             [cur_offset, 0],
                         )
 
@@ -298,17 +298,17 @@ def build_paged_attention_program(
                         kv_block_row = cur_block_idx * block_size_cfg
                         kj: pl.Tensor[[head_dim_cfg, block_size_cfg], pl.BF16, pl.DN] = pl.slice(
                             key_cache,
-                            [head_dim_cfg, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [head_dim_cfg, block_size_cfg],
                             [kv_block_row, 0],
                         )
                         vj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.slice(
                             value_cache,
-                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [block_size_cfg, head_dim_cfg],
                             [kv_block_row, 0],
                         )
 
                         sij: pl.Tensor[[q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
-                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, block_size_cfg],
                             dtype=pl.FP32,
                         )
 
@@ -316,22 +316,22 @@ def build_paged_attention_program(
                         sij = kernel_qk_matmul(qi, kj, sij)
                         sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.slice(
                             sij,
-                            [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                            [q_tile, valid_len],
                             [0, 0],
                         )
 
                         pij_f16: pl.Tensor[[q_tile, block_size_cfg], pl.BF16] = pl.create_tensor(
-                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, block_size_cfg],
                             dtype=pl.BF16,
                         )
-                        mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
-                        li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)  # type: ignore[reportArgumentType]
+                        mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
+                        li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
 
                         # Softmax prepare (VECTOR) via shared module-level InCore kernel
                         pij_f16, mi, li = kernel_softmax_prepare(sij_valid, 1.0, pij_f16, mi, li)  # type: ignore[reportArgumentType]
 
                         oi_tmp: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             dtype=pl.FP32,
                         )
                         # PV matmul (CUBE) via shared module-level InCore kernel
@@ -339,18 +339,18 @@ def build_paged_attention_program(
 
                         # Conditional flags
                         if bn == 0:
-                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)
                         else:
-                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)
                         if bn == bn_this_batch - 1:
-                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)
                         else:
-                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)
 
                         # Output view: same row offset as query view
                         out_view: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.slice(
                             out,
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             [cur_offset, 0],
                         )
                         # Online softmax update via shared module-level InCore kernel

--- a/examples/language/intermediate/activation.py
+++ b/examples/language/intermediate/activation.py
@@ -30,9 +30,9 @@ class SiluProgram:
     ) -> pl.Tensor[[32, 128], pl.FP32]:
         # SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
         tile_x: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
-        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, -1.0)  # type: ignore[reportArgumentType]
+        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, -1.0)
         exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(x_neg)
-        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
         result: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
         out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], output)
@@ -58,10 +58,10 @@ class GeluProgram:
     ) -> pl.Tensor[[32, 128], pl.FP32]:
         # GELU(x) = x * sigmoid(1.702 * x)  (fast approximation)
         tile_x: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
-        x_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
-        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
+        x_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, 1.702)
+        x_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(x_scaled, -1.0)
         exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(x_neg)
-        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
         result: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_x, sigmoid)
         out: pl.Tensor[[32, 128], pl.FP32] = pl.store(result, [0, 0], output)
@@ -89,9 +89,9 @@ class SwigluProgram:
         # SwiGLU(gate, up) = Swish(gate) * up = gate * sigmoid(gate) * up
         tile_gate: pl.Tile[[32, 128], pl.FP32] = pl.load(gate, [0, 0], [32, 128])
         tile_up: pl.Tile[[32, 128], pl.FP32] = pl.load(up, [0, 0], [32, 128])
-        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
+        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, -1.0)
         exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(gate_neg)
-        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
         swish: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, sigmoid)
         result: pl.Tile[[32, 128], pl.FP32] = pl.mul(swish, tile_up)
@@ -122,10 +122,10 @@ class GegluProgram:
         # GELU approximation: gate * sigmoid(1.702 * gate)
         tile_gate: pl.Tile[[32, 128], pl.FP32] = pl.load(gate, [0, 0], [32, 128])
         tile_up: pl.Tile[[32, 128], pl.FP32] = pl.load(up, [0, 0], [32, 128])
-        gate_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, 1.702)  # type: ignore[reportArgumentType]
-        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(gate_scaled, -1.0)  # type: ignore[reportArgumentType]
+        gate_scaled: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, 1.702)
+        gate_neg: pl.Tile[[32, 128], pl.FP32] = pl.mul(gate_scaled, -1.0)
         exp_neg: pl.Tile[[32, 128], pl.FP32] = pl.exp(gate_neg)
-        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[32, 128], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[32, 128], pl.FP32] = pl.recip(denom)
         gelu_gate: pl.Tile[[32, 128], pl.FP32] = pl.mul(tile_gate, sigmoid)
         result: pl.Tile[[32, 128], pl.FP32] = pl.mul(gelu_gate, tile_up)

--- a/examples/language/intermediate/ffn_activations.py
+++ b/examples/language/intermediate/ffn_activations.py
@@ -49,10 +49,10 @@ class FFNGeluProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         """Vector InCore: apply GELU activation — x * sigmoid(1.702 * x)."""
         tile_x: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
-        x_scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, 1.702)  # type: ignore[reportArgumentType]
-        x_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(x_scaled, -1.0)  # type: ignore[reportArgumentType]
+        x_scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, 1.702)
+        x_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(x_scaled, -1.0)
         exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(x_neg)
-        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
         result: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_x, sigmoid)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], output)
@@ -105,9 +105,9 @@ class FFNSwigluProgram:
         """Vector InCore: apply SwiGLU activation — gate * sigmoid(gate) * up."""
         tile_gate: pl.Tile[[64, 64], pl.FP32] = pl.load(gate, [0, 0], [64, 64])
         tile_up: pl.Tile[[64, 64], pl.FP32] = pl.load(up, [0, 0], [64, 64])
-        gate_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
+        gate_neg: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, -1.0)
         exp_neg: pl.Tile[[64, 64], pl.FP32] = pl.exp(gate_neg)
-        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+        denom: pl.Tile[[64, 64], pl.FP32] = pl.add(exp_neg, 1.0)
         sigmoid: pl.Tile[[64, 64], pl.FP32] = pl.recip(denom)
         swish: pl.Tile[[64, 64], pl.FP32] = pl.mul(tile_gate, sigmoid)
         result: pl.Tile[[64, 64], pl.FP32] = pl.mul(swish, tile_up)

--- a/examples/language/intermediate/layer_norm.py
+++ b/examples/language/intermediate/layer_norm.py
@@ -41,7 +41,7 @@ class LayerNormProgram:
         )
         mean: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(tile_x, tmp)
         mean_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean, [1, 32])
-        mean_T = pl.mul(mean_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        mean_T = pl.mul(mean_T, 0.015625)  # 1.0 / 64
         mean = pl.reshape(mean_T, [32, 1])
 
         # centered = x - mean (broadcast mean across hidden dim)
@@ -54,12 +54,12 @@ class LayerNormProgram:
         )
         var: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(squared, tmp2)
         var_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(var, [1, 32])
-        var_T = pl.mul(var_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        var_T = pl.mul(var_T, 0.015625)  # 1.0 / 64
         var = pl.reshape(var_T, [32, 1])
 
         # std = sqrt(var + eps)
         var_T2: pl.Tile[[1, 32], pl.FP32] = pl.reshape(var, [1, 32])
-        var_eps_T: pl.Tile[[1, 32], pl.FP32] = pl.add(var_T2, 1e-5)  # type: ignore[reportArgumentType]
+        var_eps_T: pl.Tile[[1, 32], pl.FP32] = pl.add(var_T2, 1e-5)
         std_T: pl.Tile[[1, 32], pl.FP32] = pl.sqrt(var_eps_T)
         std: pl.Tile[[32, 1], pl.FP32] = pl.reshape(std_T, [32, 1])
 

--- a/examples/language/intermediate/rms_norm.py
+++ b/examples/language/intermediate/rms_norm.py
@@ -42,12 +42,12 @@ class RMSNormProgram:
         )
         mean_sq: pl.Tile[[32, 1], pl.FP32] = pl.row_sum(squared, tmp)
         mean_sq_T: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean_sq, [1, 32])
-        mean_sq_T = pl.mul(mean_sq_T, 0.015625)  # 1.0 / 64  # type: ignore[reportArgumentType]
+        mean_sq_T = pl.mul(mean_sq_T, 0.015625)  # 1.0 / 64
         mean_sq = pl.reshape(mean_sq_T, [32, 1])
 
         # rms = sqrt(mean_sq + eps)
         mean_sq_T2: pl.Tile[[1, 32], pl.FP32] = pl.reshape(mean_sq, [1, 32])
-        rms_T: pl.Tile[[1, 32], pl.FP32] = pl.add(mean_sq_T2, 1e-5)  # type: ignore[reportArgumentType]
+        rms_T: pl.Tile[[1, 32], pl.FP32] = pl.add(mean_sq_T2, 1e-5)
         rms_T = pl.sqrt(rms_T)
         rms: pl.Tile[[32, 1], pl.FP32] = pl.reshape(rms_T, [32, 1])
 

--- a/examples/language/llm_models/llama_7b_mini.py
+++ b/examples/language/llm_models/llama_7b_mini.py
@@ -109,11 +109,11 @@ def build_llama_mini_program(
             mean_sq: pl.Tile[[seq_len, 1], pl.FP32] = pl.row_sum(squared, tmp)
             # [S, 1] is ColMajor; reshape to [1, S] for scalar mul, then back
             mean_sq_T: pl.Tile[[1, seq_len], pl.FP32] = pl.reshape(mean_sq, [1, seq_len])
-            mean_sq_T = pl.mul(mean_sq_T, inv_head_dim)  # type: ignore[reportArgumentType]
+            mean_sq_T = pl.mul(mean_sq_T, inv_head_dim)
             mean_sq = pl.reshape(mean_sq_T, [seq_len, 1])
 
             mean_sq_T2: pl.Tile[[1, seq_len], pl.FP32] = pl.reshape(mean_sq, [1, seq_len])
-            rms_T: pl.Tile[[1, seq_len], pl.FP32] = pl.add(mean_sq_T2, 1e-6)  # type: ignore[reportArgumentType]
+            rms_T: pl.Tile[[1, seq_len], pl.FP32] = pl.add(mean_sq_T2, 1e-6)
             rms_T = pl.sqrt(rms_T)
             rms: pl.Tile[[seq_len, 1], pl.FP32] = pl.reshape(rms_T, [seq_len, 1])
 
@@ -283,7 +283,7 @@ def build_llama_mini_program(
         ) -> pl.Tensor[[seq_len, seq_len], pl.FP32]:
             """Scale attention scores by 1/sqrt(head_dim)."""
             tile: pl.Tile[[seq_len, seq_len], pl.FP32] = pl.load(scores, [0, 0], [seq_len, seq_len])
-            scaled: pl.Tile[[seq_len, seq_len], pl.FP32] = pl.mul(tile, attn_scale)  # type: ignore[reportArgumentType]
+            scaled: pl.Tile[[seq_len, seq_len], pl.FP32] = pl.mul(tile, attn_scale)
             out: pl.Tensor[[seq_len, seq_len], pl.FP32] = pl.store(scaled, [0, 0], output)
             return out
 
@@ -385,9 +385,9 @@ def build_llama_mini_program(
                 up, [0, 0], [seq_len, head_dim], target_memory=pl.MemorySpace.Vec
             )
 
-            gate_neg: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.mul(tile_gate, -1.0)  # type: ignore[reportArgumentType]
+            gate_neg: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.mul(tile_gate, -1.0)
             exp_neg: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.exp(gate_neg)
-            denom: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.add(exp_neg, 1.0)  # type: ignore[reportArgumentType]
+            denom: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.add(exp_neg, 1.0)
             sigmoid: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.recip(denom)
             swish: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.mul(tile_gate, sigmoid)
             result: pl.Tile[[seq_len, head_dim], pl.FP32] = pl.mul(swish, tile_up)

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -19,6 +19,7 @@ from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core import passes as _passes
 
 from .pass_manager import OptimizationStrategy, PassManager
+from .pto_codegen import PartialCodegenError, generate
 
 
 def _write_files(files: dict[str, str], output_dir: str) -> None:
@@ -113,8 +114,6 @@ def compile(
         transformed_program = pm.run_passes(program, dump_ir=dump_passes, output_dir=passes_dump_dir)
 
     if backend_type in (BackendType.Ascend910B_PTO, BackendType.Ascend950):
-        from .pto_codegen import PartialCodegenError, generate  # noqa: PLC0415
-
         try:
             files = generate(transformed_program, output_dir, skip_ptoas=skip_ptoas)
         except PartialCodegenError as exc:

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -106,11 +106,11 @@ class RangeIterator(Generic[T]):
             If no init_values: just the loop variable (Scalar)
             If init_values provided: Tuple of (loop_var, (iter_arg_values...))
         """
-        if self.current >= self.stop:  # type: ignore[operator]
+        if self.current >= self.stop:
             raise StopIteration
 
         value = self.current
-        self.current += self.step  # type: ignore[operator]
+        self.current += self.step
 
         # Return just the value if no init_values, otherwise return (value, iter_args_tuple)
         if not self.init_values:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -56,6 +56,7 @@ __all__ = [
 
 from pypto.ir.utils import resolve_cast_mode
 from pypto.pypto_core import DataType
+from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import MemorySpace, PadValue
 
 from ..typing import IntLike, Scalar, Tensor, Tile
@@ -474,8 +475,6 @@ def cast(
     if isinstance(input, Scalar):
         if resolve_cast_mode(mode) != 2:
             raise ValueError(f"cast: Scalar inputs do not support non-default mode, got mode={mode!r}")
-        from pypto.pypto_core import ir as _ir_core  # noqa: PLC0415
-
         dtype = DataType(target_type) if isinstance(target_type, int) else target_type
         return Scalar(expr=_ir_core.cast(input.unwrap(), dtype))
     raise TypeError(f"cast: expected Tensor, Tile, or Scalar, got {type(input).__name__}")

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -890,17 +890,19 @@ class ASTParser:
         if not self._is_cond_call(stmt):
             return None
 
-        call = stmt.value  # type: ignore[union-attr]
+        assert isinstance(stmt, ast.Expr)
+        call = stmt.value
+        assert isinstance(call, ast.Call)
 
         # Parse the condition argument
-        if len(call.args) != 1:  # type: ignore[attr-defined]
+        if len(call.args) != 1:
             raise ParserSyntaxError(
                 "pl.cond() requires exactly 1 argument",
                 span=self.span_tracker.get_span(call),
                 hint="Use: pl.cond(condition)",
             )
 
-        return self.parse_expression(call.args[0])  # type: ignore[attr-defined]
+        return self.parse_expression(call.args[0])
 
     @staticmethod
     def _is_dsl_call(stmt: ast.Expr, func_name: str) -> bool:
@@ -958,10 +960,11 @@ class ASTParser:
 
     def _handle_static_print(self, stmt: ast.Expr) -> None:
         """Handle pl.static_print() — print IR info to stdout at parse time."""
-        call = stmt.value  # type: ignore[union-attr]
+        call = stmt.value
+        assert isinstance(call, ast.Call)
         span = self.span_tracker.get_span(stmt)
 
-        if not call.args:  # type: ignore[union-attr]
+        if not call.args:
             raise ParserSyntaxError(
                 "static_print() requires at least 1 argument",
                 span=span,
@@ -969,7 +972,7 @@ class ASTParser:
             )
 
         parts: list[str] = []
-        for arg in call.args:  # type: ignore[union-attr]
+        for arg in call.args:
             # String literals are printed as-is (labels)
             if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
                 parts.append(arg.value)
@@ -984,10 +987,11 @@ class ASTParser:
 
     def _handle_static_assert(self, stmt: ast.Expr) -> None:
         """Handle pl.static_assert() — assert condition at parse time."""
-        call = stmt.value  # type: ignore[union-attr]
+        call = stmt.value
+        assert isinstance(call, ast.Call)
         span = self.span_tracker.get_span(stmt)
 
-        args = call.args  # type: ignore[union-attr]
+        args = call.args
         if len(args) < 1 or len(args) > 2:
             raise ParserSyntaxError(
                 "static_assert() requires 1 or 2 arguments",

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -142,6 +142,61 @@ class Scalar(metaclass=ScalarMeta):
             "Scalar wraps a symbolic IR expression and has no concrete truth value."
         )
 
+    # ------------------------------------------------------------------
+    # Arithmetic operators — enable type-checked DSL expressions like
+    # ``n * 2`` or ``n // 4`` where ``n`` is a Scalar parameter.
+    # ------------------------------------------------------------------
+
+    def __add__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() + (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __radd__(self, other: "int | float") -> "Scalar":
+        return Scalar(expr=other + self.unwrap())
+
+    def __sub__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() - (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __rsub__(self, other: "int | float") -> "Scalar":
+        return Scalar(expr=other - self.unwrap())
+
+    def __mul__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() * (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __rmul__(self, other: "int | float") -> "Scalar":
+        return Scalar(expr=other * self.unwrap())
+
+    def __truediv__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() / (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __floordiv__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() // (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __mod__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() % (other.unwrap() if isinstance(other, Scalar) else other))
+
+    # ------------------------------------------------------------------
+    # Comparison operators — return Scalar wrapping the IR comparison node.
+    # ------------------------------------------------------------------
+
+    def __lt__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() < (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __le__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() <= (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __gt__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() > (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __ge__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() >= (other.unwrap() if isinstance(other, Scalar) else other))
+
+    # ------------------------------------------------------------------
+    # In-place operators for RangeIterator compatibility.
+    # ------------------------------------------------------------------
+
+    def __iadd__(self, other: "int | float | Scalar") -> "Scalar":
+        return self.__add__(other)
+
     @classmethod
     def __class_getitem__(cls, item: DataType) -> "Scalar":
         """Support static type checkers for Scalar[dtype] syntax."""

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -153,7 +153,7 @@ def generate_golden_source(
 
 def _init_expr(spec: TensorSpec) -> str:
     """Return the Python expression (string) used to initialise this tensor in golden.py."""
-    import torch  # type: ignore[import]  # noqa: PLC0415
+    import torch  # type: ignore[import]  # noqa: PLC0415 — optional dependency
 
     dtype_str = _torch_dtype_str(spec.dtype)
     shape_str = repr(tuple(spec.shape))
@@ -191,7 +191,7 @@ def _init_expr(spec: TensorSpec) -> str:
 
 def _tensor_literal_expr(tensor: "torch.Tensor", shape_str: str, dtype_str: str) -> str:
     """Generate an inline expression for a concrete torch.Tensor init_value."""
-    import torch  # type: ignore[import]  # noqa: PLC0415
+    import torch  # type: ignore[import]  # noqa: PLC0415 — optional dependency
 
     if tensor.numel() == 0:
         return f"torch.zeros({shape_str}, dtype={dtype_str})"
@@ -224,7 +224,7 @@ def _tensor_literal_expr(tensor: "torch.Tensor", shape_str: str, dtype_str: str)
 
 def _torch_dtype_str(dtype: "torch.dtype") -> str:
     """Return the string representation of a torch dtype (e.g. 'torch.float32')."""
-    import torch  # type: ignore[import]  # noqa: PLC0415
+    import torch  # type: ignore[import]  # noqa: PLC0415 — optional dependency
 
     _map: dict[torch.dtype, str] = {
         torch.float32: "torch.float32",

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -35,6 +35,8 @@ Typical usage::
     print(result)  # PASS / FAIL: ...
 """
 
+import os
+import sys
 import time
 import traceback
 from collections.abc import Callable
@@ -250,9 +252,6 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
         platform: Target execution platform (``"a2a3sim"`` or ``"a2a3"``).
         device_id: Hardware device index.
     """
-    import os  # noqa: PLC0415
-    import sys  # noqa: PLC0415
-
     simpler_root = os.environ.get("SIMPLER_ROOT")
     if simpler_root:
         for sub in ("examples/scripts", "python"):
@@ -260,7 +259,7 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
             if p not in sys.path:
                 sys.path.insert(0, p)
 
-    from code_runner import CodeRunner  # type: ignore[import]  # noqa: PLC0415
+    from code_runner import CodeRunner  # type: ignore[import]  # noqa: PLC0415,I001 — available after sys.path setup
 
     CodeRunner(
         kernels_dir=str(work_dir),

--- a/python/pypto/runtime/tensor_spec.py
+++ b/python/pypto/runtime/tensor_spec.py
@@ -60,7 +60,7 @@ class TensorSpec:
         Returns:
             Initialised tensor with the requested shape and dtype.
         """
-        import torch  # type: ignore[import]  # noqa: PLC0415
+        import torch  # type: ignore[import]  # noqa: PLC0415 — optional dependency
 
         if self.init_value is None or self.is_output:
             return torch.zeros(self.shape, dtype=self.dtype)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -30,7 +30,11 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 import pytest  # noqa: E402
-from harness.core.environment import ensure_simpler_available  # noqa: E402
+from harness.core.environment import (  # noqa: E402
+    ensure_simpler_available,
+    get_simpler_python_path,
+    get_simpler_scripts_path,
+)
 from harness.core.test_runner import TestRunner  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
 
@@ -48,11 +52,6 @@ def setup_simpler_dependency(request):
     """
     if request.config.getoption("--codegen-only"):
         return  # Code generation only, Simpler not needed
-
-    from harness.core.environment import (  # noqa: PLC0415
-        get_simpler_python_path,
-        get_simpler_scripts_path,
-    )
 
     simpler_root = ensure_simpler_available()
     os.environ["SIMPLER_ROOT"] = str(simpler_root)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -25,6 +25,7 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from pypto.backend import set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
@@ -262,6 +263,4 @@ class TestSuite:
 
 
 if __name__ == "__main__":
-    import pytest  # noqa: PLC0415
-
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -16,6 +16,7 @@ import pypto.language as pl
 import pytest
 from pypto import backend, codegen
 from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
 def assert_code_equal(actual: str, expected: str) -> None:
@@ -1336,8 +1337,6 @@ class TestOrchestration:
                 return output_tensor
 
         # Run the full pass pipeline to produce compound SSA suffixes
-        from pypto.ir.pass_manager import OptimizationStrategy, PassManager
-
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         transformed = pm.run_passes(ChunkedInplaceProgram)
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -149,7 +149,6 @@ def test_pto_codegen_basic_mlir_structure():
             tile_a = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             tile_b = pl.add(tile_a, 1.0)
             pl.store(tile_b, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     # Compile with Default strategy (applies necessary passes + codegen)
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
@@ -184,7 +183,6 @@ def test_pto_codegen_tensor_parameters():
             tile_b = pl.load(input_b, offsets=[0, 0], shapes=[32, 32])
             tile_c = pl.mul(tile_a, tile_b)
             pl.store(tile_c, offsets=[0, 0], output_tensor=output)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(TensorParamProgram)
@@ -217,7 +215,6 @@ def test_pto_codegen_alloc_tile():
             tile_b = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             tile_c = pl.mul(tile_a, tile_b)
             pl.store(tile_c, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(AllocTileProgram)
@@ -367,7 +364,6 @@ def test_pto_codegen_tile_load_lowering():
         def load_test(self, input: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]):
             tile = pl.load(input, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=output)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(LoadProgram)
@@ -399,7 +395,6 @@ def test_pto_codegen_tile_store_lowering():
         def store_test(self, input: pl.Tensor[[32, 32], pl.FP32], output: pl.Tensor[[32, 32], pl.FP32]):
             tile = pl.load(input, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=output)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(StoreProgram)
@@ -431,7 +426,6 @@ def test_pto_codegen_tile_mul():
             tile_b = pl.load(b, offsets=[0, 0], shapes=[32, 32])
             tile_c = pl.mul(tile_a, tile_b)
             pl.store(tile_c, offsets=[0, 0], output_tensor=c)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(MulProgram)
@@ -457,7 +451,6 @@ def test_pto_codegen_tile_adds():
             tile_a = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             tile_b = pl.add(tile_a, 3.14)
             pl.store(tile_b, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(AddsProgram)
@@ -484,7 +477,6 @@ def test_pto_codegen_constants():
         def const_test(self, a: pl.Tensor[[32, 32], pl.FP32], b: pl.Tensor[[32, 32], pl.FP32]):
             tile_a = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile_a, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(ConstantProgram)
@@ -516,7 +508,6 @@ def test_pto_codegen_ssa_naming():
             tile_b = pl.load(b, offsets=[0, 0], shapes=[32, 32])
             tile_c = pl.mul(tile_a, tile_b)
             pl.store(tile_c, offsets=[0, 0], output_tensor=c)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(SSAProgram)
@@ -542,7 +533,6 @@ def test_pto_codegen_code_generation_order():
         def order_test(self, a: pl.Tensor[[32, 32], pl.FP32], b: pl.Tensor[[32, 32], pl.FP32]):
             tile = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(OrderProgram)
@@ -575,13 +565,11 @@ def test_pto_codegen_multiple_functions():
         def func1(self, a: pl.Tensor[[32, 32], pl.FP32], b: pl.Tensor[[32, 32], pl.FP32]):
             tile = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
         @pl.function(type=pl.FunctionType.InCore)
         def func2(self, x: pl.Tensor[[32, 32], pl.FP32], y: pl.Tensor[[32, 32], pl.FP32]):
             tile = pl.load(x, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=y)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(MultiFunc)
@@ -605,7 +593,6 @@ def test_pto_codegen_reusability():
         def test_func(self, a: pl.Tensor[[32, 32], pl.FP32], b: pl.Tensor[[32, 32], pl.FP32]):
             tile = pl.load(a, offsets=[0, 0], shapes=[32, 32])
             pl.store(tile, offsets=[0, 0], output_tensor=b)
-            return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     transformed_program = pm.run_passes(ReusableProgram)

--- a/tests/ut/codegen/test_pto_codegen_paged_attn.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn.py
@@ -124,7 +124,6 @@ class PagedAttention:
         pl.store(max_tile, [0, 0], mij)
         pl.store(sum_tile, [0, 0], lij)
         pl.store(pij_bf16_tile, [0, 0], pij)
-        return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
     @pl.function(type=pl.FunctionType.InCore)
     def online_update(
@@ -166,7 +165,6 @@ class PagedAttention:
         pl.store(li_new_tile, [0, 0], li)
         pl.store(oi_updated_tile, [0, 0], oi)
         pl.store(dst_tile, [0, 0], dst)
-        return  # noqa: PLR1711 - DSL requires explicit return to build IR return statement
 
 
 def test_tile_ops_codegen():

--- a/tests/ut/ir/high_level/test_builder.py
+++ b/tests/ut/ir/high_level/test_builder.py
@@ -353,9 +353,10 @@ class TestIRBuilderIfStmt:
             if_stmt = func.body
         else:
             # If there are multiple statements, find the if
-            assert isinstance(func.body, ir.SeqStmts)
+            body = func.body
+            assert isinstance(body, ir.SeqStmts)
             if_stmt = None
-            for stmt in func.body.stmts:  # type: ignore[attr-defined]
+            for stmt in body.stmts:
                 if isinstance(stmt, ir.IfStmt):
                     if_stmt = stmt
                     break

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -816,7 +816,7 @@ class TestEdgeCases:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                unused: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)  # noqa: F841
+                _unused: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)
                 result: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
                 return result
 
@@ -824,7 +824,7 @@ class TestEdgeCases:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                unused_0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)  # noqa: F841
+                _unused_0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)
                 result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
                 return result_0
 

--- a/tests/ut/ir/transforms/test_ctrl_flow_transform.py
+++ b/tests/ut/ir/transforms/test_ctrl_flow_transform.py
@@ -883,7 +883,7 @@ def test_continue_no_iter_args():
             for i in pl.range(0, 10, 1):
                 if i < 5:
                     continue
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)  # noqa: F841
+                _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
             return x_0
 
     @pl.program
@@ -911,7 +911,7 @@ def test_break_no_iter_args():
             for i in pl.range(0, 10, 1):
                 if i > 5:
                     break
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)  # noqa: F841
+                _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
             return x_0
 
     @pl.program

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel.py
@@ -1831,9 +1831,7 @@ class TestDCERegression:
                 w_mat = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 w_right = pl.move(w_mat, target_memory=pl.MemorySpace.Right)
                 z = pl.matmul(x_left, w_right)
-                z_vec = pl.move(  # noqa: F841
-                    z, target_memory=pl.MemorySpace.Vec
-                )
+                _z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
                 # z_vec is dead — only a separate load+cast+store returns a value
                 x_tile = pl.load(x, [0, 0], [16, 128])
                 x_fp32 = pl.tile.cast(x_tile, target_type=pl.FP32, mode="round")
@@ -1865,7 +1863,7 @@ class TestDCERegression:
                 w: pl.Tensor[[128, 128], pl.BF16],
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
-                z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(  # noqa: F841
+                _z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
                     shape=[16, 128], dtype=pl.FP32, aiv_idx=0
                 )
                 x_tile = pl.load(x, [0, 0], [16, 128])

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -315,7 +315,7 @@ class TestFlattenCallInIfCondition:
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 # get_block_idx() in if condition
-                if pl.tile.get_block_idx() < 10:  # type: ignore[operator]
+                if pl.tile.get_block_idx() < 10:
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
                 return output
@@ -327,7 +327,7 @@ class TestFlattenCallInIfCondition:
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 t__tmp_v0: pl.Scalar[pl.UINT64] = pl.tile.get_block_idx()
-                if t__tmp_v0 < 10:  # type: ignore[operator]
+                if t__tmp_v0 < 10:
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
                 return output

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -503,7 +503,7 @@ class TestScalarRange:
 
         @pl.function
         def scalar_expr_stop(n: pl.Scalar[pl.INT64], x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            for i in pl.range(n * 2):  # type: ignore[operator]
+            for i in pl.range(n * 2):
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 
@@ -519,7 +519,7 @@ class TestScalarRange:
         def scalar_complex_expr(
             n: pl.Scalar[pl.INT64], x: pl.Tensor[[64], pl.FP32]
         ) -> pl.Tensor[[64], pl.FP32]:
-            for i in pl.range(n * 2 + 1):  # type: ignore[operator]
+            for i in pl.range(n * 2 + 1):
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 
@@ -535,7 +535,7 @@ class TestScalarRange:
         def scalar_floordiv_expr(
             n: pl.Scalar[pl.INT64], x: pl.Tensor[[64], pl.FP32]
         ) -> pl.Tensor[[64], pl.FP32]:
-            for i in pl.range(n // 4):  # type: ignore[operator]
+            for i in pl.range(n // 4):
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 

--- a/tests/ut/language/parser/test_text_parser.py
+++ b/tests/ut/language/parser/test_text_parser.py
@@ -543,7 +543,7 @@ class TestScalarRangeRoundTrip:
         class Before:
             @pl.function
             def main(self, n: pl.Scalar[pl.INT64], x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(n * 2):  # type: ignore[operator]
+                for i in pl.range(n * 2):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
                 return y
 


### PR DESCRIPTION
## Summary
- Remove 116 lint bypass annotations (`noqa`, `type: ignore`) by fixing the underlying type/lint issues instead of suppressing them
- Add arithmetic and comparison operators to `Scalar` class, enabling proper type checking for DSL expressions like `n * 2`, `n // 4`, `n < 10`
- Add `isinstance` type guards in `ast_parser.py` to replace blanket `type: ignore[union-attr]` suppressions
- Move deferred imports (`os`, `sys`, `pytest`, etc.) to top-level where not circular

## Changes by category

| Category | Count | Method |
|----------|-------|--------|
| `PLR1711` useless return | 15 | Removed the unnecessary `return` statements |
| `PLC0415` import not at top | 6 | Moved imports to module level |
| `F841` unused variable | 7 | Added `_` prefix to DSL variables |
| `union-attr` / `attr-defined` | 9 | Added `isinstance` type guards |
| `operator` | 8 | Added operators to `Scalar` class |
| `reportArgumentType` | 71 | Removed — pyright no longer flags these |

## Testing
- [x] All 2586 unit tests pass
- [x] ruff check passes
- [x] pyright pre-commit hook passes
- [x] Code review completed