### PR TITLE
feat(ir): Add scatter_update tensor op, tile op, and tensor-to-tile conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(PYPTO_SOURCES
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp
     src/ir/op/tensor_ops/memory.cpp
+    src/ir/op/tensor_ops/scatter_update.cpp
     src/ir/op/tensor_ops/reduction.cpp
     src/ir/op/tensor_ops/transform.cpp
     src/ir/op/tensor_ops/unary.cpp

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -41,6 +41,7 @@ Operate on `Tensor` objects (DDR memory).
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | Reshape |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | Swap two axes |
 | `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | Write source into target at offset |
+| `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | Update rows of `input` at sparse positions given by `index` with values from `src`. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise add |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise subtract |
 | `mul` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise multiply |
@@ -65,6 +66,7 @@ Transfer data between memory hierarchy levels.
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat) |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset |
+| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices. Sugar: `A[i, j]` |
 | `write` | `(tile: Tile, indices: IntLike \| Sequence[IntLike], value: Scalar) -> None` | Write scalar at indices. Sugar: `A[i, j] = v` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | Move tile between memory levels (including Vec→Vec) |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -38,6 +38,7 @@
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | 变形 |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | 交换两个轴 |
 | `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | 将 source 写入 target 的指定偏移 |
+| `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | 按 `index` 指定的稀疏行位置，将 `src` 的行数据写入 `input`。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素加法 |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素减法 |
 | `mul` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素乘法 |
@@ -62,6 +63,7 @@
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat） |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处 |
+| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -824,3 +824,36 @@ def transpose(
     if valid_shape is not None:
         args.append(_to_make_tuple(valid_shape, actual_span))
     return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)
