### PR TITLE
refactor(ir): enhance tile memory space inference and move insertion logic

### DIFF
--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -183,6 +183,13 @@ class MoveCollector : public IRVisitor {
     IRVisitor::VisitStmt_(op);
   }
 
+  void VisitStmt_(const EvalStmtPtr& op) override {
+    if (auto call = As<Call>(op->expr_)) {
+      CheckInputConstraints(call);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
  private:
   const std::map<VarPtr, MemorySpace>& var_memory_;
   std::set<MoveKey, MoveKeyLess> needed_moves_;
@@ -433,6 +440,13 @@ class TileMemoryInferredVerifier : public IRVisitor {
       VerifyInputConstraints(call);
     }
 
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const EvalStmtPtr& op) override {
+    if (auto call = As<Call>(op->expr_)) {
+      VerifyInputConstraints(call);
+    }
     IRVisitor::VisitStmt_(op);
   }
 

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -288,29 +288,48 @@ class TileMemorySpaceMutator : public IRMutator {
   std::vector<StmtPtr> VisitAndInsertMoves(const std::vector<StmtPtr>& stmts, bool& changed) {
     std::vector<StmtPtr> new_stmts;
     for (const auto& stmt : stmts) {
+      InsertMovesForConsumer(new_stmts, stmt, changed);
       auto new_stmt = IRMutator::VisitStmt(stmt);
       if (new_stmt.get() != stmt.get()) changed = true;
       new_stmts.push_back(new_stmt);
-
-      // After producer AssignStmt, insert tile.move stmts if needed
-      if (auto assign = As<AssignStmt>(stmt)) {
-        for (const auto& key : needed_moves_) {
-          if (key.first == assign->var_) {
-            InsertMoveStmt(new_stmts, assign->var_, key.second, assign->span_);
-            changed = true;
-          }
-        }
-      }
     }
     return new_stmts;
   }
 
+  void InsertMovesForConsumer(std::vector<StmtPtr>& stmts, const StmtPtr& stmt, bool& changed) {
+    CallPtr call;
+    Span span = stmt ? stmt->span_ : Span::unknown();
+    if (auto assign = As<AssignStmt>(stmt)) {
+      call = As<Call>(assign->value_);
+    } else if (auto eval = As<EvalStmt>(stmt)) {
+      call = As<Call>(eval->expr_);
+    }
+    if (!call) return;
+
+    const auto* constraints = GetInputConstraints(call->op_->name_);
+    if (!constraints) return;
+
+    for (size_t i = 0; i < constraints->size() && i < call->args_.size(); ++i) {
+      if ((*constraints)[i].empty()) continue;
+      auto var = As<Var>(call->args_[i]);
+      if (!var) continue;
+
+      MoveKey key = {var, (*constraints)[i][0]};
+      if (needed_moves_.count(key) == 0 || created_moves_.count(key) > 0) {
+        continue;
+      }
+
+      InsertMoveStmt(stmts, var, key.second, span);
+      changed = true;
+    }
+  }
+
   void InsertMoveStmt(std::vector<StmtPtr>& stmts, const VarPtr& original_var, MemorySpace target,
                       const Span& span) {
-    // Get the mutated producer var
-    auto cache_it = var_cache_.find(original_var);
-    INTERNAL_CHECK(cache_it != var_cache_.end()) << "Internal error: producer var not in cache";
-    auto mutated_producer = cache_it->second;
+    auto mutated_producer = IRMutator::VisitExpr(original_var);
+    auto mutated_producer_var = As<Var>(mutated_producer);
+    INTERNAL_CHECK(mutated_producer_var)
+        << "Internal error: inferred tile-memory producer is not a Var expression";
 
     // Create tile.move call via OpRegistry
     auto& op_reg = OpRegistry::GetInstance();
@@ -322,8 +341,6 @@ class TileMemorySpaceMutator : public IRMutator {
     INTERNAL_CHECK(move_type) << "Internal error: tile.move return type is not TileType";
     auto moved_type = std::make_shared<TileType>(move_type->shape_, move_type->dtype_, move_type->memref_,
                                                  move_type->tile_view_, target);
-    auto mutated_producer_var = As<Var>(mutated_producer);
-    INTERNAL_CHECK(mutated_producer_var) << "Internal error: mutated producer is not a Var";
     auto moved_var = std::make_shared<Var>(
         mutated_producer_var->name_hint_ + "_" + MemorySpaceToString(target), std::move(moved_type), span);
 

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -95,6 +95,16 @@ def _prepare_and_run_allocate_memory_addr(program):
     return program
 
 
+def _prepare_and_run_full_memory_pipeline(program):
+    """Run the full tile memory pipeline through address allocation."""
+
+    program = passes.infer_tile_memory_space()(program)
+    program = passes.init_mem_ref()(program)
+    program = passes.memory_reuse()(program)
+    program = passes.allocate_memory_addr()(program)
+    return program
+
+
 def test_allocate_memory_addr_simple():
     """Test AllocateMemoryAddr with a simple function containing TileType variables.
 
@@ -228,6 +238,40 @@ def test_allocate_memory_addr_rejects_overlapping_reserve_buffer_ranges():
         Exception, match=re.escape("AllocateMemoryAddr found overlapping reserve_buffer ranges")
     ):
         _prepare_and_run_allocate_memory_addr(Before)
+
+
+def test_allocate_memory_addr_reuses_right_buffer_when_moves_sink_to_consumer():
+    """Right buffers should share one address window when matmul moves do not overlap."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def main(
+            self,
+            lhs: pl.Tensor[[4, 128], pl.BF16],
+            rhs0: pl.Tensor[[128, 64], pl.BF16],
+            rhs1: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+        ) -> pl.Tensor[[4, 64], pl.FP32]:
+            lhs_tile: pl.Tile[[4, 128], pl.BF16] = pl.load(
+                lhs, [0, 0], [4, 128], target_memory=pl.MemorySpace.Mat
+            )
+            rhs0_tile: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                rhs0, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat
+            )
+            rhs1_tile: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                rhs1, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat
+            )
+            _acc0: pl.Tile[[4, 64], pl.FP32] = pl.matmul(lhs_tile, rhs0_tile)
+            acc1: pl.Tile[[4, 64], pl.FP32] = pl.matmul(lhs_tile, rhs1_tile)
+            result: pl.Tensor[[4, 64], pl.FP32] = pl.store(acc1, [0, 0], out_0)
+            return result
+
+    optimized_program = _prepare_and_run_full_memory_pipeline(Before)
+    optimized_func = list(optimized_program.functions.values())[0]
+
+    memref_addrs = get_memref_addresses_from_tiles(optimized_func)
+    assert memref_addrs["rhs0_tile_Right"] == memref_addrs["rhs1_tile_Right"]
 
 
 def test_allocate_memory_addr_empty_function():

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel.py
@@ -2770,7 +2770,7 @@ class TestDCERegression:
         assert "branch_out__rv_v0: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.yield_(acc_iter)" in aiv_str
         assert aiv_str.index(
             "z__ssa_v0_Vec: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.tpop_from_aic"
-        ) < (aiv_str.index("if i__idx_v0 == 0:"))
+        ) < (aiv_str.index("pl.tile.add(acc_iter, z__ssa_v0_Vec)"))
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -814,6 +814,32 @@ class TestAutoMoveInsertion:
         # Matmul uses the original moved vars
         assert "pl.tile.matmul(x_left, y_right)" in printed
 
