### PR TITLE
feat(st): add structured failure summary table for ST test sessions

### DIFF
--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -14,9 +14,13 @@ This configuration sets up the testing environment using the internal
 harness package (migrated from pto-testing-framework).
 """
 
+import json
 import os
 import random
+import shutil
 import sys
+import tempfile
+import textwrap
 from pathlib import Path
 
 # Add harness to path (internal package in tests/st/)
@@ -37,6 +41,17 @@ from harness.core.environment import (  # noqa: E402
 )
 from harness.core.test_runner import TestRunner  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
+
+# Environment variable names shared with test_runner.py
+_FAILURE_RECORDS_ENV = "PYPTO_FAILURE_RECORDS_DIR"
+_CURRENT_TEST_ENV = "PYPTO_CURRENT_TEST_NODEID"
+
+# Module-level storage so pytest_terminal_summary can find the records dir
+# even after the session fixture has torn down.
+_failure_records_dir: str | None = None
+# True only in the process that created the temp dir. Under --forked, each
+# child subprocess sees _failure_records_dir set but is NOT the owner.
+_is_failure_records_owner: bool = False
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -60,6 +75,39 @@ def setup_simpler_dependency(request):
     for path in [get_simpler_python_path(), get_simpler_scripts_path()]:
         if path is not None and path.exists() and str(path) not in sys.path:
             sys.path.insert(0, str(path))
+
+
+def pytest_sessionstart(session):
+    """Create the shared failure records directory at session start.
+
+    This hook runs at the beginning of each pytest session. In the parent
+    process it creates the temp dir and owns it. Under --forked, each child
+    subprocess inherits PYPTO_FAILURE_RECORDS_DIR and reuses the same
+    directory without taking ownership. Only the owner renders the summary
+    and cleans up; child sessions skip both steps.
+    """
+    global _failure_records_dir, _is_failure_records_owner  # noqa: PLW0603
+    existing = os.environ.get(_FAILURE_RECORDS_ENV)
+    if existing:
+        _failure_records_dir = existing
+        return
+    records_dir = tempfile.mkdtemp(prefix="pypto_st_failures_")
+    _failure_records_dir = records_dir
+    _is_failure_records_owner = True
+    os.environ[_FAILURE_RECORDS_ENV] = records_dir
+
+
+@pytest.fixture(autouse=True)
+def _set_current_test_nodeid(request):
+    """Expose the current pytest node ID to TestRunner via env var.
+
+    TestRunner.run() reads PYPTO_CURRENT_TEST_NODEID to tag failure records
+    with the full pytest test path. Under --forked, this fixture runs in the
+    forked child process, which is where TestRunner also runs — correct.
+    """
+    os.environ[_CURRENT_TEST_ENV] = request.node.nodeid
+    yield
+    os.environ.pop(_CURRENT_TEST_ENV, None)
 
 
 def pytest_addoption(parser):
@@ -217,3 +265,102 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_hardware)
         if "a5" in item.keywords and not platform.startswith("a5"):
             item.add_marker(skip_a5)
+
+
+# ---------------------------------------------------------------------------
+# Harness failure report
+# ---------------------------------------------------------------------------
+
+
+def _load_failure_records(records_dir: Path) -> list[dict]:
+    """Read all JSON failure records from *records_dir*."""
+    records = []
+    for path in sorted(records_dir.glob("failure_*.json")):
+        try:
+            with open(path, encoding="utf-8") as f:
+                records.append(json.load(f))
+        except (OSError, json.JSONDecodeError):
+            pass
+    return records
+
+
+def _render_failure_table(terminalreporter, records: list[dict]) -> None:
+    """Render the harness failure summary table to the terminal.
+
+    Produces one row per (test case, function) pair. Compilation errors expand
+    into one row per failed kernel function; all other errors produce a single
+    row with function="-".
+    """
+    max_error_width = 60
+
+    # Flatten records into rows: (case_name, file_path, error_type, function, summary)
+    rows: list[tuple[str, str, str, str, str]] = []
+    for rec in records:
+        nodeid = rec.get("nodeid", "")
+        file_path = nodeid.split("::")[0] if "::" in nodeid else nodeid
+        case_name = rec.get("case_name", "?")
+        error_type = rec.get("error_type", "Error")
+        for fe in rec.get("func_errors", [{"function": "-", "summary": ""}]):
+            rows.append((case_name, file_path, error_type, fe.get("function", "-"), fe.get("summary", "")))
+
+    headers = ("Case Name", "File", "Error Type", "Function", "Error")
+    col_widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            col_widths[i] = max(col_widths[i], len(cell))
+    col_widths[-1] = min(col_widths[-1], max_error_width)
+    col_widths = [w + 2 for w in col_widths]
+
+    sep = "-+-".join("-" * w for w in col_widths)
+    header_line = " | ".join(f"{h:<{col_widths[i]}}" for i, h in enumerate(headers))
+
+    tw = terminalreporter
+    tw.write_sep("=", "ST Failure Summary", red=True, bold=True)
+    tw.write_line("")
+    tw.write_line("  " + header_line)
+    tw.write_line("  " + sep)
+
+    for case_name, file_path, error_type, function, summary in rows:
+        # Wrap long error summaries
+        wrapped = textwrap.wrap(summary, width=max_error_width) or [summary]
+        cells = [
+            f"{case_name:<{col_widths[0]}}",
+            f"{file_path:<{col_widths[1]}}",
+            f"{error_type:<{col_widths[2]}}",
+            f"{function:<{col_widths[3]}}",
+            f"{wrapped[0]:<{col_widths[4]}}",
+        ]
+        tw.write_line("  " + " | ".join(cells), red=True)
+        for continuation in wrapped[1:]:
+            blank_cells = [" " * col_widths[i] for i in range(4)]
+            tw.write_line("  " + " | ".join(blank_cells) + " | " + continuation, red=True)
+
+    tw.write_line("  " + sep)
+    tw.write_line("")
+    unique_cases = len({r.get("case_name") for r in records})
+    tw.write_line(f"  {unique_cases} test case(s) failed ({len(rows)} failure(s) total)", red=True)
+    tw.write_sep("=", "", red=True)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Render the harness failure summary after all tests complete.
+
+    Only the owner process (the one that created the temp dir) renders the
+    table and cleans up. Under --forked, child subprocesses are not owners
+    and skip this step entirely to avoid deleting the shared directory before
+    the parent has had a chance to read it.
+    """
+    if not _is_failure_records_owner:
+        return
+    records_dir_str = _failure_records_dir or os.environ.get(_FAILURE_RECORDS_ENV)
+    if not records_dir_str:
+        return
+    records_dir = Path(records_dir_str)
+    if not records_dir.is_dir():
+        return
+    try:
+        records = _load_failure_records(records_dir)
+        if records:
+            _render_failure_table(terminalreporter, records)
+    finally:
+        shutil.rmtree(records_dir, ignore_errors=True)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -18,10 +18,14 @@ Orchestrates the full test execution pipeline:
 5. Validate results
 """
 
+import json
+import os
+import re
 import shutil
 import tempfile
 import time
 import traceback
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -58,6 +62,118 @@ def _resolve_platform(config_platform: str, backend_type: BackendType) -> str:
     is_sim = config_platform.endswith("sim")
     arch = _BACKEND_TO_ARCH.get(backend_type, config_platform.rstrip("sim").rstrip("_"))
     return f"{arch}sim" if is_sim else arch
+
+# Environment variable names shared with conftest.py
+_FAILURE_RECORDS_ENV = "PYPTO_FAILURE_RECORDS_DIR"
+_CURRENT_TEST_ENV = "PYPTO_CURRENT_TEST_NODEID"
+
+
+def _parse_partial_codegen_table(exc_str: str) -> list[dict]:
+    """Extract per-function errors from PartialCodegenError formatted table.
+
+    Parses multi-line table rows of the form:
+      func_name   | first line of error
+                  | continuation line
+
+    Continuation lines (empty function column) are joined with a space to
+    form a single summary string per function.
+    Skips the "Function" header row and separator lines.
+    """
+    results = []
+    current_func: str | None = None
+    current_parts: list[str] = []
+
+    for line in exc_str.split("\n"):
+        # Primary row: "  funcname   | error text"
+        m = re.match(r"^\s{2}(\w+)\s+\|\s*(.*)$", line)
+        if m:
+            func_name = m.group(1)
+            if func_name == "Function" or not func_name.strip("-"):
+                if current_func:
+                    results.append({"function": current_func, "summary": " ".join(current_parts)})
+                    current_func = None
+                    current_parts = []
+                continue
+            if current_func:
+                results.append({"function": current_func, "summary": " ".join(current_parts)})
+            current_func = func_name
+            first = m.group(2).strip()
+            current_parts = [first] if first else []
+        elif current_func:
+            # Continuation row: "            | more error text"
+            cont = re.match(r"^\s+\|\s*(.*)$", line)
+            if cont:
+                part = cont.group(1).strip()
+                if part:
+                    current_parts.append(part)
+            elif re.match(r"^\s*[-=]+\+", line):
+                results.append({"function": current_func, "summary": " ".join(current_parts)})
+                current_func = None
+                current_parts = []
+
+    if current_func:
+        results.append({"function": current_func, "summary": " ".join(current_parts)})
+
+    return results
+
+
+def _classify_error(exc: Exception) -> tuple[str, list[dict]]:
+    """Classify an exception into (error_type, func_errors).
+
+    Returns:
+        A tuple of:
+        - error_type: human-readable category string
+        - func_errors: list of {"function": str, "summary": str} dicts,
+          one per failed function (or one entry with function="-" for non-compilation errors)
+    """
+    try:
+        from pypto.backend.pto_backend import PartialCodegenError  # noqa: PLC0415
+
+        if isinstance(exc, PartialCodegenError):
+            func_errors = _parse_partial_codegen_table(str(exc))
+            if not func_errors:
+                # Fallback: use function names from exc.files without per-function summary
+                func_errors = [{"function": k, "summary": "compile failed"} for k in exc.files]
+            return "Compilation Error", func_errors
+    except ImportError:
+        pass
+
+    msg = str(exc)
+    m = re.search(r"Mismatched elements: (\d+/\d+)", msg)
+    if m or "does not match golden" in msg:
+        summary = f"Mismatched elements: {m.group(1)}" if m else "Output mismatch"
+        return "Precision Error", [{"function": "-", "summary": summary}]
+
+    m = re.search(r"launch_runtime failed: (\w+)", msg)
+    if m:
+        return "Runtime Error", [{"function": "-", "summary": f"launch_runtime failed: {m.group(1)}"}]
+
+    exc_only = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    first_line = exc_only.split("\n")[0].strip()[:80]
+    return "Error", [{"function": "-", "summary": first_line or type(exc).__name__}]
+
+
+def _write_failure_record(case_name: str, nodeid: str, error_type: str, func_errors: list[dict]) -> None:
+    """Write a JSON failure record to PYPTO_FAILURE_RECORDS_DIR.
+
+    Silently skips if the env var is not set or writing fails.
+    """
+    records_dir = os.environ.get(_FAILURE_RECORDS_ENV)
+    if not records_dir:
+        return
+    record = {
+        "nodeid": nodeid,
+        "case_name": case_name,
+        "error_type": error_type,
+        "func_errors": func_errors,
+    }
+    try:
+        os.makedirs(records_dir, exist_ok=True)
+        path = os.path.join(records_dir, f"failure_{uuid.uuid4().hex}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record, f, ensure_ascii=False)
+    except OSError:
+        pass
 
 
 def _default_work_dir(test_name: str) -> Path:
@@ -216,6 +332,9 @@ class TestRunner:
             )
 
         except Exception as e:
+            error_type, func_errors = _classify_error(e)
+            nodeid = os.environ.get(_CURRENT_TEST_ENV, "")
+            _write_failure_record(test_name, nodeid, error_type, func_errors)
             return RunResult(
                 passed=False,
                 test_name=test_name,

--- a/tests/st/runtime/test_dynamic_shape.py
+++ b/tests/st/runtime/test_dynamic_shape.py
@@ -186,7 +186,7 @@ class ValidShapeAddTestCase(PTOTestCase):
         return OptimizationStrategy.Default
 
     def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B_PTO
+        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         vr = tensors["valid_shape"][0]


### PR DESCRIPTION
TestRunner now classifies each exception (Compilation Error, Precision Error, Runtime Error, or generic Error) and writes a JSON record to a shared temp directory on failure.

conftest.py reads all records at session end and renders a formatted table grouped by case name, file, error type, and kernel function.

Under --forked, the parent process owns the temp dir via PYPTO_FAILURE_RECORDS_DIR; child subprocesses reuse it but do not render or clean up, avoiding race conditions.

Also fixes BackendType.Ascend910B_PTO → BackendType.Ascend910B in test_dynamic_shape.py.