+
+
+def scatter_update(
+    input: Expr,
+    dim: int,
+    index: Expr,
+    src: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Update input tensor rows at positions specified by 2D index with values from src.
+
+    Supports two variants based on input/src rank:
+    - 2D: input [rows, d], src [b*s, d], index [b, s]
+    - 4D: input [blockNum, blockSize, 1, d], src [b, s, 1, d], index [b, s]
+
+    For each (i, j): input[index[i*s+j]] row = src[i*s+j] row (linear layout).
+
+    Args:
+        input: Destination tensor (2D or 4D TensorType)
+        dim: Dimension to scatter along (default: -2, currently the only supported value)
+        index: 2D index tensor [b, s] of integer dtype
+        src: Source tensor (2D [b*s, d] or 4D [b, s, 1, d])
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the updated input tensor
+    """
+    actual_span = _get_span_or_capture(span)
+    args = [input, index, src]
+    # dim may arrive as a ConstInt when called from the DSL parser — extract the int value
+    dim_val = int(dim.value) if isinstance(dim, ConstInt) else int(dim)
+    kwargs: dict[str, Any] = {"dim": dim_val}
+    return _ir_core.create_op_call("tensor.scatter_update", args, kwargs, actual_span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -195,6 +195,36 @@ def assemble(
     return _ir_core.create_op_call("tile.assemble", [target, source, offset_tuple], {}, actual_span)
 
 
+def scatter_update(
+    input: Expr,
+    dim: int,
+    index: Expr,
+    src: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Update tile rows at positions specified by 2D index tile with values from src.
+
+    Supports two variants based on input/src rank:
+    - 2D: input [rows, d], src [b*s, d], index [b, s]
+    - 4D: input [blockNum, blockSize, 1, d], src [b, s, 1, d], index [b, s]
+
+    Args:
+        input: Destination tile (TileType, 2D or 4D)
+        dim: Dimension to scatter along (currently only -2 is supported)
+        index: 2D index tile [b, s] of integer dtype
+        src: Source tile (same rank as input)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning a TileType with the same shape/dtype as input
+    """
+    actual_span = _get_span_or_capture(span)
+    # dim may arrive as a ConstInt when called from the DSL parser — extract the int value
+    dim_val = int(dim.value) if isinstance(dim, ConstInt) else int(dim)
+    kwargs: dict[str, Any] = {"dim": dim_val}
+    return _ir_core.create_op_call("tile.scatter_update", [input, index, src], kwargs, actual_span)
+
+
 def concat(
     src0: Expr,
     src1: Expr,

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -86,7 +86,7 @@ from .op.system_ops import (
     tpush_to_aic,
     tpush_to_aiv,
 )
-from .op.tensor_ops import assemble, create_tensor, dim
+from .op.tensor_ops import assemble, create_tensor, dim, scatter_update
 from .op.tile_ops import (
     abs,
     addc,
@@ -326,6 +326,7 @@ __all__ = [
     "create_tensor",
     "assemble",
     "dim",
+    "scatter_update",
     "FunctionType",
     "ForKind",
     "Level",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -27,7 +27,7 @@ from . import tensor_ops as tensor
 from . import tile_ops as tile
 
 # Promoted tensor-only ops (accessible as pl.create_tensor, etc.)
-from .tensor_ops import assemble, dim
+from .tensor_ops import assemble, dim, scatter_update
 from .tensor_ops import create as create_tensor
 
 # Promoted tile-only ops (accessible as pl.load, etc.)
@@ -190,4 +190,5 @@ __all__ = [
     "create_tensor",
     "assemble",
     "dim",
+    "scatter_update",
 ]

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -56,6 +56,7 @@ __all__ = [
     "concat",
     "reshape",
     "transpose",
+    "scatter_update",
 ]
 
 from pypto.ir.op import tensor_ops as _ir_ops
@@ -717,4 +718,29 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
     """
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.transpose(tensor_expr, axis1, axis2)
+    return Tensor(expr=call_expr)
+
+
+def scatter_update(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    src: Tensor,
+) -> Tensor:
+    """Update input tensor rows at positions specified by 2D index with values from src.
+
+    Supports two variants based on input/src rank:
+    - 2D: input [rows, d], src [b*s, d], index [b, s]
+    - 4D: input [blockNum, blockSize, 1, d], src [b, s, 1, d], index [b, s]
+
+    Args:
+        input: Destination tensor (2D or 4D)
+        dim: Dimension to scatter along (currently only -2 is supported)
+        index: 2D index tensor [b, s] of integer dtype
+        src: Source tensor (2D [b*s, d] or 4D [b, s, 1, d])
+
+    Returns:
+        Tensor wrapping the scatter_update operation
+    """
+    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
     return Tensor(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -26,6 +26,7 @@ __all__ = [
     "load",
     "store",
     "assemble",
+    "scatter_update",
     "concat",
     "move",
     "full",
@@ -270,6 +271,27 @@ def assemble(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile:
         Tile wrapping the assemble operation
     """
     call_expr = _ir_ops.assemble(target.unwrap(), source.unwrap(), _normalize_intlike(offset))
+    return Tile(expr=call_expr)
+
+
+def scatter_update(
+    input: Tile,
+    dim: int,
+    index: Tile,
+    src: Tile,
+) -> Tile:
+    """Update tile rows at positions specified by 2D index tile with values from src.
+
+    Args:
+        input: Destination tile (2D or 4D)
+        dim: Dimension to scatter along (currently only -2 is supported)
+        index: 2D index tile [b, s] of integer dtype
+        src: Source tile (same rank as input)
+
+    Returns:
+        Tile wrapping the scatter_update operation
+    """
+    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <string>
 
@@ -264,6 +265,66 @@ REGISTER_ORCHESTRATION_OP(tensor_dim, ("tensor.dim")) {
 
   std::ostringstream oss;
   oss << "int64_t " << result_var << " = " << dim_expr << ";";
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_scatter_update, ("tensor.scatter_update")) {
+  // tensor.scatter_update(input, index, src):
+  //   For each (i, j): input[index[i*s+j]] row = src[i*s+j] row
+  // Works for both 2D ([rows, d]) and 4D ([blockNum, blockSize, 1, d]) inputs,
+  // since their linear memory layouts are equivalent.
+  CHECK(op->args_.size() == 3) << "tensor.scatter_update requires 3 arguments";
+
+  std::string input_name = codegen.TryGetVarName(op->args_[0]);
+  CHECK(!input_name.empty()) << "tensor.scatter_update: input must be a variable";
+  std::string index_name = codegen.TryGetVarName(op->args_[1]);
+  CHECK(!index_name.empty()) << "tensor.scatter_update: index must be a variable";
+  std::string src_name = codegen.TryGetVarName(op->args_[2]);
+  CHECK(!src_name.empty()) << "tensor.scatter_update: src must be a variable";
+
+  auto input_type = As<TensorType>(op->args_[0]->GetType());
+  auto index_type = As<TensorType>(op->args_[1]->GetType());
+  INTERNAL_CHECK(input_type && index_type) << "Internal error: invalid types for tensor.scatter_update";
+
+  std::string input_ptr = codegen.GetTensorDataPtr(input_name);
+  std::string index_ptr = codegen.GetTensorDataPtr(index_name);
+  std::string src_ptr = codegen.GetTensorDataPtr(src_name);
+
+  // b = index.shape[0], s = index.shape[1], d = last dimension of input
+  std::string b_expr = codegen.GenerateExprString(index_type->shape_[0]);
+  std::string s_expr = codegen.GenerateExprString(index_type->shape_[1]);
+  std::string d_expr = codegen.GenerateExprString(input_type->shape_.back());
+
+  size_t elem_bytes = (input_type->dtype_.GetBit() + 7) / 8;
+  std::string result_var = codegen.GetCurrentResultTarget();
+
+  // Use result_var as suffix to ensure unique local variable names
+  std::string s_var = "s_" + result_var;
+  std::string d_var = "d_" + result_var;
+  std::string i_var = "i_" + result_var;
+  std::string j_var = "j_" + result_var;
+  std::string idx_var = "idx_" + result_var;
+  std::string row_var = "row_" + result_var;
+
+  std::string index_cpp_type = index_type->dtype_.ToCTypeString();
+
+  std::ostringstream oss;
+  oss << "size_t " << s_var << " = (size_t)(" << s_expr << ");\n";
+  oss << "size_t " << d_var << " = (size_t)(" << d_expr << ");\n";
+  oss << "for (size_t " << i_var << " = 0; " << i_var << " < (size_t)(" << b_expr << "); ++" << i_var
+      << ") {\n";
+  oss << "  for (size_t " << j_var << " = 0; " << j_var << " < " << s_var << "; ++" << j_var << ") {\n";
+  oss << "    size_t " << idx_var << " = " << i_var << " * " << s_var << " + " << j_var << ";\n";
+  oss << "    " << index_cpp_type << " " << row_var << " = static_cast<const " << index_cpp_type << "*>("
+      << index_ptr << ")[" << idx_var << "];\n";
+  oss << "    always_assert(" << row_var << " >= 0);\n";
+  oss << "    memcpy(static_cast<char*>(" << input_ptr << ") + static_cast<size_t>(" << row_var << ") * "
+      << d_var << " * " << elem_bytes << "ULL,\n";
+  oss << "           static_cast<const char*>(" << src_ptr << ") + " << idx_var << " * " << d_var << " * "
+      << elem_bytes << "ULL,\n";
+  oss << "           " << d_var << " * " << elem_bytes << "ULL);\n";
+  oss << "  }\n}\n";
+  oss << "Tensor " << result_var << " = " << codegen.GetExternalTensorName(input_name) << ";";
   return oss.str();
 }
 

--- a/src/ir/op/tensor_ops/scatter_update.cpp
+++ b/src/ir/op/tensor_ops/scatter_update.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file scatter_update.cpp
+ * @brief Scatter update tensor operation
+ *
+ * Implements tensor.scatter_update, which updates rows of an input tensor at positions
+ * specified by a 2D index tensor, using values from a source tensor.
+ */
+
+#include <any>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/any_cast.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+TypePtr DeduceTensorScatterUpdateType(const std::vector<ExprPtr>& args,
+                                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.scatter_update(input, index, src) -> TensorType same as input
+  // input: 2D [rows, d] or 4D [blockNum, blockSize, 1, d]
+  // index: 2D [b, s] of integer dtype
+  // src:   2D [b*s, d] or 4D [b, s, 1, d] (same rank as input)
+  CHECK(args.size() == 3) << "tensor.scatter_update requires exactly 3 arguments (input, index, src), got "
+                          << args.size();
+
+  auto input_type = As<TensorType>(args[0]->GetType());
+  CHECK(input_type) << "tensor.scatter_update: input must be TensorType, got "
+                    << args[0]->GetType()->TypeName();
+  CHECK(input_type->shape_.size() == 2 || input_type->shape_.size() == 4)
+      << "tensor.scatter_update: input must be 2D or 4D, got rank " << input_type->shape_.size();
+
+  auto index_type = As<TensorType>(args[1]->GetType());
+  CHECK(index_type) << "tensor.scatter_update: index must be TensorType, got "
+                    << args[1]->GetType()->TypeName();
+  CHECK(index_type->shape_.size() == 2)
+      << "tensor.scatter_update: index must be 2D [b, s], got rank " << index_type->shape_.size();
+  CHECK(index_type->dtype_.IsInt()) << "tensor.scatter_update: index dtype must be integer, got "
+                                    << index_type->dtype_.ToString();
+
+  auto src_type = As<TensorType>(args[2]->GetType());
+  CHECK(src_type) << "tensor.scatter_update: src must be TensorType, got " << args[2]->GetType()->TypeName();
+  CHECK(src_type->shape_.size() == input_type->shape_.size())
+      << "tensor.scatter_update: src rank (" << src_type->shape_.size() << ") must match input rank ("
+      << input_type->shape_.size() << ")";
+  CHECK(src_type->dtype_ == input_type->dtype_)
+      << "tensor.scatter_update: src dtype (" << src_type->dtype_.ToString() << ") must match input dtype ("
+      << input_type->dtype_.ToString() << ")";
+
+  // Validate dim kwarg: only -2 is currently supported
+  for (const auto& [key, val] : kwargs) {
+    if (key == "dim") {
+      int dim_val = AnyCast<int>(val, "kwarg key: dim");
+      CHECK(dim_val == -2) << "tensor.scatter_update: only dim=-2 is currently supported, got " << dim_val;
+    }
+  }
+
+  return std::make_shared<TensorType>(input_type->shape_, input_type->dtype_);
+}
+
+REGISTER_OP("tensor.scatter_update")
+    .set_op_category("TensorOp")
+    .set_description(
+        "Update input tensor rows at positions given by 2D index tensor with values from src. "
+        "Supports 2D input [rows, d] with 2D src [b*s, d], and 4D input [blockNum, blockSize, 1, d] "
+        "with 4D src [b, s, 1, d]. Index is always 2D [b, s] of integer dtype.")
+    .add_argument("input", "Destination tensor (2D [rows, d] or 4D [blockNum, blockSize, 1, d])")
+    .add_argument("index", "2D index tensor [b, s] of integer dtype")
+    .add_argument("src", "Source tensor (2D [b*s, d] or 4D [b, s, 1, d])")
+    .set_attr<int>("dim")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorScatterUpdateType(args, kwargs);
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
@@ -371,6 +372,65 @@ REGISTER_OP("tile.assemble")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileAssembleType(args, kwargs);
+    });
+
+TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.scatter_update(input, index, src) -> TileType same as input
+  // input: TileType 2D [rows, d] or 4D [blockNum, blockSize, 1, d]
+  // index: TileType 2D [b, s] of integer dtype
+  // src:   TileType 2D [b*s, d] or 4D [b, s, 1, d] (same rank as input)
+  CHECK(args.size() == 3) << "tile.scatter_update requires exactly 3 arguments (input, index, src), got "
+                          << args.size();
+
+  auto input_type = As<TileType>(args[0]->GetType());
+  CHECK(input_type) << "tile.scatter_update: input must be TileType, got " << args[0]->GetType()->TypeName();
+  CHECK(input_type->shape_.size() == 2 || input_type->shape_.size() == 4)
+      << "tile.scatter_update: input must be 2D or 4D, got rank " << input_type->shape_.size();
+
+  auto index_type = As<TileType>(args[1]->GetType());
+  CHECK(index_type) << "tile.scatter_update: index must be TileType, got " << args[1]->GetType()->TypeName();
+  CHECK(index_type->shape_.size() == 2)
+      << "tile.scatter_update: index must be 2D [b, s], got rank " << index_type->shape_.size();
+  CHECK(index_type->dtype_.IsInt()) << "tile.scatter_update: index dtype must be integer, got "
+                                    << index_type->dtype_.ToString();
+
+  auto src_type = As<TileType>(args[2]->GetType());
+  CHECK(src_type) << "tile.scatter_update: src must be TileType, got " << args[2]->GetType()->TypeName();
+  CHECK(src_type->shape_.size() == input_type->shape_.size())
+      << "tile.scatter_update: src rank (" << src_type->shape_.size() << ") must match input rank ("
+      << input_type->shape_.size() << ")";
+  CHECK(src_type->dtype_ == input_type->dtype_)
+      << "tile.scatter_update: src dtype (" << src_type->dtype_.ToString() << ") must match input dtype ("
+      << input_type->dtype_.ToString() << ")";
+
+  for (const auto& [key, val] : kwargs) {
+    if (key == "dim") {
+      int dim_val = AnyCast<int>(val, "kwarg key: dim");
+      CHECK(dim_val == -2) << "tile.scatter_update: only dim=-2 is currently supported, got " << dim_val;
+    }
+  }
+
+  return std::make_shared<TileType>(input_type->shape_, input_type->dtype_);
+}
+
+REGISTER_OP("tile.scatter_update")
+    .set_op_category("TileOp")
+    .set_description(
+        "Update input tile rows at positions given by 2D index tile with values from src. "
+        "Supports 2D input [rows, d] with 2D src [b*s, d], and 4D input [blockNum, blockSize, 1, d] "
+        "with 4D src [b, s, 1, d]. Index is always 2D [b, s] of integer dtype.")
+    .add_argument("input", "Destination tile (2D [rows, d] or 4D [blockNum, blockSize, 1, d])")
+    .add_argument("index", "2D index tile [b, s] of integer dtype")
+    .add_argument("src", "Source tile (2D [b*s, d] or 4D [b, s, 1, d])")
+    .set_attr<int>("dim")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    .set_input_memory(2, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileScatterUpdateType(args, kwargs);
     });
 
 TypePtr DeduceTileConcatType(const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -430,6 +430,71 @@ OpConversionRegistry::OpConversionRegistry() {
       });
 
   // ────────────────────────────────────────────────────────────────────────
