### PR TITLE
docs: enhance `load` operation documentation for clarity on offsets and shapes

### DIFF
--- a/.claude/skills/compare-codegen/SKILL.md
+++ b/.claude/skills/compare-codegen/SKILL.md
@@ -3,9 +3,9 @@ name: compare-codegen
 description: >-
   Compare codegen output (.pto files and pass dumps) between origin/main and
   the current branch for a given test case. Runs the test with --save-kernels
-  --dump-passes --codegen-only on both branches via git worktree, then diffs
-  the results. Use when the user asks to compare codegen output, diff .pto
-  files between branches, or check what changed in generated code.
+  and --dump-passes on both branches via git worktree, then diffs the results.
+  Use when the user asks to compare codegen output, diff .pto files between
+  branches, or check what changed in generated code.
 ---
 
 # Compare Codegen Output Between Branches
@@ -64,10 +64,10 @@ Build (if needed) and run the test on the current branch:
 [ ! -f build/CMakeCache.txt ] && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build --parallel
 
-# Run test with codegen-only + save-kernels + dump-passes
+# Run test with save-kernels + dump-passes (full test run, not codegen-only)
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
 python -m pytest "$TEST_SPEC" -v -s --forked \
-  --codegen-only --save-kernels --dump-passes \
+  --save-kernels --dump-passes \
   --kernels-dir="$BRANCH_OUTPUT" \
   --platform="${PLATFORM:-a2a3sim}" \
   $EXTRA_ARGS
@@ -94,7 +94,7 @@ cmake --build build --parallel
 # Run test
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
 python -m pytest "$TEST_SPEC" -v -s --forked \
-  --codegen-only --save-kernels --dump-passes \
+  --save-kernels --dump-passes \
   --kernels-dir="$MAIN_OUTPUT_ABSOLUTE" \
   --platform="${PLATFORM:-a2a3sim}" \
   $EXTRA_ARGS
@@ -169,6 +169,6 @@ rm -rf build_output/compare_*/
 | ----- | -------- |
 | "fatal: worktree already exists" | `git worktree prune` then retry |
 | Build fails in worktree | Check that `origin/main` is buildable; try `git fetch origin main` first |
-| No `.pto` files in output | Verify the test produces codegen output; check `--codegen-only` was passed |
+| No `.pto` files in output | Verify the test produces codegen output; some tests emit C++ or other artifacts instead of `.pto`; optional: pass `--codegen-only` via `$EXTRA_ARGS` if you only need codegen |
 | Permission denied on tmp dir | Use `--compare-dir` to specify a writable directory |
 | Test not found | Verify the pytest node ID; use `pytest --collect-only` to list available tests |

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -65,7 +65,7 @@ Transfer data between memory hierarchy levels.
 
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
-| `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat) |
+| `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat). Both `offsets` and `shapes` use the source tensor's coordinate system. |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -62,7 +62,7 @@
 
 | 名称 | 签名 | 说明 |
 | ---- | ---- | ---- |
-| `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat） |
+| `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat）。`offsets` 和 `shapes` 均使用源 tensor 的坐标系。 |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处 |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |

--- a/examples/ir_parser/dynamic_paged_attention_example.py
+++ b/examples/ir_parser/dynamic_paged_attention_example.py
@@ -97,7 +97,7 @@ def build_dynamic_paged_attention_program(
         """QK matmul: output = qi @ kj.T (CUBE). kj transposed on load."""
         qi_l1 = pl.load(qi, [0, 0], [_Q_TILE, _HEAD_DIM], target_memory=pl.MemorySpace.Mat)
         kj_l1 = pl.load(
-            kj, [0, 0], [_HEAD_DIM, _BLOCK_SIZE], target_memory=pl.MemorySpace.Mat, transpose=True
+            kj, [0, 0], [_BLOCK_SIZE, _HEAD_DIM], target_memory=pl.MemorySpace.Mat, transpose=True
         )
         qi_l0a = pl.move(qi_l1, target_memory=pl.MemorySpace.Left)
         kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right)

