### PR TITLE
feat(backend): add tile.assemble PTO codegen and Ascend 950 support

### DIFF
--- a/examples/language/beginner/assemble.py
+++ b/examples/language/beginner/assemble.py
@@ -32,20 +32,20 @@ Hardware semantics (PTO backend):
       TINSERT ND_VEC: Vec → Vec [at offset]
       Vec → GM
 
-Programs:
-  TileAssembleZeroOffsetProgram         — Acc→Mat: matmul(a[32,16], b[16,16]) → x[32,32] at [0, 0]
-  TileAssembleRightOffsetProgram        — Acc→Mat: matmul(a[32,16], b[16,16]) → x[32,32] at [0, 16]
-  TileAssembleVecZeroOffsetProgram      — Vec→Vec: src[32,16] → x[32,32] at [0, 0]  (left half)
-  TileAssembleVecRightOffsetProgram     — Vec→Vec: src[32,16] → x[32,32] at [0, 16] (right half)
-  TileAddThenAssembleZeroOffsetProgram  — Vec→Vec: add(src, delta) then assemble into x[32,32] at [0, 0]
-  TileAddThenAssembleRightOffsetProgram — Vec→Vec: add(src, delta) then assemble into x[32,32] at [0, 16]
+Programs (one representative per distinct pattern):
+  TileAssembleAccMatProgram          — Acc→Mat: matmul(a[32,16], b[16,16]) → x[32,32] at [0, 16]
+  TileAssembleVecProgram             — Vec→Vec: src[32,16] → x[32,32] at [0, 0]  (single-shot)
+  TileAssembleRowByRowProgram        — Vec→Vec: loop i, pl.slice row i, assemble at [i, 0]
+  TileAssembleDoubleLoopProgram      — Vec→Vec: nested loops b×i, pl.slice row b*8+i, assemble at [b*8+i, 0]
+  TileAssembleLoopColBroadcastProgram — Vec→Vec: loop c, same src[32,8] at [0, c*8]  (no pl.slice)
+  TileAssembleDoubleLoopBroadcastProgram — Vec→Vec: nested b×c, same src[16,16] at [b*16, c*16]  (no pl.slice)
 """
 
 import pypto.language as pl
 
 
 @pl.program
-class TileAssembleZeroOffsetProgram:
+class TileAssembleAccMatProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def tile_assemble(
         self,
@@ -62,44 +62,7 @@ class TileAssembleZeroOffsetProgram:
         tile_a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
         tile_b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
         tile_src = pl.matmul(tile_a, tile_b)  # FP32 Acc (L0C) — same dtype as tile_x
-        # Assemble: insert tile_src into tile_x at offset [0, 0]; result stays in Mat (L1)
-        result = pl.tile.assemble(tile_x, tile_src, [0, 0])
-        # Move Mat → Vec before store
-        result_vec = pl.move(result, target_memory=pl.MemorySpace.Vec)
-        out_y = pl.store(result_vec, offsets=[0, 0], output_tensor=y)
-        return out_y
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
-        self,
-        x: pl.Tensor[[32, 32], pl.FP32],
-        a: pl.Tensor[[32, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
-    ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, a, b, y)
-        return y
-
-
-@pl.program
-class TileAssembleRightOffsetProgram:
-    @pl.function(type=pl.FunctionType.InCore)
-    def tile_assemble(
-        self,
-        x: pl.Tensor[[32, 32], pl.FP32],
-        a: pl.Tensor[[32, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
-    ) -> pl.Tensor[[32, 32], pl.FP32]:
-        # Load target into Mat (L1)
-        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Mat)
-        # Produce Acc (L0C, FP32) via matmul: GM → Mat → Left/Right → matmul
-        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Mat)
-        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[16, 16], target_memory=pl.MemorySpace.Mat)
-        tile_a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
-        tile_b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
-        tile_src = pl.matmul(tile_a, tile_b)  # FP32 Acc (L0C) — same dtype as tile_x
-        # Assemble: insert tile_src into tile_x at offset [0, 16]; result stays in Mat (L1)
+        # Assemble: insert tile_src into the right half of tile_x at offset [0, 16]
         result = pl.tile.assemble(tile_x, tile_src, [0, 16])
         # Move Mat → Vec before store
         result_vec = pl.move(result, target_memory=pl.MemorySpace.Vec)
@@ -119,7 +82,7 @@ class TileAssembleRightOffsetProgram:
 
 
 @pl.program
-class TileAssembleVecZeroOffsetProgram:
+class TileAssembleVecProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def tile_assemble(
         self,
@@ -127,10 +90,10 @@ class TileAssembleVecZeroOffsetProgram:
         src: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        # Load target and source directly into Vec (UB) — ND/RowMajor layout
+        # Load target and source into Vec (UB) — ND/RowMajor layout
         tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
         tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        # Assemble: insert tile_src into tile_x at [0, 0] — both Vec → ND_VEC mode
+        # Assemble: insert src into the left half of x at [0, 0] — ND_VEC mode
         result = pl.tile.assemble(tile_x, tile_src, [0, 0])
         out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
         return out_y
@@ -147,7 +110,7 @@ class TileAssembleVecZeroOffsetProgram:
 
 
 @pl.program
-class TileAssembleVecRightOffsetProgram:
+class TileAssembleRowByRowProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def tile_assemble(
         self,
@@ -155,12 +118,15 @@ class TileAssembleVecRightOffsetProgram:
         src: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        # Load target and source directly into Vec (UB) — ND/RowMajor layout
+        # Load target (32×32) and source (32×16) into Vec (UB)
         tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
         tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        # Assemble: insert tile_src into tile_x at [0, 16] — both Vec → ND_VEC mode
-        result = pl.tile.assemble(tile_x, tile_src, [0, 16])
-        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        # For each row i: slice src[i, :] with a dynamic row offset, assemble at [i, 0].
+        # Models the k_group gathering pattern in real workloads (e.g. Qwen KV-head loop).
+        for i in pl.range(32):
+            row = pl.slice(tile_src, [1, 16], [i, 0])
+            tile_x = pl.tile.assemble(tile_x, row, [i, 0])
+        out_y = pl.store(tile_x, offsets=[0, 0], output_tensor=y)
         return out_y
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -175,24 +141,25 @@ class TileAssembleVecRightOffsetProgram:
 
 
 @pl.program
-class TileAddThenAssembleZeroOffsetProgram:
+class TileAssembleDoubleLoopProgram:
     @pl.function(type=pl.FunctionType.InCore)
-    def tile_add_assemble(
+    def tile_assemble(
         self,
         x: pl.Tensor[[32, 32], pl.FP32],
         src: pl.Tensor[[32, 16], pl.FP32],
-        delta: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        # Load target, source, and delta into Vec (UB)
+        # Load target (32×32) and source (32×16) into Vec (UB)
         tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
         tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        tile_delta = pl.load(delta, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        # Add delta to src before assembling
-        tile_src_added = pl.add(tile_src, tile_delta)
-        # Assemble: insert tile_src_added into tile_x at [0, 0] — both Vec → ND_VEC mode
-        result = pl.tile.assemble(tile_x, tile_src_added, [0, 0])
-        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        # Outer loop: 4 row-blocks; inner loop: 8 rows per block.
+        # Row index row = b * 8 + i mirrors the batch×head two-level indexing in real workloads.
+        for b in pl.range(4):
+            for i in pl.range(8):
+                row = b * 8 + i
+                tile_row = pl.slice(tile_src, [1, 16], [row, 0])
+                tile_x = pl.tile.assemble(tile_x, tile_row, [row, 0])
+        out_y = pl.store(tile_x, offsets=[0, 0], output_tensor=y)
         return out_y
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -200,41 +167,69 @@ class TileAddThenAssembleZeroOffsetProgram:
         self,
         x: pl.Tensor[[32, 32], pl.FP32],
         src: pl.Tensor[[32, 16], pl.FP32],
-        delta: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_add_assemble(x, src, delta, y)
+        y = self.tile_assemble(x, src, y)
         return y
 
 
 @pl.program
-class TileAddThenAssembleRightOffsetProgram:
+class TileAssembleLoopColBroadcastProgram:
     @pl.function(type=pl.FunctionType.InCore)
-    def tile_add_assemble(
+    def tile_assemble(
         self,
         x: pl.Tensor[[32, 32], pl.FP32],
-        src: pl.Tensor[[32, 16], pl.FP32],
-        delta: pl.Tensor[[32, 16], pl.FP32],
+        src: pl.Tensor[[32, 8], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        # Load target, source, and delta into Vec (UB)
+        # Load target and source into Vec (UB) with static offsets — no pl.slice needed.
         tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
-        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        tile_delta = pl.load(delta, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
-        # Add delta to src before assembling
-        tile_src_added = pl.add(tile_src, tile_delta)
-        # Assemble: insert tile_src_added into tile_x at [0, 16] — both Vec → ND_VEC mode
-        result = pl.tile.assemble(tile_x, tile_src_added, [0, 16])
-        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 8], target_memory=pl.MemorySpace.Vec)
+        # Loop over 4 column-blocks (width 8 each); assemble the same tile_src at each position.
+        # Dynamic offset [0, c * 8] — no pl.slice required.
+        for c in pl.range(4):
+            tile_x = pl.tile.assemble(tile_x, tile_src, [0, c * 8])
+        out_y = pl.store(tile_x, offsets=[0, 0], output_tensor=y)
         return out_y
 
     @pl.function(type=pl.FunctionType.Orchestration)
     def orchestrator(
         self,
         x: pl.Tensor[[32, 32], pl.FP32],
-        src: pl.Tensor[[32, 16], pl.FP32],
-        delta: pl.Tensor[[32, 16], pl.FP32],
+        src: pl.Tensor[[32, 8], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_add_assemble(x, src, delta, y)
+        y = self.tile_assemble(x, src, y)
+        return y
+
+
+@pl.program
+class TileAssembleDoubleLoopBroadcastProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target and source into Vec (UB) with static offsets — no pl.slice needed.
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[16, 16], target_memory=pl.MemorySpace.Vec)
+        # Outer loop: 2 row-blocks; inner loop: 2 column-blocks.
+        # Assembles tile_src into all four [16,16] quadrants of tile_x.
+        # Both offsets [b*16, c*16] computed from loop vars — no pl.slice required.
+        for b in pl.range(2):
+            for c in pl.range(2):
+                tile_x = pl.tile.assemble(tile_x, tile_src, [b * 16, c * 16])
+        out_y = pl.store(tile_x, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_assemble(x, src, y)
         return y

--- a/examples/language/beginner/assemble.py
+++ b/examples/language/beginner/assemble.py
@@ -1,0 +1,240 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Tile assemble: write a source tile into a target tile at a specified offset.
+
+Hardware semantics (PTO backend):
+  tile.assemble maps to the TINSERT instruction. The hardware mode is inferred
+  automatically from the memory spaces of the operands:
+
+  Acc→Mat (TInsertMode::NZ) — source from Acc (L0C), target in Mat (L1):
+    - target tile: in Mat (L1), fractal layout
+    - source tile: in Acc (L0C), fractal layout (always FP32, output of tile.matmul)
+    Data flow:
+      a, b (GM) → Mat → Left/Right → tile.matmul → Acc (FP32)
+      x   (GM) → Mat (FP32) [target]
+      TINSERT NZ: Acc → Mat [at offset]
+      Mat → Vec → GM
+
+  Vec→Vec (TInsertMode::ND_VEC) — both tiles in Vec (UB), RowMajor/ND layout:
+    - target tile: in Vec (UB), ND layout
+    - source tile: in Vec (UB), ND layout
+    Data flow:
+      x   (GM) → Vec (UB) [target]
+      src (GM) → Vec (UB) [source]
+      TINSERT ND_VEC: Vec → Vec [at offset]
+      Vec → GM
+
+Programs:
+  TileAssembleZeroOffsetProgram         — Acc→Mat: matmul(a[32,16], b[16,16]) → x[32,32] at [0, 0]
+  TileAssembleRightOffsetProgram        — Acc→Mat: matmul(a[32,16], b[16,16]) → x[32,32] at [0, 16]
+  TileAssembleVecZeroOffsetProgram      — Vec→Vec: src[32,16] → x[32,32] at [0, 0]  (left half)
+  TileAssembleVecRightOffsetProgram     — Vec→Vec: src[32,16] → x[32,32] at [0, 16] (right half)
+  TileAddThenAssembleZeroOffsetProgram  — Vec→Vec: add(src, delta) then assemble into x[32,32] at [0, 0]
+  TileAddThenAssembleRightOffsetProgram — Vec→Vec: add(src, delta) then assemble into x[32,32] at [0, 16]
+"""
+
+import pypto.language as pl
+
+
+@pl.program
+class TileAssembleZeroOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        a: pl.Tensor[[32, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target into Mat (L1)
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Mat)
+        # Produce Acc (L0C, FP32) via matmul: GM → Mat → Left/Right → matmul
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[16, 16], target_memory=pl.MemorySpace.Mat)
+        tile_a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_src = pl.matmul(tile_a, tile_b)  # FP32 Acc (L0C) — same dtype as tile_x
+        # Assemble: insert tile_src into tile_x at offset [0, 0]; result stays in Mat (L1)
+        result = pl.tile.assemble(tile_x, tile_src, [0, 0])
+        # Move Mat → Vec before store
+        result_vec = pl.move(result, target_memory=pl.MemorySpace.Vec)
+        out_y = pl.store(result_vec, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        a: pl.Tensor[[32, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_assemble(x, a, b, y)
+        return y
+
+
+@pl.program
+class TileAssembleRightOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        a: pl.Tensor[[32, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target into Mat (L1)
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Mat)
+        # Produce Acc (L0C, FP32) via matmul: GM → Mat → Left/Right → matmul
+        tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[16, 16], target_memory=pl.MemorySpace.Mat)
+        tile_a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_src = pl.matmul(tile_a, tile_b)  # FP32 Acc (L0C) — same dtype as tile_x
+        # Assemble: insert tile_src into tile_x at offset [0, 16]; result stays in Mat (L1)
+        result = pl.tile.assemble(tile_x, tile_src, [0, 16])
+        # Move Mat → Vec before store
+        result_vec = pl.move(result, target_memory=pl.MemorySpace.Vec)
+        out_y = pl.store(result_vec, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        a: pl.Tensor[[32, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_assemble(x, a, b, y)
+        return y
+
+
+@pl.program
+class TileAssembleVecZeroOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target and source directly into Vec (UB) — ND/RowMajor layout
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        # Assemble: insert tile_src into tile_x at [0, 0] — both Vec → ND_VEC mode
+        result = pl.tile.assemble(tile_x, tile_src, [0, 0])
+        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_assemble(x, src, y)
+        return y
+
+
+@pl.program
+class TileAssembleVecRightOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target and source directly into Vec (UB) — ND/RowMajor layout
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        # Assemble: insert tile_src into tile_x at [0, 16] — both Vec → ND_VEC mode
+        result = pl.tile.assemble(tile_x, tile_src, [0, 16])
+        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_assemble(x, src, y)
+        return y
+
+
+@pl.program
+class TileAddThenAssembleZeroOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        delta: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target, source, and delta into Vec (UB)
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        tile_delta = pl.load(delta, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        # Add delta to src before assembling
+        tile_src_added = pl.add(tile_src, tile_delta)
+        # Assemble: insert tile_src_added into tile_x at [0, 0] — both Vec → ND_VEC mode
+        result = pl.tile.assemble(tile_x, tile_src_added, [0, 0])
+        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        delta: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_add_assemble(x, src, delta, y)
+        return y
+
+
+@pl.program
+class TileAddThenAssembleRightOffsetProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add_assemble(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        delta: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        # Load target, source, and delta into Vec (UB)
+        tile_x = pl.load(x, offsets=[0, 0], shapes=[32, 32], target_memory=pl.MemorySpace.Vec)
+        tile_src = pl.load(src, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        tile_delta = pl.load(delta, offsets=[0, 0], shapes=[32, 16], target_memory=pl.MemorySpace.Vec)
+        # Add delta to src before assembling
+        tile_src_added = pl.add(tile_src, tile_delta)
+        # Assemble: insert tile_src_added into tile_x at [0, 16] — both Vec → ND_VEC mode
+        result = pl.tile.assemble(tile_x, tile_src_added, [0, 16])
+        out_y = pl.store(result, offsets=[0, 0], output_tensor=y)
+        return out_y
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[32, 32], pl.FP32],
+        src: pl.Tensor[[32, 16], pl.FP32],
+        delta: pl.Tensor[[32, 16], pl.FP32],
+        y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        y = self.tile_add_assemble(x, src, delta, y)
+        return y

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -93,6 +93,12 @@ class RunConfig:
             raise ValueError(
                 f"Invalid platform {self.platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'."
             )
+        # Auto-correct platform to match backend_type so compilation and execution
+        # always target the same architecture.
+        expected_arch = "a5" if self.backend_type == BackendType.Ascend950 else "a2a3"
+        if not self.platform.startswith(expected_arch):
+            sim_suffix = "sim" if self.platform.endswith("sim") else ""
+            self.platform = f"{expected_arch}{sim_suffix}"
 
 
 @dataclass

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -58,8 +58,8 @@ class RunConfig:
     """Configuration for a :func:`run` invocation or harness test execution.
 
     Attributes:
-        platform: Target execution platform — ``"a2a3sim"`` (simulator) or
-            ``"a2a3"`` (real Ascend hardware).
+        platform: Target execution platform — ``"a2a3sim"`` / ``"a2a3"``
+            (Ascend 910B) or ``"a5sim"`` / ``"a5"`` (Ascend 950).
         device_id: Hardware device index (ignored for simulator).
         rtol: Relative tolerance for result comparison.
         atol: Absolute tolerance for result comparison.
@@ -89,8 +89,10 @@ class RunConfig:
     codegen_only: bool = False
 
     def __post_init__(self) -> None:
-        if self.platform not in ("a2a3sim", "a2a3"):
-            raise ValueError(f"Invalid platform {self.platform!r}. Expected 'a2a3sim' or 'a2a3'.")
+        if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
+            raise ValueError(
+                f"Invalid platform {self.platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'."
+            )
 
 
 @dataclass
@@ -249,7 +251,8 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
         work_dir: Root output directory produced by :func:`compile_program`,
             containing ``kernels/`` and ``orchestration/``.
         golden_path: Path to the generated ``golden.py`` file.
-        platform: Target execution platform (``"a2a3sim"`` or ``"a2a3"``).
+        platform: Target execution platform (``"a2a3sim"``, ``"a2a3"``,
+            ``"a5sim"``, or ``"a5"``).
         device_id: Hardware device index.
     """
     simpler_root = os.environ.get("SIMPLER_ROOT")

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -202,6 +202,56 @@ static std::string MakeCmpsCodegenPTO(const std::string& pto_op_name, const Call
   return "";
 }
 
+// Helper function for tile.assemble → pto.tinsert
+// Inserts source tile into target tile at a given row/col offset (DPS pattern).
+// pto.tinsert semantics: dst[i+row, j+col] = src[i, j]
+// Arguments: args[0] = target (destination base), args[1] = source, args[2] = offset MakeTuple
+static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 3) << "tile.assemble requires 3 arguments (target, source, offset), got "
+                               << op->args_.size();
+
+  std::string target = codegen.GetExprAsCode(op->args_[0]);
+  std::string src = codegen.GetExprAsCode(op->args_[1]);
+  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+
+  auto offset_tuple = ir::As<ir::MakeTuple>(op->args_[2]);
+  INTERNAL_CHECK(offset_tuple) << "tile.assemble third argument must be a tuple (offset)";
+  INTERNAL_CHECK(offset_tuple->elements_.size() >= 2)
+      << "tile.assemble offset tuple must have at least 2 elements (row, col), got "
+      << offset_tuple->elements_.size();
+  std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
+  std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
+
+  // pto.tinsert writes src into dst at (row, col) in place — dst must already
+  // contain target's data.  When target and dst are different buffers (i.e.
+  // memory reuse did not merge them), copy target → dst first.
+  if (target != dst) {
+    std::string target_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+    std::ostringstream mov;
+    mov << "pto.tmov ins(" << target;
+    if (!target_type.empty()) mov << " : " << target_type;
+    mov << ") outs(" << dst;
+    if (!dst_type.empty()) mov << " : " << dst_type;
+    mov << ")";
+    codegen.Emit(mov.str());
+  }
+
+  // Emit pto.tinsert ins(src, row, col) outs(dst)
+  std::ostringstream oss;
+  oss << "pto.tinsert ins(" << src << ", " << row_off << ", " << col_off;
+  if (!src_type.empty()) {
+    oss << " : " << src_type << ", index, index";
+  }
+  oss << ") outs(" << dst;
+  if (!dst_type.empty()) oss << " : " << dst_type;
+  oss << ")";
+  codegen.Emit(oss.str());
+  return "";
+}
+
 // Helper function for Assign
 static std::string MakeAssignCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                         codegen::CodegenBase& codegen_base) {
@@ -1196,6 +1246,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     oss << ")";
     codegen.Emit(oss.str());
     return std::string("");
+  });
+  reg("tile.assemble", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeTileAssembleCodegenPTO(op, codegen);
   });
   reg("tile.reshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/orchestration_op_registry.h"
 #include "pypto/core/dtype.h"
@@ -568,8 +570,21 @@ std::string GenerateConfigFunction(int expected_arg_count) {
   return oss.str();
 }
 
-std::string CoreTypeToSubmitFunc(CoreType core_type) {
-  return core_type == CoreType::CUBE ? "pto2_rt_submit_aic_task" : "pto2_rt_submit_aiv_task";
+// Returns the submit-task call prefix for the given core type and backend.
+// A2/A3: pto2_rt_submit_aiv_task(rt, id, params, n)
+//         pto2_rt_submit_aic_task(rt, id, params, n)
+// A5:    pto2_rt_submit_task(rt, id, PTO2_WORKER_VECTOR, params, n)
+//         pto2_rt_submit_task(rt, id, PTO2_WORKER_CUBE,   params, n)
+// Returns {func_call_with_rt_and_id_prefix, extra_worker_arg_or_empty}.
+// Caller emits: prefix << func_id << extra << ", " << task_var << ", " << n << ");\n"
+std::pair<std::string, std::string> CoreTypeToSubmitParts(CoreType core_type) {
+  bool is_a5 = pypto::backend::GetBackendType() == pypto::backend::BackendType::Ascend950;
+  if (is_a5) {
+    std::string worker = core_type == CoreType::CUBE ? "PTO2_WORKER_CUBE" : "PTO2_WORKER_VECTOR";
+    return {"pto2_rt_submit_task(rt, ", ", " + worker};
+  }
+  std::string func = core_type == CoreType::CUBE ? "pto2_rt_submit_aic_task" : "pto2_rt_submit_aiv_task";
+  return {func + "(rt, ", ""};
 }
 
 // Removed DataTypeToPTO2Enum — now uses DataTypeToString from dtype.h
@@ -1102,8 +1117,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << "    " << p.kind << "(" << p.value << "),\n";
     }
     code_ << ind << "};\n";
-    code_ << ind << CoreTypeToSubmitFunc(core_type) << "(rt, " << func_id << ", " << task_var << ", "
-          << params.size() << ");\n";
+    auto [submit_prefix, worker_arg] = CoreTypeToSubmitParts(core_type);
+    code_ << ind << submit_prefix << func_id << worker_arg << ", " << task_var << ", " << params.size()
+          << ");\n";
 
     task_counter_++;
   }

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -358,7 +358,15 @@ TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
       << "tile.assemble requires target and source to have the same dtype, but got "
       << target_type->dtype_.ToString() << " and " << source_type->dtype_.ToString();
 
-  return std::make_shared<TileType>(target_type->shape_, target_type->dtype_);
+  // Inherit layout metadata (blayout, slayout, fractal, pad) from the target so that
+  // the result type carries the correct tile_buf type annotation for codegen.
+  TileView tile_view;
+  if (target_type->tile_view_.has_value()) {
+    tile_view = *target_type->tile_view_;
+  }
+  tile_view.valid_shape = target_type->shape_;
+  return std::make_shared<TileType>(target_type->shape_, target_type->dtype_, std::nullopt, tile_view,
+                                    target_type->memory_space_);
 }
 
 REGISTER_OP("tile.assemble")

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -352,6 +352,9 @@ TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
   CHECK(offset_tuple_type) << "tile.assemble requires offset to be TupleType, but got "
                            << args[2]->GetType()->TypeName();
 
+  CHECK(As<MakeTuple>(args[2])) << "tile.assemble offset must be a literal tuple (e.g., (row, col)), "
+                                << "not a variable or computed expression";
+
   ValidateIndexTupleElements(offset_tuple_type, "tile.assemble", "offset");
 
   CHECK(target_type->dtype_ == source_type->dtype_)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -200,6 +200,9 @@ def tensor_shape(request):
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "hardware: mark test as requiring hardware (--platform=a2a3)")
+    config.addinivalue_line(
+        "markers", "a5: mark test as requiring Ascend 950 (--platform=a5 or a5sim)"
+    )
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "fuzz: mark test as fuzz test")
 
