### PR TITLE
test(st): Add dynamic-shape paged attention with DynVar IR caching

### DIFF
--- a/examples/ir_parser/batch_paged_attention_example.py
+++ b/examples/ir_parser/batch_paged_attention_example.py
@@ -157,16 +157,16 @@ def BuildBatchPagedAttentionProgram(
             self,
             sij_batch: pl.Tensor[[batch_q_tile, block_size], pl.FP32],
             pij_batch: pl.Out[pl.Tensor[[batch_q_tile, block_size], pl.BF16]],
-            mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
-            lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
+            mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
+            lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
             scale_value: pl.Scalar[pl.FP32],
             context_lens: pl.Tensor[[batch], pl.INT32],
             batch_count: pl.Scalar[pl.INT64],
             block_idx: pl.Scalar[pl.INT64],
         ) -> tuple[
             pl.Tensor[[batch_q_tile, block_size], pl.BF16],
-            pl.Tensor[[batch_q_tile, 1], pl.FP32],
-            pl.Tensor[[batch_q_tile, 1], pl.FP32],
+            pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
+            pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
         ]:
             """Softmax prepare: scale, row_max, exp, row_sum (VECTOR, func_id=1).
 

--- a/examples/ir_parser/dynamic_paged_attention_example.py
+++ b/examples/ir_parser/dynamic_paged_attention_example.py
@@ -1,0 +1,594 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Dynamic Paged Attention Example
+
+InCore kernel type annotations use pl.dynamic() variables (Q_HEADS, HEAD_DIM_DYN,
+BLOCK_SIZE_DYN), while load operations use closure variables (_Q_TILE, _HEAD_DIM,
+_BLOCK_SIZE) captured from build_dynamic_paged_attention_program().
+Orchestration-level tensor shapes also use pl.dynamic() variables so the program
+accepts any batch size at runtime.
+"""
+
+# DSL function bodies are parsed as AST — dynamic var names look undefined to pyright.
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+import torch  # type: ignore[import]
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+from pypto.runtime import RunConfig, TensorSpec, run
+
+# ---------------------------------------------------------------------------
+# Module-level dynamic variables — used only in InCore kernel type annotations.
+# Load operations inside the kernels use closure variables from the builder instead.
+# ---------------------------------------------------------------------------
+
+Q_HEADS = pl.dynamic("Q_HEADS")  # query tile rows   (e.g. 16)
+HEAD_DIM_DYN = pl.dynamic("HEAD_DIM_DYN")  # head dimension    (e.g. 128)
+BLOCK_SIZE_DYN = pl.dynamic("BLOCK_SIZE_DYN")  # KV block size     (e.g. 128)
+BATCH_DYN = pl.dynamic("BATCH_DYN")  # batch size (number of requests)
+QUERY_ROWS_DYN = pl.dynamic("QUERY_ROWS_DYN")  # batch * num_heads
+KEY_CACHE_ROWS_DYN = pl.dynamic("KEY_CACHE_ROWS_DYN")  # batch * max_num_blocks_per_req * block_size
+BLOCK_TABLE_FLAT_DYN = pl.dynamic("BLOCK_TABLE_FLAT_DYN")  # batch * max_num_blocks_per_req
+
+
+# ---------------------------------------------------------------------------
+# Program builders
+# ---------------------------------------------------------------------------
+
+
+def build_dynamic_paged_attention_program(
+    q_tile: int,
+    head_dim: int,
+    block_size: int,
+):
+    """Build a paged-attention @pl.program whose InCore kernels use dynamic shapes.
+
+    InCore kernel type annotations reference module-level pl.dynamic() variables so
+    shapes are resolved at runtime.  Load operations use closure variables captured
+    from the builder parameters (_Q_TILE, _HEAD_DIM, _BLOCK_SIZE).
+
+    Parameters
+    ----------
+    q_tile:     query-head tile size (number of query heads processed per InCore call)
+    head_dim:   per-head feature dimension
+    block_size: KV-cache block size (rows per physical block)
+    """
+    # Tile-size constants captured as closures by the InCore kernels below.
+    _Q_TILE: int = q_tile
+    _HEAD_DIM: int = head_dim
+    _BLOCK_SIZE: int = block_size
+
+    # -----------------------------------------------------------------------
+    # InCore kernels — defined here to capture _Q_TILE, _HEAD_DIM, _BLOCK_SIZE
+    # as closure variables; type annotations use module-level pl.dynamic() vars.
+    # -----------------------------------------------------------------------
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def dyn_kernel_init_inplace(
+        oi: pl.Out[pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32]],
+        li: pl.Out[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+        mi: pl.Out[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+    ) -> tuple[
+        pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32],
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+    ]:
+        """No-op passthrough: binds concrete tensor shapes to dynamic type annotations.
+
+        pl.create_tensor zero-initialises the buffers before this call; this
+        function exists solely to propagate the dynamic shape at the call site.
+        """
+        return oi, li, mi
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def dyn_kernel_qk_matmul(
+        qi: pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.BF16],
+        kj: pl.Tensor[[BLOCK_SIZE_DYN, HEAD_DIM_DYN], pl.BF16],
+        output: pl.Out[pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.FP32]],
+    ) -> pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.FP32]:
+        """QK matmul: output = qi @ kj.T (CUBE). kj transposed on load."""
+        qi_l1 = pl.load(qi, [0, 0], [_Q_TILE, _HEAD_DIM], target_memory=pl.MemorySpace.Mat)
+        kj_l1 = pl.load(
+            kj, [0, 0], [_HEAD_DIM, _BLOCK_SIZE], target_memory=pl.MemorySpace.Mat, transpose=True
+        )
+        qi_l0a = pl.move(qi_l1, target_memory=pl.MemorySpace.Left)
+        kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right)
+        sij_l0c = pl.matmul(qi_l0a, kj_l0b)
+        out = pl.store(sij_l0c, [0, 0], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def dyn_kernel_softmax_prepare(
+        sij: pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.FP32],
+        scale: pl.Scalar[pl.FP32],
+        out_pij: pl.Out[pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.BF16]],
+        out_mi: pl.Out[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+        out_li: pl.Out[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+    ) -> tuple[
+        pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.BF16],
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+    ]:
+        """Scale sij, compute row_max (mi), exp(sij-mi), cast to BF16, row_sum (li). VECTOR."""
+        s_tile = pl.load(sij, [0, 0], [_Q_TILE, _BLOCK_SIZE], target_memory=pl.MemorySpace.Vec)
+        scaled = pl.mul(s_tile, scale)
+        tmp_tile = pl.create_tile([_Q_TILE, _BLOCK_SIZE], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        mi_tile = pl.row_max(scaled, tmp_tile)
+        sij_centered = pl.row_expand_sub(scaled, mi_tile)
+        exp_tile = pl.exp(sij_centered)
+        pij_tile_bf16 = pl.cast(exp_tile, target_type=pl.BF16)
+        pij_tile = pl.cast(pij_tile_bf16, target_type=pl.FP32)
+        li_tile = pl.row_sum(pij_tile, tmp_tile)
+        out_pij = pl.store(pij_tile_bf16, [0, 0], out_pij)
+        out_mi = pl.store(mi_tile, [0, 0], out_mi)
+        out_li = pl.store(li_tile, [0, 0], out_li)
+        return out_pij, out_mi, out_li
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def dyn_kernel_pv_matmul(
+        pij: pl.Tensor[[Q_HEADS, BLOCK_SIZE_DYN], pl.BF16],
+        vj: pl.Tensor[[BLOCK_SIZE_DYN, HEAD_DIM_DYN], pl.BF16],
+        output: pl.Out[pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32]],
+    ) -> pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32]:
+        """PV matmul: output = pij @ vj (CUBE)."""
+        pij_l1 = pl.load(pij, [0, 0], [_Q_TILE, _BLOCK_SIZE], target_memory=pl.MemorySpace.Mat)
+        vj_l1 = pl.load(vj, [0, 0], [_BLOCK_SIZE, _HEAD_DIM], target_memory=pl.MemorySpace.Mat)
+        pij_l0a = pl.move(pij_l1, target_memory=pl.MemorySpace.Left)
+        vj_l0b = pl.move(vj_l1, target_memory=pl.MemorySpace.Right)
+        oi_l0c = pl.matmul(pij_l0a, vj_l0b)
+        out = pl.store(oi_l0c, [0, 0], output)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def dyn_kernel_online_update(
+        mij: pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        lij: pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        oi_new: pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32],
+        mi: pl.InOut[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+        li: pl.InOut[pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN]],
+        oi: pl.InOut[pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32]],
+        dst: pl.Out[pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32]],
+        is_first: pl.Scalar[pl.BOOL],
+        is_last: pl.Scalar[pl.BOOL],
+    ) -> tuple[
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        pl.Tensor[[Q_HEADS, 1], pl.FP32, pl.DN],
+        pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32],
+        pl.Tensor[[Q_HEADS, HEAD_DIM_DYN], pl.FP32],
+    ]:
+        """Merge current block's (mij, lij, oi_new) into running accumulators (mi, li, oi). VECTOR.
+
+        First block (is_first=True): directly assign accumulators, no rescaling.
+        Subsequent blocks: mi_new=max(mi,mij), alpha=exp(mi-mi_new), beta=exp(mij-mi_new),
+          li <- alpha*li + beta*lij,  oi <- alpha*oi + beta*oi_new.
+        Last block (is_last=True): write oi/li to dst; otherwise dst=zeros.
+
+        Reshape between [Q_TILE,1] and [1,Q_TILE] is required because row_expand_mul
+        broadcasts along the column axis while element-wise ops need consistent layout.
+        """
+        mij_tile = pl.load(mij, [0, 0], [_Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        lij_tile = pl.load(lij, [0, 0], [_Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        oi_new_tile = pl.load(oi_new, [0, 0], [_Q_TILE, _HEAD_DIM], target_memory=pl.MemorySpace.Vec)
+        mi_tile = pl.load(mi, [0, 0], [_Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        li_tile = pl.load(li, [0, 0], [_Q_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        oi_tile = pl.load(oi, [0, 0], [_Q_TILE, _HEAD_DIM], target_memory=pl.MemorySpace.Vec)
+
+        if is_first:
+            mi_out = pl.store(mij_tile, [0, 0], mi)
+            li_out = pl.store(lij_tile, [0, 0], li)
+            oi_out = pl.store(oi_new_tile, [0, 0], oi)
+            if is_last:
+                dst_tile = pl.row_expand_div(oi_new_tile, lij_tile)
+                dst_out = pl.store(dst_tile, [0, 0], dst)
+            else:
+                zero_tile = pl.tile.full([_Q_TILE, _HEAD_DIM], dtype=pl.FP32, value=0.0)
+                dst_out = pl.store(zero_tile, [0, 0], dst)
+        else:
+            mi_tile_nd = pl.reshape(mi_tile, [1, _Q_TILE])
+            mij_tile_nd = pl.reshape(mij_tile, [1, _Q_TILE])
+            li_tile_nd = pl.reshape(li_tile, [1, _Q_TILE])
+            lij_tile_nd = pl.reshape(lij_tile, [1, _Q_TILE])
+
+            mi_new = pl.maximum(mi_tile_nd, mij_tile_nd)
+            mi_diff = pl.sub(mi_tile_nd, mi_new)
+            alpha = pl.exp(mi_diff)
+            mij_diff = pl.sub(mij_tile_nd, mi_new)
+            beta = pl.exp(mij_diff)
+
+            li_scaled = pl.mul(alpha, li_tile_nd)
+            lij_scaled = pl.mul(beta, lij_tile_nd)
+            li_updated = pl.add(li_scaled, lij_scaled)
+
+            alpha_dn = pl.reshape(alpha, [_Q_TILE, 1])
+            oi_scaled = pl.row_expand_mul(oi_tile, alpha_dn)
+            beta_dn = pl.reshape(beta, [_Q_TILE, 1])
+            oi_new_scaled = pl.row_expand_mul(oi_new_tile, beta_dn)
+            oi_updated = pl.add(oi_scaled, oi_new_scaled)
+
+            mi_new_dn = pl.reshape(mi_new, [_Q_TILE, 1])
+            li_updated_dn = pl.reshape(li_updated, [_Q_TILE, 1])
+
+            mi_out = pl.store(mi_new_dn, [0, 0], mi)
+            li_out = pl.store(li_updated_dn, [0, 0], li)
+            oi_out = pl.store(oi_updated, [0, 0], oi)
+
+            if is_last:
+                dst_tile = pl.row_expand_div(oi_updated, li_updated_dn)
+                dst_out = pl.store(dst_tile, [0, 0], dst)
+            else:
+                zero_tile = pl.tile.full([_Q_TILE, _HEAD_DIM], dtype=pl.FP32, value=0.0)
+                dst_out = pl.store(zero_tile, [0, 0], dst)
+
+        return mi_out, li_out, oi_out, dst_out
+
+    # -----------------------------------------------------------------------
+    # Program definition
+    # -----------------------------------------------------------------------
+
+    @pl.program
+    class DynamicPagedAttentionProgram:
+        """Paged attention with dynamic-shape InCore kernels (online softmax).
+
+        InCore kernels are defined inside build_dynamic_paged_attention_program()
+        and capture _Q_TILE, _HEAD_DIM, _BLOCK_SIZE as closure variables for
+        load tile sizes, while their type annotations reference module-level
+        pl.dynamic() variables (Q_HEADS, HEAD_DIM_DYN, BLOCK_SIZE_DYN).
+        The 5-kernel pipeline and orchestration loops are identical in structure
+        to the static version in paged_attention_example.py.
+        """
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def paged_attention(
+            self,
+            query: pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.BF16],
+            key_cache: pl.Tensor[[HEAD_DIM_DYN, KEY_CACHE_ROWS_DYN], pl.BF16, pl.DN],
+            value_cache: pl.Tensor[[KEY_CACHE_ROWS_DYN, HEAD_DIM_DYN], pl.BF16],
+            block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+            context_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+            out: pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.FP32],
+        ) -> pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.FP32]:
+            """Paged attention orchestration with dynamic-shape InCore kernels.
+
+            Same 5-stage pipeline as the static version (init_inplace,
+            qk_matmul, softmax_prepare, pv_matmul, online_update).  InCore
+            kernels are closures defined inside build_dynamic_paged_attention_program()
+            and referenced here by their local names (dyn_kernel_*).
+            Shape derivations: batch = context_lens.dim(0),
+            head_dim = query.dim(1), num_heads = query.dim(0) // batch,
+            block_num = block_table.dim(0) // batch,
+            block_size = value_cache.dim(0) // block_table.dim(0).
+            """
+            batch_cfg: pl.Scalar[pl.INT64] = pl.tensor.dim(context_lens, 0)
+            query_rows: pl.Scalar[pl.INT64] = pl.tensor.dim(query, 0)
+            head_dim_cfg: pl.Scalar[pl.INT64] = pl.tensor.dim(query, 1)
+            value_cache_rows: pl.Scalar[pl.INT64] = pl.tensor.dim(value_cache, 0)
+            block_table_size: pl.Scalar[pl.INT64] = pl.tensor.dim(block_table, 0)
+            num_heads_cfg: pl.Scalar[pl.INT64] = query_rows // batch_cfg
+            block_size_cfg: pl.Scalar[pl.INT64] = value_cache_rows // block_table_size
+            block_num_cfg: pl.Scalar[pl.INT64] = block_table_size // batch_cfg
+
+            q_head_num = num_heads_cfg
+            # ceil-divide: number of q_tile-sized chunks needed to cover all query heads
+            q_loop_cfg = (q_head_num + q_tile - 1) // q_tile
+
+            for b_idx in pl.range(batch_cfg):
+                cur_seq = pl.tensor.read(context_lens, [b_idx])
+                # ceil-divide: number of KV blocks touched by this request
+                bn_this_batch = (cur_seq + block_size_cfg - 1) // block_size_cfg
+                for q_idx in pl.range(q_loop_cfg):
+                    # Row offset into the flat query tensor for this (batch, q_tile) tile
+                    cur_offset = b_idx * q_head_num + q_idx * q_tile
+
+                    # Allocate zero-initialised accumulators for the online softmax state
+                    oi_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                        [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
+                    )
+                    li_buf: pl.Tensor[[q_tile, 1], pl.FP32, pl.DN] = pl.create_tensor(
+                        [q_tile, 1],
+                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        layout=pl.DN,
+                    )
+                    mi_buf: pl.Tensor[[q_tile, 1], pl.FP32, pl.DN] = pl.create_tensor(
+                        [q_tile, 1],
+                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        layout=pl.DN,
+                    )
+                    # Bind concrete tensor shapes to dynamic type annotations (no-op passthrough)
+                    oi, li_update, mi_update = dyn_kernel_init_inplace(oi_buf, li_buf, mi_buf)
+
+                    for bn in pl.range(bn_this_batch):
+                        # Slice the query tile for this head-tile and batch entry
+                        qi: pl.Tensor[[q_tile, head_dim_cfg], pl.BF16] = pl.slice(
+                            query,
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [cur_offset, 0],
+                        )
+
+                        # Look up the physical block index in the page table
+                        cur_block_idx = pl.tensor.read(block_table, [b_idx * block_num_cfg + bn])
+                        # Number of valid tokens in this block (last block may be partial)
+                        valid_len = pl.min(block_size_cfg, cur_seq - bn * block_size_cfg)
+                        # Starting row of this physical block in the flat KV-cache pool
+                        kv_block_row = cur_block_idx * block_size_cfg
+
+                        # Slice the key block: key_cache is stored as [head_dim, KV_rows] (DN layout)
+                        kj: pl.Tensor[[head_dim_cfg, block_size_cfg], pl.BF16, pl.DN] = pl.slice(
+                            key_cache,
+                            [head_dim_cfg, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [kv_block_row, 0],
+                        )
+                        # Slice the value block: value_cache is stored as [KV_rows, head_dim]
+                        vj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.slice(
+                            value_cache,
+                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [kv_block_row, 0],
+                        )
+
+                        # Stage 1: QK matmul — sij[q_tile, block_size] = qi @ kj.T
+                        sij_buf: pl.Tensor[[q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
+                        )
+                        sij = dyn_kernel_qk_matmul(qi, kj, sij_buf)
+
+                        # Mask out padding columns beyond valid_len to avoid
+                        # including out-of-range tokens in the softmax
+                        sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.slice(
+                            sij,
+                            [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                            [0, 0],
+                        )
+
+                        # Stage 2: softmax prepare — scale, row_max (mi), exp, row_sum (li)
+                        pij_f16_buf: pl.Tensor[[q_tile, block_size_cfg], pl.BF16] = pl.create_tensor(
+                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.BF16,
+                        )
+                        mi_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
+                            [q_tile, 1],
+                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            layout=pl.DN,
+                        )
+                        li_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
+                            [q_tile, 1],
+                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            layout=pl.DN,
+                        )
+                        pij_f16, mi, li = dyn_kernel_softmax_prepare(
+                            sij_valid,
+                            1.0,  # type: ignore[reportArgumentType]
+                            pij_f16_buf,
+                            mi_sm_buf,
+                            li_sm_buf,  # type: ignore[reportArgumentType]
+                        )
+
+                        # Stage 3: PV matmul — oi_tmp[q_tile, head_dim] = pij @ vj
+                        oi_tmp_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
+                        )
+                        oi_tmp = dyn_kernel_pv_matmul(pij_f16, vj, oi_tmp_buf)
+
+                        # Determine position flags for the online softmax update kernel
+                        if bn == 0:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        else:
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                        if bn == bn_this_batch - 1:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                        else:
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+
+                        # Stage 4: online update — merge (mij, lij, oi_new) into (mi, li, oi)
+                        # and write final normalised output on the last block
+                        out_view_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.slice(
+                            out,
+                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [cur_offset, 0],
+                        )
+                        mi_update, li_update, oi, out_view = dyn_kernel_online_update(
+                            mi,
+                            li,
+                            oi_tmp,
+                            mi_update,
+                            li_update,
+                            oi,
+                            out_view_buf,
+                            is_first,
+                            is_last,
+                        )
+
+            return out
+
+    return DynamicPagedAttentionProgram
+
+
+def golden(tensors: dict, params: dict | None = None) -> None:
+    """Reference paged-attention computation (torch) for the dynamic-shape program.
+
+    Derives all shape parameters from tensor dimensions instead of a config tensor,
+    matching the orchestration function's pl.tensor.dim() derivations.
+    Scale is hardcoded to 1.0 to match the orchestration function.
+
+    Args:
+        tensors: Dict mapping tensor names to torch tensors.
+        params: Unused.
+    """
+    context_lens = tensors["context_lens"]
+    query = tensors["query"]
+    key_cache = tensors["key_cache"]
+    value_cache = tensors["value_cache"]
+    block_table_flat = tensors["block_table"]
+
+    batch = context_lens.shape[0]
+    num_heads = query.shape[0] // batch
+    head_dim = query.shape[1]
+    # Mirrors the orchestration function's pl.tensor.dim() derivation:
+    # block_size = value_cache.rows / block_table.rows  (rows per physical block)
+    block_size = value_cache.shape[0] // block_table_flat.shape[0]
+    max_num_blocks_per_req = block_table_flat.shape[0] // batch
+    scale = 1.0
+
+    # Reshape flat tensors into 3-D views for batch-matmul
+    query_3d = query.float().reshape(batch, num_heads, head_dim)
+    total_pool_blocks = batch * max_num_blocks_per_req
+    key_cache_3d = key_cache.float().reshape(total_pool_blocks, block_size, head_dim)
+    value_cache_3d = value_cache.float().reshape(total_pool_blocks, block_size, head_dim)
+    block_table = block_table_flat.reshape(batch, max_num_blocks_per_req)
+
+    out = torch.zeros((batch, num_heads, head_dim), dtype=torch.float32)
+    q_tile = 16
+    # Maximum number of KV blocks across all requests in the batch
+    max_bn = int((context_lens.max().item() + block_size - 1) // block_size)
+
+    for q_offset in range(0, num_heads, q_tile):
+        q_tile_size = min(q_tile, num_heads - q_offset)
+        qi = query_3d[:, q_offset : q_offset + q_tile_size, :]  # [batch, q_tile, head_dim]
+        # Online softmax state: sentinel init so the first block is handled by the
+        # general update formula (mi=-inf makes alpha=0, beta=1 on the first merge).
+        mi = torch.full((batch, q_tile_size, 1), float("-inf"))
+        li = torch.zeros((batch, q_tile_size, 1))
+        oi = torch.zeros((batch, q_tile_size, head_dim))
+
+        for bn in range(max_bn):
+            # valid_lens[b]: how many tokens of block bn are valid for request b
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            if not (valid_lens > 0).any():
+                break
+            block_indices = block_table[:, bn]  # [batch]
+            kj_all = key_cache_3d[block_indices]  # [batch, block_size, head_dim]
+            vj_all = value_cache_3d[block_indices]  # [batch, block_size, head_dim]
+
+            # Stage 1: QK matmul — sij[batch, q_tile, block_size] = qi @ kj.T * scale
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale  # [batch, q_tile, block_size]
+            # Mask padding columns so they don't affect row_max / row_sum
+            pos = torch.arange(block_size).unsqueeze(0)  # [1, block_size]
+            valid_mask = (pos < valid_lens.unsqueeze(1)).unsqueeze(1)  # [batch, 1, block_size]
+            sij = sij.masked_fill(~valid_mask, float("-inf"))
+
+            # Stage 2: softmax prepare — row_max, exp, cast, row_sum
+            mij = sij.max(dim=-1, keepdim=True)[0].clamp(min=-1e30)  # [batch, q_tile, 1]
+            pij = torch.exp(sij - mij).masked_fill(~valid_mask, 0.0)
+            # Simulate BF16 cast to match the InCore kernel's precision
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # [batch, q_tile, 1]
+
+            # Stage 3: PV matmul — oi_new[batch, q_tile, head_dim] = pij @ vj
+            oi_new = torch.bmm(pij, vj_all)  # [batch, q_tile, head_dim]
+
+            # Stage 4: online update — unconditional merge; the sentinel mi=-inf ensures
+            # alpha=0/beta=1 on the first valid block, making explicit bn==0 branching
+            # unnecessary and correct for heterogeneous per-request starting points.
+            mi_new = torch.maximum(mi, mij)
+            alpha = torch.exp(mi - mi_new)  # rescale factor for old accumulator
+            beta = torch.exp(mij - mi_new)  # rescale factor for new block
+            li = alpha * li + beta * lij
+            oi = alpha * oi + beta * oi_new
+            mi = mi_new
+
+        assert (li > 0).any(), "No KV blocks processed for this query tile"
+        out[:, q_offset : q_offset + q_tile_size, :] = oi / li
+
+    tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
+
+
+def build_tensor_specs(
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    max_num_blocks_per_req: int,
+    context_len: int,
+) -> list[TensorSpec]:
+    """Build the TensorSpec list matching the dynamic paged_attention orchestration signature.
+
+    The dynamic program derives all shape parameters from tensor dimensions at
+    runtime, so there is no config tensor (unlike the static version).
+
+    Args:
+        batch: Number of requests in the batch.
+        num_heads: Number of query heads.
+        head_dim: Per-head feature dimension.
+        block_size: KV-cache block size (rows per physical block).
+        max_num_blocks_per_req: Maximum number of KV blocks per request.
+        context_len: Number of valid tokens per request.
+    """
+    query_rows = batch * num_heads
+    key_cache_rows = batch * max_num_blocks_per_req * block_size
+    block_table_flat_size = batch * max_num_blocks_per_req
+
+    context_lens_data = torch.full((batch,), context_len, dtype=torch.int32)
+    block_table_data = torch.randint(
+        0, max(block_table_flat_size, 1), size=(batch, max_num_blocks_per_req), dtype=torch.int32
+    ).flatten()
+
+    return [
+        TensorSpec("query", [query_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("key_cache", [key_cache_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("value_cache", [key_cache_rows, head_dim], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("block_table", [block_table_flat_size], torch.int32, init_value=block_table_data),
+        TensorSpec("context_lens", [batch], torch.int32, init_value=context_lens_data),
+        TensorSpec("out", [query_rows, head_dim], torch.float32, is_output=True),
+    ]
+
+
+def main():
+    """Run a single dynamic paged-attention example and verify against the golden reference.
+
+    Uses a large batch (64) with 16 query heads, 128-dim heads, and 128-token KV
+    blocks.  The program is built once via build_dynamic_paged_attention_program()
+    and executed on the target device with tolerance atol/rtol=2e-2.
+    """
+    batch = 64
+    num_heads = 16
+    head_dim = 128
+    block_size = 128
+    max_model_len = 32768
+    context_len = 8192
+    q_tile = 16
+    max_num_blocks_per_req = max_model_len // block_size  # 256
+
+    program = build_dynamic_paged_attention_program(
+        q_tile=q_tile,
+        head_dim=head_dim,
+        block_size=block_size,
+    )
+
+    tensor_specs = build_tensor_specs(
+        batch=batch,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        max_num_blocks_per_req=max_num_blocks_per_req,
+        context_len=context_len,
+    )
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden,
+        config=RunConfig(
+            platform="a2a3",
+            device_id=11,
+            rtol=2e-2,
+            atol=2e-2,
+            strategy=OptimizationStrategy.Default,
+            dump_passes=True,
+            backend_type=BackendType.Ascend910B_PTO,
+        ),
+    )
+    print(f"Result: {result}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -61,7 +61,7 @@ def kernel_init_inplace(
 @pl.function(type=pl.FunctionType.InCore)
 def kernel_qk_matmul(
     qi: pl.Tensor[[16, 128], pl.BF16],
-    kj: pl.Tensor[[128, 128], pl.BF16, pl.DN],
+    kj: pl.Tensor[[128, 128], pl.BF16],
     output: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
 ) -> pl.Tensor[[16, 128], pl.FP32]:
     """QK matmul: sij = qi @ kj.T (CUBE). kj transposed during load to L1."""
@@ -79,12 +79,12 @@ def kernel_softmax_prepare(
     sij: pl.Tensor[[16, 128], pl.FP32],
     scale: pl.Scalar[pl.FP32],
     out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
-    out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
-    out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
+    out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
 ) -> tuple[
     pl.Tensor[[16, 128], pl.BF16],
-    pl.Tensor[[16, 1], pl.FP32],
-    pl.Tensor[[16, 1], pl.FP32],
+    pl.Tensor[[16, 1], pl.FP32, pl.DN],
+    pl.Tensor[[16, 1], pl.FP32, pl.DN],
 ]:
     """Softmax prepare: scale, row_max, exp, row_sum (VECTOR)."""
     s_tile = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
@@ -108,12 +108,12 @@ def kernel_softmax_prepare_unaligned(
     scale: pl.Scalar[pl.FP32],
     valid_len: pl.Scalar[pl.INDEX],
     out_pij: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
-    out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
-    out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    out_mi: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
+    out_li: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
 ) -> tuple[
     pl.Tensor[[16, 128], pl.BF16],
-    pl.Tensor[[16, 1], pl.FP32],
-    pl.Tensor[[16, 1], pl.FP32],
+    pl.Tensor[[16, 1], pl.FP32, pl.DN],
+    pl.Tensor[[16, 1], pl.FP32, pl.DN],
 ]:
     """Softmax prepare with unaligned valid_len: load, set_validshape, fillpad, scale, softmax (VECTOR)."""
     s_tile = pl.load(sij, [0, 0], [16, 128], valid_shapes=[16, valid_len], target_memory=pl.MemorySpace.Vec)

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -635,10 +635,14 @@ class TypeResolver:
             if isinstance(elem, int):
                 dims.append(elem)
             elif isinstance(elem, DynVar):
-                name = elem.name
-                if name not in self._dyn_var_cache:
-                    self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
-                dims.append(self._dyn_var_cache[name])
+                if elem._ir_var is None:
+                    name = elem.name
+                    if name not in self._dyn_var_cache:
+                        self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
+                    elem._ir_var = self._dyn_var_cache[name]
+                elif elem.name not in self._dyn_var_cache:
+                    self._dyn_var_cache[elem.name] = elem._ir_var
+                dims.append(elem._ir_var)
             else:
                 raise ParserTypeError(
                     f"Shape '{source_name}' element {i} must be int or pl.dynamic(), "
@@ -661,10 +665,14 @@ class TypeResolver:
         if isinstance(value, int):
             return value
         if isinstance(value, DynVar):
-            name = value.name
-            if name not in self._dyn_var_cache:
-                self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
-            return self._dyn_var_cache[name]
+            if value._ir_var is None:
+                name = value.name
+                if name not in self._dyn_var_cache:
+                    self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
+                value._ir_var = self._dyn_var_cache[name]
+            elif value.name not in self._dyn_var_cache:
+                self._dyn_var_cache[value.name] = value._ir_var
+            return value._ir_var
         raise ParserTypeError(
             f"Shape variable '{source_name}' must be int or pl.dynamic(), got {type(value).__name__}",
             span=span,
@@ -1121,11 +1129,15 @@ class TypeResolver:
             if name in self.expr_evaluator.closure_vars:
                 value = self.expr_evaluator.closure_vars[name]
                 if isinstance(value, DynVar):
-                    if value.name not in self._dyn_var_cache:
-                        self._dyn_var_cache[value.name] = ir.Var(
-                            value.name, ir.ScalarType(DataType.INDEX), self._get_span(node)
-                        )
-                    return self._dyn_var_cache[value.name]
+                    if value._ir_var is None:
+                        if value.name not in self._dyn_var_cache:
+                            self._dyn_var_cache[value.name] = ir.Var(
+                                value.name, ir.ScalarType(DataType.INDEX), self._get_span(node)
+                            )
+                        value._ir_var = self._dyn_var_cache[value.name]
+                    elif value.name not in self._dyn_var_cache:
+                        self._dyn_var_cache[value.name] = value._ir_var
+                    return value._ir_var
                 if isinstance(value, int):
                     return ir.ConstInt(value, DataType.INDEX, self._get_span(node))
                 raise ParserTypeError(

--- a/python/pypto/language/typing/dynamic.py
+++ b/python/pypto/language/typing/dynamic.py
@@ -9,6 +9,11 @@
 
 """Dynamic shape variables for use in type annotations."""
 
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
 
 class DynVar:
     """Dynamic shape variable for use in type annotations.
@@ -28,6 +33,10 @@ class DynVar:
         if not name.isidentifier():
             raise ValueError(f"DynVar name must be a valid identifier, got {name!r}")
         self.name = name
+        # Lazily populated on first use by TypeResolver.  Once set, all parsers
+        # that encounter this DynVar object share the same ir.Var instance,
+        # ensuring structural equality across @pl.function boundaries.
+        self._ir_var: Any = None
 
     def __repr__(self) -> str:
         return f"DynVar({self.name!r})"

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1169,7 +1169,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     INTERNAL_CHECK(it->second.offset_tuple != nullptr)
         << "Internal error: tensor.assemble offset must be MakeTuple";
-    oss << "uint64_t " << emit_var << "_offsets[" << array_len << "] = {";
+    oss << "uint32_t " << emit_var << "_offsets[" << array_len << "] = {";
     if (ndim == 0) {
       oss << "0";
     } else {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -991,7 +991,22 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       }
       stream_ << "]";
 
-      stream_ << " : !pto.tensor_view<";
+      std::string layout_str = "nd";
+      if (tensor_type->tensor_view_.has_value()) {
+        switch (tensor_type->tensor_view_.value().layout) {
+          case ir::TensorLayout::DN:
+            layout_str = "dn";
+            break;
+          case ir::TensorLayout::NZ:
+            layout_str = "nz";
+            break;
+          case ir::TensorLayout::ND:
+            break;
+        }
+      }
+      stream_ << " {layout = #pto.layout<" << layout_str << ">}";
+
+      stream_ << ": !pto.tensor_view<";
       for (size_t j = 0; j < tensor_type->shape_.size(); j++) {
         if (j > 0) stream_ << "x";
         stream_ << "?";

--- a/tests/st/codegen/test_batch_paged_attention.py
+++ b/tests/st/codegen/test_batch_paged_attention.py
@@ -123,7 +123,7 @@ class BatchQKMatmulTestCase(PTOTestCase):
             def KernelQkMatmul(
                 self,
                 query: pl.Tensor[[query_rows, head_dim], pl.BF16],
-                key_cache: pl.Tensor[[head_dim, key_cache_rows], pl.BF16, pl.DN],
+                key_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
                 sij_batch: pl.Out[pl.Tensor[[batch_q_tile, block_size], pl.FP32]],
                 block_table: pl.Tensor[[block_table_flat_size], pl.INT32],
                 batch_count: pl.Scalar[pl.INDEX],
@@ -160,7 +160,7 @@ class BatchQKMatmulTestCase(PTOTestCase):
             def Orchestrator(
                 self,
                 query: pl.Tensor[[query_rows, head_dim], pl.BF16],
-                key_cache: pl.Tensor[[head_dim, key_cache_rows], pl.BF16, pl.DN],
+                key_cache: pl.Tensor[[key_cache_rows, head_dim], pl.BF16],
                 block_table: pl.Tensor[[block_table_flat_size], pl.INT32],
                 config: pl.Tensor[[5], pl.INT64],
                 sij_batch: pl.Out[pl.Tensor[[batch_q_tile, block_size], pl.FP32]],
@@ -282,14 +282,14 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                 self,
                 sij_batch: pl.Tensor[[batch_q_tile, block_size], pl.FP32],
                 pij_batch: pl.Out[pl.Tensor[[batch_q_tile, block_size], pl.BF16]],
-                mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
-                lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
+                mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
+                lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
                 scale_value: pl.Scalar[pl.FP32],
                 context_lens: pl.Tensor[[batch], pl.INT32],
             ) -> tuple[
                 pl.Tensor[[batch_q_tile, block_size], pl.BF16],
-                pl.Tensor[[batch_q_tile, 1], pl.FP32],
-                pl.Tensor[[batch_q_tile, 1], pl.FP32],
+                pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
+                pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
             ]:
                 for b in pl.range(batch):
                     cur_seq = pl.tensor.read(context_lens, [b])
@@ -332,12 +332,12 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                 scale_config: pl.Tensor[[1], pl.FP32],
                 config: pl.Tensor[[2], pl.INT64],
                 pij_batch: pl.Out[pl.Tensor[[batch_q_tile, block_size], pl.BF16]],
-                mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
-                lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
+                mij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
+                lij_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN]],
             ) -> tuple[
                 pl.Tensor[[batch_q_tile, block_size], pl.BF16],
-                pl.Tensor[[batch_q_tile, 1], pl.FP32],
-                pl.Tensor[[batch_q_tile, 1], pl.FP32],
+                pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
+                pl.Tensor[[batch_q_tile, 1], pl.FP32, pl.DN],
             ]:
                 scale_value: pl.Scalar[pl.FP32] = pl.tensor.read(scale_config, [0])
 

--- a/tests/st/codegen/test_dynamic_paged_attention.py
+++ b/tests/st/codegen/test_dynamic_paged_attention.py
@@ -1,0 +1,249 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Dynamic shape tests for Paged Attention kernels.
+
+Dynamic shapes — InCore kernel type annotations use pl.dynamic() variables
+(Q_HEADS, HEAD_DIM_DYN, BLOCK_SIZE_DYN) instead of literal numbers, while
+load operations use concrete closure variables (_Q_TILE, _HEAD_DIM, _BLOCK_SIZE)
+captured from build_dynamic_paged_attention_program() for tile sizes.
+Matches the DynShapeAddTestCase pattern from test_dynamic_shape.py.
+
+Test cases:
+  DynamicPagedAttentionTestCase     — full paged attention with dynamic kernel shapes
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+from examples.ir_parser.dynamic_paged_attention_example import (
+    build_dynamic_paged_attention_program,
+)
+
+# ---------------------------------------------------------------------------
+# Test Case — DynamicPagedAttentionTestCase
+# Full paged attention with dynamic InCore kernel type annotations.
+# ---------------------------------------------------------------------------
+
+
+class DynamicPagedAttentionTestCase(PTOTestCase):
+    """Full paged attention with dynamic-shape InCore kernel type annotations.
+
+    InCore kernels (init_inplace, qk_matmul, softmax_prepare, pv_matmul,
+    online_update) annotate their tensor shapes with pl.dynamic() variables
+    (Q_HEADS, HEAD_DIM_DYN, BLOCK_SIZE_DYN) instead of literal numbers.
+    Load operations inside the kernels use concrete closure variables (_Q_TILE,
+    _HEAD_DIM, _BLOCK_SIZE) captured from build_dynamic_paged_attention_program(),
+    matching the DynShapeAddTestCase pattern from test_dynamic_shape.py.
+
+    Unlike PagedAttentionTestCase there is no config tensor — all shape
+    parameters are derived from tensor dimensions at runtime (mirroring the
+    orchestration function's pl.tensor.dim() calls).  Scale is hardcoded to 1.0.
+    """
+
+    def __init__(
+        self,
+        batch: int = 64,
+        num_heads: int = 16,
+        head_dim: int = 128,
+        block_size: int = 128,
+        context_len: int | list[int] = 8192,
+        max_model_len: int = 32768,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.config.atol = 2e-2
+        self.config.rtol = 2e-2
+        self.batch = batch
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.block_size = block_size
+        self.context_len = context_len
+        self.max_model_len = max_model_len
+        self.max_num_blocks_per_req = max_model_len // block_size
+
+    def get_name(self) -> str:
+        return (
+            f"dynamic_paged_attention_{self.batch}bat_{self.num_heads}h_{self.head_dim}d_{self.block_size}bs"
+        )
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B_PTO
+
+    def get_program(self) -> Any:
+        return build_dynamic_paged_attention_program(
+            q_tile=16,
+            head_dim=self.head_dim,
+            block_size=self.block_size,
+        )
+
+    def define_tensors(self) -> list[TensorSpec]:
+        B = self.batch
+        H = self.num_heads
+        D = self.head_dim
+        BS = self.block_size
+        max_blocks = self.max_num_blocks_per_req  # max KV blocks per request
+        # Total rows in the flat KV-cache pool: all requests × max blocks × tokens per block
+        total_pool_rows = B * max_blocks * BS
+
+        # Build a random page table: each request gets max_blocks physical block indices
+        # sampled from [0, B*max_blocks).  Flattened to 1-D to match orchestration input.
+        block_table = torch.randint(
+            0, max(B * max_blocks, 1), size=(B, max_blocks), dtype=torch.int32
+        ).flatten()
+
+        # context_lens can be a scalar (all requests have equal length) or a per-request list
+        if isinstance(self.context_len, list):
+            if len(self.context_len) != B:
+                raise ValueError(
+                    f"context_len list length {len(self.context_len)} does not match batch size B={B}"
+                )
+            context_lens = torch.tensor(self.context_len, dtype=torch.int32)
+        else:
+            context_lens = torch.full((B,), self.context_len, dtype=torch.int32)
+
+        return [
+            TensorSpec("query", [B * H, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("key_cache", [total_pool_rows, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("value_cache", [total_pool_rows, D], DataType.BF16, init_value=torch.randn),
+            TensorSpec("block_table", [B * max_blocks], DataType.INT32, init_value=block_table),
+            TensorSpec("context_lens", [B], DataType.INT32, init_value=context_lens),
+            TensorSpec("out", [B * H, D], DataType.FP32, is_output=True),
+        ]
+
+    def compute_expected(self, tensors, params=None):
+        context_lens = tensors["context_lens"]
+        query = tensors["query"]
+        key_cache = tensors["key_cache"]
+        value_cache = tensors["value_cache"]
+        block_table_flat = tensors["block_table"]
+
+        # Derive shape parameters from tensor dimensions — no config tensor, mirrors
+        # the orchestration function's pl.tensor.dim() derivations.
+        batch = context_lens.shape[0]
+        num_heads = query.shape[0] // batch
+        head_dim = query.shape[1]
+        # block_size = value_cache rows / block_table rows (rows per physical block)
+        block_size = value_cache.shape[0] // block_table_flat.shape[0]
+        max_num_blocks_per_req = block_table_flat.shape[0] // batch
+        scale = 1.0  # hardcoded to match orchestration function
+
+        # Reshape flat tensors into 3-D views for batch-matmul operations
+        query_3d = query.float().reshape(batch, num_heads, head_dim)
+        total_pool_blocks = batch * max_num_blocks_per_req
+        key_cache_3d = key_cache.float().reshape(total_pool_blocks, block_size, head_dim)
+        value_cache_3d = value_cache.float().reshape(total_pool_blocks, block_size, head_dim)
+        block_table = block_table_flat.reshape(batch, max_num_blocks_per_req)
+
+        out = torch.zeros((batch, num_heads, head_dim), dtype=torch.float32)
+        q_tile = 16
+        # Upper bound on KV blocks to iterate over (driven by longest request in batch)
+        max_bn = int((context_lens.max().item() + block_size - 1) // block_size)
+
+        for q_offset in range(0, num_heads, q_tile):
+            q_tile_size = min(q_tile, num_heads - q_offset)
+            qi = query_3d[:, q_offset : q_offset + q_tile_size, :]
+            # Online softmax state across KV blocks
+            oi, li, mi = None, None, None
+
+            for bn in range(max_bn):
+                # valid_lens[b]: how many tokens of block bn are valid for request b
+                valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+                if not (valid_lens > 0).any():
+                    break
+                block_indices = block_table[:, bn]
+                kj_all = key_cache_3d[block_indices].float()
+                vj_all = value_cache_3d[block_indices].float()
+
+                # Stage 1: QK matmul + mask padding columns with -inf
+                sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale
+                pos = torch.arange(block_size).unsqueeze(0)
+                valid_mask = (pos < valid_lens.unsqueeze(1)).unsqueeze(1)
+                sij = sij.masked_fill(~valid_mask, float("-inf"))
+
+                # Stage 2: softmax prepare — row_max, exp(sij - max), BF16 cast, row_sum
+                mij = sij.max(dim=-1, keepdim=True)[0].clamp(min=-1e30)
+                pij = torch.exp(sij - mij).masked_fill(~valid_mask, 0.0)
+                # Simulate BF16 cast to match InCore kernel precision
+                pij = pij.to(torch.bfloat16).to(torch.float32)
+                lij = pij.sum(dim=-1, keepdim=True)
+
+                # Stage 3: PV matmul
+                oi_new = torch.bmm(pij, vj_all)
+
+                # Stage 4: online softmax accumulator update
+                if bn == 0:
+                    # First block: initialise accumulators directly
+                    oi, li, mi = oi_new, lij, mij
+                else:
+                    # Subsequent block: rescale old and new partial results then merge
+                    mi_new = torch.maximum(mi, mij)
+                    alpha = torch.exp(mi - mi_new)  # rescale factor for old accumulator
+                    beta = torch.exp(mij - mi_new)  # rescale factor for new block
+                    li = alpha * li + beta * lij
+                    oi = alpha * oi + beta * oi_new
+                    mi = mi_new
+
+            # Final normalisation: oi / li, write into the corresponding output slice
+            out[:, q_offset : q_offset + q_tile_size, :] = oi / li
+
+        tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
+
+
+# ---------------------------------------------------------------------------
+# pytest test suite
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicPagedAttentionKernels:
+    """Integration tests for the dynamic shapes pattern.
+
+    test_dynamic_paged_attention:
+        Exercises the full 5-kernel paged attention pipeline (init_inplace,
+        qk_matmul, softmax_prepare, pv_matmul, online_update) where InCore
+        kernel type annotations use pl.dynamic() variables for the tile shape dims.
+    """
+
+    @pytest.mark.parametrize(
+        "batch,num_heads,head_dim,block_size,context_len,max_model_len",
+        [
+            (256, 16, 128, 128, 8192, 32768),
+            (256, 64, 128, 64, 8192, 32768),
+            (64, 64, 256, 64, 8192, 32768),
+            # Variable context lengths: each of 4 requests has a different length
+            (4, 16, 128, 128, [512, 4096, 8192, 768], 32768),
+        ],
+    )
+    def test_dynamic_paged_attention(
+        self, test_runner, batch, num_heads, head_dim, block_size, context_len, max_model_len
+    ):
+        """Test full paged attention with dynamic InCore kernel type annotations."""
+        test_case = DynamicPagedAttentionTestCase(
+            batch=batch,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            block_size=block_size,
+            context_len=context_len,
+            max_model_len=max_model_len,
+        )
+        result = test_runner.run(test_case)
+        assert result.passed, f"Dynamic paged attention test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/codegen/test_paged_attention.py
+++ b/tests/st/codegen/test_paged_attention.py
@@ -151,10 +151,12 @@ class SoftmaxPrepareTestCase(PTOTestCase):
                 sij: pl.Tensor[[16, 128], pl.FP32],
                 config: pl.Tensor[[1], pl.FP32],
                 pij_out: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
-                mij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
-                lij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                mij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
+                lij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
             ) -> tuple[
-                pl.Tensor[[16, 128], pl.BF16], pl.Tensor[[16, 1], pl.FP32], pl.Tensor[[16, 1], pl.FP32]
+                pl.Tensor[[16, 128], pl.BF16],
+                pl.Tensor[[16, 1], pl.FP32, pl.DN],
+                pl.Tensor[[16, 1], pl.FP32, pl.DN],
             ]:
                 # Read scale value from config tensor
                 scale: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
@@ -234,10 +236,12 @@ class SoftmaxPrepareUnalignedTestCase(PTOTestCase):
                 config: pl.Tensor[[1], pl.FP32],
                 valid_len_cfg: pl.Tensor[[1], pl.INT64],
                 pij_out: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
-                mij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
-                lij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                mij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
+                lij_out: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.DN]],
             ) -> tuple[
-                pl.Tensor[[16, 128], pl.BF16], pl.Tensor[[16, 1], pl.FP32], pl.Tensor[[16, 1], pl.FP32]
+                pl.Tensor[[16, 128], pl.BF16],
+                pl.Tensor[[16, 1], pl.FP32, pl.DN],
+                pl.Tensor[[16, 1], pl.FP32, pl.DN],
             ]:
                 scale: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
                 valid_len: pl.Scalar[pl.INT64] = pl.tensor.read(valid_len_cfg, [0])


### PR DESCRIPTION
## Summary
- Add `examples/ir_parser/dynamic_paged_attention_example.py` with
  `build_dynamic_paged_attention_program()` builder defining five InCore
  kernel closures (`dyn_kernel_init_inplace`, `dyn_kernel_qk_matmul`,
  `dyn_kernel_softmax_prepare`, `dyn_kernel_pv_matmul`,
  `dyn_kernel_online_update`); type annotations use module-level
  `pl.dynamic()` variables (`Q_HEADS`, `HEAD_DIM_DYN`, `BLOCK_SIZE_DYN`)
- Add `tests/st/codegen/test_dynamic_paged_attention.py` with
  `DynamicPagedAttentionTestCase` inheriting golden reference and tensor
  definitions from `PagedAttentionTestCase`, targeting Ascend910B PTO
  backend; 4 parametrized configurations including per-request variable
  context lengths
- Extend `tests/st/codegen/test_paged_attention.py`: `PagedAttentionTestCase`
  accepts `context_len: int | list[int]` to support heterogeneous
  per-request lengths (required by `DynamicPagedAttentionTestCase`)
- Add `_ir_var: Any = None` lazy-cache field to `DynVar` in
  `python/pypto/language/typing/dynamic.py`; once populated by
  `TypeResolver`, all parsers sharing the same `DynVar` object reuse
  a single `ir.Var` instance, ensuring structural equality across
  `@pl.function` boundaries
- Update `TypeResolver._resolve_shape_element`, `_resolve_shape_or_int`,
  and `_resolve_name_as_dyn_var` in `type_resolver.py` to read/write
  `DynVar._ir_var`: if `_ir_var` is already set, register it into
  `_dyn_var_cache` instead of creating a new `ir.Var`, guaranteeing
  `Q_HEADS`, `HEAD_DIM_DYN`, and `BLOCK_SIZE_DYN` map to the same IR
  node in every kernel of the dynamic program
- Fix `PTOCodegen::EmitMakeTensorViews` to emit
  `{layout = #pto.layout<nd|dn|nz>}` on tensor view assignments so
  DN-layout tensors (e.g. transposed `key_cache`) are correctly
  represented in generated PTO IR
- Fix `paged_attention_example.py`: annotate `[16, 1]` output tensors
  in `kernel_init_inplace` and `kernel_softmax_prepare` with `pl.DN`;
  remove `pl.DN` from `kj` parameter in `kernel_qk_matmul`; remove
  unused `size_query`, `size_key_cache`, `size_value_cache` parameters
- Fix layout mismatch in `kernel_softmax_prepare_unaligned`
  (`paged_attention_example.py`) and `KernelSoftmaxPrepare`
  (`test_batch_paged_attention.py`): add `pl.DN` to `out_mi`/`out_li`
  (`mij_batch`/`lij_batch`) parameter and return-type annotations so
  the user-specified layout matches the `dn` layout inferred by PTOAS
  for `row_max`/`row_sum` result tiles

## Testing
- [x] DynamicPagedAttentionTestCase passes on 910B PTO hardware
- [x] Pre-commit hooks pass (ruff, pyright, clang-format, cpplint)
