### PR TITLE
fix(codegen): prevent SSA name dedup for tile vars in sibling if-else branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.12
-          PTOAS_SHA256=4039660c33ae8def90099e665f85cb06713f7b912a05b91144556313b79ea280
+          PTOAS_VERSION=v0.16
+          PTOAS_SHA256=276e9a81dacffe269bf528eff0bbdf6b3acfe7bf93a26b16a4356135482e61e4
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -428,6 +428,12 @@ class PTOCodegen : public CodegenBase {
   /// This is the single source of truth for per-variable alloc_tile emission.
   std::vector<std::pair<ir::VarPtr, std::shared_ptr<const ir::TileType>>> tile_var_allocs_;
   std::set<const ir::Var*> emitted_tile_alloc_vars_;
+
+  /// Scope path for each tile variable, tracking the path through region-creating
+  /// constructs (if-else branches, for-loops, while-loops). Two variables may share
+  /// an SSA name only when the existing variable's scope path is a prefix of the new
+  /// variable's scope path (i.e., the existing def dominates).
+  std::map<const ir::Var*, std::vector<int>> tile_var_scope_paths_;
   struct TpopResultInfo {
     int split = 0;
     std::string op_name;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -310,6 +310,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   extra_alloc_tiles_.clear();
   ssa_to_tile_buf_type_.clear();
   tile_var_allocs_.clear();
+  tile_var_scope_paths_.clear();
   emitted_tile_alloc_vars_.clear();
   tpop_result_vars_.clear();
   reserve_buf_ssa_.clear();
@@ -353,21 +354,58 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // Still collect memref_to_tile_type_ for GetTileBufTypeString fallback paths
   memref_to_tile_type_ = collector.GetMemRefTileTypes();
 
-  // Per-var SSA binding: each tile variable gets its own SSA name
+  // Per-var SSA binding: reuse existing SSA name when a variable shares the
+  // same MemRef with an identical tile_buf type AND the existing definition
+  // dominates the new variable (i.e., the existing scope path is a prefix of
+  // the new one).  Variables in sibling if-else branches or separate loop bodies
+  // cannot share SSA names because alloc_tile is only visible within its
+  // enclosing region.
+  //
+  // Track scope path per MemRef for the first (canonical) variable.
+  std::map<const ir::MemRef*, std::vector<int>> memref_scope_paths;
+
   for (const auto& [tile_var, tile_type] : tile_var_allocs_) {
+    const bool force_all_dynamic = HasFillpadConsumer(tile_var.get());
+    std::string type_str = GetTileBufTypeStringFromTileType(tile_type, force_all_dynamic);
+    auto memref = ir::GetDefinedMemRef(tile_type);
+
+    auto memref_it = memref_to_mlir_.find(memref.get());
+    if (memref_it != memref_to_mlir_.end()) {
+      // MemRef already has an SSA binding — check types and dominance.
+      const std::string& existing_ssa = memref_it->second;
+      auto type_it = ssa_to_tile_buf_type_.find(existing_ssa);
+      if (type_it != ssa_to_tile_buf_type_.end() && type_it->second == type_str) {
+        // Types match. Now check scope dominance: the existing variable's scope
+        // path must be a prefix of the new variable's scope path.
+        const auto& existing_scope = memref_scope_paths[memref.get()];
+        auto new_scope_it = tile_var_scope_paths_.find(tile_var.get());
+        static const std::vector<int> kFunctionScope;
+        const auto& new_scope =
+            (new_scope_it != tile_var_scope_paths_.end()) ? new_scope_it->second : kFunctionScope;
+        bool dominates = existing_scope.size() <= new_scope.size() &&
+                         std::equal(existing_scope.begin(), existing_scope.end(), new_scope.begin());
+        if (dominates) {
+          BindVarToMlir(tile_var, existing_ssa);
+          emitted_tile_alloc_vars_.insert(tile_var.get());
+          continue;
+        }
+      }
+    }
+
     std::string ssa_name = NewNamedTemp(tile_var->name_hint_);
     BindVarToMlir(tile_var, ssa_name);
 
     // Pre-populate type so body visitors (e.g., tile.reshape no-op check)
     // can query it before per-variable alloc_tile emission runs.
-    std::string type_str = GetTileBufTypeStringFromTileType(tile_type);
     ssa_to_tile_buf_type_[ssa_name] = type_str;
 
-    auto memref = ir::GetDefinedMemRef(tile_type);
-
-    // Also maintain memref_to_mlir_ for compatibility (first var per MemRef)
+    // Maintain memref_to_mlir_ for compatibility (first var per MemRef)
     if (memref_to_mlir_.find(memref.get()) == memref_to_mlir_.end()) {
       memref_to_mlir_[memref.get()] = ssa_name;
+      auto scope_it = tile_var_scope_paths_.find(tile_var.get());
+      if (scope_it != tile_var_scope_paths_.end()) {
+        memref_scope_paths[memref.get()] = scope_it->second;
+      }
     }
   }
 
@@ -744,17 +782,26 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& tile_var_allocs;
     std::map<const ir::Var*, TpopResultInfo>& tpop_result_vars;
     std::set<const ir::Var*>& fillpad_input_vars;
+    std::map<const ir::Var*, std::vector<int>>& tile_var_scope_paths;
+
+    // Scope tracking: each region-creating construct (if-else branch, loop body)
+    // gets a unique ID. A variable's scope_path is the sequence of region IDs
+    // from root to its location.
+    std::vector<int> current_scope_path_;
+    int next_branch_id_ = 0;
 
     VarMemRefMapper(std::map<const ir::Var*, const ir::MemRef*>& mapping,
                     std::map<const ir::MemRef*, std::string>& reverse_mapping,
                     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& allocs,
                     std::map<const ir::Var*, TpopResultInfo>& tpop_vars,
-                    std::set<const ir::Var*>& fillpad_vars)
+                    std::set<const ir::Var*>& fillpad_vars,
+                    std::map<const ir::Var*, std::vector<int>>& scope_paths)
         : var_to_memref(mapping),
           memref_to_var_name(reverse_mapping),
           tile_var_allocs(allocs),
           tpop_result_vars(tpop_vars),
-          fillpad_input_vars(fillpad_vars) {}
+          fillpad_input_vars(fillpad_vars),
+          tile_var_scope_paths(scope_paths) {}
 
     void VisitStmt_(const AssignStmtPtr& op) override {
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
@@ -765,6 +812,7 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
           memref_to_var_name[ptr] = op->var_->name_hint_;
         }
         tile_var_allocs.emplace_back(op->var_, tile_type);
+        tile_var_scope_paths[op->var_.get()] = current_scope_path_;
 
         if (auto call = As<ir::Call>(op->value_)) {
           // Track tpop result vars with their split value so codegen can:
@@ -785,10 +833,58 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
       }
       ir::IRVisitor::VisitStmt_(op);
     }