@@ -209,7 +212,10 @@ def pytest_collection_modifyitems(config, items):
     platform = config.getoption("--platform")
 
     skip_hardware = pytest.mark.skip(reason="hardware tests require --platform=a2a3")
+    skip_a5 = pytest.mark.skip(reason="Ascend 950 tests require --platform=a5 or a5sim")
 
     for item in items:
         if "hardware" in item.keywords and platform != "a2a3":
             item.add_marker(skip_hardware)
+        if "a5" in item.keywords and not platform.startswith("a5"):
+            item.add_marker(skip_a5)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -200,9 +200,7 @@ def tensor_shape(request):
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "hardware: mark test as requiring hardware (--platform=a2a3)")
-    config.addinivalue_line(
-        "markers", "a5: mark test as requiring Ascend 950 (--platform=a5 or a5sim)"
-    )
+    config.addinivalue_line("markers", "a5: mark test as requiring Ascend 950 (--platform=a5 or a5sim)")
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "fuzz: mark test as fuzz test")
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -68,7 +68,7 @@ def pytest_addoption(parser):
         "--platform",
         action="store",
         default="a2a3",
-        choices=["a2a3sim", "a2a3"],
+        choices=["a2a3sim", "a2a3", "a5sim", "a5"],
         help="Target platform for tests (default: a2a3sim)",
     )
     parser.addoption(

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from pypto.backend import set_backend_type
+from pypto.backend import BackendType, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
 from pypto.runtime.runner import RunConfig, RunResult, _execute_on_device
@@ -37,6 +37,27 @@ from harness.core.harness import PTOTestCase
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
 _PROJECT_ROOT = _ST_DIR.parent.parent
+
+# Map BackendType to the architecture prefix used by the platform string.
+# "a2a3" covers Ascend 910B (PTO and CCE backends); "a5" covers Ascend 950.
+_BACKEND_TO_ARCH: dict[BackendType, str] = {
+    BackendType.Ascend910B_PTO: "a2a3",
+    BackendType.Ascend910B_CCE: "a2a3",
+    BackendType.Ascend950: "a5",
+}
+
+
+def _resolve_platform(config_platform: str, backend_type: BackendType) -> str:
+    """Return the platform string required to compile for *backend_type*.
+
+    Preserves the sim/hardware distinction from *config_platform* (i.e. the
+    ``sim`` suffix) while replacing the architecture prefix to match the
+    backend.  For example, if the global config says ``"a2a3sim"`` but the
+    test case requests ``Ascend950``, this returns ``"a5sim"``.
+    """
+    is_sim = config_platform.endswith("sim")
+    arch = _BACKEND_TO_ARCH.get(backend_type, config_platform.rstrip("sim").rstrip("_"))
+    return f"{arch}sim" if is_sim else arch
 
 
 def _default_work_dir(test_name: str) -> Path:
@@ -185,7 +206,8 @@ class TestRunner:
                     execution_time=time.time() - start_time,
                 )
 
