### PR TITLE
feat(op): support scalar rhs sugar in explicit tensor/tile ops

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -19,7 +19,17 @@ from typing import Any
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, ConstFloat, ConstInt, Expr, MemorySpace, PadValue, Span, TileLayout
+from pypto.pypto_core.ir import (
+    Call,
+    ConstFloat,
+    ConstInt,
+    Expr,
+    MemorySpace,
+    PadValue,
+    ScalarType,
+    Span,
+    TileLayout,
+)
 
 from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
 
@@ -41,6 +51,29 @@ def _validate_offsets_shapes(offsets_tuple: _ir_core.MakeTuple, shapes_tuple: _i
         )
     if len(offsets_tuple.elements) == 0:
         raise ValueError("offsets and shapes must have at least one dimension")
+
+
+def _normalize_tile_binary_rhs(rhs: int | float | Expr, span: Span) -> Expr:
+    """Normalize a tile binary-op rhs into an IR expression."""
+    return (
+        _normalize_expr(rhs, span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
+        if not isinstance(rhs, Expr)
+        else rhs
+    )
+
+
+def _create_tile_binary_call(
+    tile_op_name: str,
+    scalar_op_name: str,
+    lhs: Expr,
+    rhs: int | float | Expr,
+    span: Span,
+) -> Call:
+    """Create a tile binary call with scalar auto-dispatch."""
+    rhs_expr = _normalize_tile_binary_rhs(rhs, span)
+    if isinstance(rhs_expr.type, ScalarType):
+        return _ir_core.create_op_call(scalar_op_name, [lhs, rhs_expr], {}, span)
+    return _ir_core.create_op_call(tile_op_name, [lhs, rhs_expr], {}, span)
 
 
 # ============================================================================
@@ -346,72 +379,72 @@ def fillpad(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span | None =
 # ============================================================================
 
 
-def mul(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
-    """Element-wise multiplication of two tiles.
+def mul(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
+    """Element-wise multiplication of tile and tile or scalar.
 
-    Supports broadcasting for two tiles.
+    Supports broadcasting for two tiles. Scalar rhs canonicalizes to tile.muls.
 
     Args:
         lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
+        rhs: Right-hand side tile or scalar
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise multiplication
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.mul", [lhs, rhs], {}, actual_span)
+    return _create_tile_binary_call("tile.mul", "tile.muls", lhs, rhs, actual_span)
 
 
-def add(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
-    """Element-wise addition of two tiles.
+def add(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
+    """Element-wise addition of tile and tile or scalar.
 
-    Supports broadcasting for two tiles.
+    Supports broadcasting for two tiles. Scalar rhs canonicalizes to tile.adds.
 
     Args:
         lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
+        rhs: Right-hand side tile or scalar
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise addition
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.add", [lhs, rhs], {}, actual_span)
+    return _create_tile_binary_call("tile.add", "tile.adds", lhs, rhs, actual_span)
 
 
-def div(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
-    """Element-wise division of two tiles.
+def div(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
+    """Element-wise division of tile and tile or scalar.
 
-    Supports broadcasting for two tiles.
+    Supports broadcasting for two tiles. Scalar rhs canonicalizes to tile.divs.
 
     Args:
         lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
+        rhs: Right-hand side tile or scalar
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise division
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.div", [lhs, rhs], {}, actual_span)
+    return _create_tile_binary_call("tile.div", "tile.divs", lhs, rhs, actual_span)
 
 
-def sub(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
-    """Element-wise subtraction of two tiles.
+def sub(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
+    """Element-wise subtraction of tile and tile or scalar.
 
-    Supports broadcasting for two tiles.
+    Supports broadcasting for two tiles. Scalar rhs canonicalizes to tile.subs.
 
     Args:
         lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
+        rhs: Right-hand side tile or scalar
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise subtraction
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.sub", [lhs, rhs], {}, actual_span)
+    return _create_tile_binary_call("tile.sub", "tile.subs", lhs, rhs, actual_span)
 
 
 def rem(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -68,8 +68,8 @@ from pypto.pypto_core.ir import Expr, PadValue, TensorLayout
 from ..typing import IntLike, Scalar, Tensor
 
 
-def _unwrap_rhs(rhs: int | float | Tensor | Scalar) -> int | float | Expr:
-    """Unwrap rhs operand: extract Expr from Tensor/Scalar wrappers, pass through primitives."""
+def _unwrap_rhs(rhs: int | float | Expr | Tensor | Scalar) -> int | float | Expr:
+    """Unwrap rhs operands into the IR-layer representation."""
     if isinstance(rhs, (Tensor, Scalar)):
         return rhs.unwrap()
     return rhs
@@ -267,12 +267,11 @@ def mul(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
         Tensor wrapping the mul operation
     """
     lhs_expr = lhs.unwrap()
-    rhs_expr = _unwrap_rhs(rhs)
-    call_expr = _ir_ops.mul(lhs_expr, rhs_expr)
+    call_expr = _ir_ops.mul(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
-def muls(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
+def muls(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     """Element-wise multiplication of tensor and scalar.
 
     Args:
@@ -283,7 +282,7 @@ def muls(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
         Tensor wrapping the muls operation
     """
     lhs_expr = lhs.unwrap()
-    call_expr = _ir_ops.muls(lhs_expr, rhs)
+    call_expr = _ir_ops.muls(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
@@ -301,12 +300,11 @@ def add(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
         Tensor wrapping the add operation
     """
     lhs_expr = lhs.unwrap()
-    rhs_expr = _unwrap_rhs(rhs)
-    call_expr = _ir_ops.add(lhs_expr, rhs_expr)
+    call_expr = _ir_ops.add(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
-def adds(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
+def adds(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     """Element-wise addition of tensor and scalar.
 
     Args:
@@ -317,7 +315,7 @@ def adds(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
         Tensor wrapping the adds operation
     """
     lhs_expr = lhs.unwrap()
-    call_expr = _ir_ops.adds(lhs_expr, rhs)
+    call_expr = _ir_ops.adds(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
@@ -335,12 +333,11 @@ def sub(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
         Tensor wrapping the sub operation
     """
     lhs_expr = lhs.unwrap()
-    rhs_expr = _unwrap_rhs(rhs)
-    call_expr = _ir_ops.sub(lhs_expr, rhs_expr)
+    call_expr = _ir_ops.sub(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
-def subs(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
+def subs(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     """Element-wise subtraction of tensor and scalar.
 
     Args:
@@ -351,7 +348,7 @@ def subs(lhs: Tensor, rhs: int | float | Expr) -> Tensor:
         Tensor wrapping the subs operation
     """
     lhs_expr = lhs.unwrap()
-    call_expr = _ir_ops.subs(lhs_expr, rhs)
+    call_expr = _ir_ops.subs(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
@@ -369,8 +366,7 @@ def div(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
         Tensor wrapping the div operation
     """
     lhs_expr = lhs.unwrap()
-    rhs_expr = _unwrap_rhs(rhs)
-    call_expr = _ir_ops.div(lhs_expr, rhs_expr)
+    call_expr = _ir_ops.div(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 
@@ -385,8 +381,7 @@ def divs(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
         Tensor wrapping the divs operation
     """
     lhs_expr = lhs.unwrap()
-    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
-    call_expr = _ir_ops.divs(lhs_expr, rhs_expr)
+    call_expr = _ir_ops.divs(lhs_expr, _unwrap_rhs(rhs))
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -121,6 +121,11 @@ from .system_ops import (  # noqa: F401
 )
 
 
+def _unwrap_rhs(rhs: int | float | Expr | Tile | Scalar) -> int | float | Expr:
+    """Unwrap rhs operands into the IR-layer representation."""
+    return rhs.unwrap() if isinstance(rhs, (Tile, Scalar)) else rhs
+
+
 def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     """Unwrap Scalar elements to Expr so the sequence matches C++ binding types."""
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
@@ -378,59 +383,59 @@ def get_block_idx() -> Scalar:
     return Scalar(expr=call_expr)
 
 
-def add(lhs: Tile, rhs: Tile) -> Tile:
-    """Element-wise addition of two tiles.
+def add(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+    """Element-wise addition of tile and tile or scalar.
 
     Args:
         lhs: Left-hand side tile
-        rhs: Right-hand side tile
+        rhs: Right-hand side tile or scalar
 
     Returns:
         Tile wrapping the add operation
     """
-    call_expr = _ir_ops.add(lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.add(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
-def sub(lhs: Tile, rhs: Tile) -> Tile:
-    """Element-wise subtraction of two tiles.
+def sub(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+    """Element-wise subtraction of tile and tile or scalar.
 
     Args:
         lhs: Left-hand side tile
-        rhs: Right-hand side tile
+        rhs: Right-hand side tile or scalar
 
     Returns:
         Tile wrapping the sub operation
     """
-    call_expr = _ir_ops.sub(lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.sub(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
-def mul(lhs: Tile, rhs: Tile) -> Tile:
-    """Element-wise multiplication of two tiles.
+def mul(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+    """Element-wise multiplication of tile and tile or scalar.
 
     Args:
         lhs: Left-hand side tile
-        rhs: Right-hand side tile
+        rhs: Right-hand side tile or scalar
 
     Returns:
         Tile wrapping the mul operation
     """
-    call_expr = _ir_ops.mul(lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.mul(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
-def div(lhs: Tile, rhs: Tile) -> Tile:
-    """Element-wise division of two tiles.
+def div(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+    """Element-wise division of tile and tile or scalar.
 
     Args:
         lhs: Left-hand side tile
-        rhs: Right-hand side tile
+        rhs: Right-hand side tile or scalar
 
     Returns:
         Tile wrapping the div operation
     """
-    call_expr = _ir_ops.div(lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.div(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
@@ -444,8 +449,7 @@ def adds(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     Returns:
         Tile wrapping the adds operation
     """
-    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
-    call_expr = _ir_ops.adds(lhs.unwrap(), rhs_expr)
+    call_expr = _ir_ops.adds(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
@@ -459,8 +463,7 @@ def subs(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     Returns:
         Tile wrapping the subs operation
     """
-    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
-    call_expr = _ir_ops.subs(lhs.unwrap(), rhs_expr)
+    call_expr = _ir_ops.subs(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
@@ -474,8 +477,7 @@ def muls(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     Returns:
         Tile wrapping the muls operation
     """
-    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
-    call_expr = _ir_ops.muls(lhs.unwrap(), rhs_expr)
+    call_expr = _ir_ops.muls(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 
@@ -489,8 +491,7 @@ def divs(lhs: Tile, rhs: int | float | Expr | Scalar) -> Tile:
     Returns:
         Tile wrapping the divs operation
     """
-    rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
-    call_expr = _ir_ops.divs(lhs.unwrap(), rhs_expr)
+    call_expr = _ir_ops.divs(lhs.unwrap(), _unwrap_rhs(rhs))
     return Tile(expr=call_expr)
 
 

--- a/tests/ut/ir/operators/test_operation_span_capture.py
+++ b/tests/ut/ir/operators/test_operation_span_capture.py
@@ -166,6 +166,18 @@ class TestTileOperationSpanCapture:
         assert result.span.filename.endswith("test_operation_span_capture.py")
         assert result.span.is_valid()
 
+    def test_tile_add_scalar_captures_span(self):
+        """Test tile add scalar sugar span capture."""
+        tile_type = ir.TileType([16, 16], DataType.FP16)
+        a = ir.Var("a", tile_type, ir.Span.unknown())
+
+        line_before = get_current_line()
+        result = tile_ops.add(a, 1.0)
+
+        assert result.span.filename.endswith("test_operation_span_capture.py")
+        assert result.span.is_valid()
+        assert result.span.begin_line == line_before + 1
+
     def test_tile_load_captures_span(self):
         """Test tile load operation span capture."""
         tensor = ir.Var("tensor", ir.TensorType([64, 64], DataType.FP16), ir.Span.unknown())

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -24,6 +24,57 @@ from pypto.language.typing import Tensor, Tile
 class TestUnifiedTensorDispatch:
     """pl.X with Tensor args produces the same IR as pl.tensor.X."""
 
+    def _assert_explicit_tensor_scalar_sugar(self, op_name: str, scalar_val: int | float) -> None:
+        """Assert explicit tensor scalar ops canonicalize to scalar-only forms."""
+        if op_name == "add":
+
+            @pl.function
+            def sugared(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.add(a, scalar_val)
+                return c
+
+            @pl.function
+            def canonical(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.adds(a, scalar_val)
+                return c
+        elif op_name == "mul":
+
+            @pl.function
+            def sugared(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.mul(a, scalar_val)
+                return c
+
+            @pl.function
+            def canonical(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.muls(a, scalar_val)
+                return c
+        elif op_name == "sub":
+
+            @pl.function
+            def sugared(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.sub(a, scalar_val)
+                return c
+
+            @pl.function
+            def canonical(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.subs(a, scalar_val)
+                return c
+        elif op_name == "div":
+
+            @pl.function
+            def sugared(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.div(a, scalar_val)
+                return c
+
+            @pl.function
+            def canonical(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.tensor.divs(a, scalar_val)
+                return c
+        else:
+            raise AssertionError(f"Unsupported tensor scalar sugar op: {op_name}")
+
+        ir.assert_structural_equal(sugared, canonical)
+
     def test_add(self):
         @pl.function
         def unified(a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
@@ -140,6 +191,14 @@ class TestUnifiedTensorDispatch:
             return c
 
         ir.assert_structural_equal(unified, explicit)
+
+    @pytest.mark.parametrize(
+        ("op_name", "scalar_val"),
+        [("add", 5), ("mul", 2.0), ("sub", 3), ("div", 4.0)],
+    )
+    def test_explicit_tensor_scalar_sugars_to_scalar_op(self, op_name: str, scalar_val: int | float):
+        """Explicit tensor scalar ops sugar to scalar-only forms."""
+        self._assert_explicit_tensor_scalar_sugar(op_name, scalar_val)
 
     def test_matmul(self):
         @pl.function
@@ -676,6 +735,89 @@ class TestUnifiedBlockDispatch:
 class TestScalarAutoDispatch:
     """pl.add(Tile, scalar) produces the same IR as pl.tile.adds."""
 
+    def _assert_explicit_tile_scalar_sugar(self, op_name: str, scalar_val: int | float) -> None:
+        """Assert explicit tile scalar ops canonicalize to scalar-only forms."""
+        if op_name == "add":
+
+            @pl.function
+            def sugared(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+
+            @pl.function
+            def canonical(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.adds(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+        elif op_name == "mul":
+
+            @pl.function
+            def sugared(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.mul(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+
+            @pl.function
+            def canonical(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.muls(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+        elif op_name == "sub":
+
+            @pl.function
+            def sugared(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.sub(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+
+            @pl.function
+            def canonical(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.subs(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+        elif op_name == "div":
+
+            @pl.function
+            def sugared(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.div(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+
+            @pl.function
+            def canonical(
+                t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+                b: pl.Tile[[64, 64], pl.FP32] = pl.tile.divs(a, scalar_val)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
+                return result
+        else:
+            raise AssertionError(f"Unsupported tile scalar sugar op: {op_name}")
+
+        ir.assert_structural_equal(sugared, canonical)
+
     def test_add_tile_scalar(self):
         @pl.function
         def unified(
@@ -759,6 +901,14 @@ class TestScalarAutoDispatch:
             return result
 
         ir.assert_structural_equal(unified, explicit)
+
+    @pytest.mark.parametrize(
+        ("op_name", "scalar_val"),
+        [("add", 5), ("mul", 3.14), ("sub", 2), ("div", 4)],
+    )
+    def test_explicit_tile_scalar_sugars_to_scalar_op(self, op_name: str, scalar_val: int | float):
+        """Explicit tile scalar ops sugar to scalar-only forms."""
+        self._assert_explicit_tile_scalar_sugar(op_name, scalar_val)
 
 
 class TestPromotedOps:


### PR DESCRIPTION
## Summary
- add scalar-rhs sugar for explicit `pl.tile.add/sub/mul/div` so scalar operands canonicalize to `adds/subs/muls/divs`
- keep explicit tensor op scalar handling aligned and add focused wrapper cleanup for scalar unwrapping
- add regression coverage for explicit scalar sugar and span capture in unified/language operator tests

## Testing
- `cmake --build build --parallel`
- `python -m pytest tests/ut/language/test_unified_ops.py tests/ut/ir/operators/test_operation_span_capture.py -q`
- `ruff check python/pypto/ir/op/tile_ops.py python/pypto/language/op/tensor_ops.py python/pypto/language/op/tile_ops.py tests/ut/language/test_unified_ops.py tests/ut/ir/operators/test_operation_span_capture.py`
- `ruff format --check python/pypto/ir/op/tile_ops.py python/pypto/language/op/tensor_ops.py python/pypto/language/op/tile_ops.py tests/ut/language/test_unified_ops.py tests/ut/ir/operators/test_operation_span_capture.py`

## Notes
- split from the broader roundtrip/scalar-sugar work previously collected in #658