### PR TITLE
feat(codegen): adapt orchestration codegen for A5 (Ascend950) backend

### DIFF
--- a/docs/en/dev/codegen/02-orchestration_codegen.md
+++ b/docs/en/dev/codegen/02-orchestration_codegen.md
@@ -84,8 +84,11 @@ PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
 }
 
 // Phase 4: Entry function signature
+// A2/A3:
 void aicpu_orchestration_entry(OrchArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
+// A5 (Ascend950): PTO2Runtime* rt prepended
+// void aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)
 ```
 
 ### Phase 5–6: Tensor Setup
@@ -110,11 +113,14 @@ All task submission is wrapped in a top-level `PTO2_SCOPE()`:
 
 ```cpp
 // Phase 7–9: Top-level PTO2_SCOPE wraps all task submissions
+// A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
 PTO2_SCOPE() {
     PTOParam params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(ext_output);
+    // A2/A3: pto2_rt_submit_aiv_task(0, params_t0)
+    // A5:    pto2_rt_submit_aiv_task(rt, 0, params_t0)
     pto2_rt_submit_aiv_task(0, params_t0);
 
     // ForStmt example — plain for loop, no nested PTO2_SCOPE
@@ -166,6 +172,18 @@ Tensor& result = ext_output;  // alias — result refers to ext_output
 
 If the return name matches the `Out`/`InOut` arg name, no alias is needed. `InOut` params are never aliased — they are already the external tensor.
 
+### Backend Differences (A5 / Ascend950)
+
+When targeting Ascend950 (`BackendType::Ascend950`), the generated C++ differs in three ways:
+
+| Element | A2/A3 | A5 |
+| ------- | ----- | -- |
+| Entry function | `aicpu_orchestration_entry(OrchArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)` |
+| Scope macro | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
+| Submit calls | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
+
+The `rt` parameter is an explicit `PTO2Runtime*` pointer that A5 passes through the call chain instead of relying on thread-local storage.
+
 ### Core Type Inference
 
 The codegen determines whether to submit to AIC (CUBE) or AIV (VECTOR) based on the callee's `MemorySpace`:
@@ -204,6 +222,8 @@ When a kernel uses both AIC and AIV cores (mixed kernel), the codegen generates 
 PTOParam params_t0;
 // ... add_input / add_output / add_scalar calls ...
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
+// A2/A3: pto2_rt_submit_task(mixed_0, params_t0)
+// A5:    pto2_rt_submit_task(rt, mixed_0, params_t0)
 pto2_rt_submit_task(mixed_0, params_t0);
 ```
 
@@ -255,6 +275,7 @@ PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
 
 void aicpu_orchestration_entry(OrchArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
+    // Note: A5 adds PTO2Runtime* rt as the first parameter
     (void)arg_count;
     (void)orch_thread_num;
     (void)orch_thread_index;
@@ -268,12 +289,15 @@ void aicpu_orchestration_entry(OrchArg* orch,
     uint32_t c_shapes[2] = {16, 16};
     Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
 
+    // A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         // Task 0: kernel_add (a + b → c)
         PTOParam params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
         params_t0.add_output(c);
+        // A2/A3: pto2_rt_submit_aiv_task(0, params_t0)
+        // A5:    pto2_rt_submit_aiv_task(rt, 0, params_t0)
         pto2_rt_submit_aiv_task(0, params_t0);
 
         // Task 1: kernel_add (c + b → d)
@@ -346,6 +370,7 @@ else:
 ```cpp
 // Generated C++
 if (condition) {
+    // A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         PTOParam params_t0;
         // ... add_input / add_output calls ...

--- a/docs/zh-cn/dev/codegen/02-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/02-orchestration_codegen.md
@@ -84,8 +84,11 @@ PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
 }
 
 // 阶段 4：入口函数签名
+// A2/A3：
 void aicpu_orchestration_entry(OrchArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
+// A5（Ascend950）：在参数列表前增加 PTO2Runtime* rt
+// void aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)
 ```
 
 ### 阶段 5–6：张量设置
@@ -110,11 +113,14 @@ Tensor tmp = make_tensor(tmp_shapes, 2, DataType::FLOAT32);
 
 ```cpp
 // 阶段 7–9：顶层 PTO2_SCOPE 包裹所有任务提交
+// A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
 PTO2_SCOPE() {
     PTOParam params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(ext_output);
+    // A2/A3：pto2_rt_submit_aiv_task(0, params_t0)
+    // A5：   pto2_rt_submit_aiv_task(rt, 0, params_t0)
     pto2_rt_submit_aiv_task(0, params_t0);
 
     // ForStmt 示例 — 普通 for 循环，不嵌套独立的 PTO2_SCOPE
@@ -166,6 +172,18 @@ Tensor& result = ext_output;  // 别名 — result 引用 ext_output
 
 如果返回名称与 `Out`/`InOut` 参数名称匹配，则不需要别名。`InOut` 参数永不生成别名 — 其本身已是外部张量。
 
+### 后端差异（A5 / Ascend950）
+
+针对 Ascend950（`BackendType::Ascend950`）时，生成的 C++ 在三处有所不同：
+
+| 元素 | A2/A3 | A5 |
+| ---- | ----- | -- |
+| 入口函数 | `aicpu_orchestration_entry(OrchArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)` |
+| Scope 宏 | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
+| 提交调用 | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
+
+`rt` 参数是显式的 `PTO2Runtime*` 指针，A5 通过调用链传递，而非依赖线程局部存储。
+
 ### 核心类型推断
 
 代码生成器根据被调用函数的 `MemorySpace` 决定提交到 AIC（CUBE）还是 AIV（VECTOR）：
@@ -204,6 +222,8 @@ pto2_rt_submit_aiv_task(0, params_t0);
 PTOParam params_t0;
 // ... add_input / add_output / add_scalar 调用 ...
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
+// A2/A3：pto2_rt_submit_task(mixed_0, params_t0)
+// A5：   pto2_rt_submit_task(rt, mixed_0, params_t0)
 pto2_rt_submit_task(mixed_0, params_t0);
 ```
 
@@ -255,6 +275,7 @@ PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
 
 void aicpu_orchestration_entry(OrchArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
+    // 注意：A5 在参数列表前增加 PTO2Runtime* rt
     (void)arg_count;
     (void)orch_thread_num;
     (void)orch_thread_index;
@@ -268,12 +289,15 @@ void aicpu_orchestration_entry(OrchArg* orch,
     uint32_t c_shapes[2] = {16, 16};
     Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
 
+    // A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         // 任务 0: kernel_add (a + b → c)
         PTOParam params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
         params_t0.add_output(c);
+        // A2/A3：pto2_rt_submit_aiv_task(0, params_t0)
+        // A5：   pto2_rt_submit_aiv_task(rt, 0, params_t0)
         pto2_rt_submit_aiv_task(0, params_t0);
 
         // 任务 1: kernel_add (c + b → d)
@@ -345,6 +369,7 @@ else:
 ```cpp
 // 生成的 C++
 if (condition) {
+    // A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         PTOParam params_t0;
         // ... add_input / add_output 调用 ...

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -543,21 +543,21 @@ std::string GenerateConfigFunction(int expected_arg_count) {
   return oss.str();
 }
 
-// Returns the submit-task call prefix for the given core type and backend.
-// A2/A3: pto2_rt_submit_aiv_task(id, params, n)
-//         pto2_rt_submit_aic_task(id, params, n)
-// A5:    pto2_rt_submit_task(id, PTO2_WORKER_VECTOR, params, n)
-//         pto2_rt_submit_task(id, PTO2_WORKER_CUBE,   params, n)
-// Returns {func_call_with_rt_and_id_prefix, extra_worker_arg_or_empty}.
-// Caller emits: prefix << func_id << extra << ", " << task_var << ", " << n << ");\n"
-std::pair<std::string, std::string> CoreTypeToSubmitParts(CoreType core_type) {
-  bool is_a5 = pypto::backend::GetBackendType() == pypto::backend::BackendType::Ascend950;
-  if (is_a5) {
-    std::string worker = core_type == CoreType::CUBE ? "PTO2_WORKER_CUBE" : "PTO2_WORKER_VECTOR";
-    return {"pto2_rt_submit_task(", ", " + worker};
-  }
+// Returns true when targeting an A5 (Ascend950) backend.
+bool IsA5Backend() { return pypto::backend::GetBackendType() == pypto::backend::BackendType::Ascend950; }
+
+// Returns "rt, " for A5 backends (explicit PTO2Runtime* argument), "" otherwise (TLS-based).
+std::string RtArg() { return IsA5Backend() ? "rt, " : ""; }
+
+// Returns "rt" for A5 backends (PTO2_SCOPE(rt)), "" for A2/A3 (PTO2_SCOPE()).
+std::string ScopeArg() { return IsA5Backend() ? "rt" : ""; }
+
+// Returns the opening of a pto2_rt_submit_{aic,aiv}_task call up to (and including) any rt arg.
+// A2/A3: "pto2_rt_submit_aic_task("    caller appends: func_id << ", " << params << ");"
+// A5:    "pto2_rt_submit_aic_task(rt, " caller appends: func_id << ", " << params << ");"
+std::string CoreTypeToSubmitPrefix(CoreType core_type) {
   std::string func = core_type == CoreType::CUBE ? "pto2_rt_submit_aic_task" : "pto2_rt_submit_aiv_task";
-  return {func + "(", ""};
+  return func + "(" + RtArg();
 }
 
 // Removed DataTypeToPTO2Enum — now uses DataTypeToString from dtype.h
@@ -709,7 +709,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
           << stop_expr << "; " << loop_var << " += " << step_expr << ") {\n";
     indent_ += 4;
-    code_ << Indent() << "PTO2_SCOPE() {\n";
+    code_ << Indent() << "PTO2_SCOPE(" << ScopeArg() << ") {\n";
     indent_ += 4;
 
     auto saved = current_return_vars_;
@@ -1005,8 +1005,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& p : params) {
       code_ << ind << task_var << "." << p.kind << "(" << p.value << ");\n";
     }
-    auto [submit_prefix, worker_arg] = CoreTypeToSubmitParts(core_type);
-    code_ << ind << submit_prefix << func_id << worker_arg << ", " << task_var << ");\n";
+    code_ << ind << CoreTypeToSubmitPrefix(core_type) << func_id << ", " << task_var << ");\n";
 
     task_counter_++;
   }
@@ -1052,7 +1051,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     code_ << ind << "MixedKernels mixed_" << task_counter_ << " = {" << aic_id << ", " << aiv_id
           << ", INVALID_KERNEL_ID};\n";
-    code_ << ind << "pto2_rt_submit_task(mixed_" << task_counter_ << ", " << task_var << ");\n";
+    code_ << ind << "pto2_rt_submit_task(" << RtArg() << "mixed_" << task_counter_ << ", " << task_var
+          << ");\n";
 
     task_counter_++;
   }
@@ -1116,7 +1116,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   // Visit a branch body (then/else) inside a PTO2_SCOPE, with return vars scoped.
   void VisitScopedBranchBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
     indent_ += 4;
-    code_ << Indent() << "PTO2_SCOPE() {\n";
+    code_ << Indent() << "PTO2_SCOPE(" << ScopeArg() << ") {\n";
     indent_ += 4;
 
     auto saved = current_return_vars_;
@@ -1156,7 +1156,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     size_t ndim = result_type->shape_.size();
     size_t array_len = ndim == 0 ? 1 : ndim;
     std::ostringstream oss;
-    oss << "uint64_t " << emit_var << "_shapes[" << array_len << "] = {";
+    oss << "uint32_t " << emit_var << "_shapes[" << array_len << "] = {";
     if (ndim == 0) {
       oss << "1";
     } else {
@@ -1327,7 +1327,9 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   // 5. Entry function
   oss << "__attribute__((visibility(\"default\")))\n";
-  oss << "void aicpu_orchestration_entry(OrchArg* orch, int arg_count, "
+  std::string rt_param = IsA5Backend() ? "PTO2Runtime* rt, " : "";
+  oss << "void aicpu_orchestration_entry(" << rt_param
+      << "OrchArg* orch, int arg_count, "
          "int orch_thread_num, int orch_thread_index) {\n";
   oss << "    (void)arg_count;\n";
   oss << "    (void)orch_thread_num;\n";
@@ -1360,7 +1362,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.VisitStmt(func->body_);
 
   // 10. Emit generated code inside PTO2_SCOPE (required by runtime: scope_stack_top must be >= 0)
-  oss << "\n    PTO2_SCOPE() {\n";
+  oss << "\n    PTO2_SCOPE(" << ScopeArg() << ") {\n";
   oss << stmt_codegen.GetGeneratedCode();
   oss << "    }\n";
 

--- a/tests/st/runtime/test_assemble.py
+++ b/tests/st/runtime/test_assemble.py
@@ -54,9 +54,9 @@ class TileAssembleAccMatTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("a", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("b", [16, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("a", [32, 16], DataType.FP32, init_value=torch.rand),
+            TensorSpec("b", [16, 16], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
@@ -89,8 +89,8 @@ class TileAssembleVecTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
@@ -125,8 +125,8 @@ class TileAssembleRowByRowTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
@@ -161,8 +161,8 @@ class TileAssembleDoubleLoopTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("src", [32, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("src", [32, 16], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
@@ -197,8 +197,8 @@ class TileAssembleLoopColBroadcastTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("src", [32, 8], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("src", [32, 8], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 
@@ -233,8 +233,8 @@ class TileAssembleDoubleLoopBroadcastTestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [32, 32], DataType.FP32, init_value=lambda s: torch.rand(s)),
-            TensorSpec("src", [16, 16], DataType.FP32, init_value=lambda s: torch.rand(s)),
+            TensorSpec("x", [32, 32], DataType.FP32, init_value=torch.rand),
+            TensorSpec("src", [16, 16], DataType.FP32, init_value=torch.rand),
             TensorSpec("y", [32, 32], DataType.FP32, is_output=True),
         ]
 


### PR DESCRIPTION
Add explicit PTO2Runtime* rt support for Ascend950: prepend rt parameter to the entry function signature, pass it to PTO2_SCOPE() and all pto2_rt_submit_*_task() / pto2_rt_submit_task() call sites. A2/A3 paths are unchanged (no rt argument).

Refactor CoreTypeToSubmitParts() into focused helpers IsA5Backend(), RtArg(), ScopeArg(), and CoreTypeToSubmitPrefix() to reduce complexity.

Also fix shape array type from uint64_t to uint32_t and simplify test_assemble.py init_value lambdas.

Update EN/ZH orchestration codegen docs with a Backend Differences table and inline A2/A3 vs A5 annotations throughout code examples.