### PR TITLE
docs: update user guides and backend documentation for clarity on parameters

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -189,10 +189,12 @@ print(f"Generated code in: {output_dir}")
 | Parameter | Default | Description |
 | --------- | ------- | ----------- |
 | `program` | (required) | The `ir.Program` to compile |
-| `strategy` | `Default` | Optimization strategy (`Default` or `DebugTileOptimization`) |
-| `dump_passes` | `True` | Print IR after each optimization pass |
-| `backend_type` | `PTO` | Code generator (`PTO` or `CCE`) |
-| `output_dir` | auto-generated | Where to write output files |
+| `output_dir` | `None` → `build_output/<name>_<timestamp>` | Directory for codegen, reports, and (when dumping) pass IR |
+| `strategy` | `OptimizationStrategy.Default` | Pass pipeline preset (`Default` or `DebugTileOptimization`) |
+| `dump_passes` | `True` | When `True`, write IR snapshots under `output_dir/passes_dump/` after each pass |
+| `backend_type` | `BackendType.Ascend910B` | Target hardware for passes and codegen (`Ascend910B` or `Ascend950`) |
+| `skip_ptoas` | `False` | If `True`, skip the ptoas step and emit raw `.pto` (MLIR) instead of compiled C++ wrappers |
+| `verification_level` | `None` | Optional `ir.VerificationLevel` override; `None` uses defaults (or `PYPTO_VERIFY_LEVEL`) |
 
 `DebugTileOptimization` is a debug-only shortcut for inspecting the PTO tile
 pipeline. Prefer `Default` unless you are explicitly debugging strategy

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -477,19 +477,20 @@ output_dir = ir.compile(
     program,
     output_dir=None,                           # auto-generated if None
     strategy=ir.OptimizationStrategy.Default,  # or DebugTileOptimization
-    dump_passes=True,                          # print IR after each pass
+    dump_passes=True,                          # dump IR snapshots under output_dir/passes_dump/
     backend_type=BackendType.Ascend910B,
 )
 ```
 
 | Parameter | Options | Description |
 | --------- | ------- | ----------- |
-| `strategy` | `Default`, `DebugTileOptimization` | `Default` = full tensor-oriented pipeline. `DebugTileOptimization` = debug-only PTO tile pipeline without tensor-only passes |
-| `backend_type` | `PTO`, `CCE` | Code generator backend |
-| `dump_passes` | `True`/`False` | Print IR before/after each optimization pass |
-| `skip_ptoas` | `True`/`False` | Skip PTOAS step, emit raw MLIR files (default `False`) |
-| `output_dir` | path or `None` | Output directory (auto-created if `None`) |
-| `verification_level` | `NONE`, `BASIC` | IR verification level (`BASIC` is default) |
+| `program` | `ir.Program` | Required program object (from `@pl.program` or equivalent) |
+| `strategy` | `OptimizationStrategy.Default`, `DebugTileOptimization` | `Default` = full tensor-oriented pipeline. `DebugTileOptimization` = debug-only PTO tile pipeline without tensor-only passes |
+| `backend_type` | `BackendType.Ascend910B`, `BackendType.Ascend950` | Target hardware for passes and codegen (`import BackendType` from `pypto.backend`) |
+| `dump_passes` | `True`/`False` | If `True`, write IR snapshots under `<output_dir>/passes_dump/` after each pass (default `True`) |
+| `skip_ptoas` | `True`/`False` | Skip the ptoas step; emit raw `.pto` (MLIR) instead of compiled C++ wrappers (default `False`) |
+| `output_dir` | path or `None` | If `None`, uses `build_output/<program_name>_<timestamp>`; directory is created as needed |
+| `verification_level` | `None`, `ir.VerificationLevel.NONE`, `BASIC` | `None` = use default (`BASIC`, or override via `PYPTO_VERIFY_LEVEL`). Otherwise set explicit verification level |
 
 ### Optimization Pipeline
 
@@ -517,4 +518,4 @@ The `Default` strategy runs these passes in order:
 
 ### Debugging
 
-Use `node.as_python()` to inspect IR for functions or programs. Pass `concise=True` to omit intermediate type annotations for cleaner output. Compile with `dump_passes=True` to see IR at each optimization stage.
+Use `node.as_python()` to inspect IR for functions or programs. Pass `concise=True` to omit intermediate type annotations for cleaner output. Compile with `dump_passes=True` to dump IR snapshots for each optimization stage under `passes_dump/` in the output directory.

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -189,10 +189,12 @@ print(f"Generated code in: {output_dir}")
 | 参数 | 默认值 | 说明 |
 | ---- | ------ | ---- |
 | `program` | （必需） | 要编译的 `ir.Program` |
-| `strategy` | `Default` | 优化策略（`Default` 或 `DebugTileOptimization`） |
-| `dump_passes` | `True` | 每个优化 pass 后打印 IR |
-| `backend_type` | `PTO` | 代码生成后端（`PTO` 或 `CCE`） |
-| `output_dir` | 自动生成 | 输出文件目录 |
+| `output_dir` | `None` → `build_output/<name>_<timestamp>` | 代码生成、报告及（开启 dump 时）各 pass IR 的输出目录 |
+| `strategy` | `OptimizationStrategy.Default` | Pass 流水线预设（`Default` 或 `DebugTileOptimization`） |
+| `dump_passes` | `True` | 为 `True` 时，在每个 pass 后将 IR 快照写入 `output_dir/passes_dump/` |
+| `backend_type` | `BackendType.Ascend910B` | Pass 与代码生成的目标硬件（`Ascend910B` 或 `Ascend950`） |
+| `skip_ptoas` | `False` | 为 `True` 时跳过 ptoas，只生成原始 `.pto`（MLIR），不生成已编译的 C++ 包装代码 |
+| `verification_level` | `None` | 可选的 `ir.VerificationLevel` 覆盖；`None` 表示使用默认（或环境变量 `PYPTO_VERIFY_LEVEL`） |
 
 `DebugTileOptimization` 只是用于观察 PTO tile 流水线的调试捷径。除非你正在
 专门排查策略选择或 pass 顺序，否则应优先使用 `Default`。

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -477,19 +477,20 @@ output_dir = ir.compile(
     program,
     output_dir=None,                           # 为 None 时自动生成
     strategy=ir.OptimizationStrategy.Default,  # 或 DebugTileOptimization
-    dump_passes=True,                          # 每个 pass 后打印 IR
+    dump_passes=True,                          # 将 IR 快照写入 output_dir/passes_dump/
     backend_type=BackendType.Ascend910B,
 )
 ```
 
 | 参数 | 选项 | 说明 |
 | ---- | ---- | ---- |
