### PR TITLE
feat(codegen): reorder tpop chains for hardware pipe ordering and improve cross-core protocol

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -233,6 +233,13 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetImportBufferSSA() const;
 
   /**
+   * @brief Get the split value for a tile var produced by a tpop operation
+   * @param var Raw pointer to the tile variable
+   * @return Split value from the originating tpop (0 if not found)
+   */
+  [[nodiscard]] int GetTpopSplit(const ir::Var* var) const;
+
+  /**
    * @brief Check if the current function is an AIC (Cube) function
    */
   [[nodiscard]] bool IsAICFunction() const;
@@ -295,6 +302,14 @@ class PTOCodegen : public CodegenBase {
    * @brief Generate PTO-ISA MLIR for a single function
    */
   void GenerateFunction(const ir::FunctionPtr& func);
+
+  /**
+   * @brief Reorder top-level statements so each tpop chain follows pop-use-free order
+   *
+   * Hardware requires: tpop(tile) → use(tile) → tfree(tile) before the next tpop.
+   * Groups tpop assignment, its direct users, and its tfree into sequential chains.
+   */
+  std::vector<ir::StmtPtr> ReorderTpopChains(const std::vector<ir::StmtPtr>& stmts) const;
 
   /**
    * @brief Build variable identity to MemRef mapping from function body
@@ -380,6 +395,7 @@ class PTOCodegen : public CodegenBase {
   /// This is the single source of truth for per-variable alloc_tile emission.
   std::vector<std::pair<ir::VarPtr, std::shared_ptr<const ir::TileType>>> tile_var_allocs_;
   std::set<const ir::Var*> emitted_tile_alloc_vars_;
+  std::map<const ir::Var*, int> tpop_result_vars_;  ///< Tile vars from tpop: var -> split value
 
   // Current function context
   ir::FunctionPtr current_function_;

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -333,6 +333,54 @@ def _generate_config_file(
     return "\n".join(lines) + "\n"
 
 
+def _extract_group_member_names(
+    group_func: _ir_core.Function,
+) -> list[str]:
+    """Extract function names called by a Group function from its body."""
+    names: list[str] = []
+    stmts = _ir_core.flatten_to_stmts(group_func.body)
+    for stmt in stmts:
+        call = None
+        if isinstance(stmt, _ir_core.EvalStmt):
+            call = stmt.expr
+        elif isinstance(stmt, _ir_core.AssignStmt):
+            call = stmt.value
+        if isinstance(call, _ir_core.Call) and isinstance(call.op, _ir_core.GlobalVar):
+            names.append(call.op.name)
+    return names
+
+
+def _build_group_mapping(
+    program: _ir_core.Program,
+) -> tuple[dict[str, list[_ir_core.Function]], list[_ir_core.Function]]:
+    """Partition InCore functions into groups and ungrouped.
+
+    Returns:
+        (groups, ungrouped) where groups maps group_name to list of member
+        InCore functions, and ungrouped is a list of InCore functions not
+        belonging to any group.
+    """
+    func_by_name: dict[str, _ir_core.Function] = {f.name: f for f in program.functions.values()}
+    grouped_names: set[str] = set()
+    groups: dict[str, list[_ir_core.Function]] = {}
+
+    for func in program.functions.values():
+        if func.func_type != _ir_core.FunctionType.Group:
+            continue
+        member_names = _extract_group_member_names(func)
+        members = [func_by_name[n] for n in member_names if n in func_by_name]
+        if members:
+            groups[func.name] = members
+            grouped_names.update(n for n in member_names if n in func_by_name)
+
+    ungrouped = [
+        f
+        for f in program.functions.values()
+        if _ir_core.is_incore_type(f.func_type) and f.name not in grouped_names
+    ]
+    return groups, ungrouped
+
+
 def generate(
     transformed_program: _ir_core.Program,
     output_dir: str,
@@ -361,29 +409,68 @@ def generate(
     for func in transformed_program.functions.values():
         if func.func_type == _ir_core.FunctionType.Orchestration:
             orch_func = func
-            continue
-        if not _ir_core.is_incore_type(func.func_type):
-            continue
 
+    groups, ungrouped = _build_group_mapping(transformed_program)
+
+    def _codegen_single_function(func: _ir_core.Function, pto_code: str) -> None:
+        """Compile one InCore function's MLIR through ptoas and emit its wrapper."""
+        core_type = _codegen_core.infer_function_core_type(func)
+        ct_str = "aiv" if core_type == _ir_core.CoreType.VECTOR else "aic"
+
+        if skip_ptoas:
+            kernel_rel = os.path.join("kernels", ct_str, f"{func.name}.pto")
+            result_files[kernel_rel] = pto_code
+        else:
+            ptoas_dir = os.path.join(output_dir, "ptoas")
+            os.makedirs(ptoas_dir, exist_ok=True)
+
+            pto_path = os.path.join(ptoas_dir, f"{func.name}.pto")
+            with open(pto_path, "w") as f:
+                f.write(pto_code)
+
+            cpp_path = os.path.join(ptoas_dir, f"{func.name}.cpp")
+            _run_ptoas(
+                pto_path,
+                cpp_path,
+                ptoas_flags=[
+                    "--enable-insert-sync",
+                    "--pto-level=level3",
+                ]
+                + (
+                    ["--pto-arch", "a5"]
+                    if _backend_core.get_backend_type() == _backend_core.BackendType.Ascend950
+                    else []
+                ),
+            )
+
+            with open(cpp_path) as f:
+                ptoas_cpp = f.read()
+
+            wrapper_code = _generate_kernel_wrapper(func, ptoas_cpp)
+            kernel_rel = os.path.join("kernels", ct_str, f"{func.name}.cpp")
+            result_files[kernel_rel] = wrapper_code
+
+    # Grouped functions: one MLIR module per group
+    for group_name, members in groups.items():
         try:
-            single_program = _ir_core.Program([func], func.name, transformed_program.span)
+            grouped_program = _ir_core.Program(members, group_name, transformed_program.span)
             codegen_instance = _codegen_core.PTOCodegen()
-            pto_code = codegen_instance.generate(single_program)
-            core_type = _codegen_core.infer_function_core_type(func)
-            ct_str = "aiv" if core_type == _ir_core.CoreType.VECTOR else "aic"
+            pto_code = codegen_instance.generate(grouped_program)
 
             if skip_ptoas:
-                kernel_rel = os.path.join("kernels", ct_str, f"{func.name}.pto")
+                # One .pto file per group, keyed by group name
+                kernel_rel = os.path.join("kernels", f"{group_name}.pto")
                 result_files[kernel_rel] = pto_code
             else:
+                # ptoas: compile grouped .pto, then generate per-function wrappers
                 ptoas_dir = os.path.join(output_dir, "ptoas")
                 os.makedirs(ptoas_dir, exist_ok=True)
 
-                pto_path = os.path.join(ptoas_dir, f"{func.name}.pto")
+                pto_path = os.path.join(ptoas_dir, f"{group_name}.pto")
                 with open(pto_path, "w") as f:
                     f.write(pto_code)
 
-                cpp_path = os.path.join(ptoas_dir, f"{func.name}.cpp")
+                cpp_path = os.path.join(ptoas_dir, f"{group_name}.cpp")
                 _run_ptoas(
                     pto_path,
                     cpp_path,
@@ -401,13 +488,27 @@ def generate(
                 with open(cpp_path) as f:
                     ptoas_cpp = f.read()
 
-                wrapper_code = _generate_kernel_wrapper(func, ptoas_cpp)
-                kernel_rel = os.path.join("kernels", ct_str, f"{func.name}.cpp")
-                result_files[kernel_rel] = wrapper_code
+                for func in members:
+                    wrapper_code = _generate_kernel_wrapper(func, ptoas_cpp)
+                    core_type = _codegen_core.infer_function_core_type(func)
+                    ct_str = "aiv" if core_type == _ir_core.CoreType.VECTOR else "aic"
+                    kernel_rel = os.path.join("kernels", ct_str, f"{func.name}.cpp")
+                    result_files[kernel_rel] = wrapper_code
+        except Exception as e:
+            func_names = ", ".join(m.name for m in members)
+            logger.error("Failed to compile group '%s' [%s]: %s", group_name, func_names, e)
+            errors.append((group_name, e))
+
+    # Ungrouped functions: one MLIR module per function (existing behavior)
+    for func in ungrouped:
+        try:
+            single_program = _ir_core.Program([func], func.name, transformed_program.span)
+            codegen_instance = _codegen_core.PTOCodegen()
+            pto_code = codegen_instance.generate(single_program)
+            _codegen_single_function(func, pto_code)
         except Exception as e:
             logger.error("Failed to compile function '%s': %s", func.name, e)
             errors.append((func.name, e))
-            continue
 
     # Orchestration + config (shared codegen with CCE)
     if orch_func is not None:

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -19,7 +19,7 @@ System operations handle hardware synchronization and cross-core communication:
 """
 
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, PipeType, Span
+from pypto.pypto_core.ir import Call, Expr, PipeType, Span
 
 from ..utils import _get_span_or_capture
 from .tile_ops import (  # noqa: F401
@@ -223,27 +223,27 @@ def import_peer_buffer(*, name: str, peer_func: str, span: Span | None = None) -
 # ============================================================================
 
 
-def tfree_to_aic(*, aiv_idx: int, span: Span | None = None) -> Call:
+def tfree_to_aic(tile: Expr, span: Span | None = None) -> Call:
     """Release ring buffer slot back to AIC producer.
 
     Called by AIV consumer after finishing with data from tpop_from_aic.
 
     Args:
-        aiv_idx: AIV core index releasing the slot
+        tile: Tile expression obtained from tpop_from_aic to release
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    return _ir_core.create_op_call("system.tfree_to_aic", [], {"aiv_idx": aiv_idx}, actual_span)
+    return _ir_core.create_op_call("system.tfree_to_aic", [tile], {}, actual_span)
 
 
-def tfree_to_aiv(*, aiv_idx: int, span: Span | None = None) -> Call:
+def tfree_to_aiv(tile: Expr, span: Span | None = None) -> Call:
     """Release ring buffer slot back to AIV producer.
 
     Called by AIC consumer after finishing with data from tpop_from_aiv.
 
     Args:
-        aiv_idx: AIV core index whose slot is being released
+        tile: Tile expression obtained from tpop_from_aiv to release
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    return _ir_core.create_op_call("system.tfree_to_aiv", [], {"aiv_idx": aiv_idx}, actual_span)
+    return _ir_core.create_op_call("system.tfree_to_aiv", [tile], {}, actual_span)

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -24,8 +24,6 @@ from pypto.ir.op.system_ops import (
     bar_v,
     sync_dst,
     sync_src,
-    tfree_to_aic,
-    tfree_to_aiv,
 )
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Call, Span
@@ -95,6 +93,16 @@ def tpush_to_aiv(tile: Tile, *, split: int, span: Span | None = None) -> Call:
 def tpush_to_aic(tile: Tile, *, split: int, span: Span | None = None) -> Call:
     """Push tile data from AIV to AIC via cross-core pipe."""
     return _ir_ops.tpush_to_aic(tile.unwrap(), split=split, span=span)
+
+
+def tfree_to_aic(tile: Tile, span: Span | None = None) -> Call:
+    """Release ring buffer slot back to AIC producer."""
+    return _ir_ops.tfree_to_aic(tile.unwrap(), span=span)
+
+
+def tfree_to_aiv(tile: Tile, span: Span | None = None) -> Call:
+    """Release ring buffer slot back to AIV producer."""
+    return _ir_ops.tfree_to_aiv(tile.unwrap(), span=span)
 
 
 def tpop_from_aic(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -399,6 +399,20 @@ class ASTParser:
                     and value_expr.type.dtype == DataType.INDEX
                 ):
                     override_type = resolved
+        # If the annotation resolved to a TileType and the value is a tpop call
+        # with UnknownType, reconstruct the Call carrying the resolved TileType
+        # so that codegen can emit SSA-result tpop without a separate alloc_tile.
+        if (
+            override_type is not None
+            and isinstance(override_type, ir.TileType)
+            and isinstance(value_expr, ir.Call)
+            and isinstance(value_expr.type, ir.UnknownType)
+            and value_expr.op.name in ("tile.tpop_from_aiv", "tile.tpop_from_aic")
+        ):
+            value_expr = ir.Call(
+                value_expr.op, value_expr.args, value_expr.kwargs, override_type, value_expr.span
+            )
+
         # Reuse existing Var on reassignment (override_type is intentionally
         # discarded — the Var's type was fixed at first definition; the SSA
         # pass will create properly typed versioned copies later).

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -709,11 +709,10 @@ static std::string MakeTpopFromAicCodegenPTO(const CallPtr& op, codegen::Codegen
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
 
   std::ostringstream oss;
-  oss << "pto.tpop_from_aic {split = " << split << "} (" << result_buf;
+  oss << result_buf << " = pto.tpop_from_aic {split = " << split << "}";
   if (!result_type.empty()) {
-    oss << " : " << result_type;
+    oss << " -> " << result_type;
   }
-  oss << ")";
   codegen.Emit(oss.str());
 
   return "";
@@ -734,45 +733,51 @@ static std::string MakeTpopFromAivCodegenPTO(const CallPtr& op, codegen::Codegen
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
 
   std::ostringstream oss;
-  oss << "pto.tpop_from_aiv {split = " << split << "} (" << result_buf;
+  oss << result_buf << " = pto.tpop_from_aiv {split = " << split << "}";
   if (!result_type.empty()) {
-    oss << " : " << result_type;
+    oss << " -> " << result_type;
   }
-  oss << ")";
   codegen.Emit(oss.str());
 
   return "";
 }
 
-// system.tfree_to_aic: Release slot back to Cube producer (called by Vector consumer)
+/// tfree codegen for system.tfree_to_aic: emits pto.tfree(%tile : type) {split = N}
 static std::string MakeTfreeToAicCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
 
-  CHECK(op->args_.size() == 0) << "tfree_to_aic takes no arguments, got " << op->args_.size();
+  CHECK(op->args_.size() == 1) << "tfree requires 1 argument (tile from tpop), got " << op->args_.size();
+  auto tile = AsVarLike(op->args_[0]);
+  INTERNAL_CHECK(tile) << "tfree first argument must be a Var or IterArg";
 
-  const int aiv_idx = op->GetKwarg<int>("aiv_idx", -1);
-  CHECK(aiv_idx >= 0 && aiv_idx <= 1)
-      << "tfree_to_aic requires 'aiv_idx' attribute (0 or 1), got " << aiv_idx;
+  std::string tile_buf = codegen.GetVarName(tile);
+  std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  int split = codegen.GetTpopSplit(tile.get());
 
   std::ostringstream oss;
-  oss << "pto.tfree_to_aic {aiv_idx = " << aiv_idx << "}";
+  oss << "pto.tfree(" << tile_buf;
+  if (!tile_type.empty()) {
+    oss << " : " << tile_type;
+  }
+  oss << ") {split = " << split << "}";
   codegen.Emit(oss.str());
 
   return "";
 }
 
-// system.tfree_to_aiv: Release slot back to Vector producer (called by Cube consumer)
+// tfree codegen for system.tfree_to_aiv: emits pto.tfree_from_aiv {split = N}
 static std::string MakeTfreeToAivCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
 
-  CHECK(op->args_.size() == 0) << "tfree_to_aiv takes no arguments, got " << op->args_.size();
+  CHECK(op->args_.size() == 1) << "tfree_to_aiv requires 1 argument (tile from tpop), got "
+                               << op->args_.size();
+  auto tile = AsVarLike(op->args_[0]);
+  INTERNAL_CHECK(tile) << "tfree_to_aiv first argument must be a Var or IterArg";
 
-  const int aiv_idx = op->GetKwarg<int>("aiv_idx", -1);
-  CHECK(aiv_idx >= 0 && aiv_idx <= 1)
-      << "tfree_to_aiv requires 'aiv_idx' attribute (0 or 1), got " << aiv_idx;
+  int split = codegen.GetTpopSplit(tile.get());
 
   std::ostringstream oss;
-  oss << "pto.tfree_to_aiv {aiv_idx = " << aiv_idx << "}";
+  oss << "pto.tfree_from_aiv {split = " << split << "}";
   codegen.Emit(oss.str());
 
   return "";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -460,6 +460,21 @@ std::vector<ir::StmtPtr> PTOCodegen::ReorderTpopChains(const std::vector<ir::Stm
   std::vector<const ir::Var*> tpop_order;
   std::vector<bool> in_chain(stmts.size(), false);
 
+  // Build a set of vars defined within the tpop region (after first tpop)
+  // to detect dependency hazards when reordering.
+  std::set<const ir::Var*> region_defined_vars;
+  bool seen_first_tpop = false;
+  for (const auto& stmt : stmts) {
+    if (auto assign = As<ir::AssignStmt>(stmt)) {
+      if (!seen_first_tpop && tpop_result_vars_.count(assign->var_.get()) > 0) {
+        seen_first_tpop = true;
+      }
+      if (seen_first_tpop) {
+        region_defined_vars.insert(assign->var_.get());
+      }
+    }
+  }
+
   for (size_t i = 0; i < stmts.size(); ++i) {
     if (auto assign = As<ir::AssignStmt>(stmts[i])) {
       // Tpop assignment itself
@@ -473,6 +488,7 @@ std::vector<ir::StmtPtr> PTOCodegen::ReorderTpopChains(const std::vector<ir::Stm
       if (auto call = As<ir::Call>(assign->value_)) {
         const ir::Var* ref = nullptr;
         bool multi = false;
+        bool has_unsafe_dep = false;
         for (const auto& arg : call->args_) {
           if (auto v = ir::AsVarLike(arg); v && tpop_result_vars_.count(v.get()) > 0) {
             if (ref && ref != v.get()) {
@@ -480,9 +496,13 @@ std::vector<ir::StmtPtr> PTOCodegen::ReorderTpopChains(const std::vector<ir::Stm
               break;
             }
             ref = v.get();
+          } else if (auto v = ir::AsVarLike(arg); v && region_defined_vars.count(v.get()) > 0) {
+            // This arg references a non-tpop var defined in the region —
+            // moving this stmt could create use-before-def.
+            has_unsafe_dep = true;
           }
         }
-        if (ref && !multi && chains.count(ref) > 0) {
+        if (ref && !multi && !has_unsafe_dep && chains.count(ref) > 0) {
           chains[ref].user_idxs.push_back(i);
           in_chain[i] = true;
         }
@@ -838,10 +858,9 @@ std::string PTOCodegen::GetImportBufferSSA() const { return import_buf_ssa_; }
 
 int PTOCodegen::GetTpopSplit(const ir::Var* var) const {
   auto it = tpop_result_vars_.find(var);
-  if (it != tpop_result_vars_.end()) {
-    return it->second;
-  }
-  return 0;
+  INTERNAL_CHECK(it != tpop_result_vars_.end())
+      << "Internal error: GetTpopSplit called for var not in tpop_result_vars_";
+  return it->second;
 }
 
 bool PTOCodegen::IsAICFunction() const {
@@ -864,7 +883,7 @@ void PTOCodegen::EmitExtraAllocTiles() {
 
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-    if (tpop_result_vars_.count(GetVarKey(op->var_)) == 0) {
+    if (tpop_result_vars_.count(op->var_.get()) == 0) {
       EmitAllocTileForVar(op->var_, tile_type);
     }
   }

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -258,6 +258,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   ssa_to_tile_buf_type_.clear();
   tile_var_allocs_.clear();
   emitted_tile_alloc_vars_.clear();
+  tpop_result_vars_.clear();
   reserve_buf_ssa_.clear();
   import_buf_ssa_.clear();
   constants_section_.str("");
@@ -381,6 +382,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
   // Pre-emit i64 address constants now that indent_level_ is set
   for (const auto& [tile_var, tile_type] : tile_var_allocs_) {
+    if (tpop_result_vars_.count(tile_var.get()) > 0) continue;
     auto memref = ir::GetDefinedMemRef(tile_type);
     if (memref && As<ir::ConstInt>(memref->addr_)) {
       GetOrEmitI64Constant(As<ir::ConstInt>(memref->addr_)->value_);
@@ -417,7 +419,19 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   stream_ = std::move(body_section_);
 
   if (func->body_) {
-    VisitStmt(func->body_);
+    if (!tpop_result_vars_.empty()) {
+      auto seq = As<ir::SeqStmts>(func->body_);
+      if (seq) {
+        auto reordered = ReorderTpopChains(seq->stmts_);
+        for (const auto& stmt : reordered) {
+          VisitStmt(stmt);
+        }
+      } else {
+        VisitStmt(func->body_);
+      }
+    } else {
+      VisitStmt(func->body_);
+    }
   }
 
   std::string body_content = stream_.str();
@@ -433,17 +447,113 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   stream_ << "  }\n";
 }
 
+std::vector<ir::StmtPtr> PTOCodegen::ReorderTpopChains(const std::vector<ir::StmtPtr>& stmts) const {
+  if (tpop_result_vars_.empty()) return stmts;
+
+  // Phase 1: classify statements into tpop chains
+  struct TpopChain {
+    size_t tpop_idx;
+    std::vector<size_t> user_idxs;
+    size_t tfree_idx = SIZE_MAX;
+  };
+  std::map<const ir::Var*, TpopChain> chains;
+  std::vector<const ir::Var*> tpop_order;
+  std::vector<bool> in_chain(stmts.size(), false);
+
+  for (size_t i = 0; i < stmts.size(); ++i) {
+    if (auto assign = As<ir::AssignStmt>(stmts[i])) {
+      // Tpop assignment itself
+      if (tpop_result_vars_.count(assign->var_.get()) > 0) {
+        chains[assign->var_.get()] = {i, {}, SIZE_MAX};
+        tpop_order.push_back(assign->var_.get());
+        in_chain[i] = true;
+        continue;
+      }
+      // Check if this is a direct user of exactly one tpop var
+      if (auto call = As<ir::Call>(assign->value_)) {
+        const ir::Var* ref = nullptr;
+        bool multi = false;
+        for (const auto& arg : call->args_) {
+          if (auto v = ir::AsVarLike(arg); v && tpop_result_vars_.count(v.get()) > 0) {
+            if (ref && ref != v.get()) {
+              multi = true;
+              break;
+            }
+            ref = v.get();
+          }
+        }
+        if (ref && !multi && chains.count(ref) > 0) {
+          chains[ref].user_idxs.push_back(i);
+          in_chain[i] = true;
+        }
+      }
+    } else if (auto eval = As<ir::EvalStmt>(stmts[i])) {
+      // tfree statement
+      if (auto call = As<ir::Call>(eval->expr_)) {
+        if (call->op_ &&
+            (call->op_->name_ == "system.tfree_to_aiv" || call->op_->name_ == "system.tfree_to_aic") &&
+            !call->args_.empty()) {
+          if (auto v = ir::AsVarLike(call->args_[0]); v && tpop_result_vars_.count(v.get()) > 0) {
+            if (chains.count(v.get()) > 0) {
+              chains[v.get()].tfree_idx = i;
+              in_chain[i] = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (tpop_order.empty()) return stmts;
+
+  // Phase 2: build reordered list
+  size_t first_tpop = chains[tpop_order[0]].tpop_idx;
+  std::vector<ir::StmtPtr> result;
+  result.reserve(stmts.size());
+
+  // Prefix: stmts before first tpop
+  for (size_t i = 0; i < first_tpop; ++i) {
+    result.push_back(stmts[i]);
+  }
+
+  // Chains in order: tpop → users → tfree
+  for (const auto* var : tpop_order) {
+    auto& ch = chains[var];
+    result.push_back(stmts[ch.tpop_idx]);
+    for (size_t ui : ch.user_idxs) {
+      result.push_back(stmts[ui]);
+    }
+    if (ch.tfree_idx != SIZE_MAX) {
+      result.push_back(stmts[ch.tfree_idx]);
+    }
+  }
+
+  // Remaining independent stmts (after first tpop, not in any chain)
+  for (size_t i = first_tpop; i < stmts.size(); ++i) {
+    if (!in_chain[i]) {
+      result.push_back(stmts[i]);
+    }
+  }
+
+  return result;
+}
+
 void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
   class VarMemRefMapper : public ir::IRVisitor {
    public:
     std::map<const ir::Var*, const ir::MemRef*>& var_to_memref;
     std::map<const ir::MemRef*, std::string>& memref_to_var_name;
     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& tile_var_allocs;
+    std::map<const ir::Var*, int>& tpop_result_vars;
 
     VarMemRefMapper(std::map<const ir::Var*, const ir::MemRef*>& mapping,
                     std::map<const ir::MemRef*, std::string>& reverse_mapping,
-                    std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& allocs)
-        : var_to_memref(mapping), memref_to_var_name(reverse_mapping), tile_var_allocs(allocs) {}
+                    std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& allocs,
+                    std::map<const ir::Var*, int>& tpop_vars)
+        : var_to_memref(mapping),
+          memref_to_var_name(reverse_mapping),
+          tile_var_allocs(allocs),
+          tpop_result_vars(tpop_vars) {}
 
     void VisitStmt_(const AssignStmtPtr& op) override {
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
@@ -454,12 +564,22 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
           memref_to_var_name[ptr] = op->var_->name_hint_;
         }
         tile_var_allocs.emplace_back(op->var_, tile_type);
+
+        // Track tpop result vars with their split value so codegen can:
+        // 1. Skip alloc_tile for them
+        // 2. Propagate split to tfree
+        if (auto call = As<ir::Call>(op->value_)) {
+          if (call->op_->name_ == "tile.tpop_from_aiv" || call->op_->name_ == "tile.tpop_from_aic") {
+            int split = call->GetKwarg<int>("split", 0);
+            tpop_result_vars[op->var_.get()] = split;
+          }
+        }
       }
       ir::IRVisitor::VisitStmt_(op);
     }
   };
 
-  VarMemRefMapper mapper(var_to_memref_, memref_to_var_name_, tile_var_allocs_);
+  VarMemRefMapper mapper(var_to_memref_, memref_to_var_name_, tile_var_allocs_, tpop_result_vars_);
   if (func->body_) {
     mapper.VisitStmt(func->body_);
   }
@@ -716,6 +836,14 @@ void PTOCodegen::RecordImportBufferSSA(const std::string& ssa) {
 
 std::string PTOCodegen::GetImportBufferSSA() const { return import_buf_ssa_; }
 
+int PTOCodegen::GetTpopSplit(const ir::Var* var) const {
+  auto it = tpop_result_vars_.find(var);
+  if (it != tpop_result_vars_.end()) {
+    return it->second;
+  }
+  return 0;
+}
+
 bool PTOCodegen::IsAICFunction() const {
   return current_function_ && current_function_->func_type_ == ir::FunctionType::AIC;
 }
@@ -736,7 +864,9 @@ void PTOCodegen::EmitExtraAllocTiles() {
 
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-    EmitAllocTileForVar(op->var_, tile_type);
+    if (tpop_result_vars_.count(GetVarKey(op->var_)) == 0) {
+      EmitAllocTileForVar(op->var_, tile_type);
+    }
   }
 
   if (auto call = As<ir::Call>(op->value_)) {

--- a/src/ir/op/sync_ops/cross_core.cpp
+++ b/src/ir/op/sync_ops/cross_core.cpp
@@ -35,20 +35,18 @@ TypePtr DeduceUnknownType(const std::vector<ExprPtr>& args,
 // (tile.tpush/tpop are registered in tile_ops/cross_core.cpp)
 // ============================================================================
 
-// Release slot back to AIC producer (called by AIV consumer)
+// Release slot back to AIC producer (called by AIV consumer after tpop_from_aic)
 REGISTER_OP("system.tfree_to_aic")
-    .set_description("Release ring buffer slot back to AIC producer (AIV consumer calls after tpop_from_aic)")
+    .set_description("Release ring buffer slot back to AIC producer")
     .set_op_category("CrossCoreOp")
-    .no_argument()
-    .set_attr<int>("aiv_idx")
+    .add_argument("tile", "Tile buffer obtained from tpop to release")
     .f_deduce_type(DeduceUnknownType);
 
-// Release slot back to AIV producer (called by AIC consumer)
+// Release slot back to AIV producer (called by AIC consumer after tpop_from_aiv)
 REGISTER_OP("system.tfree_to_aiv")
-    .set_description("Release ring buffer slot back to AIV producer (AIC consumer calls after tpop_from_aiv)")
+    .set_description("Release ring buffer slot back to AIV producer")
     .set_op_category("CrossCoreOp")
-    .no_argument()
-    .set_attr<int>("aiv_idx")
+    .add_argument("tile", "Tile buffer obtained from tpop to release")
     .f_deduce_type(DeduceUnknownType);
 
 // Initialize pipe on AIC side

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -13,6 +13,7 @@
 #include <any>
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -199,43 +200,97 @@ StmtPtr MakeBody(const std::vector<StmtPtr>& stmts, const Span& span) {
 // Recursive Affinity Analysis
 // ============================================================================
 
+/// Collect Vars defined by tpop operations (tile.tpop_from_aiv / tile.tpop_from_aic).
+/// Used to avoid misclassifying tile.move from a tpop result as a cross-core boundary.
+std::unordered_set<const Var*> CollectTpopVars(const std::vector<StmtPtr>& stmts) {
+  std::unordered_set<const Var*> result;
+  for (const auto& stmt : stmts) {
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+        if (auto op = std::dynamic_pointer_cast<const Op>(call->op_)) {
+          if (op->name_ == "tile.tpop_from_aiv" || op->name_ == "tile.tpop_from_aic") {
+            result.insert(assign->var_.get());
+          }
+        }
+      }
+    }
+    // Recurse into compound statements
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      auto inner = CollectTpopVars(FlattenBody(for_stmt->body_));
+      result.insert(inner.begin(), inner.end());
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      auto inner = CollectTpopVars(FlattenBody(if_stmt->then_body_));
+      result.insert(inner.begin(), inner.end());
+      if (if_stmt->else_body_.has_value()) {
+        auto inner2 = CollectTpopVars(FlattenBody(if_stmt->else_body_.value()));
+        result.insert(inner2.begin(), inner2.end());
+      }
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto inner = CollectTpopVars(FlattenBody(while_stmt->body_));
+      result.insert(inner.begin(), inner.end());
+    }
+  }
+  return result;
+}
+
 // Forward declare
 CoreAffinity AnalyzeStmtAffinity(const StmtPtr& stmt, std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
-                                 std::unordered_map<const Var*, CoreAffinity>& var_affinity);
+                                 std::unordered_map<const Var*, CoreAffinity>& var_affinity,
+                                 const std::unordered_set<const Var*>& tpop_vars);
 
 CoreAffinity AnalyzeStmtsAffinity(const std::vector<StmtPtr>& stmts,
                                   std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
-                                  std::unordered_map<const Var*, CoreAffinity>& var_affinity) {
+                                  std::unordered_map<const Var*, CoreAffinity>& var_affinity,
+                                  const std::unordered_set<const Var*>& tpop_vars = {}) {
   CoreAffinity combined = CoreAffinity::SHARED;
   for (const auto& stmt : stmts) {
-    combined = CombineAffinity(combined, AnalyzeStmtAffinity(stmt, stmt_map, var_affinity));
+    combined = CombineAffinity(combined, AnalyzeStmtAffinity(stmt, stmt_map, var_affinity, tpop_vars));
   }
   return combined;
 }
 
 CoreAffinity AnalyzeStmtAffinity(const StmtPtr& stmt, std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
-                                 std::unordered_map<const Var*, CoreAffinity>& var_affinity) {
+                                 std::unordered_map<const Var*, CoreAffinity>& var_affinity,
+                                 const std::unordered_set<const Var*>& tpop_vars) {
   CoreAffinity result = CoreAffinity::SHARED;
 
   if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
     auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
-    if (call) result = ClassifyCallAffinity(call);
+    if (call) {
+      result = ClassifyCallAffinity(call);
+      // tile.move from a tpop result is not a cross-core boundary: the data already
+      // arrived via tpop, so the move is just internal data placement on the consuming core.
+      if (result == CoreAffinity::BOUNDARY && !call->args_.empty()) {
+        if (auto src_var = std::dynamic_pointer_cast<const Var>(call->args_[0])) {
+          if (tpop_vars.count(src_var.get()) > 0) {
+            // Reclassify by target memory space (the consuming core's side)
+            for (const auto& [key, value] : call->kwargs_) {
+              if (key == "target_memory") {
+                auto target = AnyCast<MemorySpace>(value, "target_memory");
+                result = IsCubeMemorySpace(target) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
     var_affinity[assign->var_.get()] = result;
   } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
     auto call = std::dynamic_pointer_cast<const Call>(eval->expr_);
     if (call) result = ClassifyCallAffinity(call);
   } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-    result = AnalyzeStmtsAffinity(FlattenBody(for_stmt->body_), stmt_map, var_affinity);
+    result = AnalyzeStmtsAffinity(FlattenBody(for_stmt->body_), stmt_map, var_affinity, tpop_vars);
   } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-    result = AnalyzeStmtsAffinity(FlattenBody(if_stmt->then_body_), stmt_map, var_affinity);
+    result = AnalyzeStmtsAffinity(FlattenBody(if_stmt->then_body_), stmt_map, var_affinity, tpop_vars);
     if (if_stmt->else_body_.has_value()) {
-      result = CombineAffinity(
-          result, AnalyzeStmtsAffinity(FlattenBody(if_stmt->else_body_.value()), stmt_map, var_affinity));
+      result = CombineAffinity(result, AnalyzeStmtsAffinity(FlattenBody(if_stmt->else_body_.value()),
+                                                            stmt_map, var_affinity, tpop_vars));
     }
   } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-    result = AnalyzeStmtsAffinity(FlattenBody(while_stmt->body_), stmt_map, var_affinity);
+    result = AnalyzeStmtsAffinity(FlattenBody(while_stmt->body_), stmt_map, var_affinity, tpop_vars);
   } else if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
-    result = AnalyzeStmtsAffinity(seq->stmts_, stmt_map, var_affinity);
+    result = AnalyzeStmtsAffinity(seq->stmts_, stmt_map, var_affinity, tpop_vars);
   }
 
   stmt_map[stmt.get()] = result;
@@ -252,11 +307,17 @@ struct CVBoundaryMove {
   VarPtr dest_var;      // AssignStmt LHS
   ExprPtr source_tile;  // First arg of tile.move
   TypePtr result_type;  // Return type of the tile.move call
+  /// Original tpop Call that defines source_tile (nullptr if source is not a tpop result).
+  /// Used to propagate kwargs (e.g., split) from the user-written tpop to the replacement tpop.
+  CallPtr source_tpop_call;
 };
 
 /// Collect all CV boundary tile.move statements recursively.
+/// Also looks up whether the source tile is defined by a tpop call, so that kwargs
+/// (e.g., split) can be propagated to the replacement tpop.
 void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
-                            std::unordered_map<const Stmt*, CVBoundaryMove>& boundary_moves) {
+                            std::map<const Stmt*, CVBoundaryMove>& boundary_moves,
+                            const std::unordered_map<const Var*, CallPtr>& var_to_tpop) {
   for (const auto& stmt : stmts) {
     if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
       auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
@@ -264,21 +325,30 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
         auto dir = ClassifyMoveDirection(call);
         if (dir != CVDirection::NONE) {
           INTERNAL_CHECK(!call->args_.empty()) << "Internal error: tile.move must have at least one argument";
-          boundary_moves[stmt.get()] = CVBoundaryMove{dir, assign->var_, call->args_[0], call->GetType()};
+          // Look up whether the source tile was produced by a tpop call
+          CallPtr source_tpop;
+          if (auto source_var = std::dynamic_pointer_cast<const Var>(call->args_[0])) {
+            auto it = var_to_tpop.find(source_var.get());
+            if (it != var_to_tpop.end()) {
+              source_tpop = it->second;
+            }
+          }
+          boundary_moves[stmt.get()] =
+              CVBoundaryMove{dir, assign->var_, call->args_[0], call->GetType(), source_tpop};
         }
       }
     }
 
     // Recurse into compound statements
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-      CollectCVBoundaryMoves(FlattenBody(for_stmt->body_), boundary_moves);
+      CollectCVBoundaryMoves(FlattenBody(for_stmt->body_), boundary_moves, var_to_tpop);
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-      CollectCVBoundaryMoves(FlattenBody(if_stmt->then_body_), boundary_moves);
+      CollectCVBoundaryMoves(FlattenBody(if_stmt->then_body_), boundary_moves, var_to_tpop);
       if (if_stmt->else_body_.has_value()) {
-        CollectCVBoundaryMoves(FlattenBody(if_stmt->else_body_.value()), boundary_moves);
+        CollectCVBoundaryMoves(FlattenBody(if_stmt->else_body_.value()), boundary_moves, var_to_tpop);
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-      CollectCVBoundaryMoves(FlattenBody(while_stmt->body_), boundary_moves);
+      CollectCVBoundaryMoves(FlattenBody(while_stmt->body_), boundary_moves, var_to_tpop);
     }
   }
 }
@@ -301,10 +371,12 @@ TypePtr CleanTileType(const TypePtr& tile_type) {
   return std::make_shared<TileType>(tt->shape_, tt->dtype_, std::nullopt, std::nullopt, tt->memory_space_);
 }
 
-CallPtr CreateTpop(const std::string& op_name, const TypePtr& tile_type, const Span& span) {
+CallPtr CreateTpop(const std::string& op_name, const TypePtr& tile_type, const Span& span,
+                   const std::vector<std::pair<std::string, std::any>>& kwargs = {}) {
   auto op = OpRegistry::GetInstance().GetOp(op_name);
-  return std::make_shared<Call>(op, std::vector<ExprPtr>{}, MakeSplitKwargs(), CleanTileType(tile_type),
-                                span);
+  auto effective_kwargs = kwargs.empty() ? MakeSplitKwargs() : kwargs;
+  return std::make_shared<Call>(op, std::vector<ExprPtr>{}, std::move(effective_kwargs),
+                                CleanTileType(tile_type), span);
 }
 
 // ============================================================================
@@ -922,10 +994,13 @@ enum class CoreSide { AIC, AIV };
 /// tpop_var_remap collects dest_var and (when source_tile is a Var) source_tile pointers
 /// -> clean-typed new_var mappings, so downstream references to either the pre-move or
 /// post-move variable can be updated via pointer-based substitution.
+/// superseded_tpop_vars tracks source Vars whose defining tpop is superseded by a
+/// boundary-generated tpop, so the original tpop can be eliminated.
 std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& stmts,
                                    const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
-                                   const std::unordered_map<const Stmt*, CVBoundaryMove>& boundary_moves,
-                                   std::unordered_map<const Var*, VarPtr>& tpop_var_remap) {
+                                   const std::map<const Stmt*, CVBoundaryMove>& boundary_moves,
+                                   std::unordered_map<const Var*, VarPtr>& tpop_var_remap,
+                                   std::unordered_set<const Var*>& superseded_tpop_vars) {
   // AIC keeps CUBE, skips VECTOR; AIV keeps VECTOR, skips CUBE
   CoreAffinity keep_affinity = (side == CoreSide::AIC) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
   CoreAffinity skip_affinity = (side == CoreSide::AIC) ? CoreAffinity::VECTOR : CoreAffinity::CUBE;
@@ -962,8 +1037,13 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
           if (auto source_var = std::dynamic_pointer_cast<const Var>(bm.source_tile)) {
             tpop_var_remap[source_var.get()] = clean_var;
           }
+          // Propagate kwargs from the original tpop (e.g., split=1) if available
+          std::vector<std::pair<std::string, std::any>> kwargs;
+          if (bm.source_tpop_call) {
+            kwargs = bm.source_tpop_call->kwargs_;
+          }
           result.push_back(std::make_shared<AssignStmt>(
-              clean_var, CreateTpop(pop_op, clean_type, stmt->span_), stmt->span_));
+              clean_var, CreateTpop(pop_op, clean_type, stmt->span_, kwargs), stmt->span_));
         }
         continue;
       }
@@ -973,31 +1053,36 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
 
     if (affinity == skip_affinity) continue;
 
+    // Skip original tpop statements whose results are superseded by boundary-generated tpops
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (superseded_tpop_vars.count(assign->var_.get()) > 0) continue;
+    }
+
     if (affinity == keep_affinity || affinity == CoreAffinity::SHARED) {
       result.push_back(stmt);
     } else if (affinity == CoreAffinity::MIXED) {
       // Recurse into compound statements, building pruned copies
       if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-        auto new_body =
-            BuildCoreBody(side, FlattenBody(for_stmt->body_), stmt_map, boundary_moves, tpop_var_remap);
+        auto new_body = BuildCoreBody(side, FlattenBody(for_stmt->body_), stmt_map, boundary_moves,
+                                      tpop_var_remap, superseded_tpop_vars);
         result.push_back(std::make_shared<ForStmt>(
             for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
             MakeBody(new_body, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
             for_stmt->chunk_size_, for_stmt->chunk_policy_, for_stmt->loop_origin_));
       } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-        auto new_then =
-            BuildCoreBody(side, FlattenBody(if_stmt->then_body_), stmt_map, boundary_moves, tpop_var_remap);
+        auto new_then = BuildCoreBody(side, FlattenBody(if_stmt->then_body_), stmt_map, boundary_moves,
+                                      tpop_var_remap, superseded_tpop_vars);
         std::optional<StmtPtr> new_else;
         if (if_stmt->else_body_.has_value()) {
           auto new_else_stmts = BuildCoreBody(side, FlattenBody(if_stmt->else_body_.value()), stmt_map,
-                                              boundary_moves, tpop_var_remap);
+                                              boundary_moves, tpop_var_remap, superseded_tpop_vars);
           new_else = MakeBody(new_else_stmts, if_stmt->span_);
         }
         result.push_back(std::make_shared<IfStmt>(if_stmt->condition_, MakeBody(new_then, if_stmt->span_),
                                                   new_else, if_stmt->return_vars_, if_stmt->span_));
       } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-        auto new_body =
-            BuildCoreBody(side, FlattenBody(while_stmt->body_), stmt_map, boundary_moves, tpop_var_remap);
+        auto new_body = BuildCoreBody(side, FlattenBody(while_stmt->body_), stmt_map, boundary_moves,
+                                      tpop_var_remap, superseded_tpop_vars);
         result.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_,
                                                      MakeBody(new_body, while_stmt->span_),
                                                      while_stmt->return_vars_, while_stmt->span_));
@@ -1023,22 +1108,54 @@ struct ExpandedKernel {
 ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = true) {
   auto stmts = FlattenBody(func->body_);
 
+  // Pre-scan for tpop result vars (needed by affinity analysis to avoid
+  // misclassifying tile.move from tpop results as cross-core boundaries)
+  auto tpop_vars = CollectTpopVars(stmts);
+
   // Recursive affinity analysis (descends into ForStmt/IfStmt/WhileStmt)
   std::unordered_map<const Stmt*, CoreAffinity> stmt_map;
   std::unordered_map<const Var*, CoreAffinity> var_affinity;
-  AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity);
+  AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity, tpop_vars);
 
-  // Collect CV boundary moves from explicit tile.move ops
-  std::unordered_map<const Stmt*, CVBoundaryMove> boundary_moves;
-  CollectCVBoundaryMoves(stmts, boundary_moves);
+  // Collect CV boundary moves from explicit tile.move ops.
+  // First, build a map from Var -> defining tpop Call so boundary moves can
+  // propagate kwargs (e.g., split) from the original tpop to the replacement.
+  std::unordered_map<const Var*, CallPtr> var_to_tpop;
+  for (const auto& stmt : stmts) {
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+        if (auto op = std::dynamic_pointer_cast<const Op>(call->op_)) {
+          if (op->name_ == "tile.tpop_from_aiv" || op->name_ == "tile.tpop_from_aic") {
+            var_to_tpop[assign->var_.get()] = call;
+          }
+        }
+      }
+    }
+  }
+  std::map<const Stmt*, CVBoundaryMove> boundary_moves;
+  CollectCVBoundaryMoves(stmts, boundary_moves, var_to_tpop);
 
   // Build definition map from original body for init value fixup (#533)
   std::unordered_map<const Var*, StmtPtr> original_def_map;
   BuildDefMap(stmts, original_def_map);
 
+  // Precompute the set of source Vars whose original tpop is superseded by a
+  // boundary-generated tpop.  This must be done before BuildCoreBody because
+  // the original tpop statement appears before the boundary tile.move in
+  // program order — computing it lazily inside the loop would be too late.
+  std::unordered_set<const Var*> superseded_tpop_vars;
+  for (const auto& [stmt_ptr, bm] : boundary_moves) {
+    if (bm.source_tpop_call) {
+      if (auto source_var = std::dynamic_pointer_cast<const Var>(bm.source_tile)) {
+        superseded_tpop_vars.insert(source_var.get());
+      }
+    }
+  }
+
   // Build AIC body (recursive — handles MIXED compound stmts)
   std::unordered_map<const Var*, VarPtr> aic_tpop_remap;
-  auto aic_stmts = BuildCoreBody(CoreSide::AIC, stmts, stmt_map, boundary_moves, aic_tpop_remap);
+  auto aic_stmts =
+      BuildCoreBody(CoreSide::AIC, stmts, stmt_map, boundary_moves, aic_tpop_remap, superseded_tpop_vars);
 
   // Remove ReturnStmt from AIC (AIC doesn't return values)
   std::vector<StmtPtr> aic_stmts_no_return;
@@ -1051,7 +1168,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
 
   // Build AIV body (recursive — handles MIXED compound stmts)
   std::unordered_map<const Var*, VarPtr> aiv_tpop_remap;
-  auto aiv_stmts = BuildCoreBody(CoreSide::AIV, stmts, stmt_map, boundary_moves, aiv_tpop_remap);
+  auto aiv_stmts =
+      BuildCoreBody(CoreSide::AIV, stmts, stmt_map, boundary_moves, aiv_tpop_remap, superseded_tpop_vars);
   auto aiv_final = FinalizeSplitCoreBody(aiv_stmts, original_def_map);
 
   // Helper to create fresh params and build a DeepClone var_map
@@ -1393,9 +1511,10 @@ Pass ExpandMixedKernel() {
 
       // Check if function is mixed (recursive analysis detects ops inside loops/conditionals)
       auto stmts = FlattenBody(func->body_);
+      auto tpop_vars = CollectTpopVars(stmts);
       std::unordered_map<const Stmt*, CoreAffinity> stmt_map;
       std::unordered_map<const Var*, CoreAffinity> var_affinity;
-      auto combined = AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity);
+      auto combined = AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity, tpop_vars);
 
       // A function is mixed if the combined affinity is MIXED or BOUNDARY
       // (both imply cube+vector presence). Pure CUBE or pure VECTOR are not mixed.

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1120,18 +1120,32 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   // Collect CV boundary moves from explicit tile.move ops.
   // First, build a map from Var -> defining tpop Call so boundary moves can
   // propagate kwargs (e.g., split) from the original tpop to the replacement.
+  // Uses the already-collected tpop_vars set and rescans for the full Call objects.
   std::unordered_map<const Var*, CallPtr> var_to_tpop;
-  for (const auto& stmt : stmts) {
-    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
-      if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
-        if (auto op = std::dynamic_pointer_cast<const Op>(call->op_)) {
-          if (op->name_ == "tile.tpop_from_aiv" || op->name_ == "tile.tpop_from_aic") {
-            var_to_tpop[assign->var_.get()] = call;
+  auto collect_var_to_tpop = [&](const std::vector<StmtPtr>& ss, auto&& self) -> void {
+    for (const auto& stmt : ss) {
+      if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+        if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+          if (auto op = std::dynamic_pointer_cast<const Op>(call->op_)) {
+            if (op->name_ == "tile.tpop_from_aiv" || op->name_ == "tile.tpop_from_aic") {
+              var_to_tpop[assign->var_.get()] = call;
+            }
           }
         }
       }
+      if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+        self(FlattenBody(for_stmt->body_), self);
+      } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+        self(FlattenBody(if_stmt->then_body_), self);
+        if (if_stmt->else_body_.has_value()) {
+          self(FlattenBody(if_stmt->else_body_.value()), self);
+        }
+      } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+        self(FlattenBody(while_stmt->body_), self);
+      }
     }
-  }
+  };
+  collect_var_to_tpop(stmts, collect_var_to_tpop);
   std::map<const Stmt*, CVBoundaryMove> boundary_moves;
   CollectCVBoundaryMoves(stmts, boundary_moves, var_to_tpop);
 

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -26,6 +26,7 @@ import pypto.language as pl
 import pytest
 from pypto import backend, codegen, ir, passes
 from pypto.backend import BackendType
+from pypto.backend.pto_backend import _build_group_mapping
 
 # ============================================================================
 # Test Program: Vector Producer + Cube Consumer (V2C unidirectional)
@@ -34,11 +35,18 @@ from pypto.backend import BackendType
 
 @pl.program
 class CrossCoreTpushTpopProgram:
-    @pl.function(type=pl.FunctionType.InCore)
+    """V2C unidirectional cross-core program with orchestration wrapper.
+
+    Vector producer: loads tiles a and b, computes add and sub, pushes both to Cube.
+    Cube consumer: pops tiles, performs matmul, stores result.
+    """
+
+    @pl.function(type=pl.FunctionType.AIV)
     def vector_producer(
         self,
         a: pl.Tensor[[16, 16], pl.FP16],
         b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ):
         v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
         pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer.base)
@@ -51,26 +59,49 @@ class CrossCoreTpushTpopProgram:
         pl.tpush_to_aic(result_add, split=1)
         pl.tpush_to_aic(result_sub, split=1)
 
-    @pl.function(type=pl.FunctionType.InCore)
+    @pl.function(type=pl.FunctionType.AIC)
     def cube_consumer(
         self,
-        output: pl.Tensor[[16, 16], pl.FP32],
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
         pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf.base)
 
-        received_add: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(split=1)
-        received_sub: pl.Tile[[16, 16], pl.FP16] = pl.tpop_from_aiv(split=1)
+        received_add: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=1)
+        received_sub: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=1)
         received_add_left = pl.move(received_add, target_memory=pl.Mem.Left)
         received_sub_right = pl.move(received_sub, target_memory=pl.Mem.Right)
 
         mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add_left, received_sub_right)
 
-        pl.tfree_to_aiv(aiv_idx=0)
-        pl.tfree_to_aiv(aiv_idx=0)
+        pl.tfree_to_aiv(received_add)
+        pl.tfree_to_aiv(received_sub)
 
         updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(mm_result, [0, 0], output)
         return updated
+
+    @pl.function(type=pl.FunctionType.Group)
+    def group_func(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ):
+        updated = self.cube_consumer(a, b, output)
+        self.vector_producer(a, b, output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        out = self.group_func(a, b, output)
+        return out
 
 
 # ============================================================================
@@ -117,7 +148,7 @@ class BidirectionalCrossCorProgram:
         processed: pl.Tile[[16, 16], pl.FP32] = pl.exp(mm_result)
 
         # Release C2V slot
-        pl.tfree_to_aic(aiv_idx=0)
+        pl.tfree_to_aic(mm_result)
 
         # Store final result
         updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(processed, [0, 0], output)
@@ -145,7 +176,7 @@ class BidirectionalCrossCorProgram:
         mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received, w_tile)
 
         # Release V2C slot
-        pl.tfree_to_aiv(aiv_idx=0)
+        pl.tfree_to_aiv(received)
 
         # Push matmul result back to Vector for post-processing (C2V direction)
         pl.tpush_to_aiv(mm_result, split=0)
@@ -194,7 +225,18 @@ class TestCrossCoreTpushTpopCodegen:
 
         result = {}
         codegen_instance = codegen.PTOCodegen()
-        for func in optimized.functions.values():
+        groups, ungrouped = _build_group_mapping(optimized)
+
+        # Grouped: one module per group
+        for group_name, members in groups.items():
+            grouped_program = ir.Program(members, group_name, optimized.span)
+            mlir_code = codegen_instance.generate(grouped_program)
+            result[group_name] = mlir_code
+            for func in members:
+                result[func.name] = mlir_code
+
+        # Ungrouped: one module per function (existing behavior)
+        for func in ungrouped:
             single = ir.Program([func], func.name, optimized.span)
             mlir_code = codegen_instance.generate(single)
             result[func.name] = mlir_code
@@ -236,8 +278,36 @@ class TestCrossCoreTpushTpopCodegen:
         assert "c2v_consumer_buf = " in cube_code, "Should have c2v_consumer_buf as SSA reference"
         assert "arith.constant 0 : i32" in cube_code, "Should emit i32 constant for default consumer buf"
         assert "pto.tpop_from_aiv" in cube_code, "Should contain pto.tpop_from_aiv"
-        assert "pto.tfree_to_aiv" in cube_code, "Should contain pto.tfree_to_aiv"
+        assert "= pto.tpop_from_aiv" in cube_code, "tpop should produce SSA result"
+        assert "-> !pto.tile_buf<" in cube_code, "tpop should use -> result type syntax"
+        assert "pto.tfree" in cube_code, "Should contain pto.tfree"
+        assert "{split = " in cube_code, "tfree should have split attribute"
         assert "pto.tmatmul" in cube_code, "Should contain matmul (Cube op)"
+
+    def test_tpop_chain_ordering(self):
+        """Test that tpop chains follow pop-use-free ordering per hardware requirement."""
+        codes = self._compile_and_generate(CrossCoreTpushTpopProgram)
+        cube_code = codes["cube_consumer"]
+        lines = cube_code.split("\n")
+
+        tpop_lines = [i for i, line in enumerate(lines) if "pto.tpop_from_aiv" in line]
+        tfree_lines = [i for i, line in enumerate(lines) if "pto.tfree" in line]
+        tmov_lines = [i for i, line in enumerate(lines) if "pto.tmov" in line]
+
+        assert len(tpop_lines) == 2, f"Expected 2 tpop lines, got {len(tpop_lines)}"
+        assert len(tfree_lines) == 2, f"Expected 2 tfree lines, got {len(tfree_lines)}"
+        assert len(tmov_lines) >= 2, f"Expected at least 2 tmov lines, got {len(tmov_lines)}"
+
+        # pop1 < use1 < free1 < pop2 < use2 < free2
+        assert tpop_lines[0] < tmov_lines[0] < tfree_lines[0], (
+            f"First chain out of order: tpop={tpop_lines[0]}, tmov={tmov_lines[0]}, tfree={tfree_lines[0]}"
+        )
+        assert tfree_lines[0] < tpop_lines[1], (
+            f"Second tpop should come after first tfree: tfree1={tfree_lines[0]}, tpop2={tpop_lines[1]}"
+        )
+        assert tpop_lines[1] < tmov_lines[1] < tfree_lines[1], (
+            f"Second chain out of order: tpop={tpop_lines[1]}, tmov={tmov_lines[1]}, tfree={tfree_lines[1]}"
+        )
 
     @pytest.mark.skip(reason="Only testing CrossCoreTpushTpopProgram")
     def test_bidirectional_vector(self):
@@ -265,7 +335,7 @@ class TestCrossCoreTpushTpopCodegen:
         # C2V consumer side: receive matmul result + post-process
         assert "pto.tpop_from_aic" in vector_code, "Should pop from AIC"
         assert "pto.texp" in vector_code, "Should do exp post-processing (Vector op)"
-        assert "pto.tfree_to_aic" in vector_code, "Should free C2V slot"
+        assert "pto.tfree(" in vector_code, "Should free C2V slot"
 
     @pytest.mark.skip(reason="Only testing CrossCoreTpushTpopProgram")
     def test_bidirectional_cube(self):
@@ -289,7 +359,7 @@ class TestCrossCoreTpushTpopCodegen:
         assert "v2c_consumer_buf = " in cube_code, "Should have v2c_consumer_buf as SSA reference"
         # V2C consumer side: receive preprocessed data
         assert "pto.tpop_from_aiv" in cube_code, "Should pop from AIV"
-        assert "pto.tfree_to_aiv" in cube_code, "Should free V2C slot"
+        assert "pto.tfree(" in cube_code, "Should free V2C slot"
         # C2V producer side: matmul + push back
         assert "pto.tpush_to_aiv" in cube_code, "Should push to AIV"
         assert "pto.tmatmul" in cube_code, "Should do matmul (Cube op)"
@@ -306,8 +376,7 @@ class TestCrossCoreTpushTpopCodegen:
             "pto.tpush_to_aic",
             "pto.tpop_from_aic",
             "pto.tpop_from_aiv",
-            "pto.tfree_to_aic",
-            "pto.tfree_to_aiv",
+            "pto.tfree(",
             "pto.aic_initialize_pipe",
             "pto.aiv_initialize_pipe",
             "pto.reserve_buffer",
@@ -354,7 +423,18 @@ class TestExpandMixedKernelCodegen:
 
         result = {}
         codegen_instance = codegen.PTOCodegen()
-        for func in optimized.functions.values():
+        groups, ungrouped = _build_group_mapping(optimized)
+
+        # Grouped: one module per group
+        for group_name, members in groups.items():
+            grouped_program = ir.Program(members, group_name, optimized.span)
+            mlir_code = codegen_instance.generate(grouped_program)
+            result[group_name] = mlir_code
+            for func in members:
+                result[func.name] = mlir_code
+
+        # Ungrouped: one module per function
+        for func in ungrouped:
             if not ir.is_incore_type(func.func_type):
                 continue
             single = ir.Program([func], func.name, optimized.span)


### PR DESCRIPTION
feat(codegen): reorder tpop chains for hardware pipe ordering and improve cross-core protocol

  Hardware requires sequential pop-use-free chains: tpop(tile1) → use(tile1) →
  tfree(tile1) before tpop(tile2). Add ReorderTpopChains to PTOCodegen that
  classifies top-level statements into per-tpop chains and emits them in the
  correct order, replacing the default IR-order emission that groups all tpops
  together.

  Also includes supporting cross-core improvements:
  - PTO backend: add group function support with _build_group_mapping for multi-function module generation
  - Codegen: track tpop result vars with split values, propagate split to tfree
  - Language layer: add Tile-accepting wrappers for tfree_to_aic/tfree_to_aiv (matching tpush pattern), fix IR-level parameter type from Call to Expr
  - Expand mixed kernel: update cross-core boundary handling
  - Tests: update programs to use AIC/AIV function types with Group/Orchestration, add test_tpop_chain_ordering verifying pop-use-free order