### PR TITLE
feat(auto_name): implement unique name reservation and renaming utilities

### DIFF
--- a/include/pypto/ir/transforms/utils/auto_name_utils.h
+++ b/include/pypto/ir/transforms/utils/auto_name_utils.h
@@ -16,8 +16,10 @@
 #include <cctype>
 #include <cstddef>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -242,6 +244,50 @@ inline std::string GetLegacyCompatibleBaseName(const std::string& name) {
     return parsed.base_name;
   }
   return StripLegacyBaseName(name);
+}
+
+inline std::string ReserveUniqueName(const std::string& base_name, std::set<std::string>& used_names) {
+  std::string candidate = base_name;
+  int suffix = 0;
+  while (!used_names.insert(candidate).second) {
+    ++suffix;
+    candidate = base_name + "_" + std::to_string(suffix);
+  }
+  return candidate;
+}
+
+template <typename DefNode>
+void BuildRenameMapForDefs(const std::vector<const DefNode*>& defs,
+                           std::unordered_map<const DefNode*, std::string>& rename_map,
+                           bool include_unique_names = false) {
+  rename_map.clear();
+
+  std::vector<const DefNode*> unique_defs;
+  unique_defs.reserve(defs.size());
+  std::unordered_set<const DefNode*> seen_defs;
+  for (const DefNode* def : defs) {
+    if (seen_defs.insert(def).second) unique_defs.push_back(def);
+  }
+
+  std::unordered_map<std::string, int> name_counts;
+  for (const DefNode* def : unique_defs) {
+    name_counts[def->name_hint_]++;
+  }
+
+  // Reserve unique names first so colliding defs never steal them.
+  std::set<std::string> used_names;
+  for (const DefNode* def : unique_defs) {
+    if (name_counts[def->name_hint_] == 1) {
+      used_names.insert(def->name_hint_);
+      if (include_unique_names) rename_map[def] = def->name_hint_;
+    }
+  }
+
+  for (const DefNode* def : unique_defs) {
+    const std::string& base_name = def->name_hint_;
+    if (name_counts[base_name] == 1) continue;
+    rename_map[def] = ReserveUniqueName(base_name, used_names);
+  }
 }
 
 inline std::string AddQualifier(const std::string& name, const std::string& qualifier) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -842,12 +842,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string emit_var = result_var;
     if (op_name == "tensor.create" && assign_var) {
       declared_var_ptrs_.insert(assign_var);
-      // Ensure unique C++ variable name: if the preferred name collides with
-      // a previously emitted declaration, fall back to the raw name_hint_
-      if (declared_var_names_.count(emit_var)) {
-        emit_var = assign_var->name_hint_;
-      }
-      declared_var_names_.insert(emit_var);
+      emit_var = ReserveTensorCreateEmitName(assign_var, emit_var);
     }
 
     current_result_var_ = emit_var;
@@ -983,6 +978,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
   // Resolve a Var to its C++ emit name: param name for param-derived vars,
   // GetSSABaseName for others, with collision defense against param names.
   std::string ResolveVarEmitName(const Var* var) const {
+    auto it = explicit_var_emit_names_.find(var);
+    if (it != explicit_var_emit_names_.end()) {
+      return it->second;
+    }
     const Var* param = ResolveToParam(var);
     if (param) {
       return GetParamEmitName(param);
@@ -1013,6 +1012,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return it->second;
   }
 
+  std::string ReserveTensorCreateEmitName(const Var* assign_var, const std::string& preferred_name) {
+    auto it = explicit_var_emit_names_.find(assign_var);
+    if (it != explicit_var_emit_names_.end()) {
+      return it->second;
+    }
+
+    auto parsed = auto_name::Parse(assign_var->name_hint_);
+    bool preserve_raw_name = parsed.role.has_value() && *parsed.role == "out";
+    std::string base_name = preferred_name;
+    if (preserve_raw_name || declared_var_names_.count(base_name)) {
+      base_name = assign_var->name_hint_;
+    }
+
+    std::string emit_name = auto_name::ReserveUniqueName(base_name, declared_var_names_);
+    explicit_var_emit_names_[assign_var] = emit_name;
+    return emit_name;
+  }
+
   const ProgramPtr& program_;
   std::map<std::string, int>* func_name_to_id_;
   std::map<std::string, CoreType>* func_name_to_core_type_;
@@ -1033,6 +1050,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_set<const Var*> declared_var_ptrs_;
   // String-based dedup: ensures unique C++ variable names in generated code
   std::set<std::string> declared_var_names_;
+  // Stores the final emitted name for declared local vars, keyed by Var identity.
+  std::unordered_map<const Var*, std::string> explicit_var_emit_names_;
   // VarPtr-based tracking of task-submission results (no C++ declaration exists, skip in yield)
   std::unordered_set<const Var*> call_result_var_ptrs_;
 };

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -44,6 +44,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/printer.h"
+#include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -71,49 +72,6 @@ std::string CastModeToString(int mode) {
       return "odd";
     default:
       throw ValueError("Cast round mode must be in range [0, 6], got " + std::to_string(mode));
