### PR TITLE
feat(codegen): implement pto.set_validshape for unaligned paged attention

### DIFF
--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -103,6 +103,36 @@ def kernel_softmax_prepare(
 
 
 @pl.function(type=pl.FunctionType.InCore)
+def kernel_softmax_prepare_unaligned(
+    sij: pl.Tensor[[16, 128], pl.FP32],
+    scale: pl.Scalar[pl.FP32],
+    valid_len: pl.Scalar[pl.INDEX],
+    out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+    out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+) -> tuple[
+    pl.Tensor[[16, 128], pl.BF16],
+    pl.Tensor[[16, 1], pl.FP32],
+    pl.Tensor[[16, 1], pl.FP32],
+]:
+    """Softmax prepare with unaligned valid_len: load, set_validshape, fillpad, scale, softmax (VECTOR)."""
+    s_tile = pl.load(sij, [0, 0], [16, 128], valid_shapes=[16, valid_len], target_memory=pl.MemorySpace.Vec)
+    s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+    scaled = pl.mul(s_padded, scale)
+    tmp_tile = pl.create_tile([16, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+    mi_tile = pl.row_max(scaled, tmp_tile)
+    sij_centered = pl.row_expand_sub(scaled, mi_tile)
+    exp_tile = pl.exp(sij_centered)
+    pij_tile_bf16 = pl.cast(exp_tile, target_type=pl.BF16)
+    pij_tile = pl.cast(pij_tile_bf16, target_type=pl.FP32)
+    li_tile = pl.row_sum(pij_tile, tmp_tile)
+    out_pij = pl.store(pij_tile_bf16, [0, 0], out_pij)
+    out_mi = pl.store(mi_tile, [0, 0], out_mi)
+    out_li = pl.store(li_tile, [0, 0], out_li)
+    return out_pij, out_mi, out_li
+
+
+@pl.function(type=pl.FunctionType.InCore)
 def kernel_pv_matmul(
     pij: pl.Tensor[[16, 128], pl.BF16],
     vj: pl.Tensor[[128, 128], pl.BF16],
@@ -372,13 +402,154 @@ def build_paged_attention_program(
                             [cur_offset, 0],
                         )
                         # Online softmax update via shared module-level InCore kernel
-                        mi_update, li_update, oi, out_view = kernel_online_update(
+                        mi_update, li_update, oi, _out_view = kernel_online_update(
                             mi, li, oi_tmp, mi_update, li_update, oi, out_view_buf, is_first, is_last
                         )
 
             return out
 
     return PagedAttentionProgram
+
+
+def build_paged_attention_unaligned_program(
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    max_num_blocks_per_req: int,
+    q_tile: int = 16,
+):
+    """Build a paged-attention program using set_validshape for unaligned blocks.
+
+    Unlike build_paged_attention_program which slices sij to [q_tile, valid_len],
+    this variant passes the full sij tensor to kernel_softmax_prepare_unaligned
+    with valid_len as a scalar. The kernel uses pl.load(..., valid_shapes=...)
+    + fillpad to handle the unaligned region via pto.set_validshape.
+    """
+    query_rows = batch * num_heads
+    key_cache_rows = batch * max_num_blocks_per_req * block_size
+    out_rows = batch * num_heads
+    block_table_flat_size = batch * max_num_blocks_per_req
+
+    @pl.program
+    class PagedAttentionUnalignedProgram:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def paged_attention(
+            self,
+            query: pl.Tensor[[query_rows, head_dim], pl.BF16],
+            key_cache: pl.Tensor[[head_dim, key_cache_rows], pl.BF16, pl.DN],
+            value_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
+            block_table: pl.Tensor[[block_table_flat_size], pl.INT32],
+            context_lens: pl.Tensor[[batch], pl.INT32],
+            out: pl.Out[pl.Tensor[[out_rows, head_dim], pl.FP32]],
+            config: pl.Tensor[[7], pl.INT64],
+        ) -> pl.Tensor[[out_rows, head_dim], pl.FP32]:
+            batch_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+            num_heads_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+            head_dim_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [3])
+            block_size_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [4])
+            block_num_cfg: pl.Scalar[pl.INT64] = pl.tensor.read(config, [5])
+
+            q_head_num = num_heads_cfg
+            q_loop_cfg = (q_head_num + q_tile - 1) // q_tile
+
+            for b_idx in pl.range(batch_cfg):
+                cur_seq = pl.tensor.read(context_lens, [b_idx])
+                bn_this_batch = (cur_seq + block_size_cfg - 1) // block_size_cfg
+                for q_idx in pl.range(q_loop_cfg):
+                    cur_offset = b_idx * q_head_num + q_idx * q_tile
+
+                    oi_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                        [q_tile, head_dim_cfg],
+                        dtype=pl.FP32,
+                    )
+                    li_buf: pl.Tensor[[q_tile, 1], pl.FP32, pl.DN] = pl.create_tensor(
+                        [q_tile, 1],
+                        dtype=pl.FP32,
+                        layout=pl.DN,
+                    )
+                    mi_buf: pl.Tensor[[q_tile, 1], pl.FP32, pl.DN] = pl.create_tensor(
+                        [q_tile, 1],
+                        dtype=pl.FP32,
+                        layout=pl.DN,
+                    )
+                    oi, li_update, mi_update = kernel_init_inplace(oi_buf, li_buf, mi_buf)
+
+                    for bn in pl.range(bn_this_batch):
+                        qi: pl.Tensor[[q_tile, head_dim_cfg], pl.BF16] = pl.slice(
+                            query,
+                            [q_tile, head_dim_cfg],
+                            [cur_offset, 0],
+                        )
+                        cur_block_idx = pl.tensor.read(block_table, [b_idx * block_num_cfg + bn])
+                        valid_len = pl.min(block_size_cfg, cur_seq - bn * block_size_cfg)
+
+                        kv_block_row = cur_block_idx * block_size_cfg
+                        kj: pl.Tensor[[head_dim_cfg, block_size_cfg], pl.BF16, pl.DN] = pl.slice(
+                            key_cache,
+                            [head_dim_cfg, block_size_cfg],
+                            [kv_block_row, 0],
+                        )
+                        vj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.slice(
+                            value_cache,
+                            [block_size_cfg, head_dim_cfg],
+                            [kv_block_row, 0],
+                        )
+
+                        sij_buf: pl.Tensor[[q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, block_size_cfg],
+                            dtype=pl.FP32,
+                        )
+                        sij = kernel_qk_matmul(qi, kj, sij_buf)
+
+                        # Unaligned: pass full sij + valid_len to kernel_softmax_prepare_unaligned
+                        # (no pl.slice — kernel handles padding via set_validshape + fillpad)
+                        pij_f16_buf: pl.Tensor[[q_tile, block_size_cfg], pl.BF16] = pl.create_tensor(
+                            [q_tile, block_size_cfg],
+                            dtype=pl.BF16,
+                        )
+                        mi_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
+                            [q_tile, 1], dtype=pl.FP32
+                        )
+                        li_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
+                            [q_tile, 1], dtype=pl.FP32
+                        )
+                        pij_f16, mi, li = kernel_softmax_prepare_unaligned(
+                            sij,
+                            1.0,  # type: ignore[reportArgumentType]
+                            valid_len,
+                            pij_f16_buf,
+                            mi_sm_buf,
+                            li_sm_buf,
+                        )
+
+                        oi_tmp_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, head_dim_cfg],
+                            dtype=pl.FP32,
+                        )
+                        oi_tmp = kernel_pv_matmul(pij_f16, vj, oi_tmp_buf)
+
+                        if bn == 0:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)
+                        else:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)
+                        if bn == bn_this_batch - 1:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)
+                        else:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)
+
+                        out_view_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.slice(
+                            out,
+                            [q_tile, head_dim_cfg],
+                            [cur_offset, 0],
+                        )
+                        mi_update, li_update, oi, _out_view = kernel_online_update(
+                            mi, li, oi_tmp, mi_update, li_update, oi, out_view_buf, is_first, is_last
+                        )
+
+            return out
+
+    return PagedAttentionUnalignedProgram
 
 
 def golden(tensors: dict, params: dict | None = None) -> None:

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -116,6 +116,21 @@ class PTOCodegen : public CodegenBase {
   std::string GetOrEmitI32Constant(int32_t value);
 
   /**
+   * @brief Emit arith.index_cast if var is not already index type
+   *
+   * Valid_shape vars may be INT64/INT32 (from pl.min(...)), but pto.alloc_tile
+   * and pto.set_validshape need index type operands.
+   *
+   * @param var IR variable to cast
+   * @param mlir_name Current MLIR SSA name for the variable
+   * @return SSA name of the index-typed value (original if already index)
+   */
+  std::string EmitCastToIndex(const ir::VarPtr& var, const std::string& mlir_name);
+
+  /// Check if a tile variable is consumed by a tile.fillpad operation.
+  bool HasFillpadConsumer(const ir::Var* var) const;
+
+  /**
    * @brief Register a variable to an MLIR SSA name
    *
    * @param var IR variable
@@ -187,7 +202,8 @@ class PTOCodegen : public CodegenBase {
    * Needed when multiple variables with different shapes share the same MemRef
    * (e.g., reshape input/output).
    */
-  std::string GetTileBufTypeStringFromTileType(const std::shared_ptr<const ir::TileType>& tile_type) const;
+  std::string GetTileBufTypeStringFromTileType(const std::shared_ptr<const ir::TileType>& tile_type,
+                                               bool force_all_dynamic = false) const;
 
   /**
    * @brief Allocate a new tile buffer for codegen (emitted at function scope)
@@ -417,7 +433,8 @@ class PTOCodegen : public CodegenBase {
     std::string op_name;
   };
   std::map<const ir::Var*, TpopResultInfo>
-      tpop_result_vars_;  ///< Tile vars from tpop: var -> split + op name
+      tpop_result_vars_;                         ///< Tile vars from tpop: var -> split + op name
+  std::set<const ir::Var*> fillpad_input_vars_;  ///< Tile vars consumed by tile.fillpad
 
   // Current function context
   ir::FunctionPtr current_function_;

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -367,6 +367,46 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";
   tload_line << tile_buf << " : " << tile_buf_type << ")";
   codegen.Emit(tload_line.str());
+
+  // Emit pto.set_validshape after tload only when a fillpad consumer exists.
+  // Physical dims were used for alloc_tile (correct DMA stride); set_validshape
+  // sets the actual valid region before fillpad pads the rest.
+  auto result_var = codegen.GetCurrentResultVar();
+  if (result_var) {
+    auto tile_type = ir::As<ir::TileType>(result_var->GetType());
+    if (tile_type && tile_type->tile_view_.has_value() && codegen.HasFillpadConsumer(result_var.get())) {
+      const auto& tv = tile_type->tile_view_.value();
+      bool has_dynamic = false;
+      std::string vr, vc;
+
+      // Extract valid_row SSA
+      if (tv.valid_shape.size() >= 1) {
+        if (auto var = ir::As<ir::Var>(tv.valid_shape[0])) {
+          std::string mlir_name = codegen.GetVarName(var);
+          vr = codegen.EmitCastToIndex(var, mlir_name);
+          has_dynamic = true;
+        } else if (auto c = ir::As<ir::ConstInt>(tv.valid_shape[0])) {
+          vr = codegen.GetIndexConstant(c->value_);
+        }
+      }
+
+      // Extract valid_col SSA
+      if (tv.valid_shape.size() >= 2) {
+        if (auto var = ir::As<ir::Var>(tv.valid_shape[1])) {
+          std::string mlir_name = codegen.GetVarName(var);
+          vc = codegen.EmitCastToIndex(var, mlir_name);
+          has_dynamic = true;
+        } else if (auto c = ir::As<ir::ConstInt>(tv.valid_shape[1])) {
+          vc = codegen.GetIndexConstant(c->value_);
+        }
+      }
+
+      if (has_dynamic && !vr.empty() && !vc.empty()) {
+        codegen.Emit("pto.set_validshape " + tile_buf + ", " + vr + ", " + vc + " : " + tile_buf_type);
+      }
+    }
+  }
+
   return "";
 }
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -743,15 +743,18 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
     std::map<const ir::MemRef*, std::string>& memref_to_var_name;
     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& tile_var_allocs;
     std::map<const ir::Var*, TpopResultInfo>& tpop_result_vars;
+    std::set<const ir::Var*>& fillpad_input_vars;
 
     VarMemRefMapper(std::map<const ir::Var*, const ir::MemRef*>& mapping,
                     std::map<const ir::MemRef*, std::string>& reverse_mapping,
                     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& allocs,
-                    std::map<const ir::Var*, TpopResultInfo>& tpop_vars)
+                    std::map<const ir::Var*, TpopResultInfo>& tpop_vars,
+                    std::set<const ir::Var*>& fillpad_vars)
         : var_to_memref(mapping),
           memref_to_var_name(reverse_mapping),
           tile_var_allocs(allocs),
-          tpop_result_vars(tpop_vars) {}
+          tpop_result_vars(tpop_vars),
+          fillpad_input_vars(fillpad_vars) {}
 
     void VisitStmt_(const AssignStmtPtr& op) override {
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
@@ -763,13 +766,20 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
         }
         tile_var_allocs.emplace_back(op->var_, tile_type);
 
-        // Track tpop result vars with their split value so codegen can:
-        // 1. Skip alloc_tile for them
-        // 2. Propagate split to tfree
         if (auto call = As<ir::Call>(op->value_)) {
+          // Track tpop result vars with their split value so codegen can:
+          // 1. Skip alloc_tile for them
+          // 2. Propagate split to tfree
           if (call->op_->name_ == "tile.tpop_from_aiv" || call->op_->name_ == "tile.tpop_from_aic") {
             int split = call->GetKwarg<int>("split", 0);
             tpop_result_vars[op->var_.get()] = TpopResultInfo{split, call->op_->name_};
+          }
+          // Track fillpad input variables so we know which tiles need
+          // physical dims on alloc_tile + set_validshape after tload.
+          if (call->op_->name_ == "tile.fillpad" && !call->args_.empty()) {
+            if (auto input_var = As<ir::Var>(call->args_[0])) {
+              fillpad_input_vars.insert(input_var.get());
+            }
           }
         }
       }
@@ -777,7 +787,8 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
     }
   };
 
-  VarMemRefMapper mapper(var_to_memref_, memref_to_var_name_, tile_var_allocs_, tpop_result_vars_);
+  VarMemRefMapper mapper(var_to_memref_, memref_to_var_name_, tile_var_allocs_, tpop_result_vars_,
+                         fillpad_input_vars_);
   if (func->body_) {
     mapper.VisitStmt(func->body_);
   }
@@ -879,13 +890,43 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
       << "Tile var " << tile_var->name_hint_ << " not found in var_to_mlir_";
   std::string tile_buf = mlir_it->second;
 
+  // Generate type string first — ExtractTileTypeInfo already decides v_row=?/v_col=?.
+  // For tiles consumed by fillpad, force ALL dynamic dims (pto.set_validshape requires both ?).
+  bool has_fillpad = HasFillpadConsumer(tile_var.get());
+  std::string type_str = GetTileBufTypeStringFromTileType(tile_type, has_fillpad);
+  bool type_is_dynamic =
+      (type_str.find("v_row=?") != std::string::npos || type_str.find("v_col=?") != std::string::npos);
+
   std::string valid_row_mlir;
   std::string valid_col_mlir;
-  auto [valid_row_var, valid_col_var] = GetTileValidShapeVars(tile_type);
-  if (valid_row_var) valid_row_mlir = GetVarName(valid_row_var);
-  if (valid_col_var) valid_col_mlir = GetVarName(valid_col_var);
-
-  std::string type_str = GetTileBufTypeStringFromTileType(tile_type);
+  if (tile_type->tile_view_.has_value()) {
+    const auto& tv = tile_type->tile_view_.value();
+    bool has_pad = (tv.pad != ir::PadValue::null);
+    if (!has_pad && type_is_dynamic) {
+      // Check if this tile is consumed by fillpad.
+      // If yes: use physical dims so TLOAD DMA uses correct stride; set_validshape sets actual region.
+      // If no: use dynamic variable as operand (TLOAD respects valid_shape for DMA).
+      if (has_fillpad) {
+        if (tile_type->shape_.size() >= 1) {
+          if (auto c = As<ir::ConstInt>(tile_type->shape_[0])) {
+            valid_row_mlir = GetOrEmitIndexConstant(c->value_);
+          }
+        }
+        if (tile_type->shape_.size() >= 2) {
+          if (auto c = As<ir::ConstInt>(tile_type->shape_[1])) {
+            valid_col_mlir = GetOrEmitIndexConstant(c->value_);
+          }
+        }
+      } else {
+        // No fillpad: use dynamic variable as operand (old behavior).
+        auto [valid_row_var, valid_col_var] = GetTileValidShapeVars(tile_type);
+        if (valid_row_var) valid_row_mlir = GetVarName(valid_row_var);
+        if (valid_col_var) valid_col_mlir = GetVarName(valid_col_var);
+      }
+    }
+    // Static v_row/v_col: type string already encodes the values (e.g. v_row=48).
+    // PTOAS requires valid_row/valid_col operands to be ABSENT when static.
+  }
   auto memref = ir::GetDefinedMemRef(tile_type);
   std::string addr_ssa;
   if (memref) {
@@ -1108,7 +1149,8 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       // This ensures that even when multiple variables share a MemRef, each
       // variable's SSA value carries its correct typed annotation.
       if (result_tile_type && !current_result_buf_.empty()) {
-        std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type);
+        bool fillpad_force = HasFillpadConsumer(op->var_.get());
+        std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type, fillpad_force);
         if (!var_type_str.empty()) {
           ssa_to_tile_buf_type_[current_result_buf_] = var_type_str;
         }
@@ -1363,7 +1405,8 @@ static std::string FormatTileBufTypeString(const std::string& loc, const std::st
 static void ExtractTileTypeInfo(const TileType& tile_type, const PTOCodegen& codegen, std::string& dtype_str,
                                 int64_t& rows, int64_t& cols, ir::TileLayout& blayout,
                                 ir::TileLayout& slayout, uint64_t& fractal, ir::PadValue& pad, int64_t& v_row,
-                                int64_t& v_col, bool& v_row_dynamic, bool& v_col_dynamic) {
+                                int64_t& v_col, bool& v_row_dynamic, bool& v_col_dynamic,
+                                bool force_all_dynamic = false) {
   dtype_str = codegen.GetTypeString(tile_type.dtype_);
   if (tile_type.shape_.size() >= 2) {
     if (auto c0 = As<ir::ConstInt>(tile_type.shape_[0])) rows = c0->value_;
@@ -1383,20 +1426,32 @@ static void ExtractTileTypeInfo(const TileType& tile_type, const PTOCodegen& cod
     slayout = tv.slayout;
     fractal = tv.fractal;
     pad = tv.pad;
-    // Extract valid_shape values
-    if (tv.valid_shape.size() >= 1) {
+    // Extract valid_shape values.
+    // When pad is set (fillpad result), the tile is fully valid — keep static
+    // v_row/v_col at physical dims. Only mark dynamic when there's no pad.
+    bool has_pad = (pad != ir::PadValue::null);
+    bool has_any_dynamic = false;
+    if (!has_pad && tv.valid_shape.size() >= 1) {
       if (auto c0 = As<ir::ConstInt>(tv.valid_shape[0])) {
         v_row = c0->value_;
       } else if (As<ir::Var>(tv.valid_shape[0])) {
         v_row_dynamic = true;
+        has_any_dynamic = true;
       }
     }
-    if (tv.valid_shape.size() >= 2) {
+    if (!has_pad && tv.valid_shape.size() >= 2) {
       if (auto c1 = As<ir::ConstInt>(tv.valid_shape[1])) {
         v_col = c1->value_;
       } else if (As<ir::Var>(tv.valid_shape[1])) {
         v_col_dynamic = true;
+        has_any_dynamic = true;
       }
+    }
+    // pto.set_validshape requires the source tile to have ALL dims dynamic (?, ?).
+    // Only force both dynamic when the caller signals a fillpad consumer exists.
+    if (force_all_dynamic && has_any_dynamic) {
+      v_row_dynamic = true;
+      v_col_dynamic = true;
     }
   } else if (cols == 1 && rows > 1) {
     // Infer blayout from shape: column vectors [N, 1] use col_major (DN format convention)
@@ -1431,8 +1486,8 @@ std::string PTOCodegen::GetTileBufTypeString(const ir::MemRef* memref) const {
                                  v_row_dynamic, v_col_dynamic);
 }
 
-std::string PTOCodegen::GetTileBufTypeStringFromTileType(
-    const std::shared_ptr<const ir::TileType>& tile_type) const {
+std::string PTOCodegen::GetTileBufTypeStringFromTileType(const std::shared_ptr<const ir::TileType>& tile_type,
+                                                         bool force_all_dynamic) const {
   INTERNAL_CHECK(tile_type) << "Internal error: tile_type must not be null";
   auto memory_space = tile_type->GetMemorySpace();
   INTERNAL_CHECK(memory_space.has_value()) << "Internal error: tile_type must have memory_space";
@@ -1451,7 +1506,7 @@ std::string PTOCodegen::GetTileBufTypeStringFromTileType(
   bool v_col_dynamic = false;
 
   ExtractTileTypeInfo(*tile_type, *this, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row, v_col,
-                      v_row_dynamic, v_col_dynamic);
+                      v_row_dynamic, v_col_dynamic, force_all_dynamic);
 
   return FormatTileBufTypeString(loc, dtype_str, rows, cols, blayout, slayout, fractal, pad, v_row, v_col,
                                  v_row_dynamic, v_col_dynamic);
@@ -1515,6 +1570,13 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
 }
 
 std::string PTOCodegen::GetCurrentResultTileBufTypeString() const {
+  // Prefer type registered by alloc_tile (may have force_all_dynamic for fillpad tiles)
+  if (!current_result_buf_.empty()) {
+    auto ssa_it = ssa_to_tile_buf_type_.find(current_result_buf_);
+    if (ssa_it != ssa_to_tile_buf_type_.end()) {
+      return ssa_it->second;
+    }
+  }
   if (current_result_tile_type_ && current_result_tile_type_->memref_.has_value()) {
     return GetTileBufTypeString(current_result_tile_type_->memref_.value().get());
   }
@@ -1698,6 +1760,27 @@ void PTOCodegen::VisitExpr_(const ir::CastPtr& op) {
   Emit(result + " = " + mlir_op + " " + src + " : " + src_type + " to " + dst_type);
   current_expr_value_ = result;
 }
+
+// Imperative counterpart of VisitExpr_(CastPtr) for the index-cast case.
+// VisitExpr_ requires an ir::Cast node in the IR; this helper directly casts
+// a known SSA value when no Cast node exists (e.g. valid_shape vars in
+// pto.set_validshape that need index type operands).
+std::string PTOCodegen::EmitCastToIndex(const ir::VarPtr& var, const std::string& mlir_name) {
+  if (auto scalar_type = As<ScalarType>(var->GetType())) {
+    CHECK(!scalar_type->dtype_.IsFloat())
+        << "EmitCastToIndex does not support floating-point types (got " << GetTypeString(scalar_type->dtype_)
+        << " for var '" << var->name_hint_ << "')";
+    if (scalar_type->dtype_ != DataType::INDEX) {
+      std::string idx_name = NewNamedTemp(var->name_hint_ + "_idx");
+      std::string src_type = GetTypeString(scalar_type->dtype_);
+      Emit(idx_name + " = arith.index_cast " + mlir_name + " : " + src_type + " to index");
+      return idx_name;
+    }
+  }
+  return mlir_name;
+}
+
+bool PTOCodegen::HasFillpadConsumer(const ir::Var* var) const { return fillpad_input_vars_.count(var) > 0; }
 
 // ========================================================================
 // Expression visitors - Logical & Bitwise

--- a/tests/st/codegen/test_paged_attention.py
+++ b/tests/st/codegen/test_paged_attention.py
@@ -41,10 +41,12 @@ from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.ir_parser.paged_attention_example import (
     build_paged_attention_program,
+    build_paged_attention_unaligned_program,
     kernel_online_update,
     kernel_pv_matmul,
     kernel_qk_matmul,
     kernel_softmax_prepare,
+    kernel_softmax_prepare_unaligned,
 )
 
 DEFAULT_SCALE = 0.0884
@@ -166,6 +168,94 @@ class SoftmaxPrepareTestCase(PTOTestCase):
         scale = tensors["config"][0]
 
         sij = tensors["sij"]
+        sij_scaled = sij * scale
+        mij = torch.max(sij_scaled, axis=1, keepdims=True).values
+        pij = torch.exp(sij_scaled - mij)
+        pij_bf16 = pij.to(torch.bfloat16)
+        pij = pij_bf16.to(torch.float32)
+        lij = torch.sum(pij, axis=1, keepdims=True)
+
+        tensors["pij"][:] = pij_bf16
+        tensors["mij"][:] = mij
+        tensors["lij"][:] = lij
+
+
+class SoftmaxPrepareUnalignedTestCase(PTOTestCase):
+    """Test case for softmax_prepare with unaligned valid_len.
+
+    Uses pl.load(..., valid_shapes=[16, valid_len]) + fillpad(pad_value=min)
+    to handle non-block-aligned KV cache lengths. Columns beyond valid_len
+    are padded with -inf before softmax.
+    """
+
+    def __init__(
+        self,
+        num_heads: int = 16,
+        block_size: int = 128,
+        valid_len: int = 100,
+        scale: float = DEFAULT_SCALE,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.num_heads = num_heads
+        self.block_size = block_size
+        self.valid_len = valid_len
+        self.scale = scale
+
+    def get_name(self) -> str:
+        return f"softmax_prepare_unaligned_{self.num_heads}h_{self.block_size}b_{self.valid_len}v"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "sij", [self.num_heads, self.block_size], DataType.FP32, init_value=torch.randn
+            ),  # attention scores input
+            TensorSpec(
+                "config", [1], DataType.FP32, init_value=self.scale
+            ),  # single-element FP32 tensor storing the scale factor
+            TensorSpec(
+                "valid_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([self.valid_len], dtype=torch.int64),
+            ),  # valid_len as INT64 config
+            TensorSpec("pij", [self.num_heads, self.block_size], DataType.BF16, is_output=True),  # exp output
+            TensorSpec("mij", [self.num_heads, 1], DataType.FP32, is_output=True),  # row-max output
+            TensorSpec("lij", [self.num_heads, 1], DataType.FP32, is_output=True),  # row-sum of pij output
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class SoftmaxPrepareUnalignedProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                sij: pl.Tensor[[16, 128], pl.FP32],
+                config: pl.Tensor[[1], pl.FP32],
+                valid_len_cfg: pl.Tensor[[1], pl.INT64],
+                pij_out: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+                mij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                lij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> tuple[
+                pl.Tensor[[16, 128], pl.BF16], pl.Tensor[[16, 1], pl.FP32], pl.Tensor[[16, 1], pl.FP32]
+            ]:
+                scale: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                valid_len: pl.Scalar[pl.INT64] = pl.tensor.read(valid_len_cfg, [0])
+                pij_out, mij_out, lij_out = kernel_softmax_prepare_unaligned(
+                    sij, scale, valid_len, pij_out, mij_out, lij_out
+                )
+                return pij_out, mij_out, lij_out
+
+        return SoftmaxPrepareUnalignedProgram
+
+    def compute_expected(self, tensors, params=None):
+        scale = tensors["config"][0]
+        valid_len = int(tensors["valid_len_cfg"][0].item())
+        block_size = tensors["sij"].shape[1]  # derive from tensor shape (golden_writer can't access self.*)
+
+        sij = tensors["sij"].clone()
+        # Mask columns beyond valid_len to -inf (fillpad with PadValue.min)
+        sij[:, valid_len:block_size] = float("-inf")
         sij_scaled = sij * scale
         mij = torch.max(sij_scaled, axis=1, keepdims=True).values
         pij = torch.exp(sij_scaled - mij)
@@ -498,6 +588,137 @@ class PagedAttentionTestCase(PTOTestCase):
         tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
 
 
+class UnalignedPagedAttentionTestCase(PTOTestCase):
+    """Full paged attention with unaligned context_len (not a multiple of block_size).
+
+    Uses build_paged_attention_unaligned_program which calls
+    kernel_softmax_prepare_unaligned (set_validshape + fillpad) instead of
+    slicing sij to valid_len.
+    """
+
+    def __init__(
+        self,
+        batch: int = 64,
+        num_heads: int = 16,
+        head_dim: int = 128,
+        block_size: int = 128,
+        context_len: int = 8100,
+        max_model_len: int = 32768,
+        scale: float = 1.0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.config.atol = 2e-2
+        self.config.rtol = 2e-2
+        self.batch = batch
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.block_size = block_size
+        self.context_len = context_len
+        self.max_model_len = max_model_len
+        self.scale = scale
+        self.max_num_blocks_per_req = max_model_len // block_size
+
+    def get_name(self) -> str:
+        return (
+            f"paged_attention_unaligned_{self.batch}bat_{self.num_heads}h_"
+            f"{self.head_dim}d_{self.block_size}bs_{self.context_len}ctx"
+        )
+
+    def define_tensors(self) -> list[TensorSpec]:
+        B = self.batch
+        H = self.num_heads
+        D = self.head_dim
+        BS = self.block_size
+        max_blocks = self.max_num_blocks_per_req
+        total_pool_rows = B * max_blocks * BS
+
+        scale_bits = struct.unpack("I", struct.pack("f", self.scale))[0]
+        config = torch.tensor(
+            [B, H, 1, D, BS, max_blocks, scale_bits],
+            dtype=torch.int64,
+        )
+        block_table = torch.randint(
+            0, max(B * max_blocks, 1), size=(B, max_blocks), dtype=torch.int32
+        ).flatten()
+        context_lens = torch.full((B,), self.context_len, dtype=torch.int32)
+
+        return [
+            TensorSpec("query", [B * H, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("key_cache", [total_pool_rows, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("value_cache", [total_pool_rows, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("block_table", [B * max_blocks], DataType.INT32, init_value=block_table),
+            TensorSpec("context_lens", [B], DataType.INT32, init_value=context_lens),
+            TensorSpec("out", [B * H, D], DataType.FP32, is_output=True),
+            TensorSpec("config", [7], DataType.INT64, init_value=config),
+        ]
+
+    def get_program(self) -> Any:
+        return build_paged_attention_unaligned_program(
+            batch=self.batch,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            block_size=self.block_size,
+            max_num_blocks_per_req=self.max_num_blocks_per_req,
+        )
+
+    def compute_expected(self, tensors, params=None):
+        config = tensors["config"]
+        batch = int(config[0].item())
+        num_heads = int(config[1].item())
+        head_dim = int(config[3].item())
+        block_size = int(config[4].item())
+        max_num_blocks_per_req = int(config[5].item())
+        scale_bits = int(config[6].item())
+        scale_value = struct.unpack("f", struct.pack("I", scale_bits & 0xFFFFFFFF))[0]
+
+        query = tensors["query"].float().reshape(batch, num_heads, head_dim)
+        total_pool_blocks = batch * max_num_blocks_per_req
+        key_cache = tensors["key_cache"].float().reshape(total_pool_blocks, block_size, head_dim)
+        value_cache = tensors["value_cache"].float().reshape(total_pool_blocks, block_size, head_dim)
+        block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+        context_lens = tensors["context_lens"]
+
+        out = torch.zeros((batch, num_heads, head_dim), dtype=torch.float32)
+        q_tile = 16
+        max_bn = int((context_lens.max().item() + block_size - 1) // block_size)
+
+        for q_offset in range(0, num_heads, q_tile):
+            q_tile_size = min(q_tile, num_heads - q_offset)
+            qi = query[:, q_offset : q_offset + q_tile_size, :]
+            oi, li, mi = None, None, None
+
+            for bn in range(max_bn):
+                valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+                if not (valid_lens > 0).any():
+                    break
+                block_indices = block_table[:, bn]
+                kj_all = key_cache[block_indices].float()
+                vj_all = value_cache[block_indices].float()
+                sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+                pos = torch.arange(block_size).unsqueeze(0)
+                valid_mask = (pos < valid_lens.unsqueeze(1)).unsqueeze(1)
+                sij = sij.masked_fill(~valid_mask, float("-inf"))
+                mij = sij.max(dim=-1, keepdim=True)[0].clamp(min=-1e30)
+                pij = torch.exp(sij - mij).masked_fill(~valid_mask, 0.0)
+                pij = pij.to(torch.bfloat16).to(torch.float32)
+                lij = pij.sum(dim=-1, keepdim=True)
+                oi_new = torch.bmm(pij, vj_all)
+                if bn == 0:
+                    oi, li, mi = oi_new, lij, mij
+                else:
+                    mi_new = torch.maximum(mi, mij)
+                    alpha = torch.exp(mi - mi_new)
+                    beta = torch.exp(mij - mi_new)
+                    li = alpha * li + beta * lij
+                    oi = alpha * oi + beta * oi_new
+                    mi = mi_new
+
+            out[:, q_offset : q_offset + q_tile_size, :] = oi / li
+
+        tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
+
+
 class PTOASTestCaseMixin:
     """Mixin for test cases using PTO backend and Default optimization strategy."""
 
@@ -543,6 +764,23 @@ class PagedAttentionPTOASTestCase(PTOASTestCaseMixin, PagedAttentionTestCase):
 
     def get_name(self) -> str:
         return f"paged_attention_ptoas_{self.batch}bat_{self.num_heads}h_{self.head_dim}d_{self.block_size}bs"
+
+
+class SoftmaxPrepareUnalignedPTOASTestCase(PTOASTestCaseMixin, SoftmaxPrepareUnalignedTestCase):
+    """Test unaligned softmax prepare with PTO backend and PTOAS optimization strategy."""
+
+    def get_name(self) -> str:
+        return f"softmax_prepare_unaligned_ptoas_{self.num_heads}h_{self.block_size}b_{self.valid_len}v"
+
+
+class UnalignedPagedAttentionPTOASTestCase(PTOASTestCaseMixin, UnalignedPagedAttentionTestCase):
+    """Test full paged attention with unaligned context_len using PTOAS."""
+
+    def get_name(self) -> str:
+        return (
+            f"paged_attention_unaligned_ptoas_{self.batch}bat_{self.num_heads}h_"
+            f"{self.head_dim}d_{self.block_size}bs_{self.context_len}ctx"
+        )
 
 
 class TestPagedAttentionKernels:
@@ -676,6 +914,48 @@ class TestPagedAttentionKernels:
         )
         result = test_runner.run(test_case)
         assert result.passed, f"Paged attention PTOAS test failed: {result.error}"
+
+    # ── Unaligned variants ────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "num_heads,block_size,valid_len",
+        [
+            (16, 128, 100),  # unaligned
+            (16, 128, 128),  # full block (aligned)
+        ],
+    )
+    def test_softmax_prepare_unaligned_ptoas(self, test_runner, num_heads, block_size, valid_len):
+        """Test unaligned softmax prepare with PTO backend and PTOAS optimization."""
+        test_case = SoftmaxPrepareUnalignedPTOASTestCase(
+            num_heads=num_heads, block_size=block_size, valid_len=valid_len
+        )
+        result = test_runner.run(test_case)
+        assert result.passed, (
+            f"Softmax prepare unaligned PTOAS test failed (valid_len={valid_len}): {result.error}"
+        )
+
+    @pytest.mark.parametrize(
+        "batch,num_heads,head_dim,block_size,context_len,max_model_len",
+        [
+            (64, 16, 128, 128, 8100, 32768),  # context_len=8100 not a multiple of block_size=128
+        ],
+    )
+    def test_paged_attention_unaligned_ptoas(
+        self, test_runner, batch, num_heads, head_dim, block_size, context_len, max_model_len
+    ):
+        """Test full paged attention with unaligned context_len using set_validshape."""
+        test_case = UnalignedPagedAttentionPTOASTestCase(
+            batch=batch,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            block_size=block_size,
+            context_len=context_len,
+            max_model_len=max_model_len,
+        )
+        result = test_runner.run(test_case)
+        assert result.passed, (
+            f"Paged attention unaligned PTOAS test failed (context_len={context_len}): {result.error}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_dynamic_shape.py
+++ b/tests/ut/codegen/test_dynamic_shape.py
@@ -134,11 +134,14 @@ def test_add_kernel_valid_shape_pto_codegen():
     assert "partition_tensor_view<128x128xf32>" in mlir_code
     # tload is generated for each load
     assert "pto.tload" in mlir_code
-    # alloc_tile carries valid_row/valid_col for dynamic valid_shapes
-    assert "pto.alloc_tile addr = %c0i valid_row = %arg3 valid_col = %arg4" in mlir_code
-    # v_row and v_col are wildcards (?) when valid_shape is dynamic
+    # alloc_tile has dynamic type (v_row=?, v_col=?) with dynamic operands
     assert "v_row=?" in mlir_code
     assert "v_col=?" in mlir_code
+    # No fillpad consumer → valid_row/valid_col use dynamic variable operands (%arg3, %arg4)
+    assert "valid_row = %arg3" in mlir_code
+    assert "valid_col = %arg4" in mlir_code
+    # No set_validshape without fillpad (TLOAD respects valid_shape directly)
+    assert "pto.set_validshape" not in mlir_code
 
 
 def test_add_kernel_loop_dynamic_pto_codegen():

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -329,13 +329,13 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     # Both share the same addr (same MemRef)
     assert "addr = %c0i" in alloc_lines[0]
     assert "addr = %c0i" in alloc_lines[1]
-    # One should carry valid_row/valid_col dynamic shapes
-    dynamic_allocs = [line for line in alloc_lines if "valid_row = %arg2 valid_col = %arg3" in line]
-    assert len(dynamic_allocs) >= 1
-    assert "v_row=?" in alloc_lines[0]
-    assert "v_col=?" in alloc_lines[0]
-    assert "pad=" in alloc_lines[1]
+    # Dynamic valid_shape tile: type has v_row=?, v_col=? (both dynamic per PTOAS requirement)
+    assert "v_row=?" in alloc_lines[0], f"Expected dynamic v_row=? in alloc: {alloc_lines[0]}"
+    assert "v_col=?" in alloc_lines[0], f"Expected dynamic v_col=? in alloc: {alloc_lines[0]}"
+    # Padded tile has static v_row/v_col (physical dims) since fillpad makes it fully valid
     assert "pad=2>" in alloc_lines[1], f"Expected fillpad pad metadata to be preserved: {alloc_lines[1]}"
+    assert "v_row=128" in alloc_lines[1], f"Expected static v_row in padded tile: {alloc_lines[1]}"
+    assert "v_col=128" in alloc_lines[1], f"Expected static v_col in padded tile: {alloc_lines[1]}"
 
 
 def test_pto_codegen_dynamic_valid_shape_scalar_defined_in_body():
@@ -367,16 +367,13 @@ def test_pto_codegen_dynamic_valid_shape_scalar_defined_in_body():
 
     assert len(alloc_lines) == 1, f"Expected one alloc_tile, got: {alloc_lines}"
     alloc_line = alloc_lines[0]
-    assert "valid_col = %" in alloc_line, (
-        f"Expected alloc_tile to reference in-body valid_shape SSA, got: {alloc_line}"
-    )
-    assert "valid_row = %" not in alloc_line, f"Did not expect dynamic valid_row in alloc_tile: {alloc_line}"
+    # Only the actually dynamic dim (v_col) is ?, v_row stays static
     assert "v_row=1" in alloc_line, f"Expected static v_row=1 in tile_buf type, got: {alloc_line}"
-    assert "v_col=?" in alloc_line, f"Expected dynamic v_col in tile_buf type, got: {alloc_line}"
-    assert "valid_col = %arg" not in alloc_line, (
-        f"Expected valid_shape SSA from body, not direct arg reuse: {alloc_line}"
-    )
+    assert "v_col=?" in alloc_line, f"Expected dynamic v_col=? in tile_buf type, got: {alloc_line}"
+    # No fillpad → dynamic variable used as operand, no set_validshape
+    assert "valid_col" in alloc_line, f"Expected valid_col operand in alloc: {alloc_line}"
     assert "%c-1" not in mlir_code
+    assert "pto.set_validshape" not in mlir_code
 
 
 def test_pto_codegen_dynamic_valid_shape_row_defined_in_body():
@@ -408,15 +405,12 @@ def test_pto_codegen_dynamic_valid_shape_row_defined_in_body():
 
     assert len(alloc_lines) == 1, f"Expected one alloc_tile, got: {alloc_lines}"
     alloc_line = alloc_lines[0]
-    assert "valid_row = %" in alloc_line, (
-        f"Expected alloc_tile to reference in-body valid_shape SSA, got: {alloc_line}"
-    )
-    assert "valid_col = %" not in alloc_line, f"Did not expect dynamic valid_col in alloc_tile: {alloc_line}"
-    assert "v_row=?" in alloc_line, f"Expected dynamic v_row in tile_buf type, got: {alloc_line}"
+    # Only the actually dynamic dim (v_row) is ?, v_col stays static
+    assert "v_row=?" in alloc_line, f"Expected dynamic v_row=? in tile_buf type, got: {alloc_line}"
     assert "v_col=16" in alloc_line, f"Expected static v_col=16 in tile_buf type, got: {alloc_line}"
-    assert "valid_row = %arg" not in alloc_line, (
-        f"Expected valid_shape SSA from body, not direct arg reuse: {alloc_line}"
-    )
+    # No fillpad → dynamic variable used as valid_row operand, no set_validshape
+    assert "valid_row" in alloc_line, f"Expected valid_row operand in alloc: {alloc_line}"
+    assert "pto.set_validshape" not in mlir_code
 
 
 def test_pto_codegen_tile_load_lowering():

--- a/tests/ut/codegen/test_pto_codegen_paged_attn.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn.py
@@ -183,5 +183,82 @@ def test_tile_ops_codegen():
         assert mlir_code, f"Generated MLIR code for {func_name} should not be empty"
 
 
+@pl.program
+class UnalignedPagedAttention:
+    """Unaligned paged attention with dynamic valid_len for softmax_prepare."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def softmax_prepare_unaligned(
+        self,
+        sij: pl.Tensor[[16, 128], pl.FP32],
+        pij: pl.Tensor[[16, 128], pl.BF16],
+        mij: pl.Tensor[[16, 1], pl.FP32],
+        lij: pl.Tensor[[16, 1], pl.FP32],
+        scale_value: pl.Scalar[pl.FP32],
+        valid_len: pl.Scalar[pl.INDEX],
+    ):
+        sij_tile: pl.Tile[[16, 128], pl.FP32] = pl.tile.load(
+            sij,
+            [0, 0],
+            [16, 128],
+            [16, valid_len],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        sij_padded = pl.tile.fillpad(sij_tile, pad_value=pl.PadValue.min)
+        tmp_tile: pl.Tile[[16, 128], pl.FP32] = pl.tile.sub(sij_padded, sij_padded)
+        sij_scaled = pl.tile.muls(sij_padded, scale_value)
+        max_tile: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_max(sij_scaled, tmp_tile)
+        pij_tile: pl.Tile[[16, 128], pl.FP32] = pl.tile.row_expand_sub(sij_scaled, max_tile)
+        pij_tile = pl.tile.exp(pij_tile)
+        pij_bf16_tile = pl.tile.cast(pij_tile, mode="round", target_type=pl.BF16)
+        pij_fp16_tile = pl.tile.cast(pij_bf16_tile, mode="round", target_type=pl.FP16)
+        sum_tile: pl.Tile[[16, 1], pl.FP16] = pl.tile.row_sum(pij_fp16_tile, tmp_tile)
+        pl.store(max_tile, [0, 0], mij)
+        pl.store(sum_tile, [0, 0], lij)
+        pl.store(pij_bf16_tile, [0, 0], pij)
+
+
+def test_unaligned_tile_ops_codegen():
+    """Test that unaligned paged attention emits pto.set_validshape."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B_PTO)
+
+    program = UnalignedPagedAttention
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized_program = pm.run_passes(program)
+    codegen_instance = codegen.PTOCodegen()
+
+    # Generate MLIR for the softmax_prepare_unaligned function
+    func = None
+    for f in optimized_program.functions.values():
+        if f.name == "softmax_prepare_unaligned":
+            func = f
+            break
+    assert func is not None, "softmax_prepare_unaligned function not found in optimized program"
+    single_func_program = ir.Program([func], func.name, optimized_program.span)
+    mlir_code = codegen_instance.generate(single_func_program)
+    assert mlir_code, "Generated MLIR code should not be empty"
+
+    # pto.set_validshape must be present
+    assert "pto.set_validshape" in mlir_code, f"Expected pto.set_validshape in MLIR output, got:\n{mlir_code}"
+
+    # sij_tile alloc: dynamic type (v_row=?, v_col=?)
+    alloc_lines = [line.strip() for line in mlir_code.split("\n") if "pto.alloc_tile" in line]
+    sij_alloc = [line for line in alloc_lines if "sij_tile" in line or "s_tile" in line]
+    assert len(sij_alloc) >= 1, f"Expected sij/s_tile alloc, got alloc_lines: {alloc_lines}"
+    assert "v_col=?" in sij_alloc[0], f"Expected dynamic v_col=? in sij_tile alloc: {sij_alloc[0]}"
+    assert "v_row=?" in sij_alloc[0], f"Expected dynamic v_row=? in sij_tile alloc: {sij_alloc[0]}"
+
+    # sij_padded alloc: static v_col=128 and pad=3 (PadValue.min)
+    sij_padded_alloc = [line for line in alloc_lines if "sij_padded" in line or "s_padded" in line]
+    assert len(sij_padded_alloc) >= 1, f"Expected sij_padded/s_padded alloc, got: {alloc_lines}"
+    assert "pad=3>" in sij_padded_alloc[0], (
+        f"Expected pad=3 (PadValue.min) in sij_padded alloc: {sij_padded_alloc[0]}"
+    )
+    assert "v_col=128" in sij_padded_alloc[0], (
+        f"Expected static v_col=128 in padded alloc: {sij_padded_alloc[0]}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -533,16 +533,12 @@ class TestLegalizeWithCodegen:
         addr_values = _get_alloc_addrs(alloc_lines)
         assert addr_values[0] == addr_values[1], f"Expected same addr for shared MemRef, got: {addr_values}"
 
-        dynamic_allocs = [line for line in alloc_lines if "valid_row = %" in line]
-        assert len(dynamic_allocs) == 1, f"Expected one alloc_tile with dynamic valid_row, got: {alloc_lines}"
-        assert "valid_col = %" not in dynamic_allocs[0], (
-            f"Did not expect dynamic valid_col in alloc_tile: {dynamic_allocs[0]}"
+        # Dynamic valid_shape: type has v_row=?, v_col=? (PTOAS requires both dynamic)
+        assert "v_row=?" in alloc_lines[0], (
+            f"Expected dynamic v_row=? in tile_buf type, got: {alloc_lines[0]}"
         )
-        assert "v_row=?" in dynamic_allocs[0], (
-            f"Expected dynamic v_row in tile_buf type, got: {dynamic_allocs[0]}"
-        )
-        assert "v_col=128" in dynamic_allocs[0], (
-            f"Expected static v_col=128 in tile_buf type, got: {dynamic_allocs[0]}"
+        assert "v_col=?" in alloc_lines[0], (
+            f"Expected dynamic v_col=? in tile_buf type, got: {alloc_lines[0]}"
         )
 
         padded_allocs = [line for line in alloc_lines if "pad=2>" in line]


### PR DESCRIPTION
## Summary

- Implement `pto.set_validshape` codegen for unaligned paged attention, replacing the previous `tload + tmov` workaround
- When `pl.load(..., valid_shapes=[M, valid_len])` uses a dynamic `valid_len`, allocate tile with physical dims for correct DMA stride, then emit `pto.set_validshape` to set the actual valid region before `pto.tfillpad`
- Add `EmitCastToIndex` helper for INT64/INT32 → index type conversion needed by `pto.set_validshape` operands

### C++ Changes
- `ExtractTileTypeInfo`: mark both `v_row` and `v_col` as dynamic when any valid_shape dim is dynamic (PTOAS requirement)
- `EmitAllocTileForVar`: use `type_str` as single source of truth for dynamic detection; emit physical dims as `valid_row`/`valid_col` operands
- `MakeTileLoadCodegenPTO`: emit `pto.set_validshape` after `pto.tload` when tile has dynamic valid_shape

### Target MLIR pattern
```mlir
%tile = pto.alloc_tile valid_row = %c16 valid_col = %c128
    : !pto.tile_buf<..., v_row=?, v_col=?, ..., pad=0>
pto.tload ins(%view : ...) outs(%tile : ...)
pto.set_validshape %tile, %c16, %valid_len_idx : ...
pto.tfillpad ins(%tile : ...) outs(%padded : !pto.tile_buf<..., v_col=128, pad=3>)
```

## Testing
- [x] UT: `test_pto_codegen_paged_attn.py` — verifies `pto.set_validshape` in MLIR output, dynamic `v_row=?`/`v_col=?` type, padded tile `pad=3`
- [x] UT: `test_pto_codegen.py`, `test_dynamic_shape.py`, `test_legalize_pto_buffer_reuse.py` — updated assertions for new alloc pattern
- [x] ST: `test_paged_attention.py` — unaligned softmax_prepare (valid_len=100, 128) and full unaligned paged attention (context_len=8100)
- [x] Example: `paged_attention_example.py` — added `kernel_softmax_prepare_unaligned` + `build_paged_attention_unaligned_program`