-            _execute_on_device(work_dir, golden_path, self.config.platform, self.config.device_id)
+            platform = _resolve_platform(self.config.platform, backend_type)
+            _execute_on_device(work_dir, golden_path, platform, self.config.device_id)
 
             return RunResult(
                 passed=True,

--- a/tests/st/runtime/conftest.py
+++ b/tests/st/runtime/conftest.py
@@ -27,8 +27,8 @@ def check_hardware_availability(request):
     """
     platform = request.config.getoption("--platform")
 
-    # If platform is a2a3 (real hardware) but no hardware is available
-    if platform == "a2a3" and not is_hardware_available():
+    # If platform is real hardware but no hardware is available
+    if platform in ("a2a3", "a5") and not is_hardware_available():
         pytest.skip(
             "Hardware not available: Ascend NPU device nodes not found "
             "(checked /dev/davinci*, /dev/npu*, /dev/ascend*). "

--- a/tests/st/runtime/test_assemble.py
+++ b/tests/st/runtime/test_assemble.py
@@ -101,7 +101,7 @@ class TileAssembleRightOffsetTestCase(PTOTestCase):
         tensors["y"][:, 16:] = src
 
 
-@pytest.mark.skip(reason="Pending adaptation for A5")
+@pytest.mark.a5
 class TestAssembleOperations:
     """Test suite for tile.assemble operations."""
 
@@ -174,7 +174,7 @@ class TileAssembleVecRightOffsetTestCase(PTOTestCase):
         tensors["y"][:, 16:] = tensors["src"]
 
 
-@pytest.mark.skip(reason="Pending adaptation for A5")
+@pytest.mark.a5
 class TestVecAssembleOperations:
     """Test suite for UB-to-UB (Vec→Vec) tile.assemble operations (TInsertMode::ND_VEC)."""
 

--- a/tests/st/runtime/test_assemble.py
+++ b/tests/st/runtime/test_assemble.py
@@ -1,0 +1,276 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for tile.assemble (write a source tile into a target tile at a specified offset).
+
+Hardware semantics (PTO backend):
+  tile.assemble maps to TINSERT. The mode is inferred from operand memory spaces:
+
+  Acc→Mat (TInsertMode::NZ):
+    source: Acc (L0C), FP32, fractal layout  [output of tile.matmul]
+    target: Mat (L1), FP32, fractal layout
+    Data flow: a, b (GM) → Mat → Left/Right → matmul → Acc → TINSERT → Mat → Vec → GM
+
+  Vec→Vec (TInsertMode::ND_VEC):
+    source: Vec (UB), FP32, ND/RowMajor layout
+    target: Vec (UB), FP32, ND/RowMajor layout
+    Data flow: x, src (GM) → Vec → TINSERT → Vec → GM
+"""
+
+from typing import Any
+
+import pytest
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+from examples.language.beginner.assemble import (
+    TileAddThenAssembleRightOffsetProgram,
+    TileAddThenAssembleZeroOffsetProgram,
+    TileAssembleRightOffsetProgram,
+    TileAssembleVecRightOffsetProgram,
+    TileAssembleVecZeroOffsetProgram,
+    TileAssembleZeroOffsetProgram,
+)
+
+
+class TileAssembleZeroOffsetTestCase(PTOTestCase):
+    """Test case for tile.assemble at [0, 0]: matmul(a,b)[32x16] overwrites the left half of x[32x32]."""
+
+    def get_name(self) -> str:
+        return "tile_assemble_zero_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("a", [32, 16], DataType.FP32, init_value=1.0),
+            TensorSpec("b", [16, 16], DataType.FP32, init_value=1.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleZeroOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # assemble at [0, 0]: matmul(a, b) overwrites columns 0..15; columns 16..31 remain x (1.0)
+        src = tensors["a"] @ tensors["b"]
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, :16] = src
+
+
+class TileAssembleRightOffsetTestCase(PTOTestCase):
+    """Test case for tile.assemble at [0, 16]: matmul(a,b)[32x16] overwrites the right half of x[32x32]."""
+
+    def get_name(self) -> str:
+        return "tile_assemble_right_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("a", [32, 16], DataType.FP32, init_value=1.0),
+            TensorSpec("b", [16, 16], DataType.FP32, init_value=1.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleRightOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # assemble at [0, 16]: columns 0..15 remain x (1.0); matmul(a, b) overwrites columns 16..31
+        src = tensors["a"] @ tensors["b"]
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, 16:] = src
+
+
+@pytest.mark.skip(reason="Pending adaptation for A5")
+class TestAssembleOperations:
+    """Test suite for tile.assemble operations."""
+
+    def test_tile_assemble_zero_offset(self, test_runner):
+        """Test tile.assemble: write matmul result into left half of target at offset [0, 0]."""
+        test_case = TileAssembleZeroOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_assemble_right_offset(self, test_runner):
+        """Test tile.assemble: write matmul result into right half of target at offset [0, 16]."""
+        test_case = TileAssembleRightOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TileAssembleVecZeroOffsetTestCase(PTOTestCase):
+    """Test case for Vec-to-Vec tile.assemble at [0, 0]: src[32x16] overwrites the left half of x[32x32]."""
+
+    def get_name(self) -> str:
+        return "tile_assemble_vec_zero_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleVecZeroOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # assemble at [0, 0]: src overwrites columns 0..15; columns 16..31 remain x (1.0)
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, :16] = tensors["src"]
+
+
+class TileAssembleVecRightOffsetTestCase(PTOTestCase):
+    """Test case for Vec-to-Vec tile.assemble at [0, 16]: src[32x16] overwrites the right half of x[32x32]."""
+
+    def get_name(self) -> str:
+        return "tile_assemble_vec_right_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleVecRightOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # assemble at [0, 16]: columns 0..15 remain x (1.0); src overwrites columns 16..31
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, 16:] = tensors["src"]
+
+
+@pytest.mark.skip(reason="Pending adaptation for A5")
+class TestVecAssembleOperations:
+    """Test suite for UB-to-UB (Vec→Vec) tile.assemble operations (TInsertMode::ND_VEC)."""
+
+    def test_tile_assemble_vec_zero_offset(self, test_runner):
+        """Test Vec tile.assemble: write src into left half of target at offset [0, 0]."""
+        test_case = TileAssembleVecZeroOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_assemble_vec_right_offset(self, test_runner):
+        """Test Vec tile.assemble: write src into right half of target at offset [0, 16]."""
+        test_case = TileAssembleVecRightOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TileAddThenAssembleZeroOffsetTestCase(PTOTestCase):
+    """Test case for add-then-assemble at [0, 0].
+
+    add(src, delta)[32x16] overwrites the left half of x[32x32].
+    """
+
+    def get_name(self) -> str:
+        return "tile_add_then_assemble_zero_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("delta", [32, 16], DataType.FP32, init_value=3.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAddThenAssembleZeroOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # add then assemble at [0, 0]: (src + delta) overwrites columns 0..15; columns 16..31 remain x (1.0)
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, :16] = tensors["src"] + tensors["delta"]
+
+
+class TileAddThenAssembleRightOffsetTestCase(PTOTestCase):
+    """Test case for add-then-assemble at [0, 16].
+
+    add(src, delta)[32x16] overwrites the right half of x[32x32].
+    """
+
+    def get_name(self) -> str:
+        return "tile_add_then_assemble_right_offset"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("delta", [32, 16], DataType.FP32, init_value=3.0),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAddThenAssembleRightOffsetProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        # add then assemble at [0, 16]: columns 0..15 remain x (1.0); (src + delta) overwrites columns 16..31
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, 16:] = tensors["src"] + tensors["delta"]
+
+
+@pytest.mark.skip(reason="Pending adaptation for A5")
+class TestAddThenAssembleOperations:
+    """Test suite for add-then-assemble: pl.add on source tile before Vec→Vec tile.assemble."""
+
+    def test_tile_add_then_assemble_zero_offset(self, test_runner):
+        """Test add-then-assemble: write add(src, delta) into left half of target at offset [0, 0]."""
+        test_case = TileAddThenAssembleZeroOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_add_then_assemble_right_offset(self, test_runner):
+        """Test add-then-assemble: write add(src, delta) into right half of target at offset [0, 16]."""
+        test_case = TileAddThenAssembleRightOffsetTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/test_assemble.py
+++ b/tests/st/runtime/test_assemble.py
@@ -27,36 +27,41 @@ Hardware semantics (PTO backend):
 from typing import Any
 
 import pytest