+
+    void VisitStmt_(const ir::IfStmtPtr& op) override {
+      VisitExpr(op->condition_);
+      int then_id = next_branch_id_++;
+      current_scope_path_.push_back(then_id);
+      VisitStmt(op->then_body_);
+      current_scope_path_.pop_back();
+      if (op->else_body_.has_value()) {
+        int else_id = next_branch_id_++;
+        current_scope_path_.push_back(else_id);
+        VisitStmt(op->else_body_.value());
+        current_scope_path_.pop_back();
+      }
+      for (const auto& rv : op->return_vars_) {
+        VisitExpr(rv);
+      }
+    }
+
+    void VisitStmt_(const ir::ForStmtPtr& op) override {
+      VisitExpr(op->loop_var_);
+      VisitExpr(op->start_);
+      VisitExpr(op->stop_);
+      VisitExpr(op->step_);
+      for (const auto& iter_arg : op->iter_args_) {
+        VisitExpr(iter_arg);
+      }
+      int loop_id = next_branch_id_++;
+      current_scope_path_.push_back(loop_id);
+      VisitStmt(op->body_);
+      current_scope_path_.pop_back();
+      for (const auto& rv : op->return_vars_) {
+        VisitExpr(rv);
+      }
+    }
+
+    void VisitStmt_(const ir::WhileStmtPtr& op) override {
+      VisitExpr(op->condition_);
+      for (const auto& iter_arg : op->iter_args_) {
+        VisitExpr(iter_arg);
+      }
+      int loop_id = next_branch_id_++;
+      current_scope_path_.push_back(loop_id);
+      VisitStmt(op->body_);
+      current_scope_path_.pop_back();
+      for (const auto& rv : op->return_vars_) {
+        VisitExpr(rv);
+      }
+    }
   };
 
   VarMemRefMapper mapper(var_to_memref_, memref_to_var_name_, tile_var_allocs_, tpop_result_vars_,
-                         fillpad_input_vars_);
+                         fillpad_input_vars_, tile_var_scope_paths_);
   if (func->body_) {
     mapper.VisitStmt(func->body_);
   }

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1264,5 +1264,94 @@ def test_pto_codegen_mixed_scalar_and_tile_iter_args():
     assert "index" in yield_line, f"Expected index type in scf.yield: {yield_line}"
 
 
