### PR TITLE
refactor(codegen): rename OrchArg to TaskArg and to_tensor() to from_task_arg()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,11 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
-      - name: Clone simpler repository (stable)
+      - name: Clone and install simpler repository (stable)
         run: |
           git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          cd $GITHUB_WORKSPACE/simpler
+          pip install -v .
 
       - name: Test system tests
         run: pytest tests/st -v --device=$DEVICE_ID --forked
@@ -145,9 +147,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -v .[dev]
 
-      - name: Clone simpler repository (stable)
+      - name: Clone and install simpler repository (stable)
         run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler "${GITHUB_WORKSPACE}/simpler"
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          cd $GITHUB_WORKSPACE/simpler
+          pip install -v .
 
       - name: Run fuzz tests (sim mode)
         id: run_fuzz

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -4,7 +4,7 @@
 
 The orchestration codegen generates PTO2 runtime C++ code that manages task-graph execution on Ascend hardware. While [PTO codegen](00-pto_codegen.md) produces InCore kernel code (tile-level compute), orchestration codegen produces the host-side code that:
 
-- Wraps device memory pointers (via `OrchArg`) into `Tensor` objects
+- Wraps device memory pointers (via `TaskArg`) into `Tensor` objects
 - Builds `PTOParam` objects and calls `add_input`/`add_output`/`add_inout`/`add_scalar` to classify parameters
 - Submits tasks to AIC (CUBE) or AIV (VECTOR) cores via `pto2_rt_submit_*_task`
 - Handles control flow (loops, conditionals) with `PTO2_SCOPE`
