### PR TITLE
fix(pass): Avoid unnecessary MemRef splits for PTO-materializable layouts

### DIFF
--- a/include/pypto/codegen/pto/tile_buf_signature.h
+++ b/include/pypto/codegen/pto/tile_buf_signature.h
@@ -142,6 +142,7 @@ struct TileBufSignature {
    *  - pad only (fillpad)
    *  - valid_shape only (load with padding / dynamic valid shape)
    *  - shape only (reshape) — memory_space & dtype must match
+   *  - [1, N] RowMajor ↔ [N, 1] ColMajor — physically identical byte layout
    */
   [[nodiscard]] bool IsPTOMaterializable(const TileBufSignature& other) const {
     if (memory_space != other.memory_space || dtype != other.dtype) return false;
@@ -155,6 +156,19 @@ struct TileBufSignature {
       const __int128 lhs_elems = static_cast<__int128>(rows) * static_cast<__int128>(cols);
       const __int128 rhs_elems = static_cast<__int128>(other.rows) * static_cast<__int128>(other.cols);
       return lhs_elems == rhs_elems;
+    }
+
+    // [1, N] RowMajor and [N, 1] ColMajor are physically identical in memory
+    // (same N elements, same byte sequence); tile.reshape converts between them at zero cost.
+    if (slayout == other.slayout && fractal == other.fractal) {
+      const bool is_1d_transpose =
+          (rows == 1 && cols > 1 && blayout == ir::TileLayout::row_major && other.rows > 1 &&
+           other.cols == 1 && other.blayout == ir::TileLayout::col_major &&
+           rows * cols == other.rows * other.cols) ||
+          (rows > 1 && cols == 1 && blayout == ir::TileLayout::col_major && other.rows == 1 &&
+           other.cols > 1 && other.blayout == ir::TileLayout::row_major &&
+           rows * cols == other.rows * other.cols);
+      if (is_1d_transpose) return true;
     }
 
     return false;

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -136,11 +136,12 @@ class MemRefUsageCollector : public IRVisitor {
 // Phase 2 — Decide which MemRefs must be split
 // -------------------------------------------------------------------------
 
-/// For each MemRef that has multiple writers with incompatible root
-/// signatures, collect the set of Var* that need a fresh MemRef.
+/// For each MemRef that has multiple writers with incompatible signatures,
+/// collect the set of Var* that need a fresh MemRef.
 ///
 /// Strategy: the first writer keeps the original MemRef.  Every subsequent
-/// writer whose root signature differs gets a new MemRef.
+/// writer that is not PTO-materializable from the first writer's signature
+/// gets a new MemRef.
 void PropagateSplitToViewUsers(const MemRefUsageInfo& info, const std::vector<const Var*>& split_roots,
                                const MemRefPtr& new_memref, std::map<const Var*, MemRefPtr>& splits) {
   std::vector<const Var*> worklist = split_roots;
@@ -169,32 +170,32 @@ std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const MemRef*, M
   for (const auto& [memref_ptr, info] : usages) {
     if (info.writers.size() <= 1) continue;
 
-    const auto& root_sig = info.writers[0].second.RootSignature();
+    const auto& ref_sig = info.writers[0].second;
     bool needs_split = false;
     for (size_t i = 1; i < info.writers.size(); ++i) {
-      if (info.writers[i].second.RootSignature() != root_sig) {
+      if (!ref_sig.IsPTOMaterializable(info.writers[i].second)) {
         needs_split = true;
         break;
       }
     }
     if (!needs_split) continue;
 
-    // Group writers by root signature; first group keeps original MemRef
+    // Group writers by materializable-compatibility; first group keeps original MemRef
     std::map<int, std::vector<size_t>> sig_groups;
-    std::vector<TileBufSignature> distinct_roots;
+    std::vector<TileBufSignature> group_reps;
 
     for (size_t i = 0; i < info.writers.size(); ++i) {
-      auto root = info.writers[i].second.RootSignature();
+      const auto& sig = info.writers[i].second;
       int group_id = -1;
-      for (size_t g = 0; g < distinct_roots.size(); ++g) {
-        if (distinct_roots[g] == root) {
+      for (size_t g = 0; g < group_reps.size(); ++g) {
+        if (group_reps[g].IsPTOMaterializable(sig)) {
           group_id = static_cast<int>(g);
           break;
         }
       }
       if (group_id < 0) {
-        group_id = static_cast<int>(distinct_roots.size());
-        distinct_roots.push_back(root);
+        group_id = static_cast<int>(group_reps.size());
+        group_reps.push_back(sig);
       }
       sig_groups[group_id].push_back(i);
     }


### PR DESCRIPTION
## Summary
- Extend `IsPTOMaterializable` to recognize `[1, N] RowMajor ↔ [N, 1] ColMajor` as physically identical (same byte sequence, converted via `tile.reshape` at zero cost)
- Replace root-signature equality check in `PlanMemRefSplits` with `IsPTOMaterializable`, so writers whose signatures are mutually materializable are grouped together and share one MemRef instead of being needlessly split
- Rename `distinct_roots` / `root_sig` to `group_reps` / `ref_sig` to reflect that grouping is now based on materializable-compatibility, not root signature

Closes #750