### PR TITLE
feat(codegen): add split attribute to tpop ops and fix SSA naming for buffer ops

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -121,22 +121,24 @@ print(pto_code)
 
 | PyPTO Operation | Generated PTO-ISA | Description |
 | --------------- | ----------------- | ----------- |
-| `tile.tpush_to_aiv(tile, aiv_idx=N)` | `pto.tpush_to_aiv ins(%tile : type) {aiv_idx = N}` | Cube → Vector push |
-| `tile.tpush_to_aic(tile, aiv_idx=N)` | `pto.tpush_to_aic ins(%tile : type) {aiv_idx = N}` | Vector → Cube push |
-| `tile.tpop_from_aic(aiv_idx=N)` | `pto.tpop_from_aic outs(%buf : type) {aiv_idx = N}` | Pop from Cube pipe |
-| `tile.tpop_from_aiv(aiv_idx=N)` | `pto.tpop_from_aiv outs(%buf : type) {aiv_idx = N}` | Pop from Vector pipe |
+| `tile.tpush_to_aiv(tile, split=N)` | `pto.tpush_to_aiv ins(%tile : type) {split = N}` | Cube → Vector push |
+| `tile.tpush_to_aic(tile, split=N)` | `pto.tpush_to_aic ins(%tile : type) {split = N}` | Vector → Cube push |
+| `tile.tpop_from_aic(split=N)` | `pto.tpop_from_aic outs(%buf : type) {split = N}` | Pop from Cube pipe |
+| `tile.tpop_from_aiv(split=N)` | `pto.tpop_from_aiv outs(%buf : type) {split = N}` | Pop from Vector pipe |
 | `system.tfree_to_aic(aiv_idx=N)` | `pto.tfree_to_aic {aiv_idx = N}` | Release slot to Cube |
 | `system.tfree_to_aiv(aiv_idx=N)` | `pto.tfree_to_aiv {aiv_idx = N}` | Release slot to Vector |
-| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S, ...}` | Cube pipe init |
-| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {dir_mask = D, slot_size = S, ...}` | Vector pipe init |
-| `system.reserve_buffer(...)` | `pto.reserve_buffer {name = "N", size = S, base = B}` | Reserve buffer |
-| `system.import_peer_buffer(...)` | `pto.import_peer_buffer {name = "N", peer_func = "F"}` | Import peer buffer |
+| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube pipe init |
+| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector pipe init |
+| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = A} -> i32` | Reserve buffer |
+| `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | Import peer buffer |
 
 **Notes:**
 
 - Push ops use `ins()` clause with typed tile buffer; pop ops use `outs()` clause
-- `initialize_pipe` only emits `c2v_consumer_buf`/`v2c_consumer_buf` when the value is ≥ 0 (i.e., not AUTO)
-- `reserve_buffer` emits `base = auto` when base is AUTO (-1), or `base = <value>` for explicit addresses
+- `reserve_buffer` and `import_reserved_buffer` return `i32` SSA values; `initialize_pipe` references them as operands
+- `reserve_buffer` emits `auto = true` when base is AUTO, or `auto = false, base = <value>` for explicit addresses
+- `reserve_buffer` location is `mat` for AIC functions, `vec` for AIV/InCore functions
+- `import_reserved_buffer` uses MLIR symbol syntax (`@func_name`) for `peer_func`
 - Buffer name and peer_func strings are validated by `CheckSafeIdentifier` (alphanumeric + underscore only)
 
 ### Parameter Type Handling

--- a/docs/en/reference/pto-isa/01-tpush_tpop.md
+++ b/docs/en/reference/pto-isa/01-tpush_tpop.md
@@ -135,36 +135,38 @@ Four direction-specific instructions — direction is encoded in the opcode, no 
 
 | Instruction | Core | Role | Direction |
 | ----------- | ---- | ---- | --------- |
-| `tpush_to_aiv(TILE, AIV_IDX)` | Cube | Producer | C2V |
-| `tpush_to_aic(TILE, AIV_IDX)` | Vector | Producer | V2C |
-| `tpop_from_aic(TILE, AIV_IDX)` | Vector | Consumer | C2V |
-| `tpop_from_aiv(TILE, AIV_IDX)` | Cube | Consumer | V2C |
+| `tpush_to_aiv(TILE, SPLIT)` | Cube | Producer | C2V |
+| `tpush_to_aic(TILE, SPLIT)` | Vector | Producer | V2C |
+| `tpop_from_aic(TILE, SPLIT)` | Vector | Consumer | C2V |
+| `tpop_from_aiv(TILE, SPLIT)` | Cube | Consumer | V2C |
 
-**Parameters:**
+**Parameters (tpush):**
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `TILE` | `Tile&` | Source (push) or destination (pop) tile |
-| `AIV_IDX` | `uint8_t` | Buddy Vector core index (0 or 1) — see note below |
+| `TILE` | `Tile&` | Source tile to push |
+| `SPLIT` | `int` | Split mode (0=none, 1=up-down, 2=left-right) |
 
-> **`AIV_IDX` semantics vary by core type:**
->
-> - On **Cube-executed** instructions (`tpush_to_aiv`, `tpop_from_aiv`): `AIV_IDX` is the **target/source buddy Vector core index**.
-> - On **Vector-executed** instructions (`tpush_to_aic`, `tpop_from_aic`): `AIV_IDX` is **this Vector core's own index**, identifying which hardware flag pair to use.
+**Parameters (tpop):**
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `TILE` | `Tile&` | Destination tile to receive into |
+| `SPLIT` | `int` | Split mode (0=none, 1=up-down, 2=left-right) |
 
 ### Push Protocol (`tpush_to_aiv` / `tpush_to_aic`)
 
 ```text
-function tpush_*(TILE, AIV_IDX):
+function tpush_*(TILE, SPLIT):
     // 1. Wait for slot to be free (consumer has released it)
-    WAIT flag_free[dir, AIV_IDX]: target_tag
+    WAIT flag_free[dir]: target_tag
 
     // 2. DMA tile data into ring buffer slot
     MTE_copy(src=TILE.data, dst=ring_buf + target_tag * SLOT_SIZE, size=SLOT_SIZE)
     SET mte_flag; WAIT mte_flag           // ensure DMA complete
 
     // 3. Signal consumer: data in slot is ready
-    SET flag_ready[dir, AIV_IDX]: target_tag
+    SET flag_ready[dir]: target_tag
 
     // 4. Advance to next slot
     target_tag = (target_tag + 1) % SLOT_NUM
@@ -173,9 +175,9 @@ function tpush_*(TILE, AIV_IDX):
 ### Pop Protocol (`tpop_from_aic` / `tpop_from_aiv`)
 
 ```text
-function tpop_*(TILE, AIV_IDX):
+function tpop_*(TILE, SPLIT):
     // 1. Wait for data to be ready (producer has filled the slot)
-    WAIT flag_ready[dir, AIV_IDX]: target_tag
+    WAIT flag_ready[dir]: target_tag
 
     // 2. Load tile data from ring buffer slot
     if PLATFORM_A2A3:
@@ -185,7 +187,7 @@ function tpop_*(TILE, AIV_IDX):
         TILE.data = ring_buf + target_tag * SLOT_SIZE   // zero-copy
 
     // 3. Signal producer: slot is free for reuse
-    SET flag_free[dir, AIV_IDX]: target_tag
+    SET flag_free[dir]: target_tag
 
     // 4. Advance to next slot
     target_tag = (target_tag + 1) % SLOT_NUM
@@ -254,7 +256,7 @@ Flag usage (per AIV peer):
 2. **Backpressure** — producer blocks when all slots full; consumer blocks when empty
 3. **FIFO order** — strict round-robin `(tag + 1) % SLOT_NUM`
 4. **Decoupled DMA** — async MTE transfer with explicit flag wait
-5. **Buddy core selection** — `AIV_IDX` selects which Vector core (0 or 1)
+5. **Buddy core selection** — handled by initialization, not per-instruction
 6. **Static direction** — direction encoded in opcode, verified at compile time
 
 ## API Summary
@@ -263,7 +265,7 @@ Flag usage (per AIV peer):
 | --- | ---- | ---- | ----------- |
 | `aic_initialize_pipe(...)` | Cube | Setup | Bind ring buffer, init tags, pre-signal free slots for V2C |
 | `aiv_initialize_pipe(...)` | Vector | Setup | Bind ring buffer, init tags, pre-signal free slots for C2V |