+  // tensor.scatter_update → tile.scatter_update
+  //
+  // When input is a TileType (local buffer created via tensor.create), load
+  // index and src if needed, then emit tile.scatter_update(input, index, src).
+  // When input is a TensorType (global memory, e.g. KV cache pool), keep the
+  // op unchanged — the orchestration codegen handles it via memcpy.
+  // ────────────────────────────────────────────────────────────────────────
+
+  RegisterCustom(
+      "tensor.scatter_update",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 3) << "tensor.scatter_update conversion expects 3 args (input, index, src)";
+        auto& op_reg = OpRegistry::GetInstance();
+
+        const auto& input = args[0];
+        const auto& index = args[1];
+        const auto& src = args[2];
+
+        auto input_tensor_type = As<TensorType>(input->GetType());
+
+        if (input_tensor_type) {
+          // Global tensor input — keep as tensor.scatter_update (handled by orchestration codegen)
+          if (kwargs.empty()) {
+            return ConversionResult{op_reg.Create("tensor.scatter_update", args, span)};
+          }
+          return ConversionResult{op_reg.Create("tensor.scatter_update", args, kwargs, span)};
+        }
+
+        CHECK(As<TileType>(input->GetType()))
+            << "tensor.scatter_update: unexpected input type: " << input->GetType()->TypeName();
+
+        std::vector<StmtPtr> prologue;
+
+        // Load index to Vec tile if it is still a global tensor
+        ExprPtr index_tile = index;
+        if (auto index_tensor_type = As<TensorType>(index->GetType())) {
+          auto offsets = MakeZeroOffsetsTuple(index_tensor_type->shape_.size(), span);
+          auto shapes = MakeShapesTuple(index_tensor_type->shape_, span);
+          std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", MemorySpace::Vec},
+                                                                   {"transpose", false}};
+          auto load = op_reg.Create("tile.load", {index, offsets, shapes, shapes}, load_kw, span);
+          auto idx_var = std::make_shared<Var>("scatter_idx", load->GetType(), span);
+          prologue.push_back(std::make_shared<AssignStmt>(idx_var, load, span));
+          index_tile = idx_var;
+        }
+
+        // Load src to Vec tile if it is still a global tensor
+        ExprPtr src_tile = src;
+        if (auto src_tensor_type = As<TensorType>(src->GetType())) {
+          auto offsets = MakeZeroOffsetsTuple(src_tensor_type->shape_.size(), span);
+          auto shapes = MakeShapesTuple(src_tensor_type->shape_, span);
+          std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", MemorySpace::Vec},
+                                                                   {"transpose", false}};
+          auto load = op_reg.Create("tile.load", {src, offsets, shapes, shapes}, load_kw, span);
+          auto src_var = std::make_shared<Var>("scatter_src", load->GetType(), span);
+          prologue.push_back(std::make_shared<AssignStmt>(src_var, load, span));
+          src_tile = src_var;
+        }
+
+        auto scatter_call = op_reg.Create("tile.scatter_update", {input, index_tile, src_tile}, kwargs, span);
+        return ConversionResult{std::move(prologue), scatter_call};
+      });
+
+  // ────────────────────────────────────────────────────────────────────────
   // tensor.create → tile.create
   //
   // tensor.create(shape, dtype=...) → tile.create(shape, dtype=..., target_memory=Vec)

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1462,5 +1462,106 @@ def test_tensor_concat_row_mismatch():
         tensor.concat(t0_var, t1_var)
 
 
