### PR TITLE
fix(test): fix KernelSoftmaxPrepare for PTO backend with valid_shapes + fillpad

### DIFF
--- a/examples/ir_parser/batch_paged_attention_example.py
+++ b/examples/ir_parser/batch_paged_attention_example.py
@@ -184,13 +184,12 @@ def BuildBatchPagedAttentionProgram(
                     [b * q_tile, 0],
                     [q_tile, block_size],
                     target_memory=pl.MemorySpace.Vec,
+                    valid_shapes=[q_tile, valid_len],
                 )
 
-                # Keep the allocated tile static and narrow only the logical valid columns.
-                sij_dyn = pl.tile.slice(s_tile, [q_tile, block_size], [0, 0], valid_shape=[q_tile, valid_len])
-                s_tile = pl.tile.fillpad(sij_dyn)
+                s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
 
-                scaled = pl.mul(s_tile, scale_value)
+                scaled = pl.mul(s_padded, scale_value)
                 tmp_tile = pl.create_tile(
                     [q_tile, block_size],
                     dtype=pl.FP32,

--- a/tests/st/codegen/test_batch_paged_attention.py
+++ b/tests/st/codegen/test_batch_paged_attention.py
@@ -245,6 +245,12 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
     def get_name(self) -> str:
         return f"batch_softmax_prepare_{self.batch}b_{self.block_size}bs_bi{self.block_idx}"
 
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
     def define_tensors(self) -> list[TensorSpec]:
         batch_q_tile = self.batch * self.q_tile
 
@@ -265,6 +271,7 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
         batch = self.batch
         block_size = self.block_size
         q_tile = self.q_tile
+        block_idx = self.block_idx
 
         batch_q_tile = batch * q_tile
 
@@ -279,15 +286,13 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                 lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
                 scale_value: pl.Scalar[pl.FP32],
                 context_lens: pl.Tensor[[batch], pl.INT32],
-                batch_count: pl.Scalar[pl.INT64],
-                block_idx: pl.Scalar[pl.INT64],
             ) -> tuple[
                 pl.Tensor[[batch_q_tile, block_size], pl.BF16],
                 pl.Tensor[[batch_q_tile, 1], pl.FP32],
                 pl.Tensor[[batch_q_tile, 1], pl.FP32],
             ]:
-                for b in pl.range(batch_count):
-                    cur_seq = pl.read(context_lens, b)
+                for b in pl.range(batch):
+                    cur_seq = pl.tensor.read(context_lens, [b])
                     start = block_idx * block_size
                     remaining = cur_seq - start
                     valid_len = pl.max(pl.min(remaining, block_size), 0)
@@ -299,9 +304,9 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                         valid_shapes=[q_tile, valid_len],
                         target_memory=pl.MemorySpace.Vec,
                     )
-                    s_tile = pl.tile.fillpad(s_tile)
+                    s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
 
-                    scaled = pl.mul(s_tile, scale_value)
+                    scaled = pl.mul(s_padded, scale_value)
                     tmp_tile = pl.create_tile(
                         [q_tile, block_size],
                         dtype=pl.FP32,
@@ -314,9 +319,9 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                     pij_tile = pl.cast(pij_tile_f16, target_type=pl.FP32)
                     li_tile = pl.row_sum(pij_tile, tmp_tile)
 
-                    pij_batch = pl.store(pij_tile_f16, [b * q_tile, 0], [q_tile, block_size], pij_batch)
-                    mij_batch = pl.store(mi_tile, [b * q_tile, 0], [q_tile, 1], mij_batch)
-                    lij_batch = pl.store(li_tile, [b * q_tile, 0], [q_tile, 1], lij_batch)
+                    pij_batch = pl.store(pij_tile_f16, [b * q_tile, 0], pij_batch)
+                    mij_batch = pl.store(mi_tile, [b * q_tile, 0], mij_batch)
+                    lij_batch = pl.store(li_tile, [b * q_tile, 0], lij_batch)
                 return pij_batch, mij_batch, lij_batch
 
             @pl.function(type=pl.FunctionType.Orchestration)
@@ -334,8 +339,6 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                 pl.Tensor[[batch_q_tile, 1], pl.FP32],
                 pl.Tensor[[batch_q_tile, 1], pl.FP32],
             ]:
-                batch_count: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
-                block_idx: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
                 scale_value: pl.Scalar[pl.FP32] = pl.tensor.read(scale_config, [0])
 
                 pij_batch, mij_batch, lij_batch = self.KernelSoftmaxPrepare(
@@ -345,8 +348,6 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                     lij_batch,
                     scale_value,
                     context_lens,
-                    batch_count,
-                    block_idx,
                 )
                 return pij_batch, mij_batch, lij_batch
 
@@ -378,11 +379,11 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
             s_scaled = s * scale_value
             mi = s_scaled.max(dim=1, keepdim=True).values
             pij = torch.exp(s_scaled - mi)
-            pij_f16 = pij.to(torch.float16)
-            pij_f32 = pij_f16.float()
+            pij_bf16 = pij.to(torch.bfloat16)
+            pij_f32 = pij_bf16.float()
             li = pij_f32.sum(dim=1, keepdim=True)
 
-            tensors["pij_batch"][b * q_tile : (b + 1) * q_tile, :] = pij_f16
+            tensors["pij_batch"][b * q_tile : (b + 1) * q_tile, :] = pij_bf16
             tensors["mij_batch"][b * q_tile : (b + 1) * q_tile, :] = mi
             tensors["lij_batch"][b * q_tile : (b + 1) * q_tile, :] = li
 
@@ -1012,7 +1013,6 @@ class TestBatchPagedAttentionKernels:
         result = test_runner.run(test_case)
         assert result.passed, f"Batch QK matmul test failed: {result.error}"
 
-    @pytest.mark.skip(reason="Under debugging and fixing")
     @pytest.mark.parametrize(
         "batch,block_size,block_idx,context_lens",
         [


### PR DESCRIPTION
## Summary

- **Example**: Replace deprecated `pl.tile.slice` + `fillpad` pattern with `pl.load(valid_shapes=...)` + `fillpad(pad_value=PadValue.min)` for correct unaligned softmax masking in `KernelSoftmaxPrepare`
- **ST test**: Switch `BatchSoftmaxPrepareTestCase` to `BackendType.Ascend910B_PTO` + `OptimizationStrategy.Default` since `tensor.read` requires PTO codegen
- **ST test**: Use closure constants for `batch`/`block_idx` instead of runtime INT64 scalars, avoiding PTOAS `i64` vs `index` type mismatch in `scf.for` loop bounds
- **ST test**: Fix `pl.store` to 3-arg signature, fix golden computation to use `torch.bfloat16` (matching `pl.BF16`)

## Test plan

- [x] `test_batch_softmax_prepare[2-16-1-context_lens0]` passes on device (--device=13)
- [ ] Verify no regression on other batch paged attention tests (`test_batch_qk_matmul`, `test_batch_pv_matmul`, `test_batch_online_update`)