@@ -78,25 +78,25 @@ static inline Tensor make_tensor_2d_dn(...) { ... }
 
 ```cpp
 // Phase 3: Config function — returns expected argument count
-PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
 // Phase 4: Entry function signature
 // A2/A3:
-void aicpu_orchestration_entry(OrchArg* orch,
+void aicpu_orchestration_entry(TaskArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
 // A5 (Ascend950): PTO2Runtime* rt prepended
-// void aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)
+// void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)
 ```
 
 ### Phase 5–6: Tensor Setup
 
 ```cpp
-// Phase 5: External tensors — ND layout via to_tensor()
-Tensor ext_a = orch[0].to_tensor();
-Tensor ext_b = orch[1].to_tensor();
+// Phase 5: External tensors — ND layout via from_task_arg()
+Tensor ext_a = from_task_arg(orch[0]);
+Tensor ext_b = from_task_arg(orch[1]);
 
 // DN layout: pass logical shape — make_tensor_external_2d_dn handles axis transposition internally
 uint32_t dn_shapes[2] = {orch[2].tensor.shapes[0], orch[2].tensor.shapes[1]};
@@ -136,11 +136,11 @@ PTO2_SCOPE() {
 
 | Type | Source | C++ Construction | Naming |
 | ---- | ------ | ---------------- | ------ |
-| External (ND) | Function parameters (`In`/`Out`/`InOut`) | `orch[N].to_tensor()` | `ext_<name>` |
+| External (ND) | Function parameters (`In`/`Out`/`InOut`) | `from_task_arg(orch[N])` | `ext_<name>` |
 | External (DN) | Function parameters, DN layout | `make_tensor_external_2d_dn(orch[N].data<void>(), {orch[N].tensor.shapes[0], orch[N].tensor.shapes[1]}, ...)` — axis ordering handled internally | `ext_<name>` |
 | Internal | `pl.create_tensor(...)` in function body | `make_tensor(shapes, ndims, dtype)` | `<name>` (no prefix) |
 
-External tensors wrap device memory pointers passed from the host via `OrchArg`. Internal tensors are temporary workspace allocated by the runtime.
+External tensors wrap device memory pointers passed from the host via `TaskArg`. Internal tensors are temporary workspace allocated by the runtime.
 
 ### Parameter Direction
 
@@ -178,7 +178,7 @@ When targeting Ascend950 (`BackendType::Ascend950`), the generated C++ differs i
 
 | Element | A2/A3 | A5 |
 | ------- | ----- | -- |
-| Entry function | `aicpu_orchestration_entry(OrchArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)` |
+| Entry function | `aicpu_orchestration_entry(TaskArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)` |
 | Scope macro | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
 | Submit calls | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
 
@@ -235,7 +235,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | Read scalar from host tensor |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
-| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | Runtime dimension from OrchArg |
+| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | Runtime dimension from TaskArg |
 
 ## Complete Example
 
@@ -268,22 +268,22 @@ static uint64_t float_to_u64(float f) { /* ... */ }
 
 extern "C" {
 
-PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
-void aicpu_orchestration_entry(OrchArg* orch,
+void aicpu_orchestration_entry(TaskArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
     // Note: A5 adds PTO2Runtime* rt as the first parameter
     (void)arg_count;
     (void)orch_thread_num;
     (void)orch_thread_index;
 
-    // External tensors (from OrchArg)
-    Tensor ext_a = orch[0].to_tensor();
-    Tensor ext_b = orch[1].to_tensor();
-    Tensor ext_d = orch[2].to_tensor();
+    // External tensors (from TaskArg)
+    Tensor ext_a = from_task_arg(orch[0]);
+    Tensor ext_b = from_task_arg(orch[1]);
+    Tensor ext_d = from_task_arg(orch[2]);
 
     // Internal tensor (intermediate)
     uint32_t c_shapes[2] = {16, 16};
@@ -333,7 +333,7 @@ names in the output), but never for identity decisions.
 | External tensor | `ext_<name>` | `ext_a` |
 | Internal tensor | `<name>` (no prefix) | `c` |
 | Task params | `params_t<N>` | `params_t0` |
-| OrchArg index | `orch[N]` (N-th tensor parameter) | `orch[0]` |
+| TaskArg index | `orch[N]` (N-th tensor parameter) | `orch[0]` |
 
 ## Control Flow Generation
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -4,7 +4,7 @@
 
 编排代码生成器（Orchestration Codegen）生成 PTO2 运行时 C++ 代码，用于管理昇腾硬件上的任务图执行。[PTO 代码生成](00-pto_codegen.md)产生 InCore 核函数代码（Tile 级计算），而编排代码生成器产生主机侧代码，负责：
 
-- 将设备内存指针（通过 `OrchArg`）封装为 `Tensor` 对象
+- 将设备内存指针（通过 `TaskArg`）封装为 `Tensor` 对象
 - 构建 `PTOParam` 对象，调用 `add_input`/`add_output`/`add_inout`/`add_scalar` 对参数分类
 - 通过 `pto2_rt_submit_*_task` 向 AIC（CUBE）或 AIV（VECTOR）核心提交任务
 - 处理控制流（循环、条件分支），使用 `PTO2_SCOPE`
@@ -78,25 +78,25 @@ static inline Tensor make_tensor_2d_dn(...) { ... }
 
 ```cpp
 // 阶段 3：配置函数 — 返回期望的参数数量
-PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
 // 阶段 4：入口函数签名
 // A2/A3：