-  }
-}
-
-template <typename DefNode>
-void BuildRenameMapForDefs(const std::vector<const DefNode*>& defs,
-                           std::unordered_map<const DefNode*, std::string>& rename_map,
-                           bool include_unique_names = false) {
-  rename_map.clear();
-
-  std::vector<const DefNode*> unique_defs;
-  unique_defs.reserve(defs.size());
-  std::unordered_set<const DefNode*> seen_defs;
-  for (const DefNode* def : defs) {
-    if (seen_defs.insert(def).second) unique_defs.push_back(def);
-  }
-
-  std::unordered_map<std::string, int> name_counts;
-  for (const DefNode* def : unique_defs) {
-    name_counts[def->name_hint_]++;
-  }
-
-  // Pre-pass: reserve names that are already unique so suffix generation
-  // for colliding names never picks a reserved name (e.g., defs [M, M, M_1]
-  // must not assign "M_1" to the second M when a real M_1 def exists).
-  std::set<std::string> used_names;
-  for (const DefNode* def : unique_defs) {
-    if (name_counts[def->name_hint_] == 1) {
-      used_names.insert(def->name_hint_);
-      if (include_unique_names) rename_map[def] = def->name_hint_;
-    }
-  }
-
-  for (const DefNode* def : unique_defs) {
-    const std::string& base_name = def->name_hint_;
-    if (name_counts[base_name] == 1) continue;  // Already handled above
-
-    std::string candidate = base_name;
-    int suffix = 0;
-    while (!used_names.insert(candidate).second) {
-      ++suffix;
-      candidate = base_name + "_" + std::to_string(suffix);
-    }
-    rename_map[def] = candidate;
   }
 }
 
@@ -1207,13 +1165,13 @@ void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
   std::vector<const Var*> defs;
   for (auto& p : func->params_) defs.push_back(p.get());
   if (func->body_) CollectVarDefsInOrder(func->body_, defs);
-  BuildRenameMapForDefs(defs, var_rename_map_);
+  auto_name::BuildRenameMapForDefs(defs, var_rename_map_);
 }
 
 void IRPythonPrinter::BuildMemRefRenameMap(const FunctionPtr& func) {
   std::vector<const MemRef*> defs;
   if (func->body_) CollectMemRefDefsInOrder(func->body_, defs);
-  BuildRenameMapForDefs(defs, memref_rename_map_, true);
+  auto_name::BuildRenameMapForDefs(defs, memref_rename_map_, true);
 }
 
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
@@ -1503,7 +1461,7 @@ static std::unordered_map<const Var*, std::string> CollectDynVarMapping(const Pr
   // include_unique_names=true so VisitProgram can iterate the full map for
   // pl.dynamic() declarations.
   std::unordered_map<const Var*, std::string> result;
-  BuildRenameMapForDefs(dyn_var_ptrs, result, /*include_unique_names=*/true);
+  auto_name::BuildRenameMapForDefs(dyn_var_ptrs, result, /*include_unique_names=*/true);
   return result;
 }
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1418,6 +1418,48 @@ class TestOrchestration:
         # Tuple-return elements must not be collapsed into a single alias
         assert "Tensor& out =" not in code
 
+    def test_repeated_auto_output_buffers_get_unique_names(self):
+        """Repeated auto-generated output buffers should keep distinct emitted names."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B_CCE)
+
+        @pl.program
+        class RepeatedAutoOutputProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.add(x, y)
+                return z
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_repeat(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                first: pl.Tensor[[64], pl.FP32] = self.kernel_add(x, y)
+                second: pl.Tensor[[64], pl.FP32] = self.kernel_add(first, y)
+                return second
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(RepeatedAutoOutputProgram)
+
+        generator = codegen.CCECodegen()
+        files = generator.generate(transformed)
+        code = files["orchestration/orch_repeat.cpp"]
+
+        assert code.count("Tensor ret0__out = make_tensor(") == 1
+        assert code.count("Tensor ret0__out_1 = make_tensor(") == 1
+        assert "make_output_param(ret0__out)" in code
+        assert "make_output_param(ret0__out_1)" in code
+        assert "Tensor& first = ret0__out;" in code
+        assert "Tensor& second = ret0__out_1;" in code
+        assert "make_output_param(ret0)," not in code
+
 
 class TestTensorReadWriteOffsetCodegen:
     """Tests verifying that multi-dimensional indices are correctly converted to flat offsets in codegen."""


### PR DESCRIPTION
- Added `ReserveUniqueName` function to generate unique names by appending suffixes to base names.
- Introduced `BuildRenameMapForDefs` template function to create a mapping of definitions to unique names, handling collisions effectively.
- Updated `orchestration_codegen` to utilize the new name reservation logic for emitted variable names.
- Integrated the new utilities into the `python_printer` for consistent name handling across generated code.
- Added tests to ensure unique names are generated correctly for repeated auto-generated output buffers.

This enhances the code generation process by preventing name collisions in emitted C++ code.