### PR TITLE
refactor(ir): move tile.store MemRef reuse rule into OpRegistry

### DIFF
--- a/docs/en/dev/passes/12-init_memref.md
+++ b/docs/en/dev/passes/12-init_memref.md
@@ -45,9 +45,9 @@ program_with_memrefs = init_pass(program)
 
 1. **Normalize structure**: Call `NormalizeStmtStructure` to ensure flat `SeqStmts` structure
 2. **Initialize MemRef**: Read `memory_space` from `TileType` (set by InferTileMemorySpace), create MemRef objects (addr=-1) and attach to variable types
-   - **tile.store**: result shares MemRef with the output tensor argument
+   - **tile.store**: result shares MemRef with the output tensor argument (specified by `output_reuses_input_arg` registry attribute)
    - **View ops** (e.g. `tile.reshape`): output shares MemRef with the input tile
-   - **Accumulate ops** (e.g. `tile.matmul_acc`, `tile.gemv_acc`): output shares MemRef with the accumulator input (specified by `output_reuses_input_arg` registry attribute)
+   - **Reuse-input ops** (e.g. `tile.matmul_acc`, `tile.gemv_acc`): output shares MemRef with the specified input (via `output_reuses_input_arg` registry attribute)
    - **ForStmt/IfStmt return_vars**: patched to share MemRef with corresponding yield values
 3. **Collect non-DDR MemRefs**: Gather unique MemRef objects from TileType variables that are not in DDR
 4. **Create alloc statements**: For each non-DDR MemRef, create `tile.alloc(memspace, -1, size, id)`
@@ -86,8 +86,8 @@ Key observations:
 
 - `addr=-1` indicates addresses are not yet assigned (done later by AllocateMemoryAddr)
 - DDR MemRefs (params) do not get `tile.alloc` statements
-- `tile.store` result shares MemRef with the output tensor parameter
-- Accumulate ops (`matmul_acc`, `gemv_acc`) share MemRef with their accumulator input, preventing redundant Acc allocs
+- `tile.store` result shares MemRef with the output tensor parameter (via `output_reuses_input_arg` registry attribute)
+- Reuse-input ops (`tile.store`, `matmul_acc`, `gemv_acc`) share MemRef with their designated input, preventing redundant allocs
 - Alloc statements are placed at the beginning of the function body's top-level `SeqStmts`
 
 ## ForStmt Loop-Carry Variables
@@ -120,7 +120,7 @@ Pass InitMemRef();
 
 - `NormalizeStmtStructure` is called internally before MemRef initialization
 - `InitMemRefMutator` reads `memory_space` from `TileType` and creates MemRef objects
-  - Handles MemRef sharing for `tile.store`, view ops, accumulate ops, and ForStmt/IfStmt yield values
+  - Handles MemRef sharing for view ops, reuse-input ops (`tile.store`, `matmul_acc`, `gemv_acc`), and ForStmt/IfStmt yield values
 - `NonDDRMemRefCollector` collects unique non-DDR MemRefs
 - `CreateAllocStatement` / `InsertAllocsIntoBody` create and insert alloc ops
 

--- a/docs/zh-cn/dev/passes/12-init_memref.md
+++ b/docs/zh-cn/dev/passes/12-init_memref.md
@@ -45,9 +45,9 @@ program_with_memrefs = init_pass(program)
 
 1. **规范化结构**：调用 `NormalizeStmtStructure` 确保 `SeqStmts` 为扁平结构
 2. **初始化 MemRef**：从 `TileType` 读取 `memory_space`（由 InferTileMemorySpace 设置），创建 MemRef 对象（addr=-1）并附加到变量类型
-   - **tile.store**：结果与输出 tensor 参数共享 MemRef
+   - **tile.store**：结果与输出 tensor 参数共享 MemRef（由 `output_reuses_input_arg` 注册表属性指定）
    - **View 操作**（如 `tile.reshape`）：输出与输入 tile 共享 MemRef
-   - **累加操作**（如 `tile.matmul_acc`、`tile.gemv_acc`）：输出与累加器输入共享 MemRef（由 `output_reuses_input_arg` 注册表属性指定）
+   - **复用输入操作**（如 `tile.matmul_acc`、`tile.gemv_acc`）：输出与指定输入共享 MemRef（由 `output_reuses_input_arg` 注册表属性指定）
    - **ForStmt/IfStmt return_vars**：修补为与对应 yield 值共享 MemRef
 3. **收集非 DDR MemRef**：从 TileType 变量中收集不在 DDR 中的唯一 MemRef 对象
 4. **创建 alloc 语句**：为每个非 DDR MemRef 创建 `tile.alloc(memspace, -1, size, id)`