-void aicpu_orchestration_entry(OrchArg* orch,
+void aicpu_orchestration_entry(TaskArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
 // A5（Ascend950）：在参数列表前增加 PTO2Runtime* rt
-// void aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)
+// void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)
 ```
 
 ### 阶段 5–6：张量设置
 
 ```cpp
-// 阶段 5：外部张量 — ND 布局直接调用 to_tensor()
-Tensor ext_a = orch[0].to_tensor();
-Tensor ext_b = orch[1].to_tensor();
+// 阶段 5：外部张量 — ND 布局直接调用 from_task_arg()
+Tensor ext_a = from_task_arg(orch[0]);
+Tensor ext_b = from_task_arg(orch[1]);
 
 // DN 布局：传入逻辑形状 — make_tensor_external_2d_dn 内部处理轴转置
 uint32_t dn_shapes[2] = {orch[2].tensor.shapes[0], orch[2].tensor.shapes[1]};
@@ -136,11 +136,11 @@ PTO2_SCOPE() {
 
 | 类型 | 来源 | C++ 构造方式 | 命名 |
 | ---- | ---- | ------------ | ---- |
-| 外部（ND） | 函数参数（`In`/`Out`/`InOut`） | `orch[N].to_tensor()` | `ext_<name>` |
+| 外部（ND） | 函数参数（`In`/`Out`/`InOut`） | `from_task_arg(orch[N])` | `ext_<name>` |
 | 外部（DN） | 函数参数，DN 布局 | `make_tensor_external_2d_dn(orch[N].data<void>(), {orch[N].tensor.shapes[0], orch[N].tensor.shapes[1]}, ...)` — 轴排序由函数内部处理 | `ext_<name>` |
 | 内部（Internal） | 函数体中的 `pl.create_tensor(...)` | `make_tensor(shapes, ndims, dtype)` | `<name>`（无前缀） |
 
-外部张量封装从主机通过 `OrchArg` 传入的设备内存指针。内部张量是运行时分配的临时工作空间。
+外部张量封装从主机通过 `TaskArg` 传入的设备内存指针。内部张量是运行时分配的临时工作空间。
 
 ### 参数方向
 
@@ -178,7 +178,7 @@ Tensor& result = ext_output;  // 别名 — result 引用 ext_output
 
 | 元素 | A2/A3 | A5 |
 | ---- | ----- | -- |
-| 入口函数 | `aicpu_orchestration_entry(OrchArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, OrchArg* orch, ...)` |
+| 入口函数 | `aicpu_orchestration_entry(TaskArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)` |
 | Scope 宏 | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
 | 提交调用 | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
 
@@ -235,7 +235,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | 从主机张量读取标量 |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
-| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | 从 OrchArg 获取运行时维度 |
+| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | 从 TaskArg 获取运行时维度 |
 
 ## 完整示例
 
@@ -268,22 +268,22 @@ static uint64_t float_to_u64(float f) { /* ... */ }
 
 extern "C" {
 
-PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
-void aicpu_orchestration_entry(OrchArg* orch,
+void aicpu_orchestration_entry(TaskArg* orch,
     int arg_count, int orch_thread_num, int orch_thread_index) {
     // 注意：A5 在参数列表前增加 PTO2Runtime* rt
     (void)arg_count;
     (void)orch_thread_num;
     (void)orch_thread_index;
 
-    // 外部张量（来自 OrchArg）
-    Tensor ext_a = orch[0].to_tensor();
-    Tensor ext_b = orch[1].to_tensor();
-    Tensor ext_d = orch[2].to_tensor();
+    // 外部张量（来自 TaskArg）
+    Tensor ext_a = from_task_arg(orch[0]);
+    Tensor ext_b = from_task_arg(orch[1]);
+    Tensor ext_d = from_task_arg(orch[2]);
 
     // 内部张量（中间变量）
     uint32_t c_shapes[2] = {16, 16};
@@ -332,7 +332,7 @@ void aicpu_orchestration_entry(OrchArg* orch,
 | 外部张量 | `ext_<name>` | `ext_a` |
 | 内部张量 | `<name>`（无前缀） | `c` |
 | 任务参数 | `params_t<N>` | `params_t0` |
-| OrchArg 索引 | `orch[N]`（第 N 个张量参数） | `orch[0]` |
+| TaskArg 索引 | `orch[N]`（第 N 个张量参数） | `orch[0]` |
 
 ## 控制流生成
 

--- a/include/pypto/codegen/orchestration/orchestration_codegen.h
+++ b/include/pypto/codegen/orchestration/orchestration_codegen.h
@@ -37,9 +37,9 @@ struct OrchestrationResult {
  * @brief Generate C++ orchestration code for a function
  *
  * Generates C++ code using PTO2 runtime API:
- * - aicpu_orchestration_config(OrchArg* orch_args) returns PTO2OrchestrationConfig
- * - aicpu_orchestration_entry(OrchArg* orch, int arg_count, int orch_thread_num, int orch_thread_index)
- * - OrchArg::to_tensor() for ND external tensors, make_tensor for internal tensors
+ * - aicpu_orchestration_config(TaskArg* orch_args) returns PTO2OrchestrationConfig
+ * - aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index)
+ * - from_task_arg() for ND external tensors, make_tensor for internal tensors
  * - PTOParam + pto2_rt_submit_task for task submission
  * - No manual dependency management (runtime handles automatically)
  *

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -71,7 +71,7 @@ def write_golden(
         rtol: Relative tolerance used by CodeRunner for result comparison.
         atol: Absolute tolerance used by CodeRunner for result comparison.
         scalar_specs: Optional list of scalar parameter specifications.  Scalar
-            OrchArg entries appear after all tensor entries in the generated list.
+            TaskArg entries appear after all tensor entries in the generated list.
 
     Returns:
         The resolved ``output_path`` after writing.
@@ -103,9 +103,9 @@ def generate_golden_source(
             When provided, *golden_fn* is ignored and this string is used directly.
             Use this when the source comes from a method that requires caller-side
             transformation (e.g. stripping ``self`` from the signature).
-        scalar_specs: Optional list of scalar OrchArg specifications.  Entries are
+        scalar_specs: Optional list of scalar TaskArg specifications.  Entries are
             placed after all tensor entries in the returned list, matching the
-            OrchArg slot order produced by orchestration codegen.
+            TaskArg slot order produced by orchestration codegen.
 
     Returns:
         Full Python source for ``golden.py`` as a string.

--- a/python/pypto/runtime/tensor_spec.py
+++ b/python/pypto/runtime/tensor_spec.py
@@ -89,9 +89,9 @@ SCALAR_CTYPE_MAP: dict[str, str] = {
 
 @dataclass
 class ScalarSpec:
-    """Specification for a scalar OrchArg parameter.
+    """Specification for a scalar TaskArg parameter.
 
-    Scalar parameters occupy OrchArg slots after all tensor parameters.
+    Scalar parameters occupy TaskArg slots after all tensor parameters.
     The generated golden.py emits ``ctypes`` scalar values so that
     Simpler's CodeRunner populates ``orch[i].scalar`` correctly.
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -494,7 +494,7 @@ std::string GenerateHelperFunctions() {
   return oss.str();
 }
 
-// Generate scalar variable declaration from OrchArg scalar slot.
+// Generate scalar variable declaration from TaskArg scalar slot.
 // Uses value_as<T>() for type-safe reinterpretation (memcpy-based type punning).
 std::string GenerateScalarUnpack(const std::string& var_name, int orch_index,
                                  const ScalarTypePtr& scalar_type) {
@@ -542,7 +542,7 @@ static inline Tensor make_tensor_2d_dn(
 std::string GenerateConfigFunction(int expected_arg_count) {
   std::ostringstream oss;
   oss << "__attribute__((visibility(\"default\")))\n";
-  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {\n";
+  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {\n";
   oss << "    (void)orch_args;\n";
   oss << "    return PTO2OrchestrationConfig{\n";
   oss << "        .expected_arg_count = " << expected_arg_count << ",\n";
@@ -573,7 +573,7 @@ std::string CoreTypeToSubmitPrefix(CoreType core_type) {
 
 // Removed DataTypeToPTO2Enum — now uses DataTypeToString from dtype.h
 
-// Generate external tensor declaration from OrchArg
+// Generate external tensor declaration from TaskArg
 std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_index,
                                        const TensorTypePtr& tensor_type, const CodegenBase& codegen) {
   std::ostringstream oss;
@@ -591,8 +591,8 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
         << "orch[" << orch_index << "].data<void>(), " << var_name << "_shapes, " << ndim << ", "
         << codegen.GetRuntimeDataTypeString(tensor_type->dtype_) << ");\n";
   } else {
-    // ND layout: use OrchArg::to_tensor() directly
-    oss << "    Tensor ext_" << var_name << " = orch[" << orch_index << "].to_tensor();\n";
+    // ND layout: use from_task_arg() to convert TaskArg to Tensor
+    oss << "    Tensor ext_" << var_name << " = from_task_arg(orch[" << orch_index << "]);\n";
   }
 
   return oss.str();
@@ -1296,7 +1296,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   std::set<std::string> param_name_set;
   std::map<std::string, int> param_name_to_orch_index;
   int tensor_param_count = 0;
-  // Collect scalar params in declaration order for OrchArg assignment after tensors
+  // Collect scalar params in declaration order for TaskArg assignment after tensors
   struct ScalarParamInfo {
     std::string emit_name;
     ScalarTypePtr scalar_type;
@@ -1314,7 +1314,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  // Scalar params occupy OrchArg slots after all tensor params
+  // Scalar params occupy TaskArg slots after all tensor params
   int scalar_param_start = tensor_param_count;
   for (size_t i = 0; i < scalar_params.size(); ++i) {
     param_name_to_orch_index[scalar_params[i].emit_name] = scalar_param_start + static_cast<int>(i);
@@ -1351,7 +1351,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   oss << "__attribute__((visibility(\"default\")))\n";
   std::string rt_param = IsA5Backend() ? "PTO2Runtime* rt, " : "";
   oss << "void aicpu_orchestration_entry(" << rt_param
-      << "OrchArg* orch, int arg_count, "
+      << "TaskArg* orch, int arg_count, "
          "int orch_thread_num, int orch_thread_index) {\n";
   oss << "    (void)arg_count;\n";
   oss << "    (void)orch_thread_num;\n";
@@ -1367,7 +1367,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.SetAssembleViewInfos(buffer_info.assemble_view_infos);
   stmt_codegen.SetNonOptimizableAssembleRoots(buffer_info.non_optimizable_assemble_roots);
 
-  // 6. External tensors (from OrchArg — all from params)
+  // 6. External tensors (from TaskArg — all from params)
   oss << "    // External tensors\n";
   int orch_idx = 0;
   for (const auto& var : func->params_) {
@@ -1379,7 +1379,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  // 7. Scalar params (from OrchArg — slots after tensors)
+  // 7. Scalar params (from TaskArg — slots after tensors)
   if (!scalar_params.empty()) {
     oss << "\n    // Scalar params\n";
     for (size_t i = 0; i < scalar_params.size(); ++i) {

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -265,7 +265,7 @@ REGISTER_ORCHESTRATION_OP(tensor_dim, ("tensor.dim")) {
   // For a compile-time constant dim, emit the literal directly.
   // For a dynamic dim (e.g. pl.dynamic("M")), GenerateExprString returns the
   // dynamic var name (e.g. "M"), which is not a valid C++ identifier in the
-  // orchestration scope.  Read the runtime shape from the OrchArg instead.
+  // orchestration scope.  Read the runtime shape from the TaskArg instead.
   std::string dim_expr;
   if (As<ConstInt>(tensor_type->shape_[axis])) {
     dim_expr = codegen.GenerateExprString(tensor_type->shape_[axis]);

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -179,10 +179,10 @@ class PTOTestCase(ABC):
         return BackendType.Ascend910B
 
     def define_scalars(self) -> list[ScalarSpec]:
-        """Define scalar OrchArg parameters for this test.
+        """Define scalar TaskArg parameters for this test.
 
         Override to provide scalar values that are passed to the orchestration
-        function via OrchArg scalar slots (after all tensor slots).
+        function via TaskArg scalar slots (after all tensor slots).
 
         Returns:
             List of ScalarSpec objects.  Empty by default.

--- a/tests/st/runtime/test_dyn_orch_shape.py
+++ b/tests/st/runtime/test_dyn_orch_shape.py
@@ -15,13 +15,13 @@ Four scenarios are covered, mirroring the UT codegen tests in
 tests/ut/codegen/test_orchestration_codegen.py (TestDynShapeOrchestration).
 The key feature under test is that the **orchestration function itself** uses
 ``pl.dynamic()`` dims (``M``, ``N``) in its tensor type annotations, exercising
-the ``OrchArg::to_tensor()`` path introduced by the dynamic-shape commit.
+the ``from_task_arg()`` path introduced by the dynamic-shape commit.
 
 Scenarios:
-- Scenario 1 — fully dynamic M×N orch: both InCore and orchestration use
-  ``pl.Tensor[[M, N], pl.FP32]``; validates ``OrchArg::to_tensor()`` for
+- Scenario 1 — fully dynamic MxN orch: both InCore and orchestration use
+  ``pl.Tensor[[M, N], pl.FP32]``; validates ``from_task_arg()`` for
   external tensors with no static shape information in the orch signature.
-- Scenario 2 — dynamic orch + valid_shapes scalars: orchestration uses M×N
+- Scenario 2 — dynamic orch + valid_shapes scalars: orchestration uses MxN
   dims; m, n scalars are read from an INT64 tensor via ``pl.tensor.read`` and
   forwarded to the InCore kernel as valid_shapes.
 - Scenario 3 — mixed dynamic M / static cols: orchestration uses
@@ -81,7 +81,7 @@ class DynOrchAddTestCase(PTOTestCase):
 
     Key difference from DynShapeAddTestCase in test_dynamic_shape.py: the
     orchestration signature uses ``pl.Tensor[[M, N], pl.FP32]`` (dynamic dims)
-    instead of closure-variable static dims.  Validates that OrchArg::to_tensor()
+    instead of closure-variable static dims.  Validates that from_task_arg()
     correctly delivers runtime tensor metadata for fully dynamic external params.
     Expected result: c = a + b over the full rows×cols tile.
     """
@@ -241,7 +241,7 @@ class DynOrchLoopMixedDimsAddTestCase(PTOTestCase):
     match the static dim in the orchestration type annotation.  rows must be
     divisible by 2 — the loop processes pairs of rows per iteration.  The InCore
     function reads M from the first tensor dimension via pl.tensor.dim.
-    Validates OrchArg::to_tensor() for mixed dynamic/static dim tensors.
+    Validates from_task_arg() for mixed dynamic/static dim tensors.
     Expected result: c = a + b over the full rows×cols tile.
     """
 
@@ -381,7 +381,7 @@ class DynOrchDimOnDynParamAddTestCase(PTOTestCase):
 class DynOrchPagedAttentionTestCase(PTOTestCase):
     """Paged attention where the orchestration uses fully dynamic dims (QR, KCR, HD, BT, B).
 
-    Exercises OrchArg::to_tensor() for all external tensors in the paged attention
+    Exercises from_task_arg() for all external tensors in the paged attention
     pipeline.  All runtime configuration values (batch, num_heads, head_dim,
     block_size, max_blocks) are derived from tensor shapes via pl.tensor.dim()
     and scalar arithmetic — no config_t tensor is needed.

--- a/tests/ut/codegen/test_golden_writer.py
+++ b/tests/ut/codegen/test_golden_writer.py
@@ -33,7 +33,7 @@ class _BoundGoldenCase:
 
 
 class TestGoldenWriterScalar:
-    """Tests for scalar OrchArg entries in generated golden.py."""
+    """Tests for scalar TaskArg entries in generated golden.py."""
 
     def test_scalar_int64_in_generate_inputs(self):
         """Scalar INT64 entry appears after tensors with ctypes.c_int64."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -112,7 +112,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -153,15 +153,15 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(OrchArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
+            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
                 (void)arg_count;
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_a = orch[0].to_tensor();
-                Tensor ext_b = orch[1].to_tensor();
-                Tensor ext_d = orch[2].to_tensor();
+                Tensor ext_a = from_task_arg(orch[0]);
+                Tensor ext_b = from_task_arg(orch[1]);
+                Tensor ext_d = from_task_arg(orch[2]);
 
                 PTO2_SCOPE() {
                     uint32_t c_shapes[2] = {16, 16};
@@ -298,7 +298,7 @@ class TestOrchestration:
         # Two return tensors: c and d are both external
         assert "ext_c" in code
         assert "ext_d" in code
-        assert "to_tensor()" in code
+        assert "from_task_arg(" in code
 
         # Two tasks submitted
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -401,7 +401,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -442,15 +442,15 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(OrchArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
+            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
                 (void)arg_count;
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_a = orch[0].to_tensor();
-                Tensor ext_b = orch[1].to_tensor();
-                Tensor ext_f = orch[2].to_tensor();
+                Tensor ext_a = from_task_arg(orch[0]);
+                Tensor ext_b = from_task_arg(orch[1]);
+                Tensor ext_f = from_task_arg(orch[2]);
 
                 PTO2_SCOPE() {
                     uint32_t c_shapes[2] = {16, 16};
@@ -560,7 +560,7 @@ class TestOrchestration:
         assert "DataType::FLOAT32" in code
 
         # Return tensor result is external
-        assert "orch[2].to_tensor()" in code
+        assert "from_task_arg(orch[2])" in code
 
         # Two tasks: kernel_pair + kernel_add
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -604,11 +604,11 @@ class TestOrchestration:
 
         code = _generate_orch_code(TupleOutputProgram)
 
-        # Both x and y are return tensors: orch[].to_tensor()
+        # Both x and y are return tensors: from_task_arg(orch[])
         assert "ext_x" in code
         assert "ext_y" in code
-        assert "orch[2].to_tensor()" in code
-        assert "orch[3].to_tensor()" in code
+        assert "from_task_arg(orch[2])" in code
+        assert "from_task_arg(orch[3])" in code
 
         # Only one task: kernel_pair
         assert code.count("pto2_rt_submit_aiv_task") == 1
@@ -683,13 +683,13 @@ class TestOrchestration:
         code = _generate_orch_code(FourTupleProgram)
 
         # All orch params are external tensors (mij=0, lij=1, oi_new=2, mi_in=3, li_in=4, oi_in=5, dst_in=6, final=7)
-        assert "Tensor ext_mi_in = orch[3].to_tensor()" in code
-        assert "Tensor ext_li_in = orch[4].to_tensor()" in code
-        assert "Tensor ext_oi_in = orch[5].to_tensor()" in code
-        assert "Tensor ext_dst_in = orch[6].to_tensor()" in code
+        assert "Tensor ext_mi_in = from_task_arg(orch[3])" in code
+        assert "Tensor ext_li_in = from_task_arg(orch[4])" in code
+        assert "Tensor ext_oi_in = from_task_arg(orch[5])" in code
+        assert "Tensor ext_dst_in = from_task_arg(orch[6])" in code
 
         # Final return tensor is external
-        assert "Tensor ext_final = orch[7].to_tensor()" in code
+        assert "Tensor ext_final = from_task_arg(orch[7])" in code
 
         # Two tasks: online_update + kernel_add
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -820,7 +820,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(OrchArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 7,
@@ -861,19 +861,19 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(OrchArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
+            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
                 (void)arg_count;
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_mij = orch[0].to_tensor();
-                Tensor ext_lij = orch[1].to_tensor();
-                Tensor ext_oi_new = orch[2].to_tensor();
-                Tensor ext_mi = orch[3].to_tensor();
-                Tensor ext_li = orch[4].to_tensor();
-                Tensor ext_oi = orch[5].to_tensor();
-                Tensor ext_dst = orch[6].to_tensor();
+                Tensor ext_mij = from_task_arg(orch[0]);
+                Tensor ext_lij = from_task_arg(orch[1]);
+                Tensor ext_oi_new = from_task_arg(orch[2]);
+                Tensor ext_mi = from_task_arg(orch[3]);
+                Tensor ext_li = from_task_arg(orch[4]);
+                Tensor ext_oi = from_task_arg(orch[5]);
+                Tensor ext_dst = from_task_arg(orch[6]);
 
                 PTO2_SCOPE() {
 
@@ -1220,8 +1220,8 @@ class TestOrchestration:
         assert "b_acc = b_acc;" not in code
 
         # make_tensor declarations exist (exactly once each)
-        # a_acc is a return value → external (orch[].to_tensor())
-        assert code.count("Tensor ext_a_acc = orch[1].to_tensor()") == 1
+        # a_acc is a return value → external (from_task_arg(orch[]))
+        assert code.count("Tensor ext_a_acc = from_task_arg(orch[1])") == 1
         assert code.count("Tensor b_acc = make_tensor(") == 1
 
         # For loop exists with correct structure
@@ -1269,8 +1269,8 @@ class TestOrchestration:
         # Inplace detection: output_tensor return var should match the param,
         # so only 2 orch arg slots (input_tensor + output_tensor), not 3
         assert "expected_arg_count = 2" in code
-        assert "orch[0].to_tensor()" in code  # input_tensor
-        assert "orch[1].to_tensor()" in code  # output_tensor
+        assert "from_task_arg(orch[0])" in code  # input_tensor
+        assert "from_task_arg(orch[1])" in code  # output_tensor
 
         # No third orch entry for the compound-named return var
         assert "orch[2]" not in code
@@ -1429,9 +1429,9 @@ class TestOrchestration:
         code = _generate_orch_code(NumericSuffixProgram)
 
         # Each param must get a distinct orch index
-        assert "orch[0].to_tensor()" in code  # x
-        assert "orch[1].to_tensor()" in code  # out_0
-        assert "orch[2].to_tensor()" in code  # out_1
+        assert "from_task_arg(orch[0])" in code  # x
+        assert "from_task_arg(orch[1])" in code  # out_0
+        assert "from_task_arg(orch[2])" in code  # out_1
 
         # No collapsed names
         assert "ARG_PTR" not in code
@@ -1486,8 +1486,8 @@ class TestOrchestration:
         assert "Tensor& second = ret0__out_1;" in code
         assert "add_output(ret0)" not in code
 
-    def test_scalar_orcharg(self):
-        """Scalar params (INT64, INT32, FP32) get OrchArg slots after tensors and use value_as<T>()."""
+    def test_scalar_taskarg(self):
+        """Scalar params (INT64, INT32, FP32) get TaskArg slots after tensors and use value_as<T>()."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1521,8 +1521,8 @@ class TestOrchestration:
         code = _generate_orch_code(MultiScalarProgram)
 
         # Tensors at orch[0..1], scalars at orch[2..4]
-        assert "orch[0].to_tensor()" in code
-        assert "orch[1].to_tensor()" in code
+        assert "from_task_arg(orch[0])" in code
+        assert "from_task_arg(orch[1])" in code
         assert "int64_t factor = orch[2].value_as<int64_t>();" in code
         assert "int32_t count = orch[3].value_as<int32_t>();" in code
         assert "float scale = orch[4].value_as<float>();" in code


### PR DESCRIPTION
Update orchestration codegen, ST/UT tests, harness docstrings, and EN/ZH
docs to reflect the renamed runtime API. Also install simpler as a pip
package in CI before running system tests.