-| `tpush_to_aiv(TILE, AIV_IDX)` | Cube | Producer | Wait free → DMA tile → signal ready |
-| `tpush_to_aic(TILE, AIV_IDX)` | Vector | Producer | Wait free → DMA tile → signal ready |
-| `tpop_from_aic(TILE, AIV_IDX)` | Vector | Consumer | Wait ready → load tile → signal free |
-| `tpop_from_aiv(TILE, AIV_IDX)` | Cube | Consumer | Wait ready → load tile → signal free |
+| `tpush_to_aiv(TILE, SPLIT)` | Cube | Producer | Wait free → DMA tile → signal ready |
+| `tpush_to_aic(TILE, SPLIT)` | Vector | Producer | Wait free → DMA tile → signal ready |
+| `tpop_from_aic(TILE, SPLIT)` | Vector | Consumer | Wait ready → load tile → signal free |
+| `tpop_from_aiv(TILE, SPLIT)` | Cube | Consumer | Wait ready → load tile → signal free |

--- a/docs/en/reference/pto-isa/02-buffer_management.md
+++ b/docs/en/reference/pto-isa/02-buffer_management.md
@@ -135,7 +135,7 @@ def my_vector_kernel(self, ...):
     )
 
     for ...:
-        tile = pl.tpop_from_aic(aiv_idx=0)    # zero-copy from pipe_buf on A5
+        tile = pl.tpop_from_aic()              # zero-copy from pipe_buf on A5
         # ... compute on tile ...
         pl.tfree_to_aic(aiv_idx=0)             # release slot
 ```
@@ -158,7 +158,7 @@ def my_cube_kernel(self, ...):
     )
 
     for ...:
-        pl.tpush_to_aiv(tile, aiv_idx=0)    # DMA to peer_buf.base on A5
+        pl.tpush_to_aiv(tile, split=0)       # DMA to peer_buf.base on A5
 ```
 
 ### DSL Summary
@@ -171,30 +171,43 @@ def my_cube_kernel(self, ...):
 
 ## IR Representation
 
-`pl.reserve_buffer` lowers to a `ReserveBuffer` node:
+`pl.reserve_buffer` lowers to a `pto.reserve_buffer` op that returns an `i32` SSA value:
 
-```text
+```mlir
 func @my_vector_kernel(...) {
-    %pipe_buf = reserve_buffer {
+    %c2v_slot_buffer = pto.reserve_buffer {
         name = "c2v_slot_buffer",
-        size = 4096,              // SLOT_NUM * SLOT_SIZE
-        base = auto,              // or literal 0x1000
-        memory_space = "UB"       // inferred from core type
-    }
+        size = 4096,
+        location = #pto.address_space<vec>,
+        auto = true
+    } -> i32
     ...
 }
 ```
 
-`pl.import_peer_buffer` lowers to an `ImportPeerBuffer` node:
+`pl.import_peer_buffer` lowers to a `pto.import_reserved_buffer` op that returns an `i32` SSA value, using MLIR symbol syntax for `peer_func`:
 
-```text
+```mlir
 func @my_cube_kernel(...) {
-    %peer_buf = import_peer_buffer {
+    %c2v_slot_buffer_import = pto.import_reserved_buffer {
         name = "c2v_slot_buffer",
         peer_func = @my_vector_kernel
-    }
+    } -> i32
     ...
 }
+```
+
+The `initialize_pipe` ops reference these SSA values as operands instead of integer attributes:
+
+```mlir
+// Cube side (AIC): consumer for V2C (reserve_buffer), producer for C2V (import)
+%c0_i32 = arith.constant 0 : i32
+%v2c_buf = pto.reserve_buffer {name = "v2c_slot_buffer", size = 4096,
+    location = #pto.address_space<mat>, auto = false, base = 4096} -> i32
+%c2v_import = pto.import_reserved_buffer {name = "c2v_slot_buffer",
+    peer_func = @my_vector_kernel} -> i32
+pto.aic_initialize_pipe {dir_mask = 3, slot_size = 512}
+    (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %v2c_buf : i32)
 ```
 
 ## Allocator Handling

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -121,22 +121,24 @@ print(pto_code)
 
 | PyPTO 操作 | 生成的 PTO-ISA | 描述 |
 | ---------- | -------------- | ---- |
-| `tile.tpush_to_aiv(tile, aiv_idx=N)` | `pto.tpush_to_aiv ins(%tile : type) {aiv_idx = N}` | Cube → Vector 推送 |
-| `tile.tpush_to_aic(tile, aiv_idx=N)` | `pto.tpush_to_aic ins(%tile : type) {aiv_idx = N}` | Vector → Cube 推送 |
-| `tile.tpop_from_aic(aiv_idx=N)` | `pto.tpop_from_aic outs(%buf : type) {aiv_idx = N}` | 从 Cube 管道弹出 |
-| `tile.tpop_from_aiv(aiv_idx=N)` | `pto.tpop_from_aiv outs(%buf : type) {aiv_idx = N}` | 从 Vector 管道弹出 |
+| `tile.tpush_to_aiv(tile, split=N)` | `pto.tpush_to_aiv ins(%tile : type) {split = N}` | Cube → Vector 推送 |
+| `tile.tpush_to_aic(tile, split=N)` | `pto.tpush_to_aic ins(%tile : type) {split = N}` | Vector → Cube 推送 |
+| `tile.tpop_from_aic(split=N)` | `pto.tpop_from_aic outs(%buf : type) {split = N}` | 从 Cube 管道弹出 |
+| `tile.tpop_from_aiv(split=N)` | `pto.tpop_from_aiv outs(%buf : type) {split = N}` | 从 Vector 管道弹出 |
 | `system.tfree_to_aic(aiv_idx=N)` | `pto.tfree_to_aic {aiv_idx = N}` | 释放槽位给 Cube |
 | `system.tfree_to_aiv(aiv_idx=N)` | `pto.tfree_to_aiv {aiv_idx = N}` | 释放槽位给 Vector |
-| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S, ...}` | Cube 管道初始化 |
-| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {dir_mask = D, slot_size = S, ...}` | Vector 管道初始化 |
-| `system.reserve_buffer(...)` | `pto.reserve_buffer {name = "N", size = S, base = B}` | 预留缓冲区 |
-| `system.import_peer_buffer(...)` | `pto.import_peer_buffer {name = "N", peer_func = "F"}` | 导入对等缓冲区 |
+| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube 管道初始化 |
+| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector 管道初始化 |
+| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = A} -> i32` | 预留缓冲区 |
+| `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | 导入对等缓冲区 |
 
 **说明：**
 
 - Push 操作使用带类型的 `ins()` 子句；Pop 操作使用 `outs()` 子句
-- `initialize_pipe` 仅在值 ≥ 0（即非 AUTO）时输出 `c2v_consumer_buf`/`v2c_consumer_buf`
-- `reserve_buffer` 在 base 为 AUTO (-1) 时输出 `base = auto`，显式地址时输出 `base = <value>`
+- `reserve_buffer` 和 `import_reserved_buffer` 返回 `i32` SSA 值；`initialize_pipe` 以操作数引用这些值
+- `reserve_buffer` 在 base 为 AUTO 时输出 `auto = true`，显式地址时输出 `auto = false, base = <value>`
+- `reserve_buffer` location 对于 AIC 函数为 `mat`，对于 AIV/InCore 函数为 `vec`
+- `import_reserved_buffer` 使用 MLIR 符号语法（`@func_name`）表示 `peer_func`
 - 缓冲区名称和 peer_func 字符串由 `CheckSafeIdentifier` 验证（仅允许字母数字和下划线）
 
 ### 参数类型处理

