### PR TITLE
refactor(pass): extract allocation policy from AllocateMemoryAddr

### DIFF
--- a/docs/en/dev/passes/15-allocate_memory_addr.md
+++ b/docs/en/dev/passes/15-allocate_memory_addr.md
@@ -42,18 +42,20 @@ program_with_addrs = alloc_pass(program)
 1. **Collect MemRefs**: Traverse function body to find all unique MemRef objects from TileType variables
 2. **Group by memory space**: Organize MemRefs by memory space (Vec, Mat, Left, Right, Acc)
 3. **Resolve reserve buffers**: For each function, scan `system.reserve_buffer` calls, assign explicit bases to AUTO buffers, and compute the reserved end address per memory space
-4. **Allocate addresses**: For each memory space, sort MemRefs by ID and assign sequential 32-byte aligned addresses starting from that space's reserved end (or `0` when no reserve buffer exists)
+4. **Allocate addresses**: For each memory space, delegate to a `MemoryAllocatorPolicy` to filter spaces, order MemRefs, and align addresses. The default policy sorts by ID, uses 32-byte alignment, and starts from the reserved end (or `0`)
 5. **Update in place**: Use `MemRefUpdateMutator` to:
    - Replace old MemRef references in variable types (TileType/TensorType) with new MemRefs containing real addresses
    - Update existing `tile.alloc` `AssignStmt`s: replace LHS MemRef and update addr argument in the Call expression
    - Rewrite `system.reserve_buffer` kwargs with the resolved explicit `base`
 
-**Address allocation**:
+**Address allocation (default policy)**:
 
 - Each memory space has its own address space starting from 0 unless `system.reserve_buffer` already reserved a leading window in that space
 - Addresses are 32-byte aligned: `next_addr = align32(current_addr + size)`
 - MemRefs are sorted by ID for deterministic allocation order
 - DDR MemRefs are skipped (addresses managed externally)
