### PR TITLE
fix(ir,runtime): fix VarRefCollector scope and golden writer closures

### DIFF
--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -55,16 +55,32 @@ class VarRefCollector : public IRVisitor {
 
   void VisitExpr_(const IterArgPtr& op) override {
     var_refs.insert(op.get());
-    // Use dynamic_pointer_cast (not As<Var>) to match both Var and IterArg,
-    // avoiding recursive initValue_ traversal that would pull in outer-scope vars.
-    if (op->initValue_) {
-      auto as_var = std::dynamic_pointer_cast<const Var>(op->initValue_);
-      if (as_var) {
-        var_refs.insert(as_var.get());
-      } else {
-        VisitExpr(op->initValue_);
+    // Do not traverse initValue_: when an IterArg appears as an expression
+    // reference (defined by an outer loop), its initValue_ belongs to that
+    // outer loop's initialization, not to the scope being analyzed.
+    // InitValues of IterArgs defined by inner ForStmt/WhileStmt are visited
+    // explicitly in VisitStmt_ overrides below.
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    // Explicitly visit initValue_ for IterArgs defined by THIS ForStmt.
+    // These are genuine references to variables from the enclosing scope
+    // that must be captured as inputs when outlining.
+    for (const auto& iter_arg : op->iter_args_) {
+      if (iter_arg->initValue_) {
+        VisitExpr(iter_arg->initValue_);
       }
     }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    for (const auto& iter_arg : op->iter_args_) {
+      if (iter_arg->initValue_) {
+        VisitExpr(iter_arg->initValue_);
+      }
+    }
+    IRVisitor::VisitStmt_(op);
   }
 };
 

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -34,9 +34,12 @@ Generated file format::
 """
 
 import ast
+import builtins
 import inspect
+import math
 import re
 import textwrap
+import types
 from collections.abc import Callable
 from pathlib import Path
 
@@ -336,6 +339,12 @@ def _extract_compute_golden(golden_fn: Callable) -> str:
     source = "\n".join(renamed_lines)
     if is_method:
         source = _inline_bound_self_attributes(source, golden_fn.__self__)
+
+    # Inject closure variable values as constants above the function definition.
+    closure_lines = _extract_closure_constants(golden_fn)
+    if closure_lines:
+        source = "\n".join(closure_lines) + "\n\n" + source
+
     return source
 
 
@@ -359,3 +368,66 @@ def _inline_bound_self_attributes(source: str, bound_instance: object) -> str:
         source = re.sub(rf"\bself\.{attr_name}\b", literal_value, source)
 
     return source
+
+
+def _extract_closure_constants(fn: Callable) -> list[str]:
+    """Extract closure and global variable bindings as top-level constant assignments.
+
+    Handles two categories of captured variables:
+
+    1. **Closure variables** (free variables from an enclosing scope).
+    2. **Global constants** referenced by the function that are simple scalar
+       values (not builtins, modules, or callables).
+
+    Only supports int, float, str, bool, and None values. Unsupported types
+    are silently skipped (the generated code may still fail at runtime if those
+    variables are actually used).
+    """
+    lines: list[str] = []
+    seen: set[str] = set()
+    _SIMPLE_TYPES = (int, float, str, bool, type(None))
+
+    def _safe_repr(value: object) -> str | None:
+        """Return a repr that is valid Python, or None for non-finite floats."""
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        return repr(value)
+
+    # 1. Closure (free) variables
+    closure = getattr(fn, "__closure__", None)
+    freevars = getattr(getattr(fn, "__code__", None), "co_freevars", ())
+    if closure and freevars:
+        for name, cell in zip(freevars, closure, strict=True):
+            try:
+                value = cell.cell_contents
+            except ValueError:
+                continue
+            if isinstance(value, _SIMPLE_TYPES):
+                literal = _safe_repr(value)
+                if literal is not None:
+                    lines.append(f"{name} = {literal}")
+                    seen.add(name)
+
+    # 2. Global constants — names referenced via LOAD_GLOBAL that resolve to
+    #    simple scalar values in the function's __globals__.
+    code = getattr(fn, "__code__", None)
+    fn_globals = getattr(fn, "__globals__", {})
+    if code and fn_globals:
+        builtin_names = set(dir(builtins))
+        for name in code.co_names:
+            if name in seen or name in builtin_names:
+                continue
+            value = fn_globals.get(name)
+            if value is None and name not in fn_globals:
+                continue  # Name not in globals at all
+            if isinstance(value, (types.ModuleType, type)):
+                continue
+            if callable(value):
+                continue
+            if isinstance(value, _SIMPLE_TYPES):
+                literal = _safe_repr(value)
+                if literal is not None:
+                    lines.append(f"{name} = {literal}")
+                    seen.add(name)
+
+    return lines

--- a/tests/ut/codegen/test_golden_writer.py
+++ b/tests/ut/codegen/test_golden_writer.py
@@ -10,7 +10,11 @@
 """Unit tests for pypto.runtime.golden_writer."""
 
 import pytest
-from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
+from pypto.runtime.golden_writer import (
+    _extract_closure_constants,
+    _extract_compute_golden,
+    generate_golden_source,
+)
 from pypto.runtime.tensor_spec import ScalarSpec, TensorSpec
 
 torch = pytest.importorskip("torch")
@@ -146,6 +150,75 @@ class TestGoldenWriterScalar:
         namespace["compute_golden"](tensors)
 
         assert torch.equal(tensors["out"], torch.full((4,), 2.5, dtype=torch.float32))
+
+
+class TestExtractClosureConstants:
+    """Tests for _extract_closure_constants."""
+
+    def test_closure_variable_captured(self):
+        """Closure variables with simple scalar values are extracted."""
+        scale = 42
+        offset = 3.14
+
+        def fn(tensors, params=None):
+            tensors["out"][:] = tensors["a"] * scale + offset
+
+        lines = _extract_closure_constants(fn)
+        assert "scale = 42" in lines
+        assert "offset = 3.14" in lines
+
+    def test_closure_string_and_none(self):
+        """String and None closure values are captured."""
+        tag = "hello"
+        sentinel = None
+
+        def fn(tensors, params=None):
+            _ = tag, sentinel
+
+        lines = _extract_closure_constants(fn)
+        assert "tag = 'hello'" in lines
+        assert "sentinel = None" in lines
+
+    def test_closure_non_simple_types_skipped(self):
+        """Non-scalar closure values (lists, dicts, objects) are silently skipped."""
+        data = [1, 2, 3]
+
+        def fn(tensors, params=None):
+            _ = data
+
+        lines = _extract_closure_constants(fn)
+        assert len(lines) == 0
+
+    def test_non_finite_floats_skipped(self):
+        """nan and inf closure values are skipped (repr produces invalid Python)."""
+        nan_val = float("nan")
+        inf_val = float("inf")
+
+        def fn(tensors, params=None):
+            _ = nan_val, inf_val
+
+        lines = _extract_closure_constants(fn)
+        assert len(lines) == 0
+
+    def test_no_closure_returns_empty(self):
+        """Functions without closures return an empty list."""
+
+        def fn(tensors, params=None):
+            tensors["out"][:] = tensors["a"] * 2
+
+        lines = _extract_closure_constants(fn)
+        assert lines == []
+
+    def test_closure_injected_into_extract_compute_golden(self):
+        """Closure constants appear above function def in _extract_compute_golden output."""
+        factor = 5
+
+        def my_golden(tensors, params=None):
+            tensors["out"][:] = tensors["a"] * factor
+
+        src = _extract_compute_golden(my_golden)
+        assert "factor = 5" in src
+        assert src.index("factor = 5") < src.index("def compute_golden(")
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -518,6 +518,40 @@ class TestOutlineIncoreScopes:
             "orchestration must pass 'acc' to the outlined function"
         )
 
+    def test_outline_scope_does_not_capture_outer_init_value(self):
+        """Outer loop's init value must NOT become a parameter of the outlined incore function.
+
+        When an incore scope uses a loop-carried variable (IterArg) from an
+        outer ForStmt, only the IterArg itself should be captured as a
+        parameter, not its initValue_ expression.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, init: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for sb, (acc,) in pl.range(4, init_values=(init,)):
+                    with pl.incore():
+                        result: pl.Tensor[[64], pl.FP32] = pl.add(acc, y)
+                    acc_rv = pl.yield_(result)
+                return acc_rv
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(Before)
+
+        printed = After.as_python()
+        incore_section = printed.split("@pl.function(type=pl.FunctionType.InCore)")[1].split("@pl.function")[
+            0
+        ]
+        incore_params = incore_section.split("(self,")[1].split(")")[0]
+
+        assert "acc" in incore_params, "loop-carried 'acc' must be a parameter"
+        assert "init" not in incore_params, (
+            "outer loop's init value 'init' must NOT be a parameter of the incore function"
+        )
+
 
 class TestSplitIncoreOrchVerifier:
     """Regression tests for the SplitIncoreOrch property verifier."""


### PR DESCRIPTION
## Summary

- **VarRefCollector**: fix IterArg initValue scope — do not traverse initValue_ during expression visits; instead visit initValues explicitly in ForStmt/WhileStmt overrides. Prevents outer loop init values from being incorrectly captured as incore function parameters during scope outlining.

- **Golden writer**: extract closure and global scalar constants (`int`, `float`, `str`, `bool`, `None`) as top-level assignments above the function definition, making generated golden code self-contained and executable.

## Testing

- [x] Unit tests added for VarRefCollector and golden writer fixes
- [x] `test_outline_scope_does_not_capture_outer_init_value` — verifies VarRefCollector fix
- [x] `test_extract_closure_constants_*` — verifies golden writer closure extraction
- [x] All existing UTs pass (`pytest tests/ut/ -n auto`)