### PR TITLE
chore(ci): skip full project build in clang-tidy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,10 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install project and dependencies
+    - name: Install clang-tidy and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install nanobind
-        pip install -v .[dev]
+        pip install clang-tidy==21.1.0 nanobind
 
     - name: Run clang-tidy
       run: |


### PR DESCRIPTION
## Summary
- Remove `pip install -v .[dev]` from the clang-tidy CI job, which was triggering a full C++ build via scikit-build-core
- Replace with `pip install clang-tidy==21.1.0 nanobind` — the only two packages the job actually needs
- The `clang_tidy.py` script already handles CMake configure (for `compile_commands.json`) and building `libbacktrace` internally

## Testing
- [ ] clang-tidy CI job passes on this PR