### PR TITLE
feat(ir): enhance tensor-to-tile conversion with IterArg init value tracing

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -97,6 +97,28 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
 
   [[nodiscard]] const std::unordered_set<const Var*>& GetUsed() const { return used_; }
 
+  /**
+   * @brief Trace from collected IterArgs to their ForStmt/WhileStmt initValue_ expressions.
+   *
+   * When an IterArg is in used_ (consumed by a converted op), its initValue_ may be a
+   * function parameter that also needs a Phase-1 tile.load.  This fixpoint loop propagates
+   * through chains of IterArgs (e.g. nested loops) until no new entries are added.
+   */
+  void TraceIterArgInitValues() {
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (const auto& [iter_arg_ptr, init_expr] : iter_arg_to_init_) {
+        if (used_.count(iter_arg_ptr) == 0) continue;
+        if (auto var = As<Var>(init_expr)) {
+          if (As<TensorType>(var->GetType()) && used_.insert(var.get()).second) {
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
     if (!op) return;
@@ -124,9 +146,26 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
     IRVisitor::VisitStmt_(op);
   }
 
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (!op) return;
+    for (const auto& iter_arg : op->iter_args_) {
+      iter_arg_to_init_[iter_arg.get()] = iter_arg->initValue_;
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    if (!op) return;
+    for (const auto& iter_arg : op->iter_args_) {
+      iter_arg_to_init_[iter_arg.get()] = iter_arg->initValue_;
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
  private:
   const OpConversionRegistry& conv_registry_;
   std::unordered_set<const Var*> used_;
+  std::unordered_map<const Var*, ExprPtr> iter_arg_to_init_;
 };
 
 /**
@@ -1278,6 +1317,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   // NOT get an additional Vec-space load inserted here.
   TensorArgsInConvertedOpsCollector collector(conv_registry);
   collector.VisitStmt(func->body_);
+  collector.TraceIterArgInitValues();
   const auto& params_used_by_converted_ops = collector.GetUsed();
 
   for (const auto& var : func->params_) {

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1543,6 +1543,67 @@ class TestNestedControlFlow:
         with pytest.raises(Exception, match="has no registered tile conversion"):
             passes.convert_tensor_to_tile_ops()(prog)
 
+    def test_iter_arg_init_from_tensor_param_gets_preloaded(self):
+        """Tensor parameter used only as ForStmt iter_arg initValue must be pre-loaded.
+
+        Regression test: when a TensorType function parameter is used exclusively as
+        the init value of a ForStmt iter_arg (not as a direct argument to any converted
+        op), Phase 1 must still insert a tile.load for it. Otherwise the iter_arg stays
+        TensorType and later tile ops (e.g. tile.add) fail type-checking.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                acc: pl.Tensor[[64], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for i, (running_sum,) in pl.range(3, init_values=(acc,)):
+                    new_sum: pl.Tensor[[64], pl.FP32] = pl.add(running_sum, x)
+                    result = pl.yield_(new_sum)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                acc: pl.Tensor[[64], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                acc: pl.Tensor[[64], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                acc_tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                for i, (running_sum,) in pl.range(3, init_values=(acc_tile,)):
+                    new_sum_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(running_sum, x_tile)
+                    result = pl.yield_(new_sum_tile)
+                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(result, [0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                acc: pl.Tensor[[64], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x, out_0)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestGmLocalTensorConversion:
     """Test gm_tensor vs local_tensor differentiated conversion."""


### PR DESCRIPTION
fix #705

- Implemented `TraceIterArgInitValues` method to propagate init values from IterArgs to ensure proper tile.load insertion for TensorType parameters used in ForStmt and WhileStmt.
- Updated `VisitStmt_` methods for ForStmt and WhileStmt to collect IterArg init values.
- Added a regression test to verify that TensorType function parameters used as ForStmt init values are correctly pre-loaded, preventing type-checking failures in subsequent tile operations.

This enhancement improves the handling of TensorType parameters in the conversion process, ensuring correct initialization and type compatibility.