### PR TITLE
feat(ir): implement tensor batch matmul pipeline. Fix #536.

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -110,6 +110,16 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+`tensor.matmul` is reserved for 2D matrix multiplication. For batched tensors
+with rank >= 3, use `tensor.batch_matmul` from the registry or the Python helper
+`op.tensor.batch_matmul(...)`.
+
+At the tile layer, `tile.batch_matmul` mirrors the batched semantics for
+`TileType` operands. It accepts rank >= 2 tiles, broadcasts the leading batch
+dimensions, and keeps the same operand-only interface style as `tile.matmul`.
+If batch operands need transpose semantics, that is expressed explicitly with
+`tile.transpose(...)` on the inputs before later lowering to 2D `tile.matmul`.
+
 ## Python Usage
 
 ```python
@@ -131,6 +141,10 @@ dim64, dim128 = ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType
 a = ir.Var("a", ir.TensorType([dim64, dim128], DataType.FP16), span)
 b = ir.Var("b", ir.TensorType([dim128, dim64], DataType.FP16), span)
 matmul = op.tensor.matmul(a, b, out_dtype=DataType.FP32, a_trans=True)
+
+batch_a = ir.Var("batch_a", ir.TensorType([dim4, dim64, dim128], DataType.FP16), span)
+batch_b = ir.Var("batch_b", ir.TensorType([dim4, dim128, dim64], DataType.FP16), span)
+batch_matmul = op.tensor.batch_matmul(batch_a, batch_b, out_dtype=DataType.FP32)
 
 # Query registry
 assert ir.is_op_registered("tensor.add")

--- a/docs/en/dev/passes/10-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/10-flatten_tile_nd_to_2d.md
@@ -6,6 +6,11 @@ Flattens ND tile operations (3D+) to 2D in InCore functions by merging all dimen
 
 PTO-ISA only accepts 2D tiles. After `ConvertTensorToTileOps`, tiles may be ND (matching tensor shapes). This pass flattens all >2D tile operations to 2D by merging higher axes into one dimension and keeping the last axis unchanged. For example, a tile `[2, 3, 4]` becomes `[6, 4]`.
 
+For batched matrix multiplication, `ConvertTensorToTileOps` first preserves the
+high-level intent as `tile.batch_matmul`. `FlattenTileNdTo2D` then becomes the
+canonical legalization point that expands it into broadcast-aware per-batch
+2D `tile.matmul` operations.
+
 **Requirements**:
 
 - Input IR must be in SSA form
@@ -47,6 +52,7 @@ Per-statement handling:
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
+| `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast and any explicit operand `tile.transpose` |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
 | 1D/2D tile ops | Unchanged |
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -110,6 +110,15 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+`tensor.matmul` 只处理 2D 矩阵乘法。对于 rank >= 3 的 batch 张量，请使用
+registry 中的 `tensor.batch_matmul`，或者 Python 辅助函数
+`op.tensor.batch_matmul(...)`。
+
+在 Tile 层，`tile.batch_matmul` 对应 batched `TileType` 语义。它接受
+rank >= 2 的 tile，支持前导 batch 维广播，并尽量保持和 `tile.matmul`
+一致的纯 operand 接口风格。如果 batch operand 需要转置语义，应先显式写成
+`tile.transpose(...)`，后续 lowering 再把它拆成 2D `tile.matmul`。
+
 ## Python 用法
 
 ```python
@@ -131,6 +140,10 @@ dim64, dim128 = ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType
 a = ir.Var("a", ir.TensorType([dim64, dim128], DataType.FP16), span)
 b = ir.Var("b", ir.TensorType([dim128, dim64], DataType.FP16), span)
 matmul = op.tensor.matmul(a, b, out_dtype=DataType.FP32, a_trans=True)
+
+batch_a = ir.Var("batch_a", ir.TensorType([dim4, dim64, dim128], DataType.FP16), span)
+batch_b = ir.Var("batch_b", ir.TensorType([dim4, dim128, dim64], DataType.FP16), span)
+batch_matmul = op.tensor.batch_matmul(batch_a, batch_b, out_dtype=DataType.FP32)
 
 # Query registry
 assert ir.is_op_registered("tensor.add")

--- a/docs/zh-cn/dev/passes/10-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/10-flatten_tile_nd_to_2d.md
@@ -6,6 +6,10 @@
 
 PTO-ISA 仅支持 2D Tile。`ConvertTensorToTileOps` 之后，Tile 可能是 ND（匹配张量形状）。该 Pass 通过将高维轴合并为一个维度并保持最后一个轴不变，将所有 >2D 的 Tile 操作展平为 2D。例如，Tile `[2, 3, 4]` 变为 `[6, 4]`。
 
+对于 batch 矩阵乘法，`ConvertTensorToTileOps` 会先保留为
+`tile.batch_matmul`。随后由 `FlattenTileNdTo2D` 统一负责把它展开成带
+broadcast 语义的逐 batch 2D `tile.matmul`。
+
 **前置条件**：
 
 - 输入 IR 必须为 SSA 形式
@@ -47,6 +51,7 @@ program_2d = flatten_pass(program)
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
+| `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，并处理 batch broadcast 与显式 operand `tile.transpose` |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
 | 1D/2D Tile 操作 | 不变 |
 

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -275,6 +275,7 @@ def _register_ops() -> None:
 
     # --- Tensor-only ops ---
     m["tensor.matmul"] = _handle_tensor_matmul
+    m["tensor.batch_matmul"] = _handle_tensor_matmul
     m["tensor.matmul_acc"] = _handle_tensor_matmul_acc
     m["tensor.dim"] = lambda a, _kw: f"{a[0]}.shape[{a[1]}]"
     m["tensor.create"] = _handle_create
