### PR TITLE
fix(pass): extend initValue lifetime across loop return_var uses in MemoryReuse

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -155,9 +155,15 @@ class LifetimeAnalyzer : public IRVisitor {
     }
   }
 
-  void VisitStmt_(const ForStmtPtr& op) override { ProcessLoopBody(op->iter_args_, op->body_); }
+  void VisitStmt_(const ForStmtPtr& op) override {
+    ProcessLoopBody(op->iter_args_, op->body_);
+    RegisterReturnVars(op->iter_args_, op->return_vars_);
+  }
 
-  void VisitStmt_(const WhileStmtPtr& op) override { ProcessLoopBody(op->iter_args_, op->body_); }
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    ProcessLoopBody(op->iter_args_, op->body_);
+    RegisterReturnVars(op->iter_args_, op->return_vars_);
+  }
 
  private:
   int current_order_ = 0;
@@ -174,6 +180,11 @@ class LifetimeAnalyzer : public IRVisitor {
   std::map<VarPtr, int> var_def_order_;
   std::map<VarPtr, int> var_raw_last_use_;  // Raw last use (without loop extension)
   std::map<VarPtr, StmtPtr> var_def_stmt_;
+
+  // Maps ForStmt/WhileStmt return_vars to their corresponding initValue vars.
+  // YieldFixup will place return_vars into initValue's MemRef buffer,
+  // so any post-loop use of a return_var must extend the initValue's lifetime.
+  std::map<VarPtr, VarPtr> return_var_to_init_var_;
 
   void CollectUsesFromExpr(const ExprPtr& expr, int use_order) {
     if (!expr) return;
@@ -203,15 +214,36 @@ class LifetimeAnalyzer : public IRVisitor {
     loop_scopes_.push_back({loop_start, loop_end});
   }
 
+  void RegisterReturnVars(const std::vector<IterArgPtr>& iter_args, const std::vector<VarPtr>& return_vars) {
+    size_t count = std::min(return_vars.size(), iter_args.size());
+    for (size_t i = 0; i < count; ++i) {
+      const auto& rv = return_vars[i];
+      if (!As<TileType>(rv->GetType())) continue;
+
+      // Map return_var -> initValue var so that post-loop uses of the
+      // return_var extend the initValue's lifetime (not the return_var's).
+      // We do NOT register return_vars in ordered_defs_ -- they must not
+      // participate in sharing group computation, which would inflate
+      // group lifetimes and block unrelated reuse opportunities.
+      auto init_var = As<Var>(iter_args[i]->initValue_);
+      if (init_var && var_def_order_.count(init_var)) {
+        return_var_to_init_var_[rv] = init_var;
+      }
+    }
+  }
+
   void RecordRawUse(const VarPtr& var, int use_order) {
-    if (!var_def_order_.count(var)) {
+    // If var is a loop return_var, redirect the use to its initValue var.
+    // YieldFixup will alias the return_var to the initValue's MemRef,
+    // so keeping the initValue live prevents premature buffer reuse.
+    auto it = return_var_to_init_var_.find(var);
+    const VarPtr& target = (it != return_var_to_init_var_.end()) ? it->second : var;
+
+    if (!var_def_order_.count(target)) {
       return;
     }
-    if (var_raw_last_use_.count(var)) {
-      var_raw_last_use_[var] = std::max(var_raw_last_use_[var], use_order);
-    } else {
-      var_raw_last_use_[var] = use_order;
-    }
+    // operator[] default-inserts 0 for missing keys; use_order is always >= 0.
+    var_raw_last_use_[target] = std::max(var_raw_last_use_[target], use_order);
   }
 
   /**

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1040,6 +1040,42 @@ class TestControlFlow:
         # tile_a's last use is in the else-yield which ends before tile_e's def
         _assert_shares_memref(func, "tile_a", "tile_e")
 
+    def test_loop_return_var_blocks_init_memref_reuse(self):
+        """Return_var used after loop must block reuse of initValue's MemRef.
+
+        Regression test for issue #768: MemoryReuse allowed a post-loop
+        variable to reuse the initValue's MemRef, but YieldFixup later
+        placed the loop output in the same buffer, causing the accumulated
+        result to be overwritten before the final add consumed it.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                input_b: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                o_acc: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+                    [64, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                o_acc_z: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tile.muls(o_acc, 0.0)
+                for _kb, (acc,) in pl.range(0, 4, init_values=(o_acc_z,)):
+                    chunk: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [64, 64])
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc, chunk)
+                    loop_out = pl.yield_(acc_next)
+                # loop_out is live here -- it shares initValue's MemRef after YieldFixup
+                resid: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_b, [0, 0], [64, 64])
+                # resid must NOT reuse o_acc_z's MemRef -- loop_out still needs it
+                final: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(loop_out, resid)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(final, [0, 0], output)
+                return result
+
+        func = _run_memory_reuse(Before)
+        _assert_not_shares_memref(func, "o_acc_z", "resid")
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fix MemoryReuse pass liveness bug where ForStmt/WhileStmt `return_vars` were invisible to lifetime analysis, allowing premature buffer reuse that caused silent data corruption after YieldFixup
- Map return_vars to their initValue and redirect post-loop uses in `RecordRawUse` to extend initValue lifetimes; return_vars are excluded from `ordered_defs_` to avoid inflating sharing group lifetimes
- Add regression test `test_loop_return_var_blocks_init_memref_reuse` verifying post-loop variables cannot reuse initValue's MemRef

Fixes #768

## Test plan

- [x] All 32 memory reuse tests pass (including new regression test)
- [x] Full UT suite passes (3202 passed, 0 failed)