### PR TITLE
feat(ir): add tensor.full op for constant-filled tensor creation

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, ConstInt, Expr, PadValue, ScalarType, Span, TensorLayout
+from pypto.pypto_core.ir import Call, ConstFloat, ConstInt, Expr, PadValue, ScalarType, Span, TensorLayout
 
 from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
 
@@ -47,6 +47,33 @@ def create(
 
 
 create_tensor = create
+
+
+def full(
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
+    dtype: DataType,
+    value: int | float,
+    span: Span | None = None,
+) -> Call:
+    """Create a tensor of specified shape filled with a constant value.
+
+    Args:
+        shape: Shape of the tensor (list of int/Expr, or MakeTuple)
+        dtype: Data type of tensor elements
+        value: Filling scalar value (int or float)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns a TensorType
+    """
+    actual_span = _get_span_or_capture(span)
+    shape_tuple = _to_make_tuple(shape, actual_span)
+    if isinstance(value, int):
+        value_expr = ConstInt(value, dtype, actual_span)
+    else:
+        value_expr = ConstFloat(value, dtype, actual_span)
+    kwargs: dict[str, Any] = {"dtype": dtype}
+    return _ir_core.create_op_call("tensor.full", [shape_tuple, value_expr], kwargs, actual_span)
 
 
 def read(

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -86,7 +86,7 @@ from .op.system_ops import (
     tpush_to_aic,
     tpush_to_aiv,
 )
-from .op.tensor_ops import assemble, create_tensor, dim, scatter_update
+from .op.tensor_ops import assemble, create_tensor, dim, full, scatter_update
 from .op.tile_ops import (
     abs,
     addc,
@@ -326,6 +326,7 @@ __all__ = [
     "create_tensor",
     "assemble",
     "dim",
+    "full",
     "scatter_update",
     "FunctionType",
     "ForKind",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -23,6 +23,7 @@ __all__ = [
     "dim",
     "slice",
     "fillpad",
+    "full",
     "matmul",
     "matmul_acc",
     "mul",
@@ -184,6 +185,21 @@ def fillpad(tensor: Tensor, pad_value: PadValue = PadValue.zero) -> Tensor:
         Tensor wrapping the fillpad operation
     """
     call_expr = _ir_ops.fillpad(tensor.unwrap(), pad_value=pad_value)
+    return Tensor(expr=call_expr)
+
+
+def full(shape: Sequence[IntLike], dtype: DataType, value: int | float) -> Tensor:
+    """Create a tensor of specified shape filled with a constant value.
+
+    Args:
+        shape: Shape of the tensor
+        dtype: Data type of tensor elements
+        value: Filling scalar value (int or float)
+
+    Returns:
+        Tensor wrapping the full operation
+    """
+    call_expr = _ir_ops.full(_normalize_intlike(shape), dtype, value)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2405,6 +2405,7 @@ class ASTParser:
         "create_tensor",
         "dim",
         "assemble",
+        "full",
     }
     _TILE_ONLY_OPS = {
         "load",

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -272,6 +272,57 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
   return std::make_shared<TensorType>(target_type->shape_, target_type->dtype_);
 }
 
+TypePtr DeduceTensorFullType(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 2) << "tensor.full requires exactly 2 arguments (shape, value), but got "
+                          << args.size();
+
+  // Extract dtype from kwargs
+  bool found_dtype = false;
+  DataType dtype;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "dtype") {
+      dtype = AnyCast<DataType>(value, "kwarg key: dtype");
+      found_dtype = true;
+      break;
+    }
+  }
+  CHECK(found_dtype) << "tensor.full requires 'dtype' kwarg";
+
+  // First argument must be TupleType (shape)
+  auto shape_tuple_type = As<TupleType>(args[0]->GetType());
+  CHECK(shape_tuple_type) << "tensor.full requires shape to be TupleType, but got "
+                          << args[0]->GetType()->TypeName();
+
+  // Validate all shape elements are ScalarType with integer dtype
+  for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+    auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
+    CHECK(scalar_type) << "tensor.full shape element " << i << " must be ScalarType, but got "
+                       << shape_tuple_type->types_[i]->TypeName();
+    CHECK(scalar_type->dtype_.IsInt())
+        << "tensor.full shape element " << i << " must have integer dtype, but got "
+        << scalar_type->dtype_.ToString();
+  }
+
+  // Second argument must be ConstInt or ConstFloat
+  CHECK(As<ConstInt>(args[1]) || As<ConstFloat>(args[1]))
+      << "tensor.full requires value to be ConstInt or ConstFloat, but got " << args[1]->TypeName();
+
+  // Extract shape dimensions (same pattern as tensor.create)
+  std::vector<ExprPtr> shape;
+  shape.reserve(shape_tuple_type->types_.size());
+
+  if (auto make_tuple = As<MakeTuple>(args[0])) {
+    shape = make_tuple->elements_;
+  } else {
+    for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+      shape.emplace_back(std::make_shared<TupleGetItemExpr>(args[0], static_cast<int>(i), args[0]->span_));
+    }
+  }
+
+  return std::make_shared<TensorType>(shape, dtype);
+}
+
 // ============================================================================
 // Registration Function for Tensor Memory Operations
 // ============================================================================
@@ -327,6 +378,17 @@ REGISTER_OP("tensor.fillpad")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorFillpadType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.full")
+    .set_op_category("TensorOp")
+    .set_description("Create a tensor of specified shape filled with a constant value")
+    .add_argument("shape", "Shape dimensions (TupleType of ScalarType(INT64))")
+    .add_argument("value", "Filling value (ConstInt or ConstFloat)")
+    .set_attr<DataType>("dtype")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorFullType(args, kwargs);
     });
 
 TypePtr DeduceTensorDimType(const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -948,7 +948,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "tensor.slice" || op_name == "tensor.create") {
+  if (op_name == "tensor.slice" || op_name == "tensor.create" || op_name == "tensor.full") {
     for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
     }

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -158,6 +158,9 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterSimple("tensor.transpose", "tile.transpose");
   RegisterSimple("tensor.concat", "tile.concat");
 
+  // Memory creation ops
+  RegisterSimple("tensor.full", "tile.full");
+
   // ────────────────────────────────────────────────────────────────────────
   // Broadcast-aware elementwise binary ops
   //

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2326,5 +2326,28 @@ class TestScatterUpdateConversion:
         assert "tile.scatter_update" in after_str
 
 
+class TestTensorFullConversion:
+    def test_tensor_full_conversion(self):
+        """tensor.full -> tile.full conversion."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tensor[[64], pl.FP32] = pl.full([64], dtype=pl.FP32, value=0.0)
+                y: pl.Tensor[[64], pl.FP32] = pl.add(t, x)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir_str = str(After)
+        assert "tile.full" in ir_str
+        assert "tensor.full" not in ir_str
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `tensor.full` operator that creates a tensor of specified shape filled with a constant value (int or float)
- Implements full cross-layer support: C++ op registration/type deduction, Python IR wrapper, language DSL wrapper, AST parser registration
- Adds `tensor.full` → `tile.full` conversion in `ConvertTensorToTileOps` pass with op conversion registry entry
- Includes unit test verifying tensor-to-tile conversion

## Testing
- [x] All 3188 existing tests pass
- [x] New `TestTensorFullConversion` test verifies tensor.full → tile.full conversion
- [x] Clang-tidy clean
- [x] Pre-commit hooks pass (ruff, pyright, clang-format, cpplint)