@@ -86,8 +86,8 @@ def main(
 
 - `addr=-1` 表示地址尚未分配（稍后由 AllocateMemoryAddr 完成）
 - DDR MemRef（参数）不会生成 `tile.alloc` 语句
-- `tile.store` 结果与输出张量参数共享 MemRef
-- 累加操作（`matmul_acc`、`gemv_acc`）与累加器输入共享 MemRef，避免冗余 Acc alloc
+- `tile.store` 结果与输出张量参数共享 MemRef（通过 `output_reuses_input_arg` 注册表属性指定）
+- 复用输入操作（`tile.store`、`matmul_acc`、`gemv_acc`）与指定输入共享 MemRef，避免冗余 alloc
 - Alloc 语句放置在函数体顶层 `SeqStmts` 的开头
 
 ## ForStmt 循环携带变量
@@ -120,7 +120,7 @@ Pass InitMemRef();
 
 - `NormalizeStmtStructure` 在 MemRef 初始化之前被内部调用
 - `InitMemRefMutator` 从 `TileType` 读取 `memory_space` 并创建 MemRef 对象
-  - 处理 `tile.store`、view 操作、累加操作以及 ForStmt/IfStmt yield 值的 MemRef 共享
+  - 处理 view 操作、复用输入操作（`tile.store`、`matmul_acc`、`gemv_acc`）以及 ForStmt/IfStmt yield 值的 MemRef 共享
 - `NonDDRMemRefCollector` 收集唯一的非 DDR MemRef
 - `CreateAllocStatement` / `InsertAllocsIntoBody` 创建并插入 alloc 操作
 

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -500,6 +500,7 @@ REGISTER_OP("tile.store")
                   "Optional ND partition shape (TupleType). "
                   "Injected by FlattenTileNdTo2D for ND tensors.")
     .set_input_memory(0, {MemorySpace::Vec, MemorySpace::Acc})
+    .set_output_reuses_input(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileStoreType(args, kwargs, "tile.store");

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -201,8 +201,6 @@ class InitMemRefMutator : public IRMutator {
     return std::static_pointer_cast<const Expr>(GetNewVar(var_ptr));
   }
 
-  // Handle tile.store specially: return value should share the same MemRef as the 3rd argument
-  // (output_tensor)
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     // First visit the value (RHS)
     auto new_value = VisitExpr(op->value_);
@@ -240,7 +238,7 @@ class InitMemRefMutator : public IRMutator {
         }
       }
 
-      // Handle accumulate operations: output shares MemRef with a specific input arg
+      // Handle ops whose output reuses a specific input arg's MemRef (registry-based)
       auto reuse_arg_idx = GetOutputReusesInputArg(call->op_->name_);
       if (reuse_arg_idx.has_value()) {
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
@@ -256,30 +254,6 @@ class InitMemRefMutator : public IRMutator {
                 source_memory_space);
             VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
             var_map_[op->var_] = new_var;
-            return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
-          }
-        }
-      }
-
-      // Check if the RHS is a tile.store call
-      if (call->op_->name_ == "tile.store") {
-        // Get the 3rd argument (output tensor) after mutation
-        auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
-        if (new_call && new_call->args_.size() > 2) {
-          auto output_tensor_arg = new_call->args_[2];
-
-          // Extract MemRef from the output tensor
-          auto shared_memref = GetTypeMemRef(output_tensor_arg->GetType());
-
-          // Create new variable with the shared MemRef
-          if (shared_memref.has_value()) {
-            TypePtr new_type = CloneTypeWithMemRefAndRemapExprs(
-                op->var_->GetType(), shared_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
-                ResolveTileMemorySpace(op->var_->GetType()));
-
-            VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
-            var_map_[op->var_] = new_var;
-
             return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
           }
         }


### PR DESCRIPTION
Fixes #541

Replace the hard-coded tile.store branch in InitMemRef with the existing registry-based `set_output_reuses_input(2)` declaration. The generic GetOutputReusesInputArg path now handles tile.store alongside matmul_acc and gemv_acc, eliminating the last op-name string match in the pass.

Made-with: Cursor