-| `strategy` | `Default`、`DebugTileOptimization` | `Default` = 完整的 tensor 导向流水线。`DebugTileOptimization` = 仅用于调试的 PTO tile 流水线，不包含 tensor-only pass |
-| `backend_type` | `PTO`、`CCE` | 代码生成后端 |
-| `dump_passes` | `True`/`False` | 每个优化 pass 前后打印 IR |
-| `skip_ptoas` | `True`/`False` | 跳过 PTOAS 步骤，输出原始 MLIR 文件（默认 `False`） |
-| `output_dir` | 路径或 `None` | 输出目录（`None` 时自动创建） |
-| `verification_level` | `NONE`、`BASIC` | IR 校验级别（默认 `BASIC`） |
+| `program` | `ir.Program` | 必填，待编译的程序对象（来自 `@pl.program` 等） |
+| `strategy` | `OptimizationStrategy.Default`、`DebugTileOptimization` | `Default` = 完整 tensor 导向流水线。`DebugTileOptimization` = 仅用于调试的 PTO tile 流水线，不包含 tensor-only pass |
+| `backend_type` | `BackendType.Ascend910B`、`BackendType.Ascend950` | Pass 与代码生成的目标硬件（从 `pypto.backend` 导入 `BackendType`） |
+| `dump_passes` | `True`/`False` | 为 `True` 时在每个 pass 后将 IR 快照写入 `<output_dir>/passes_dump/`（默认 `True`） |
+| `skip_ptoas` | `True`/`False` | 跳过 ptoas；只生成原始 `.pto`（MLIR），不生成已编译的 C++ 包装代码（默认 `False`） |
+| `output_dir` | 路径或 `None` | `None` 时使用 `build_output/<program_name>_<timestamp>`；目录按需创建 |
+| `verification_level` | `None`、`ir.VerificationLevel.NONE`、`BASIC` | `None` 表示使用默认（`BASIC`，或由环境变量 `PYPTO_VERIFY_LEVEL` 覆盖）；否则显式指定校验级别 |
 
 ### 优化流水线
 