--- a/docs/zh-cn/reference/pto-isa/01-tpush_tpop.md
+++ b/docs/zh-cn/reference/pto-isa/01-tpush_tpop.md
@@ -135,36 +135,38 @@ function aic_initialize_pipe(DIR_MASK, SLOT_SIZE, GM_SLOT_BUFFER,
 
 | 指令 | 核心 | 角色 | 方向 |
 | ---- | ---- | ---- | ---- |
-| `tpush_to_aiv(TILE, AIV_IDX)` | Cube | 生产者 | C2V |
-| `tpush_to_aic(TILE, AIV_IDX)` | Vector | 生产者 | V2C |
-| `tpop_from_aic(TILE, AIV_IDX)` | Vector | 消费者 | C2V |
-| `tpop_from_aiv(TILE, AIV_IDX)` | Cube | 消费者 | V2C |
+| `tpush_to_aiv(TILE, SPLIT)` | Cube | 生产者 | C2V |
+| `tpush_to_aic(TILE, SPLIT)` | Vector | 生产者 | V2C |
+| `tpop_from_aic(TILE, SPLIT)` | Vector | 消费者 | C2V |
+| `tpop_from_aiv(TILE, SPLIT)` | Cube | 消费者 | V2C |
 
-**参数：**
+**参数（tpush）：**
 
 | 参数 | 类型 | 说明 |
 | ---- | ---- | ---- |
-| `TILE` | `Tile&` | 源（push）或目标（pop）tile |
-| `AIV_IDX` | `uint8_t` | 伙伴 Vector 核心索引（0 或 1）— 见下方说明 |
+| `TILE` | `Tile&` | 要推送的源 tile |
+| `SPLIT` | `int` | 分割模式（0=无，1=上下，2=左右） |
 
-> **`AIV_IDX` 语义因核心类型而异：**
->
-> - **Cube 执行**的指令（`tpush_to_aiv`、`tpop_from_aiv`）：`AIV_IDX` 是**目标/源伙伴 Vector 核心索引**。
-> - **Vector 执行**的指令（`tpush_to_aic`、`tpop_from_aic`）：`AIV_IDX` 是**本 Vector 核心自身的索引**，标识使用哪组硬件标志位。
+**参数（tpop）：**
+
+| 参数 | 类型 | 说明 |
+| ---- | ---- | ---- |
+| `TILE` | `Tile&` | 接收数据的目标 tile |
+| `SPLIT` | `int` | 分割模式（0=无，1=上下，2=左右） |
 
 ### Push 协议（`tpush_to_aiv` / `tpush_to_aic`）
 
 ```text
-function tpush_*(TILE, AIV_IDX):
+function tpush_*(TILE, SPLIT):
     // 1. Wait for slot to be free (consumer has released it)
-    WAIT flag_free[dir, AIV_IDX]: target_tag
+    WAIT flag_free[dir]: target_tag
 
     // 2. DMA tile data into ring buffer slot
     MTE_copy(src=TILE.data, dst=ring_buf + target_tag * SLOT_SIZE, size=SLOT_SIZE)
     SET mte_flag; WAIT mte_flag           // ensure DMA complete
 
     // 3. Signal consumer: data in slot is ready
-    SET flag_ready[dir, AIV_IDX]: target_tag
+    SET flag_ready[dir]: target_tag
 
     // 4. Advance to next slot
     target_tag = (target_tag + 1) % SLOT_NUM
@@ -173,9 +175,9 @@ function tpush_*(TILE, AIV_IDX):
 ### Pop 协议（`tpop_from_aic` / `tpop_from_aiv`）
 
 ```text
-function tpop_*(TILE, AIV_IDX):
+function tpop_*(TILE, SPLIT):
     // 1. Wait for data to be ready (producer has filled the slot)
-    WAIT flag_ready[dir, AIV_IDX]: target_tag
+    WAIT flag_ready[dir]: target_tag
 
     // 2. Load tile data from ring buffer slot
     if PLATFORM_A2A3:
@@ -185,7 +187,7 @@ function tpop_*(TILE, AIV_IDX):
         TILE.data = ring_buf + target_tag * SLOT_SIZE   // zero-copy
 
     // 3. Signal producer: slot is free for reuse
-    SET flag_free[dir, AIV_IDX]: target_tag
+    SET flag_free[dir]: target_tag
 
     // 4. Advance to next slot
     target_tag = (target_tag + 1) % SLOT_NUM
@@ -254,7 +256,7 @@ Flag usage (per AIV peer):
 2. **背压（Backpressure）** — 生产者在所有槽满时阻塞；消费者在无数据时阻塞
 3. **FIFO 顺序** — 严格的轮询 `(tag + 1) % SLOT_NUM`
 4. **解耦 DMA** — 异步 MTE 传输，显式标志位等待
-5. **伙伴核心选择** — `AIV_IDX` 选择 Vector 核心（0 或 1）
+5. **伙伴核心选择** — 由初始化处理，非逐指令指定
 6. **静态方向** — 方向编码在操作码中，编译时验证
 
 ## API 总结
@@ -263,7 +265,7 @@ Flag usage (per AIV peer):
 | --- | ---- | ---- | ---- |
 | `aic_initialize_pipe(...)` | Cube | 初始化 | 绑定环形缓冲区，初始化标签，预信号 V2C 空闲槽 |
 | `aiv_initialize_pipe(...)` | Vector | 初始化 | 绑定环形缓冲区，初始化标签，预信号 C2V 空闲槽 |
-| `tpush_to_aiv(TILE, AIV_IDX)` | Cube | 生产者 | 等待空闲 → DMA tile → 信号就绪 |
-| `tpush_to_aic(TILE, AIV_IDX)` | Vector | 生产者 | 等待空闲 → DMA tile → 信号就绪 |
-| `tpop_from_aic(TILE, AIV_IDX)` | Vector | 消费者 | 等待就绪 → 加载 tile → 信号空闲 |
-| `tpop_from_aiv(TILE, AIV_IDX)` | Cube | 消费者 | 等待就绪 → 加载 tile → 信号空闲 |
+| `tpush_to_aiv(TILE, SPLIT)` | Cube | 生产者 | 等待空闲 → DMA tile → 信号就绪 |
+| `tpush_to_aic(TILE, SPLIT)` | Vector | 生产者 | 等待空闲 → DMA tile → 信号就绪 |
+| `tpop_from_aic(TILE, SPLIT)` | Vector | 消费者 | 等待就绪 → 加载 tile → 信号空闲 |
+| `tpop_from_aiv(TILE, SPLIT)` | Cube | 消费者 | 等待就绪 → 加载 tile → 信号空闲 |

--- a/docs/zh-cn/reference/pto-isa/02-buffer_management.md
+++ b/docs/zh-cn/reference/pto-isa/02-buffer_management.md
@@ -135,7 +135,7 @@ def my_vector_kernel(self, ...):
     )
 
     for ...:
-        tile = pl.tpop_from_aic(aiv_idx=0)    # zero-copy from pipe_buf on A5
+        tile = pl.tpop_from_aic()              # 从 pipe_buf 零拷贝读取（A5 平台）
         # ... compute on tile ...
         pl.tfree_to_aic(aiv_idx=0)             # release slot
 ```
@@ -158,7 +158,7 @@ def my_cube_kernel(self, ...):
     )
 
     for ...:
-        pl.tpush_to_aiv(tile, aiv_idx=0)    # DMA to peer_buf.base on A5
+        pl.tpush_to_aiv(tile, split=0)       # DMA 到 peer_buf.base（A5 平台）
 ```
 
 ### DSL 总结
@@ -171,30 +171,43 @@ def my_cube_kernel(self, ...):
 
 ## IR 表示
 
-`pl.reserve_buffer` 降级为 `ReserveBuffer` 节点：
+`pl.reserve_buffer` 降级为 `pto.reserve_buffer` 操作，返回 `i32` SSA 值：
 