+    def test_eval_stmt_consumer_collects_and_inserts_move(self):
+        """EvalStmt consumers should also trigger required auto-inserted moves."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                value: pl.Scalar[pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                x_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    x, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                pl.tile.write(x_tile, [0, 0], value)
+                return out_0
+
+        After = passes.infer_tile_memory_space()(Before)
+        printed = ir.python_print(After)
+
+        _assert_var_memory_space(printed, "x_tile", "Mat")
+        _assert_var_memory_space(printed, "x_tile_Vec", "Vec")
+        assert "pl.tile.write(x_tile_Vec, [0, 0], value)" in printed
+        assert printed.count("pl.tile.move") == 1
+
     def test_store_no_move_for_vec(self):
         """tile.store accepts Vec — no move needed for Vec tile."""
 

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -725,6 +725,54 @@ class TestAutoMoveInsertion:
         _assert_var_memory_space(printed, "y_tile_Right", "Right")
         assert "pl.tile.matmul(x_tile_Left, y_tile_Right)" in printed
 
+    def test_matmul_moves_are_inserted_at_first_consumer(self):
+        """Auto-inserted moves should be materialized at first constrained use."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[4, 128], pl.BF16],
+                rhs0: pl.Tensor[[128, 64], pl.BF16],
+                rhs1: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                lhs_tile: pl.Tile[[4, 128], pl.BF16] = pl.load(
+                    lhs, [0, 0], [4, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs0_tile: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                    rhs0, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                rhs1_tile: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                    rhs1, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                _acc0: pl.Tile[[4, 64], pl.FP32] = pl.matmul(lhs_tile, rhs0_tile)
+                acc1: pl.Tile[[4, 64], pl.FP32] = pl.matmul(lhs_tile, rhs1_tile)
+                out_0_store: pl.Tensor[[4, 64], pl.FP32] = pl.store(acc1, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[4, 128], pl.BF16],
+                rhs0: pl.Tensor[[128, 64], pl.BF16],
+                rhs1: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                out_0: pl.Tensor[[4, 64], pl.FP32] = pl.create_tensor([4, 64], dtype=pl.FP32)
+                result: pl.Tensor[[4, 64], pl.FP32] = self.main_incore_0(lhs, rhs0, rhs1, out_0)
+                return result
+
+        After = passes.infer_tile_memory_space()(Before)
+        printed = ir.python_print(After)
+
+        first_rhs_move = printed.index("rhs0_tile_Right")
+        first_matmul = printed.index("pl.tile.matmul(lhs_tile_Left, rhs0_tile_Right)")
+        second_rhs_move = printed.index("rhs1_tile_Right")
+        second_matmul = printed.index("pl.tile.matmul(lhs_tile_Left, rhs1_tile_Right)")
+
+        assert first_rhs_move < first_matmul < second_rhs_move < second_matmul
+
     def test_no_move_when_already_correct(self):
         """No move inserted when input already in correct space."""
 


### PR DESCRIPTION
fix #627 
- Introduced `InsertMovesForConsumer` method to streamline the insertion of move statements for consumer nodes, improving clarity and maintainability.
- Updated `VisitAndInsertMoves` to utilize the new method, enhancing the overall structure of the tile memory space inference process.
- Added tests to validate the correct insertion of moves at the first consumer, ensuring that memory reuse is handled properly in the context of matrix multiplication operations.
- Implemented a new utility function `_prepare_and_run_full_memory_pipeline` to facilitate comprehensive testing of the tile memory pipeline.

## Testing
- New tests confirm that moves are inserted correctly and that memory addresses are reused as expected in optimized programs.