+def test_pto_codegen_shared_memref_dedup_respects_if_else_scope():
+    """Variables sharing the same MemRef+type in sibling if-else branches must each
+    get their own alloc_tile; variables in parent-child scopes may be deduplicated."""
+    span = ir.Span.unknown()
+    zero = ir.ConstInt(0, DataType.INDEX, span)
+    size16 = ir.ConstInt(16, DataType.INDEX, span)
+    size128 = ir.ConstInt(128, DataType.INDEX, span)
+
+    flag = ir.Var("flag", ir.ScalarType(DataType.BOOL), span)
+    input_tensor = ir.Var("inp", ir.TensorType([16, 128], DataType.FP32), span)
+    out_tensor = ir.Var("out", ir.TensorType([16, 128], DataType.FP32), span)
+
+    shared_memref = ir.MemRef(ir.MemorySpace.Vec, zero, 16 * 128 * 4, 0)
+    tile_view = ir.TileView()
+    tile_view.valid_shape = [size16, size128]
+    tile_type = ir.TileType([16, 128], DataType.FP32, shared_memref, tile_view, ir.MemorySpace.Vec)
+
+    # Both if and else branches load into a tile sharing the same MemRef+type
+    then_tile = ir.Var("tile_then", tile_type, span)
+    else_tile = ir.Var("tile_else", tile_type, span)
+
+    offsets = ir.MakeTuple([zero, zero], span)
+    shapes = ir.MakeTuple([size16, size128], span)
+    then_load = ir.Call(ir.Op("tile.load"), [input_tensor, offsets, shapes], {}, tile_type, span)
+    else_load = ir.Call(ir.Op("tile.load"), [input_tensor, offsets, shapes], {}, tile_type, span)
+
+    result_type = ir.TensorType([16, 128], DataType.FP32)
+
+    then_store_var = ir.Var("then_out", result_type, span)
+    then_store = ir.Call(ir.Op("tile.store"), [then_tile, offsets, out_tensor], result_type, span)
+    else_store_var = ir.Var("else_out", result_type, span)
+    else_store = ir.Call(ir.Op("tile.store"), [else_tile, offsets, out_tensor], result_type, span)
+
+    result_var = ir.Var("result", result_type, span)
+
+    then_body = ir.SeqStmts(
+        [
+            ir.AssignStmt(then_tile, then_load, span),
+            ir.AssignStmt(then_store_var, then_store, span),
+            ir.YieldStmt([then_store_var], span),
+        ],
+        span,
+    )
+    else_body = ir.SeqStmts(
+        [
+            ir.AssignStmt(else_tile, else_load, span),
+            ir.AssignStmt(else_store_var, else_store, span),
+            ir.YieldStmt([else_store_var], span),
+        ],
+        span,
+    )
+    if_stmt = ir.IfStmt(flag, then_body, else_body, [result_var], span)
+
+    body = ir.SeqStmts(
+        [if_stmt, ir.ReturnStmt([result_var], span)],
+        span,
+    )
+    func = ir.Function(
+        "shared_memref_if_else",
+        [
+            (flag, ir.ParamDirection.In),
+            (input_tensor, ir.ParamDirection.In),
+            (out_tensor, ir.ParamDirection.Out),
+        ],
+        [result_type],
+        body,
+        span,
+        ir.FunctionType.InCore,
+    )
+    program = ir.Program([func], "test_program", span)
+    mlir_code = _generate_mlir(program)
+
+    # Both branches must have their own alloc_tile (sibling scopes, no dominance)
+    alloc_lines = _get_alloc_tile_lines(mlir_code)
+    vec_allocs = [line for line in alloc_lines if "loc=vec" in line and "rows=16, cols=128" in line]
+    assert len(vec_allocs) >= 2, (
+        f"Expected at least 2 alloc_tiles for if-else sibling branches "
+        f"sharing the same MemRef+type, got {len(vec_allocs)}: {vec_allocs}"
+    )
+
+    # Each branch's alloc_tile should use a distinct SSA name
+    ssa_names = set()
+    for line in vec_allocs:
+        match = re.match(r"(%[\w\d_]+)\s*=\s*pto\.alloc_tile", line)
+        if match:
+            ssa_names.add(match.group(1))
+    assert len(ssa_names) >= 2, f"Expected distinct SSA names in sibling if-else branches, got: {ssa_names}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
fix(codegen): prevent SSA name dedup for tile vars in sibling if-else branches

  Tile variables sharing the same MemRef and type but defined in sibling
  if-else branches were incorrectly deduplicated to a single alloc_tile.
  Track scope paths during IR traversal and only reuse an SSA name when
  the existing definition dominates the new one (its scope path is a
  prefix of the new variable's scope path).