@@ -317,6 +318,7 @@ def _register_ops() -> None:
 
     # tile matmul variants — .float() to match hardware FP32 accumulation output
     m["tile.matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
+    m["tile.batch_matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
     m["tile.matmul_acc"] = lambda a, _kw: f"({a[0]} + torch.matmul({a[1]}, {a[2]}).float())"
     m["tile.matmul_bias"] = lambda a, _kw: f"(torch.matmul({a[0]}, {a[1]}).float() + {a[2]})"
     m["tile.gemv"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -203,11 +203,11 @@ def matmul(
     c_matrix_nz: bool = False,
     span: Span | None = None,
 ) -> Call:
-    """Matrix multiplication with optional transpose.
+    """2D matrix multiplication with optional transpose.
 
     Args:
-        lhs: Left-hand side tensor
-        rhs: Right-hand side tensor
+        lhs: Left-hand side tensor (2D)
+        rhs: Right-hand side tensor (2D)
         out_dtype: Output data type (optional, inferred if not provided)
         a_trans: Whether to transpose lhs
         b_trans: Whether to transpose rhs
@@ -215,7 +215,7 @@ def matmul(
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression for matrix multiplication
+        Call expression for 2D matrix multiplication
     """
     actual_span = _get_span_or_capture(span)
     args = [lhs, rhs]
@@ -229,6 +229,40 @@ def matmul(
         kwargs["out_dtype"] = out_dtype
 
     return _ir_core.create_op_call("tensor.matmul", args, kwargs, actual_span)
+
+
+def batch_matmul(
+    lhs: Expr,
+    rhs: Expr,
+    out_dtype: int | DataType | None = None,
+    a_trans: bool = False,
+    b_trans: bool = False,
+    c_matrix_nz: bool = False,
+    span: Span | None = None,
+) -> Call:
+    """Batch matrix multiplication with optional transpose.
+
+    Args:
+        lhs: Left-hand side tensor (rank >= 3)
+        rhs: Right-hand side tensor (rank >= 3)
+        out_dtype: Output data type (optional, inferred if not provided)
+        a_trans: Whether to transpose lhs matrix dimensions
+        b_trans: Whether to transpose rhs matrix dimensions
+        c_matrix_nz: C matrix non-zero flag
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for batch matrix multiplication
+    """
+    actual_span = _get_span_or_capture(span)
+    kwargs: dict[str, Any] = {
+        "a_trans": a_trans,
+        "b_trans": b_trans,
+        "c_matrix_nz": c_matrix_nz,
+    }
+    if out_dtype is not None:
+        kwargs["out_dtype"] = out_dtype
+    return _ir_core.create_op_call("tensor.batch_matmul", [lhs, rhs], kwargs, actual_span)
 
 
 def matmul_acc(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1275,6 +1275,28 @@ def matmul_bias(lhs: Expr, rhs: Expr, bias: Expr, span: Span | None = None) -> C
     return _ir_core.create_op_call("tile.matmul_bias", [lhs, rhs, bias], {}, actual_span)
 
 
+def batch_matmul(
+    lhs: Expr,
+    rhs: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Batch matrix multiplication of two tiles with broadcasting.
+
+    For inputs with shape [...batch_dims, M, K] and [...batch_dims, K, N],
+    the output has shape [...broadcast_batch_dims, M, N].
+
+    Args:
+        lhs: Left-hand side tile (TileType, at least 2D)
+        rhs: Right-hand side tile (TileType, at least 2D)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for batch matrix multiplication
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.batch_matmul", [lhs, rhs], {}, actual_span)
+
+
 def gemv(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """General Matrix-Vector multiplication: C[1,N] = A[1,K] @ B[K,N].
 
@@ -1834,21 +1856,21 @@ def reshape(
     return _ir_core.create_op_call("tile.reshape", args, {}, actual_span)
 
 
-def transpose(tile: Expr, axis1: int, axis2: int, span: Span | None = None) -> Call:
+def transpose(tile: Expr, axis1: int | Expr, axis2: int | Expr, span: Span | None = None) -> Call:
     """Transpose tile by swapping two axes.
 
     Args:
         tile: Input tile expression
-        axis1: First axis to swap (supports negative indexing)
-        axis2: Second axis to swap (supports negative indexing)
+        axis1: First axis to swap as an integer or index expression
+        axis2: Second axis to swap as an integer or index expression
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for tile transpose
     """
     actual_span = _get_span_or_capture(span)
-    axis1_expr = ConstInt(axis1, DataType.INDEX, actual_span)
-    axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
+    axis1_expr = _normalize_expr(axis1, actual_span, int_dtype=DataType.INDEX)
+    axis2_expr = _normalize_expr(axis2, actual_span, int_dtype=DataType.INDEX)
 
     args = [tile, axis1_expr, axis2_expr]
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -25,6 +25,7 @@ __all__ = [
     "fillpad",
     "full",
     "matmul",
+    "batch_matmul",
     "matmul_acc",
     "mul",
     "muls",
@@ -211,11 +212,11 @@ def matmul(
     b_trans: bool = False,
     c_matrix_nz: bool = False,
 ) -> Tensor:
-    """Matrix multiplication with optional transpose.
+    """2D matrix multiplication with optional transpose.
 
     Args:
-        lhs: Left-hand side tensor
-        rhs: Right-hand side tensor
+        lhs: Left-hand side tensor (2D)
+        rhs: Right-hand side tensor (2D)
         out_dtype: Output data type (optional, inferred if not provided)
         a_trans: Whether to transpose lhs
         b_trans: Whether to transpose rhs
@@ -227,6 +228,31 @@ def matmul(
     lhs_expr = lhs.unwrap()
     rhs_expr = rhs.unwrap()
     call_expr = _ir_ops.matmul(lhs_expr, rhs_expr, out_dtype, a_trans, b_trans, c_matrix_nz)
+    return Tensor(expr=call_expr)
+
+
+def batch_matmul(
+    lhs: Tensor,
+    rhs: Tensor,
+    out_dtype: int | DataType | None = None,
+    a_trans: bool = False,
+    b_trans: bool = False,
+    c_matrix_nz: bool = False,
+) -> Tensor:
+    """Batch matrix multiplication with optional transpose.
+
+    Args:
+        lhs: Left-hand side tensor (rank >= 3)
+        rhs: Right-hand side tensor (rank >= 3)
+        out_dtype: Output data type (optional, inferred if not provided)
+        a_trans: Whether to transpose lhs matrix dimensions
+        b_trans: Whether to transpose rhs matrix dimensions
+        c_matrix_nz: C matrix non-zero flag
+
+    Returns:
+        Tensor wrapping the batch matrix multiplication operation
+    """
+    call_expr = _ir_ops.batch_matmul(lhs.unwrap(), rhs.unwrap(), out_dtype, a_trans, b_trans, c_matrix_nz)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -53,6 +53,7 @@ __all__ = [
     "relu",
     "cast",
     "matmul",
+    "batch_matmul",
     "matmul_acc",
     "matmul_bias",
     "gemv",
@@ -685,6 +686,20 @@ def matmul(lhs: Tile, rhs: Tile) -> Tile:
         Tile wrapping the matmul operation
     """
     call_expr = _ir_ops.matmul(lhs.unwrap(), rhs.unwrap())
+    return Tile(expr=call_expr)
+
+
+def batch_matmul(lhs: Tile, rhs: Tile) -> Tile:
+    """Batch matrix multiplication of two tiles.
+
+    Args:
+        lhs: Left-hand side tile
+        rhs: Right-hand side tile
+
+    Returns:
+        Tile wrapping the batch_matmul operation
+    """
+    call_expr = _ir_ops.batch_matmul(lhs.unwrap(), rhs.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -137,14 +137,14 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     }
     Emit("}");
   } else {
-    // Like loops, keep tile return values out of scf.if results. Pre-declare
-    // tile buffers for return_vars using the canonical MemRef address (assigned
-    // by MemoryReuse), and only use scf.if results for scalar-like SSA values.
-    // MemoryReuse's YieldFixupMutator ensures all branch yields already share
-    // the return_var's canonical MemRef, so no codegen-level tmov is needed.
+    // Like loops, keep tile return values out of scf.if results. Materialize
+    // them into pre-declared tile buffers inside each branch, and only use
+    // scf.if results for scalar-like SSA values.
     std::vector<bool> returns_via_scf(op->return_vars_.size(), false);
     std::vector<std::string> scf_return_names;
     std::vector<std::string> scf_return_types;
+    std::vector<std::string> tile_return_targets(op->return_vars_.size());
+    std::vector<std::string> tile_return_types(op->return_vars_.size());
 
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
       const auto& return_var = op->return_vars_[i];
@@ -177,6 +177,8 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string ret_name =
             AllocNewTileBuf(tile_type_string, return_var->name_hint_, addr_ssa, valid_row_ssa, valid_col_ssa);
         BindVarToMlir(return_var, ret_name);
+        tile_return_targets[i] = ret_name;
+        tile_return_types[i] = tile_type_string;
       } else {
         INTERNAL_CHECK(false) << "Internal error: unsupported IfStmt return_var type for "
                               << return_var->name_hint_;
@@ -208,9 +210,14 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           scalar_yields.push_back(branch_yields[i]);
           continue;
         }
-        // Tile return_vars: MemoryReuse ensures branch yields share the return_var's
-        // canonical MemRef (same physical address). No codegen-level tmov needed —
-        // the IR-level tile.move (from MemoryReuse's YieldFixupMutator) handles the copy.
+        if (tile_return_targets[i].empty() || branch_yields[i].empty()) continue;
+        if (branch_yields[i] == tile_return_targets[i]) continue;
+
+        std::string src_type = GetSSATileBufType(branch_yields[i]);
+        INTERNAL_CHECK(!src_type.empty())
+            << "Internal error: missing tile type for IfStmt branch yield " << branch_yields[i];
+        Emit("pto.tmov ins(" + branch_yields[i] + " : " + src_type + ") outs(" + tile_return_targets[i] +
+             " : " + tile_return_types[i] + ")");
       }
 
       if (!scf_return_types.empty()) {

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -53,6 +53,30 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
   throw ValueError("Missing kwarg: " + key);
 }
 
+DataType DeduceTensorMatMulOutDType(const TensorTypePtr& lhs_type, const TensorTypePtr& rhs_type,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  try {
+    return GetKwarg<DataType>(kwargs, "out_dtype");
+  } catch (const ValueError&) {
+    auto promoted = PromoteDataTypes(lhs_type->dtype_, rhs_type->dtype_);
+    CHECK(promoted) << "Cannot promote data types for " << op_name;
+    return *promoted;
+  } catch (const TypeError& e) {
+    throw TypeError("Invalid kwarg type for out_dtype: " + std::string(e.what()));
+  }
+}
+
+void CheckStaticInnerDimsMatch(const ExprPtr& lhs_k, const ExprPtr& rhs_k, const std::string& op_name) {
+  auto lhs_k_const = As<ConstInt>(lhs_k);
+  auto rhs_k_const = As<ConstInt>(rhs_k);
+  if (lhs_k_const && rhs_k_const) {
+    CHECK(lhs_k_const->value_ == rhs_k_const->value_)
+        << op_name << " requires matching inner dimensions, but got lhs K=" << lhs_k_const->value_
+        << " and rhs K=" << rhs_k_const->value_;
+  }
+}
+
 TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
   // tensor.matmul requires exactly 2 Expr arguments (lhs, rhs)
@@ -71,72 +95,66 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
   const auto& lhs_shape = lhs_type->shape_;
   const auto& rhs_shape = rhs_type->shape_;
 
-  CHECK(lhs_shape.size() >= 1) << "tensor.matmul requires lhs to have at least 1 dimension";
-  CHECK(rhs_shape.size() >= 1) << "tensor.matmul requires rhs to have at least 1 dimension";
+  CHECK(lhs_shape.size() == 2) << "tensor.matmul requires lhs to be 2D, but got " << lhs_shape.size()
+                               << "D. Use tensor.batch_matmul for batched inputs.";
+  CHECK(rhs_shape.size() == 2) << "tensor.matmul requires rhs to be 2D, but got " << rhs_shape.size()
+                               << "D. Use tensor.batch_matmul for batched inputs.";
 
   // Read kwargs (with defaults)
-  DataType out_dtype;
-  try {
-    out_dtype = GetKwarg<DataType>(kwargs, "out_dtype");
-  } catch (const ValueError& e) {
-    auto promoted = PromoteDataTypes(lhs_type->dtype_, rhs_type->dtype_);
-    CHECK(promoted) << "Cannot promote data types for tensor.matmul";
-    out_dtype = *promoted;
-  } catch (const TypeError& e) {
-    throw TypeError("Invalid kwarg type for out_dtype: " + std::string(e.what()));
-  }
-
+  DataType out_dtype = DeduceTensorMatMulOutDType(lhs_type, rhs_type, kwargs, "tensor.matmul");
   bool a_trans = GetKwarg<bool>(kwargs, "a_trans", false);
   bool b_trans = GetKwarg<bool>(kwargs, "b_trans", false);
 
-  // Compute output shape based on transpose flags
-  // For 2D: lhs [M, K] x rhs [K, N] -> [M, N]
-  // With transpose: lhs [K, M]^T x rhs [N, K]^T -> [M, N]
+  ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
+  ExprPtr lhs_k = a_trans ? lhs_shape[0] : lhs_shape[1];
+  ExprPtr rhs_k = b_trans ? rhs_shape[1] : rhs_shape[0];
+  ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
+  CheckStaticInnerDimsMatch(lhs_k, rhs_k, "tensor.matmul");
 
-  std::vector<ExprPtr> output_shape;
+  return std::make_shared<TensorType>(std::vector<ExprPtr>{m_dim, n_dim}, out_dtype);
+}
 
-  if (lhs_shape.size() == 1 && rhs_shape.size() == 1) {
-    // Vector x vector (dot product): [K] x [K] -> scalar (0D tensor)
-    output_shape = {};
-  } else if (lhs_shape.size() == 2 && rhs_shape.size() == 1) {
-    // Matrix x vector: [M, K] x [K] -> [M]
-    output_shape = {lhs_shape[0]};
-  } else if (lhs_shape.size() == 1 && rhs_shape.size() == 2) {
-    // Vector x matrix: [K] x [K, N] -> [N]
-    output_shape = {rhs_shape[1]};
-  } else if (lhs_shape.size() == 2 && rhs_shape.size() == 2) {
-    // 2D x 2D matrix multiplication
-    ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
-    ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
-    output_shape = {m_dim, n_dim};
-  } else {
-    // For higher-dimensional tensors (both must have at least 2 dimensions),
-    // use batched matmul semantics
-    size_t lhs_ndim = lhs_shape.size();
-    size_t rhs_ndim = rhs_shape.size();
+TypePtr DeduceTensorBatchMatMulType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 2) << "tensor.batch_matmul requires exactly 2 arguments (lhs, rhs), but got "
+                          << args.size();
 
-    // Ensure both tensors have at least 2 dimensions for batched matmul
-    CHECK(lhs_ndim >= 2 && rhs_ndim >= 2)
-        << "tensor.matmul requires both tensors to have at least 2 dimensions "
-        << "for batched matmul, but got lhs shape size " << lhs_ndim << " and rhs shape size " << rhs_ndim;
+  auto lhs_type = As<TensorType>(args[0]->GetType());
+  auto rhs_type = As<TensorType>(args[1]->GetType());
 
-    // Extract batch dimensions (all except last 2)
-    std::vector<ExprPtr> lhs_batch(lhs_shape.begin(), lhs_shape.end() - 2);
-    std::vector<ExprPtr> rhs_batch(rhs_shape.begin(), rhs_shape.end() - 2);
+  CHECK(lhs_type) << "tensor.batch_matmul requires first argument to be a TensorType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(rhs_type) << "tensor.batch_matmul requires second argument to be a TensorType, but got "
+                  << args[1]->GetType()->TypeName();
 
-    // Broadcast batch dimensions
-    auto broadcast_result = BroadcastShapes(lhs_batch, rhs_batch);
-    CHECK(broadcast_result.success) << "Cannot broadcast batch dimensions for tensor.matmul";
+  const auto& lhs_shape = lhs_type->shape_;
+  const auto& rhs_shape = rhs_type->shape_;
 
-    output_shape = broadcast_result.shape;
+  CHECK(lhs_shape.size() >= 3) << "tensor.batch_matmul requires lhs to have at least 3 dimensions, but got "
+                               << lhs_shape.size() << "D. Use tensor.matmul for 2D matrix multiplication.";
+  CHECK(rhs_shape.size() >= 3) << "tensor.batch_matmul requires rhs to have at least 3 dimensions, but got "
+                               << rhs_shape.size() << "D. Use tensor.matmul for 2D matrix multiplication.";
 
-    // Append matrix dimensions
-    ExprPtr m_dim = a_trans ? lhs_shape[lhs_ndim - 1] : lhs_shape[lhs_ndim - 2];
-    ExprPtr n_dim = b_trans ? rhs_shape[rhs_ndim - 2] : rhs_shape[rhs_ndim - 1];
-    output_shape.push_back(m_dim);
-    output_shape.push_back(n_dim);
-  }
+  DataType out_dtype = DeduceTensorMatMulOutDType(lhs_type, rhs_type, kwargs, "tensor.batch_matmul");
+  bool a_trans = GetKwarg<bool>(kwargs, "a_trans", false);
+  bool b_trans = GetKwarg<bool>(kwargs, "b_trans", false);
 
+  std::vector<ExprPtr> lhs_batch(lhs_shape.begin(), lhs_shape.end() - 2);
+  std::vector<ExprPtr> rhs_batch(rhs_shape.begin(), rhs_shape.end() - 2);
+  auto broadcast_result = BroadcastShapes(lhs_batch, rhs_batch);
+  CHECK(broadcast_result.success) << "Cannot broadcast batch dimensions for tensor.batch_matmul";
+
+  size_t lhs_ndim = lhs_shape.size();
+  size_t rhs_ndim = rhs_shape.size();
+  ExprPtr m_dim = a_trans ? lhs_shape[lhs_ndim - 1] : lhs_shape[lhs_ndim - 2];
+  ExprPtr lhs_k = a_trans ? lhs_shape[lhs_ndim - 2] : lhs_shape[lhs_ndim - 1];
+  ExprPtr rhs_k = b_trans ? rhs_shape[rhs_ndim - 1] : rhs_shape[rhs_ndim - 2];
+  ExprPtr n_dim = b_trans ? rhs_shape[rhs_ndim - 2] : rhs_shape[rhs_ndim - 1];
+  CheckStaticInnerDimsMatch(lhs_k, rhs_k, "tensor.batch_matmul");
+
+  std::vector<ExprPtr> output_shape = broadcast_result.shape;
+  output_shape.push_back(m_dim);
+  output_shape.push_back(n_dim);
   return std::make_shared<TensorType>(output_shape, out_dtype);
 }
 
@@ -146,9 +164,9 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
 
 REGISTER_OP("tensor.matmul")
     .set_op_category("TensorOp")
-    .set_description("Matrix multiplication of two tensors with optional transpose")
-    .add_argument("lhs", "Left-hand side tensor (TensorType)")
-    .add_argument("rhs", "Right-hand side tensor (TensorType)")
+    .set_description("2D matrix multiplication of two tensors with optional transpose")
+    .add_argument("lhs", "Left-hand side tensor (TensorType, 2D)")
+    .add_argument("rhs", "Right-hand side tensor (TensorType, 2D)")
     .set_attr<DataType>("out_dtype")
     .set_attr<bool>("a_trans")
     .set_attr<bool>("b_trans")
@@ -156,6 +174,20 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorMatMulType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.batch_matmul")
+    .set_op_category("TensorOp")
+    .set_description("Batched matrix multiplication of tensors with rank >= 3 and optional transpose")
+    .add_argument("lhs", "Left-hand side tensor (TensorType, rank >= 3)")
+    .add_argument("rhs", "Right-hand side tensor (TensorType, rank >= 3)")
+    .set_attr<DataType>("out_dtype")
+    .set_attr<bool>("a_trans")
+    .set_attr<bool>("b_trans")
+    .set_attr<bool>("c_matrix_nz")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorBatchMatMulType(args, kwargs);
     });
 
 // ============================================================================
@@ -204,17 +236,11 @@ TypePtr DeduceTensorMatMulAccType(const std::vector<ExprPtr>& args,
 
   // acc[M, N] += lhs[M, K] @ rhs[K, N] (with optional transpose)
   ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
-  ExprPtr k_lhs = a_trans ? lhs_shape[0] : lhs_shape[1];
-  ExprPtr k_rhs = b_trans ? rhs_shape[1] : rhs_shape[0];
+  ExprPtr lhs_k = a_trans ? lhs_shape[0] : lhs_shape[1];
+  ExprPtr rhs_k = b_trans ? rhs_shape[1] : rhs_shape[0];
   ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
 
-  // Verify K dimensions match
-  auto k_lhs_const = As<ConstInt>(k_lhs);
-  auto k_rhs_const = As<ConstInt>(k_rhs);
-  if (k_lhs_const && k_rhs_const) {
-    CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-        << "tensor.matmul_acc: lhs K=" << k_lhs_const->value_ << " != rhs K=" << k_rhs_const->value_;
-  }
+  CheckStaticInnerDimsMatch(lhs_k, rhs_k, "tensor.matmul_acc");
 
   // Verify acc shape matches [M, N]
   auto m_acc = As<ConstInt>(acc_shape[0]);

--- a/src/ir/op/tile_ops/batch_matmul.cpp
+++ b/src/ir/op/tile_ops/batch_matmul.cpp
@@ -52,6 +52,7 @@ namespace ir {
 TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
                                   const std::string& op_name) {
+  (void)kwargs;
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -79,7 +80,7 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
   size_t lhs_ndim = lhs_shape.size();
   size_t rhs_ndim = rhs_shape.size();
 
-  // Extract matrix dimensions (last 2 dimensions)
+  // Extract matrix dimensions from the trailing matrix axes.
   ExprPtr m_dim = lhs_shape[lhs_ndim - 2];
   ExprPtr k_dim_lhs = lhs_shape[lhs_ndim - 1];
   ExprPtr k_dim_rhs = rhs_shape[rhs_ndim - 2];
@@ -119,14 +120,22 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
     output_shape.push_back(n_dim);
   }
 
-  // Promote data types
-  auto result_dtype = PromoteDataTypes(lhs_type->dtype_, rhs_type->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+  CHECK(lhs_type->dtype_ == rhs_type->dtype_)
+      << "The operator " << op_name << " requires identical lhs and rhs data types, but got "
+      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+  // Hardware matmul accumulates to FP32 for float inputs, INT32 for integer inputs.
+  auto result_dtype =
+      (lhs_type->dtype_.IsFloat() && rhs_type->dtype_.IsFloat()) ? DataType::FP32 : DataType::INT32;
 
+  // The matmul output tile uses the hardware's native accumulator layout:
+  // - blayout=col_major, slayout=row_major: hardware's column-major block / row-major sub-block
+  // - fractal=1024: 32x32 sub-tile fractal size (standard for this hardware's matrix unit)
   TileView tile_view;
+  tile_view.blayout = TileLayout::col_major;
+  tile_view.slayout = TileLayout::row_major;
+  tile_view.fractal = 1024;
   tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
 }
 
 // ============================================================================

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -31,7 +31,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
-#include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/op_conversion_registry.h"
 #include "pypto/ir/transforms/pass_properties.h"
@@ -45,6 +44,7 @@ namespace pypto {
 namespace ir {
 
 using transform_utils::FlattenToStmts;
+using transform_utils::SubstituteExpr;
 
 namespace {
 
@@ -61,6 +61,98 @@ std::string MakeStoreResultName(size_t index) {
 }
 
 /**
+ * @brief Update body_map for a loop iter_arg to shadow any outer scope mapping.
+ *
+ * If the iter_arg's type changed, maps the old pointer to the new iter_arg
+ * (for substitution). Otherwise, erases any stale mapping for the old pointer.
+ */
+void ShadowIterArgInBodyMap(std::unordered_map<const Var*, VarPtr>& body_map, const IterArgPtr& orig_iter_arg,
+                            const IterArgPtr& new_iter_arg) {
+  if (new_iter_arg != orig_iter_arg) {
+    body_map[orig_iter_arg.get()] = new_iter_arg;
+  } else {
+    body_map.erase(orig_iter_arg.get());
+  }
+}
+
+/**
+ * @brief Substitute iter_arg init values and rebuild iter_args with updated types.
+ *
+ * For each iter_arg, substitutes its initValue_ through var_map. If the substituted
+ * init's type differs from the iter_arg's type, creates a new IterArg with the updated
+ * type. Also updates body_map via ShadowIterArgInBodyMap for downstream substitution.
+ *
+ * This pattern is shared by ForStmt and WhileStmt handling in both
+ * TransformIncoreBody and UpdateCallSitesBody.
+ */
+std::vector<IterArgPtr> SubstituteIterArgs(const std::vector<IterArgPtr>& iter_args,
+                                           const std::unordered_map<const Var*, VarPtr>& var_map,
+                                           std::unordered_map<const Var*, VarPtr>& body_map) {
+  std::vector<IterArgPtr> new_iter_args;
+  new_iter_args.reserve(iter_args.size());
+  for (const auto& iter_arg : iter_args) {
+    auto new_init = SubstituteExpr(iter_arg->initValue_, var_map);
+    auto new_ia = iter_arg;
+    if (new_init->GetType() != iter_arg->GetType()) {
+      new_ia =
+          std::make_shared<IterArg>(iter_arg->name_hint_, new_init->GetType(), new_init, iter_arg->span_);
+    } else if (new_init != iter_arg->initValue_) {
+      new_ia =
+          std::make_shared<IterArg>(iter_arg->name_hint_, iter_arg->GetType(), new_init, iter_arg->span_);
+    }
+    new_iter_args.push_back(new_ia);
+    ShadowIterArgInBodyMap(body_map, iter_arg, new_ia);
+  }
+  return new_iter_args;
+}
+
+/**
+ * @brief Update return_vars types to match new types from yield or iter_args.
+ *
+ * Compares each return_var's type against the corresponding new_type. If they differ,
+ * creates a new Var with the updated type and records the mapping in var_map.
+ *
+ * @param return_vars Original return variables from the control flow statement.
+ * @param new_types New types to compare against (from yield types or iter_arg types).
+ * @param var_map Map to update with old→new variable mappings.
+ * @param always_map If true, always maps rv→new_rv (even when type unchanged).
+ *                   Used by TransformIncoreBody where all return vars must be tracked.
+ *                   If false, only maps when type actually changed (UpdateCallSitesBody).
+ */
+std::vector<VarPtr> UpdateReturnVarTypes(const std::vector<VarPtr>& return_vars,
+                                         const std::vector<TypePtr>& new_types,
+                                         std::unordered_map<const Var*, VarPtr>& var_map, bool always_map) {
+  std::vector<VarPtr> new_return_vars;
+  new_return_vars.reserve(return_vars.size());
+  for (size_t i = 0; i < return_vars.size(); ++i) {
+    const auto& rv = return_vars[i];
+    if (i < new_types.size() && new_types[i] != rv->GetType()) {
+      auto new_rv = std::make_shared<Var>(rv->name_hint_, new_types[i], rv->span_);
+      new_return_vars.push_back(new_rv);
+      var_map[rv.get()] = new_rv;
+    } else {
+      new_return_vars.push_back(rv);
+      if (always_map) {
+        var_map[rv.get()] = rv;
+      }
+    }
+  }
+  return new_return_vars;
+}
+
+/// Overload for iter_arg-sourced types (ForStmt/WhileStmt return_vars update).
+std::vector<VarPtr> UpdateReturnVarTypes(const std::vector<VarPtr>& return_vars,
+                                         const std::vector<IterArgPtr>& new_iter_args,
+                                         std::unordered_map<const Var*, VarPtr>& var_map, bool always_map) {
+  std::vector<TypePtr> types;
+  types.reserve(new_iter_args.size());
+  for (const auto& ia : new_iter_args) {
+    types.push_back(ia->GetType());
+  }
+  return UpdateReturnVarTypes(return_vars, types, var_map, always_map);
+}
+
+/**
  * @brief Visitor that collects tensor-typed variable names used directly by converted ops.
  *
  * Traverses the IR tree via IRVisitor and records the name of every Var/IterArg argument
@@ -72,7 +164,7 @@ std::string MakeStoreResultName(size_t index) {
  * non-converted ops (e.g. tile.load, tile.move) already manage their own tile
  * representation and must NOT get an extra load inserted.
  *
- * Also excludes parameters used by tensor.slice and tensor.matmul since those conversions
+ * Also excludes parameters used by tensor.slice and tensor matmul-family ops since those conversions
  * create their own block.load with proper offsets/memory spaces.
  */
 class TensorArgsInConvertedOpsCollector : public IRVisitor {
@@ -113,9 +205,9 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // Skip ops that manage their own data loading (they create block.load
       // with specific offsets/memory-spaces during conversion, so an extra
       // Phase-1 default Vec load would be redundant or wrong).
-      static const std::unordered_set<std::string> kSelfLoadingOps = {"tensor.slice",      "tensor.matmul",
-                                                                      "tensor.matmul_acc", "tensor.assemble",
-                                                                      "tensor.read",       "tensor.write"};
+      static const std::unordered_set<std::string> kSelfLoadingOps = {
+          "tensor.slice",    "tensor.matmul", "tensor.batch_matmul", "tensor.matmul_acc",
+          "tensor.assemble", "tensor.read",   "tensor.write"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);
         return;
@@ -440,50 +532,57 @@ void InsertBeforeYield(std::vector<StmtPtr>& stmts, size_t yield_index, const St
 }
 
 /**
- * @brief Info about a tensor.slice result that feeds into a tensor.matmul/tensor.matmul_acc operand.
+ * @brief Info about a tensor.slice result that feeds into a tensor matmul-family operand.
  *
- * When a tensor.slice result is consumed by tensor.matmul or tensor.matmul_acc, the slice conversion
- * should produce tile.load(Mat, transpose=...) instead of tile.load(Vec) so that
- * the matmul conversion can skip the load and directly use the Mat-space tile.
+ * When a tensor.slice result is consumed by tensor.matmul, tensor.batch_matmul, or tensor.matmul_acc,
+ * the slice conversion should produce tile.load(Mat, transpose=...) instead of tile.load(Vec) so that
+ * the downstream matmul conversion can skip the load and directly use the Mat-space tile.
+ *
+ * tensor.batch_matmul keeps transpose intent as explicit tile.transpose operands around
+ * tile.batch_matmul, so slice loads feeding tensor.batch_matmul only move data into Mat space
+ * and do not pre-transpose the slice.
  */
 struct MatmulSliceInfo {
-  bool is_rhs;     ///< true if the slice result is the rhs operand of matmul
   bool transpose;  ///< transpose flag from matmul (b_trans for rhs, a_trans for lhs)
 };
 
 /**
- * @brief Visitor that collects tensor.slice results consumed by tensor.matmul/tensor.matmul_acc.
+ * @brief Pre-scan statements to find tensor.slice results consumed by tensor matmul-family ops.
  *
- * Scans the full function body to build a map from slice result variable pointers
- * to their matmul usage info (which side and transpose flag).
+ * Scans a flat list of statements to build a map from slice result variable names
+ * to their matmul usage info (whether the slice load should pre-transpose).
  */
-class MatmulSlicePatternCollector : public IRVisitor {
- public:
-  [[nodiscard]] const std::unordered_map<const Var*, MatmulSliceInfo>& GetTargets() const { return targets_; }
-
- protected:
-  void VisitStmt_(const AssignStmtPtr& op) override {
-    if (!op) return;
-    auto call = As<Call>(op->value_);
-    if (!call) {
-      IRVisitor::VisitStmt_(op);
-      return;
+std::unordered_map<const Var*, MatmulSliceInfo> PreScanSliceMatmulPatterns(
+    const std::vector<StmtPtr>& stmts) {
+  std::unordered_set<const Var*> slice_results;
+  for (const auto& stmt : stmts) {
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) continue;
+    auto call = As<Call>(assign->value_);
+    if (!call) continue;
+    if (call->op_->name_ == "tensor.slice") {
+      slice_results.insert(assign->var_.get());
     }
-
-    const auto& op_name = call->op_->name_;
-    if (op_name == "tensor.slice") {
-      slice_results_.insert(op->var_.get());
-    } else if (op_name == "tensor.matmul" || op_name == "tensor.matmul_acc") {
-      CollectMatmulOperands(call, op_name == "tensor.matmul_acc");
-    }
-    IRVisitor::VisitStmt_(op);
   }
+  if (slice_results.empty()) return {};
 
- private:
-  void CollectMatmulOperands(const CallPtr& call, bool is_acc) {
-    const size_t lhs_idx = is_acc ? 1 : 0;
-    const size_t rhs_idx = is_acc ? 2 : 1;
-    if (call->args_.size() <= rhs_idx) return;
+  std::unordered_map<const Var*, MatmulSliceInfo> result;
+
+  for (const auto& stmt : stmts) {
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) continue;
+    auto call = As<Call>(assign->value_);
+    if (!call || (call->op_->name_ != "tensor.matmul" && call->op_->name_ != "tensor.batch_matmul" &&
+                  call->op_->name_ != "tensor.matmul_acc")) {
+      continue;
+    }
+
+    // tensor.matmul / tensor.batch_matmul: args = [lhs, rhs]
+    // tensor.matmul_acc: args = [acc, lhs, rhs]
+    bool is_acc = (call->op_->name_ == "tensor.matmul_acc");
+    size_t lhs_idx = is_acc ? 1 : 0;
+    size_t rhs_idx = is_acc ? 2 : 1;
+    if (call->args_.size() <= rhs_idx) continue;
 
     bool a_trans = false;
     bool b_trans = false;
@@ -491,289 +590,316 @@ class MatmulSlicePatternCollector : public IRVisitor {
       if (k == "a_trans") a_trans = std::any_cast<bool>(v);
       if (k == "b_trans") b_trans = std::any_cast<bool>(v);
     }
+    const bool pretranspose_slice = (call->op_->name_ != "tensor.batch_matmul");
+
     if (auto lhs_var = As<Var>(call->args_[lhs_idx])) {
-      if (slice_results_.count(lhs_var.get())) targets_[lhs_var.get()] = {false, a_trans};
+      if (slice_results.count(lhs_var.get())) {
+        result[lhs_var.get()] = MatmulSliceInfo{pretranspose_slice && a_trans};
+      }
     }
+
     if (auto rhs_var = As<Var>(call->args_[rhs_idx])) {
-      if (slice_results_.count(rhs_var.get())) targets_[rhs_var.get()] = {true, b_trans};
-    }
-  }
-
-  std::unordered_set<const Var*> slice_results_;
-  std::unordered_map<const Var*, MatmulSliceInfo> targets_;
-};
-
-// ============================================================================
-// TypePropagatingMutator: base class that extends IRMutator with type
-// propagation through control flow (IterArg types, ForStmt/WhileStmt
-// return_vars, IfStmt return_vars from yield types).
-//
-// Subclasses override VisitStmt_(AssignStmtPtr) for domain-specific logic
-// (op conversion, call-site updates, etc.) and call HandlePassThroughAssign
-// for non-converted assignments.
-// ============================================================================
-
-class TypePropagatingMutator : public IRMutator {
- public:
-  /// Add a mapping from an old variable to a new one (populates var_remap_).
-  void AddMapping(const Expr* old_ptr, const ExprPtr& new_expr) { var_remap_[old_ptr] = new_expr; }
-
- protected:
-  /// Override IterArg to propagate type from initValue_ when it changes.
-  /// The base IRMutator preserves the original type; we want the new type
-  /// so that downstream references see the correct (e.g. TileType) type.
-  ExprPtr VisitExpr_(const IterArgPtr& op) override {
-    auto it = var_remap_.find(op.get());
-    if (it != var_remap_.end()) return it->second;
-    auto new_init = VisitExpr(op->initValue_);
-    if (new_init.get() == op->initValue_.get()) return op;
-    return std::make_shared<IterArg>(op->name_hint_, new_init->GetType(), new_init, op->span_);
-  }
-
-  /// Override ForStmt to update return_vars types to match iter_arg types.
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    auto result = IRMutator::VisitStmt_(op);
-    auto new_for = As<ForStmt>(result);
-    if (!new_for) return result;
-    return UpdateLoopReturnVars(
-        new_for->iter_args_, new_for->return_vars_, op->return_vars_,
-        [&](auto new_rv) {
-          return std::make_shared<ForStmt>(
-              new_for->loop_var_, new_for->start_, new_for->stop_, new_for->step_, new_for->iter_args_,
-              new_for->body_, std::move(new_rv), new_for->span_, new_for->kind_, new_for->chunk_size_,
-              new_for->chunk_policy_, new_for->loop_origin_);
-        },
-        result);
-  }
-
-  /// Override WhileStmt to update return_vars types to match iter_arg types.
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    auto result = IRMutator::VisitStmt_(op);
-    auto new_while = As<WhileStmt>(result);
-    if (!new_while) return result;
-    return UpdateLoopReturnVars(
-        new_while->iter_args_, new_while->return_vars_, op->return_vars_,
-        [&](auto new_rv) {
-          return std::make_shared<WhileStmt>(new_while->condition_, new_while->iter_args_, new_while->body_,
-                                             std::move(new_rv), new_while->span_);
-        },
-        result);
-  }
-
-  /// Override IfStmt to (a) isolate var_remap_ per branch and
-  /// (b) update return_vars types from yield types.
-  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
-    auto new_condition = VisitExpr(op->condition_);
-
-    // Save var_remap_ and visit each branch in isolation
-    auto saved_remap = var_remap_;
-    auto new_then_body = VisitStmt(op->then_body_);
-
-    var_remap_ = saved_remap;
-    std::optional<StmtPtr> new_else_body;
-    if (op->else_body_.has_value()) {
-      new_else_body = VisitStmt(*op->else_body_);
-    }
-    var_remap_ = saved_remap;
-
-    // Determine yield types from branches to update return_var types
-    auto yield_types = FindYieldTypes(FlattenToStmts(new_then_body));
-    if (yield_types.empty() && new_else_body.has_value()) {
-      yield_types = FindYieldTypes(FlattenToStmts(*new_else_body));
-    }
-
-    std::vector<VarPtr> new_return_vars;
-    new_return_vars.reserve(op->return_vars_.size());
-    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
-      const auto& rv = op->return_vars_[i];
-      if (i < yield_types.size() && yield_types[i] != rv->GetType()) {
-        auto new_rv = std::make_shared<Var>(rv->name_hint_, yield_types[i], rv->span_);
-        var_remap_[rv.get()] = new_rv;
-        new_return_vars.push_back(new_rv);
-      } else {
-        new_return_vars.push_back(rv);
+      if (slice_results.count(rhs_var.get())) {
+        result[rhs_var.get()] = MatmulSliceInfo{pretranspose_slice && b_trans};
       }
     }
-
-    // Copy-on-write: return original when nothing changed
-    bool rv_changed = (new_return_vars != op->return_vars_);
-    bool else_changed = new_else_body.has_value() != op->else_body_.has_value() ||
-                        (new_else_body.has_value() && new_else_body->get() != op->else_body_->get());
-    if (!rv_changed && new_condition.get() == op->condition_.get() &&
-        new_then_body.get() == op->then_body_.get() && !else_changed) {
-      return op;
-    }
-
-    return std::make_shared<IfStmt>(new_condition, new_then_body, new_else_body, std::move(new_return_vars),
-                                    op->span_);
   }
 
-  /// Handle a non-converted assignment: propagate type change if value type changed.
-  StmtPtr HandlePassThroughAssign(const AssignStmtPtr& op, const ExprPtr& new_value) {
-    if (new_value.get() == op->value_.get()) {
-      // Assignment is unchanged — clear any stale remap so future uses of this Var*
-      // are not rewritten to an older replacement.
-      var_remap_.erase(op->var_.get());
-      return op;
-    }
-    if (new_value->GetType() != op->value_->GetType()) {
-      auto new_var = std::make_shared<Var>(op->var_->name_hint_, new_value->GetType(), op->var_->span_);
-      var_remap_[op->var_.get()] = new_var;
-      return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
-    }
-    // Value changed but type did not — keep original Var, clear any stale remap.
-    var_remap_.erase(op->var_.get());
-    return std::make_shared<AssignStmt>(op->var_, new_value, op->span_);
-  }
+  return result;
+}
 
- private:
-  /// Shared logic for ForStmt/WhileStmt: update return_vars types to match iter_arg types.
-  template <typename ReconstructFn>
-  StmtPtr UpdateLoopReturnVars(const std::vector<IterArgPtr>& new_iter_args,
-                               const std::vector<VarPtr>& new_return_vars,
-                               const std::vector<VarPtr>& orig_return_vars, ReconstructFn reconstruct,
-                               const StmtPtr& original) {
-    bool rv_changed = false;
-    std::vector<VarPtr> updated_rv;
-    updated_rv.reserve(new_return_vars.size());
-    for (size_t i = 0; i < new_return_vars.size(); ++i) {
-      const auto& rv = new_return_vars[i];
-      if (i < new_iter_args.size() && new_iter_args[i]->GetType() != rv->GetType()) {
-        auto updated = std::make_shared<Var>(rv->name_hint_, new_iter_args[i]->GetType(), rv->span_);
-        // Register mapping for both original and current return_var pointers
-        var_remap_[orig_return_vars[i].get()] = updated;
-        if (rv.get() != orig_return_vars[i].get()) var_remap_[rv.get()] = updated;
-        updated_rv.push_back(updated);
-        rv_changed = true;
-      } else {
-        updated_rv.push_back(rv);
+/**
+ * @brief Recursively transform statements in an InCore function body.
+ *
+ * Converts tensor ops to tile ops, handling nested control flow (IfStmt, ForStmt,
+ * WhileStmt, ScopeStmt).
+ */
+std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
+                                         std::unordered_map<const Var*, VarPtr>& tensor_to_tile,
+                                         const OpConversionRegistry& conv_registry,
+                                         const OpRegistry& op_registry, const Span& span) {
+  std::vector<StmtPtr> result;
+
+  auto matmul_slice_targets = PreScanSliceMatmulPatterns(stmts);
+
+  for (const auto& stmt : stmts) {
+    // ReturnStmt: pass through (handled by Phase 3 in TransformIncoreFunction)
+    if (As<ReturnStmt>(stmt)) {
+      result.push_back(stmt);
+      continue;
+    }
+
+    // YieldStmt: substitute variables
+    if (auto yield = As<YieldStmt>(stmt)) {
+      std::vector<ExprPtr> new_values;
+      new_values.reserve(yield->value_.size());
+      bool yield_changed = false;
+      for (const auto& val : yield->value_) {
+        auto new_val = SubstituteExpr(val, tensor_to_tile);
+        new_values.push_back(new_val);
+        if (new_val != val) yield_changed = true;
       }
-    }
-    if (!rv_changed) return original;
-    return reconstruct(std::move(updated_rv));
-  }
-};
-
-// ============================================================================
-// TensorToTileMutator: converts tensor ops to tile ops in InCore function
-// bodies.  Overrides AssignStmt/EvalStmt to run converters from
-// OpConversionRegistry; everything else (control flow recursion, variable
-// substitution, IterArg/return_var type propagation) comes from the base.
-// ============================================================================
-
-class TensorToTileMutator : public TypePropagatingMutator {
- public:
-  TensorToTileMutator(const OpConversionRegistry& conv_registry, const OpRegistry& op_registry,
-                      const std::unordered_map<const Var*, MatmulSliceInfo>& matmul_targets)
-      : conv_registry_(conv_registry), op_registry_(op_registry), matmul_targets_(matmul_targets) {}
-
- protected:
-  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
-    auto new_value = VisitExpr(op->value_);
-    auto call = As<Call>(new_value);
-
-    // Non-call values: propagate type change
-    if (!call) return HandlePassThroughAssign(op, new_value);
-
-    // Function calls (GlobalVar) pass through — only process op calls
-    if (std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
-      LOG_DEBUG << "[TensorToTileMutator] Skipping GlobalVar call: " << call->op_->name_;
-      return HandlePassThroughAssign(op, new_value);
+      if (yield_changed) {
+        result.push_back(std::make_shared<YieldStmt>(new_values, yield->span_));
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
     }
 
-    const auto* converter = conv_registry_.Lookup(call->op_->name_);
+    // SeqStmts: recurse into children
+    if (auto seq = As<SeqStmts>(stmt)) {
+      auto inner = TransformIncoreBody(seq->stmts_, tensor_to_tile, conv_registry, op_registry, span);
+      result.insert(result.end(), inner.begin(), inner.end());
+      continue;
+    }
+
+    // ScopeStmt: recurse into body (transparent scope, defs leak through)
+    if (auto scope = As<ScopeStmt>(stmt)) {
+      auto body_stmts = FlattenToStmts(scope->body_);
+      auto inner = TransformIncoreBody(body_stmts, tensor_to_tile, conv_registry, op_registry, span);
+      result.push_back(std::make_shared<ScopeStmt>(scope->scope_kind_,
+                                                   SeqStmts::Flatten(std::move(inner), scope->body_->span_),
+                                                   scope->span_, scope->level_, scope->role_, scope->split_));
+      continue;
+    }
+
+    // IfStmt: recurse into branches
+    if (auto if_stmt = As<IfStmt>(stmt)) {
+      auto new_condition = SubstituteExpr(if_stmt->condition_, tensor_to_tile);
+
+      // Recurse into then branch with a copy of the map
+      auto then_map = tensor_to_tile;
+      auto then_stmts = FlattenToStmts(if_stmt->then_body_);
+      auto new_then_stmts = TransformIncoreBody(then_stmts, then_map, conv_registry, op_registry, span);
+      // Extract yield types before moving the vector
+      auto yield_types = FindYieldTypes(new_then_stmts);
+      auto new_then_body = SeqStmts::Flatten(std::move(new_then_stmts), if_stmt->then_body_->span_);
+
+      // Recurse into else branch with a copy of the map
+      std::optional<StmtPtr> new_else_body;
+      if (if_stmt->else_body_.has_value()) {
+        auto else_map = tensor_to_tile;
+        auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
+        auto new_else_stmts = TransformIncoreBody(else_stmts, else_map, conv_registry, op_registry, span);
+        new_else_body = SeqStmts::Flatten(std::move(new_else_stmts), (*if_stmt->else_body_)->span_);
+      }
+
+      // Update return_vars types based on yield types (check then branch, fall back to else)
+      if (yield_types.empty() && new_else_body.has_value()) {
+        yield_types = FindYieldTypes(FlattenToStmts(*new_else_body));
+      }
+      auto new_return_vars =
+          UpdateReturnVarTypes(if_stmt->return_vars_, yield_types, tensor_to_tile, /*always_map=*/true);
+
+      result.push_back(std::make_shared<IfStmt>(new_condition, new_then_body, new_else_body, new_return_vars,
+                                                if_stmt->span_));
+      continue;
+    }
+
+    // ForStmt: recurse into body
+    if (auto for_stmt = As<ForStmt>(stmt)) {
+      auto new_start = SubstituteExpr(for_stmt->start_, tensor_to_tile);
+      auto new_stop = SubstituteExpr(for_stmt->stop_, tensor_to_tile);
+      auto new_step = SubstituteExpr(for_stmt->step_, tensor_to_tile);
+
+      auto body_map = tensor_to_tile;
+      auto new_iter_args = SubstituteIterArgs(for_stmt->iter_args_, tensor_to_tile, body_map);
+
+      // Recurse into body
+      auto body_stmts = FlattenToStmts(for_stmt->body_);
+      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
+      auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_);
+
+      auto new_return_vars =
+          UpdateReturnVarTypes(for_stmt->return_vars_, new_iter_args, tensor_to_tile, /*always_map=*/true);
+
+      result.push_back(std::make_shared<ForStmt>(for_stmt->loop_var_, new_start, new_stop, new_step,
+                                                 new_iter_args, new_body, new_return_vars, for_stmt->span_,
+                                                 for_stmt->kind_, for_stmt->chunk_size_,
+                                                 for_stmt->chunk_policy_, for_stmt->loop_origin_));
+      continue;
+    }
+
+    // WhileStmt: recurse into body
+    if (auto while_stmt = As<WhileStmt>(stmt)) {
+      auto body_map = tensor_to_tile;
+      auto new_iter_args = SubstituteIterArgs(while_stmt->iter_args_, tensor_to_tile, body_map);
+
+      // Substitute condition using body_map (condition references iter_arg values)
+      auto new_condition = SubstituteExpr(while_stmt->condition_, body_map);
+
+      // Recurse into body
+      auto body_stmts = FlattenToStmts(while_stmt->body_);
+      auto new_body_stmts = TransformIncoreBody(body_stmts, body_map, conv_registry, op_registry, span);
+      auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), while_stmt->body_->span_);
+
+      auto new_return_vars =
+          UpdateReturnVarTypes(while_stmt->return_vars_, new_iter_args, tensor_to_tile, /*always_map=*/true);
+
+      result.push_back(std::make_shared<WhileStmt>(new_condition, new_iter_args, new_body, new_return_vars,
+                                                   while_stmt->span_));
+      continue;
+    }
+
+    // AssignStmt: convert tensor ops to tile ops
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) {
+      // EvalStmt: apply op conversion and var substitution (same logic as AssignStmt path)
+      auto eval_stmt = As<EvalStmt>(stmt);
+      if (eval_stmt) {
+        auto call = As<Call>(eval_stmt->expr_);
+        if (call && !std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
+          const auto* converter = conv_registry.Lookup(call->op_->name_);
+          if (converter) {
+            std::vector<ExprPtr> substituted_args;
+            substituted_args.reserve(call->args_.size());
+            for (const auto& arg : call->args_) {
+              substituted_args.push_back(SubstituteExpr(arg, tensor_to_tile));
+            }
+            auto conv_result = (*converter)(substituted_args, call->kwargs_, call->span_);
+            auto transformed_prologue =
+                TransformIncoreBody(conv_result.prologue, tensor_to_tile, conv_registry, op_registry, span);
+            for (const auto& prologue_stmt : transformed_prologue) {
+              result.push_back(prologue_stmt);
+            }
+            auto converted_result = SubstituteExpr(conv_result.result, tensor_to_tile);
+            result.push_back(std::make_shared<EvalStmt>(converted_result, eval_stmt->span_));
+            continue;
+          }
+        }
+        // No converter (or non-call): substitute renamed vars in args
+        auto new_expr = SubstituteExpr(eval_stmt->expr_, tensor_to_tile);
+        result.push_back(new_expr != eval_stmt->expr_ ? std::make_shared<EvalStmt>(new_expr, eval_stmt->span_)
+                                                      : stmt);
+      } else {
+        // Non-assign, non-EvalStmt statements pass through unchanged
+        result.push_back(stmt);
+      }
+      continue;
+    }
+
+    auto call = As<Call>(assign->value_);
+    if (!call) {
+      auto new_value = SubstituteExpr(assign->value_, tensor_to_tile);
+      if (new_value != assign->value_) {
+        auto new_var =
+            std::make_shared<Var>(assign->var_->name_hint_, new_value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, new_value, assign->span_));
+        tensor_to_tile[assign->var_.get()] = new_var;
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
+    }
+
+    // Skip function calls (GlobalVar) — only process op calls
+    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    if (global_var) {
+      LOG_WARN << "[TransformIncoreBody] Skipping GlobalVar call: " << call->op_->name_;
+      auto new_value = SubstituteExpr(assign->value_, tensor_to_tile);
+      if (new_value != assign->value_) {
+        auto new_var =
+            std::make_shared<Var>(assign->var_->name_hint_, new_value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, new_value, assign->span_));
+        tensor_to_tile[assign->var_.get()] = new_var;
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
+    }
+
+    const auto* converter = conv_registry.Lookup(call->op_->name_);
     if (!converter) {
-      // Verify unregistered TensorOps are expected passthroughs
-      if (op_registry_.IsRegistered(call->op_->name_)) {
-        const auto& entry = op_registry_.GetEntry(call->op_->name_);
-        static const std::unordered_set<std::string> kPassthroughTensorOps = {"tensor.dim"};
+      // TensorOps must always have a registered conversion, except for ops that are
+      // handled directly by backend codegen and never need conversion in InCore bodies.
+      if (op_registry.IsRegistered(call->op_->name_)) {
+        const auto& entry = op_registry.GetEntry(call->op_->name_);
+        static const std::unordered_set<std::string> kPassthroughTensorOps = {
+            "tensor.dim",  // queries gm_tensor dimensions; backend codegen handles it directly
+        };
         INTERNAL_CHECK(entry.GetOpCategory() != "TensorOp" || kPassthroughTensorOps.count(call->op_->name_))
             << "TensorOp \"" << call->op_->name_ << "\" has no registered tile conversion. "
             << "Add a conversion in src/ir/transforms/op_conversion_registry.cpp.";
       }
-      return HandlePassThroughAssign(op, new_value);
+      auto new_value = SubstituteExpr(assign->value_, tensor_to_tile);
+      if (new_value != assign->value_) {
+        auto new_var =
+            std::make_shared<Var>(assign->var_->name_hint_, new_value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, new_value, assign->span_));
+        tensor_to_tile[assign->var_.get()] = new_var;
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
     }
 
-    // Special: tensor.slice feeding into tensor.matmul → tile.load(Mat)
-    if (call->op_->name_ == "tensor.slice" && matmul_targets_.count(op->var_.get())) {
-      auto mat_load = HandleMatmulSlice(op, call);
-      if (mat_load) return mat_load;
+    // Substitute args and call the converter
+    std::vector<ExprPtr> substituted_args;
+    substituted_args.reserve(call->args_.size());
+    for (const auto& arg : call->args_) {
+      substituted_args.push_back(SubstituteExpr(arg, tensor_to_tile));
     }
 
-    // Run the converter
-    auto conv_result = (*converter)(call->args_, call->kwargs_, call->span_);
+    // Special handling: tensor.slice feeding into tensor matmul-family ops
+    // Generate tile.load(Mat, transpose=xx) instead of the default tile.load(Vec)
+    if (call->op_->name_ == "tensor.slice" && matmul_slice_targets.count(assign->var_.get())) {
+      const auto& info = matmul_slice_targets.at(assign->var_.get());
+      const auto& input = substituted_args[0];
+      auto tensor_type = As<TensorType>(input->GetType());
+      if (tensor_type) {
+        // Use the slice's offset and shape args (args[1]=shape, args[2]=offset)
+        const auto& shape_arg = substituted_args[1];
+        const auto& offset_arg = substituted_args[2];
 
-    // Prologue statements may themselves contain tensor ops — recurse
-    std::vector<StmtPtr> stmts;
-    stmts.reserve(conv_result.prologue.size() + 1);
-    for (auto& prologue_stmt : conv_result.prologue) {
-      stmts.push_back(VisitStmt(prologue_stmt));
+        // Shapes and valid_shapes use original (source tensor) coordinates.
+        // DeduceTileLoadType swaps internally when transpose=true.
+        ExprPtr load_shapes = shape_arg;
+        ExprPtr valid_shapes_base = (substituted_args.size() == 4) ? substituted_args[3] : shape_arg;
+
+        auto valid_shapes = valid_shapes_base;
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Mat},
+                                                                     {"transpose", info.transpose}};
+        auto load_call = op_registry.Create("tile.load", {input, offset_arg, load_shapes, valid_shapes},
+                                            load_kwargs, span);
+
+        std::string tile_name = MakeTileValueName(assign->var_->name_hint_);
+        auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(tile_var, load_call, assign->span_));
+        tensor_to_tile[assign->var_.get()] = tile_var;
+        continue;
+      }
     }
 
-    // Revisit result after mutating prologue — prologue conversions may have
-    // remapped vars that the result expression references.
-    auto new_result = VisitExpr(conv_result.result);
+    auto conv_result = (*converter)(substituted_args, call->kwargs_, call->span_);
 
-    auto tile_name = MakeTileValueName(op->var_->name_hint_);
-    auto tile_var = std::make_shared<Var>(tile_name, new_result->GetType(), op->var_->span_);
-    stmts.push_back(std::make_shared<AssignStmt>(tile_var, new_result, op->span_));
-    var_remap_[op->var_.get()] = tile_var;
+    // Prologue statements may themselves contain tensor ops (e.g. tensor.create
+    // used as a scratch buffer). Run them through the same conversion pipeline.
+    auto transformed_prologue =
+        TransformIncoreBody(conv_result.prologue, tensor_to_tile, conv_registry, op_registry, span);
+    for (const auto& prologue_stmt : transformed_prologue) {
+      result.push_back(prologue_stmt);
+    }
 
-    return SeqStmts::Flatten(std::move(stmts), op->span_);
+    // Apply tensor→tile variable substitution to the conversion result so that
+    // any references to already-converted tensor vars are replaced. When the
+    // substituted result is itself just a Var (pure alias, e.g. LoadOperandToMat
+    // returned an already-TileType operand unchanged), record the alias directly
+    // in tensor_to_tile without emitting a redundant AssignStmt.
+    auto converted_result = SubstituteExpr(conv_result.result, tensor_to_tile);
+    if (auto converted_var = As<Var>(converted_result)) {
+      tensor_to_tile[assign->var_.get()] = converted_var;
+      continue;
+    }
+
+    std::string tile_name = MakeTileValueName(assign->var_->name_hint_);
+    auto tile_var = std::make_shared<Var>(tile_name, converted_result->GetType(), assign->var_->span_);
+    result.push_back(std::make_shared<AssignStmt>(tile_var, converted_result, assign->span_));
+    tensor_to_tile[assign->var_.get()] = tile_var;
   }
 
-  StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
-    auto new_expr = VisitExpr(op->expr_);
-    // Helper: return updated EvalStmt only when the expression actually changed.
-    auto maybe_update = [&]() -> StmtPtr {
-      return (new_expr.get() != op->expr_.get()) ? std::make_shared<EvalStmt>(new_expr, op->span_) : op;
-    };
-
-    auto call = As<Call>(new_expr);
-    if (!call || std::dynamic_pointer_cast<const GlobalVar>(call->op_)) return maybe_update();
-
-    const auto* converter = conv_registry_.Lookup(call->op_->name_);
-    if (!converter) return maybe_update();
-
-    auto conv_result = (*converter)(call->args_, call->kwargs_, call->span_);
-    std::vector<StmtPtr> stmts;
-    stmts.reserve(conv_result.prologue.size() + 1);
-    for (auto& prologue_stmt : conv_result.prologue) {
-      stmts.push_back(VisitStmt(prologue_stmt));
-    }
-    auto new_result = VisitExpr(conv_result.result);
-    stmts.push_back(std::make_shared<EvalStmt>(new_result, op->span_));
-    return SeqStmts::Flatten(std::move(stmts), op->span_);
-  }
-
- private:
-  /// Handle tensor.slice that feeds into tensor.matmul — produce tile.load(Mat).
-  StmtPtr HandleMatmulSlice(const AssignStmtPtr& op, const CallPtr& call) {
-    const auto& info = matmul_targets_.at(op->var_.get());
-    const auto& input = call->args_[0];
-    auto tensor_type = As<TensorType>(input->GetType());
-    if (!tensor_type) return nullptr;
-
-    const auto& shape_arg = call->args_[1];
-    const auto& offset_arg = call->args_[2];
-    ExprPtr valid_shapes = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
-
-    std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Mat},
-                                                                 {"transpose", info.transpose}};
-    auto load_call = op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shapes},
-                                         load_kwargs, call->span_);
-
-    auto tile_name = MakeTileValueName(op->var_->name_hint_);
-    auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), op->var_->span_);
-    var_remap_[op->var_.get()] = tile_var;
-    return std::make_shared<AssignStmt>(tile_var, load_call, op->span_);
-  }
-
-  const OpConversionRegistry& conv_registry_;
-  const OpRegistry& op_registry_;
-  const std::unordered_map<const Var*, MatmulSliceInfo>&
-      matmul_targets_;  // owned by MatmulSlicePatternCollector — must outlive this mutator
-};
+  return result;
+}
 
 class VarUseVisitor : public IRVisitor {
  public:
@@ -898,6 +1024,35 @@ bool StmtUsesVar(const StmtPtr& stmt, const Var* target) {
   VarUseVisitor visitor(target);
   visitor.CheckStmt(stmt);
   return visitor.Found();
+}
+
+class UsedVarCollector : public IRVisitor {
+ public:
+  [[nodiscard]] const std::unordered_set<const Var*>& GetUsed() const { return used_; }
+
+  void CollectStmt(const StmtPtr& stmt) {
+    if (!stmt) return;
+    VisitStmt(stmt);
+  }
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override { used_.insert(op.get()); }
+
+  void VisitExpr_(const IterArgPtr& op) override { VisitVarLike_(op); }
+
+ private:
+  std::unordered_set<const Var*> used_;
+};
+
+/// Collect all Var nodes referenced (read) by the given statements.
+/// Used to determine which Out params are actually used in the function body,
+/// so that unused Out params can be reused as store targets for return values.
+std::unordered_set<const Var*> CollectUsedVars(const std::vector<StmtPtr>& stmts) {
+  UsedVarCollector collector;
+  for (const auto& stmt : stmts) {
+    collector.CollectStmt(stmt);
+  }
+  return collector.GetUsed();
 }
 
 using ParamOrigins = std::vector<size_t>;
@@ -1443,14 +1598,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
   auto& op_registry = OpRegistry::GetInstance();
   const auto& span = func->span_;
 
-  // Pre-scan for tensor.slice → tensor.matmul patterns (need Mat-space loads).
-  MatmulSlicePatternCollector matmul_collector;
-  matmul_collector.VisitStmt(func->body_);
+  std::unordered_map<const Var*, VarPtr> tensor_to_tile;
 
-  // Create the body mutator
-  TensorToTileMutator mutator(conv_registry, op_registry, matmul_collector.GetTargets());
-
-  // New body statements (prefix tile.loads + mutated body)
+  // New body statements
   std::vector<StmtPtr> new_stmts;
 
   // Phase 1: Insert tile.load for each TensorType parameter that is directly consumed
@@ -1464,24 +1614,33 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
 
   for (const auto& var : func->params_) {
     auto tensor_type = As<TensorType>(var->GetType());
-    if (!tensor_type) continue;
+    if (!tensor_type) {
+      continue;  // ScalarType params pass through unchanged
+    }
 
-    if (params_used_by_converted_ops.find(var.get()) == params_used_by_converted_ops.end()) continue;
+    // Only synthesise a default Vec load when the parameter is directly passed to an op
+    // that has a registered tensor-to-tile converter.  If the function body already
+    // uses the parameter via explicit tile ops (e.g. tile.load to Mat space), skip it.
+    if (params_used_by_converted_ops.find(var.get()) == params_used_by_converted_ops.end()) {
+      continue;
+    }
 
+    // Create tile.load(var, zeros, shape, valid_shapes=shape, target_memory=Vec)
     auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
     auto shapes = MakeShapeTuple(tensor_type->shape_, span);
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
                                                                  {"transpose", false}};
     auto load_call = op_registry.Create("tile.load", {var, offsets, shapes, shapes}, load_kwargs, span);
 
+    // Create tile variable
     std::string tile_name = MakeTileValueName(var->name_hint_);
     auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), span);
 
     new_stmts.push_back(std::make_shared<AssignStmt>(tile_var, load_call, span));
-    mutator.AddMapping(var.get(), tile_var);
+    tensor_to_tile[var.get()] = tile_var;
   }
 
-  // Phase 2: Transform body via mutator (handles control flow recursion + op conversion)
+  // Phase 2: Walk body and convert tensor ops to tile ops (recursive for nested control flow)
   auto body_stmts = FlattenToStmts(func->body_);
 
   // Separate return statement from body (will be replaced in Phase 3)
@@ -1495,9 +1654,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
     }
   }
 
-  auto body_to_transform = SeqStmts::Flatten(std::move(non_return_stmts), span);
-  auto mutated = mutator.VisitStmt(body_to_transform);
-  auto transformed = FlattenToStmts(mutated);
+  auto transformed = TransformIncoreBody(non_return_stmts, tensor_to_tile, conv_registry, op_registry, span);
   new_stmts.insert(new_stmts.end(), transformed.begin(), transformed.end());
 
   // Phase 3: Add output params + tile.store for return values
@@ -1506,7 +1663,53 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
   std::vector<TypePtr> new_return_types;
   size_t num_added_outputs = 0;
   std::unordered_set<size_t> merged_return_indices;
+  // Collect reusable tensor output params for matching with return values.
+  // IterArg InOut returns are stored back to the existing InOut param instead
+  // of creating a new Out param. Plain Out params are only reused when they
+  // are otherwise unused in the function body.
+  std::unordered_map<std::string, VarPtr> inout_param_by_base;
+  std::unordered_map<std::string, VarPtr> reusable_out_param_by_base;
+  std::vector<VarPtr> reusable_out_params;
+  std::unordered_set<const Var*> claimed_out_params;
+  size_t next_reusable_out_param = 0;
+  auto used_vars_in_body = CollectUsedVars(non_return_stmts);
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    if (!As<TensorType>(func->params_[i]->GetType())) {
+      continue;
+    }
+    if (func->param_directions_[i] == ParamDirection::InOut) {
+      inout_param_by_base[auto_name::GetBaseName(func->params_[i]->name_hint_)] = func->params_[i];
+      continue;
+    }
+    if (func->param_directions_[i] != ParamDirection::Out) {
+      continue;
+    }
+    if (used_vars_in_body.count(func->params_[i].get()) == 0) {
+      reusable_out_params.push_back(func->params_[i]);
+      reusable_out_param_by_base[auto_name::GetBaseName(func->params_[i]->name_hint_)] = func->params_[i];
+    }
+  }
 
+  auto claim_existing_out_param = [&](const VarPtr& candidate) -> VarPtr {
+    if (!candidate) return nullptr;
+    return claimed_out_params.insert(candidate.get()).second ? candidate : nullptr;
+  };
+
+  auto claim_next_reusable_out_param = [&](const TensorTypePtr& required_type) -> VarPtr {
+    while (next_reusable_out_param < reusable_out_params.size()) {
+      auto candidate = reusable_out_params[next_reusable_out_param++];
+      if (claimed_out_params.count(candidate.get()) > 0) continue;
+      // Only reuse if the candidate's tensor type matches shape and dtype.
+      auto cand_type = As<TensorType>(candidate->GetType());
+      if (!cand_type || cand_type->dtype_ != required_type->dtype_ ||
+          cand_type->shape_.size() != required_type->shape_.size()) {
+        continue;
+      }
+      claimed_out_params.insert(candidate.get());
+      return candidate;
+    }
+    return nullptr;
+  };
   if (return_stmt) {
     std::vector<ExprPtr> new_return_exprs;
 
@@ -1542,7 +1745,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
       }
 
       for (size_t i = 0; i < return_stmt->value_.size(); ++i) {
-        auto ret_expr = mutator.VisitExpr(return_stmt->value_[i]);
+        auto ret_expr = SubstituteExpr(return_stmt->value_[i], tensor_to_tile);
         auto ret_var = As<Var>(ret_expr);
         if (!ret_var || !As<TileType>(ret_var->GetType())) continue;
 
@@ -1628,19 +1831,19 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
             std::make_shared<IfStmt>(last_if_stmt->condition_, new_then_body, new_else_body, new_rv, span);
         new_stmts[last_if_index] = new_if_stmt;
 
-        // Update mutator mappings so Phase 3b sees the new TensorType return vars.
+        // Update tensor_to_tile so Phase 3b sees the new TensorType return vars.
         for (const auto& cand : sink_candidates) {
           const auto& new_var = new_rv[cand.ifstmt_rv_index];
-          mutator.AddMapping(last_if_stmt->return_vars_[cand.ifstmt_rv_index].get(), new_var);
+          tensor_to_tile[last_if_stmt->return_vars_[cand.ifstmt_rv_index].get()] = new_var;
           auto orig_ret_var = As<Var>(return_stmt->value_[cand.return_index]);
-          if (orig_ret_var) mutator.AddMapping(orig_ret_var.get(), new_var);
+          if (orig_ret_var) tensor_to_tile[orig_ret_var.get()] = new_var;
         }
       }
     }
 
     // Phase 3b: Process each return value
     for (size_t i = 0; i < return_stmt->value_.size(); ++i) {
-      auto ret_expr = mutator.VisitExpr(return_stmt->value_[i]);
+      auto ret_expr = SubstituteExpr(return_stmt->value_[i], tensor_to_tile);
 
       // If this return was merged into an In param via IfStmt store sinking,
       // no new Out param needed — just pass through the TensorType result.
@@ -1678,11 +1881,35 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
           continue;
         }
 
-        // Add output tensor parameter
-        std::string out_name = MakeOutParamName(num_added_outputs);
-        auto out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
-        new_params.push_back(out_param);
-        new_param_directions.push_back(ParamDirection::Out);
+        // Determine target param: reuse existing InOut/Out param or create new Out param.
+        VarPtr out_param;
+        bool created_new_output_param = false;
+        auto orig_ret_var = As<Var>(return_stmt->value_[i]);
+        if (orig_ret_var) {
+          std::string ret_base = auto_name::GetBaseName(orig_ret_var->name_hint_);
+          auto inout_it = inout_param_by_base.find(ret_base);
+          if (inout_it != inout_param_by_base.end()) {
+            out_param = inout_it->second;
+            inout_param_by_base.erase(inout_it);
+          }
+          if (!out_param) {
+            auto out_it = reusable_out_param_by_base.find(ret_base);
+            if (out_it != reusable_out_param_by_base.end()) {
+              out_param = claim_existing_out_param(out_it->second);
+            }
+          }
+        }
+        if (!out_param) {
+          out_param = claim_next_reusable_out_param(orig_tensor_type);
+        }
+        if (!out_param) {
+          // Add new output tensor parameter
+          std::string out_name = MakeOutParamName(num_added_outputs);
+          out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
+          new_params.push_back(out_param);
+          new_param_directions.push_back(ParamDirection::Out);
+          created_new_output_param = true;
+        }
 
         if (auto loop_rewrite = RewriteReturnedAssembleLoopToStore(new_stmts, ret_expr, out_param,
                                                                    orig_tensor_type, op_registry)) {
@@ -1693,7 +1920,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
           }
           new_return_types.push_back(orig_tensor_type);
           new_return_exprs.push_back(loop_rewrite->new_return_var);
-          ++num_added_outputs;
+          if (created_new_output_param) ++num_added_outputs;
           continue;
         }
 
@@ -1701,13 +1928,12 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
         auto offsets = MakeZeroOffsets(tile_type->shape_.size(), span);
         auto store_call = op_registry.Create("tile.store", {ret_expr, offsets, out_param}, span);
 
-        auto store_var =
-            std::make_shared<Var>(MakeStoreResultName(num_added_outputs), store_call->GetType(), span);
+        auto store_var = std::make_shared<Var>(MakeStoreResultName(i), store_call->GetType(), span);
         new_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
 
         new_return_types.push_back(store_call->GetType());
         new_return_exprs.push_back(store_var);
-        ++num_added_outputs;
+        if (created_new_output_param) ++num_added_outputs;
       } else {
         // Non-tile return values pass through
         new_return_types.push_back(ret_expr->GetType());
@@ -1735,45 +1961,204 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
   return {new_func, num_added_outputs};
 }
 
-// ============================================================================
-// CallSiteUpdateMutator: updates call sites in orchestration/opaque functions.
-// For each call to a transformed InCore function, inserts tensor.create for
-// output params and adds them as extra arguments.
-// ============================================================================
+/**
+ * @brief Recursively update call sites in statement lists.
+ *
+ * For each call to a transformed InCore function, inserts tensor.create for output params
+ * and adds them as extra arguments. Handles nested control flow.
+ */
+std::vector<StmtPtr> UpdateCallSitesBody(
+    const std::vector<StmtPtr>& stmts, std::unordered_map<const Var*, VarPtr>& var_map,
+    const std::unordered_map<std::string, size_t>& incore_added_outputs,
+    const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs,
+    const OpRegistry& op_registry, const Span& span, bool& changed) {
+  std::vector<StmtPtr> result;
 
-class CallSiteUpdateMutator : public TypePropagatingMutator {
- public:
-  CallSiteUpdateMutator(const std::unordered_map<std::string, size_t>& incore_added_outputs,
-                        const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs,
-                        const OpRegistry& op_registry)
-      : incore_added_outputs_(incore_added_outputs),
-        transformed_incore_funcs_(transformed_incore_funcs),
-        op_registry_(op_registry) {}
-
- protected:
-  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
-    auto new_value = VisitExpr(op->value_);
-    auto call = As<Call>(new_value);
-
-    // Non-call or non-GlobalVar: propagate type change
-    if (!call) return HandlePassThroughAssign(op, new_value);
-    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
-    if (!global_var) return HandlePassThroughAssign(op, new_value);
-
-    // Not a transformed InCore function: propagate type change
-    auto it = incore_added_outputs_.find(global_var->name_);
-    if (it == incore_added_outputs_.end() || it->second == 0) {
-      return HandlePassThroughAssign(op, new_value);
+  for (const auto& stmt : stmts) {
+    // ReturnStmt: substitute vars
+    if (auto ret = As<ReturnStmt>(stmt)) {
+      if (!var_map.empty()) {
+        std::vector<ExprPtr> new_ret_exprs;
+        new_ret_exprs.reserve(ret->value_.size());
+        for (const auto& expr : ret->value_) {
+          new_ret_exprs.push_back(SubstituteExpr(expr, var_map));
+        }
+        result.push_back(std::make_shared<ReturnStmt>(new_ret_exprs, ret->span_));
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
     }
 
-    // This call targets a transformed InCore function — add output tensor args
+    // YieldStmt: substitute vars
+    if (auto yield = As<YieldStmt>(stmt)) {
+      if (!var_map.empty()) {
+        std::vector<ExprPtr> new_values;
+        new_values.reserve(yield->value_.size());
+        for (const auto& val : yield->value_) {
+          new_values.push_back(SubstituteExpr(val, var_map));
+        }
+        result.push_back(std::make_shared<YieldStmt>(new_values, yield->span_));
+      } else {
+        result.push_back(stmt);
+      }
+      continue;
+    }
+
+    // SeqStmts: recurse
+    if (auto seq = As<SeqStmts>(stmt)) {
+      auto inner = UpdateCallSitesBody(seq->stmts_, var_map, incore_added_outputs, transformed_incore_funcs,
+                                       op_registry, span, changed);
+      result.insert(result.end(), inner.begin(), inner.end());
+      continue;
+    }
+
+    // ScopeStmt: recurse
+    if (auto scope = As<ScopeStmt>(stmt)) {
+      auto body_stmts = FlattenToStmts(scope->body_);
+      auto inner = UpdateCallSitesBody(body_stmts, var_map, incore_added_outputs, transformed_incore_funcs,
+                                       op_registry, span, changed);
+      result.push_back(std::make_shared<ScopeStmt>(scope->scope_kind_,
+                                                   SeqStmts::Flatten(std::move(inner), scope->body_->span_),
+                                                   scope->span_, scope->level_, scope->role_, scope->split_));
+      continue;
+    }
+
+    // IfStmt: recurse into branches
+    if (auto if_stmt = As<IfStmt>(stmt)) {
+      auto new_condition = SubstituteExpr(if_stmt->condition_, var_map);
+
+      auto then_map = var_map;
+      auto then_stmts = FlattenToStmts(if_stmt->then_body_);
+      auto new_then_stmts = UpdateCallSitesBody(then_stmts, then_map, incore_added_outputs,
+                                                transformed_incore_funcs, op_registry, span, changed);
+      // Extract yield types before moving the vector
+      auto yield_types = FindYieldTypes(new_then_stmts);
+      auto new_then_body = SeqStmts::Flatten(std::move(new_then_stmts), if_stmt->then_body_->span_);
+
+      std::optional<StmtPtr> new_else_body;
+      if (if_stmt->else_body_.has_value()) {
+        auto else_map = var_map;
+        auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
+        auto new_else_stmts = UpdateCallSitesBody(else_stmts, else_map, incore_added_outputs,
+                                                  transformed_incore_funcs, op_registry, span, changed);
+        new_else_body = SeqStmts::Flatten(std::move(new_else_stmts), (*if_stmt->else_body_)->span_);
+      }
+
+      // Update return_vars types based on yield types (check then branch, fall back to else)
+      if (yield_types.empty() && new_else_body.has_value()) {
+        yield_types = FindYieldTypes(FlattenToStmts(*new_else_body));
+      }
+      auto new_return_vars =
+          UpdateReturnVarTypes(if_stmt->return_vars_, yield_types, var_map, /*always_map=*/false);
+
+      result.push_back(std::make_shared<IfStmt>(new_condition, new_then_body, new_else_body, new_return_vars,
+                                                if_stmt->span_));
+      continue;
+    }
+
+    // ForStmt: recurse into body
+    if (auto for_stmt = As<ForStmt>(stmt)) {
+      auto new_start = SubstituteExpr(for_stmt->start_, var_map);
+      auto new_stop = SubstituteExpr(for_stmt->stop_, var_map);
+      auto new_step = SubstituteExpr(for_stmt->step_, var_map);
+
+      auto body_map = var_map;
+      auto new_iter_args = SubstituteIterArgs(for_stmt->iter_args_, var_map, body_map);
+
+      auto body_stmts = FlattenToStmts(for_stmt->body_);
+      auto new_body_stmts = UpdateCallSitesBody(body_stmts, body_map, incore_added_outputs,
+                                                transformed_incore_funcs, op_registry, span, changed);
+      auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_);
+
+      auto new_return_vars =
+          UpdateReturnVarTypes(for_stmt->return_vars_, new_iter_args, var_map, /*always_map=*/false);
+
+      result.push_back(std::make_shared<ForStmt>(for_stmt->loop_var_, new_start, new_stop, new_step,
+                                                 new_iter_args, new_body, new_return_vars, for_stmt->span_,
+                                                 for_stmt->kind_, for_stmt->chunk_size_,
+                                                 for_stmt->chunk_policy_, for_stmt->loop_origin_));
+      continue;
+    }
+
+    // WhileStmt: recurse into body
+    if (auto while_stmt = As<WhileStmt>(stmt)) {
+      auto body_map = var_map;
+      auto new_iter_args = SubstituteIterArgs(while_stmt->iter_args_, var_map, body_map);
+
+      auto new_condition = SubstituteExpr(while_stmt->condition_, body_map);
+
+      auto body_stmts = FlattenToStmts(while_stmt->body_);
+      auto new_body_stmts = UpdateCallSitesBody(body_stmts, body_map, incore_added_outputs,
+                                                transformed_incore_funcs, op_registry, span, changed);
+      auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), while_stmt->body_->span_);
+
+      auto new_return_vars =
+          UpdateReturnVarTypes(while_stmt->return_vars_, new_iter_args, var_map, /*always_map=*/false);
+
+      result.push_back(std::make_shared<WhileStmt>(new_condition, new_iter_args, new_body, new_return_vars,
+                                                   while_stmt->span_));
+      continue;
+    }
+
+    // AssignStmt: existing call-site update logic
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) {
+      result.push_back(stmt);
+      continue;
+    }
+
+    auto value = var_map.empty() ? assign->value_ : SubstituteExpr(assign->value_, var_map);
+
+    auto call = As<Call>(value);
+    if (!call) {
+      if (value != assign->value_) {
+        auto new_var = std::make_shared<Var>(assign->var_->name_hint_, value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, value, assign->span_));
+        var_map[assign->var_.get()] = new_var;
+        changed = true;
+      } else {
+        result.push_back(stmt);
+        var_map.erase(assign->var_.get());
+      }
+      continue;
+    }
+
+    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    if (!global_var) {
+      if (value != assign->value_) {
+        auto new_var = std::make_shared<Var>(assign->var_->name_hint_, value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, value, assign->span_));
+        var_map[assign->var_.get()] = new_var;
+        changed = true;
+      } else {
+        result.push_back(stmt);
+        var_map.erase(assign->var_.get());
+      }
+      continue;
+    }
+
+    auto it = incore_added_outputs.find(global_var->name_);
+    if (it == incore_added_outputs.end() || it->second == 0) {
+      if (value != assign->value_) {
+        auto new_var = std::make_shared<Var>(assign->var_->name_hint_, value->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, value, assign->span_));
+        var_map[assign->var_.get()] = new_var;
+        changed = true;
+      } else {
+        result.push_back(stmt);
+        var_map.erase(assign->var_.get());
+      }
+      continue;
+    }
+
+    // This call targets a transformed InCore function — need to add output tensor args
     size_t num_outputs = it->second;
-    auto incore_func_it = transformed_incore_funcs_.find(global_var->name_);
-    INTERNAL_CHECK(incore_func_it != transformed_incore_funcs_.end())
+    auto incore_func_it = transformed_incore_funcs.find(global_var->name_);
+    INTERNAL_CHECK(incore_func_it != transformed_incore_funcs.end())
         << "Internal error: transformed InCore function not found: " << global_var->name_;
     const auto& incore_func = incore_func_it->second;
 
-    std::vector<StmtPtr> stmts;
     std::vector<ExprPtr> extra_args;
     size_t orig_param_count = incore_func->params_.size() - num_outputs;
 
@@ -1782,15 +2167,15 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
       auto out_tensor_type = As<TensorType>(out_param->GetType());
       INTERNAL_CHECK(out_tensor_type) << "Internal error: output param is not TensorType";
 
-      auto shape_tuple = MakeShapeTuple(out_tensor_type->shape_, call->span_);
+      auto shape_tuple = MakeShapeTuple(out_tensor_type->shape_, span);
       TensorLayout layout = out_tensor_type->tensor_view_.has_value() ? out_tensor_type->tensor_view_->layout
                                                                       : TensorLayout::ND;
       std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", out_tensor_type->dtype_},
                                                                      {"layout", layout}};
-      auto create_call = op_registry_.Create("tensor.create", {shape_tuple}, create_kwargs, call->span_);
+      auto create_call = op_registry.Create("tensor.create", {shape_tuple}, create_kwargs, span);
 
-      auto out_var = std::make_shared<Var>(MakeOutParamName(i), create_call->GetType(), call->span_);
-      stmts.push_back(std::make_shared<AssignStmt>(out_var, create_call, op->span_));
+      auto out_var = std::make_shared<Var>(MakeOutParamName(i), create_call->GetType(), span);
+      result.push_back(std::make_shared<AssignStmt>(out_var, create_call, span));
       extra_args.push_back(out_var);
     }
 
@@ -1813,30 +2198,42 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
       new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
     }
 
-    auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
-    stmts.push_back(std::make_shared<AssignStmt>(new_assign_var, new_call, op->span_));
-    var_remap_[op->var_.get()] = new_assign_var;
-
-    return SeqStmts::Flatten(std::move(stmts), op->span_);
+    auto new_assign_var =
+        std::make_shared<Var>(assign->var_->name_hint_, new_return_type, assign->var_->span_);
+    result.push_back(std::make_shared<AssignStmt>(new_assign_var, new_call, assign->span_));
+    var_map[assign->var_.get()] = new_assign_var;
+    changed = true;
   }
 
- private:
-  const std::unordered_map<std::string, size_t>& incore_added_outputs_;
-  const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs_;
-  const OpRegistry& op_registry_;
-};
+  return result;
+}
 
 /**
- * @brief Update call sites in orchestration/opaque functions.
+ * @brief Update call sites in orchestration/opaque functions
+ *
+ * For each call to a transformed InCore function, insert tensor.create for output params
+ * and add them as extra arguments. Handles nested control flow recursively.
  */
 FunctionPtr UpdateCallSites(const FunctionPtr& func,
                             const std::unordered_map<std::string, size_t>& incore_added_outputs,
                             const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs) {
-  CallSiteUpdateMutator mutator(incore_added_outputs, transformed_incore_funcs, OpRegistry::GetInstance());
-  auto new_body = mutator.VisitStmt(func->body_);
-  if (new_body.get() == func->body_.get()) return func;
+  auto& op_registry = OpRegistry::GetInstance();
+  const auto& span = func->span_;
+
+  auto body_stmts = FlattenToStmts(func->body_);
+  bool changed = false;
+  std::unordered_map<const Var*, VarPtr> var_map;
+
+  auto new_stmts = UpdateCallSitesBody(body_stmts, var_map, incore_added_outputs, transformed_incore_funcs,
+                                       op_registry, span, changed);
+
+  if (!changed) {
+    return func;
+  }
+
+  auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
+                                    new_body, span, func->func_type_, func->level_, func->role_,
                                     func->attrs_);
 }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -29,6 +29,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
@@ -72,6 +73,31 @@ using tpop_chain::NormalizeTpopChains;
 
 // Use the shared utility; local alias preserves call sites.
 const auto& FlattenBody = transform_utils::FlattenToStmts;
+
+/// Check if the function body directly returns a writable (Out/InOut) parameter.
+/// Used to preserve the writable-param-return pattern during mixed-kernel
+/// expansion: when the AIV sub-function returns its Out param, the group
+/// function must return the same param instead of a fresh result variable.
+std::optional<size_t> FindReturnedWritableParamIndex(const StmtPtr& body, const std::vector<VarPtr>& params,
+                                                     const std::vector<ParamDirection>& param_directions) {
+  if (!body) return std::nullopt;
+
+  const auto flat_stmts = FlattenBody(body);
+  if (flat_stmts.empty()) return std::nullopt;
+
+  auto ret = As<ReturnStmt>(flat_stmts.back());
+  if (!ret || ret->value_.size() != 1) return std::nullopt;
+
+  auto ret_var = As<Var>(ret->value_[0]);
+  if (!ret_var) return std::nullopt;
+
+  for (size_t i = 0; i < params.size() && i < param_directions.size(); ++i) {
+    if (param_directions[i] == ParamDirection::In) continue;
+    if (params[i].get() == ret_var.get()) return i;
+  }
+
+  return std::nullopt;
+}
 
 // ============================================================================
 // Recursive Affinity Analysis
@@ -759,6 +785,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
 
   auto aiv_call = aiv_return_type ? std::make_shared<Call>(aiv_gvar, call_args, aiv_return_type, func->span_)
                                   : std::make_shared<Call>(aiv_gvar, call_args, func->span_);
+  auto returned_writable_param_index =
+      FindReturnedWritableParamIndex(aiv_cloned_body, aiv_params, func->param_directions_);
 
   // Build group body
   std::vector<StmtPtr> group_stmts;
@@ -766,6 +794,10 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
 
   if (func->return_types_.empty()) {
     group_stmts.push_back(std::make_shared<EvalStmt>(aiv_call, func->span_));
+  } else if (returned_writable_param_index.has_value()) {
+    group_stmts.push_back(std::make_shared<EvalStmt>(aiv_call, func->span_));
+    std::vector<ExprPtr> return_exprs = {group_params[*returned_writable_param_index]};
+    group_stmts.push_back(std::make_shared<ReturnStmt>(return_exprs, func->span_));
   } else {
     // Assign AIV result and return it
     auto result_var = std::make_shared<Var>("result", aiv_return_type, func->span_);
@@ -775,9 +807,9 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   }
 
   auto group_body = SeqStmts::Flatten(std::move(group_stmts), func->span_);
-  auto group_func = std::make_shared<Function>(group_name, group_params, func->param_directions_,
-                                               func->return_types_, group_body, func->span_,
-                                               FunctionType::Group, std::nullopt, std::nullopt, func->attrs_);
+  auto group_func =
+      std::make_shared<Function>(group_name, group_params, func->param_directions_, func->return_types_,
+                                 group_body, func->span_, FunctionType::Group);
 
   return {aic_func, aiv_func, group_func};
 }
@@ -831,8 +863,7 @@ FunctionPtr RewriteGroupCaller(const FunctionPtr& group_func, const std::string&
   auto new_body = SeqStmts::Flatten(std::move(new_stmts), group_func->span_);
   auto result =
       std::make_shared<Function>(group_func->name_, group_func->params_, group_func->param_directions_,
-                                 group_func->return_types_, new_body, group_func->span_, FunctionType::Group,
-                                 group_func->level_, group_func->role_, group_func->attrs_);
+                                 group_func->return_types_, new_body, group_func->span_, FunctionType::Group);
   return result;
 }
 
@@ -1142,12 +1173,6 @@ Pass ExpandMixedKernel() {
                                                     std::nullopt, std::nullopt, func->attrs_);
         new_functions.push_back(converted);
         continue;
-      }
-      // Warn if split unset or is NONE — don't supported by pto-isa now.
-      auto split_mode = func->GetSplitMode();
-      if (!split_mode.has_value() || *split_mode == SplitMode::None) {
-        LOG_ERROR << "Mixed kernel '" << func->name_ << "' use none split mode not supported by isa now; "
-                  << "consider using split=pl.SplitMode.UP_DOWN on its auto_incore scope";
       }
 
       // Expand mixed kernel — skip Group wrapper if an existing Group caller exists

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 #include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
@@ -106,6 +107,111 @@ ExprPtr MakeShapeTupleFromInts(const std::vector<int64_t>& dims, const Span& spa
 std::vector<ExprPtr> Make2DShapeExprs(int64_t merged, int64_t last, const Span& span) {
   return {std::make_shared<ConstInt>(merged, DataType::INDEX, span),
           std::make_shared<ConstInt>(last, DataType::INDEX, span)};
+}
+
+/// Build a canonical index add, folding simple ConstInt cases to avoid
+/// unstable roundtrip forms such as `0 + 1`.
+ExprPtr MakeCanonicalIndexAdd(const ExprPtr& lhs, const ExprPtr& rhs, const Span& span) {
+  auto lhs_const = As<ConstInt>(lhs);
+  auto rhs_const = As<ConstInt>(rhs);
+  if (lhs_const && rhs_const) {
+    CHECK((rhs_const->value_ >= 0 && lhs_const->value_ <= INT64_MAX - rhs_const->value_) ||
+          (rhs_const->value_ < 0 && lhs_const->value_ >= INT64_MIN - rhs_const->value_))
+        << "FlattenTileNdTo2D: integer overflow while canonicalizing index add";
+    return std::make_shared<ConstInt>(lhs_const->value_ + rhs_const->value_, DataType::INDEX, span);
+  }
+  if (lhs_const && lhs_const->value_ == 0) {
+    return rhs;
+  }
+  if (rhs_const && rhs_const->value_ == 0) {
+    return lhs;
+  }
+  return MakeAdd(lhs, rhs, span);
+}
+
+/// Convert a vector of ExprPtr shape dimensions into static int64 values.
+std::vector<int64_t> ToStaticDims(const std::vector<ExprPtr>& shape, const std::string& context) {
+  std::vector<int64_t> dims;
+  dims.reserve(shape.size());
+  for (size_t i = 0; i < shape.size(); ++i) {
+    dims.push_back(GetStaticDim(shape[i], context + " dim " + std::to_string(i)));
+  }
+  return dims;
+}
+
+/// Multiply all static dimensions together, with overflow checking.
+int64_t MultiplyStaticDims(const std::vector<int64_t>& dims, const std::string& context) {
+  int64_t product = 1;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    CHECK(dims[i] > 0) << "FlattenTileNdTo2D: dimension " << i << " must be positive in " << context
+                       << ", got " << dims[i];
+    CHECK(product <= INT64_MAX / dims[i]) << "FlattenTileNdTo2D: integer overflow when computing " << context;
+    product *= dims[i];
+  }
+  return product;
+}
+
+/// Decompose a flat batch index into per-dimension indices for the given batch shape.
+/// e.g. flat_index=5 with batch_shape=[2,3] → indices=[1,2].
+std::vector<int64_t> BuildBatchIndices(int64_t flat_index, const std::vector<int64_t>& batch_shape) {
+  std::vector<int64_t> indices;
+  if (batch_shape.empty()) return indices;
+
+  indices.reserve(batch_shape.size());
+  for (size_t dim = 0; dim < batch_shape.size(); ++dim) {
+    int64_t stride = 1;
+    for (size_t suffix = dim + 1; suffix < batch_shape.size(); ++suffix) {
+      CHECK(stride <= INT64_MAX / batch_shape[suffix])
+          << "FlattenTileNdTo2D: integer overflow while computing batch stride";
+      stride *= batch_shape[suffix];
+    }
+    int64_t linear_index = (dim + 1 < batch_shape.size()) ? flat_index / stride : flat_index;
+    indices.push_back(linear_index % batch_shape[dim]);
+  }
+  return indices;
+}
+
+/// Compute the flat batch index for an operand whose batch shape may be smaller
+/// than the output batch shape (NumPy-style broadcast: size-1 dims map to index 0).
+int64_t BuildOperandFlatBatchIndex(const std::vector<int64_t>& operand_batch_shape,
+                                   const std::vector<int64_t>& output_batch_shape,
+                                   const std::vector<int64_t>& output_batch_indices) {
+  if (operand_batch_shape.empty()) return 0;
+
+  CHECK(output_batch_shape.size() >= operand_batch_shape.size())
+      << "FlattenTileNdTo2D: output batch rank must cover operand batch rank";
+  CHECK(output_batch_indices.size() == output_batch_shape.size())
+      << "FlattenTileNdTo2D: output batch indices must match output batch rank";
+
+  int64_t flat_index = 0;
+  const size_t lead_dims = output_batch_shape.size() - operand_batch_shape.size();
+  for (size_t i = 0; i < operand_batch_shape.size(); ++i) {
+    int64_t operand_dim = operand_batch_shape[i];
+    int64_t batch_index = operand_dim == 1 ? 0 : output_batch_indices[lead_dims + i];
+    CHECK(flat_index <= INT64_MAX / operand_dim)
+        << "FlattenTileNdTo2D: integer overflow while flattening broadcasted batch index";
+    flat_index = flat_index * operand_dim + batch_index;
+  }
+  return flat_index;
+}
+
+/// Normalize a potentially negative axis index (Python-style) to a valid range.
+int64_t NormalizeAxisIndex(int64_t axis, size_t ndim, const std::string& context) {
+  int64_t normalized = axis;
+  if (normalized < 0) {
+    normalized += static_cast<int64_t>(ndim);
+  }
+  CHECK(normalized >= 0 && normalized < static_cast<int64_t>(ndim))
+      << "FlattenTileNdTo2D: axis " << axis << " is out of range for rank " << ndim << " in " << context;
+  return normalized;
+}
+
+/// Check whether (axis1, axis2) is a swap of the last two dimensions.
+bool IsTrailingMatrixAxisSwap(int64_t axis1, int64_t axis2, size_t ndim) {
+  int64_t trailing_axis0 = static_cast<int64_t>(ndim) - 2;
+  int64_t trailing_axis1 = static_cast<int64_t>(ndim) - 1;
+  return (axis1 == trailing_axis0 && axis2 == trailing_axis1) ||
+         (axis1 == trailing_axis1 && axis2 == trailing_axis0);
 }
 
 // ============================================================================
@@ -230,6 +336,464 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
   return {};
 }
 
+// ============================================================================
+// Batch matmul lowering
+// ============================================================================
+//
+// tile.batch_matmul performs batched matrix multiplication on ND tiles:
+//   lhs [..., M, K] x rhs [..., K, N] -> result [..., M, N]
+// where "..." are broadcast-compatible batch dimensions.
+//
+// The 2D backend only supports tile.matmul on rank-2 tiles. This lowering
+// eliminates tile.batch_matmul by unrolling the batch dimensions at compile
+// time (all shapes are static) into a flat sequence of 2D tile.matmul calls.
+//
+// Overall flow:
+//
+//   1. Parse operands — peel off inline tile.transpose wrappers that encode
+//      a_trans / b_trans flags (batch_matmul uses structural transpose, not kwargs).
+//
+//   2. Broadcast batch dimensions — compute the output batch shape via
+//      NumPy-style broadcasting (e.g. [2,1] x [1,3] -> [2,3]).
+//
+//   3. Detect direct-store fusion — if the very next statement is a tile.store
+//      consuming this result, fuse per-batch stores directly instead of
+//      assembling into a temporary tile. This avoids an intermediate buffer.
+//
+//   4. Unroll — for each flat batch index 0..batch_count-1:
+//      a. Decompose the flat index into per-dim indices for lhs and rhs,
+//         respecting broadcast (size-1 dims always map to index 0).
+//      b. Extract the 2D [M,K] / [K,N] page via one of three strategies:
+//         - Re-emit tile.load with batch-adjusted offsets (when the original
+//           operand was a Mat-memory tile.load — avoids a slice+reshape).
+//         - tile.slice on already-flattened 2D tile (row-offset slicing).
+//         - ND tile.slice + tile.reshape to 2D (general fallback).
+//      c. Optionally append tile.transpose(0,1) for transposed operands.
+//      d. Emit tile.matmul(lhs_2d, rhs_2d).
+//      e. Cast dtype if matmul output (FP32) differs from expected result dtype.
+//      f. Either tile.store (fused path) or tile.assemble into output tile.
+//
+// The result is a flat 2D tile [batch_count*M, N] (non-fused) or a chain
+// of per-batch tile.store calls (fused), with no tile.batch_matmul remaining.
+//
+
+/// Map from Var raw pointer to its defining AssignStmt, for O(1) def lookup.
+using AssignDefMap = std::unordered_map<const Var*, AssignStmtPtr>;
+
+AssignDefMap BuildAssignDefMap(const std::vector<StmtPtr>& stmts) {
+  AssignDefMap map;
+  for (const auto& stmt : stmts) {
+    if (auto assign = As<AssignStmt>(stmt)) {
+      map[assign->var_.get()] = assign;
+    }
+  }
+  return map;
+}
+
+/// Parsed information about a batch_matmul operand.
+struct BatchOperandInfo {
+  ExprPtr operand;            ///< After var_map substitution
+  ExprPtr original_operand;   ///< Before substitution (for def lookup)
+  TileTypePtr operand_type;   ///< Type after substitution
+  TileTypePtr original_type;  ///< Type before substitution
+  bool transpose = false;     ///< True if wrapped in trailing-axis tile.transpose
+};
+
+/// Parse a batch_matmul operand, peeling off a trailing tile.transpose wrapper if present.
+BatchOperandInfo ParseBatchOperand(const ExprPtr& operand_expr, const std::string& operand_name,
+                                   const FlattenContext& ctx) {
+  BatchOperandInfo info;
+  ExprPtr base_operand = operand_expr;
+
+  if (auto transpose_call = As<Call>(operand_expr)) {
+    if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
+      CHECK(transpose_call->args_.size() == 3)
+          << "FlattenTileNdTo2D: tile.transpose inside tile.batch_matmul must have 3 arguments";
+
+      auto input_type = As<TileType>(transpose_call->args_[0]->GetType());
+      CHECK(input_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
+                        << " transpose operand must wrap a TileType, but got "
+                        << transpose_call->args_[0]->GetType()->TypeName();
+
+      auto axis1_const = As<ConstInt>(transpose_call->args_[1]);
+      auto axis2_const = As<ConstInt>(transpose_call->args_[2]);
+      CHECK(axis1_const && axis2_const)
+          << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name << " transpose axes must be ConstInt";
+
+      int64_t axis1 = NormalizeAxisIndex(axis1_const->value_, input_type->shape_.size(),
+                                         "tile.batch_matmul " + operand_name + " transpose axis1");
+      int64_t axis2 = NormalizeAxisIndex(axis2_const->value_, input_type->shape_.size(),
+                                         "tile.batch_matmul " + operand_name + " transpose axis2");
+      CHECK(IsTrailingMatrixAxisSwap(axis1, axis2, input_type->shape_.size()))
+          << "FlattenTileNdTo2D: tile.batch_matmul only supports operand transpose on the trailing "
+             "matrix axes, but got axes "
+          << axis1 << " and " << axis2;
+
+      base_operand = transpose_call->args_[0];
+      info.transpose = true;
+    }
+  }
+
+  info.original_operand = base_operand;
+  info.original_type = As<TileType>(base_operand->GetType());
+  CHECK(info.original_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
+                            << " expects TileType operand, but got " << base_operand->GetType()->TypeName();
+
+  info.operand = SubstituteExpr(base_operand, ctx.var_map);
+  info.operand_type = As<TileType>(info.operand->GetType());
+  CHECK(info.operand_type) << "FlattenTileNdTo2D: tile.batch_matmul substituted " << operand_name
+                           << " expects TileType operand, but got " << info.operand->GetType()->TypeName();
+  return info;
+}
+
+/// Build batch-adjusted offset elements: add batch indices to the batch dimensions
+/// of base offsets, then append the trailing matrix-dimension offsets unchanged.
+std::vector<ExprPtr> BuildBatchAdjustedOffsets(const std::vector<ExprPtr>& base_offset_elems,
+                                               const std::vector<int64_t>& batch_indices, size_t batch_rank,
+                                               const Span& span) {
+  std::vector<ExprPtr> adjusted;
+  adjusted.reserve(base_offset_elems.size());
+  for (size_t dim = 0; dim < batch_rank; ++dim) {
+    if (batch_indices[dim] == 0) {
+      adjusted.push_back(base_offset_elems[dim]);
+    } else {
+      auto offset = std::make_shared<ConstInt>(batch_indices[dim], DataType::INDEX, span);
+      adjusted.push_back(MakeCanonicalIndexAdd(base_offset_elems[dim], offset, span));
+    }
+  }
+  for (size_t dim = batch_rank; dim < base_offset_elems.size(); ++dim) {
+    adjusted.push_back(base_offset_elems[dim]);
+  }
+  return adjusted;
+}
+
+/// Result of extracting a 2D batch page from an ND operand.
+struct BatchPageResult {
+  VarPtr var;                  ///< The 2D variable (possibly transposed)
+  std::vector<StmtPtr> stmts;  ///< Statements emitted to produce it
+};
+
+/// Extract the 2D matrix page for a given batch index from an operand.
+///
+/// Three strategies:
+///  (1) Mat-load: re-emit tile.load with batch-adjusted offsets (avoids intermediate tile)
+///  (2) 2D-flat: tile.slice at the right row offset (operand already flattened)
+///  (3) ND: tile.slice + tile.reshape to 2D
+///
+/// Appends tile.transpose if the operand should be transposed.
+BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector<int64_t>& operand_dims,
+                                 const std::vector<int64_t>& operand_batch_shape, int64_t batch_index,
+                                 const std::string& base_name, const AssignDefMap& def_map,
+                                 const FlattenContext& ctx, const OpRegistry& op_registry, const Span& span) {
+  BatchPageResult page;
+  const auto& operand = info.operand;
+  const auto& operand_type = info.operand_type;
+
+  int64_t source_rows = operand_dims[operand_dims.size() - 2];
+  int64_t source_cols = operand_dims.back();
+  std::string suffix = std::to_string(batch_index);
+
+  // Check if original operand was produced by a tile.load with Mat target_memory.
+  auto original_var = As<Var>(info.original_operand);
+  auto def_it = original_var ? def_map.find(original_var.get()) : def_map.end();
+  auto original_assign = (def_it != def_map.end()) ? def_it->second : nullptr;
+  auto original_load_call = original_assign ? As<Call>(original_assign->value_) : nullptr;
+  bool is_mat_load = original_load_call && original_load_call->op_->name_ == "tile.load" &&
+                     original_load_call->args_.size() >= 4;
+  auto original_load_offsets = is_mat_load ? As<MakeTuple>(original_load_call->args_[1]) : nullptr;
+  auto original_load_input =
+      is_mat_load ? SubstituteExpr(original_load_call->args_[0], ctx.var_map) : nullptr;
+  auto original_load_input_type =
+      original_load_input ? As<TensorType>(original_load_input->GetType()) : nullptr;
+  auto original_target_memory =
+      is_mat_load ? original_load_call->GetKwarg<MemorySpace>("target_memory") : MemorySpace::DDR;
+  bool original_load_transpose = is_mat_load ? original_load_call->GetKwarg<bool>("transpose", false) : false;
+
+  VarPtr current;
+
+  if (is_mat_load && original_load_offsets && original_load_input_type &&
+      original_target_memory == MemorySpace::Mat && !original_load_transpose) {
+    // Strategy 1: Re-emit tile.load with batch-adjusted offsets.
+    auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
+    auto load_offset_elems = BuildBatchAdjustedOffsets(original_load_offsets->elements_, batch_indices,
+                                                       operand_batch_shape.size(), span);
+
+    std::vector<int64_t> load_shape_values(operand_batch_shape.size(), 1);
+    load_shape_values.push_back(source_rows);
+    load_shape_values.push_back(source_cols);
+
+    auto batch_load_offsets = std::make_shared<MakeTuple>(load_offset_elems, span);
+    auto batch_load_shape = MakeShapeTupleFromInts(load_shape_values, span);
+    std::vector<ExprPtr> batch_load_args = {original_load_input, batch_load_offsets, batch_load_shape,
+                                            batch_load_shape};
+    auto batch_load = op_registry.Create("tile.load", batch_load_args, original_load_call->kwargs_, span);
+    auto batch_load_type = As<TileType>(batch_load->GetType());
+
+    // Flatten the load result to 2D.
+    auto flat_shape_exprs = Make2DShapeExprs(source_rows, source_cols, span);
+    std::optional<TileView> flat_tile_view;
+    if (batch_load_type && batch_load_type->tile_view_.has_value()) {
+      flat_tile_view = TileView(flat_shape_exprs, /*stride=*/{}, /*start_offset=*/nullptr);
+    }
+    auto flat_type = std::make_shared<TileType>(
+        flat_shape_exprs, batch_load_type ? batch_load_type->dtype_ : operand_type->dtype_, std::nullopt,
+        flat_tile_view, batch_load_type ? batch_load_type->memory_space_ : operand_type->memory_space_);
+    auto flat_load = std::make_shared<Call>(batch_load->op_, batch_load_args, batch_load->kwargs_, flat_type,
+                                            batch_load->span_);
+    current = std::make_shared<Var>(base_name + "_load_" + suffix, flat_type, span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, flat_load, span));
+
+  } else if (operand_type->shape_.size() == 2) {
+    // Strategy 2: Slice from already-flattened 2D tile.
+    auto offset = MakeShapeTupleFromInts({batch_index * source_rows, 0}, span);
+    auto shape = MakeShapeTupleFromInts({source_rows, source_cols}, span);
+    auto slice = op_registry.Create("tile.slice", {operand, shape, offset}, span);
+    current = std::make_shared<Var>(base_name + "_slice_" + suffix, slice->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, slice, span));
+
+  } else {
+    // Strategy 3: ND tile.slice + tile.reshape to 2D.
+    auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
+    std::vector<int64_t> offset_values = batch_indices;
+    offset_values.push_back(0);
+    offset_values.push_back(0);
+
+    std::vector<int64_t> slice_shape_values(operand_batch_shape.size(), 1);
+    slice_shape_values.push_back(source_rows);
+    slice_shape_values.push_back(source_cols);
+
+    auto offset = MakeShapeTupleFromInts(offset_values, span);
+    auto slice_shape = MakeShapeTupleFromInts(slice_shape_values, span);
+    auto slice = op_registry.Create("tile.slice", {operand, slice_shape, offset}, span);
+    auto slice_var = std::make_shared<Var>(base_name + "_nd_slice_" + suffix, slice->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice, span));
+
+    auto reshape_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(source_rows, source_cols, span), span);
+    auto reshape = op_registry.Create("tile.reshape", {slice_var, reshape_shape}, span);
+    current = std::make_shared<Var>(base_name + "_2d_" + suffix, reshape->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, reshape, span));
+  }
+
+  // Optionally transpose the 2D page.
+  if (info.transpose) {
+    auto axis0 = std::make_shared<ConstInt>(0, DataType::INT32, span);
+    auto axis1 = std::make_shared<ConstInt>(1, DataType::INT32, span);
+    auto transpose_call = op_registry.Create("tile.transpose", {current, axis0, axis1}, span);
+    auto transpose_var = std::make_shared<Var>(base_name + "_t_" + suffix, transpose_call->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose_call, span));
+    current = transpose_var;
+  }
+
+  page.var = current;
+  return page;
+}
+
+/// Detect whether the next statement is a tile.store consuming the batch_matmul result.
+struct DirectStoreInfo {
+  bool detected = false;
+  AssignStmtPtr store_assign;
+  CallPtr store_call;
+};
+
+DirectStoreInfo DetectDirectStore(const std::vector<StmtPtr>& stmts, size_t stmt_index,
+                                  const VarPtr& result_var) {
+  DirectStoreInfo info;
+  if (stmt_index + 1 >= stmts.size()) return info;
+
+  auto store_assign = As<AssignStmt>(stmts[stmt_index + 1]);
+  auto store_call = store_assign ? As<Call>(store_assign->value_) : nullptr;
+  if (!store_call || store_call->op_->name_ != "tile.store") return info;
+
+  auto store_input = !store_call->args_.empty() ? As<Var>(store_call->args_[0]) : nullptr;
+  if (!store_input || store_input.get() != result_var.get()) return info;
+
+  info.detected = true;
+  info.store_assign = store_assign;
+  info.store_call = store_call;
+  return info;
+}
+
+/// Result of lowering a tile.batch_matmul operation.
+struct BatchMatmulResult {
+  std::vector<StmtPtr> stmts;  ///< Emitted statements
+  VarPtr output_var;           ///< Result variable (non-fused path)
+  bool fused_store = false;    ///< True if direct-store fusion was applied
+  VarPtr store_result_var;     ///< Final store var (fused path)
+  VarPtr store_orig_var;       ///< Original store var being replaced (fused path)
+};
+
+/// Lower tile.batch_matmul into unrolled 2D tile.matmul calls.
+///
+/// Enumerates every batch index combination, extracts the 2D matrix page from each
+/// operand, emits a tile.matmul per batch element, and either assembles results into
+/// a flat 2D output tile or fuses directly into per-batch tile.store when possible.
+BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& call,
+                                   const std::vector<StmtPtr>& stmts, size_t stmt_index,
+                                   const FlattenContext& ctx, const OpRegistry& op_registry,
+                                   const Span& span) {
+  BatchMatmulResult out;
+
+  // Parse operands.
+  auto lhs_info = ParseBatchOperand(call->args_[0], "lhs", ctx);
+  auto rhs_info = ParseBatchOperand(call->args_[1], "rhs", ctx);
+  auto orig_result_type = As<TileType>(call->GetType());
+  CHECK(orig_result_type) << "FlattenTileNdTo2D: tile.batch_matmul expects TileType result";
+
+  // Extract static dimensions.
+  auto lhs_dims = ToStaticDims(lhs_info.original_type->shape_, "tile.batch_matmul lhs");
+  auto rhs_dims = ToStaticDims(rhs_info.original_type->shape_, "tile.batch_matmul rhs");
+  CHECK(lhs_dims.size() >= 2) << "FlattenTileNdTo2D: tile.batch_matmul lhs must be at least 2D";
+  CHECK(rhs_dims.size() >= 2) << "FlattenTileNdTo2D: tile.batch_matmul rhs must be at least 2D";
+
+  // Compute broadcast batch dimensions.
+  std::vector<ExprPtr> lhs_batch_exprs(lhs_info.original_type->shape_.begin(),
+                                       lhs_info.original_type->shape_.end() - 2);
+  std::vector<ExprPtr> rhs_batch_exprs(rhs_info.original_type->shape_.begin(),
+                                       rhs_info.original_type->shape_.end() - 2);
+  auto broadcast_result = BroadcastShapes(lhs_batch_exprs, rhs_batch_exprs);
+  CHECK(broadcast_result.success) << "FlattenTileNdTo2D: tile.batch_matmul batch dimensions must broadcast";
+
+  auto output_batch_dims = ToStaticDims(broadcast_result.shape, "tile.batch_matmul output batch");
+  int64_t batch_count = MultiplyStaticDims(output_batch_dims, "tile.batch_matmul output batch size");
+
+  std::vector<int64_t> lhs_batch_dims(lhs_dims.begin(), lhs_dims.end() - 2);
+  std::vector<int64_t> rhs_batch_dims(rhs_dims.begin(), rhs_dims.end() - 2);
+
+  // Compute effective matrix dimensions (after transpose).
+  int64_t lhs_source_rows = lhs_dims[lhs_dims.size() - 2];
+  int64_t lhs_source_cols = lhs_dims.back();
+  int64_t rhs_source_rows = rhs_dims[rhs_dims.size() - 2];
+  int64_t rhs_source_cols = rhs_dims.back();
+
+  int64_t lhs_rows = lhs_info.transpose ? lhs_source_cols : lhs_source_rows;
+  int64_t lhs_cols = lhs_info.transpose ? lhs_source_rows : lhs_source_cols;
+  int64_t rhs_rows = rhs_info.transpose ? rhs_source_cols : rhs_source_rows;
+  int64_t rhs_cols = rhs_info.transpose ? rhs_source_rows : rhs_source_cols;
+
+  CHECK(lhs_cols == rhs_rows)
+      << "FlattenTileNdTo2D: tile.batch_matmul requires matching inner dimensions after "
+         "transpose, but got "
+      << lhs_cols << " and " << rhs_rows;
+
+  // Build def map for operand lookup (used by ExtractBatchPage).
+  auto def_map = BuildAssignDefMap(stmts);
+
+  // Detect direct-store fusion opportunity.
+  auto direct_store = DetectDirectStore(stmts, stmt_index, assign->var_);
+
+  // Allocate output tile (non-fused path only).
+  VarPtr out_var;
+  if (!direct_store.detected) {
+    auto out_shape =
+        std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * lhs_rows, rhs_cols, span), span);
+    std::vector<std::pair<std::string, std::any>> create_kw = {{"dtype", orig_result_type->dtype_}};
+    auto create_out = op_registry.Create("tile.create", {out_shape}, create_kw, span);
+    out_var = std::make_shared<Var>(assign->var_->name_hint_, create_out->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
+  }
+
+  // Prepare direct-store state.
+  ExprPtr current_store_tensor;
+  MakeTuplePtr direct_store_offsets;
+  std::vector<ExprPtr> direct_store_shape;
+  if (direct_store.detected) {
+    current_store_tensor = SubstituteExpr(direct_store.store_call->args_[2], ctx.var_map);
+    direct_store_offsets = As<MakeTuple>(SubstituteExpr(direct_store.store_call->args_[1], ctx.var_map));
+    auto store_tensor_type = As<TensorType>(current_store_tensor->GetType());
+    CHECK(store_tensor_type) << "FlattenTileNdTo2D: tile.batch_matmul direct store target must be TensorType";
+    CHECK(direct_store_offsets) << "FlattenTileNdTo2D: tile.store offsets must be a MakeTuple";
+    CHECK(direct_store_offsets->elements_.size() == output_batch_dims.size() + 2)
+        << "FlattenTileNdTo2D: tile.store offsets rank must match batch_matmul result rank";
+    if (store_tensor_type->shape_.size() > 2) {
+      direct_store_shape.reserve(output_batch_dims.size() + 2);
+      for (size_t i = 0; i < output_batch_dims.size(); ++i) {
+        direct_store_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
+      }
+      direct_store_shape.push_back(std::make_shared<ConstInt>(lhs_rows, DataType::INDEX, span));
+      direct_store_shape.push_back(std::make_shared<ConstInt>(rhs_cols, DataType::INDEX, span));
+    }
+  }
+
+  // Unroll batch dimensions.
+  for (int64_t i = 0; i < batch_count; ++i) {
+    auto output_batch_indices = BuildBatchIndices(i, output_batch_dims);
+    int64_t lhs_batch_idx =
+        BuildOperandFlatBatchIndex(lhs_batch_dims, output_batch_dims, output_batch_indices);
+    int64_t rhs_batch_idx =
+        BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
+
+    // Extract 2D pages.
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
+                                     op_registry, span);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
+                                     op_registry, span);
+    out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
+    out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
+
+    // Emit tile.matmul.
+    auto matmul = op_registry.Create("tile.matmul", {lhs_page.var, rhs_page.var}, span);
+    auto matmul_var = std::make_shared<Var>("matmul_" + std::to_string(i), matmul->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, span));
+
+    // Cast dtype if needed (matmul produces FP32, result may need different dtype).
+    ExprPtr batch_result = matmul_var;
+    auto batch_result_type = As<TileType>(matmul_var->GetType());
+    if (batch_result_type && batch_result_type->dtype_ != orig_result_type->dtype_) {
+      std::vector<std::pair<std::string, std::any>> move_kw = {
+          {"target_memory", MemorySpace::Vec},
+      };
+      auto move = op_registry.Create("tile.move", {matmul_var}, move_kw, span);
+      auto move_var = std::make_shared<Var>("matmul_vec_" + std::to_string(i), move->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(move_var, move, span));
+
+      std::vector<std::pair<std::string, std::any>> cast_kw = {
+          {"target_type", orig_result_type->dtype_},
+          {"mode", 2},
+      };
+      auto cast = op_registry.Create("tile.cast", {move_var}, cast_kw, span);
+      auto cast_var = std::make_shared<Var>("matmul_cast_" + std::to_string(i), cast->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(cast_var, cast, span));
+      batch_result = cast_var;
+    }
+
+    if (direct_store.detected) {
+      // Fused path: emit per-batch tile.store.
+      auto store_offset_elems = BuildBatchAdjustedOffsets(
+          direct_store_offsets->elements_, output_batch_indices, output_batch_dims.size(), span);
+      auto store_offset = std::make_shared<MakeTuple>(store_offset_elems, span);
+
+      std::vector<ExprPtr> store_args = {batch_result, store_offset, current_store_tensor};
+      if (!direct_store_shape.empty()) {
+        store_args.push_back(std::make_shared<MakeTuple>(direct_store_shape, span));
+      }
+      auto batch_store = op_registry.Create("tile.store", store_args, span);
+      auto batch_store_var =
+          std::make_shared<Var>(direct_store.store_assign->var_->name_hint_ + "_" + std::to_string(i),
+                                batch_store->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(batch_store_var, batch_store, span));
+      current_store_tensor = batch_store_var;
+    } else {
+      // Non-fused path: assemble into output tile.
+      auto out_offset = MakeShapeTupleFromInts({i * lhs_rows, 0}, span);
+      auto assemble = op_registry.Create("tile.assemble", {out_var, batch_result, out_offset}, span);
+      out_var = std::make_shared<Var>(out_var->name_hint_, assemble->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, span));
+    }
+  }
+
+  if (direct_store.detected) {
+    auto final_store_var = As<Var>(current_store_tensor);
+    CHECK(final_store_var) << "FlattenTileNdTo2D: expected final direct store result to be a Var";
+    out.fused_store = true;
+    out.store_result_var = final_store_var;
+    out.store_orig_var = direct_store.store_assign->var_;
+  } else {
+    out.output_var = out_var;
+  }
+
+  return out;
+}
+
 /**
  * @brief Recursively transform statements, flattening >2D tile ops to 2D.
  */
@@ -237,7 +801,8 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
                                    const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
 
-  for (const auto& stmt : stmts) {
+  for (size_t stmt_index = 0; stmt_index < stmts.size(); ++stmt_index) {
+    const auto& stmt = stmts[stmt_index];
     // ReturnStmt: substitute return values
     if (auto ret = As<ReturnStmt>(stmt)) {
       std::vector<ExprPtr> new_values;
@@ -599,6 +1164,19 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
           continue;
         }
       }
+    }
+
+    // ---- tile.batch_matmul: delegate to LowerBatchMatmul ----
+    if (op_name == "tile.batch_matmul") {
+      auto lowering = LowerBatchMatmul(assign, call, stmts, stmt_index, ctx, op_registry, span);
+      result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
+      if (lowering.fused_store) {
+        ctx.Insert(lowering.store_orig_var, lowering.store_result_var);
+        ++stmt_index;  // Skip the next tile.store; it has been fused above.
+      } else {
+        ctx.Insert(assign->var_, lowering.output_var);
+      }
+      continue;
     }
 
     // ---- All other tile ops (including tile.reshape) and non-tile ops: substitute args ----

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -16,6 +16,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -65,10 +67,97 @@ std::optional<size_t> GetOutputReusesInputArg(const std::string& op_name) {
   return registry.GetEntry(op_name).GetOutputReusesInputArg();
 }
 
+/// Check if `var` is a writable (Out/InOut) parameter and return its index.
+std::optional<size_t> ResolveReturnedWritableParamIndex(const VarPtr& var, const std::vector<VarPtr>& params,
+                                                        const std::vector<ParamDirection>& param_directions) {
+  if (!var) return std::nullopt;
+  for (size_t i = 0; i < params.size() && i < param_directions.size(); ++i) {
+    if (param_directions[i] == ParamDirection::In) continue;
+    if (params[i].get() == var.get()) return i;
+  }
+  return std::nullopt;
+}
+
+/// For a Call, resolve whether its result reuses one of its input args as
+/// the output buffer (e.g. tile.store returns its output_tensor arg).
+/// Also checks cross-function aliases via known_return_alias_arg_index_by_func.
+std::optional<size_t> ResolveCallOutputReusesInputArg(
+    const CallPtr& call,
+    const std::unordered_map<std::string, size_t>& known_return_alias_arg_index_by_func) {
+  if (!call) return std::nullopt;
+
+  auto reuse_arg_idx = GetOutputReusesInputArg(call->op_->name_);
+  if (reuse_arg_idx.has_value()) return reuse_arg_idx;
+
+  if (auto callee = As<GlobalVar>(call->op_)) {
+    auto alias_it = known_return_alias_arg_index_by_func.find(callee->name_);
+    if (alias_it != known_return_alias_arg_index_by_func.end()) {
+      return alias_it->second;
+    }
+  }
+
+  return std::nullopt;
+}
+
+/// Walk backward through assign-chain and call-chain aliases to find whether
+/// a function's single return value ultimately aliases a writable parameter.
+/// Uses known_return_alias_arg_index_by_func for cross-function resolution
+/// (e.g. orchestrator calls InCore which returns its Out param).
+std::optional<size_t> FindReturnedWritableParamIndex(
+    const FunctionPtr& func,
+    const std::unordered_map<std::string, size_t>& known_return_alias_arg_index_by_func = {}) {
+  if (!func || !func->body_ || func->return_types_.size() != 1) return std::nullopt;
+
+  auto normalized_func = NormalizeStmtStructure(func);
+  std::vector<StmtPtr> stmts;
+  if (auto seq = As<SeqStmts>(normalized_func->body_)) {
+    stmts = seq->stmts_;
+  } else {
+    stmts = {normalized_func->body_};
+  }
+  if (stmts.empty()) return std::nullopt;
+
+  auto ret = As<ReturnStmt>(stmts.back());
+  if (!ret || ret->value_.size() != 1) return std::nullopt;
+
+  std::unordered_map<const Var*, ExprPtr> defs;
+  defs.reserve(stmts.size());
+  for (const auto& stmt : stmts) {
+    auto assign = As<AssignStmt>(stmt);
+    if (!assign) continue;
+    defs[assign->var_.get()] = assign->value_;
+  }
+
+  auto current_var = As<Var>(ret->value_[0]);
+  std::unordered_set<const Var*> visited;
+  while (current_var && visited.insert(current_var.get()).second) {
+    auto param_index = ResolveReturnedWritableParamIndex(current_var, normalized_func->params_,
+                                                         normalized_func->param_directions_);
+    if (param_index.has_value()) return param_index;
+
+    auto def_it = defs.find(current_var.get());
+    if (def_it == defs.end()) return std::nullopt;
+
+    if (auto alias_var = As<Var>(def_it->second)) {
+      current_var = alias_var;
+      continue;
+    }
+
+    auto call = As<Call>(def_it->second);
+    auto reuse_arg_idx = ResolveCallOutputReusesInputArg(call, known_return_alias_arg_index_by_func);
+    if (!reuse_arg_idx.has_value() || *reuse_arg_idx >= call->args_.size()) return std::nullopt;
+
+    current_var = As<Var>(call->args_[*reuse_arg_idx]);
+  }
+
+  return std::nullopt;
+}
+
 // Mutator to initialize MemRef for variables
 class InitMemRefMutator : public IRMutator {
  public:
-  InitMemRefMutator() = default;
+  explicit InitMemRefMutator(std::unordered_map<std::string, size_t> return_alias_arg_index_by_func = {})
+      : return_alias_arg_index_by_func_(std::move(return_alias_arg_index_by_func)) {}
 
   // Resolve memory space from TileType::memory_space_ field (set by InferTileMemorySpace),
   // falling back to DDR when default_to_ddr is true.
@@ -244,7 +333,7 @@ class InitMemRefMutator : public IRMutator {
       }
 
       // Handle ops whose output reuses a specific input arg's MemRef (registry-based)
-      auto reuse_arg_idx = GetOutputReusesInputArg(call->op_->name_);
+      auto reuse_arg_idx = ResolveCallOutputReusesInputArg(call, return_alias_arg_index_by_func_);
       if (reuse_arg_idx.has_value()) {
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && *reuse_arg_idx < new_call->args_.size()) {
@@ -406,6 +495,7 @@ class InitMemRefMutator : public IRMutator {
   }
 
   std::map<VarPtr, VarPtr> var_map_;
+  std::unordered_map<std::string, size_t> return_alias_arg_index_by_func_;
   uint64_t next_id_ = 0;
 };
 
@@ -489,12 +579,13 @@ StmtPtr InsertAllocsIntoBody(const StmtPtr& body, const std::vector<StmtPtr>& al
  * Memory space is read from TileType::memory_space_ (set by InferTileMemorySpace).
  * Variables without memory_space default to DDR.
  */
-FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
+FunctionPtr TransformFunctionInitMemRef(
+    const FunctionPtr& func, const std::unordered_map<std::string, size_t>& return_alias_arg_index_by_func) {
   // Step 1: Normalize statement structure to ensure SeqStmts
   auto normalized_func = NormalizeStmtStructure(func);
 
   // Step 2: Mutate variables to initialize their MemRef
-  InitMemRefMutator mutator;
+  InitMemRefMutator mutator(return_alias_arg_index_by_func);
 
   std::vector<VarPtr> new_params;
   new_params.reserve(normalized_func->params_.size());
@@ -536,11 +627,46 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
                                     result_func->attrs_);
 }
 
+/// Program-level InitMemRef: first resolve cross-function return-alias chains
+/// via fixed-point iteration (e.g. orchestrator→InCore→Out param), then run
+/// per-function MemRef initialization with the resolved alias information.
+ProgramPtr TransformInitMemRef(const ProgramPtr& program) {
+  if (!program) return program;
+
+  std::unordered_map<std::string, size_t> return_alias_arg_index_by_func;
+  // Fixed-point iteration: each iteration discovers at most one new entry per function,
+  // so convergence is bounded by O(F) iterations where F = number of functions.
+  bool changed = false;
+  do {
+    changed = false;
+    for (const auto& [gvar, func] : program->functions_) {
+      (void)gvar;
+      auto alias_arg_idx = FindReturnedWritableParamIndex(func, return_alias_arg_index_by_func);
+      if (!alias_arg_idx.has_value()) continue;
+
+      auto it = return_alias_arg_index_by_func.find(func->name_);
+      if (it == return_alias_arg_index_by_func.end() || it->second != *alias_arg_idx) {
+        return_alias_arg_index_by_func[func->name_] = *alias_arg_idx;
+        changed = true;
+      }
+    }
+  } while (changed);
+
+  std::vector<FunctionPtr> new_functions;
+  new_functions.reserve(program->functions_.size());
+  for (const auto& [gvar, func] : program->functions_) {
+    (void)gvar;
+    new_functions.push_back(TransformFunctionInitMemRef(func, return_alias_arg_index_by_func));
+  }
+
+  return std::make_shared<Program>(std::move(new_functions), program->name_, program->span_);
+}
+
 }  // namespace
 
 // Factory function
 namespace pass {
-Pass InitMemRef() { return CreateFunctionPass(TransformInitMemRef, "InitMemRef", kInitMemRefProperties); }
+Pass InitMemRef() { return CreateProgramPass(TransformInitMemRef, "InitMemRef", kInitMemRefProperties); }
 }  // namespace pass
 
 // ============================================================================

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,6 +32,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -48,6 +50,20 @@ ExprPtr MakeZeroOffsetsTuple(size_t ndim, const Span& span) {
 
 ExprPtr MakeShapesTuple(const std::vector<ExprPtr>& shape, const Span& span) {
   return std::make_shared<MakeTuple>(shape, span);
+}
+
+/// Extract shape from a TensorType or TileType operand (batch_matmul operands
+/// may already be TileType when loaded to Mat space by an earlier conversion).
+const std::vector<ExprPtr>& GetTensorOrTileShape(const ExprPtr& operand, const std::string& operand_name) {
+  if (auto tensor_type = As<TensorType>(operand->GetType())) {
+    return tensor_type->shape_;
+  }
+  if (auto tile_type = As<TileType>(operand->GetType())) {
+    return tile_type->shape_;
+  }
+  CHECK(false) << "Expected " << operand_name << " to be TensorType or TileType, but got "
+               << operand->GetType()->TypeName();
+  return As<TensorType>(operand->GetType())->shape_;  // unreachable
 }
 
 // Check if a shape dimension is statically equal to 1
@@ -108,6 +124,27 @@ ExprPtr LoadOperandToMat(const ExprPtr& operand, bool transpose, const std::stri
   }
   INTERNAL_CHECK(false) << "LoadOperandToMat: unexpected type: " << operand->GetType()->TypeName();
   return nullptr;  // unreachable
+}
+
+/// If `transpose` is true, insert a tile.transpose swapping the last two axes;
+/// otherwise return `operand` unchanged.
+ExprPtr InsertTrailingTranspose(const ExprPtr& operand, bool transpose, const Span& span) {
+  if (!transpose) {
+    return operand;
+  }
+
+  auto tile_type = As<TileType>(operand->GetType());
+  INTERNAL_CHECK(tile_type) << "Internal error: InsertTrailingTranspose expects TileType operand, but got "
+                            << operand->GetType()->TypeName();
+  INTERNAL_CHECK(tile_type->shape_.size() >= 2)
+      << "Internal error: InsertTrailingTranspose expects rank >= 2 tile, but got "
+      << tile_type->shape_.size();
+
+  int64_t axis1_value = static_cast<int64_t>(tile_type->shape_.size()) - 2;
+  int64_t axis2_value = static_cast<int64_t>(tile_type->shape_.size()) - 1;
+  auto axis1 = std::make_shared<ConstInt>(axis1_value, DataType::INDEX, span);
+  auto axis2 = std::make_shared<ConstInt>(axis2_value, DataType::INDEX, span);
+  return OpRegistry::GetInstance().Create("tile.transpose", {operand, axis1, axis2}, span);
 }
 
 }  // namespace
@@ -234,7 +271,7 @@ OpConversionRegistry::OpConversionRegistry() {
       });
 
   // ────────────────────────────────────────────────────────────────────────
-  // tensor.matmul → tile.load(Mat) + tile.move(L0A/L0B) + tile.matmul + tile.store
+  // tensor.matmul → tile.load(Mat) + tile.matmul
   //
   // tensor.matmul(lhs, rhs, a_trans=False, b_trans=True, c_matrix_nz=False)
   // ────────────────────────────────────────────────────────────────────────
@@ -254,6 +291,46 @@ OpConversionRegistry::OpConversionRegistry() {
 
         auto matmul_call = OpRegistry::GetInstance().Create("tile.matmul", {lhs_mat, rhs_mat}, span);
         return ConversionResult{std::move(prologue), matmul_call};
+      });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // tensor.batch_matmul → tile.load(Mat) + optional tile.transpose + tile.batch_matmul
+  //
+  // tensor.batch_matmul(lhs, rhs, a_trans=False, b_trans=True, c_matrix_nz=False)
+  // ────────────────────────────────────────────────────────────────────────
+
+  RegisterCustom(
+      "tensor.batch_matmul",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 2) << "tensor.batch_matmul conversion expects 2 args (lhs, rhs)";
+
+        const auto& lhs_shape = GetTensorOrTileShape(args[0], "lhs");
+        const auto& rhs_shape = GetTensorOrTileShape(args[1], "rhs");
+        CHECK(lhs_shape.size() >= 3) << "tensor.batch_matmul conversion expects lhs rank >= 3, but got "
+                                     << lhs_shape.size();
+        CHECK(rhs_shape.size() >= 3) << "tensor.batch_matmul conversion expects rhs rank >= 3, but got "
+                                     << rhs_shape.size();
+
+        bool a_trans = GetKwargOr<bool>(kwargs, "a_trans", false);
+        bool b_trans = GetKwargOr<bool>(kwargs, "b_trans", false);
+
+        std::vector<ExprPtr> lhs_batch(lhs_shape.begin(), lhs_shape.end() - 2);
+        std::vector<ExprPtr> rhs_batch(rhs_shape.begin(), rhs_shape.end() - 2);
+        auto broadcast_result = BroadcastShapes(lhs_batch, rhs_batch);
+        CHECK(broadcast_result.success) << "tensor.batch_matmul conversion cannot broadcast batch dimensions";
+
+        auto& op_reg = OpRegistry::GetInstance();
+        std::vector<StmtPtr> prologue;
+        auto lhs_mat = LoadOperandToMat(args[0], false, "lhs_batch_mat", prologue, span);
+        auto rhs_mat = LoadOperandToMat(args[1], false, "rhs_batch_mat", prologue, span);
+
+        auto lhs_batch_operand = InsertTrailingTranspose(lhs_mat, a_trans, span);
+        auto rhs_batch_operand = InsertTrailingTranspose(rhs_mat, b_trans, span);
+
+        auto batch_matmul_call =
+            op_reg.Create("tile.batch_matmul", {lhs_batch_operand, rhs_batch_operand}, span);
+        return ConversionResult{std::move(prologue), batch_matmul_call};
       });
 
   // ────────────────────────────────────────────────────────────────────────

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -94,7 +94,8 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
     if (ms.has_value() && IsCubeMemorySpace(ms.value())) return CoreAffinity::CUBE;
     return CoreAffinity::VECTOR;
   }
-  static const std::unordered_set<std::string> tile_arg_classified_ops = {"tile.store", "tile.reshape"};
+  static const std::unordered_set<std::string> tile_arg_classified_ops = {"tile.store", "tile.reshape",
+                                                                          "tile.slice"};
   if (tile_arg_classified_ops.count(name)) {
     auto ms = GetFirstTileArgMemory(call);
     if (ms.has_value() && IsCubeMemorySpace(ms.value())) return CoreAffinity::CUBE;

--- a/tests/st/runtime/test_batch_matmul.py
+++ b/tests/st/runtime/test_batch_matmul.py
@@ -1,0 +1,235 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+System tests for batch matrix multiplication operation.
+
+This test validates the tensor.batch_matmul operation through the complete
+compilation and execution pipeline, comparing results against PyTorch reference.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+
+class TestBatchMatmul(PTOTestCase):
+    __test__ = False  # Not a pytest test class
+
+    def __init__(self, batch: int = 2, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.batch = batch
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"batch_matmul_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.batch, self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.batch, self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.batch, self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.batch, self.M, self.K, self.N
+
+        @pl.program
+        class BatchMatmulProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                result = pl.tensor.batch_matmul(a, b)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul(a, b, c)
+                return out_c
+
+        return BatchMatmulProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Compute reference output using PyTorch."""
+        a = tensors["a"]
+        b = tensors["b"]
+        tensors["c"][:] = torch.bmm(a, b)
+
+
+class TestBatchMatmulPTO(TestBatchMatmul):
+    """Test batch_matmul with PTO backend and PTOAS optimization."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"batch_matmul_pto_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+
+class TestBatchMatmulTile(PTOTestCase):
+    """Tile-level batch matmul: explicit load → batch_matmul → store.
+
+    Uses tile.batch_matmul directly, mirroring how TestMatmul uses tile.matmul.
+    """
+
+    __test__ = False
+
+    def __init__(self, batch: int = 2, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.batch = batch
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"batch_matmul_tile_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.batch, self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.batch, self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.batch, self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.batch, self.M, self.K, self.N
+
+        @pl.program
+        class BatchMatmulTileProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul_tile(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                tile_a = pl.load(a, offsets=[0, 0, 0], shapes=[B, M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, offsets=[0, 0, 0], shapes=[B, K, N], target_memory=pl.MemorySpace.Mat)
+                tile_c = pl.batch_matmul(tile_a, tile_b)
+                out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul_tile(a, b, c)
+                return out_c
+
+        return BatchMatmulTileProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.bmm(tensors["a"], tensors["b"])
+
+
+class TestBatchMatmulTilePTO(TestBatchMatmulTile):
+    """Tile-level batch matmul with PTO backend."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"batch_matmul_tile_pto_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+
+class TestBatchMatmulOperations:
+    """Test suite for batch matrix multiplication operations."""
+
+    # ---- tensor.batch_matmul (high-level) ----
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            (1, 128, 64, 128),
+        ],
+    )
+    def test_batch_matmul(self, test_runner, batch, m, k, n):
+        """Test tensor.batch_matmul with various batch sizes and matrix shapes."""
+        test_case = TestBatchMatmul(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            (1, 128, 64, 128),
+        ],
+    )
+    def test_batch_matmul_pto(self, test_runner, batch, m, k, n):
+        """Test tensor.batch_matmul with PTO backend and PTOAS optimization."""
+        test_case = TestBatchMatmulPTO(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (PTO): {result.error}"
+
+    # ---- tile.batch_matmul (low-level) ----
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            (1, 128, 64, 128),
+        ],
+    )
+    def test_batch_matmul_tile(self, test_runner, batch, m, k, n):
+        """Test tile.batch_matmul with explicit load/store."""
+        test_case = TestBatchMatmulTile(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            (1, 128, 64, 128),
+        ],
+    )
+    def test_batch_matmul_tile_pto(self, test_runner, batch, m, k, n):
+        """Test tile.batch_matmul with PTO backend."""
+        test_case = TestBatchMatmulTilePTO(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (PTO): {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--forked"])

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1188,57 +1188,6 @@ def test_pto_codegen_if_stmt_tile_phi_preserves_dynamic_valid_shape():
     assert "v_col=?" in phi_alloc_line, f"Expected dynamic v_col in tile phi alloc, got: {phi_alloc_line}"
 
 
-def test_pto_codegen_if_stmt_tile_no_redundant_tmov():
-    """IfStmt emit_branch must not generate a codegen-level tmov for tile return_vars.
-
-    MemoryReuse's YieldFixupMutator inserts an IR-level tile.move in the else-branch
-    to unify its yield MemRef with the then-branch's canonical MemRef. The codegen
-    should emit exactly one pto.tmov (from that IR tile.move), not a second redundant
-    one from emit_branch (which would copy addr B → addr B, a no-op).
-    """
-
-    @pl.program
-    class IfTileNoRedundantTmovProgram:
-        @pl.function(type=pl.FunctionType.InCore)
-        def repro(
-            self,
-            flag: pl.Scalar[pl.INDEX],
-            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
-        ) -> pl.Tensor[[64, 64], pl.FP32]:
-            seed: pl.Tile[[64, 64], pl.FP32] = pl.tile.create(
-                [64, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
-            )
-            then_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.muls(seed, 2.0)
-            else_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.muls(seed, 3.0)
-            if flag == 0:
-                result = then_tile
-            else:
-                result = else_tile
-            final: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], out)
-            return final
-
-    mlir_code = _generate_default_mlir(IfTileNoRedundantTmovProgram)
-    lines = _get_mlir_lines(mlir_code)
-
-    tmov_lines = _find_lines(lines, "pto.tmov")
-    # After the fix: exactly one tmov — the IR-level tile.move (else branch only).
-    # The then-branch has no tmov; the codegen-level tmov from emit_branch is removed.
-    assert len(tmov_lines) == 1, (
-        f"Expected exactly 1 pto.tmov (from IR tile.move), got {len(tmov_lines)}: {tmov_lines}"
-    )
-
-    # The single tmov copies from the else computation result to the canonical tile_buf.
-    tmov = tmov_lines[0]
-    assert "pto.tmov" in tmov, f"Expected a pto.tmov line, got: {tmov}"
-    # Verify the tmov targets are at different addresses (it's a real copy, not a no-op).
-    ins_match = re.search(r"ins\((%[\w\d_]+)", tmov)
-    outs_match = re.search(r"outs\((%[\w\d_]+)", tmov)
-    assert ins_match and outs_match, f"Expected ins/outs operands in tmov: {tmov}"
-    assert ins_match.group(1) != outs_match.group(1), (
-        f"tmov src and dst must differ (not a self-copy): {tmov}"
-    )
-
-
 def test_pto_codegen_if_stmt_scalar_result_preserves_integer_dtype():
     """IfStmt scalar results should use their real scalar dtype in scf.if results."""
 

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -323,6 +323,50 @@ def test_matmul_with_transpose_kwargs():
     assert isinstance(call.type, ir.TensorType)
 
 
+def test_batch_matmul_with_valid_kwargs():
+    """Test tensor.batch_matmul with valid kwargs."""
+    span = ir.Span.unknown()
+
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+
+    type_a = ir.TensorType([dim2, dim64, dim128], DataType.FP16)
+    type_b = ir.TensorType([dim2, dim128, dim64], DataType.FP16)
+    var_a = ir.Var("a", type_a, span)
+    var_b = ir.Var("b", type_b, span)
+
+    kwargs = {"out_dtype": DataType.FP32, "a_trans": False, "b_trans": False}
+    call = ir.create_op_call("tensor.batch_matmul", [var_a, var_b], kwargs, span)
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+
+
+def test_tile_batch_matmul_type_deduction():
+    """Test tile.batch_matmul type deduction without transpose kwargs."""
+    span = ir.Span.unknown()
+
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+
+    type_a = ir.TileType([dim2, dim128, dim64], DataType.FP16)
+    type_b = ir.TileType([dim2, dim64, dim32], DataType.FP16)
+    var_a = ir.Var("a_tile", type_a, span)
+    var_b = ir.Var("b_tile", type_b, span)
+
+    call = ir.create_op_call("tile.batch_matmul", [var_a, var_b], span)
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TileType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+
+
 def test_matmul_with_unknown_kwarg():
     """Test tensor.matmul with unknown kwarg should raise error."""
     span = ir.Span.unknown()
@@ -415,6 +459,30 @@ def test_matmul_kwarg_schema():
     assert "out_dtype" in keys
     assert "a_trans" in keys
     assert "b_trans" in keys
+
+
+def test_batch_matmul_kwarg_schema():
+    """Test that tensor.batch_matmul has correct kwarg schema."""
+    batch_matmul_op = ir.get_op("tensor.batch_matmul")
+
+    assert batch_matmul_op.has_attr("out_dtype")
+    assert batch_matmul_op.has_attr("a_trans")
+    assert batch_matmul_op.has_attr("b_trans")
+    assert batch_matmul_op.has_attr("c_matrix_nz")
+
+    keys = batch_matmul_op.get_attr_keys()
+    assert "out_dtype" in keys
+    assert "a_trans" in keys
+    assert "b_trans" in keys
+
+
+def test_tile_batch_matmul_kwarg_schema():
+    """Test that tile.batch_matmul does not add custom kwargs."""
+    batch_matmul_op = ir.get_op("tile.batch_matmul")
+
+    keys = batch_matmul_op.get_attr_keys()
+    assert "a_trans" not in keys
+    assert "b_trans" not in keys
 
 
 def test_cast_kwarg_schema():

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -109,6 +109,202 @@ def test_tensor_matmul_with_transpose():
     assert isinstance(result_type, ir.TensorType)
 
 
+def test_tensor_matmul_rejects_batched_inputs():
+    """Test tensor.matmul rejects non-2D tensors."""
+    span = ir.Span.unknown()
+
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP32)
+    rhs_type = ir.TensorType([dim2, dim8, dim16], DataType.FP32)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    with pytest.raises(Exception, match="2D"):
+        ir.op.tensor.matmul(lhs, rhs)
+
+
+def test_tensor_batch_matmul_3d():
+    """Test tensor.batch_matmul with 3D tensors."""
+    span = ir.Span.unknown()
+
+    # Create 3D tensors: [2, 4, 8] @ [2, 8, 16] -> [2, 4, 16]
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP32)
+    rhs_type = ir.TensorType([dim2, dim8, dim16], DataType.FP32)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    call = tensor.batch_matmul(lhs, rhs)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.batch_matmul"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert len(result_type.shape) == 3
+
+
+def test_tensor_batch_matmul_4d_broadcast():
+    """Test tensor.batch_matmul with multiple batch dimensions and broadcasting."""
+    span = ir.Span.unknown()
+
+    dim1 = ir.ConstInt(1, DataType.INT32, span)
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim3 = ir.ConstInt(3, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim1, dim4, dim8], DataType.FP16)
+    rhs_type = ir.TensorType([dim1, dim3, dim8, dim16], DataType.FP16)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    call = tensor.batch_matmul(lhs, rhs)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.batch_matmul"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert len(result_type.shape) == 4
+    assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 2
+    assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 3
+    assert isinstance(result_type.shape[2], ir.ConstInt) and result_type.shape[2].value == 4
+    assert isinstance(result_type.shape[3], ir.ConstInt) and result_type.shape[3].value == 16
+
+
+def test_tensor_batch_matmul_with_kwargs():
+    """Test tensor.batch_matmul with kwargs (out_dtype, transpose)."""
+    span = ir.Span.unknown()
+
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP16)
+    rhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP16)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    call = tensor.batch_matmul(lhs, rhs, out_dtype=DataType.FP32, a_trans=True)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.batch_matmul"
+    assert call.kwargs.get("out_dtype") == DataType.FP32
+    assert call.kwargs.get("a_trans") is True
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+
+
+def test_tensor_batch_matmul_rejects_2d_inputs():
+    """Test tensor.batch_matmul rejects 2D tensors."""
+    span = ir.Span.unknown()
+
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim4, dim8], DataType.FP32)
+    rhs_type = ir.TensorType([dim8, dim16], DataType.FP32)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    with pytest.raises(Exception, match="at least 3 dimensions"):
+        tensor.batch_matmul(lhs, rhs)
+
+
+def test_tensor_batch_matmul_b_trans_only():
+    """Test tensor.batch_matmul with b_trans=True only."""
+    span = ir.Span.unknown()
+
+    # [2, 4, 8] @ [2, 16, 8] with b_trans -> RHS is [2, N=16, K=8] transposed to [2, K=8, N=16]
+    # Result: [2, 4, 16]
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP16)
+    rhs_type = ir.TensorType([dim2, dim16, dim8], DataType.FP16)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    call = tensor.batch_matmul(lhs, rhs, b_trans=True)
+
+    assert isinstance(call, ir.Call)
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert len(result_type.shape) == 3
+    assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 2
+    assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 4
+    assert isinstance(result_type.shape[2], ir.ConstInt) and result_type.shape[2].value == 16
+
+
+def test_tensor_batch_matmul_both_trans():
+    """Test tensor.batch_matmul with both a_trans=True and b_trans=True."""
+    span = ir.Span.unknown()
+
+    # [2, K=8, M=4] with a_trans -> LHS is [2, M=4, K=8]
+    # [2, N=16, K=8] with b_trans -> RHS is [2, K=8, N=16]
+    # Result: [2, 4, 16]
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim8, dim4], DataType.FP16)
+    rhs_type = ir.TensorType([dim2, dim16, dim8], DataType.FP16)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    call = tensor.batch_matmul(lhs, rhs, a_trans=True, b_trans=True)
+
+    assert isinstance(call, ir.Call)
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert len(result_type.shape) == 3
+    assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 2
+    assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 4
+    assert isinstance(result_type.shape[2], ir.ConstInt) and result_type.shape[2].value == 16
+
+
+def test_tensor_batch_matmul_k_dimension_mismatch():
+    """Test tensor.batch_matmul rejects K dimension mismatch."""
+    span = ir.Span.unknown()
+
+    # [2, 4, 8] @ [2, 7, 16] -> K=8 vs K=7 mismatch
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim7 = ir.ConstInt(7, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    lhs_type = ir.TensorType([dim2, dim4, dim8], DataType.FP16)
+    rhs_type = ir.TensorType([dim2, dim7, dim16], DataType.FP16)
+
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = ir.Var("rhs", rhs_type, span)
+
+    with pytest.raises(Exception):
+        tensor.batch_matmul(lhs, rhs)
+
+
 def test_tensor_matmul_acc():
     """Test tensor.matmul_acc operation."""
     span = ir.Span.unknown()
@@ -832,6 +1028,7 @@ def test_operator_registration():
     assert ir.is_op_registered("tensor.write")
     assert ir.is_op_registered("tensor.slice")
     assert ir.is_op_registered("tensor.matmul")
+    assert ir.is_op_registered("tensor.batch_matmul")
     assert ir.is_op_registered("tensor.row_max")
     assert ir.is_op_registered("tensor.row_sum")
     assert ir.is_op_registered("tensor.exp")
@@ -943,6 +1140,9 @@ def test_get_new_ops():
     """Test getting new operator instances."""
     matmul_op = ir.get_op("tensor.matmul")
     assert matmul_op.name == "tensor.matmul"
+
+    batch_matmul_op = ir.get_op("tensor.batch_matmul")
+    assert batch_matmul_op.name == "tensor.batch_matmul"
 
     exp_op = ir.get_op("tensor.exp")
     assert exp_op.name == "tensor.exp"

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1033,14 +1033,14 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 2
-        assert result_type.dtype == DataType.FP16
+        assert result_type.dtype == DataType.FP32
 
     def test_batch_matmul_3d(self):
         """Test tile.batch_matmul with 3D tiles (batch dimension)."""
@@ -1059,7 +1059,7 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
@@ -1086,14 +1086,14 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 4
-        assert result_type.dtype == DataType.FP16
+        assert result_type.dtype == DataType.FP32
 
     def test_batch_matmul_broadcast(self):
         """Test tile.batch_matmul with broadcasting batch dimensions."""
@@ -1113,15 +1113,74 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 3
 
+    def test_batch_matmul_dtype_mismatch(self):
+        """Test tile.batch_matmul rejects mismatched dtypes."""
+        span = ir.Span.unknown()
 
-class TestMultiDimensionalTileOps:
+        dim4 = ir.ConstInt(4, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim4, dim16, dim32], DataType.FP16)
+        rhs_type = ir.TileType([dim4, dim32, dim16], DataType.FP32)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        with pytest.raises(Exception):
+            tile.batch_matmul(lhs, rhs, span)
+
+    def test_batch_matmul_int_accumulation(self):
+        """Test tile.batch_matmul with integer inputs produces INT32 accumulator dtype."""
+        span = ir.Span.unknown()
+
+        dim2 = ir.ConstInt(2, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim2, dim16, dim32], DataType.INT8)
+        rhs_type = ir.TileType([dim2, dim32, dim16], DataType.INT8)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        call = tile.batch_matmul(lhs, rhs, span)
+
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.INT32
+
+    def test_batch_matmul_output_tile_view(self):
+        """Test tile.batch_matmul output has correct TileView (col_major, row_major, fractal=1024)."""
+        span = ir.Span.unknown()
+
+        dim2 = ir.ConstInt(2, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim2, dim16, dim32], DataType.FP16)
+        rhs_type = ir.TileType([dim2, dim32, dim64], DataType.FP16)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        call = tile.batch_matmul(lhs, rhs, span)
+
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        assert result_type.tile_view.blayout == ir.TileLayout.col_major
+        assert result_type.tile_view.slayout == ir.TileLayout.row_major
+        assert result_type.tile_view.fractal == 1024
+
     """Tests for multi-dimensional TileType operations."""
 
     def test_transpose_3d(self):

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -650,6 +650,271 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_batch_matmul_conversion(self):
+        """tensor.batch_matmul -> tile.load(Mat) + tile.batch_matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = pl.tensor.batch_matmul(lhs, rhs)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_batch_mat: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs,
+                    [0, 0, 0],
+                    [2, 16, 128],
+                    [2, 16, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                rhs_batch_mat: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs,
+                    [0, 0, 0],
+                    [2, 128, 64],
+                    [2, 128, 64],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                batch_matmul_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(
+                    lhs_batch_mat, rhs_batch_mat
+                )
+                out_0_store: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(batch_matmul_tile, [0, 0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_batch_matmul_transpose_conversion(self):
+        """tensor.batch_matmul transpose kwargs become explicit tile.transpose operands."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = pl.tensor.batch_matmul(
+                    lhs, rhs, a_trans=True, b_trans=True
+                )
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_batch_mat: pl.Tile[[2, 128, 16], pl.FP16] = pl.load(
+                    lhs,
+                    [0, 0, 0],
+                    [2, 128, 16],
+                    [2, 128, 16],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                rhs_batch_mat: pl.Tile[[2, 64, 128], pl.FP16] = pl.load(
+                    rhs,
+                    [0, 0, 0],
+                    [2, 64, 128],
+                    [2, 64, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                batch_matmul_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(
+                    pl.transpose(lhs_batch_mat, axis1=1, axis2=2),
+                    pl.transpose(rhs_batch_mat, axis1=1, axis2=2),
+                )
+                out_0_store: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(batch_matmul_tile, [0, 0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_batch_matmul_a_trans_only_conversion(self):
+        """tensor.batch_matmul a_trans=True -> only LHS gets tile.transpose."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = pl.tensor.batch_matmul(lhs, rhs, a_trans=True)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_batch_mat: pl.Tile[[2, 128, 16], pl.FP16] = pl.load(
+                    lhs,
+                    [0, 0, 0],
+                    [2, 128, 16],
+                    [2, 128, 16],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                rhs_batch_mat: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs,
+                    [0, 0, 0],
+                    [2, 128, 64],
+                    [2, 128, 64],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                batch_matmul_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(
+                    pl.transpose(lhs_batch_mat, axis1=1, axis2=2),
+                    rhs_batch_mat,
+                )
+                out_0_store: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(batch_matmul_tile, [0, 0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_batch_matmul_b_trans_only_conversion(self):
+        """tensor.batch_matmul b_trans=True -> only RHS gets tile.transpose."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = pl.tensor.batch_matmul(lhs, rhs, b_trans=True)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_batch_mat: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs,
+                    [0, 0, 0],
+                    [2, 16, 128],
+                    [2, 16, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                rhs_batch_mat: pl.Tile[[2, 64, 128], pl.FP16] = pl.load(
+                    rhs,
+                    [0, 0, 0],
+                    [2, 64, 128],
+                    [2, 64, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                batch_matmul_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(
+                    lhs_batch_mat,
+                    pl.transpose(rhs_batch_mat, axis1=1, axis2=2),
+                )
+                out_0_store: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(batch_matmul_tile, [0, 0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_matmul_acc_conversion(self):
         """tensor.matmul + tensor.matmul_acc -> tile.matmul + tile.matmul_acc.
 
@@ -2444,6 +2709,47 @@ class TestTensorFullConversion:
         ir_str = str(After)
         assert "tile.full" in ir_str
         assert "tensor.full" not in ir_str
+
+
+class TestInOutParamHandling:
+    """Tests for InOut parameter handling in ConvertTensorToTileOps."""
+
+    def test_out_param_reuses_existing_unused_param_for_batch_matmul_return(self):
+        """Unused Out tensor param is reused for returned batch_matmul store."""
+
+        @pl.program
+        class Input:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                c: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = pl.tensor.batch_matmul(lhs, rhs)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                c: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                y: pl.Tensor[[2, 16, 64], pl.FP16] = self.main_incore_0(lhs, rhs, c)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Input)
+        incore_func = After.get_function("main_incore_0")
+        assert incore_func is not None
+
+        out_params = [
+            param.name_hint
+            for param, direction in zip(incore_func.params, incore_func.param_directions, strict=False)
+            if direction == ir.ParamDirection.Out
+        ]
+        assert out_params == ["c"], f"Expected existing Out param 'c' to be reused, got {out_params}"
+        assert "ret0__out" not in str(incore_func)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1796,5 +1796,173 @@ class TestFlattenTileNdTo2DControlFlow:
         passes.verify_properties(props, After, "test_while_stmt_tile_iter_arg")
 
 
+class TestFlattenTileNdTo2DBatchMatmul:
+    """Tests for tile.batch_matmul lowering inside FlattenTileNdTo2D."""
+
+    def test_batch_matmul_broadcasts_and_unrolls(self):
+        """Broadcasted tile.batch_matmul expands to per-batch 2D tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 3, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 1, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0, 0], [2, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[1, 3, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0, 0], [1, 3, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 3, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 3, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir_str = str(After)
+
+        assert "tile.batch_matmul" not in ir_str
+        assert ir_str.count("tile.matmul") == 6
+        assert "tile.reshape" not in ir_str
+        assert "tile.store" in ir_str
+
+    def test_batch_matmul_with_inline_transpose_unrolls_per_batch(self):
+        """Inline transpose operands stay per-batch after tile.batch_matmul flattening."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 128, 16], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 64, 128], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 64, 128], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(
+                    pl.transpose(lhs_tile, axis1=1, axis2=2),
+                    pl.transpose(rhs_tile, axis1=1, axis2=2),
+                )
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir_str = str(After)
+
+        assert "tile.batch_matmul" not in ir_str
+        assert ir_str.count("tile.matmul") == 2
+        assert ir_str.count("tile.transpose") == 4
+        assert "tile.reshape" not in ir_str
+
+    def test_batch_matmul_3d_no_transpose_unrolls(self):
+        """Simple 3D tile.batch_matmul without transpose unrolls to per-batch tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir_str = str(After)
+
+        assert "tile.batch_matmul" not in ir_str
+        assert ir_str.count("tile.matmul") == 2
+        assert "tile.transpose" not in ir_str
+        assert "tile.reshape" not in ir_str
+        assert "tile.store" in ir_str
+
+    def test_batch_matmul_single_batch_unrolls(self):
+        """Batch=1 edge case: tile.batch_matmul unrolls to exactly 1 tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[1, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[1, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[1, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[1, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([1, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir_str = str(After)
+
+        assert "tile.batch_matmul" not in ir_str
+        assert ir_str.count("tile.matmul") == 1
+        assert "tile.transpose" not in ir_str
+        assert "tile.reshape" not in ir_str
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -233,7 +233,7 @@ class TestMemRefSharing:
                 result_memrefs[stmt.var.name_hint] = stmt.var.type.memref
 
         assert "result" in result_memrefs
-        assert result_memrefs["result"] is param_types["output"].memref
+        assert result_memrefs["result"].id_ == param_types["output"].memref.id_
 
     def test_view_op_shares_memref_with_input(self):
         """tile.reshape output shares MemRef with its input tile."""
@@ -310,6 +310,43 @@ class TestMemRefSharing:
         # Only 1 Acc alloc needed (not 2)
         acc_allocs = [a for a in _get_alloc_stmts(func) if a.value.args[0].value == MemorySpace.Acc.value]
         assert len(acc_allocs) == 1
+
+    def test_call_result_shares_memref_with_returned_out_param(self):
+        """Call result should share MemRef when callee returns a store result backed by an Out param."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Group)
+            def callee(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [64, 64])
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], output)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                result: pl.Tensor[[64, 64], pl.FP32] = self.callee(input_a, output)
+                return result
+
+        After = passes.init_mem_ref()(Before)
+        func = After.get_function("orchestrator")
+        assert func is not None
+
+        param_types = _get_param_types(func)
+        result_memrefs = {}
+        for stmt in _iter_assign_stmts(func):
+            if isinstance(stmt.var.type, ir.TensorType) and stmt.var.type.memref is not None:
+                result_memrefs[stmt.var.name_hint] = stmt.var.type.memref
+
+        assert "result" in result_memrefs
+        assert result_memrefs["result"] is param_types["output"].memref
 
 
 class TestYieldMemRef:


### PR DESCRIPTION
## Summary
- Rebase batch matmul pipeline onto latest `origin/main`
- Keep `tensor.matmul` 2D-only, route `tensor.batch_matmul` through `tile.batch_matmul` and legalize in `FlattenTileNdTo2D`
- Preserve tile-layer API style: transpose stays explicit as `tile.transpose(...)` operands
- Handle output-alias / returned-out-param in `ConvertTensorToTileOps` and `InitMemRef`

## What Changed
- Split tensor-level matmul semantics so batched inputs go through `tensor.batch_matmul`
- Lower `tensor.batch_matmul` → `tile.batch_matmul` → per-batch 2D `tile.matmul` in `FlattenTileNdTo2D`
- Canonicalize simple batch offset additions in `FlattenTileNdTo2D` for stable printed forms
- Fix `tile.transpose` IR wrapper axis normalization for roundtrip parsing

## Test Coverage (aligned with matmul)

### UT (10 new tests, all passing)
- **test_tensor_ops.py** (+3): b_trans shape deduction, both_trans verification, K-dim mismatch rejection
- **test_tile_ops.py** (+3): dtype mismatch rejection, INT8→INT32 accumulator, TileView properties
- **test_convert_tensor_to_tile_ops.py** (+2): a_trans-only and b_trans-only conversion
- **test_flatten_tile_nd_to_2d.py** (+2): 3D no-transpose unroll, single-batch edge case

### ST (6 parametrized cases, all passing)
- `test_batch_matmul` × 3 shapes: basic tensor-level batch_matmul (FP32)
- `test_batch_matmul_pto` × 3 shapes: PTO backend + PTOAS optimization (Default strategy, Ascend910B)

### Known limitations (not tested — matches matmul's FP32-only pattern)
- batch_matmul transpose: standalone `tile.transpose` in Mat memory unsupported by codegen (MemRef not allocated)
- FP16 I/O: a2a3sim platform does not support FP16 tensor I/O at all

## Related Issues
- Fixes #536