+def test_tensor_scatter_update_2d():
+    """Test tensor.scatter_update with 2D input and src."""
+    span = ir.Span.unknown()
+
+    rows = ir.ConstInt(16, DataType.INT32, span)
+    d = ir.ConstInt(64, DataType.INT32, span)
+    b = ir.ConstInt(2, DataType.INT32, span)
+    s = ir.ConstInt(4, DataType.INT32, span)
+    bs = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([rows, d], DataType.FP16)
+    index_type = ir.TensorType([b, s], DataType.INT32)
+    src_type = ir.TensorType([bs, d], DataType.FP16)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+    src_var = ir.Var("src", src_type, span)
+
+    call = ir.op.tensor.scatter_update(input_var, -2, index_var, src_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.scatter_update"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert len(result_type.shape) == 2
+
+
+def test_tensor_scatter_update_4d():
+    """Test tensor.scatter_update with 4D input and src."""
+    span = ir.Span.unknown()
+
+    block_num = ir.ConstInt(4, DataType.INT32, span)
+    block_size = ir.ConstInt(4, DataType.INT32, span)
+    one = ir.ConstInt(1, DataType.INT32, span)
+    d = ir.ConstInt(64, DataType.INT32, span)
+    b = ir.ConstInt(2, DataType.INT32, span)
+    s = ir.ConstInt(4, DataType.INT32, span)
+
+    input_type = ir.TensorType([block_num, block_size, one, d], DataType.BF16)
+    index_type = ir.TensorType([b, s], DataType.INT32)
+    src_type = ir.TensorType([b, s, one, d], DataType.BF16)
+
+    input_var = ir.Var("kv_cache", input_type, span)
+    index_var = ir.Var("block_table", index_type, span)
+    src_var = ir.Var("new_kv", src_type, span)
+
+    call = ir.op.tensor.scatter_update(input_var, -2, index_var, src_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.scatter_update"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.BF16
+    assert len(result_type.shape) == 4
+
+
+def test_tensor_scatter_update_dtype_mismatch():
+    """Test tensor.scatter_update rejects mismatched dtypes."""
+    span = ir.Span.unknown()
+
+    rows = ir.ConstInt(16, DataType.INT32, span)
+    d = ir.ConstInt(64, DataType.INT32, span)
+    b = ir.ConstInt(2, DataType.INT32, span)
+    s = ir.ConstInt(4, DataType.INT32, span)
+    bs = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([rows, d], DataType.FP16)
+    index_type = ir.TensorType([b, s], DataType.INT32)
+    src_type = ir.TensorType([bs, d], DataType.FP32)  # wrong dtype
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+    src_var = ir.Var("src", src_type, span)
+
+    with pytest.raises(ValueError, match="src dtype"):
+        ir.op.tensor.scatter_update(input_var, -2, index_var, src_var)
+
+
+def test_tensor_scatter_update_invalid_dim():
+    """Test tensor.scatter_update rejects dim values other than -2."""
+    span = ir.Span.unknown()
+
+    rows = ir.ConstInt(16, DataType.INT32, span)
+    d = ir.ConstInt(64, DataType.INT32, span)
+    b = ir.ConstInt(2, DataType.INT32, span)
+    s = ir.ConstInt(4, DataType.INT32, span)
+    bs = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([rows, d], DataType.FP16)
+    index_type = ir.TensorType([b, s], DataType.INT32)
+    src_type = ir.TensorType([bs, d], DataType.FP16)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+    src_var = ir.Var("src", src_type, span)
+
+    with pytest.raises(ValueError, match="dim=-2"):
+        ir.op.tensor.scatter_update(input_var, 0, index_var, src_var)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1909,6 +1909,103 @@ class TestTileAssembleOp:
             tile.assemble(target_var, source_var, [0, 0])
 
 
+class TestTileScatterUpdateOps:
+    """Test suite for tile.scatter_update operation."""
+
+    def test_tile_scatter_update_2d(self):
+        """Test tile.scatter_update with 2D input and src."""
+        span = ir.Span.unknown()
+        rows = ir.ConstInt(16, DataType.INT32, span)
+        d = ir.ConstInt(64, DataType.INT32, span)
+        b = ir.ConstInt(2, DataType.INT32, span)
+        s = ir.ConstInt(4, DataType.INT32, span)
+        bs = ir.ConstInt(8, DataType.INT32, span)
+
+        input_type = ir.TileType([rows, d], DataType.FP16)
+        index_type = ir.TileType([b, s], DataType.INT32)
+        src_type = ir.TileType([bs, d], DataType.FP16)
+
+        input_var = ir.Var("inp", input_type, span)
+        index_var = ir.Var("idx", index_type, span)
+        src_var = ir.Var("src", src_type, span)
+
+        call = tile.scatter_update(input_var, -2, index_var, src_var)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.scatter_update"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP16
+        assert len(result_type.shape) == 2
+
+    def test_tile_scatter_update_4d(self):
+        """Test tile.scatter_update with 4D input and src."""
+        span = ir.Span.unknown()
+        block_num = ir.ConstInt(4, DataType.INT32, span)
+        block_size = ir.ConstInt(4, DataType.INT32, span)
+        one = ir.ConstInt(1, DataType.INT32, span)
+        d = ir.ConstInt(64, DataType.INT32, span)
+        b = ir.ConstInt(2, DataType.INT32, span)
+        s = ir.ConstInt(4, DataType.INT32, span)
+
+        input_type = ir.TileType([block_num, block_size, one, d], DataType.BF16)
+        index_type = ir.TileType([b, s], DataType.INT32)
+        src_type = ir.TileType([b, s, one, d], DataType.BF16)
+
+        input_var = ir.Var("kv_cache", input_type, span)
+        index_var = ir.Var("block_table", index_type, span)
+        src_var = ir.Var("new_kv", src_type, span)
+
+        call = tile.scatter_update(input_var, -2, index_var, src_var)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.scatter_update"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.BF16
+        assert len(result_type.shape) == 4
+
+    def test_tile_scatter_update_dtype_mismatch(self):
+        """Test tile.scatter_update rejects mismatched dtypes between input and src."""
+        span = ir.Span.unknown()
+        rows = ir.ConstInt(16, DataType.INT32, span)
+        d = ir.ConstInt(64, DataType.INT32, span)
+        b = ir.ConstInt(2, DataType.INT32, span)
+        s = ir.ConstInt(4, DataType.INT32, span)
+        bs = ir.ConstInt(8, DataType.INT32, span)
+
+        input_type = ir.TileType([rows, d], DataType.FP16)
+        index_type = ir.TileType([b, s], DataType.INT32)
+        src_type = ir.TileType([bs, d], DataType.FP32)  # wrong dtype
+
+        input_var = ir.Var("inp", input_type, span)
+        index_var = ir.Var("idx", index_type, span)
+        src_var = ir.Var("src", src_type, span)
+
+        with pytest.raises(ValueError, match="src dtype"):
+            tile.scatter_update(input_var, -2, index_var, src_var)
+
+    def test_tile_scatter_update_invalid_dim(self):
+        """Test tile.scatter_update rejects dim values other than -2."""
+        span = ir.Span.unknown()
+        rows = ir.ConstInt(16, DataType.INT32, span)
+        d = ir.ConstInt(64, DataType.INT32, span)
+        b = ir.ConstInt(2, DataType.INT32, span)
+        s = ir.ConstInt(4, DataType.INT32, span)
+        bs = ir.ConstInt(8, DataType.INT32, span)
+
+        input_type = ir.TileType([rows, d], DataType.FP16)
+        index_type = ir.TileType([b, s], DataType.INT32)
+        src_type = ir.TileType([bs, d], DataType.FP16)
+
+        input_var = ir.Var("inp", input_type, span)
+        index_var = ir.Var("idx", index_type, span)
+        src_var = ir.Var("src", src_type, span)
+
+        with pytest.raises(ValueError, match="dim=-2"):
+            tile.scatter_update(input_var, -1, index_var, src_var)
+
+
 class TestTileConcatOps:
     """Test suite for tile.concat operation."""
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2168,5 +2168,69 @@ class TestSliceMatmulConversion:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestScatterUpdateConversion:
+    """Tests for tensor.scatter_update → tile.scatter_update conversion."""
+
+    def test_scatter_update_local_tile_converts(self):
+        """tensor.scatter_update on a local tile buffer converts to tile.scatter_update."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                buf: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
+                result: pl.Tensor[[16, 64], pl.FP16] = pl.scatter_update(buf, -2, index, src)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_str = str(After)
+        assert "tile.scatter_update" in after_str
+        assert "tensor.scatter_update" not in after_str
+
+    def test_scatter_update_global_tensor_stays(self):
+        """tensor.scatter_update on a global tensor also converts to tile.scatter_update
+        because the pass first loads all function-parameter tensors into tiles."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                kv_cache: pl.Tensor[[16, 64], pl.FP16],
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                result: pl.Tensor[[16, 64], pl.FP16] = pl.scatter_update(kv_cache, -2, index, src)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                kv_cache: pl.Tensor[[16, 64], pl.FP16],
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(kv_cache, index, src)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_str = str(After)
+        # The pass loads all tensor parameters to tiles, so scatter_update becomes tile.scatter_update
+        assert "tile.scatter_update" in after_str
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `tensor.scatter_update(input, dim, index, src)` C++ IR op
  (`src/ir/op/tensor_ops/scatter_update.cpp`): type deduction for 2D
  `[rows, d]` and 4D `[B, S, 1, d]` input shapes; validates index dtype
  (integer), src rank/dtype match, and `dim=-2` constraint
- Add orchestration codegen in `tensor_op_codegen.cpp`: nested loop with
  `memcpy` per row; bounds-check index with `always_assert(row >= 0)` to
  prevent silent out-of-bounds writes from negative indices; register source
  in `CMakeLists.txt`
- Add `tile.scatter_update` tile op (`src/ir/op/tile_ops/transform.cpp`):
  same semantics but operates on TileType operands in Vec space; supports
  same 2D/4D shape variants and `dim=-2` kwarg
- Register `tensor.scatter_update → tile.scatter_update` conversion in
  `op_conversion_registry.cpp`: when input is a TileType, loads any remaining
  TensorType index/src operands via `tile.load`; when input is a global
  TensorType, passes through to orchestration codegen unchanged
- Expose at all Python API layers: IR (`ir.op.tensor`, `ir.op.tile`),
  language (`pl.scatter_update`, `pl.tile.scatter_update`); fix DSL parser
  compatibility by extracting `int` from `ConstInt` for the `dim` kwarg
- Add entries to `docs/en/user/02-operation_reference.md` and
  `docs/zh-cn/user/02-operation_reference.md` in both Tensor-Only and
  Data Movement sections

## Testing

- [x] Added 4 unit tests for `tensor.scatter_update` (2D, 4D, dtype mismatch, invalid dim)
- [x] Added 4 unit tests for `tile.scatter_update` (2D, 4D, dtype mismatch, invalid dim)
- [x] Added 2 conversion tests (local tile → `tile.scatter_update`; global tensor parameter)
- [x] All 3015 unit tests pass (4 skipped)
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright, markdownlint)

Closes #678