-```text
+```mlir
 func @my_vector_kernel(...) {
-    %pipe_buf = reserve_buffer {
+    %c2v_slot_buffer = pto.reserve_buffer {
         name = "c2v_slot_buffer",
-        size = 4096,              // SLOT_NUM * SLOT_SIZE
-        base = auto,              // or literal 0x1000
-        memory_space = "UB"       // inferred from core type
-    }
+        size = 4096,
+        location = #pto.address_space<vec>,
+        auto = true
+    } -> i32
     ...
 }
 ```
 
-`pl.import_peer_buffer` 降级为 `ImportPeerBuffer` 节点：
+`pl.import_peer_buffer` 降级为 `pto.import_reserved_buffer` 操作，返回 `i32` SSA 值，`peer_func` 使用 MLIR 符号语法：
 
-```text
+```mlir
 func @my_cube_kernel(...) {
-    %peer_buf = import_peer_buffer {
+    %c2v_slot_buffer_import = pto.import_reserved_buffer {
         name = "c2v_slot_buffer",
         peer_func = @my_vector_kernel
-    }
+    } -> i32
     ...
 }
+```
+
+`initialize_pipe` 操作以 SSA 操作数引用这些值，而非整数属性：
+
+```mlir
+// Cube 侧（AIC）：V2C 方向为消费者（reserve_buffer），C2V 方向为生产者（import）
+%c0_i32 = arith.constant 0 : i32
+%v2c_buf = pto.reserve_buffer {name = "v2c_slot_buffer", size = 4096,
+    location = #pto.address_space<mat>, auto = false, base = 4096} -> i32
+%c2v_import = pto.import_reserved_buffer {name = "c2v_slot_buffer",
+    peer_func = @my_vector_kernel} -> i32
+pto.aic_initialize_pipe {dir_mask = 3, slot_size = 512}
+    (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %v2c_buf : i32)
 ```
 
 ## 分配器处理

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -108,6 +108,14 @@ class PTOCodegen : public CodegenBase {
   std::string GetIndexConstant(int64_t val);
 
   /**
+   * @brief Get or emit i32 constant (for cross-core consumer buffer addresses)
+   *
+   * @param value Constant value
+   * @return SSA variable name for the constant (e.g., "%c0_i32")
+   */
+  std::string GetOrEmitI32Constant(int32_t value);
+
+  /**
    * @brief Register a variable to an MLIR SSA name
    *
    * @param var IR variable
@@ -203,6 +211,36 @@ class PTOCodegen : public CodegenBase {
   void SetCurrentResultBuf(const std::string& buf);
   void RegisterTileBufType(const std::string& ssa_name, const std::string& type_string);
   std::string GetSSATileBufType(const std::string& ssa_name) const;
+
+  /**
+   * @brief Record the SSA name produced by reserve_buffer for cross-core pipe setup
+   */
+  void RecordReserveBufferSSA(const std::string& ssa);
+
+  /**
+   * @brief Get the recorded reserve_buffer SSA name (empty if none)
+   */
+  [[nodiscard]] std::string GetReserveBufferSSA() const;
+
+  /**
+   * @brief Record the SSA name produced by import_reserved_buffer for cross-core pipe setup
+   */
+  void RecordImportBufferSSA(const std::string& ssa);
+
+  /**
+   * @brief Get the recorded import_reserved_buffer SSA name (empty if none)
+   */
+  [[nodiscard]] std::string GetImportBufferSSA() const;
+
+  /**
+   * @brief Check if the current function is an AIC (Cube) function
+   */
+  [[nodiscard]] bool IsAICFunction() const;
+
+  /**
+   * @brief Check if the current function is an AIV (Vector) function
+   */
+  [[nodiscard]] bool IsAIVFunction() const;
 
  protected:
   // Override visitor methods for code generation - Statements
@@ -321,6 +359,7 @@ class PTOCodegen : public CodegenBase {
   std::map<const ir::MemRef*, std::shared_ptr<const ir::TileType>> memref_to_tile_type_;
   std::map<int64_t, std::string> emitted_constants_;
   std::map<int64_t, std::string> emitted_i64_constants_;
+  std::map<int32_t, std::string> emitted_i32_constants_;
   std::set<double> emitted_float_constants_;
   std::map<double, std::string> float_const_names_;
 
@@ -349,6 +388,14 @@ class PTOCodegen : public CodegenBase {
   std::shared_ptr<const ir::TileType> current_result_tile_type_;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info
+
+  // Cross-core buffer SSA tracking (per function)
+  // NOTE: These are singletons because the cross-core protocol guarantees at most
+  // one reserve_buffer and one import_peer_buffer per function.  If the protocol
+  // evolves to support multiple buffers per direction, these should be replaced
+  // with a map keyed by buffer name or direction.
+  std::string reserve_buf_ssa_;  ///< SSA name from reserve_buffer
+  std::string import_buf_ssa_;   ///< SSA name from import_reserved_buffer
 
   // Control flow expression result communication
   std::string current_expr_value_;         ///< SSA name from expression visitors

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1754,7 +1754,7 @@ def tpop_from_aic(
     result_type: _ir_core.Type | None = None,
     shape: list[int] | None = None,
     dtype: DataType | None = None,
-    aiv_idx: int,
+    split: int = 0,
     span: Span | None = None,
 ) -> Call:
     """Pop tile data from AIC cross-core pipe into AIV.
@@ -1763,15 +1763,15 @@ def tpop_from_aic(
         result_type: Explicit result type (e.g. TileType). Mutually exclusive with shape/dtype.
         shape: Shape of the tile to receive (alternative to result_type).
         dtype: Data type of the tile to receive (alternative to result_type).
-        aiv_idx: Target AIV core index
+        split: Split mode (0=none, 1=up-down, 2=left-right)
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     resolved_type = _resolve_tpop_type(result_type, shape, dtype, MemorySpace.Vec)
     if resolved_type is not None:
         op = _ir_core.get_op("tile.tpop_from_aic")
-        return _ir_core.Call(op, [], {"aiv_idx": aiv_idx}, resolved_type, actual_span)
-    return _ir_core.create_op_call("tile.tpop_from_aic", [], {"aiv_idx": aiv_idx}, actual_span)
+        return _ir_core.Call(op, [], {"split": split}, resolved_type, actual_span)
+    return _ir_core.create_op_call("tile.tpop_from_aic", [], {"split": split}, actual_span)
 
 
 def tpop_from_aiv(
@@ -1779,7 +1779,7 @@ def tpop_from_aiv(
     result_type: _ir_core.Type | None = None,
     shape: list[int] | None = None,
     dtype: DataType | None = None,
-    aiv_idx: int,
+    split: int = 0,
     span: Span | None = None,
 ) -> Call:
     """Pop tile data from AIV cross-core pipe into AIC.
@@ -1788,12 +1788,12 @@ def tpop_from_aiv(
         result_type: Explicit result type (e.g. TileType). Mutually exclusive with shape/dtype.
         shape: Shape of the tile to receive (alternative to result_type).
         dtype: Data type of the tile to receive (alternative to result_type).
-        aiv_idx: Source AIV core index
+        split: Split mode (0=none, 1=up-down, 2=left-right)
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     resolved_type = _resolve_tpop_type(result_type, shape, dtype, MemorySpace.Mat)
     if resolved_type is not None:
         op = _ir_core.get_op("tile.tpop_from_aiv")
-        return _ir_core.Call(op, [], {"aiv_idx": aiv_idx}, resolved_type, actual_span)
-    return _ir_core.create_op_call("tile.tpop_from_aiv", [], {"aiv_idx": aiv_idx}, actual_span)
+        return _ir_core.Call(op, [], {"split": split}, resolved_type, actual_span)
+    return _ir_core.create_op_call("tile.tpop_from_aiv", [], {"split": split}, actual_span)

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -101,7 +101,7 @@ def tpop_from_aic(
     *,
     shape: list[int] | None = None,
     dtype: DataType | None = None,
-    aiv_idx: int,
+    split: int = 0,
     span: Span | None = None,
 ) -> Tile:
     """Pop tile data from AIC cross-core pipe into AIV.
@@ -109,10 +109,10 @@ def tpop_from_aic(
     Args:
         shape: Shape of the tile to receive
         dtype: Data type of the tile to receive
-        aiv_idx: Target AIV core index
+        split: Split mode (0=none, 1=up-down, 2=left-right)
         span: Optional source span
     """
-    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, aiv_idx=aiv_idx, span=span)
+    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, split=split, span=span)
     return Tile(expr=call)
 
 
@@ -120,7 +120,7 @@ def tpop_from_aiv(
     *,
     shape: list[int] | None = None,
     dtype: DataType | None = None,
-    aiv_idx: int,
+    split: int = 0,
     span: Span | None = None,
 ) -> Tile:
     """Pop tile data from AIV cross-core pipe into AIC.
@@ -128,10 +128,10 @@ def tpop_from_aiv(
     Args:
         shape: Shape of the tile to receive
         dtype: Data type of the tile to receive
-        aiv_idx: Source AIV core index
+        split: Split mode (0=none, 1=up-down, 2=left-right)
         span: Optional source span
     """
-    call = _ir_ops.tpop_from_aiv(shape=shape, dtype=dtype, aiv_idx=aiv_idx, span=span)
+    call = _ir_ops.tpop_from_aiv(shape=shape, dtype=dtype, split=split, span=span)
     return Tile(expr=call)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -658,7 +658,7 @@ static std::string MakeTpushToAivCodegenPTO(const CallPtr& op, codegen::CodegenB
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
   std::ostringstream oss;
-  oss << "pto.tpush_to_aiv ins(" << tile_buf;
+  oss << "pto.tpush_to_aiv(" << tile_buf;
   if (!tile_type.empty()) {
     oss << " : " << tile_type;
   }
@@ -684,7 +684,7 @@ static std::string MakeTpushToAicCodegenPTO(const CallPtr& op, codegen::CodegenB
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
   std::ostringstream oss;
-  oss << "pto.tpush_to_aic ins(" << tile_buf;
+  oss << "pto.tpush_to_aic(" << tile_buf;
   if (!tile_type.empty()) {
     oss << " : " << tile_type;
   }
@@ -700,20 +700,20 @@ static std::string MakeTpopFromAicCodegenPTO(const CallPtr& op, codegen::Codegen
 
   CHECK(op->args_.size() == 0) << "tpop_from_aic takes no arguments, got " << op->args_.size();
 
-  const int aiv_idx = op->GetKwarg<int>("aiv_idx", -1);
-  CHECK(aiv_idx >= 0 && aiv_idx <= 1)
-      << "tpop_from_aic requires 'aiv_idx' attribute (0 or 1), got " << aiv_idx;
+  const int split = op->GetKwarg<int>("split", 0);
+  CHECK(split >= 0 && split <= 2)
+      << "tpop_from_aic requires 'split' attribute (0=none, 1=up-down, 2=left-right), got " << split;
 
   std::string result_buf = codegen.GetCurrentResultTarget();
   INTERNAL_CHECK(!result_buf.empty()) << "tpop_from_aic requires assignment target (tile_buf)";
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
 
   std::ostringstream oss;
-  oss << "pto.tpop_from_aic outs(" << result_buf;
+  oss << "pto.tpop_from_aic {split = " << split << "} (" << result_buf;
   if (!result_type.empty()) {
     oss << " : " << result_type;
   }
-  oss << ") {aiv_idx = " << aiv_idx << "}";
+  oss << ")";
   codegen.Emit(oss.str());
 
   return "";
@@ -725,20 +725,20 @@ static std::string MakeTpopFromAivCodegenPTO(const CallPtr& op, codegen::Codegen
 
   CHECK(op->args_.size() == 0) << "tpop_from_aiv takes no arguments, got " << op->args_.size();
 
-  const int aiv_idx = op->GetKwarg<int>("aiv_idx", -1);
-  CHECK(aiv_idx >= 0 && aiv_idx <= 1)
-      << "tpop_from_aiv requires 'aiv_idx' attribute (0 or 1), got " << aiv_idx;
+  const int split = op->GetKwarg<int>("split", 0);
+  CHECK(split >= 0 && split <= 2)
+      << "tpop_from_aiv requires 'split' attribute (0=none, 1=up-down, 2=left-right), got " << split;
 
   std::string result_buf = codegen.GetCurrentResultTarget();
   INTERNAL_CHECK(!result_buf.empty()) << "tpop_from_aiv requires assignment target (tile_buf)";
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
 
   std::ostringstream oss;
-  oss << "pto.tpop_from_aiv outs(" << result_buf;
+  oss << "pto.tpop_from_aiv {split = " << split << "} (" << result_buf;
   if (!result_type.empty()) {
     oss << " : " << result_type;
   }
-  oss << ") {aiv_idx = " << aiv_idx << "}";
+  oss << ")";
   codegen.Emit(oss.str());
 
   return "";
@@ -784,20 +784,19 @@ static std::string MakeAicInitializePipeCodegenPTO(const CallPtr& op, codegen::C
 
   const int dir_mask = op->GetKwarg<int>("dir_mask", -1);
   const int slot_size = op->GetKwarg<int>("slot_size", -1);
-  const int c2v_consumer_buf = op->GetKwarg<int>("c2v_consumer_buf", -1);
-  const int v2c_consumer_buf = op->GetKwarg<int>("v2c_consumer_buf", -1);
   CHECK(dir_mask >= 0) << "aic_initialize_pipe requires 'dir_mask' attribute";
   CHECK(slot_size > 0) << "aic_initialize_pipe requires 'slot_size' attribute";
 
+  // AIC (Cube): consumer for V2C (reserve), producer for C2V (import)
+  std::string v2c_ssa = codegen.GetReserveBufferSSA();
+  std::string c2v_ssa = codegen.GetImportBufferSSA();
+  if (v2c_ssa.empty()) v2c_ssa = codegen.GetOrEmitI32Constant(0);
+  if (c2v_ssa.empty()) c2v_ssa = codegen.GetOrEmitI32Constant(0);
+
   std::ostringstream oss;
-  oss << "pto.aic_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size;
-  if (c2v_consumer_buf >= 0) {
-    oss << ", c2v_consumer_buf = " << c2v_consumer_buf;
-  }
-  if (v2c_consumer_buf >= 0) {
-    oss << ", v2c_consumer_buf = " << v2c_consumer_buf;
-  }
-  oss << "}";
+  oss << "pto.aic_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}"
+      << " (c2v_consumer_buf = " << c2v_ssa << " : i32"
+      << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
   codegen.Emit(oss.str());
 
   return "";
@@ -809,20 +808,19 @@ static std::string MakeAivInitializePipeCodegenPTO(const CallPtr& op, codegen::C
 
   const int dir_mask = op->GetKwarg<int>("dir_mask", -1);
   const int slot_size = op->GetKwarg<int>("slot_size", -1);
-  const int c2v_consumer_buf = op->GetKwarg<int>("c2v_consumer_buf", -1);
-  const int v2c_consumer_buf = op->GetKwarg<int>("v2c_consumer_buf", -1);
   CHECK(dir_mask >= 0) << "aiv_initialize_pipe requires 'dir_mask' attribute";
   CHECK(slot_size > 0) << "aiv_initialize_pipe requires 'slot_size' attribute";
 
+  // AIV (Vector): consumer for C2V (reserve), producer for V2C (import)
+  std::string c2v_ssa = codegen.GetReserveBufferSSA();
+  std::string v2c_ssa = codegen.GetImportBufferSSA();
+  if (c2v_ssa.empty()) c2v_ssa = codegen.GetOrEmitI32Constant(0);
+  if (v2c_ssa.empty()) v2c_ssa = codegen.GetOrEmitI32Constant(0);
+
   std::ostringstream oss;
-  oss << "pto.aiv_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size;
-  if (c2v_consumer_buf >= 0) {
-    oss << ", c2v_consumer_buf = " << c2v_consumer_buf;
-  }
-  if (v2c_consumer_buf >= 0) {
-    oss << ", v2c_consumer_buf = " << v2c_consumer_buf;
-  }
-  oss << "}";
+  oss << "pto.aiv_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}"
+      << " (c2v_consumer_buf = " << c2v_ssa << " : i32"
+      << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
   codegen.Emit(oss.str());
 
   return "";
@@ -1137,15 +1135,32 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     CHECK(size > 0) << "reserve_buffer requires positive 'size' attribute, got " << size;
     CheckSafeIdentifier(name, "reserve_buffer 'name'");
 
-    std::ostringstream oss;
-    oss << "pto.reserve_buffer {name = \"" << name << "\", size = " << size;
-    if (base >= 0) {
-      oss << ", base = " << base;
-    } else {
-      oss << ", base = auto";
+    std::string ssa_name = codegen.GetCurrentResultTarget();
+    if (ssa_name.empty()) {
+      // EvalStmt context — derive SSA name from buffer name hint
+      ssa_name = codegen.NewNamedTemp(name);
     }
-    oss << "}";
+
+    std::string location;
+    if (codegen.IsAICFunction()) {
+      location = "mat";
+    } else if (codegen.IsAIVFunction()) {
+      location = "vec";
+    } else {
+      location = "undefined";
+    }
+
+    std::ostringstream oss;
+    oss << ssa_name << " = pto.reserve_buffer {name = \"" << name << "\", size = " << size
+        << ", location = #pto.address_space<" << location << ">";
+    if (base >= 0) {
+      oss << ", auto = false, base = " << base;
+    } else {
+      oss << ", auto = true";
+    }
+    oss << "} -> i32";
     codegen.Emit(oss.str());
+    codegen.RecordReserveBufferSSA(ssa_name);
 
     return std::string("");
   });
@@ -1160,9 +1175,16 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     CheckSafeIdentifier(name, "import_peer_buffer 'name'");
     CheckSafeIdentifier(peer_func, "import_peer_buffer 'peer_func'");
 
+    std::string ssa_name = codegen.GetCurrentResultTarget();
+    if (ssa_name.empty()) {
+      ssa_name = codegen.NewNamedTemp(name + "_import");
+    }
+
     std::ostringstream oss;
-    oss << "pto.import_peer_buffer {name = \"" << name << "\", peer_func = \"" << peer_func << "\"}";
+    oss << ssa_name << " = pto.import_reserved_buffer {name = \"" << name << "\", peer_func = @" << peer_func
+        << "} -> i32";
     codegen.Emit(oss.str());
+    codegen.RecordImportBufferSSA(ssa_name);
 
     return std::string("");
   });

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -251,12 +251,15 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   memref_to_tile_type_.clear();
   emitted_constants_.clear();
   emitted_i64_constants_.clear();
+  emitted_i32_constants_.clear();
   emitted_float_constants_.clear();
   float_const_names_.clear();
   extra_alloc_tiles_.clear();
   ssa_to_tile_buf_type_.clear();
   tile_var_allocs_.clear();
   emitted_tile_alloc_vars_.clear();
+  reserve_buf_ssa_.clear();
+  import_buf_ssa_.clear();
   constants_section_.str("");
   constants_section_.clear();
   body_section_.str("");
@@ -644,6 +647,32 @@ std::string PTOCodegen::GetOrEmitI64Constant(int64_t value) {
   return name;
 }
 
+std::string PTOCodegen::GetOrEmitI32Constant(int32_t value) {
+  auto it = emitted_i32_constants_.find(value);
+  if (it != emitted_i32_constants_.end()) {
+    return it->second;
+  }
+  std::string ssa_id;
+  if (value == 0) {
+    ssa_id = "c0_i32";
+  } else if (value < 0) {
+    uint32_t magnitude = static_cast<uint32_t>(-(value + 1)) + 1;
+    ssa_id = "cn" + std::to_string(magnitude) + "_i32";
+  } else {
+    ssa_id = "c" + std::to_string(value) + "_i32";
+  }
+  std::string name;
+  if (used_ssa_names_.find(ssa_id) == used_ssa_names_.end()) {
+    used_ssa_names_.insert(ssa_id);
+    name = "%" + ssa_id;
+  } else {
+    name = NewTemp();
+  }
+  constants_section_ << GetIndent() << name << " = arith.constant " << value << " : i32\n";
+  emitted_i32_constants_[value] = name;
+  return name;
+}
+
 std::string PTOCodegen::GetTileBufForMemRef(const MemRefPtr& memref) {
   auto it = memref_to_mlir_.find(memref.get());
   INTERNAL_CHECK(it != memref_to_mlir_.end()) << "MemRef not found in mapping";
@@ -667,6 +696,22 @@ void PTOCodegen::RegisterTileBufType(const std::string& ssa_name, const std::str
 std::string PTOCodegen::GetSSATileBufType(const std::string& ssa_name) const {
   auto it = ssa_to_tile_buf_type_.find(ssa_name);
   return it != ssa_to_tile_buf_type_.end() ? it->second : std::string{};
+}
+
+void PTOCodegen::RecordReserveBufferSSA(const std::string& ssa) { reserve_buf_ssa_ = ssa; }
+
+std::string PTOCodegen::GetReserveBufferSSA() const { return reserve_buf_ssa_; }
+
+void PTOCodegen::RecordImportBufferSSA(const std::string& ssa) { import_buf_ssa_ = ssa; }
+
+std::string PTOCodegen::GetImportBufferSSA() const { return import_buf_ssa_; }
+
+bool PTOCodegen::IsAICFunction() const {
+  return current_function_ && current_function_->func_type_ == ir::FunctionType::AIC;
+}
+
+bool PTOCodegen::IsAIVFunction() const {
+  return current_function_ && current_function_->func_type_ == ir::FunctionType::AIV;
 }
 
 void PTOCodegen::EmitExtraAllocTiles() {
@@ -700,8 +745,9 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         result_tile_type = tile_type;
       } else if (auto tile_type = As<TileType>(op->var_->GetType())) {
         result_tile_type = tile_type;
-      } else if (As<ScalarType>(op->var_->GetType())) {
-        // Pre-allocate an SSA name for scalar-result backend ops (e.g., tile.getval).
+      } else {
+        // Pre-allocate a %-prefixed SSA name for non-tile backend ops (e.g., scalar
+        // results like tile.getval, or i32 results like reserve_buffer / import_peer_buffer).
         // Register it in var_to_mlir_ so subsequent expressions can resolve the variable.
         result_buf = NewNamedTemp(op->var_->name_hint_);
         BindVarToMlir(op->var_, result_buf);

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -698,11 +698,21 @@ std::string PTOCodegen::GetSSATileBufType(const std::string& ssa_name) const {
   return it != ssa_to_tile_buf_type_.end() ? it->second : std::string{};
 }
 
-void PTOCodegen::RecordReserveBufferSSA(const std::string& ssa) { reserve_buf_ssa_ = ssa; }
+void PTOCodegen::RecordReserveBufferSSA(const std::string& ssa) {
+  INTERNAL_CHECK(reserve_buf_ssa_.empty())
+      << "Internal error: multiple reserve_buffer ops in the same function not supported, "
+      << "existing: " << reserve_buf_ssa_ << ", new: " << ssa;
+  reserve_buf_ssa_ = ssa;
+}
 
 std::string PTOCodegen::GetReserveBufferSSA() const { return reserve_buf_ssa_; }
 
-void PTOCodegen::RecordImportBufferSSA(const std::string& ssa) { import_buf_ssa_ = ssa; }
+void PTOCodegen::RecordImportBufferSSA(const std::string& ssa) {
+  INTERNAL_CHECK(import_buf_ssa_.empty())
+      << "Internal error: multiple import_peer_buffer ops in the same function not supported, "
+      << "existing: " << import_buf_ssa_ << ", new: " << ssa;
+  import_buf_ssa_ = ssa;
+}
 
 std::string PTOCodegen::GetImportBufferSSA() const { return import_buf_ssa_; }
 

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -57,7 +57,7 @@ REGISTER_OP("tile.tpop_from_aic")
     .set_description("Pop tile data from AIC cross-core pipe into AIV")
     .set_op_category("CrossCoreOp")
     .no_argument()
-    .set_attr<int>("aiv_idx")
+    .set_attr<int>("split")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
 
@@ -66,7 +66,7 @@ REGISTER_OP("tile.tpop_from_aiv")
     .set_description("Pop tile data from AIV cross-core pipe into AIC")
     .set_op_category("CrossCoreOp")
     .no_argument()
-    .set_attr<int>("aiv_idx")
+    .set_attr<int>("split")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -287,7 +287,6 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
 // TPUSH / TPOP creation helpers
 // ============================================================================
 
-std::vector<std::pair<std::string, std::any>> MakeAivIdxKwargs() { return {{"aiv_idx", std::any(0)}}; }
 std::vector<std::pair<std::string, std::any>> MakeSplitKwargs() { return {{"split", std::any(0)}}; }
 
 CallPtr CreateTpush(const std::string& op_name, const ExprPtr& tile, const Span& span) {
@@ -304,7 +303,7 @@ TypePtr CleanTileType(const TypePtr& tile_type) {
 
 CallPtr CreateTpop(const std::string& op_name, const TypePtr& tile_type, const Span& span) {
   auto op = OpRegistry::GetInstance().GetOp(op_name);
-  return std::make_shared<Call>(op, std::vector<ExprPtr>{}, MakeAivIdxKwargs(), CleanTileType(tile_type),
+  return std::make_shared<Call>(op, std::vector<ExprPtr>{}, MakeSplitKwargs(), CleanTileType(tile_type),
                                 span);
 }
 

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -59,10 +59,12 @@ class CrossCoreTpushTpopProgram:
         pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
         pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf.base)
 
-        received_add: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(aiv_idx=0)
-        received_sub: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(aiv_idx=0)
+        received_add: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(split=1)
+        received_sub: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(split=1)
+        received_add_left = pl.move(received_add, target_memory=pl.Mem.Left)
+        received_sub_right = pl.move(received_sub, target_memory=pl.Mem.Right)
 
-        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add, received_sub)
+        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add_left, received_sub_right)
 
         pl.tfree_to_aiv(aiv_idx=0)
         pl.tfree_to_aiv(aiv_idx=0)
@@ -109,7 +111,7 @@ class BidirectionalCrossCorProgram:
         pl.tpush_to_aic(sum_tile, split=0)
 
         # Receive matmul result back from Cube (C2V direction)
-        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.tpop_from_aic(aiv_idx=0)
+        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.tpop_from_aic(split=0)
 
         # Post-process: apply exp (Vector op)
         processed: pl.Tile[[16, 16], pl.FP32] = pl.exp(mm_result)
@@ -136,7 +138,7 @@ class BidirectionalCrossCorProgram:
         )
 
         # Receive preprocessed tile from Vector (V2C direction)
-        received: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(aiv_idx=0)
+        received: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(split=0)
 
         # Matmul (Cube op)
         w_tile: pl.Tile[[16, 16], pl.FP16] = pl.load(weight, [0, 0], [16, 16])
@@ -167,6 +169,7 @@ class TestCrossCoreTpushTpopCodegen:
         """
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B_PTO)
+        # backend.set_backend_type(BackendType.Ascend950)
 
         pipeline = passes.PassPipeline()
         for factory in [
@@ -203,11 +206,15 @@ class TestCrossCoreTpushTpopCodegen:
         vector_code = codes["vector_producer"]
 
         assert vector_code, "Vector producer MLIR should not be empty"
-        assert "pto.import_peer_buffer" in vector_code, "Should contain pto.import_peer_buffer"
-        assert 'peer_func = "cube_consumer"' in vector_code, "Should reference cube_consumer"
+        assert "pto.import_reserved_buffer" in vector_code, "Should contain pto.import_reserved_buffer"
+        assert "peer_func = @cube_consumer" in vector_code, (
+            "Should reference cube_consumer with MLIR symbol syntax"
+        )
+        assert "-> i32" in vector_code, "import_reserved_buffer should return i32"
         assert "pto.aiv_initialize_pipe" in vector_code, "Should contain pto.aiv_initialize_pipe"
         assert "dir_mask = 2" in vector_code, "Should have dir_mask = 2 (V2C)"
-        assert "v2c_consumer_buf = 4096" in vector_code, "Should have v2c_consumer_buf = 4096 (0x1000)"
+        assert "v2c_consumer_buf = " in vector_code, "Should have v2c_consumer_buf as SSA reference"
+        assert "c2v_consumer_buf = " in vector_code, "Should have c2v_consumer_buf as SSA reference"
         assert "pto.tpush_to_aic" in vector_code, "Should contain pto.tpush_to_aic"
         assert "pto.tadd" in vector_code, "Should contain elementwise add (Vector op)"
 
@@ -219,10 +226,15 @@ class TestCrossCoreTpushTpopCodegen:
         assert cube_code, "Cube consumer MLIR should not be empty"
         assert "pto.reserve_buffer" in cube_code, "Should contain pto.reserve_buffer"
         assert 'name = "v2c_slot_buffer"' in cube_code, "Should reference v2c_slot_buffer"
+        assert "auto = false" in cube_code, "Should have auto = false for explicit base address"
         assert "base = 4096" in cube_code, "Should have explicit base address (0x1000 = 4096)"
+        assert "location = #pto.address_space<" in cube_code, "Should have location attribute"
+        assert "-> i32" in cube_code, "reserve_buffer should return i32"
         assert "pto.aic_initialize_pipe" in cube_code, "Should contain pto.aic_initialize_pipe"
         assert "dir_mask = 2" in cube_code, "Should have dir_mask = 2 (V2C)"
-        assert "v2c_consumer_buf = 4096" in cube_code, "Should have v2c_consumer_buf = 4096 (0x1000)"
+        assert "v2c_consumer_buf = " in cube_code, "Should have v2c_consumer_buf as SSA reference"
+        assert "c2v_consumer_buf = " in cube_code, "Should have c2v_consumer_buf as SSA reference"
+        assert "arith.constant 0 : i32" in cube_code, "Should emit i32 constant for default consumer buf"
         assert "pto.tpop_from_aiv" in cube_code, "Should contain pto.tpop_from_aiv"
         assert "pto.tfree_to_aiv" in cube_code, "Should contain pto.tfree_to_aiv"
         assert "pto.tmatmul" in cube_code, "Should contain matmul (Cube op)"
@@ -237,14 +249,16 @@ class TestCrossCoreTpushTpopCodegen:
         # Buffer setup: C2V consumer reserves buffer, V2C producer imports peer buffer
         assert "pto.reserve_buffer" in vector_code, "Should reserve buffer for C2V"
         assert 'name = "c2v_slot_buffer"' in vector_code, "Should reference c2v_slot_buffer"
+        assert "auto = false" in vector_code, "Should have auto = false for explicit base"
         assert "base = 8192" in vector_code, "Should have explicit base address (0x2000 = 8192)"
-        assert "pto.import_peer_buffer" in vector_code, "Should import peer buffer for V2C"
-        assert 'peer_func = "cube_bidir"' in vector_code, "Should reference cube_bidir"
+        assert "-> i32" in vector_code, "Buffer ops should return i32"
+        assert "pto.import_reserved_buffer" in vector_code, "Should import peer buffer for V2C"
+        assert "peer_func = @cube_bidir" in vector_code, "Should reference cube_bidir"
         # Bidirectional init
         assert "pto.aiv_initialize_pipe" in vector_code, "Should contain aiv_initialize_pipe"
         assert "dir_mask = 3" in vector_code, "Should have dir_mask = 3 (bidirectional)"
-        assert "c2v_consumer_buf = 8192" in vector_code, "Should have c2v_consumer_buf = 8192 (0x2000)"
-        assert "v2c_consumer_buf = 4096" in vector_code, "Should have v2c_consumer_buf = 4096 (0x1000)"
+        assert "c2v_consumer_buf = " in vector_code, "Should have c2v_consumer_buf as SSA reference"
+        assert "v2c_consumer_buf = " in vector_code, "Should have v2c_consumer_buf as SSA reference"
         # V2C producer side: preprocess + push
         assert "pto.tadd" in vector_code, "Should do elementwise add (Vector op)"
         assert "pto.tpush_to_aic" in vector_code, "Should push to AIC"
@@ -263,14 +277,16 @@ class TestCrossCoreTpushTpopCodegen:
         # Buffer setup: V2C consumer reserves buffer with explicit base, C2V producer imports peer buffer
         assert "pto.reserve_buffer" in cube_code, "Should reserve buffer for V2C"
         assert 'name = "v2c_slot_buffer"' in cube_code, "Should reference v2c_slot_buffer"
+        assert "auto = false" in cube_code, "Should have auto = false for explicit base"
         assert "base = 4096" in cube_code, "Should have explicit base address (0x1000 = 4096)"
-        assert "pto.import_peer_buffer" in cube_code, "Should import peer buffer for C2V"
-        assert 'peer_func = "vector_bidir"' in cube_code, "Should reference vector_bidir"
-        # Bidirectional init with explicit consumer buffer addresses
+        assert "-> i32" in cube_code, "Buffer ops should return i32"
+        assert "pto.import_reserved_buffer" in cube_code, "Should import peer buffer for C2V"
+        assert "peer_func = @vector_bidir" in cube_code, "Should reference vector_bidir"
+        # Bidirectional init with SSA consumer buffer references
         assert "pto.aic_initialize_pipe" in cube_code, "Should contain aic_initialize_pipe"
         assert "dir_mask = 3" in cube_code, "Should have dir_mask = 3 (bidirectional)"
-        assert "c2v_consumer_buf = 8192" in cube_code, "Should have c2v_consumer_buf = 8192 (0x2000)"
-        assert "v2c_consumer_buf = 4096" in cube_code, "Should have v2c_consumer_buf = 4096 (0x1000)"
+        assert "c2v_consumer_buf = " in cube_code, "Should have c2v_consumer_buf as SSA reference"
+        assert "v2c_consumer_buf = " in cube_code, "Should have v2c_consumer_buf as SSA reference"
         # V2C consumer side: receive preprocessed data
         assert "pto.tpop_from_aiv" in cube_code, "Should pop from AIV"
         assert "pto.tfree_to_aiv" in cube_code, "Should free V2C slot"
@@ -295,7 +311,7 @@ class TestCrossCoreTpushTpopCodegen:
             "pto.aic_initialize_pipe",
             "pto.aiv_initialize_pipe",
             "pto.reserve_buffer",
-            "pto.import_peer_buffer",
+            "pto.import_reserved_buffer",
         ]
         for op in expected_ops:
             assert op in all_code, f"Expected PTO op '{op}' not found in generated MLIR"

--- a/tests/ut/ir/test_cross_core_ops.py
+++ b/tests/ut/ir/test_cross_core_ops.py
@@ -31,7 +31,7 @@ def test_tpop_ops_return_tile_type():
 
     for op_name in ["tile.tpop_from_aic", "tile.tpop_from_aiv"]:
         op = ir.get_op(op_name)
-        call = ir.Call(op, [], {"aiv_idx": 0}, tile_type, span)
+        call = ir.Call(op, [], {"split": 0}, tile_type, span)
         assert isinstance(call.type, ir.TileType)
         assert call.type.shape == [64]
         assert call.type.dtype == DataType.FP32

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel.py
@@ -233,7 +233,7 @@ class TestSplitStructure:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -316,7 +316,7 @@ class TestCrossCoreBoundaries:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 w_tile = pl.exp(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(w_tile, [0, 0], out_0)
@@ -370,7 +370,7 @@ class TestCrossCoreBoundaries:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ):
                 x_sum_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
-                    shape=[16, 128], dtype=pl.BF16, aiv_idx=0
+                    shape=[16, 128], dtype=pl.BF16
                 )
                 x_sum_left = pl.move(x_sum_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -389,7 +389,7 @@ class TestCrossCoreBoundaries:
                 x_sum = pl.add(x_tile, x_tile)
                 pl.tpush_to_aic(x_sum, split=0)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -465,7 +465,7 @@ class TestCubeOpVariants:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(d_vec, [0, 0], out_0)
                 return out_0_store
@@ -523,7 +523,7 @@ class TestCubeOpVariants:
                 bias_tile = pl.load(bias, [0, 0], [1, 128])
                 pl.tpush_to_aic(bias_tile, split=0)
                 c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
@@ -595,7 +595,7 @@ class TestCubeOpVariants:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
@@ -666,7 +666,7 @@ class TestCubeOpVariants:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(d_vec, [0, 0], out_0)
                 return out_0_store
@@ -724,7 +724,7 @@ class TestCubeOpVariants:
                 bias_tile = pl.load(bias, [0, 0], [1, 128])
                 pl.tpush_to_aic(bias_tile, split=0)
                 c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
@@ -793,7 +793,7 @@ class TestVectorOpClassification:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ):
                 x_sub_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
-                    shape=[16, 128], dtype=pl.BF16, aiv_idx=0
+                    shape=[16, 128], dtype=pl.BF16
                 )
                 x_sub_left = pl.move(x_sub_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -812,7 +812,7 @@ class TestVectorOpClassification:
                 x_sub = pl.sub(x_tile, x_tile)
                 pl.tpush_to_aic(x_sub, split=0)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -884,7 +884,7 @@ class TestVectorOpClassification:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 z_exp = pl.exp(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_exp, [0, 0], out_0)
@@ -961,7 +961,7 @@ class TestRealisticPatterns:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 exp_tile = pl.exp(z_vec)
                 sum_tile = pl.add(exp_tile, exp_tile)
@@ -1030,7 +1030,7 @@ class TestRealisticPatterns:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 z_exp = pl.exp(z_vec)
                 z_mul = pl.mul(z_exp, z_exp)
@@ -1122,7 +1122,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -1160,7 +1160,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
@@ -1247,7 +1247,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -1354,7 +1354,7 @@ class TestNestedStructures:
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 for i in pl.range(4):
                     z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0
@@ -1410,7 +1410,7 @@ class TestNestedStructures:
             ):
                 for i in pl.range(4):
                     x_sum_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
-                        shape=[16, 128], dtype=pl.BF16, aiv_idx=0
+                        shape=[16, 128], dtype=pl.BF16
                     )
                     x_sum_left = pl.move(x_sum_mat, target_memory=pl.MemorySpace.Left)
                     y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -1432,7 +1432,7 @@ class TestNestedStructures:
                     x_sum = pl.add(x_tile, x_tile)
                     pl.tpush_to_aic(x_sum, split=0)
                     z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     w_tile = pl.exp(z_vec)
                     out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(w_tile, [0, 0], out_0)
@@ -1498,7 +1498,7 @@ class TestNestedStructures:
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 for i in pl.range(2):
                     z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0
@@ -1576,7 +1576,7 @@ class TestEdgeCases:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
@@ -1703,7 +1703,7 @@ class TestDCERegression:
                 acc_1 = pl.tile.muls(acc_0, 0.0)
                 for i, (acc_iter,) in pl.range(4, init_values=(acc_1,)):
                     z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     acc_new = pl.tile.add(acc_iter, z_vec)
                     acc_out = pl.yield_(acc_new)
@@ -1767,7 +1767,7 @@ class TestDCERegression:
             ):
                 for i in pl.range(4):
                     x_sum_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
-                        shape=[16, 128], dtype=pl.BF16, aiv_idx=0
+                        shape=[16, 128], dtype=pl.BF16
                     )
                     x_left = pl.move(x_sum_mat, target_memory=pl.MemorySpace.Left)
                     w_mat = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -1789,7 +1789,7 @@ class TestDCERegression:
                     x_sum = pl.add(x_tile, x_tile)
                     pl.tpush_to_aic(x_sum, split=0)
                     z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     acc_new = pl.tile.add(acc_iter, z_vec)
                     acc_out = pl.yield_(acc_new)
@@ -1864,7 +1864,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 _z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                    shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                    shape=[16, 128], dtype=pl.FP32
                 )
                 x_tile = pl.load(x, [0, 0], [16, 128])
                 x_fp32 = pl.tile.cast(x_tile, target_type=pl.FP32, mode="round")
@@ -1941,10 +1941,10 @@ class TestDCERegression:
                 up_1 = pl.tile.muls(up_0, 0.0)
                 for i, (gate_iter, up_iter) in pl.range(2, init_values=(gate_1, up_1)):
                     g_vec: pl.Tile[[4, 32], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[4, 32], dtype=pl.FP32, aiv_idx=0
+                        shape=[4, 32], dtype=pl.FP32
                     )
                     u_vec: pl.Tile[[4, 32], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[4, 32], dtype=pl.FP32, aiv_idx=0
+                        shape=[4, 32], dtype=pl.FP32
                     )
                     gate_new = pl.tile.add(gate_iter, g_vec)
                     up_new = pl.tile.add(up_iter, u_vec)
@@ -2105,7 +2105,7 @@ class TestDCERegression:
                 for i, (acc_iter,) in pl.range(4, init_values=(acc_1,)):
                     if i == 0:
                         z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                            shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                            shape=[16, 128], dtype=pl.FP32
                         )
                         acc_then = pl.tile.add(acc_iter, z_vec)
                         branch_out = pl.yield_(acc_then)
@@ -2194,7 +2194,7 @@ class TestDCERegression:
                 acc_init = pl.tile.muls(vec_init, 0.0)
                 for i, (acc_iter,) in pl.range(4, init_values=(acc_init,)):
                     tmp: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     carried_next = pl.tile.add(tmp, tmp)
                     acc_out = pl.yield_(carried_next)
@@ -2284,10 +2284,10 @@ class TestDCERegression:
                 acc_1 = pl.tile.muls(acc_0, 0.0)
                 for i, (acc_iter,) in pl.range(4, init_values=(acc_1,)):
                     z_pop_a: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     z_pop_b: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
-                        shape=[16, 128], dtype=pl.FP32, aiv_idx=0
+                        shape=[16, 128], dtype=pl.FP32
                     )
                     if i == 0:
                         acc_then = pl.tile.add(acc_iter, z_pop_a)

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -249,7 +249,7 @@ class test_program:
         class Before:
             @pl.function(type=pl.FunctionType.AIV)
             def kernel(self) -> pl.Tile[[64], pl.FP32]:
-                received: pl.Tile[[64], pl.FP32] = pl.tile.tpop_from_aic(aiv_idx=0)
+                received: pl.Tile[[64], pl.FP32] = pl.tile.tpop_from_aic()
                 return received
 
         printed = Before.as_python()
@@ -264,7 +264,7 @@ class test_program:
         class Before:
             @pl.function(type=pl.FunctionType.AIC)
             def kernel(self) -> pl.Tile[[64], pl.FP32]:
-                received: pl.Tile[[64], pl.FP32] = pl.tile.tpop_from_aiv(aiv_idx=0)
+                received: pl.Tile[[64], pl.FP32] = pl.tile.tpop_from_aiv()
                 return received
 
         printed = Before.as_python()
@@ -294,7 +294,7 @@ class test_program:
         class Before:
             @pl.function(type=pl.FunctionType.AIV)
             def kernel(self) -> pl.Tile[[64], pl.FP32]:
-                received: pl.Tile[[64], pl.FP32] = pl.tpop_from_aic(aiv_idx=0)
+                received: pl.Tile[[64], pl.FP32] = pl.tpop_from_aic()
                 return received
 
         printed = Before.as_python()
@@ -340,7 +340,7 @@ class test_program:
         class Before:
             @pl.function(type=pl.FunctionType.AIC)
             def kernel(self) -> pl.Tile[[64], pl.FP32]:
-                received: pl.Tile[[64], pl.FP32] = pl.tpop_from_aiv(aiv_idx=0)
+                received: pl.Tile[[64], pl.FP32] = pl.tpop_from_aiv()
                 return received
 
         printed = Before.as_python()


### PR DESCRIPTION
feat(codegen): add split attribute to tpop ops and fix SSA naming for buffer ops

  Add `split` attribute (0=none, 1=up-down, 2=left-right) to tpop_from_aic
  and tpop_from_aiv, matching tpush ops. Fix a codegen bug where
  reserve_buffer and import_peer_buffer SSA names lacked the MLIR `%`
  prefix — non-tile, non-scalar result variables now get proper SSA names
  via NewNamedTemp. Update documentation (en/zh-cn) to reflect the new
  tpop split attribute and corrected MLIR output format for buffer ops.