+import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.language.beginner.assemble import (
-    TileAddThenAssembleRightOffsetProgram,
-    TileAddThenAssembleZeroOffsetProgram,
-    TileAssembleRightOffsetProgram,
-    TileAssembleVecRightOffsetProgram,
-    TileAssembleVecZeroOffsetProgram,
-    TileAssembleZeroOffsetProgram,
+    TileAssembleAccMatProgram,
+    TileAssembleDoubleLoopBroadcastProgram,
+    TileAssembleDoubleLoopProgram,
+    TileAssembleLoopColBroadcastProgram,
+    TileAssembleRowByRowProgram,
+    TileAssembleVecProgram,
 )
 
+# ---------------------------------------------------------------------------
+# Acc→Mat (NZ mode): matmul result assembled into a Mat target
+# ---------------------------------------------------------------------------
 
-class TileAssembleZeroOffsetTestCase(PTOTestCase):
-    """Test case for tile.assemble at [0, 0]: matmul(a,b)[32x16] overwrites the left half of x[32x32]."""
+
+class TileAssembleAccMatTestCase(PTOTestCase):
+    """Acc→Mat: matmul(a[32,16], b[16,16]) assembled into the right half of x[32,32] at [0, 16]."""
 
     def get_name(self) -> str:
-        return "tile_assemble_zero_offset"
+        return "tile_assemble_acc_mat"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("a", [32, 16], DataType.FP32, init_value=1.0),
-            TensorSpec("b", [16, 16], DataType.FP32, init_value=1.0),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("a", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("b", [16, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return TileAssembleZeroOffsetProgram
+        return TileAssembleAccMatProgram
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -65,74 +70,32 @@ class TileAssembleZeroOffsetTestCase(PTOTestCase):
         return BackendType.Ascend950
 
     def compute_expected(self, tensors, params=None):
-        # assemble at [0, 0]: matmul(a, b) overwrites columns 0..15; columns 16..31 remain x (1.0)
-        src = tensors["a"] @ tensors["b"]
-        tensors["y"][:] = tensors["x"]
-        tensors["y"][:, :16] = src
-
-
-class TileAssembleRightOffsetTestCase(PTOTestCase):
-    """Test case for tile.assemble at [0, 16]: matmul(a,b)[32x16] overwrites the right half of x[32x32]."""
-
-    def get_name(self) -> str:
-        return "tile_assemble_right_offset"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("a", [32, 16], DataType.FP32, init_value=1.0),
-            TensorSpec("b", [16, 16], DataType.FP32, init_value=1.0),
-            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return TileAssembleRightOffsetProgram
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-    def compute_expected(self, tensors, params=None):
-        # assemble at [0, 16]: columns 0..15 remain x (1.0); matmul(a, b) overwrites columns 16..31
+        # matmul(a, b) overwrites the right half; left half (columns 0..15) remains x (1.0)
         src = tensors["a"] @ tensors["b"]
         tensors["y"][:] = tensors["x"]
         tensors["y"][:, 16:] = src
 
 
-@pytest.mark.a5
-class TestAssembleOperations:
-    """Test suite for tile.assemble operations."""
-
-    def test_tile_assemble_zero_offset(self, test_runner):
-        """Test tile.assemble: write matmul result into left half of target at offset [0, 0]."""
-        test_case = TileAssembleZeroOffsetTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
-
-    def test_tile_assemble_right_offset(self, test_runner):
-        """Test tile.assemble: write matmul result into right half of target at offset [0, 16]."""
-        test_case = TileAssembleRightOffsetTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
+# ---------------------------------------------------------------------------
+# Vec→Vec single-shot (ND_VEC mode)
+# ---------------------------------------------------------------------------
 
 
-class TileAssembleVecZeroOffsetTestCase(PTOTestCase):
-    """Test case for Vec-to-Vec tile.assemble at [0, 0]: src[32x16] overwrites the left half of x[32x32]."""
+class TileAssembleVecTestCase(PTOTestCase):
+    """Vec→Vec single-shot: src[32,16] assembled into the left half of x[32,32] at [0, 0]."""
 
     def get_name(self) -> str:
-        return "tile_assemble_vec_zero_offset"
+        return "tile_assemble_vec"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return TileAssembleVecZeroOffsetProgram
+        return TileAssembleVecProgram
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -141,26 +104,34 @@ class TileAssembleVecZeroOffsetTestCase(PTOTestCase):
         return BackendType.Ascend950
 
     def compute_expected(self, tensors, params=None):
-        # assemble at [0, 0]: src overwrites columns 0..15; columns 16..31 remain x (1.0)
         tensors["y"][:] = tensors["x"]
         tensors["y"][:, :16] = tensors["src"]
 
 
-class TileAssembleVecRightOffsetTestCase(PTOTestCase):
-    """Test case for Vec-to-Vec tile.assemble at [0, 16]: src[32x16] overwrites the right half of x[32x32]."""
+# ---------------------------------------------------------------------------
+# Vec→Vec single loop + pl.slice: dynamic row gather
+# ---------------------------------------------------------------------------
+
+
+class TileAssembleRowByRowTestCase(PTOTestCase):
+    """Vec→Vec row-by-row: for each row i, pl.slice src[i,:] and assemble at [i, 0].
+
+    Semantically equivalent to TileAssembleVecTestCase but exercises the
+    loop + pl.slice + dynamic-offset assemble code path.
+    """
 
     def get_name(self) -> str:
-        return "tile_assemble_vec_right_offset"
+        return "tile_assemble_row_by_row"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return TileAssembleVecRightOffsetProgram
+        return TileAssembleRowByRowProgram
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
@@ -169,106 +140,156 @@ class TileAssembleVecRightOffsetTestCase(PTOTestCase):
         return BackendType.Ascend950
 
     def compute_expected(self, tensors, params=None):
-        # assemble at [0, 16]: columns 0..15 remain x (1.0); src overwrites columns 16..31
         tensors["y"][:] = tensors["x"]
-        tensors["y"][:, 16:] = tensors["src"]
+        tensors["y"][:, :16] = tensors["src"]
+
+
+# ---------------------------------------------------------------------------
+# Vec→Vec nested loops + pl.slice: batch×head two-level index
+# ---------------------------------------------------------------------------
+
+
+class TileAssembleDoubleLoopTestCase(PTOTestCase):
+    """Vec→Vec nested loops: outer b in range(4), inner i in range(8).
+
+    Row index row = b*8+i; pl.slice src[row,:] assembled at [row, 0].
+    Models the batch×head two-level indexing pattern in real workloads.
+    """
+
+    def get_name(self) -> str:
+        return "tile_assemble_double_loop"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleDoubleLoopProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        tensors["y"][:] = tensors["x"]
+        tensors["y"][:, :16] = tensors["src"]
+
+
+# ---------------------------------------------------------------------------
+# Vec→Vec single loop, no pl.slice: dynamic column broadcast
+# ---------------------------------------------------------------------------
+
+
+class TileAssembleLoopColBroadcastTestCase(PTOTestCase):
+    """Vec→Vec column broadcast: loop c in range(4), same src[32,8] assembled at [0, c*8].
+
+    No pl.slice — the entire source is loaded once and written to each column-block.
+    Result: all column-blocks of y equal src.
+    """
+
+    def get_name(self) -> str:
+        return "tile_assemble_loop_col_broadcast"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("src", [32, 8], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleLoopColBroadcastProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        for c in range(4):
+            tensors["y"][:, c * 8 : (c + 1) * 8] = tensors["src"]
+
+
+# ---------------------------------------------------------------------------
+# Vec→Vec nested loops, no pl.slice: 2-D position broadcast
+# ---------------------------------------------------------------------------
+
+
+class TileAssembleDoubleLoopBroadcastTestCase(PTOTestCase):
+    """Vec→Vec 2-D broadcast: nested b×c in range(2)×range(2), src[16,16] at [b*16, c*16].
+
+    No pl.slice — same source tile fills all four [16,16] quadrants of y.
+    Result: all quadrants of y equal src.
+    """
+
+    def get_name(self) -> str:
+        return "tile_assemble_double_loop_broadcast"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("src", [16, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAssembleDoubleLoopBroadcastProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+    def compute_expected(self, tensors, params=None):
+        for b in range(2):
+            for c in range(2):
+                tensors["y"][b * 16 : (b + 1) * 16, c * 16 : (c + 1) * 16] = tensors["src"]
+
+
+# ---------------------------------------------------------------------------
+# Test suites
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.a5
-class TestVecAssembleOperations:
-    """Test suite for UB-to-UB (Vec→Vec) tile.assemble operations (TInsertMode::ND_VEC)."""
+class TestAssembleOperations:
+    """Test suite for tile.assemble: one test per distinct pattern."""
 
-    def test_tile_assemble_vec_zero_offset(self, test_runner):
-        """Test Vec tile.assemble: write src into left half of target at offset [0, 0]."""
-        test_case = TileAssembleVecZeroOffsetTestCase()
-        result = test_runner.run(test_case)
+    def test_tile_assemble_acc_mat(self, test_runner):
+        """Acc→Mat (NZ mode): matmul result assembled into right half of Mat target."""
+        result = test_runner.run(TileAssembleAccMatTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_assemble_vec_right_offset(self, test_runner):
-        """Test Vec tile.assemble: write src into right half of target at offset [0, 16]."""
-        test_case = TileAssembleVecRightOffsetTestCase()
-        result = test_runner.run(test_case)
+    def test_tile_assemble_vec(self, test_runner):
+        """Vec→Vec single-shot (ND_VEC mode): src assembled into left half of target."""
+        result = test_runner.run(TileAssembleVecTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
-
-class TileAddThenAssembleZeroOffsetTestCase(PTOTestCase):
-    """Test case for add-then-assemble at [0, 0].
-
-    add(src, delta)[32x16] overwrites the left half of x[32x32].
-    """
-
-    def get_name(self) -> str:
-        return "tile_add_then_assemble_zero_offset"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
-            TensorSpec("delta", [32, 16], DataType.FP32, init_value=3.0),
-            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return TileAddThenAssembleZeroOffsetProgram
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-    def compute_expected(self, tensors, params=None):
-        # add then assemble at [0, 0]: (src + delta) overwrites columns 0..15; columns 16..31 remain x (1.0)
-        tensors["y"][:] = tensors["x"]
-        tensors["y"][:, :16] = tensors["src"] + tensors["delta"]
-
-
-class TileAddThenAssembleRightOffsetTestCase(PTOTestCase):
-    """Test case for add-then-assemble at [0, 16].
-
-    add(src, delta)[32x16] overwrites the right half of x[32x32].
-    """
-
-    def get_name(self) -> str:
-        return "tile_add_then_assemble_right_offset"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=1.0),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=2.0),
-            TensorSpec("delta", [32, 16], DataType.FP32, init_value=3.0),
-            TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return TileAddThenAssembleRightOffsetProgram
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-    def compute_expected(self, tensors, params=None):
-        # add then assemble at [0, 16]: columns 0..15 remain x (1.0); (src + delta) overwrites columns 16..31
-        tensors["y"][:] = tensors["x"]
-        tensors["y"][:, 16:] = tensors["src"] + tensors["delta"]
-
-
-@pytest.mark.skip(reason="Pending adaptation for A5")
-class TestAddThenAssembleOperations:
-    """Test suite for add-then-assemble: pl.add on source tile before Vec→Vec tile.assemble."""
-
-    def test_tile_add_then_assemble_zero_offset(self, test_runner):
-        """Test add-then-assemble: write add(src, delta) into left half of target at offset [0, 0]."""
-        test_case = TileAddThenAssembleZeroOffsetTestCase()
-        result = test_runner.run(test_case)
+    def test_tile_assemble_row_by_row(self, test_runner):
+        """Vec→Vec single loop + pl.slice: dynamic row gather into left half."""
+        result = test_runner.run(TileAssembleRowByRowTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_add_then_assemble_right_offset(self, test_runner):
-        """Test add-then-assemble: write add(src, delta) into right half of target at offset [0, 16]."""
-        test_case = TileAddThenAssembleRightOffsetTestCase()
-        result = test_runner.run(test_case)
+    def test_tile_assemble_double_loop(self, test_runner):
+        """Vec→Vec nested loops + pl.slice: batch×head two-level index (b*8+i)."""
+        result = test_runner.run(TileAssembleDoubleLoopTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_assemble_loop_col_broadcast(self, test_runner):
+        """Vec→Vec single loop, no pl.slice: same src column-block at each c*8 offset."""
+        result = test_runner.run(TileAssembleLoopColBroadcastTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_assemble_double_loop_broadcast(self, test_runner):
+        """Vec→Vec nested loops, no pl.slice: same src[16,16] fills all four quadrants."""
+        result = test_runner.run(TileAssembleDoubleLoopBroadcastTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -789,11 +789,12 @@ def test_compile_writes_orchestration_on_partial_codegen_failure(tmp_path):
         def bad_kernel(
             self,
             a: pl.Tensor[[16, 16], pl.FP32],
-        ) -> pl.Tensor[[16, 16], pl.FP32]:
-            source = pl.slice(a, [16, 16], [0, 0])
-            result = pl.create_tensor([16, 16], dtype=pl.FP32)
-            result = pl.assemble(result, source, [0, 0])
-            return result
+            output: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            tile = pl.load(a, offsets=[0, 0], shapes=[16, 16])
+            result = pl.tile.sum(tile, axis=1)
+            out = pl.store(result, offsets=[0, 0], output_tensor=output)
+            return out
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def orch(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:


### PR DESCRIPTION
- Implement MakeTileAssembleCodegenPTO to lower tile.assemble to pto.tinsert, supporting both Acc→Mat (NZ mode) and Vec→Vec (ND_VEC mode) insert paths
- Fix DeduceTileAssembleType to propagate layout metadata (blayout, slayout, fractal, pad) and memory_space from the target tile so codegen receives correct type annotations
- Fix pto.tpush_to_aiv/aic and pto.tpop_from_aic/aiv PTO syntax
- Add Ascend 950 (a5/a5sim) platform support in orchestration codegen via CoreTypeToSubmitParts, switching to pto2_rt_submit_task with PTO2_WORKER_CUBE/VECTOR arguments
- Extend RunConfig, test harness conftest, and runtime runner to accept a5/a5sim platforms; add _resolve_platform to auto-select the correct platform string per test case's BackendType
- Add examples/language/beginner/assemble.py demonstrating six tile.assemble programs (Acc→Mat and Vec→Vec, zero/right offsets, add-then-assemble)
- Add tests/st/runtime/test_assemble.py with six runtime test cases validating tile.assemble correctness on Ascend 950