+
+Backends can override these defaults by supplying a custom `MemoryAllocatorPolicy` via `Backend::CreateMemoryAllocatorPolicy()`. See [Allocation Policy](#allocation-policy) below.
 
 ## Example
 
@@ -106,9 +108,8 @@ Pass AllocateMemoryAddr();
 **Implementation**: `src/ir/transforms/allocate_memory_addr_pass.cpp`
 
 - `MemRefCollectorVisitor` collects unique MemRefs from TileType variables
-- `AllocateMemoryAddresses` assigns sequential aligned addresses per memory space
+- `AllocateMemoryAddresses` assigns sequential aligned addresses per memory space using a `MemoryAllocatorPolicy`
 - `MemRefUpdateMutator` updates both variable types and `tile.alloc` statement arguments in a single traversal
-- DDR MemRefs are skipped (no address allocation needed)
 
 **Python binding**: `python/bindings/modules/passes.cpp`
 
@@ -124,3 +125,45 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - Tests empty function (no tiles)
 - Tests alloc statements are prepended to the function body's top-level `SeqStmts`
 - Tests raw pointer uniqueness for MemRef deduplication
+- Tests default policy behavior without a backend configured
+
+## Allocation Policy
+
+The pass delegates placement decisions to a `MemoryAllocatorPolicy` interface (`include/pypto/ir/memory_allocator_policy.h`), making the allocation strategy extensible without modifying the pass itself.
+
+### Interface
+
+```cpp
+class MemoryAllocatorPolicy {
+ public:
+  virtual ~MemoryAllocatorPolicy() = default;
+  virtual bool ShouldAllocate(MemorySpace space) const = 0;
+  virtual uint64_t AlignAddress(uint64_t addr, MemorySpace space) const = 0;
+  virtual void OrderMemRefs(std::vector<MemRefPtr>& refs) const = 0;
+};
+```
+
+| Method | Purpose | Default behavior |
+| ------ | ------- | ---------------- |
+| `ShouldAllocate` | Filter which memory spaces receive addresses | Skip DDR; allocate all on-chip spaces |
+| `AlignAddress` | Align a raw address for a given space | 32-byte alignment |
+| `OrderMemRefs` | Sort MemRefs within a space before allocation | Ascending by `MemRef::id_` |
+
+### Default policy
+
+`DefaultMemoryAllocatorPolicy` preserves the original hard-coded behavior (skip DDR, 32-byte alignment, sort by ID).
+
+### Backend override
+
+When a backend is configured (`BackendConfig::IsConfigured()`), the pass calls `Backend::CreateMemoryAllocatorPolicy()` to obtain the policy. The default `Backend` implementation returns `DefaultMemoryAllocatorPolicy`. Custom backends can override this virtual method to provide different alignment rules, ordering, or space filtering:
+
+```cpp
+class MyBackend : public Backend {
+ public:
+  MemoryAllocatorPolicyPtr CreateMemoryAllocatorPolicy() const override {
+    return std::make_unique<MyCustomPolicy>();
+  }
+};
+```
+
+When no backend is configured (e.g., in unit tests), the pass falls back to `DefaultMemoryAllocatorPolicy` automatically.

--- a/docs/zh-cn/dev/passes/15-allocate_memory_addr.md
+++ b/docs/zh-cn/dev/passes/15-allocate_memory_addr.md
@@ -42,18 +42,20 @@ program_with_addrs = alloc_pass(program)
 1. **收集 MemRef**：遍历函数体，从 TileType 变量中找到所有唯一的 MemRef 对象
 2. **按内存空间分组**：按内存空间（Vec、Mat、Left、Right、Acc）组织 MemRef
 3. **解析 reserve_buffer**：在每个函数中扫描 `system.reserve_buffer`，为 AUTO buffer 分配显式 base，并计算每个内存空间的保留区末尾地址
-4. **分配地址**：对于每个内存空间，按 ID 排序 MemRef，并从该空间保留区末尾开始分配顺序的 32 字节对齐地址；如果没有 reserve_buffer，则仍从 `0` 开始
+4. **分配地址**：对于每个内存空间，委托给 `MemoryAllocatorPolicy` 进行空间过滤、MemRef 排序和地址对齐。默认策略按 ID 排序、使用 32 字节对齐，并从保留区末尾（或 `0`）开始分配
 5. **原地更新**：使用 `MemRefUpdateMutator` 完成以下操作：
    - 将变量类型（TileType/TensorType）中的旧 MemRef 引用替换为包含实际地址的新 MemRef
    - 更新已有的 `tile.alloc` `AssignStmt`：替换左值 MemRef 并更新 Call 表达式 (Expression) 中的 addr 参数
    - 把 `system.reserve_buffer` 的 kwargs 改写为显式 `base`
 
-**地址分配**：
+**地址分配（默认策略）**：
 
 - 每个内存空间有独立的地址空间；如果该空间前面已有 `system.reserve_buffer` 保留窗口，则 tile 会从该窗口之后开始分配
 - 地址 32 字节对齐：`next_addr = align32(current_addr + size)`
 - MemRef 按 ID 排序以确保确定性的分配顺序
 - DDR MemRef 被跳过（地址由外部管理）
+
+后端可以通过 `Backend::CreateMemoryAllocatorPolicy()` 提供自定义 `MemoryAllocatorPolicy` 来覆盖上述默认行为。详见下方[分配策略](#分配策略)章节。
 
 ## 示例
 
@@ -106,9 +108,8 @@ Pass AllocateMemoryAddr();
 **实现文件**：`src/ir/transforms/allocate_memory_addr_pass.cpp`
 
 - `MemRefCollectorVisitor` 从 TileType 变量中收集唯一的 MemRef
-- `AllocateMemoryAddresses` 在每个内存空间内分配顺序对齐的地址
+- `AllocateMemoryAddresses` 使用 `MemoryAllocatorPolicy` 在每个内存空间内分配顺序对齐的地址
 - `MemRefUpdateMutator` 在一次遍历中同时更新变量类型和 `tile.alloc` 语句参数
-- DDR MemRef 被跳过（无需地址分配）
 
 **Python 绑定**：`python/bindings/modules/passes.cpp`
 
@@ -124,3 +125,45 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - 测试空函数（无 Tile）
 - 测试 alloc 语句被前置到函数体顶层 `SeqStmts`
 - 测试 MemRef 去重的原始指针唯一性
+- 测试无后端配置时的默认策略行为
+
+## 分配策略
+
+该 Pass 将放置决策委托给 `MemoryAllocatorPolicy` 接口 (`include/pypto/ir/memory_allocator_policy.h`)，使分配策略可扩展而无需修改 Pass 本身。
+
+### 接口
+
+```cpp
+class MemoryAllocatorPolicy {
+ public:
+  virtual ~MemoryAllocatorPolicy() = default;
+  virtual bool ShouldAllocate(MemorySpace space) const = 0;
+  virtual uint64_t AlignAddress(uint64_t addr, MemorySpace space) const = 0;
+  virtual void OrderMemRefs(std::vector<MemRefPtr>& refs) const = 0;
+};
+```
+
+| 方法 | 用途 | 默认行为 |
+| ---- | ---- | -------- |
+| `ShouldAllocate` | 过滤哪些内存空间需要分配地址 | 跳过 DDR；分配所有片上空间 |
+| `AlignAddress` | 对给定空间的原始地址进行对齐 | 32 字节对齐 |
+| `OrderMemRefs` | 在分配前对空间内的 MemRef 排序 | 按 `MemRef::id_` 升序 |
+
+### 默认策略
+
+`DefaultMemoryAllocatorPolicy` 保留了原始硬编码行为（跳过 DDR、32 字节对齐、按 ID 排序）。
+
+### 后端覆盖
+
+当后端已配置（`BackendConfig::IsConfigured()`）时，Pass 调用 `Backend::CreateMemoryAllocatorPolicy()` 获取策略。默认的 `Backend` 实现返回 `DefaultMemoryAllocatorPolicy`。自定义后端可以覆盖此虚方法以提供不同的对齐规则、排序策略或空间过滤：
+
+```cpp
+class MyBackend : public Backend {
+ public:
+  MemoryAllocatorPolicyPtr CreateMemoryAllocatorPolicy() const override {
+    return std::make_unique<MyCustomPolicy>();
+  }
+};
+```
+
+当未配置后端时（例如在单元测试中），Pass 会自动回退到 `DefaultMemoryAllocatorPolicy`。

--- a/include/pypto/backend/common/backend.h
+++ b/include/pypto/backend/common/backend.h
@@ -24,6 +24,7 @@
 
 #include "pypto/backend/common/soc.h"
 #include "pypto/core/common.h"
+#include "pypto/ir/memory_allocator_policy.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/type.h"
@@ -268,6 +269,30 @@ class Backend {
    * @return Memory size in bytes, or 0 if not found
    */
   [[nodiscard]] uint64_t GetMemSize(ir::MemorySpace mem_type) const;
+
+  /**
+   * @brief Get memory alignment for a specific memory type
+   *
+   * Returns the alignment requirement of a single memory component of the
+   * given type. If the type exists in multiple cores, returns the alignment
+   * from the first occurrence.
+   *
+   * @param mem_type Memory space type
+   * @return Alignment in bytes, or 0 if not found
+   */
+  [[nodiscard]] uint64_t GetMemAlignment(ir::MemorySpace mem_type) const;
+
+  /**
+   * @brief Create a memory allocator policy for address allocation
+   *
+   * Returns a policy object that controls how AllocateMemoryAddr assigns
+   * addresses (alignment, space filtering, ordering). The default
+   * implementation returns a DefaultMemoryAllocatorPolicy. Derived backends
+   * can override this to provide custom placement strategies.
+   *
+   * @return Owning pointer to the policy
+   */
+  [[nodiscard]] virtual ir::MemoryAllocatorPolicyPtr CreateMemoryAllocatorPolicy() const;
 
   /**
    * @brief Get backend type name for serialization

--- a/include/pypto/ir/memory_allocator_policy.h
+++ b/include/pypto/ir/memory_allocator_policy.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_MEMORY_ALLOCATOR_POLICY_H_
+#define PYPTO_IR_MEMORY_ALLOCATOR_POLICY_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/memref.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief Abstract interface for memory address allocation strategy
+ *
+ * Encapsulates the placement policy used by AllocateMemoryAddr to assign
+ * addresses to MemRefs. Backends can provide custom implementations to
+ * control alignment requirements, space filtering, and allocation ordering.
+ */
+class MemoryAllocatorPolicy {
+ public:
+  virtual ~MemoryAllocatorPolicy() = default;
+
+  /**
+   * @brief Whether the given memory space should be allocated by this policy
+   *
+   * Spaces that return false are skipped entirely (their MemRefs keep
+   * the original address). For example, DDR addresses are typically
+   * managed externally and should not be allocated by this pass.
+   *
+   * @param space Memory space to check
+   * @return true if addresses should be allocated for this space
+   */
+  [[nodiscard]] virtual bool ShouldAllocate(MemorySpace space) const = 0;
+
+  /**
+   * @brief Align an address for the given memory space
+   *
+   * Returns the smallest address >= addr that satisfies the alignment
+   * requirement of the given memory space.
+   *
+   * @param addr Raw address to align
+   * @param space Memory space whose alignment rule applies
+   * @return Aligned address
+   */
+  [[nodiscard]] virtual uint64_t AlignAddress(uint64_t addr, MemorySpace space) const = 0;
+
+  /**
+   * @brief Order MemRefs within a single memory space before allocation
+   *
+   * The allocation pass calls this to sort the MemRef vector for a space
+   * before assigning sequential addresses.  The default strategy sorts
+   * by MemRef id for deterministic output.
+   *
+   * @param refs Mutable vector of MemRefs to sort in-place
+   */
+  virtual void OrderMemRefs(std::vector<MemRefPtr>& refs) const = 0;
+};
+
+using MemoryAllocatorPolicyPtr = std::unique_ptr<MemoryAllocatorPolicy>;
+
+/**
+ * @brief Default allocation policy matching the original hard-coded behavior
+ *
+ * - Skips DDR (addresses managed externally)
+ * - Uses 32-byte alignment for all on-chip memory spaces
+ * - Sorts MemRefs by id_ for deterministic allocation order
+ */
+class DefaultMemoryAllocatorPolicy : public MemoryAllocatorPolicy {
+ public:
+  [[nodiscard]] bool ShouldAllocate(MemorySpace space) const override { return space != MemorySpace::DDR; }
+
+  [[nodiscard]] uint64_t AlignAddress(uint64_t addr, [[maybe_unused]] MemorySpace space) const override {
+    return (addr + 31) & ~static_cast<uint64_t>(31);
+  }
+
+  void OrderMemRefs(std::vector<MemRefPtr>& refs) const override {
+    std::sort(refs.begin(), refs.end(),
+              [](const MemRefPtr& a, const MemRefPtr& b) { return a->id_ < b->id_; });
+  }
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_MEMORY_ALLOCATOR_POLICY_H_

--- a/src/backend/common/backend.cpp
+++ b/src/backend/common/backend.cpp
@@ -30,6 +30,7 @@
 #include "pypto/backend/910B/backend_910b.h"
 #include "pypto/backend/950/backend_950.h"
 #include "pypto/backend/common/backend_registry.h"
+#include "pypto/ir/memory_allocator_policy.h"
 
 // clang-format off
 #include <msgpack.hpp>
@@ -366,6 +367,25 @@ uint64_t Backend::GetMemSize(ir::MemorySpace mem_type) const {
 
   // Memory type not found in SoC
   return 0;
+}
+
+uint64_t Backend::GetMemAlignment(ir::MemorySpace mem_type) const {
+  for (const auto& [die, die_count] : soc_->GetDieCounts()) {
+    for (const auto& [cluster, cluster_count] : die.GetClusterCounts()) {
+      for (const auto& [core, core_count] : cluster.GetCoreCounts()) {
+        for (const auto& mem : core.GetMems()) {
+          if (mem.GetMemType() == mem_type) {
+            return mem.GetAlignment();
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+ir::MemoryAllocatorPolicyPtr Backend::CreateMemoryAllocatorPolicy() const {
+  return std::make_unique<ir::DefaultMemoryAllocatorPolicy>();
 }
 
 // ========== Operator Registration ==========

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_allocator_policy.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/program.h"
@@ -49,9 +50,6 @@ namespace pypto {
 namespace ir {
 
 namespace {
-
-// Helper function to align address to 32-byte boundary
-inline uint64_t Align32(uint64_t addr) { return (addr + 31) & ~31ULL; }
 
 using MemRefWithSpace = std::pair<MemRefPtr, MemorySpace>;
 using ReserveBufferBaseMap = std::unordered_map<const Call*, int64_t>;
@@ -134,7 +132,8 @@ struct ReserveBufferResolution {
   ReservedEndBySpace reserved_end_by_space;
 };
 
-ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func) {
+ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func,
+                                                  const MemoryAllocatorPolicy& policy) {
   ReserveBufferResolution resolution;
   if (!func || !func->body_) return resolution;
 
@@ -160,7 +159,8 @@ ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func) {
         << "': " << resolved_base;
     resolution.resolved_bases[reserve.call] = static_cast<int64_t>(resolved_base);
 
-    const uint64_t buffer_end = Align32(resolved_base + static_cast<uint64_t>(reserve.size));
+    const uint64_t buffer_end =
+        policy.AlignAddress(resolved_base + static_cast<uint64_t>(reserve.size), reserve_space);
     auto& reserved_ranges = reserved_ranges_by_space[reserve_space];
     auto next_it = reserved_ranges.lower_bound(resolved_base);
     auto overlaps = [&](const std::pair<const uint64_t, uint64_t>& range) {
@@ -336,10 +336,11 @@ void CollectMemRefsFromStatement(const StmtPtr& stmt, std::vector<MemRefWithSpac
 }
 
 /**
- * @brief Allocate memory addresses for non-DDR memory spaces
+ * @brief Allocate memory addresses using the given allocation policy
  */
 std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
-    const std::vector<MemRefWithSpace>& memrefs, const ReservedEndBySpace& reserved_end_by_space) {
+    const std::vector<MemRefWithSpace>& memrefs, const ReservedEndBySpace& reserved_end_by_space,
+    const MemoryAllocatorPolicy& policy) {
   // Group MemRefs by memory space
   std::unordered_map<MemorySpace, std::vector<MemRefPtr>> space_to_memrefs;
   for (const auto& [memref, memory_space] : memrefs) {
@@ -350,14 +351,11 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
   std::vector<std::pair<const MemRef*, MemRefPtr>> memref_pairs;
 
   for (auto& [space, refs] : space_to_memrefs) {
-    // Skip DDR space - keep original MemRefs
-    if (space == MemorySpace::DDR) {
+    if (!policy.ShouldAllocate(space)) {
       continue;
     }
 
-    // Sort by ID for deterministic allocation
-    std::sort(refs.begin(), refs.end(),
-              [](const MemRefPtr& a, const MemRefPtr& b) { return a->id_ < b->id_; });
+    policy.OrderMemRefs(refs);
 
     // Allocate sequential aligned addresses
     uint64_t current_addr = 0;
@@ -377,7 +375,7 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       memref_pairs.emplace_back(old_memref.get(), new_memref);
 
       // Next address = align(current + size)
-      current_addr = Align32(current_addr + old_memref->size_);
+      current_addr = policy.AlignAddress(current_addr + old_memref->size_, space);
     }
   }
 
@@ -405,15 +403,20 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
  * and the alloc statement arguments in place.
  */
 FunctionPtr TransformAllocateMemoryAddr(const FunctionPtr& func) {
+  // Obtain the allocation policy from the backend (or fall back to the default).
+  auto policy = backend::BackendConfig::IsConfigured() ? backend::GetBackend()->CreateMemoryAllocatorPolicy()
+                                                       : std::make_unique<DefaultMemoryAllocatorPolicy>();
+  CHECK(policy) << "Backend::CreateMemoryAllocatorPolicy() returned null";
+
   // Step 1: Resolve reserve_buffer bases before assigning tile addresses.
-  auto reserve_resolution = ResolveReserveBufferBases(func);
+  auto reserve_resolution = ResolveReserveBufferBases(func, *policy);
 
   // Step 2: Collect all unique MemRef objects from TileType variables
   std::vector<MemRefWithSpace> memrefs;
   CollectMemRefsFromStatement(func->body_, memrefs);
 
-  // Step 3: Allocate memory addresses for non-DDR spaces
-  auto memref_pairs = AllocateMemoryAddresses(memrefs, reserve_resolution.reserved_end_by_space);
+  // Step 3: Allocate memory addresses using the policy
+  auto memref_pairs = AllocateMemoryAddresses(memrefs, reserve_resolution.reserved_end_by_space, *policy);
 
   if (memref_pairs.empty() && reserve_resolution.resolved_bases.empty()) {
     return func;

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -12,6 +12,7 @@ import re
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
+from pypto.backend import is_backend_configured, reset_for_testing
 
 
 def _iter_all_stmts(func):
@@ -461,6 +462,50 @@ def test_allocated_memory_addr_verifier_via_pipeline():
     with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
         result = pipeline.run(Before)
         assert result is not None
+
+
+def test_allocate_memory_addr_uses_default_policy_without_backend():
+    """Test that AllocateMemoryAddr falls back to DefaultMemoryAllocatorPolicy when no backend is configured.
+
+    Without a backend, the pass should still produce correct 32-byte aligned
+    addresses using the default policy (skip DDR, sort by id, 32-byte alignment).
+    """
+    was_configured = is_backend_configured()
+    if was_configured:
+        reset_for_testing()
+    try:
+        assert not is_backend_configured(), "Backend must not be configured for this test"
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Tensor[[64, 64], pl.FP32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+                tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+                tile_c: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_b, tile_b)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                return result
+
+        optimized_program = _prepare_and_run_allocate_memory_addr(Before)
+        optimized_func = next(iter(optimized_program.functions.values()))
+
+        memref_addrs = get_memref_addresses_from_tiles(optimized_func)
+        assert len(memref_addrs) == 3, f"Expected 3 MemRef addresses, got {len(memref_addrs)}"
+
+        for var_name, addr in memref_addrs.items():
+            assert addr >= 0, f"MemRef address for '{var_name}' should be non-negative"
+            assert addr % 32 == 0, f"Address {addr} for {var_name} should be 32-byte aligned (default policy)"
+
+        sorted_addrs = sorted(memref_addrs.values())
+        for i in range(1, len(sorted_addrs)):
+            assert sorted_addrs[i] > sorted_addrs[i - 1], "Addresses should be strictly increasing"
+    finally:
+        if was_configured:
+            reset_for_testing()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #543
Introduce MemoryAllocatorPolicy abstract interface to decouple the placement strategy (alignment, space filtering, ordering) from the AllocateMemoryAddr pass. The pass now obtains a policy from Backend::CreateMemoryAllocatorPolicy() when a backend is configured, falling back to DefaultMemoryAllocatorPolicy which preserves the original hard-coded behavior (skip DDR, 32-byte alignment, sort by ID).
- Add include/pypto/ir/memory_allocator_policy.h with abstract interface and DefaultMemoryAllocatorPolicy
- Add Backend::GetMemAlignment() and virtual CreateMemoryAllocatorPolicy()
- Replace Align32() and hardcoded DDR/sort logic with policy calls
- Update English and Chinese documentation with allocation policy section