### PR TITLE
refactor(arith): add Unbind API and deduplicate test boilerplate

### DIFF
--- a/include/pypto/ir/arith/analyzer.h
+++ b/include/pypto/ir/arith/analyzer.h
@@ -76,6 +76,9 @@ class ConstIntBoundAnalyzer {
   /// Update a variable's bound (inclusive on both ends).
   void Update(const VarPtr& var, const ConstIntBound& bound);
 
+  /// Remove a variable's binding, restoring it to the default (everything) state.
+  void Unbind(const VarPtr& var);
+
   /// Enter a constraint scope (e.g., inside an if-branch where expr is known true).
   /// Returns a recovery function that restores original bounds.
   std::function<void()> EnterConstraint(const ExprPtr& constraint);
@@ -122,6 +125,9 @@ class ModularSetAnalyzer {
 
   /// Update a variable's modular set information.
   void Update(const VarPtr& var, const ModularSet& info);
+
+  /// Remove a variable's modular set information, restoring it to the default (everything) state.
+  void Unbind(const VarPtr& var);
 
   /// Enter a constraint scope. Returns a recovery function.
   std::function<void()> EnterConstraint(const ExprPtr& constraint);
@@ -238,6 +244,9 @@ class Analyzer : public std::enable_shared_from_this<Analyzer> {
   /// Bind a variable to the half-open range [min_val, max_val_exclusive).
   /// \note allow_override is reserved for future use and currently has no effect.
   void Bind(const VarPtr& var, int64_t min_val, int64_t max_val_exclusive, bool allow_override = false);
+
+  /// Remove a variable's binding from all sub-analyzers, restoring it to an unbound state.
+  void Unbind(const VarPtr& var);
 
   /// Simplify an expression by iterative rewrite simplification.
   /// \param steps Number of simplification rounds (default 2).

--- a/python/bindings/modules/arith.cpp
+++ b/python/bindings/modules/arith.cpp
@@ -128,7 +128,9 @@ void BindArith(nb::module_& m) {
            nb::arg("max_val_exclusive"),
            "Bind a variable to the half-open range [min_val, max_val_exclusive).")
       .def("update", &ir::arith::ConstIntBoundAnalyzer::Update, nb::arg("var"), nb::arg("bound"),
-           "Update a variable's bound (inclusive on both ends).");
+           "Update a variable's bound (inclusive on both ends).")
+      .def("unbind", &ir::arith::ConstIntBoundAnalyzer::Unbind, nb::arg("var"),
+           "Remove a variable's binding, restoring it to the default (everything) state.");
 
   // ModularSet
   nb::class_<ir::arith::ModularSet>(arith, "ModularSet",
@@ -152,6 +154,8 @@ void BindArith(nb::module_& m) {
            "Compute modular set for an expression.")
       .def("update", &ir::arith::ModularSetAnalyzer::Update, nb::arg("var"), nb::arg("info"),
            "Update a variable's modular set information.")
+      .def("unbind", &ir::arith::ModularSetAnalyzer::Unbind, nb::arg("var"),
+           "Remove a variable's modular set information, restoring it to the default (everything) state.")
       .def("enter_constraint", &ir::arith::ModularSetAnalyzer::EnterConstraint, nb::arg("constraint"),
            "Enter a constraint scope. Returns a recovery function, or None if constraint is not useful.");
 
@@ -180,6 +184,8 @@ void BindArith(nb::module_& m) {
            "Prove that expr < upper_bound for all possible variable values.")
       .def("can_prove_equal", &ir::arith::Analyzer::CanProveEqual, nb::arg("lhs"), nb::arg("rhs"),
            "Prove that lhs and rhs are always equal.")
+      .def("unbind", &ir::arith::Analyzer::Unbind, nb::arg("var"),
+           "Remove a variable's binding from all sub-analyzers, restoring it to an unbound state.")
       .def("can_prove", &ir::arith::Analyzer::CanProve, nb::arg("cond"),
            "Prove that a boolean condition is always true.")
       .def(

--- a/python/pypto/pypto_core/arith.pyi
+++ b/python/pypto/pypto_core/arith.pyi
@@ -138,6 +138,10 @@ class ConstIntBoundAnalyzer:
         """Update a variable's bound (inclusive on both ends)."""
         ...
 
+    def unbind(self, var: Var) -> None:
+        """Remove a variable's binding, restoring it to the default (everything) state."""
+        ...
+
 class ModularSet:
     """Modular arithmetic properties: value = coeff * k + base."""
 
@@ -171,6 +175,10 @@ class ModularSetAnalyzer:
         """Update a variable's modular set information."""
         ...
 
+    def unbind(self, var: Var) -> None:
+        """Remove a variable's modular set information, restoring it to the default (everything) state."""
+        ...
+
     def enter_constraint(self, constraint: Expr) -> Callable[[], None] | None:
         """Enter a constraint scope. Returns a recovery function, or None."""
         ...
@@ -192,6 +200,10 @@ class Analyzer:
     def bind(self, var: Var, min_val: int, max_val_exclusive: int, allow_override: bool = False) -> None: ...
     def bind(self, var: Var, *args, **kwargs) -> None:
         """Bind a variable to an expression or half-open range [min_val, max_val_exclusive)."""
+        ...
+
+    def unbind(self, var: Var) -> None:
+        """Remove a variable's binding from all sub-analyzers, restoring it to an unbound state."""
         ...
 
     def simplify(self, expr: Expr, steps: int = 2) -> Expr:

--- a/src/ir/arith/analyzer.cpp
+++ b/src/ir/arith/analyzer.cpp
@@ -63,6 +63,12 @@ void Analyzer::Bind(const VarPtr& var, int64_t min_val, int64_t max_val_exclusiv
   }
 }
 
+void Analyzer::Unbind(const VarPtr& var) {
+  const_int_bound.Unbind(var);
+  modular_set.Unbind(var);
+  rewrite_simplify.Update(var, nullptr);
+}
+
 ExprPtr Analyzer::Simplify(const ExprPtr& expr, int steps) {
   CHECK(steps >= 0) << "Simplify requires non-negative steps, got " << steps;
   ExprPtr result = expr;

--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -170,6 +170,8 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
 
   void Bind(const VarPtr& var, const Bound& bound) { var_map_[var.get()] = bound; }
 
+  void Unbind(const VarPtr& var) { var_map_.erase(var.get()); }
+
   std::function<void()> EnterConstraint(const ExprPtr& constraint);
 
   Bound VisitExpr(const ExprPtr& expr) override { return ExprFunctor<Bound>::VisitExpr(expr); }
@@ -500,6 +502,8 @@ void ConstIntBoundAnalyzer::Update(const VarPtr& var, const Bound& bound) {
       << "Update requires min_value <= max_value, got [" << bound.min_value << ", " << bound.max_value << "]";
   impl_->Bind(var, bound);
 }
+
+void ConstIntBoundAnalyzer::Unbind(const VarPtr& var) { impl_->Unbind(var); }
 
 std::function<void()> ConstIntBoundAnalyzer::EnterConstraint(const ExprPtr& constraint) {
   return impl_->EnterConstraint(constraint);

--- a/src/ir/arith/modular_set.cpp
+++ b/src/ir/arith/modular_set.cpp
@@ -110,6 +110,8 @@ class ModularSetAnalyzer::Impl : public ExprFunctor<Entry> {
 
   void Update(const VarPtr& var, const Entry& entry) { var_map_[var.get()] = entry; }
 
+  void Unbind(const VarPtr& var) { var_map_.erase(var.get()); }
+
   std::function<void()> EnterConstraint(const ExprPtr& constraint);
 
   Entry VisitExpr(const ExprPtr& expr) override { return ExprFunctor<Entry>::VisitExpr(expr); }
@@ -361,6 +363,8 @@ void ModularSetAnalyzer::Update(const VarPtr& var, const ModularSet& info) {
   CHECK(info.coeff >= 0) << "ModularSet coeff must be non-negative, got " << info.coeff;
   impl_->Update(var, {info.coeff, info.base});
 }
+
+void ModularSetAnalyzer::Unbind(const VarPtr& var) { impl_->Unbind(var); }
 
 std::function<void()> ModularSetAnalyzer::EnterConstraint(const ExprPtr& constraint) {
   return impl_->EnterConstraint(constraint);

--- a/tests/ut/ir/arith/test_analyzer.py
+++ b/tests/ut/ir/arith/test_analyzer.py
@@ -31,6 +31,13 @@ def assert_is_const_int(expr: ir.Expr, expected: int) -> None:
     assert expr.value == expected, f"Expected {expected}, got {expr.value}"
 
 
+# Module-level shared instances
+analyzer = Analyzer()
+x = make_var("x")
+y = make_var("y")
+z = make_var("z")
+
+
 # ============================================================================
 # Construction and basic usage
 # ============================================================================
@@ -38,14 +45,12 @@ def assert_is_const_int(expr: ir.Expr, expected: int) -> None:
 
 class TestConstruction:
     def test_create_analyzer(self):
-        ana = Analyzer()
-        assert ana is not None
+        assert analyzer is not None
 
     def test_sub_analyzers_accessible(self):
-        ana = Analyzer()
-        assert ana.const_int_bound is not None
-        assert ana.modular_set is not None
-        assert ana.rewrite_simplify is not None
+        assert analyzer.const_int_bound is not None
+        assert analyzer.modular_set is not None
+        assert analyzer.rewrite_simplify is not None
 
 
 # ============================================================================
@@ -55,37 +60,32 @@ class TestConstruction:
 
 class TestBindRange:
     def test_bind_range_propagates_to_const_int_bound(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 8)
-        bound = ana.const_int_bound(x)
+        analyzer.bind(x, 0, 8)
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == 0
         assert bound.max_value == 7
+        analyzer.unbind(x)
 
     def test_bind_range_single_value(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 5, 6)  # [5, 6) = exactly 5
-        bound = ana.const_int_bound(x)
+        analyzer.bind(x, 5, 6)  # [5, 6) = exactly 5
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == 5
         assert bound.max_value == 5
         # Should also substitute in rewrite simplifier
-        result = ana.simplify(x)
+        result = analyzer.simplify(x)
         assert_is_const_int(result, 5)
+        analyzer.unbind(x)
 
     def test_bind_range_invalid_raises(self):
-        ana = Analyzer()
-        x = make_var("x")
         with pytest.raises(ValueError):
-            ana.bind(x, 5, 5)  # empty range
+            analyzer.bind(x, 5, 5)  # empty range
 
     def test_bind_range_negative(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, -10, 0)
-        bound = ana.const_int_bound(x)
+        analyzer.bind(x, -10, 0)
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == -10
         assert bound.max_value == -1
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -95,22 +95,84 @@ class TestBindRange:
 
 class TestBindExpr:
     def test_bind_expr_const(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, ci(42))
-        bound = ana.const_int_bound(x)
+        analyzer.bind(x, ci(42))
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == 42
         assert bound.max_value == 42
+        analyzer.unbind(x)
 
     def test_bind_expr_variable(self):
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 10)
-        ana.bind(y, ir.Add(x, ci(1), INT, S))
-        bound = ana.const_int_bound(y)
+        analyzer.bind(x, 0, 10)
+        analyzer.bind(y, ir.Add(x, ci(1), INT, S))
+        bound = analyzer.const_int_bound(y)
         assert bound.min_value == 1
         assert bound.max_value == 10
+        analyzer.unbind(y)
+        analyzer.unbind(x)
+
+
+# ============================================================================
+# Unbind
+# ============================================================================
+
+
+class TestUnbind:
+    def test_unbind_restores_bound_to_everything(self):
+        """After unbind, const_int_bound returns [-inf, +inf]."""
+        analyzer.bind(x, 0, 10)
+        assert analyzer.const_int_bound(x).min_value == 0
+        analyzer.unbind(x)
+        bound = analyzer.const_int_bound(x)
+        assert bound.is_everything()
+
+    def test_unbind_restores_modular_set_to_everything(self):
+        """After unbind, modular_set returns {coeff=1, base=0}."""
+        analyzer.bind(x, ci(42))
+        assert analyzer.modular_set(x).is_exact()
+        analyzer.unbind(x)
+        m = analyzer.modular_set(x)
+        assert m.is_everything()
+
+    def test_unbind_removes_rewrite_substitution(self):
+        """After unbind, rewrite simplifier no longer substitutes the variable."""
+        analyzer.bind(x, ci(7))
+        assert_is_const_int(analyzer.simplify(x), 7)
+        analyzer.unbind(x)
+        result = analyzer.simplify(x)
+        assert result is x
+
+    def test_unbind_unbound_var_is_noop(self):
+        """Unbinding an already-unbound variable does not raise."""
+        analyzer.unbind(x)
+        bound = analyzer.const_int_bound(x)
+        assert bound.is_everything()
+
+    def test_unbind_only_affects_target_var(self):
+        """Unbinding x does not affect y's binding."""
+        analyzer.bind(x, 0, 10)
+        analyzer.bind(y, 100, 200)
+        analyzer.unbind(x)
+        assert analyzer.const_int_bound(x).is_everything()
+        assert analyzer.const_int_bound(y).min_value == 100
+        assert analyzer.const_int_bound(y).max_value == 199
+        analyzer.unbind(y)
+
+    def test_rebind_after_unbind(self):
+        """A variable can be rebound after unbinding."""
+        analyzer.bind(x, 0, 10)
+        analyzer.unbind(x)
+        analyzer.bind(x, 50, 60)
+        bound = analyzer.const_int_bound(x)
+        assert bound.min_value == 50
+        assert bound.max_value == 59
+        analyzer.unbind(x)
+
+    def test_unbind_range_bound(self):
+        """Unbind works for range-bound variables."""
+        analyzer.bind(x, -5, 5)
+        assert analyzer.can_prove_less(x, 5) is True
+        analyzer.unbind(x)
+        assert analyzer.can_prove_less(x, 5) is False
 
 
 # ============================================================================
@@ -120,62 +182,51 @@ class TestBindExpr:
 
 class TestSimplify:
     def test_simplify_identity(self):
-        ana = Analyzer()
-        x = make_var("x")
         # x + 0 -> x
-        result = ana.simplify(ir.Add(x, ci(0), INT, S))
+        result = analyzer.simplify(ir.Add(x, ci(0), INT, S))
         assert result is x
 
     def test_simplify_const_fold(self):
-        ana = Analyzer()
-        result = ana.simplify(ir.Add(ci(3), ci(4), INT, S))
+        result = analyzer.simplify(ir.Add(ci(3), ci(4), INT, S))
         assert_is_const_int(result, 7)
 
     def test_simplify_x_minus_x(self):
-        ana = Analyzer()
-        x = make_var("x")
-        result = ana.simplify(ir.Sub(x, x, INT, S))
+        result = analyzer.simplify(ir.Sub(x, x, INT, S))
         assert_is_const_int(result, 0)
 
     def test_simplify_with_bound_info(self):
         """Range-aware simplification: x // 8 -> 0 when x in [0, 8)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 8)
-        result = ana.simplify(ir.FloorDiv(x, ci(8), INT, S))
+        analyzer.bind(x, 0, 8)
+        result = analyzer.simplify(ir.FloorDiv(x, ci(8), INT, S))
         assert_is_const_int(result, 0)
+        analyzer.unbind(x)
 
     def test_simplify_floormod_with_bound(self):
         """x % 8 -> x when x in [0, 8)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 8)
-        result = ana.simplify(ir.FloorMod(x, ci(8), INT, S))
+        analyzer.bind(x, 0, 8)
+        result = analyzer.simplify(ir.FloorMod(x, ci(8), INT, S))
         assert result is x
+        analyzer.unbind(x)
 
     def test_simplify_steps_parameter(self):
-        ana = Analyzer()
-        x = make_var("x")
         # steps=0 should return the expression unchanged
         expr = ir.Add(x, ci(0), INT, S)
-        result = ana.simplify(expr, steps=0)
+        result = analyzer.simplify(expr, steps=0)
         assert result is expr
 
     def test_simplify_min_with_bound(self):
         """min(x, 10) -> x when x in [0, 8)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 8)
-        result = ana.simplify(ir.Min(x, ci(10), INT, S))
+        analyzer.bind(x, 0, 8)
+        result = analyzer.simplify(ir.Min(x, ci(10), INT, S))
         assert result is x
+        analyzer.unbind(x)
 
     def test_simplify_max_with_bound(self):
         """max(x, -1) -> x when x in [0, 8)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 8)
-        result = ana.simplify(ir.Max(x, ci(-1), INT, S))
+        analyzer.bind(x, 0, 8)
+        result = analyzer.simplify(ir.Max(x, ci(-1), INT, S))
         assert result is x
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -185,71 +236,59 @@ class TestSimplify:
 
 class TestCanProve:
     def test_can_prove_greater_equal_true(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
-        assert ana.can_prove_greater_equal(x, 0) is True
+        analyzer.bind(x, 0, 10)
+        assert analyzer.can_prove_greater_equal(x, 0) is True
+        analyzer.unbind(x)
 
     def test_can_prove_greater_equal_false(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
-        assert ana.can_prove_greater_equal(x, 1) is False
+        analyzer.bind(x, 0, 10)
+        assert analyzer.can_prove_greater_equal(x, 1) is False
+        analyzer.unbind(x)
 
     def test_can_prove_less_true(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
-        assert ana.can_prove_less(x, 10) is True
+        analyzer.bind(x, 0, 10)
+        assert analyzer.can_prove_less(x, 10) is True
+        analyzer.unbind(x)
 
     def test_can_prove_less_false(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
-        assert ana.can_prove_less(x, 9) is False
+        analyzer.bind(x, 0, 10)
+        assert analyzer.can_prove_less(x, 9) is False
+        analyzer.unbind(x)
 
     def test_can_prove_equal_identity(self):
-        ana = Analyzer()
-        x = make_var("x")
-        assert ana.can_prove_equal(x, x) is True
+        assert analyzer.can_prove_equal(x, x) is True
 
     def test_can_prove_equal_via_simplify(self):
-        ana = Analyzer()
-        x = make_var("x")
         lhs = ir.Add(x, ci(0), INT, S)
-        assert ana.can_prove_equal(lhs, x) is True
+        assert analyzer.can_prove_equal(lhs, x) is True
 
     def test_can_prove_bool_const_true(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
+        analyzer.bind(x, 0, 10)
         # x < 10 is always true when x in [0, 10)
         cond = ir.Lt(x, ci(10), BOOL, S)
-        assert ana.can_prove(cond) is True
+        assert analyzer.can_prove(cond) is True
+        analyzer.unbind(x)
 
     def test_can_prove_bool_const_false(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
+        analyzer.bind(x, 0, 10)
         # x >= 10 is always false when x in [0, 10)
         cond = ir.Ge(x, ci(10), BOOL, S)
-        assert ana.can_prove(cond) is False
+        assert analyzer.can_prove(cond) is False
+        analyzer.unbind(x)
 
     def test_can_prove_greater_equal_with_expr(self):
         """x + 1 >= 1 when x in [0, 10)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
+        analyzer.bind(x, 0, 10)
         expr = ir.Add(x, ci(1), INT, S)
-        assert ana.can_prove_greater_equal(expr, 1) is True
+        assert analyzer.can_prove_greater_equal(expr, 1) is True
+        analyzer.unbind(x)
 
     def test_can_prove_less_with_expr(self):
         """x + 1 < 11 when x in [0, 10)."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 10)
+        analyzer.bind(x, 0, 10)
         expr = ir.Add(x, ci(1), INT, S)
-        assert ana.can_prove_less(expr, 11) is True
+        assert analyzer.can_prove_less(expr, 11) is True
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -259,63 +298,58 @@ class TestCanProve:
 
 class TestConstraintContext:
     def test_context_manager(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, -10, 10)
+        analyzer.bind(x, -10, 10)
 
         # Before constraint: cannot prove x >= 0
-        assert ana.can_prove_greater_equal(x, 0) is False
+        assert analyzer.can_prove_greater_equal(x, 0) is False
 
         constraint = ir.Ge(x, ci(0), BOOL, S)
-        with ana.constraint_context(constraint):
+        with analyzer.constraint_context(constraint):
             # Within constraint: can prove x >= 0
-            assert ana.can_prove_greater_equal(x, 0) is True
+            assert analyzer.can_prove_greater_equal(x, 0) is True
 
         # After constraint: back to original bounds
-        assert ana.can_prove_greater_equal(x, 0) is False
+        assert analyzer.can_prove_greater_equal(x, 0) is False
+        analyzer.unbind(x)
 
     def test_constraint_tightens_bounds(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 100)
+        analyzer.bind(x, 0, 100)
 
         constraint = ir.Lt(x, ci(10), BOOL, S)
-        with ana.constraint_context(constraint):
-            bound = ana.const_int_bound(x)
+        with analyzer.constraint_context(constraint):
+            bound = analyzer.const_int_bound(x)
             assert bound.max_value == 9
 
         # Restored
-        bound = ana.const_int_bound(x)
+        bound = analyzer.const_int_bound(x)
         assert bound.max_value == 99
+        analyzer.unbind(x)
 
     def test_nested_constraints(self):
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 100)
+        analyzer.bind(x, 0, 100)
 
-        with ana.constraint_context(ir.Ge(x, ci(10), BOOL, S)):
-            assert ana.can_prove_greater_equal(x, 10) is True
-            assert ana.can_prove_less(x, 20) is False
+        with analyzer.constraint_context(ir.Ge(x, ci(10), BOOL, S)):
+            assert analyzer.can_prove_greater_equal(x, 10) is True
+            assert analyzer.can_prove_less(x, 20) is False
 
-            with ana.constraint_context(ir.Lt(x, ci(20), BOOL, S)):
-                assert ana.can_prove_greater_equal(x, 10) is True
-                assert ana.can_prove_less(x, 20) is True
+            with analyzer.constraint_context(ir.Lt(x, ci(20), BOOL, S)):
+                assert analyzer.can_prove_greater_equal(x, 10) is True
+                assert analyzer.can_prove_less(x, 20) is True
 
             # Inner scope exited
-            assert ana.can_prove_less(x, 20) is False
+            assert analyzer.can_prove_less(x, 20) is False
 
         # Outer scope exited
-        assert ana.can_prove_greater_equal(x, 10) is False
+        assert analyzer.can_prove_greater_equal(x, 10) is False
+        analyzer.unbind(x)
 
     def test_constraint_enables_simplification(self):
         """x // 8 -> 0 when constrained to x < 8 and x >= 0."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, -100, 100)
+        analyzer.bind(x, -100, 100)
 
         # Without constraint, x // 8 is not simplified
         expr = ir.FloorDiv(x, ci(8), INT, S)
-        result = ana.simplify(expr)
+        result = analyzer.simplify(expr)
         assert not isinstance(result, ir.ConstInt)
 
         constraint = ir.And(
@@ -324,53 +358,51 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
-            result = ana.simplify(expr)
+        with analyzer.constraint_context(constraint):
+            result = analyzer.simplify(expr)
             assert_is_const_int(result, 0)
+        analyzer.unbind(x)
 
     # --- Multiple constraints on a single variable ---
 
     def test_successive_tightening_single_var(self):
         """Nested constraints progressively tighten a single variable's bounds."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 100)
+        analyzer.bind(x, 0, 100)
 
-        with ana.constraint_context(ir.Ge(x, ci(20), BOOL, S)):
-            bound = ana.const_int_bound(x)
+        with analyzer.constraint_context(ir.Ge(x, ci(20), BOOL, S)):
+            bound = analyzer.const_int_bound(x)
             assert bound.min_value == 20
             assert bound.max_value == 99
 
-            with ana.constraint_context(ir.Lt(x, ci(50), BOOL, S)):
-                bound = ana.const_int_bound(x)
+            with analyzer.constraint_context(ir.Lt(x, ci(50), BOOL, S)):
+                bound = analyzer.const_int_bound(x)
                 assert bound.min_value == 20
                 assert bound.max_value == 49
 
-                with ana.constraint_context(ir.Ge(x, ci(30), BOOL, S)):
-                    bound = ana.const_int_bound(x)
+                with analyzer.constraint_context(ir.Ge(x, ci(30), BOOL, S)):
+                    bound = analyzer.const_int_bound(x)
                     assert bound.min_value == 30
                     assert bound.max_value == 49
 
                 # Innermost exited: back to [20, 49]
-                bound = ana.const_int_bound(x)
+                bound = analyzer.const_int_bound(x)
                 assert bound.min_value == 20
                 assert bound.max_value == 49
 
             # Middle exited: back to [20, 99]
-            bound = ana.const_int_bound(x)
+            bound = analyzer.const_int_bound(x)
             assert bound.min_value == 20
             assert bound.max_value == 99
 
         # All exited: back to [0, 99]
-        bound = ana.const_int_bound(x)
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == 0
         assert bound.max_value == 99
+        analyzer.unbind(x)
 
     def test_and_constraint_single_var(self):
         """A single And constraint tightens both ends at once."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, -100, 100)
+        analyzer.bind(x, -100, 100)
 
         constraint = ir.And(
             ir.Ge(x, ci(10), BOOL, S),
@@ -378,92 +410,86 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
-            bound = ana.const_int_bound(x)
+        with analyzer.constraint_context(constraint):
+            bound = analyzer.const_int_bound(x)
             assert bound.min_value == 10
             assert bound.max_value == 19
 
-        bound = ana.const_int_bound(x)
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == -100
         assert bound.max_value == 99
+        analyzer.unbind(x)
 
     def test_eq_constraint_single_var(self):
         """Eq constraint pins a variable to a single value."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 0, 100)
+        analyzer.bind(x, 0, 100)
 
-        with ana.constraint_context(ir.Eq(x, ci(42), BOOL, S)):
-            bound = ana.const_int_bound(x)
+        with analyzer.constraint_context(ir.Eq(x, ci(42), BOOL, S)):
+            bound = analyzer.const_int_bound(x)
             assert bound.min_value == 42
             assert bound.max_value == 42
-            assert ana.can_prove_equal(x, ci(42)) is True
+            assert analyzer.can_prove_equal(x, ci(42)) is True
 
-        bound = ana.const_int_bound(x)
+        bound = analyzer.const_int_bound(x)
         assert bound.min_value == 0
         assert bound.max_value == 99
+        analyzer.unbind(x)
 
     def test_redundant_constraint_single_var(self):
         """A constraint weaker than the existing bound is a no-op."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 10, 20)  # [10, 19]
+        analyzer.bind(x, 10, 20)  # [10, 19]
 
         # x >= 0 is weaker than existing min=10
-        with ana.constraint_context(ir.Ge(x, ci(0), BOOL, S)):
-            bound = ana.const_int_bound(x)
+        with analyzer.constraint_context(ir.Ge(x, ci(0), BOOL, S)):
+            bound = analyzer.const_int_bound(x)
             assert bound.min_value == 10  # Not weakened
             assert bound.max_value == 19
+        analyzer.unbind(x)
 
     def test_simplify_enabled_by_constraint_single_var(self):
         """Constraint makes floordiv(x, x) -> 1 by proving x != 0."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, -100, 100)
+        analyzer.bind(x, -100, 100)
 
         # Without constraint: x could be 0, so floordiv(x, x) is not simplified
         expr = ir.FloorDiv(x, x, INT, S)
-        result = ana.simplify(expr)
+        result = analyzer.simplify(expr)
         assert not isinstance(result, ir.ConstInt)
 
         # With constraint x >= 1, floordiv(x, x) -> 1
-        with ana.constraint_context(ir.Ge(x, ci(1), BOOL, S)):
-            result = ana.simplify(expr)
+        with analyzer.constraint_context(ir.Ge(x, ci(1), BOOL, S)):
+            result = analyzer.simplify(expr)
             assert_is_const_int(result, 1)
+        analyzer.unbind(x)
 
     # --- Multiple constraints on multiple variables ---
 
     def test_independent_constraints_multi_var(self):
         """Constraints on different variables are independent."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
 
-        with ana.constraint_context(ir.Lt(x, ci(10), BOOL, S)):
+        with analyzer.constraint_context(ir.Lt(x, ci(10), BOOL, S)):
             # x is [0, 9], y is still [0, 99]
-            assert ana.can_prove_less(x, 10) is True
-            assert ana.can_prove_less(y, 10) is False
+            assert analyzer.can_prove_less(x, 10) is True
+            assert analyzer.can_prove_less(y, 10) is False
 
-            with ana.constraint_context(ir.Ge(y, ci(50), BOOL, S)):
+            with analyzer.constraint_context(ir.Ge(y, ci(50), BOOL, S)):
                 # x is [0, 9], y is [50, 99]
-                assert ana.can_prove_less(x, 10) is True
-                assert ana.can_prove_greater_equal(y, 50) is True
+                assert analyzer.can_prove_less(x, 10) is True
+                assert analyzer.can_prove_greater_equal(y, 50) is True
 
             # y restored
-            assert ana.can_prove_greater_equal(y, 50) is False
+            assert analyzer.can_prove_greater_equal(y, 50) is False
 
         # x restored
-        assert ana.can_prove_less(x, 10) is False
+        assert analyzer.can_prove_less(x, 10) is False
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_and_constraint_multi_var(self):
         """A single And constraint can tighten multiple variables."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
 
         constraint = ir.And(
             ir.Ge(x, ci(10), BOOL, S),
@@ -471,24 +497,23 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
-            assert ana.can_prove_greater_equal(x, 10) is True
-            assert ana.can_prove_less(y, 20) is True
+        with analyzer.constraint_context(constraint):
+            assert analyzer.can_prove_greater_equal(x, 10) is True
+            assert analyzer.can_prove_less(y, 20) is True
 
-        assert ana.can_prove_greater_equal(x, 10) is False
-        assert ana.can_prove_less(y, 20) is False
+        assert analyzer.can_prove_greater_equal(x, 10) is False
+        assert analyzer.can_prove_less(y, 20) is False
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_constraint_enables_min_max_multi_var(self):
         """Constraints on two variables enable min/max simplification."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
 
         # Without constraints, min(x, y) cannot be simplified
         expr = ir.Min(x, y, INT, S)
-        result = ana.simplify(expr)
+        result = analyzer.simplify(expr)
         assert isinstance(result, ir.Min)
 
         # Constrain x < 10 and y >= 50 → min(x, y) = x
@@ -498,17 +523,16 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
-            result = ana.simplify(expr)
+        with analyzer.constraint_context(constraint):
+            result = analyzer.simplify(expr)
             assert result is x
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_constraint_proves_cross_var_comparison(self):
         """Constraints on two variables let us prove cross-variable comparisons."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
 
         # x + y < 20 when both are constrained to < 10
         constraint = ir.And(
@@ -517,20 +541,18 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
+        with analyzer.constraint_context(constraint):
             expr = ir.Add(x, y, INT, S)
-            assert ana.can_prove_less(expr, 19) is True
-            assert ana.can_prove_greater_equal(expr, 0) is True
+            assert analyzer.can_prove_less(expr, 19) is True
+            assert analyzer.can_prove_greater_equal(expr, 0) is True
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_triple_and_constraint(self):
         """Three-way And constraint (nested And nodes)."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
-        ana.bind(z, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
+        analyzer.bind(z, 0, 100)
 
         # (x >= 10 && y >= 20) && z >= 30
         constraint = ir.And(
@@ -544,36 +566,38 @@ class TestConstraintContext:
             BOOL,
             S,
         )
-        with ana.constraint_context(constraint):
-            assert ana.can_prove_greater_equal(x, 10) is True
-            assert ana.can_prove_greater_equal(y, 20) is True
-            assert ana.can_prove_greater_equal(z, 30) is True
+        with analyzer.constraint_context(constraint):
+            assert analyzer.can_prove_greater_equal(x, 10) is True
+            assert analyzer.can_prove_greater_equal(y, 20) is True
+            assert analyzer.can_prove_greater_equal(z, 30) is True
 
         # All restored
-        assert ana.can_prove_greater_equal(x, 10) is False
-        assert ana.can_prove_greater_equal(y, 20) is False
-        assert ana.can_prove_greater_equal(z, 30) is False
+        assert analyzer.can_prove_greater_equal(x, 10) is False
+        assert analyzer.can_prove_greater_equal(y, 20) is False
+        assert analyzer.can_prove_greater_equal(z, 30) is False
+        analyzer.unbind(x)
+        analyzer.unbind(y)
+        analyzer.unbind(z)
 
     def test_nested_multi_var_restore_order(self):
         """Verify that nested scopes on different variables restore correctly."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 100)
-        ana.bind(y, 0, 100)
+        analyzer.bind(x, 0, 100)
+        analyzer.bind(y, 0, 100)
 
-        with ana.constraint_context(ir.Ge(x, ci(50), BOOL, S)):
-            with ana.constraint_context(ir.Ge(y, ci(60), BOOL, S)):
-                assert ana.const_int_bound(x).min_value == 50
-                assert ana.const_int_bound(y).min_value == 60
+        with analyzer.constraint_context(ir.Ge(x, ci(50), BOOL, S)):
+            with analyzer.constraint_context(ir.Ge(y, ci(60), BOOL, S)):
+                assert analyzer.const_int_bound(x).min_value == 50
+                assert analyzer.const_int_bound(y).min_value == 60
 
             # y restored, x still constrained
-            assert ana.const_int_bound(x).min_value == 50
-            assert ana.const_int_bound(y).min_value == 0
+            assert analyzer.const_int_bound(x).min_value == 50
+            assert analyzer.const_int_bound(y).min_value == 0
 
         # Both restored
-        assert ana.const_int_bound(x).min_value == 0
-        assert ana.const_int_bound(y).min_value == 0
+        assert analyzer.const_int_bound(x).min_value == 0
+        assert analyzer.const_int_bound(y).min_value == 0
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 # ============================================================================
@@ -584,51 +608,45 @@ class TestConstraintContext:
 class TestCrossAnalyzer:
     def test_trycompare_enables_floordiv_simplification(self):
         """With parent Analyzer, rewrite rules use bound info for floordiv(x, x) -> 1."""
-        ana = Analyzer()
-        x = make_var("x")
-        ana.bind(x, 1, 10)  # x is positive (non-zero)
-        result = ana.simplify(ir.FloorDiv(x, x, INT, S))
+        analyzer.bind(x, 1, 10)  # x is positive (non-zero)
+        result = analyzer.simplify(ir.FloorDiv(x, x, INT, S))
         assert_is_const_int(result, 1)
+        analyzer.unbind(x)
 
     def test_trycompare_enables_min_simplification(self):
         """min(x, y) -> x when x <= y is provable."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 5)
-        ana.bind(y, 10, 20)
-        result = ana.simplify(ir.Min(x, y, INT, S))
+        analyzer.bind(x, 0, 5)
+        analyzer.bind(y, 10, 20)
+        result = analyzer.simplify(ir.Min(x, y, INT, S))
         assert result is x
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_trycompare_enables_max_simplification(self):
         """max(x, y) -> y when x <= y is provable."""
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 5)
-        ana.bind(y, 10, 20)
-        result = ana.simplify(ir.Max(x, y, INT, S))
+        analyzer.bind(x, 0, 5)
+        analyzer.bind(y, 10, 20)
+        result = analyzer.simplify(ir.Max(x, y, INT, S))
         assert result is y
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_standalone_simplifier_no_bound_awareness(self):
         """Standalone RewriteSimplifier cannot simplify min/max based on bounds."""
         s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         # Without parent Analyzer, min(x, y) stays as-is
         result = s(ir.Min(x, y, INT, S))
         assert isinstance(result, ir.Min)
 
     def test_multi_variable_bounds(self):
-        ana = Analyzer()
-        x = make_var("x")
-        y = make_var("y")
-        ana.bind(x, 0, 8)
-        ana.bind(y, 0, 8)
+        analyzer.bind(x, 0, 8)
+        analyzer.bind(y, 0, 8)
         # x + y is in [0, 14], so x + y >= 0
         expr = ir.Add(x, y, INT, S)
-        assert ana.can_prove_greater_equal(expr, 0) is True
-        assert ana.can_prove_less(expr, 15) is True
+        assert analyzer.can_prove_greater_equal(expr, 0) is True
+        assert analyzer.can_prove_less(expr, 15) is True
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/arith/test_canonical_simplify.py
+++ b/tests/ut/ir/arith/test_canonical_simplify.py
@@ -47,6 +47,12 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
     )
 
 
+# Module-level shared instances
+simplifier = CanonicalSimplifier()
+x = make_var("x")
+y = make_var("y")
+
+
 # ============================================================================
 # Basic functionality
 # ============================================================================
@@ -54,46 +60,37 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
 
 class TestBasics:
     def test_construction(self):
-        s = CanonicalSimplifier()
-        assert s is not None
+        assert simplifier is not None
 
     def test_identity_const(self):
-        s = CanonicalSimplifier()
         c = ci(42)
-        result = s(c)
+        result = simplifier(c)
         assert_is_const_int(result, 42)
 
     def test_identity_var(self):
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(x)
+        result = simplifier(x)
         assert_same_expr(result, x)
 
     def test_const_fold(self):
-        s = CanonicalSimplifier()
-        result = s(ir.Add(ci(3), ci(5), INT, S))
+        result = simplifier(ir.Add(ci(3), ci(5), INT, S))
         assert_is_const_int(result, 8)
 
     def test_var_substitution(self):
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        s.update(x, ci(10))
-        result = s(ir.Add(x, ci(5), INT, S))
+        simplifier.update(x, ci(10))
+        result = simplifier(ir.Add(x, ci(5), INT, S))
         assert_is_const_int(result, 15)
+        simplifier.update(x, None)
 
     def test_remove_substitution(self):
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        s.update(x, ci(10))
-        s.update(x, None)
-        result = s(x)
+        simplifier.update(x, ci(10))
+        simplifier.update(x, None)
+        result = simplifier(x)
         assert_same_expr(result, x)
 
     def test_float_unchanged(self):
-        s = CanonicalSimplifier()
-        x = ir.ConstFloat(3.14, DataType.FP32, S)
-        result = s(x)
-        assert result is x
+        f = ir.ConstFloat(3.14, DataType.FP32, S)
+        result = simplifier(f)
+        assert result is f
 
 
 # ============================================================================
@@ -106,70 +103,53 @@ class TestCoefficientCollection:
 
     def test_x_plus_x(self):
         """x + x => x * 2"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Add(x, x, INT, S))
+        result = simplifier(ir.Add(x, x, INT, S))
         assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
         assert result.left is x
         assert isinstance(result.right, ir.ConstInt) and result.right.value == 2
 
     def test_x_times_2_plus_x(self):
         """x*2 + x => x * 3"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         expr = ir.Add(ir.Mul(x, ci(2), INT, S), x, INT, S)
-        result = s(expr)
+        result = simplifier(expr)
         assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
         assert result.left is x
         assert isinstance(result.right, ir.ConstInt) and result.right.value == 3
 
     def test_x_minus_x(self):
         """x - x => 0"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Sub(x, x, INT, S))
+        result = simplifier(ir.Sub(x, x, INT, S))
         assert_is_const_int(result, 0)
 
     def test_3x_minus_2x(self):
         """x*3 - x*2 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         lhs = ir.Mul(x, ci(3), INT, S)
         rhs = ir.Mul(x, ci(2), INT, S)
-        result = s(ir.Sub(lhs, rhs, INT, S))
+        result = simplifier(ir.Sub(lhs, rhs, INT, S))
         assert_same_expr(result, x)
 
     def test_constant_collection(self):
         """x + 3 + 5 => x + 8"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         inner = ir.Add(x, ci(3), INT, S)
-        result = s(ir.Add(inner, ci(5), INT, S))
+        result = simplifier(ir.Add(inner, ci(5), INT, S))
         assert isinstance(result, ir.Add), f"Expected Add, got {type(result).__name__}"
         assert result.left is x
         assert isinstance(result.right, ir.ConstInt) and result.right.value == 8
 
     def test_multi_variable(self):
         """x + y - x => y"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         inner = ir.Add(x, y, INT, S)
-        result = s(ir.Sub(inner, x, INT, S))
+        result = simplifier(ir.Sub(inner, x, INT, S))
         assert_same_expr(result, y)
 
     def test_x_plus_zero(self):
         """x + 0 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Add(x, ci(0), INT, S))
+        result = simplifier(ir.Add(x, ci(0), INT, S))
         assert_same_expr(result, x)
 
     def test_zero_minus_x(self):
         """0 - x => -x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Sub(ci(0), x, INT, S))
+        result = simplifier(ir.Sub(ci(0), x, INT, S))
         assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
 
 
@@ -183,37 +163,27 @@ class TestMulDistribution:
 
     def test_mul_distribute(self):
         """(x + 1) * 2 => x * 2 + 2"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(ir.Add(x, ci(1), INT, S), ci(2), INT, S))
+        result = simplifier(ir.Mul(ir.Add(x, ci(1), INT, S), ci(2), INT, S))
         assert isinstance(result, ir.Add), f"Expected Add, got {type(result).__name__}"
 
     def test_mul_zero(self):
         """x * 0 => 0"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(x, ci(0), INT, S))
+        result = simplifier(ir.Mul(x, ci(0), INT, S))
         assert_is_const_int(result, 0)
 
     def test_mul_one(self):
         """x * 1 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(x, ci(1), INT, S))
+        result = simplifier(ir.Mul(x, ci(1), INT, S))
         assert_same_expr(result, x)
 
     def test_mul_neg_one(self):
         """x * (-1) => -x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(x, ci(-1), INT, S))
+        result = simplifier(ir.Mul(x, ci(-1), INT, S))
         assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
 
     def test_distribute_left(self):
         """2 * (x + 3) => x * 2 + 6"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(ci(2), ir.Add(x, ci(3), INT, S), INT, S))
+        result = simplifier(ir.Mul(ci(2), ir.Add(x, ci(3), INT, S), INT, S))
         assert isinstance(result, ir.Add), f"Expected Add, got {type(result).__name__}"
 
 
@@ -227,49 +197,37 @@ class TestFloorDiv:
 
     def test_factor_div(self):
         """(x * 4) // 4 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(4), INT, S), ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(4), INT, S), ci(4), INT, S))
         assert_same_expr(result, x)
 
     def test_partial_factor_div(self):
         """(x * 4) // 2 => x * 2"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(4), INT, S), ci(2), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(4), INT, S), ci(2), INT, S))
         assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
         assert result.left is x
         assert isinstance(result.right, ir.ConstInt) and result.right.value == 2
 
     def test_sum_div_all_divisible(self):
         """(4*x + 6*y + 8) // 2 => 2*x + 3*y + 4"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         inner = ir.Add(ir.Add(ir.Mul(x, ci(4), INT, S), ir.Mul(y, ci(6), INT, S), INT, S), ci(8), INT, S)
-        result = s(ir.FloorDiv(inner, ci(2), INT, S))
+        result = simplifier(ir.FloorDiv(inner, ci(2), INT, S))
         # Result should not contain FloorDiv
         assert not isinstance(result, ir.FloorDiv), "Expected simplified, got FloorDiv"
 
     def test_div_by_scale_factor(self):
         """(x * 6) // 3 => x * 2"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
         assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
 
     def test_nested_div(self):
         """(x * 12) // 4 // 3 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         inner = ir.FloorDiv(ir.Mul(x, ci(12), INT, S), ci(4), INT, S)
-        result = s(ir.FloorDiv(inner, ci(3), INT, S))
+        result = simplifier(ir.FloorDiv(inner, ci(3), INT, S))
         assert_same_expr(result, x)
 
     def test_const_fold_div(self):
         """12 // 4 => 3"""
-        s = CanonicalSimplifier()
-        result = s(ir.FloorDiv(ci(12), ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(ci(12), ci(4), INT, S))
         assert_is_const_int(result, 3)
 
 
@@ -283,31 +241,23 @@ class TestFloorMod:
 
     def test_factor_mod(self):
         """(x * 4) % 4 => 0"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorMod(ir.Mul(x, ci(4), INT, S), ci(4), INT, S))
+        result = simplifier(ir.FloorMod(ir.Mul(x, ci(4), INT, S), ci(4), INT, S))
         assert_is_const_int(result, 0)
 
     def test_all_scales_divisible_mod(self):
         """(4*x + 6*y + 5) % 2 => 1"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         inner = ir.Add(ir.Add(ir.Mul(x, ci(4), INT, S), ir.Mul(y, ci(6), INT, S), INT, S), ci(5), INT, S)
-        result = s(ir.FloorMod(inner, ci(2), INT, S))
+        result = simplifier(ir.FloorMod(inner, ci(2), INT, S))
         assert_is_const_int(result, 1)
 
     def test_mul_scale_mod(self):
         """(x * 6) % 3 => 0"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorMod(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorMod(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
         assert_is_const_int(result, 0)
 
     def test_const_fold_mod(self):
         """13 % 4 => 1"""
-        s = CanonicalSimplifier()
-        result = s(ir.FloorMod(ci(13), ci(4), INT, S))
+        result = simplifier(ir.FloorMod(ci(13), ci(4), INT, S))
         assert_is_const_int(result, 1)
 
 
@@ -321,29 +271,23 @@ class TestDivModRecombination:
 
     def test_basic_recombination(self):
         """(x // 4) * 4 + x % 4 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         div_part = ir.Mul(ir.FloorDiv(x, ci(4), INT, S), ci(4), INT, S)
         mod_part = ir.FloorMod(x, ci(4), INT, S)
-        result = s(ir.Add(div_part, mod_part, INT, S))
+        result = simplifier(ir.Add(div_part, mod_part, INT, S))
         assert_same_expr(result, x)
 
     def test_recombination_reversed(self):
         """x % 4 + (x // 4) * 4 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         mod_part = ir.FloorMod(x, ci(4), INT, S)
         div_part = ir.Mul(ir.FloorDiv(x, ci(4), INT, S), ci(4), INT, S)
-        result = s(ir.Add(mod_part, div_part, INT, S))
+        result = simplifier(ir.Add(mod_part, div_part, INT, S))
         assert_same_expr(result, x)
 
     def test_recombination_with_8(self):
         """(x // 8) * 8 + x % 8 => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         div_part = ir.Mul(ir.FloorDiv(x, ci(8), INT, S), ci(8), INT, S)
         mod_part = ir.FloorMod(x, ci(8), INT, S)
-        result = s(ir.Add(div_part, mod_part, INT, S))
+        result = simplifier(ir.Add(div_part, mod_part, INT, S))
         assert_same_expr(result, x)
 
 
@@ -356,29 +300,22 @@ class TestNeg:
     """Tests for negation through canonical form."""
 
     def test_neg_const(self):
-        s = CanonicalSimplifier()
-        result = s(ir.Neg(ci(5), INT, S))
+        result = simplifier(ir.Neg(ci(5), INT, S))
         assert_is_const_int(result, -5)
 
     def test_neg_var(self):
         """-(x) stays as Neg(x)"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Neg(x, INT, S))
+        result = simplifier(ir.Neg(x, INT, S))
         assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
 
     def test_neg_neg(self):
         """-(-(x)) => x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Neg(ir.Neg(x, INT, S), INT, S))
+        result = simplifier(ir.Neg(ir.Neg(x, INT, S), INT, S))
         assert_same_expr(result, x)
 
     def test_neg_sum(self):
         """-(x + 3) => -x - 3 (canonical: Neg(x) + (-3))"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Neg(ir.Add(x, ci(3), INT, S), INT, S))
+        result = simplifier(ir.Neg(ir.Add(x, ci(3), INT, S), INT, S))
         # Should not still be a Neg of Add
         assert not (isinstance(result, ir.Neg) and isinstance(result.operand, ir.Add))
 
@@ -393,15 +330,12 @@ class TestPassthrough:
 
     def test_comparison_const_fold(self):
         """1 + 2 == 3 => true"""
-        s = CanonicalSimplifier()
-        result = s(ir.Eq(ir.Add(ci(1), ci(2), INT, S), ci(3), INT, S))
+        result = simplifier(ir.Eq(ir.Add(ci(1), ci(2), INT, S), ci(3), INT, S))
         assert_is_const_bool(result, True)
 
     def test_comparison_simplifies_children(self):
         """(x + 0) == x should simplify the left side to x"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s(ir.Eq(ir.Add(x, ci(0), INT, S), x, INT, S))
+        result = simplifier(ir.Eq(ir.Add(x, ci(0), INT, S), x, INT, S))
         # Both sides simplify to x (same pointer), but TryConstFoldBinary
         # only handles ConstInt/ConstFloat — non-const equality like x == x
         # is handled by the RewriteSimplifier's pattern rules, not here.
@@ -411,24 +345,20 @@ class TestPassthrough:
 
     def test_min_const_fold(self):
         """min(3, 5) => 3"""
-        s = CanonicalSimplifier()
-        result = s(ir.Min(ci(3), ci(5), INT, S))
+        result = simplifier(ir.Min(ci(3), ci(5), INT, S))
         assert_is_const_int(result, 3)
 
     def test_max_const_fold(self):
         """max(3, 5) => 5"""
-        s = CanonicalSimplifier()
-        result = s(ir.Max(ci(3), ci(5), INT, S))
+        result = simplifier(ir.Max(ci(3), ci(5), INT, S))
         assert_is_const_int(result, 5)
 
     def test_bool_and_fold(self):
-        s = CanonicalSimplifier()
-        result = s(ir.And(cb(True), cb(False), DataType.BOOL, S))
+        result = simplifier(ir.And(cb(True), cb(False), DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_bool_or_fold(self):
-        s = CanonicalSimplifier()
-        result = s(ir.Or(cb(True), cb(False), DataType.BOOL, S))
+        result = simplifier(ir.Or(cb(True), cb(False), DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
 
@@ -440,45 +370,37 @@ class TestPassthrough:
 class TestEdgeCases:
     def test_large_coefficient(self):
         """x * 1000000 + x * 2000000 => x * 3000000"""
-        s = CanonicalSimplifier()
-        x = make_var("x")
         lhs = ir.Mul(x, ci(1000000), INT, S)
         rhs = ir.Mul(x, ci(2000000), INT, S)
-        result = s(ir.Add(lhs, rhs, INT, S))
+        result = simplifier(ir.Add(lhs, rhs, INT, S))
         assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
 
     def test_zero_const(self):
         """0 + 0 => 0"""
-        s = CanonicalSimplifier()
-        result = s(ir.Add(ci(0), ci(0), INT, S))
+        result = simplifier(ir.Add(ci(0), ci(0), INT, S))
         assert_is_const_int(result, 0)
 
     def test_sub_constants(self):
         """10 - 3 => 7"""
-        s = CanonicalSimplifier()
-        result = s(ir.Sub(ci(10), ci(3), INT, S))
+        result = simplifier(ir.Sub(ci(10), ci(3), INT, S))
         assert_is_const_int(result, 7)
 
     def test_nested_add_constants(self):
         """(1 + 2) + (3 + 4) => 10"""
-        s = CanonicalSimplifier()
-        result = s(ir.Add(ir.Add(ci(1), ci(2), INT, S), ir.Add(ci(3), ci(4), INT, S), INT, S))
+        result = simplifier(ir.Add(ir.Add(ci(1), ci(2), INT, S), ir.Add(ci(3), ci(4), INT, S), INT, S))
         assert_is_const_int(result, 10)
 
     def test_enter_constraint_standalone(self):
         """Standalone mode: enter_constraint returns None."""
-        s = CanonicalSimplifier()
-        x = make_var("x")
-        result = s.enter_constraint(ir.Gt(x, ci(0), INT, S))
+        result = simplifier.enter_constraint(ir.Gt(x, ci(0), INT, S))
         assert result is None
 
     def test_index_dtype(self):
         """CanonicalSimplifier works with INDEX-typed expressions."""
-        s = CanonicalSimplifier()
-        x = ir.Var("x", ir.ScalarType(IDX), S)
-        result = s(ir.Add(x, x, IDX, S))
+        x_idx = ir.Var("x", ir.ScalarType(IDX), S)
+        result = simplifier(ir.Add(x_idx, x_idx, IDX, S))
         assert isinstance(result, ir.Mul)
-        assert result.left is x
+        assert result.left is x_idx
         assert isinstance(result.right, ir.ConstInt) and result.right.value == 2
 
 

--- a/tests/ut/ir/arith/test_const_int_bound.py
+++ b/tests/ut/ir/arith/test_const_int_bound.py
@@ -25,6 +25,17 @@ def ci(value: int) -> ir.ConstInt:
     return ir.ConstInt(value, INT, S)
 
 
+# Module-level shared instances
+analyzer = ConstIntBoundAnalyzer()
+x = make_var("x")
+y = make_var("y")
+z = make_var("z")
+i = make_var("i")
+
+INT64_MIN = -(2**63)
+INT64_MAX = 2**63 - 1
+
+
 # ============================================================================
 # Helpers and basic structure
 # ============================================================================
@@ -32,48 +43,39 @@ def ci(value: int) -> ir.ConstInt:
 
 class TestConstIntBoundBasics:
     def test_const_int_exact_bound(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ci(42))
         assert b.min_value == 42
         assert b.max_value == 42
         assert b.is_const()
 
     def test_const_int_negative(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ci(-7))
         assert b.min_value == -7
         assert b.max_value == -7
 
     def test_const_int_zero(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ci(0))
         assert b.min_value == 0
         assert b.max_value == 0
 
     def test_unknown_var(self):
-        analyzer = ConstIntBoundAnalyzer()
-        z = make_var("z")
         b = analyzer(z)
         assert b.min_value == ConstIntBound.kNegInf
         assert b.max_value == ConstIntBound.kPosInf
         assert b.is_everything()
 
     def test_bound_var(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 8)  # [0, 8) = [0, 7]
         b = analyzer(x)
         assert b.min_value == 0
         assert b.max_value == 7
+        analyzer.unbind(x)
 
     def test_bound_repr(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ci(5))
         assert "5" in repr(b)
 
     def test_inf_repr(self):
-        analyzer = ConstIntBoundAnalyzer()
-        z = make_var("z")
         b = analyzer(z)
         assert "+inf" in repr(b)
         assert "-inf" in repr(b)
@@ -86,30 +88,27 @@ class TestConstIntBoundBasics:
 
 class TestAddBound:
     def test_add_const(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.Add(ci(3), ci(5), INT, S))
         assert b.min_value == 8
         assert b.max_value == 8
 
     def test_add_var(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 0, 11)  # [0, 10]
         analyzer.bind(y, 0, 11)  # [0, 10]
         b = analyzer(ir.Add(x, y, INT, S))
         assert b.min_value == 0
         assert b.max_value == 20
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_add_mixed_sign(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, -5, 6)  # [-5, 5]
         analyzer.bind(y, 1, 4)  # [1, 3]
         b = analyzer(ir.Add(x, y, INT, S))
         assert b.min_value == -4
         assert b.max_value == 8
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 # ============================================================================
@@ -119,20 +118,18 @@ class TestAddBound:
 
 class TestSubBound:
     def test_sub_const(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.Sub(ci(10), ci(3), INT, S))
         assert b.min_value == 7
         assert b.max_value == 7
 
     def test_sub_var(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 5, 11)  # [5, 10]
         analyzer.bind(y, 1, 4)  # [1, 3]
         b = analyzer(ir.Sub(x, y, INT, S))
         assert b.min_value == 2  # 5 - 3
         assert b.max_value == 9  # 10 - 1
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 # ============================================================================
@@ -142,37 +139,33 @@ class TestSubBound:
 
 class TestMulBound:
     def test_mul_const(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.Mul(ci(3), ci(4), INT, S))
         assert b.min_value == 12
         assert b.max_value == 12
 
     def test_mul_positive(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 2, 6)  # [2, 5]
         analyzer.bind(y, 3, 8)  # [3, 7]
         b = analyzer(ir.Mul(x, y, INT, S))
         assert b.min_value == 6  # 2 * 3
         assert b.max_value == 35  # 5 * 7
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_mul_mixed_sign(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -5, 6)  # [-5, 5]
         b = analyzer(ir.Mul(x, x, INT, S))
         # Four-corner: min(25, -25, -25, 25) = -25, max = 25
         assert b.min_value == -25
         assert b.max_value == 25
+        analyzer.unbind(x)
 
     def test_mul_by_zero(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 11)  # [0, 10]
         b = analyzer(ir.Mul(x, ci(0), INT, S))
         assert b.min_value == 0
         assert b.max_value == 0
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -183,53 +176,47 @@ class TestMulBound:
 class TestFloorDivBound:
     def test_floordiv_simplifies_to_zero(self):
         """x in [0, 8) => x // 8 == 0."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 8)  # [0, 7]
         b = analyzer(ir.FloorDiv(x, ci(8), INT, S))
         assert b.min_value == 0
         assert b.max_value == 0
+        analyzer.unbind(x)
 
     def test_floordiv_positive(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 16)  # [0, 15]
         b = analyzer(ir.FloorDiv(x, ci(4), INT, S))
         assert b.min_value == 0  # 0 // 4
         assert b.max_value == 3  # 15 // 4
+        analyzer.unbind(x)
 
     def test_floordiv_negative_dividend(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -10, 0)  # [-10, -1]
         b = analyzer(ir.FloorDiv(x, ci(3), INT, S))
         assert b.min_value == -4  # -10 // 3 = -4
         assert b.max_value == -1  # -1 // 3 = -1
+        analyzer.unbind(x)
 
     def test_floordiv_mixed_dividend(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -5, 6)  # [-5, 5]
         b = analyzer(ir.FloorDiv(x, ci(3), INT, S))
         assert b.min_value == -2  # -5 // 3 = -2
         assert b.max_value == 1  # 5 // 3 = 1
+        analyzer.unbind(x)
 
     def test_floordiv_negative_divisor(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 1, 11)  # [1, 10]
         b = analyzer(ir.FloorDiv(x, ci(-3), INT, S))
         assert b.min_value == -4  # 10 // -3 = -4
         assert b.max_value == -1  # 1 // -3 = -1
+        analyzer.unbind(x)
 
     def test_floordiv_by_larger_value(self):
         """When x < divisor, result is 0."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 5)  # [0, 4]
         b = analyzer(ir.FloorDiv(x, ci(100), INT, S))
         assert b.min_value == 0
         assert b.max_value == 0
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -239,24 +226,21 @@ class TestFloorDivBound:
 
 class TestFloorModBound:
     def test_floormod_basic(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 101)  # [0, 100]
         b = analyzer(ir.FloorMod(x, ci(8), INT, S))
         assert b.min_value == 0
         assert b.max_value == 7
+        analyzer.unbind(x)
 
     def test_floormod_small_range(self):
         """When a_max < b, mod bound can be tighter."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 4)  # [0, 3]
         b = analyzer(ir.FloorMod(x, ci(8), INT, S))
         assert b.min_value == 0
         assert b.max_value == 3  # min(3, 7) = 3
+        analyzer.unbind(x)
 
     def test_floormod_const(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.FloorMod(ci(17), ci(5), INT, S))
         assert b.min_value == 0
         assert b.max_value == 4  # conservative for mod 5
@@ -269,24 +253,22 @@ class TestFloorModBound:
 
 class TestMinMaxBound:
     def test_min_bound(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 0, 11)  # [0, 10]
         analyzer.bind(y, 5, 16)  # [5, 15]
         b = analyzer(ir.Min(x, y, INT, S))
         assert b.min_value == 0  # min(0, 5)
         assert b.max_value == 10  # min(10, 15)
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_max_bound(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 0, 11)  # [0, 10]
         analyzer.bind(y, 5, 16)  # [5, 15]
         b = analyzer(ir.Max(x, y, INT, S))
         assert b.min_value == 5  # max(0, 5)
         assert b.max_value == 15  # max(10, 15)
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 # ============================================================================
@@ -296,36 +278,32 @@ class TestMinMaxBound:
 
 class TestUnaryBound:
     def test_neg_bound(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 2, 8)  # [2, 7]
         b = analyzer(ir.Neg(x, INT, S))
         assert b.min_value == -7
         assert b.max_value == -2
+        analyzer.unbind(x)
 
     def test_abs_positive(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 3, 11)  # [3, 10]
         b = analyzer(ir.Abs(x, INT, S))
         assert b.min_value == 3
         assert b.max_value == 10
+        analyzer.unbind(x)
 
     def test_abs_negative(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -10, -2)  # [-10, -3]
         b = analyzer(ir.Abs(x, INT, S))
         assert b.min_value == 3
         assert b.max_value == 10
+        analyzer.unbind(x)
 
     def test_abs_mixed(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -3, 8)  # [-3, 7]
         b = analyzer(ir.Abs(x, INT, S))
         assert b.min_value == 0
         assert b.max_value == 7
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -335,26 +313,18 @@ class TestUnaryBound:
 
 class TestComparisonBound:
     def test_comparison_always_bool(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         for op_cls in [ir.Eq, ir.Ne, ir.Lt, ir.Le, ir.Gt, ir.Ge]:
             b = analyzer(op_cls(x, y, DataType.BOOL, S))
             assert b.min_value == 0
             assert b.max_value == 1
 
     def test_logical_always_bool(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         for op_cls in [ir.And, ir.Or]:
             b = analyzer(op_cls(x, y, DataType.BOOL, S))
             assert b.min_value == 0
             assert b.max_value == 1
 
     def test_not_always_bool(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         b = analyzer(ir.Not(x, DataType.BOOL, S))
         assert b.min_value == 0
         assert b.max_value == 1
@@ -368,20 +338,17 @@ class TestComparisonBound:
 class TestCompositeExprBound:
     def test_nested_add_mul(self):
         """(x + y) * 2 where x in [1, 5], y in [2, 3]."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 1, 6)  # [1, 5]
         analyzer.bind(y, 2, 4)  # [2, 3]
         expr = ir.Mul(ir.Add(x, y, INT, S), ci(2), INT, S)
         b = analyzer(expr)
         assert b.min_value == 6  # (1+2)*2
         assert b.max_value == 16  # (5+3)*2
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_index_expression(self):
         """Typical tiling: (i // 8) * 8 + i % 8 should have same bounds as i."""
-        analyzer = ConstIntBoundAnalyzer()
-        i = make_var("i")
         analyzer.bind(i, 0, 64)  # [0, 63]
         div_part = ir.Mul(ir.FloorDiv(i, ci(8), INT, S), ci(8), INT, S)
         mod_part = ir.FloorMod(i, ci(8), INT, S)
@@ -392,6 +359,7 @@ class TestCompositeExprBound:
         # sum: [0, 63]
         assert b.min_value == 0
         assert b.max_value == 63
+        analyzer.unbind(i)
 
 
 # ============================================================================
@@ -401,22 +369,20 @@ class TestCompositeExprBound:
 
 class TestBitwiseBound:
     def test_bit_and_non_negative(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 0, 256)  # [0, 255]
         analyzer.bind(y, 0, 16)  # [0, 15]
         b = analyzer(ir.BitAnd(x, y, INT, S))
         assert b.min_value == 0
         assert b.max_value == 15  # min(255, 15)
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_shift_right_non_negative(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 0, 256)  # [0, 255]
         b = analyzer(ir.BitShiftRight(x, ci(4), INT, S))
         assert b.min_value == 0
         assert b.max_value == 15  # 255 >> 4
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -426,19 +392,16 @@ class TestBitwiseBound:
 
 class TestConstBoolFloat:
     def test_const_bool_true(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.ConstBool(True, S))
         assert b.min_value == 1
         assert b.max_value == 1
 
     def test_const_bool_false(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.ConstBool(False, S))
         assert b.min_value == 0
         assert b.max_value == 0
 
     def test_const_float(self):
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.ConstFloat(3.7, DataType.FP32, S))
         assert b.min_value == 3  # floor(3.7)
         assert b.max_value == 4  # ceil(3.7)
@@ -451,28 +414,25 @@ class TestConstBoolFloat:
 
 class TestPowBound:
     def test_pow_zero_exponent(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 1, 11)  # [1, 10]
         b = analyzer(ir.Pow(x, ci(0), INT, S))
         assert b.min_value == 1
         assert b.max_value == 1
+        analyzer.unbind(x)
 
     def test_pow_one_exponent(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 2, 6)  # [2, 5]
         b = analyzer(ir.Pow(x, ci(1), INT, S))
         assert b.min_value == 2
         assert b.max_value == 5
+        analyzer.unbind(x)
 
     def test_pow_square_non_negative(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 2, 5)  # [2, 4]
         b = analyzer(ir.Pow(x, ci(2), INT, S))
         assert b.min_value == 4  # 2^2
         assert b.max_value == 16  # 4^2
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -483,37 +443,32 @@ class TestPowBound:
 class TestVarIdentity:
     def test_different_vars_independent(self):
         """Two vars with same name are different objects."""
-        analyzer = ConstIntBoundAnalyzer()
         x1 = make_var("x")
         x2 = make_var("x")
         analyzer.bind(x1, 0, 10)
         analyzer.bind(x2, 100, 200)
         assert analyzer(x1).min_value == 0
         assert analyzer(x2).min_value == 100
+        analyzer.unbind(x1)
+        analyzer.unbind(x2)
 
     def test_unbound_var_is_everything(self):
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.bind(x, 0, 10)
         bx = analyzer(x)
         by = analyzer(y)
         assert bx.min_value == 0
         assert by.is_everything()
+        analyzer.unbind(x)
 
 
 # ============================================================================
 # Edge cases: overflow, INT64 boundaries, unsigned cast
 # ============================================================================
 
-INT64_MIN = -(2**63)
-INT64_MAX = 2**63 - 1
-
 
 class TestEdgeCases:
     def test_neg_int64_min(self):
         """Negating INT64_MIN should not cause UB — saturate to kPosInf."""
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.Neg(ci(INT64_MIN), INT, S))
         # -INT64_MIN overflows int64, so bound saturates
         assert b.min_value == ConstIntBound.kPosInf
@@ -521,40 +476,36 @@ class TestEdgeCases:
 
     def test_abs_int64_min(self):
         """Abs of INT64_MIN should saturate rather than UB."""
-        analyzer = ConstIntBoundAnalyzer()
         b = analyzer(ir.Abs(ci(INT64_MIN), INT, S))
         assert b.min_value == ConstIntBound.kPosInf
         assert b.max_value == ConstIntBound.kPosInf
 
     def test_large_pow_exponent(self):
         """Large exponent should not cause O(e) slowdown — O(log e) expected."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, 2, 4)  # [2, 3]
         b = analyzer(ir.Pow(x, ci(1000000), INT, S))
         # Result overflows to inf but should compute fast
         assert b.min_value == ConstIntBound.kPosInf or b.min_value > 0
         assert b.max_value == ConstIntBound.kPosInf
+        analyzer.unbind(x)
 
     def test_cast_to_unsigned(self):
         """Cast to unsigned type should use [0, 2^bits-1] range."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -10, 300)  # [-10, 299]
         b = analyzer(ir.Cast(x, DataType.UINT8, S))
         # UINT8 range is [0, 255], intersected with [-10, 299]
         assert b.min_value == 0
         assert b.max_value == 255
+        analyzer.unbind(x)
 
     def test_cast_to_signed(self):
         """Cast to signed type should use [-2^(bits-1), 2^(bits-1)-1] range."""
-        analyzer = ConstIntBoundAnalyzer()
-        x = make_var("x")
         analyzer.bind(x, -200, 200)  # [-200, 199]
         b = analyzer(ir.Cast(x, DataType.INT8, S))
         # INT8 range is [-128, 127]
         assert b.min_value == -128
         assert b.max_value == 127
+        analyzer.unbind(x)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/arith/test_modular_set.py
+++ b/tests/ut/ir/arith/test_modular_set.py
@@ -26,6 +26,12 @@ def ci(value: int) -> ir.ConstInt:
     return ir.ConstInt(value, INT, S)
 
 
+# Module-level shared instances
+analyzer = ModularSetAnalyzer()
+x = make_var("x")
+y = make_var("y")
+
+
 # ============================================================================
 # Basic structure and leaf nodes
 # ============================================================================
@@ -33,39 +39,33 @@ def ci(value: int) -> ir.ConstInt:
 
 class TestModularSetBasics:
     def test_const_int_exact(self):
-        analyzer = ModularSetAnalyzer()
         m = analyzer(ci(42))
         assert m.coeff == 0
         assert m.base == 42
         assert m.is_exact()
 
     def test_const_int_zero(self):
-        analyzer = ModularSetAnalyzer()
         m = analyzer(ci(0))
         assert m.coeff == 0
         assert m.base == 0
 
     def test_const_int_negative(self):
-        analyzer = ModularSetAnalyzer()
         m = analyzer(ci(-7))
         assert m.coeff == 0
         assert m.base == -7
 
     def test_unknown_var(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         m = analyzer(x)
         assert m.coeff == 1
         assert m.base == 0
         assert m.is_everything()
 
     def test_updated_var(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(4, 1))
         m = analyzer(x)
         assert m.coeff == 4
         assert m.base == 1
+        analyzer.unbind(x)
 
     def test_repr(self):
         m = ModularSet(4, 1)
@@ -80,42 +80,36 @@ class TestModularSetBasics:
 
 class TestModularSetArithmetic:
     def test_add_consts(self):
-        analyzer = ModularSetAnalyzer()
         m = analyzer(ir.Add(ci(3), ci(5), INT, S))
         assert m.coeff == 0
         assert m.base == 8
 
     def test_add_vars(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.update(x, ModularSet(4, 1))  # x = 4k + 1
         analyzer.update(y, ModularSet(6, 2))  # y = 6j + 2
         m = analyzer(ir.Add(x, y, INT, S))
         # coeff = gcd(4, 6) = 2, base = (1 + 2) % 2 = 1
         assert m.coeff == 2
         assert m.base == 1
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_sub_consts(self):
-        analyzer = ModularSetAnalyzer()
         m = analyzer(ir.Sub(ci(10), ci(3), INT, S))
         assert m.coeff == 0
         assert m.base == 7
 
     def test_sub_vars(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.update(x, ModularSet(4, 3))  # x = 4k + 3
         analyzer.update(y, ModularSet(6, 1))  # y = 6j + 1
         m = analyzer(ir.Sub(x, y, INT, S))
         # coeff = gcd(4, 6) = 2, base = (3 - 1) % 2 = 0
         assert m.coeff == 2
         assert m.base == 0
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_mul_const_by_var(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         # 2 is {coeff=0, base=2}, x is {coeff=1, base=0}
         # pq = 0*1 = 0, pm = 0*0 = 0, qn = 2*1 = 2
         # coeff = gcd(0, gcd(0, 2)) = 2, base = 2*0 = 0
@@ -124,9 +118,6 @@ class TestModularSetArithmetic:
         assert m.base == 0
 
     def test_mul_vars(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.update(x, ModularSet(2, 1))  # x = 2k + 1
         analyzer.update(y, ModularSet(3, 0))  # y = 3j
         # (2k+1)(3j) = 6kj + 3j: pq=6, pm=2*0=0, qn=1*3=3
@@ -134,15 +125,16 @@ class TestModularSetArithmetic:
         m = analyzer(ir.Mul(x, y, INT, S))
         assert m.coeff == 3
         assert m.base == 0
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_neg(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(4, 1))  # x = 4k + 1
         m = analyzer(ir.Neg(x, INT, S))
         # neg: coeff=4, base=-1 → normalized to base=3
         assert m.coeff == 4
         assert m.base == 3
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -152,58 +144,51 @@ class TestModularSetArithmetic:
 
 class TestModularSetFloorDivMod:
     def test_floordiv_exact(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(8, 0))  # x = 8k
         m = analyzer(ir.FloorDiv(x, ci(4), INT, S))
         # coeff % val == 0: 8 % 4 == 0, base == 0
         # result: coeff = |8/4| = 2, base = 0
         assert m.coeff == 2
         assert m.base == 0
+        analyzer.unbind(x)
 
     def test_floordiv_with_base(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(8, 4))  # x = 8k + 4
         m = analyzer(ir.FloorDiv(x, ci(4), INT, S))
         # coeff % val == 0: 8 % 4 == 0, base > 0, val > 0
         # result: coeff = 8/4 = 2, base = 4/4 = 1
         assert m.coeff == 2
         assert m.base == 1
+        analyzer.unbind(x)
 
     def test_floordiv_not_divisible(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(3, 1))  # x = 3k + 1
         m = analyzer(ir.FloorDiv(x, ci(2), INT, S))
         # 3 % 2 != 0, so everything
         assert m.coeff == 1
         assert m.base == 0
+        analyzer.unbind(x)
 
     def test_floormod_basic(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(4, 1))  # x = 4k + 1
         m = analyzer(ir.FloorMod(x, ci(2), INT, S))
         # coeff = gcd(4, 2) = 2, base % coeff = 1 % 2 = 1
         # a.base (1) > 0 → returns Entry(2, 1)
         assert m.coeff == 2
         assert m.base == 1
+        analyzer.unbind(x)
 
     def test_floormod_aligned(self):
         """x = 6k → x % 3 should have coeff 3, base 0."""
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(6, 0))  # x = 6k
         m = analyzer(ir.FloorMod(x, ci(3), INT, S))
         # coeff = gcd(6, 3) = 3, base = 0 % 3 = 0
         assert m.coeff == 3
         assert m.base == 0
+        analyzer.unbind(x)
 
     def test_two_x_mod_two(self):
         """(2*x) % 2 → coeff=2, meaning always 0 mod 2."""
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         expr = ir.FloorMod(ir.Mul(ci(2), x, INT, S), ci(2), INT, S)
         m = analyzer(expr)
         # 2*x has modular set {2, 0}
@@ -219,20 +204,16 @@ class TestModularSetFloorDivMod:
 
 class TestModularSetMinMax:
     def test_min(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.update(x, ModularSet(4, 1))
         analyzer.update(y, ModularSet(4, 1))
         m = analyzer(ir.Min(x, y, INT, S))
         # Union of {4, 1} and {4, 1} = {4, 1}
         assert m.coeff == 4
         assert m.base == 1
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
     def test_max_different(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
-        y = make_var("y")
         analyzer.update(x, ModularSet(4, 0))
         analyzer.update(y, ModularSet(4, 2))
         m = analyzer(ir.Max(x, y, INT, S))
@@ -240,6 +221,8 @@ class TestModularSetMinMax:
         # base0 != base1 → gcd(gcd(0, 2), 4) = gcd(2, 4) = 2, base=0
         assert m.coeff == 2
         assert m.base == 0
+        analyzer.unbind(x)
+        analyzer.unbind(y)
 
 
 # ============================================================================
@@ -250,36 +233,33 @@ class TestModularSetMinMax:
 class TestModularSetBitwise:
     def test_bitand_power_of_two_mask(self):
         """x & 7 is equivalent to x % 8."""
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(16, 3))  # x = 16k + 3
         m = analyzer(ir.BitAnd(x, ci(7), INT, S))
         # mask=7, mask+1=8 is power of 2
         # FloorModByConst(x, 8): gcd(16, 8) = 8, base = 3 % 8 = 3
         assert m.coeff == 8
         assert m.base == 3
+        analyzer.unbind(x)
 
     def test_shift_right(self):
         """x >> 2 is equivalent to x // 4."""
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(8, 0))  # x = 8k
         m = analyzer(ir.BitShiftRight(x, ci(2), INT, S))
         # FloorDivByConst(x, 4): 8 % 4 == 0, base == 0
         # result: coeff = 2, base = 0
         assert m.coeff == 2
         assert m.base == 0
+        analyzer.unbind(x)
 
     def test_shift_left(self):
         """x << 3 is equivalent to x * 8."""
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(3, 1))  # x = 3k + 1
         m = analyzer(ir.BitShiftLeft(x, ci(3), INT, S))
         # x * 8: coeff = gcd(0, 3*8) = 24, base = 1*8 = 8
         # Normalized: base = 8 % 24 = 8
         assert m.coeff == 24
         assert m.base == 8
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -289,13 +269,12 @@ class TestModularSetBitwise:
 
 class TestModularSetCast:
     def test_cast_preserves_modular_info(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         analyzer.update(x, ModularSet(4, 1))
         cast_expr = ir.Cast(x, DataType.INT32, S)
         m = analyzer(cast_expr)
         assert m.coeff == 4
         assert m.base == 1
+        analyzer.unbind(x)
 
 
 # ============================================================================
@@ -305,8 +284,6 @@ class TestModularSetCast:
 
 class TestModularSetConstraint:
     def test_enter_floormod_constraint(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         # Constraint: floormod(x, 4) == 1 → x = 4k + 1
         constraint = ir.Eq(ir.FloorMod(x, ci(4), INT, S), ci(1), BOOL, S)
         recover = analyzer.enter_constraint(constraint)
@@ -320,8 +297,6 @@ class TestModularSetConstraint:
         assert m.is_everything()
 
     def test_enter_eq_constraint(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         # Constraint: x == 5 → exact value
         constraint = ir.Eq(x, ci(5), BOOL, S)
         recover = analyzer.enter_constraint(constraint)
@@ -332,8 +307,6 @@ class TestModularSetConstraint:
             recover()
 
     def test_no_constraint_match(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         # x > 0 doesn't give modular info
         constraint = ir.Gt(x, ci(0), BOOL, S)
         recover = analyzer.enter_constraint(constraint)
@@ -347,8 +320,6 @@ class TestModularSetConstraint:
 
 class TestModularSetValidation:
     def test_negative_coeff_raises(self):
-        analyzer = ModularSetAnalyzer()
-        x = make_var("x")
         with pytest.raises(Exception, match="non-negative"):
             analyzer.update(x, ModularSet(-2, 1))
 

--- a/tests/ut/ir/arith/test_rewrite_simplify.py
+++ b/tests/ut/ir/arith/test_rewrite_simplify.py
@@ -47,6 +47,13 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
     )
 
 
+# Module-level shared instances
+simplifier = RewriteSimplifier()
+x = make_var("x")
+y = make_var("y")
+z = make_var("z")
+
+
 # ============================================================================
 # Basic functionality
 # ============================================================================
@@ -54,32 +61,26 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
 
 class TestBasics:
     def test_construction(self):
-        s = RewriteSimplifier()
-        assert s is not None
+        assert simplifier is not None
 
     def test_identity_const(self):
-        s = RewriteSimplifier()
         c = ci(42)
-        result = s(c)
+        result = simplifier(c)
         assert_is_const_int(result, 42)
 
     def test_identity_var(self):
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(x)
+        result = simplifier(x)
         assert_same_expr(result, x)
 
     def test_const_fold(self):
-        s = RewriteSimplifier()
-        result = s(ir.Add(ci(3), ci(5), INT, S))
+        result = simplifier(ir.Add(ci(3), ci(5), INT, S))
         assert_is_const_int(result, 8)
 
     def test_var_substitution(self):
-        s = RewriteSimplifier()
-        x = make_var("x")
-        s.update(x, ci(10))
-        result = s(ir.Add(x, ci(5), INT, S))
+        simplifier.update(x, ci(10))
+        result = simplifier(ir.Add(x, ci(5), INT, S))
         assert_is_const_int(result, 15)
+        simplifier.update(x, None)
 
 
 # ============================================================================
@@ -90,24 +91,18 @@ class TestBasics:
 class TestAddRules:
     def test_add_zero_right(self):
         """x + 0 => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Add(x, ci(0), INT, S))
+        result = simplifier(ir.Add(x, ci(0), INT, S))
         assert_same_expr(result, x)
 
     def test_add_zero_left(self):
         """0 + x => x (via canonicalization c1 + x => x + c1, then x + 0 => x)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Add(ci(0), x, INT, S))
+        result = simplifier(ir.Add(ci(0), x, INT, S))
         assert_same_expr(result, x)
 
     def test_add_const_reassociation(self):
         """(x + c1) + c2 => x + (c1 + c2)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.Add(x, ci(3), INT, S)
-        result = s(ir.Add(inner, ci(5), INT, S))
+        result = simplifier(ir.Add(inner, ci(5), INT, S))
         # Should be x + 8
         assert isinstance(result, ir.Add)
         assert result.left is x
@@ -115,54 +110,37 @@ class TestAddRules:
 
     def test_sub_cancel_add(self):
         """(x - y) + y => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Add(ir.Sub(x, y, INT, S), y, INT, S))
+        result = simplifier(ir.Add(ir.Sub(x, y, INT, S), y, INT, S))
         assert_same_expr(result, x)
 
     def test_add_reverse_cancel(self):
         """x + (y - x) => y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Add(x, ir.Sub(y, x, INT, S), INT, S))
+        result = simplifier(ir.Add(x, ir.Sub(y, x, INT, S), INT, S))
         assert_same_expr(result, y)
 
     def test_add_self(self):
         """x + x => x * 2"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Add(x, x, INT, S))
+        result = simplifier(ir.Add(x, x, INT, S))
         assert isinstance(result, ir.Mul)
         assert result.left is x
         assert_is_const_int(result.right, 2)
 
     def test_floordiv_mul_floormod(self):
         """floordiv(x, y) * y + floormod(x, y) => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         c = ci(4)
         fd = ir.FloorDiv(x, c, INT, S)
         fm = ir.FloorMod(x, c, INT, S)
-        result = s(ir.Add(ir.Mul(fd, c, INT, S), fm, INT, S))
+        result = simplifier(ir.Add(ir.Mul(fd, c, INT, S), fm, INT, S))
         assert_same_expr(result, x)
 
     def test_min_sub_add(self):
         """min(x - z, y) + z => min(x, y + z)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Add(ir.Min(ir.Sub(x, z, INT, S), y, INT, S), z, INT, S))
+        result = simplifier(ir.Add(ir.Min(ir.Sub(x, z, INT, S), y, INT, S), z, INT, S))
         assert isinstance(result, ir.Min)
 
     def test_max_min_sum(self):
         """max(x, y) + min(x, y) => x + y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Add(ir.Max(x, y, INT, S), ir.Min(x, y, INT, S), INT, S))
+        result = simplifier(ir.Add(ir.Max(x, y, INT, S), ir.Min(x, y, INT, S), INT, S))
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert result.right is y
@@ -176,99 +154,67 @@ class TestAddRules:
 class TestSubRules:
     def test_sub_self(self):
         """x - x => 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Sub(x, x, INT, S))
+        result = simplifier(ir.Sub(x, x, INT, S))
         assert_is_const_int(result, 0)
 
     def test_sub_add_cancel_left(self):
         """(x + y) - y => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Sub(ir.Add(x, y, INT, S), y, INT, S))
+        result = simplifier(ir.Sub(ir.Add(x, y, INT, S), y, INT, S))
         assert_same_expr(result, x)
 
     def test_sub_add_cancel_right(self):
         """(x + y) - x => y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Sub(ir.Add(x, y, INT, S), x, INT, S))
+        result = simplifier(ir.Sub(ir.Add(x, y, INT, S), x, INT, S))
         assert_same_expr(result, y)
 
     def test_sub_const_reassociation(self):
         """(x + c1) - c2 => x + (c1 - c2)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.Add(x, ci(10), INT, S)
-        result = s(ir.Sub(inner, ci(3), INT, S))
+        result = simplifier(ir.Sub(inner, ci(3), INT, S))
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert_is_const_int(result.right, 7)
 
     def test_sub_extract_floormod(self):
         """x - floordiv(x, c1) * c1 => floormod(x, c1) when c1 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         c = ci(4)
         fd = ir.FloorDiv(x, c, INT, S)
-        result = s(ir.Sub(x, ir.Mul(fd, c, INT, S), INT, S))
+        result = simplifier(ir.Sub(x, ir.Mul(fd, c, INT, S), INT, S))
         assert isinstance(result, ir.FloorMod)
         assert result.left is x
         assert_is_const_int(result.right, 4)
 
     def test_sub_const_cross(self):
         """(c1 - x) - (c2 - y) => (y - x) + (c1 - c2)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Sub(ir.Sub(ci(10), x, INT, S), ir.Sub(ci(3), y, INT, S), INT, S))
+        result = simplifier(ir.Sub(ir.Sub(ci(10), x, INT, S), ir.Sub(ci(3), y, INT, S), INT, S))
         assert isinstance(result, ir.Add)
 
     def test_sub_min_cancel(self):
         """min(x, y) - min(y, x) => 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Sub(ir.Min(x, y, INT, S), ir.Min(y, x, INT, S), INT, S))
+        result = simplifier(ir.Sub(ir.Min(x, y, INT, S), ir.Min(y, x, INT, S), INT, S))
         assert_is_const_int(result, 0)
 
     def test_sub_max_cancel(self):
         """max(x, y) - max(y, x) => 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Sub(ir.Max(x, y, INT, S), ir.Max(y, x, INT, S), INT, S))
+        result = simplifier(ir.Sub(ir.Max(x, y, INT, S), ir.Max(y, x, INT, S), INT, S))
         assert_is_const_int(result, 0)
 
     def test_sub_min_add_extract(self):
         """min(x+y, z) - x => min(y, z-x)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Sub(ir.Min(ir.Add(x, y, INT, S), z, INT, S), x, INT, S))
+        result = simplifier(ir.Sub(ir.Min(ir.Add(x, y, INT, S), z, INT, S), x, INT, S))
         assert isinstance(result, ir.Min)
 
     def test_sub_floordiv_extended(self):
         """x - floordiv(x+y, c1)*c1 => floormod(x+y, c1) - y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         xy = ir.Add(x, y, INT, S)
         fd = ir.FloorDiv(xy, ci(4), INT, S)
-        result = s(ir.Sub(x, ir.Mul(fd, ci(4), INT, S), INT, S))
+        result = simplifier(ir.Sub(x, ir.Mul(fd, ci(4), INT, S), INT, S))
         # Should contain floormod(x+y, 4)
         assert isinstance(result, ir.Sub)
 
     def test_sub_canonicalize_nested(self):
         """x - (y - z) => (x + z) - y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Sub(x, ir.Sub(y, z, INT, S), INT, S))
+        result = simplifier(ir.Sub(x, ir.Sub(y, z, INT, S), INT, S))
         assert isinstance(result, ir.Sub)
 
 
@@ -280,44 +226,32 @@ class TestSubRules:
 class TestMulRules:
     def test_mul_zero(self):
         """x * 0 => 0 (via const fold when x is const, or mul rule)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(x, ci(0), INT, S))
+        result = simplifier(ir.Mul(x, ci(0), INT, S))
         assert_is_const_int(result, 0)
 
     def test_mul_one(self):
         """x * 1 => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Mul(x, ci(1), INT, S))
+        result = simplifier(ir.Mul(x, ci(1), INT, S))
         assert_same_expr(result, x)
 
     def test_mul_const_reassociation(self):
         """(x * c1) * c2 => x * (c1 * c2)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.Mul(x, ci(3), INT, S)
-        result = s(ir.Mul(inner, ci(5), INT, S))
+        result = simplifier(ir.Mul(inner, ci(5), INT, S))
         assert isinstance(result, ir.Mul)
         assert result.left is x
         assert_is_const_int(result.right, 15)
 
     def test_mul_min_max(self):
         """min(x,y) * max(x,y) => x * y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Mul(ir.Min(x, y, INT, S), ir.Max(x, y, INT, S), INT, S))
+        result = simplifier(ir.Mul(ir.Min(x, y, INT, S), ir.Max(x, y, INT, S), INT, S))
         assert isinstance(result, ir.Mul)
         assert result.left is x
         assert result.right is y
 
     def test_mul_neg_flip(self):
         """(x - y) * (-3) => (y - x) * 3"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Mul(ir.Sub(x, y, INT, S), ci(-3), INT, S))
+        result = simplifier(ir.Mul(ir.Sub(x, y, INT, S), ci(-3), INT, S))
         assert isinstance(result, ir.Mul)
         assert isinstance(result.left, ir.Sub)
         assert result.left.left is y
@@ -333,61 +267,47 @@ class TestMulRules:
 class TestFloorDivRules:
     def test_floordiv_by_one(self):
         """floordiv(x, 1) => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(x, ci(1), INT, S))
+        result = simplifier(ir.FloorDiv(x, ci(1), INT, S))
         assert_same_expr(result, x)
 
     def test_floordiv_factor(self):
         """floordiv(x * c1, c2) => x * (c1 / c2) when c1 % c2 == 0 and c2 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
         assert isinstance(result, ir.Mul)
         assert result.left is x
         assert_is_const_int(result.right, 2)
 
     def test_floordiv_nested(self):
         """floordiv(floordiv(x, c1), c2) => floordiv(x, c1*c2) when c1 > 0, c2 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.FloorDiv(x, ci(3), INT, S)
-        result = s(ir.FloorDiv(inner, ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(inner, ci(4), INT, S))
         assert isinstance(result, ir.FloorDiv)
         assert result.left is x
         assert_is_const_int(result.right, 12)
 
     def test_floordiv_add_offset(self):
         """floordiv(x + c1, c2) => floordiv(x, c2) + c1/c2 when c1 % c2 == 0, c2 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Add(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Add(x, ci(6), INT, S), ci(3), INT, S))
         assert isinstance(result, ir.Add)
         assert isinstance(result.left, ir.FloorDiv)
         assert_is_const_int(result.right, 2)
 
     def test_floordiv_self(self):
         """floordiv(x, x) => 1 is dormant in standalone mode (requires x != 0 proof)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(x, x, INT, S))
+        result = simplifier(ir.FloorDiv(x, x, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
         assert isinstance(result, ir.FloorDiv)
 
     def test_floordiv_mul_self(self):
         """floordiv(x * c1, x) => c1 is dormant in standalone mode (requires x != 0 proof)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(5), INT, S), x, INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(5), INT, S), x, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
         assert isinstance(result, ir.FloorDiv)
 
     def test_floordiv_nested_offset(self):
         """floordiv(floordiv(x, c1) + c2, c3) => floordiv(x + c1*c2, c1*c3)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.Add(ir.FloorDiv(x, ci(3), INT, S), ci(2), INT, S)
-        result = s(ir.FloorDiv(inner, ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(inner, ci(4), INT, S))
         assert isinstance(result, ir.FloorDiv)
         # Should be floordiv(x + 6, 12)
         assert isinstance(result.left, ir.Add)
@@ -395,10 +315,8 @@ class TestFloorDivRules:
 
     def test_floordiv_sub_floormod(self):
         """floordiv(x - floormod(x, c1), c1) => floordiv(x, c1)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         fm = ir.FloorMod(x, ci(4), INT, S)
-        result = s(ir.FloorDiv(ir.Sub(x, fm, INT, S), ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Sub(x, fm, INT, S), ci(4), INT, S))
         assert isinstance(result, ir.FloorDiv)
         assert result.left is x
         assert_is_const_int(result.right, 4)
@@ -412,35 +330,26 @@ class TestFloorDivRules:
 class TestFloorModRules:
     def test_floormod_multiple(self):
         """floormod(x * c1, c2) => 0 when c1 % c2 == 0 and c2 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorMod(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorMod(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
         assert_is_const_int(result, 0)
 
     def test_floormod_add_multiple_offset(self):
         """floormod(x + c1, c2) => floormod(x, c2) when c1 % c2 == 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorMod(ir.Add(x, ci(6), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorMod(ir.Add(x, ci(6), INT, S), ci(3), INT, S))
         assert isinstance(result, ir.FloorMod)
         assert result.left is x
         assert_is_const_int(result.right, 3)
 
     def test_floormod_mul_var(self):
         """floormod(x * y, y) => 0 is dormant in standalone mode (requires y != 0 proof)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.FloorMod(ir.Mul(x, y, INT, S), y, INT, S))
+        result = simplifier(ir.FloorMod(ir.Mul(x, y, INT, S), y, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
         assert isinstance(result, ir.FloorMod)
 
     def test_floormod_coeff_reduction(self):
         """floormod(x * c1, c2) => floormod(x * floormod(c1, c2), c2)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         # floormod(x*7, 3) => floormod(x*1, 3) => floormod(x, 3)
-        result = s(ir.FloorMod(ir.Mul(x, ci(7), INT, S), ci(3), INT, S))
+        result = simplifier(ir.FloorMod(ir.Mul(x, ci(7), INT, S), ci(3), INT, S))
         assert isinstance(result, ir.FloorMod)
 
 
@@ -452,138 +361,94 @@ class TestFloorModRules:
 class TestMinMaxRules:
     def test_min_self(self):
         """min(x, x) => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Min(x, x, INT, S))
+        result = simplifier(ir.Min(x, x, INT, S))
         assert_same_expr(result, x)
 
     def test_max_self(self):
         """max(x, x) => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Max(x, x, INT, S))
+        result = simplifier(ir.Max(x, x, INT, S))
         assert_same_expr(result, x)
 
     def test_min_factor_sub(self):
         """min(y - x, z - x) => min(y, z) - x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Min(ir.Sub(y, x, INT, S), ir.Sub(z, x, INT, S), INT, S))
+        result = simplifier(ir.Min(ir.Sub(y, x, INT, S), ir.Sub(z, x, INT, S), INT, S))
         assert isinstance(result, ir.Sub)
         assert isinstance(result.left, ir.Min)
         assert result.right is x
 
     def test_max_factor_add(self):
         """max(x + y, x + z) => x + max(y, z)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Max(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), INT, S))
+        result = simplifier(ir.Max(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), INT, S))
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert isinstance(result.right, ir.Max)
 
     def test_min_absorption(self):
         """min(max(x, y), y) => y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Min(ir.Max(x, y, INT, S), y, INT, S))
+        result = simplifier(ir.Min(ir.Max(x, y, INT, S), y, INT, S))
         assert_same_expr(result, y)
 
     def test_max_absorption(self):
         """max(min(x, y), y) => y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Max(ir.Min(x, y, INT, S), y, INT, S))
+        result = simplifier(ir.Max(ir.Min(x, y, INT, S), y, INT, S))
         assert_same_expr(result, y)
 
     def test_min_const_reassociation(self):
         """min(min(x, c1), c2) => min(x, min(c1, c2))"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         inner = ir.Min(x, ci(5), INT, S)
-        result = s(ir.Min(inner, ci(3), INT, S))
+        result = simplifier(ir.Min(inner, ci(3), INT, S))
         assert isinstance(result, ir.Min)
         assert result.left is x
         assert_is_const_int(result.right, 3)
 
     def test_min_const_offsets(self):
         """min(x + 3, x + 7) => x + 3"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Min(ir.Add(x, ci(3), INT, S), ir.Add(x, ci(7), INT, S), INT, S))
+        result = simplifier(ir.Min(ir.Add(x, ci(3), INT, S), ir.Add(x, ci(7), INT, S), INT, S))
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert_is_const_int(result.right, 3)
 
     def test_max_const_offsets(self):
         """max(x + 3, x + 7) => x + 7"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Max(ir.Add(x, ci(3), INT, S), ir.Add(x, ci(7), INT, S), INT, S))
+        result = simplifier(ir.Max(ir.Add(x, ci(3), INT, S), ir.Add(x, ci(7), INT, S), INT, S))
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert_is_const_int(result.right, 7)
 
     def test_min_nested_collapse(self):
         """min(min(x, y), x) => min(x, y)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         inner = ir.Min(x, y, INT, S)
-        result = s(ir.Min(inner, x, INT, S))
+        result = simplifier(ir.Min(inner, x, INT, S))
         assert isinstance(result, ir.Min)
 
     def test_max_nested_collapse(self):
         """max(max(x, y), x) => max(x, y)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         inner = ir.Max(x, y, INT, S)
-        result = s(ir.Max(inner, x, INT, S))
+        result = simplifier(ir.Max(inner, x, INT, S))
         assert isinstance(result, ir.Max)
 
     def test_min_cross_distribution(self):
         """min(max(x,y), max(x,z)) => max(min(y,z), x)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Min(ir.Max(x, y, INT, S), ir.Max(x, z, INT, S), INT, S))
+        result = simplifier(ir.Min(ir.Max(x, y, INT, S), ir.Max(x, z, INT, S), INT, S))
         assert isinstance(result, ir.Max)
         assert isinstance(result.left, ir.Min)
 
     def test_max_cross_distribution(self):
         """max(min(x,y), min(x,z)) => min(max(y,z), x)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Max(ir.Min(x, y, INT, S), ir.Min(x, z, INT, S), INT, S))
+        result = simplifier(ir.Max(ir.Min(x, y, INT, S), ir.Min(x, z, INT, S), INT, S))
         assert isinstance(result, ir.Min)
         assert isinstance(result.left, ir.Max)
 
     def test_min_scaling(self):
         """min(x * 3, y * 3) => min(x, y) * 3"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Min(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), INT, S))
+        result = simplifier(ir.Min(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), INT, S))
         assert isinstance(result, ir.Mul)
         assert isinstance(result.left, ir.Min)
         assert_is_const_int(result.right, 3)
 
     def test_max_scaling(self):
         """max(x * 3, y * 3) => max(x, y) * 3"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Max(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), INT, S))
+        result = simplifier(ir.Max(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), INT, S))
         assert isinstance(result, ir.Mul)
         assert isinstance(result.left, ir.Max)
         assert_is_const_int(result.right, 3)
@@ -597,120 +462,80 @@ class TestMinMaxRules:
 class TestComparisonRules:
     def test_eq_self(self):
         """x == x => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Eq(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Eq(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_ne_self(self):
         """x != x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Ne(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Ne(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_lt_self(self):
         """x < x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Lt(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Lt(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_le_self(self):
         """x <= x => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Le(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Le(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_gt_self(self):
         """x > x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Gt(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Gt(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_ge_self(self):
         """x >= x => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Ge(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Ge(x, x, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_gt_delegation(self):
         """x > y delegates to y < x (Gt -> Lt delegation)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         # x + y > x + z should simplify to z < y (via Lt delegation)
-        z = make_var("z")
-        result = s(ir.Gt(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
+        result = simplifier(ir.Gt(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
         assert isinstance(result, ir.Lt)
 
     def test_ge_delegation(self):
         """x >= y delegates to y <= x (Ge -> Le delegation)"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Ge(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
+        result = simplifier(ir.Ge(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
         assert isinstance(result, ir.Le)
 
     def test_lt_self_offset(self):
         """x < x + z => 0 < z"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        z = make_var("z")
-        result = s(ir.Lt(x, ir.Add(x, z, INT, S), DataType.BOOL, S))
+        result = simplifier(ir.Lt(x, ir.Add(x, z, INT, S), DataType.BOOL, S))
         assert isinstance(result, ir.Lt)
         assert_is_const_int(result.left, 0)
         assert result.right is z
 
     def test_lt_floordiv(self):
         """floordiv(x, c1) < c2 => x < c1*c2 when c1 > 0"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         fd = ir.FloorDiv(x, ci(4), INT, S)
-        result = s(ir.Lt(fd, ci(3), DataType.BOOL, S))
+        result = simplifier(ir.Lt(fd, ci(3), DataType.BOOL, S))
         assert isinstance(result, ir.Lt)
         assert result.left is x
         assert_is_const_int(result.right, 12)
 
     def test_lt_min_decompose(self):
         """min(x, y) < z => x < z || y < z"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Lt(ir.Min(x, y, INT, S), z, DataType.BOOL, S))
+        result = simplifier(ir.Lt(ir.Min(x, y, INT, S), z, DataType.BOOL, S))
         assert isinstance(result, ir.Or)
 
     def test_lt_max_decompose(self):
         """max(x, y) < z => x < z && y < z"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Lt(ir.Max(x, y, INT, S), z, DataType.BOOL, S))
+        result = simplifier(ir.Lt(ir.Max(x, y, INT, S), z, DataType.BOOL, S))
         assert isinstance(result, ir.And)
 
     def test_le_sub_cancel(self):
         """x - y <= x - z => z <= y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
-        result = s(ir.Le(ir.Sub(x, y, INT, S), ir.Sub(x, z, INT, S), DataType.BOOL, S))
+        result = simplifier(ir.Le(ir.Sub(x, y, INT, S), ir.Sub(x, z, INT, S), DataType.BOOL, S))
         assert isinstance(result, ir.Le)
         assert result.left is z
         assert result.right is y
 
     def test_le_mul_positive(self):
         """x * 3 <= y * 3 => x <= y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Le(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), DataType.BOOL, S))
+        result = simplifier(ir.Le(ir.Mul(x, ci(3), INT, S), ir.Mul(y, ci(3), INT, S), DataType.BOOL, S))
         assert isinstance(result, ir.Le)
         assert result.left is x
         assert result.right is y
@@ -724,130 +549,99 @@ class TestComparisonRules:
 class TestBooleanRules:
     def test_double_negation(self):
         """!!x => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Not(ir.Not(x, DataType.BOOL, S), DataType.BOOL, S))
+        result = simplifier(ir.Not(ir.Not(x, DataType.BOOL, S), DataType.BOOL, S))
         assert_same_expr(result, x)
 
     def test_not_lt(self):
         """!(x < y) => y <= x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Not(ir.Lt(x, y, DataType.BOOL, S), DataType.BOOL, S))
+        result = simplifier(ir.Not(ir.Lt(x, y, DataType.BOOL, S), DataType.BOOL, S))
         assert isinstance(result, ir.Le)
         assert result.left is y
         assert result.right is x
 
     def test_not_le(self):
         """!(x <= y) => y < x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Not(ir.Le(x, y, DataType.BOOL, S), DataType.BOOL, S))
+        result = simplifier(ir.Not(ir.Le(x, y, DataType.BOOL, S), DataType.BOOL, S))
         assert isinstance(result, ir.Lt)
         assert result.left is y
         assert result.right is x
 
     def test_not_eq(self):
         """!(x == y) => x != y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Not(ir.Eq(x, y, DataType.BOOL, S), DataType.BOOL, S))
+        result = simplifier(ir.Not(ir.Eq(x, y, DataType.BOOL, S), DataType.BOOL, S))
         assert isinstance(result, ir.Ne)
 
     def test_and_contradiction(self):
         """x && !x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         not_x = ir.Not(x, DataType.BOOL, S)
-        result = s(ir.And(x, not_x, DataType.BOOL, S))
+        result = simplifier(ir.And(x, not_x, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_or_tautology(self):
         """x || !x => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         not_x = ir.Not(x, DataType.BOOL, S)
-        result = s(ir.Or(x, not_x, DataType.BOOL, S))
+        result = simplifier(ir.Or(x, not_x, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_and_idempotent(self):
         """x && x => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.And(x, x, DataType.BOOL, S))
+        result = simplifier(ir.And(x, x, DataType.BOOL, S))
         assert_same_expr(result, x)
 
     def test_or_idempotent(self):
         """x || x => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Or(x, x, DataType.BOOL, S))
+        result = simplifier(ir.Or(x, x, DataType.BOOL, S))
         assert_same_expr(result, x)
 
     def test_and_eq_ne_contradiction(self):
         """x == y && x != y => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         eq = ir.Eq(x, y, DataType.BOOL, S)
         ne = ir.Ne(x, y, DataType.BOOL, S)
-        result = s(ir.And(eq, ne, DataType.BOOL, S))
+        result = simplifier(ir.And(eq, ne, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_and_le_lt_contradiction(self):
         """x <= y && y < x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.And(ir.Le(x, y, DataType.BOOL, S), ir.Lt(y, x, DataType.BOOL, S), DataType.BOOL, S))
+        le = ir.Le(x, y, DataType.BOOL, S)
+        lt = ir.Lt(y, x, DataType.BOOL, S)
+        result = simplifier(ir.And(le, lt, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_and_range_contradiction(self):
         """x < 3 && 5 < x => false"""
-        s = RewriteSimplifier()
-        x = make_var("x")
         lt1 = ir.Lt(x, ci(3), DataType.BOOL, S)
         lt2 = ir.Lt(ci(5), x, DataType.BOOL, S)
-        result = s(ir.And(lt1, lt2, DataType.BOOL, S))
+        result = simplifier(ir.And(lt1, lt2, DataType.BOOL, S))
         assert_is_const_bool(result, False)
 
     def test_or_eq_ne_tautology(self):
         """x == y || x != y => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         eq = ir.Eq(x, y, DataType.BOOL, S)
         ne = ir.Ne(x, y, DataType.BOOL, S)
-        result = s(ir.Or(eq, ne, DataType.BOOL, S))
+        result = simplifier(ir.Or(eq, ne, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_or_le_lt_tautology(self):
         """x <= y || y < x => true"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Or(ir.Le(x, y, DataType.BOOL, S), ir.Lt(y, x, DataType.BOOL, S), DataType.BOOL, S))
+        le = ir.Le(x, y, DataType.BOOL, S)
+        lt = ir.Lt(y, x, DataType.BOOL, S)
+        result = simplifier(ir.Or(le, lt, DataType.BOOL, S))
         assert_is_const_bool(result, True)
 
     def test_or_lt_eq_to_le(self):
         """x < y || x == y => x <= y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Or(ir.Lt(x, y, DataType.BOOL, S), ir.Eq(x, y, DataType.BOOL, S), DataType.BOOL, S))
+        lt = ir.Lt(x, y, DataType.BOOL, S)
+        eq = ir.Eq(x, y, DataType.BOOL, S)
+        result = simplifier(ir.Or(lt, eq, DataType.BOOL, S))
         assert isinstance(result, ir.Le)
         assert result.left is x
         assert result.right is y
 
     def test_or_lt_exclusive(self):
         """x < y || y < x => x != y"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Or(ir.Lt(x, y, DataType.BOOL, S), ir.Lt(y, x, DataType.BOOL, S), DataType.BOOL, S))
+        lt1 = ir.Lt(x, y, DataType.BOOL, S)
+        lt2 = ir.Lt(y, x, DataType.BOOL, S)
+        result = simplifier(ir.Or(lt1, lt2, DataType.BOOL, S))
         assert isinstance(result, ir.Ne)
 
 
@@ -859,17 +653,12 @@ class TestBooleanRules:
 class TestNegRules:
     def test_neg_neg(self):
         """neg(neg(x)) => x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.Neg(ir.Neg(x, INT, S), INT, S))
+        result = simplifier(ir.Neg(ir.Neg(x, INT, S), INT, S))
         assert_same_expr(result, x)
 
     def test_neg_sub(self):
         """neg(x - y) => y - x"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        result = s(ir.Neg(ir.Sub(x, y, INT, S), INT, S))
+        result = simplifier(ir.Neg(ir.Sub(x, y, INT, S), INT, S))
         assert isinstance(result, ir.Sub)
         assert result.left is y
         assert result.right is x
@@ -882,17 +671,13 @@ class TestNegRules:
 
 class TestConstraintAndSubstitution:
     def test_update_substitution(self):
-        s = RewriteSimplifier()
-        x = make_var("x")
-        s.update(x, ci(7))
-        assert_is_const_int(s(x), 7)
+        simplifier.update(x, ci(7))
+        assert_is_const_int(simplifier(x), 7)
+        simplifier.update(x, None)
 
     def test_enter_constraint(self):
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
         constraint = ir.Eq(x, y, DataType.BOOL, S)
-        exit_fn = s.enter_constraint(constraint)
+        exit_fn = simplifier.enter_constraint(constraint)
         assert callable(exit_fn)
         exit_fn()
 
@@ -905,21 +690,15 @@ class TestConstraintAndSubstitution:
 class TestCombinedRewrites:
     def test_nested_add_sub(self):
         """(x + y) - y + z => x + z"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        y = make_var("y")
-        z = make_var("z")
         expr = ir.Add(ir.Sub(ir.Add(x, y, INT, S), y, INT, S), z, INT, S)
-        result = s(expr)
+        result = simplifier(expr)
         assert isinstance(result, ir.Add)
         assert result.left is x
         assert result.right is z
 
     def test_complex_mul_div(self):
         """floordiv(x * 12, 4) => x * 3"""
-        s = RewriteSimplifier()
-        x = make_var("x")
-        result = s(ir.FloorDiv(ir.Mul(x, ci(12), INT, S), ci(4), INT, S))
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(12), INT, S), ci(4), INT, S))
         assert isinstance(result, ir.Mul)
         assert result.left is x
         assert_is_const_int(result.right, 3)


### PR DESCRIPTION
## Summary
- Add `Unbind` method to `ConstIntBoundAnalyzer`, `ModularSetAnalyzer`, and `Analyzer` to remove variable bindings and restore default state
- Refactor all 5 arith test files to use module-level shared instances for analyzers and variables, eliminating redundant per-test instantiation
- Add `TestUnbind` class with 7 standalone tests for the new API
- Net reduction of ~300 lines of test boilerplate

## Cross-Layer Changes
- **C++ header**: `Unbind()` declared on `ConstIntBoundAnalyzer`, `ModularSetAnalyzer`, `Analyzer`
- **C++ impl**: Erases from internal `var_map_`; `Analyzer::Unbind` delegates to all sub-analyzers
- **Python bindings**: `.def("unbind", ...)` exposed on all three classes
- **Type stubs**: `unbind(self, var: Var) -> None` added to all three classes

## Testing
- [x] All 3012 tests pass (379 arith tests)
- [x] Code review passed
- [x] Clang-tidy clean
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)