@@ -517,4 +518,4 @@ output_dir = ir.compile(
 
 ### 调试
 
-使用 `node.as_python()` 查看函数或程序的 IR。传入 `concise=True` 可省略中间类型标注以获得更清晰的输出。编译时设置 `dump_passes=True` 以查看每个优化阶段的 IR。
+使用 `node.as_python()` 查看函数或程序的 IR。传入 `concise=True` 可省略中间类型标注以获得更清晰的输出。编译时设置 `dump_passes=True`，可在输出目录下的 `passes_dump/` 中得到各优化阶段的 IR 快照。

--- a/include/pypto/backend/common/backend_config.h
+++ b/include/pypto/backend/common/backend_config.h
@@ -37,7 +37,7 @@ class BackendConfig {
    * times with the same type (idempotent), but will throw an error if
    * attempting to change to a different type.
    *
-   * \param type The backend type to use (CCE or PTO)
+   * \param type The backend type to use (Ascend910B or Ascend950)
    * \throws pypto::ValueError if attempting to change an already-set type
    */
   static void SetBackendType(BackendType type);

--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -25,9 +25,9 @@ namespace pypto {
 namespace codegen {
 
 /**
- * @brief Base class for platform code generators (CCE, PTO, etc.)
+ * @brief Base class for platform code generators (Ascend910B, Ascend950, etc.)
  *
- * Provides a common API used by operator codegen callbacks (f_codegen_cce, f_codegen_pto).
+ * Provides a common API used by operator codegen callbacks (f_codegen_ascend910b, f_codegen_ascend950).
  * Subclasses implement platform-specific code generation while sharing this contract.
  * Does not define Generate() as each platform has different signature (e.g. map vs string).
  */

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -142,9 +142,6 @@ The test framework provides extensive configuration through pytest command-line 
 ### Usage Examples
 
 ```bash
-# Test with CCE optimization strategy
-pytest tests/st/ -v --forked --strategy=CCE
-
 # Run hardware tests on device 1
 pytest tests/st/ -v --forked --platform=a2a3 --device=1
 
@@ -161,7 +158,7 @@ pytest tests/st/ -v --forked --save-kernels --dump-passes
 pytest tests/st/ -v --forked --codegen-only --save-kernels
 
 # Combine multiple options
-pytest tests/st/ -v --forked --platform=a2a3sim --strategy=CCE --save-kernels --dump-passes
+pytest tests/st/ -v --forked --platform=a2a3sim --save-kernels --dump-passes
 ```
 
 ## Advanced Usage
@@ -245,13 +242,10 @@ PyPTO supports different optimization strategies. Select at runtime:
 
 ```bash
 # Use Default optimization strategy (default)
-pytest tests/st/ -v --forked --strategy=Default
-
-# Use CCE optimization strategy
-pytest tests/st/ -v --forked --strategy=CCE
+pytest tests/st/ -v --forked
 
 # Combine with other options
-pytest tests/st/ -v --forked --strategy=CCE --save-kernels --dump-passes
+pytest tests/st/ -v --forked --save-kernels --dump-passes
 ```
 
 You can also override the strategy in individual test cases by implementing the `get_strategy()` method:

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -82,7 +82,7 @@ def pytest_addoption(parser):
         "--strategy",
         action="store",
         default="Default",
-        choices=["Default", "CCE"],
+        choices=["Default"],
         help="Optimization strategy for PyPTO pass pipeline (default: Default)",
     )
     parser.addoption(


### PR DESCRIPTION
- Enhanced the English and Chinese documentation for the `getting_started` and `language_guide` sections, providing clearer descriptions of parameters such as `output_dir`, `strategy`, `dump_passes`, `backend_type`, `skip_ptoas`, and `verification_level`.
- Updated the backend configuration documentation to reflect the new backend types (Ascend910B and Ascend950) instead of the previous CCE and PTO references.
- Adjusted examples and explanations to ensure users understand the implications of each parameter in the context of the code generation process.