--- a/examples/ir_parser/paged_attention_multi_config_example.py
+++ b/examples/ir_parser/paged_attention_multi_config_example.py
@@ -310,7 +310,7 @@ def make_kernel_qk_matmul(
             kj_l1 = pl.load(
                 key_cache,
                 [kj_row, 0],
-                [head_dim, block_size],
+                [block_size, head_dim],
                 target_memory=pl.MemorySpace.Mat,
                 transpose=True,
             )

--- a/examples/language/llm_models/llama_7b_mini.py
+++ b/examples/language/llm_models/llama_7b_mini.py
@@ -174,10 +174,10 @@ def build_llama_mini_program(
         def kernel_matmul_trans_b(
             self,
             a: pl.Tensor[[seq_len, head_dim], pl.FP32],
-            b: pl.Tensor[[head_dim, seq_len], pl.FP32, pl.DN],
+            b: pl.Tensor[[seq_len, head_dim], pl.FP32],
             output: pl.Out[pl.Tensor[[seq_len, seq_len], pl.FP32]],
         ) -> pl.Tensor[[seq_len, seq_len], pl.FP32]:
-            """[S,D] @ [D,S](DN) → [S,S]: Q @ K^T via K-tiled 16-wide blocks.
+            """[S,D] @ [S,D](DN)^T → [S,S]: Q @ K^T via K-tiled 16-wide blocks.
 
             Tiles K-dimension (head_dim) into 4×k_tile_width=16 blocks so each
             TMOV operates on Mat[S,16] → Right[S,16], satisfying the hardware
@@ -185,7 +185,7 @@ def build_llama_mini_program(
             """
             # K-tile 0: columns [0 : k_tile_width]
             a0 = pl.load(a, [0, 0], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat)
-            b0 = pl.load(b, [0, 0], [k_tile_width, seq_len], target_memory=pl.MemorySpace.Mat, transpose=True)
+            b0 = pl.load(b, [0, 0], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat, transpose=True)
             a0_l = pl.move(a0, target_memory=pl.MemorySpace.Left)
             b0_r = pl.move(b0, target_memory=pl.MemorySpace.Right)
             acc: pl.Tile[[seq_len, seq_len], pl.FP32] = pl.matmul(a0_l, b0_r)
@@ -193,7 +193,7 @@ def build_llama_mini_program(
             # K-tile 1: columns [k1 : k1+k_tile_width]
             a1 = pl.load(a, [0, k1], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat)
             b1 = pl.load(
-                b, [k1, 0], [k_tile_width, seq_len], target_memory=pl.MemorySpace.Mat, transpose=True
+                b, [0, k1], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat, transpose=True
             )
             a1_l = pl.move(a1, target_memory=pl.MemorySpace.Left)
             b1_r = pl.move(b1, target_memory=pl.MemorySpace.Right)
@@ -202,7 +202,7 @@ def build_llama_mini_program(
             # K-tile 2: columns [k2 : k2+k_tile_width]
             a2 = pl.load(a, [0, k2], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat)
             b2 = pl.load(
-                b, [k2, 0], [k_tile_width, seq_len], target_memory=pl.MemorySpace.Mat, transpose=True
+                b, [0, k2], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat, transpose=True
             )
             a2_l = pl.move(a2, target_memory=pl.MemorySpace.Left)
             b2_r = pl.move(b2, target_memory=pl.MemorySpace.Right)
@@ -211,7 +211,7 @@ def build_llama_mini_program(
             # K-tile 3: columns [k3 : k3+k_tile_width]
             a3 = pl.load(a, [0, k3], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat)
             b3 = pl.load(
-                b, [k3, 0], [k_tile_width, seq_len], target_memory=pl.MemorySpace.Mat, transpose=True
+                b, [0, k3], [seq_len, k_tile_width], target_memory=pl.MemorySpace.Mat, transpose=True
             )
             a3_l = pl.move(a3, target_memory=pl.MemorySpace.Left)
             b3_r = pl.move(b3, target_memory=pl.MemorySpace.Right)
@@ -456,8 +456,8 @@ def build_llama_mini_program(
                 [seq_len, head_dim], dtype=pl.FP32
             )
             q_rot = self.kernel_rope(q, cos_emb, sin_emb, q_rot)
-            k_rot_buf: pl.Tensor[[head_dim, seq_len], pl.FP32, pl.DN] = pl.create_tensor(
-                [head_dim, seq_len], dtype=pl.FP32, layout=pl.DN
+            k_rot_buf: pl.Tensor[[seq_len, head_dim], pl.FP32] = pl.create_tensor(
+                [seq_len, head_dim], dtype=pl.FP32
             )
             k_rot = self.kernel_rope(k, cos_emb, sin_emb, k_rot_buf)
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -120,12 +120,17 @@ def load(
 
     Args:
         tensor: Source tensor (TensorType)
-        offsets: Offsets in each dimension (sequence of scalars), or a MakeTuple
-        shapes: Shape of the tile in each dimension (sequence of scalars), or a MakeTuple
+        offsets: Offsets in each dimension (sequence of scalars), or a MakeTuple.
+            Always in the source tensor's coordinate system.
+        shapes: Shape of the region to load in each dimension (sequence of scalars),
+            or a MakeTuple. Always in the source tensor's coordinate system, even
+            when transpose=True. The output TileType shape will be transposed
+            automatically by the type deduction layer.
         valid_shapes: Valid shape of the tile in each dimension (sequence of scalars), or a
             MakeTuple. When provided, sets TileView.valid_shape in the output TileType.
             When omitted, shapes is used as valid_shape. Useful for dynamic shapes where
             the actual valid data region differs from the allocated tile size.
+            Uses the same coordinate convention as shapes.
         target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat)
         transpose: Whether to transpose the tile during load (default: False).
             Only supported when target_memory is MemorySpace.Mat (L1).
@@ -137,8 +142,8 @@ def load(
     Example:
         >>> # 2D load
         >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32])
-        >>> # 2D load with transpose to L1
-        >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32],
+        >>> # 2D load with transpose to L1 (tensor is [N, K], output tile is [K, N])
+        >>> tile = load(tensor, offsets=[0, 0], shapes=[N, K],
         ...             target_memory=MemorySpace.Mat, transpose=True)
     """
     # Validate target_memory: only Vec and Mat are allowed for load

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -203,12 +203,15 @@ def load(
 
     Args:
         tensor: Source tensor
-        offsets: Offsets in each dimension
-        shapes: Shape of the tile in each dimension
+        offsets: Offsets in each dimension. Always in the source tensor's
+            coordinate system.
+        shapes: Shape of the region to load in each dimension. Always in the
+            source tensor's coordinate system, even when transpose=True. The
+            output TileType shape will be transposed automatically.
         target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat)
         valid_shapes: Valid shape of the tile in each dimension. When provided, sets
             TileView.valid_shape in the output TileType. When omitted, shapes is used
-            as valid_shape.
+            as valid_shape. Uses the same coordinate convention as shapes.
         transpose: Whether to transpose the tile during load (default: False).
             Only supported when target_memory is MemorySpace.Mat (L1).
 
@@ -218,8 +221,8 @@ def load(
     Example:
         >>> # 2D load
         >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32])
-        >>> # 2D load with transpose to L1
-        >>> tile = load(tensor, offsets=[0, 0], shapes=[K, N],
+        >>> # 2D load with transpose to L1 (tensor is [N, K], output tile is [K, N])
+        >>> tile = load(tensor, offsets=[0, 0], shapes=[N, K],
         ...             target_memory=pl.MemorySpace.Mat, transpose=True)
     """
     if valid_shapes is None:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -392,10 +392,18 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
   // Build partition type with all ND dimensions to match the sizes attribute.
+  // For DN layout, swap the last two shape elements (same as offsets) so that
+  // sizes are in the transposed coordinate system used by make_tensor_view.
+  bool is_dn =
+      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
+  auto shape_elems = shapes_tuple->elements_;
+  if (is_dn && shape_elems.size() >= 2) {
+    std::iter_swap(shape_elems.rbegin(), shape_elems.rbegin() + 1);
+  }
   std::string partition_type = "!pto.partition_tensor_view<";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) partition_type += "x";
-    partition_type += std::to_string(codegen.GetConstIntValue(shapes_tuple->elements_[i]));
+    partition_type += std::to_string(codegen.GetConstIntValue(shape_elems[i]));
   }
   partition_type += "x" + dtype_str + ">";
 
@@ -407,8 +415,6 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   // base address is in the transposed coordinate system used by make_tensor_view.
   // With the "original coordinates" DSL convention, offsets are always written in
   // the tensor's declared coordinate system, so a swap is always needed for DN.
-  bool is_dn =
-      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
   auto offset_elems = offsets_tuple->elements_;
   if (is_dn && offset_elems.size() >= 2) {
     std::iter_swap(offset_elems.rbegin(), offset_elems.rbegin() + 1);
@@ -421,9 +427,9 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   }
   partition_line << "]";
   partition_line << ", sizes = [";
-  for (size_t i = 0; i < shapes_tuple->elements_.size(); ++i) {
+  for (size_t i = 0; i < shape_elems.size(); ++i) {
     if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetIndexConstant(codegen.GetConstIntValue(shapes_tuple->elements_[i]));
+    partition_line << codegen.GetIndexConstant(codegen.GetConstIntValue(shape_elems[i]));
   }
   partition_line << "]";
   partition_line << " : " << tensor_view_type << " -> " << partition_type;

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -132,13 +132,20 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
     tile_view.blayout = TileLayout::col_major;
   }
 
-  // Build tile shape from shapes tuple
-  std::vector<ExprPtr> tile_shape;
-  for (const auto& shape_expr : shapes_tuple->elements_) {
-    tile_shape.push_back(shape_expr);
+  // Build tile shape from shapes tuple.
+  // When transpose=true, shapes are in original (source tensor) coordinates;
+  // swap to transposed coordinates for the output TileType.
+  auto shape_elements = shapes_tuple->elements_;
+  if (transpose && shape_elements.size() == 2) {
+    std::swap(shape_elements[0], shape_elements[1]);
   }
+  std::vector<ExprPtr> tile_shape(shape_elements.begin(), shape_elements.end());
 
-  tile_view.valid_shape = valid_shapes_tuple->elements_;
+  auto valid_elements = valid_shapes_tuple->elements_;
+  if (transpose && valid_elements.size() == 2) {
+    std::swap(valid_elements[0], valid_elements[1]);
+  }
+  tile_view.valid_shape = valid_elements;
 
   // Return TileType with same dtype as tensor and TileView containing valid_shape
   return std::make_shared<TileType>(tile_shape, tensor_type->dtype_, std::nullopt, tile_view);
@@ -479,9 +486,14 @@ REGISTER_OP("tile.load")
     .set_op_category("TileOp")
     .set_description("Copy data from tensor to unified buffer (tile)")
     .add_argument("tensor", "Source tensor (TensorType)")
-    .add_argument("offsets", "Offsets in each dimension (TupleType of ScalarType)")
-    .add_argument("shapes", "Shape of tile in each dimension (TupleType of ScalarType)")
-    .add_argument("valid_shapes", "Valid shape of tile in each dimension (TupleType of ScalarType). ")
+    .add_argument("offsets",
+                  "Offsets in each dimension, in source tensor coordinates (TupleType of ScalarType)")
+    .add_argument(
+        "shapes",
+        "Shape of region to load in each dimension, in source tensor coordinates (TupleType of ScalarType)")
+    .add_argument(
+        "valid_shapes",
+        "Valid shape of tile in each dimension, in source tensor coordinates (TupleType of ScalarType). ")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<bool>("transpose")
     .set_output_memory_from_kwarg("target_memory", MemorySpace::Vec)

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -591,21 +591,10 @@ std::vector<StmtPtr> TransformIncoreBody(const std::vector<StmtPtr>& stmts,
         const auto& shape_arg = substituted_args[1];
         const auto& offset_arg = substituted_args[2];
 
-        // For transpose, swap shape dims: [N,K] → [K,N]
+        // Shapes and valid_shapes use original (source tensor) coordinates.
+        // DeduceTileLoadType swaps internally when transpose=true.
         ExprPtr load_shapes = shape_arg;
         ExprPtr valid_shapes_base = (substituted_args.size() == 4) ? substituted_args[3] : shape_arg;
-        if (info.transpose) {
-          auto shape_tuple = As<MakeTuple>(shape_arg);
-          if (shape_tuple && shape_tuple->elements_.size() == 2) {
-            std::vector<ExprPtr> swapped = {shape_tuple->elements_[1], shape_tuple->elements_[0]};
-            load_shapes = std::make_shared<MakeTuple>(swapped, shape_arg->span_);
-          }
-          auto valid_tuple = As<MakeTuple>(valid_shapes_base);
-          if (valid_tuple && valid_tuple->elements_.size() == 2) {
-            std::vector<ExprPtr> swapped = {valid_tuple->elements_[1], valid_tuple->elements_[0]};
-            valid_shapes_base = std::make_shared<MakeTuple>(swapped, valid_shapes_base->span_);
-          }
-        }
 
         auto valid_shapes = valid_shapes_base;
         std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Mat},

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -94,9 +94,6 @@ ExprPtr LoadOperandToMat(const ExprPtr& operand, bool transpose, const std::stri
   if (tensor_type) {
     auto offsets = MakeZeroOffsetsTuple(tensor_type->shape_.size(), span);
     auto shape = tensor_type->shape_;
-    if (transpose && shape.size() == 2) {
-      std::swap(shape[0], shape[1]);
-    }
     auto shapes = MakeShapesTuple(shape, span);
     std::vector<std::pair<std::string, std::any>> kw = {{"target_memory", MemorySpace::Mat},
                                                         {"transpose", transpose}};

--- a/tests/st/codegen/test_batch_paged_attention.py
+++ b/tests/st/codegen/test_batch_paged_attention.py
@@ -146,7 +146,7 @@ class BatchQKMatmulTestCase(PTOTestCase):
                     kj_l1 = pl.load(
                         key_cache,
                         [kj_row, 0],
-                        [head_dim, block_size],
+                        [block_size, head_dim],
                         target_memory=pl.MemorySpace.Mat,
                         transpose=True,
                     )

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -120,7 +120,7 @@ class TestMatmulBTranspose(PTOTestCase):
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat)
                 tile_b_l1 = pl.load(
-                    b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat, transpose=True
+                    b, offsets=[0, 0], shapes=[N, K], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
@@ -181,7 +181,7 @@ class TestMatmulATranspose(PTOTestCase):
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a_l1 = pl.load(
-                    a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat, transpose=True
+                    a, offsets=[0, 0], shapes=[K, M], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
@@ -243,10 +243,10 @@ class TestMatmulABTranspose(PTOTestCase):
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a_l1 = pl.load(
-                    a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat, transpose=True
+                    a, offsets=[0, 0], shapes=[K, M], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_b_l1 = pl.load(
-                    b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat, transpose=True
+                    b, offsets=[0, 0], shapes=[N, K], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)

--- a/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
@@ -225,7 +225,7 @@ def make_kernel_qk_matmul(
             kj_l1 = pl.load(
                 key_cache,
                 [kj_row, 0],
-                [head_dim, block_size],
+                [block_size, head_dim],
                 target_memory=pl.MemorySpace.Mat,
                 transpose=True,
             )

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -631,7 +631,7 @@ class TestConvertTensorToTileOps:
                     lhs, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
                 )
                 rhs_mat: pl.Tile[[128, 64], pl.BF16] = pl.load(
-                    rhs, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True
+                    rhs, [0, 0], [64, 128], [64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 y_tile: pl.Tile[[16, 64], pl.FP32] = pl.matmul(lhs_mat, rhs_mat)
                 out_0_store: pl.Tensor[[16, 64], pl.BF16] = pl.store(y_tile, [0, 0], out_0)
@@ -2130,7 +2130,7 @@ class TestSliceMatmulConversion:
         ir.assert_structural_equal(After, Expected)
 
     def test_slice_then_matmul_btrans(self):
-        """slice + matmul(b_trans=True) -> tile.load(Mat, transpose=True) with swapped shapes."""
+        """slice + matmul(b_trans=True) -> tile.load(Mat, transpose=True) with original shapes."""
 
         @pl.program
         class Before:
@@ -2165,8 +2165,8 @@ class TestSliceMatmulConversion:
                 k_slice_tile: pl.Tile[[128, 120], pl.BF16] = pl.load(
                     k_cache,
                     [0, 0],
-                    [128, 120],
-                    [128, 120],
+                    [120, 128],
+                    [120, 128],
                     target_memory=pl.MemorySpace.Mat,
                     transpose=True,
                 )
@@ -2196,7 +2196,7 @@ class TestSliceMatmulConversion:
         ir.assert_structural_equal(After, Expected)
 
     def test_slice_then_matmul_atrans(self):
-        """slice + matmul(a_trans=True) -> tile.load(Mat, transpose=True) for lhs with swapped shapes."""
+        """slice + matmul(a_trans=True) -> tile.load(Mat, transpose=True) for lhs with original shapes."""
 
         @pl.program
         class Before:
@@ -2231,8 +2231,8 @@ class TestSliceMatmulConversion:
                 a_slice_tile: pl.Tile[[16, 128], pl.BF16] = pl.load(
                     a,
                     [0, 0],
-                    [16, 128],
-                    [16, 128],
+                    [128, 16],
+                    [128, 16],
                     target_memory=pl.MemorySpace.Mat,
                     transpose=True,
                 )

--- a/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py
@@ -31,7 +31,7 @@ class TestResolveTransposeLayoutBTranspose:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -56,7 +56,7 @@ class TestResolveTransposeLayoutBTranspose:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -88,7 +88,7 @@ class TestResolveTransposeLayoutBTranspose:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -113,7 +113,7 @@ class TestResolveTransposeLayoutBTranspose:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -148,7 +148,7 @@ class TestResolveTransposeLayoutATranspose:
                 b: pl.Tensor[[K, N], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
@@ -173,7 +173,7 @@ class TestResolveTransposeLayoutATranspose:
                 b: pl.Tensor[[K, N], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
@@ -209,8 +209,8 @@ class TestResolveTransposeLayoutABTranspose:
                 b: pl.Tensor[[N, K], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -234,8 +234,8 @@ class TestResolveTransposeLayoutABTranspose:
                 b: pl.Tensor[[N, K], pl.FP32, pl.DN],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -266,8 +266,8 @@ class TestResolveTransposeLayoutABTranspose:
                 b: pl.Tensor[[N, K], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -291,8 +291,8 @@ class TestResolveTransposeLayoutABTranspose:
                 b: pl.Tensor[[N, K], pl.FP32, pl.DN],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -360,7 +360,7 @@ class TestResolveTransposeLayoutNoOp:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -453,7 +453,7 @@ class TestResolveTransposeLayoutMixed:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -478,7 +478,7 @@ class TestResolveTransposeLayoutMixed:
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -509,7 +509,7 @@ class TestResolveTransposeLayoutMixed:
                 b: pl.Tensor[[K, N], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
@@ -534,7 +534,7 @@ class TestResolveTransposeLayoutMixed:
                 b: pl.Tensor[[K, N], pl.FP32],
                 c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
@@ -576,7 +576,7 @@ class TestResolveTransposeLayoutPartialLoad:
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
                 tile_k = pl.load(
-                    key_cache, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True
+                    key_cache, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_a_l0 = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_k_l0 = pl.move(tile_k, target_memory=pl.MemorySpace.Right)
@@ -605,7 +605,7 @@ class TestResolveTransposeLayoutPartialLoad:
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
                 tile_k = pl.load(
-                    key_cache, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True
+                    key_cache, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
                 )
                 tile_a_l0 = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_k_l0 = pl.move(tile_k, target_memory=pl.MemorySpace.Right)


### PR DESCRIPTION
- Updated the documentation for the `load` operation in both English and Chinese to clarify that both `offsets` and `shapes` are defined in the source tensor's coordinate system.
- Added examples to illustrate the behavior of the `load` operation when using the `transpose` parameter, ensuring users understand the implications for tensor shapes.

All changes aim to improve user understanding and reduce potential confusion regarding tensor coordinate systems in the context of loading operations.