### PR TITLE
fix(ir): canonicalize tile types for roundtrip stability

### DIFF
--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -96,6 +96,12 @@ tile_with_view = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Lef
 `TileType` carries a `MemRef`, provide the tile memory space on the `TileType`
 itself.
 
+For Python DSL annotations, omitted `TileView` syntax is normalized to an
+implicit TileView derived from the tile shape and, when present, the tile
+memory space. Redundant explicit defaults such as `pl.TileView()` are treated
+as semantically equivalent to the omitted form and may print back in canonical
+syntax.
+
 ### TupleType
 
 Heterogeneous tuple of types.

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -86,6 +86,16 @@ tile: pl.Tile[
 ]
 ```
 
+**Notes:**
+
+- Omitting `pl.TileView(...)` does **not** mean "no TileView semantics". The DSL infers an implicit
+  TileView from the tile shape and, when present, the tile memory space.
+- In that implicit form, `valid_shape` defaults to the tile shape. Layout/fractal defaults are also
+  inferred from the shape / memory-space combination.
+- An explicit `pl.TileView()` (or one that only repeats those implicit defaults) is treated as
+  semantically equivalent to the omitted form. Parser / printer roundtrips may canonicalize both
+  forms to the same printed syntax.
+
 ## Expressions
 
 ### Variables and Constants

--- a/docs/zh-cn/dev/ir/02-types.md
+++ b/docs/zh-cn/dev/ir/02-types.md
@@ -95,6 +95,11 @@ tile_with_view = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Lef
 `TileType.memory_space` 才是 Tile 放置位置的唯一来源。如果 `TileType`
 携带 `MemRef`, 请在 `TileType` 自身上显式提供 tile 内存空间。
 
+对于 Python DSL 类型标注，省略的 `TileView` 语法会被规范化为一个隐式
+TileView：它由 tile shape 以及（如果存在）tile memory space 推导得到。
+像 `pl.TileView()` 这样的冗余显式默认写法，会与省略写法被视为语义等价，
+并且在 printer 输出时可能统一成规范形式。
+
 ### TupleType
 
 异构类型元组。

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -86,6 +86,15 @@ tile: pl.Tile[
 ]
 ```
 
+**说明：**
+
+- 省略 `pl.TileView(...)` **不**表示“没有 TileView 语义”。DSL 会根据 tile 的 shape，以及在存在时的
+  tile memory space，推导一个隐式 TileView。
+- 在这种隐式形式下，`valid_shape` 默认等于 tile shape；布局 / fractal 默认值也会根据
+  shape / memory-space 组合推导。
+- 显式写出的 `pl.TileView()`（或只是在重复这些隐式默认值的写法）与省略写法在语义上等价。
+  parser / printer 的往返过程中，二者可能会被规范化为同一种打印形式。
+
 ## 表达式 (Expression)
 
 ### 变量和常量

--- a/include/pypto/ir/transforms/utils/tile_view_semantics.h
+++ b/include/pypto/ir/transforms/utils/tile_view_semantics.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_TILE_VIEW_SEMANTICS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_TILE_VIEW_SEMANTICS_H_
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/type.h"
+
+namespace pypto::ir::tile_view_semantics {
+
+/// Return whether two shape-like expression lists are statically identical.
+inline bool ShapeExprListsEquivalent(const std::vector<ExprPtr>& lhs, const std::vector<ExprPtr>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] == rhs[i]) {
+      continue;
+    }
+    auto lhs_const = As<ConstInt>(lhs[i]);
+    auto rhs_const = As<ConstInt>(rhs[i]);
+    if (!lhs_const || !rhs_const || lhs_const->value_ != rhs_const->value_) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Infer the implicit block layout used when Python syntax omits TileView.
+inline TileLayout InferImplicitTileLayoutFromShape(const std::vector<ExprPtr>& shape) {
+  if (shape.size() != 2) {
+    return TileLayout::row_major;
+  }
+
+  auto rows_const = As<ConstInt>(shape[0]);
+  auto cols_const = As<ConstInt>(shape[1]);
+  if (!rows_const || !cols_const) {
+    return TileLayout::row_major;
+  }
+  return (cols_const->value_ == 1 && rows_const->value_ > 1) ? TileLayout::col_major : TileLayout::row_major;
+}
+
+/// Build the implicit TileView semantics represented by omitted Python syntax.
+inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
+                                    const std::optional<MemorySpace>& memory_space = std::nullopt) {
+  TileView implicit_view;
+  implicit_view.valid_shape = shape;
+  implicit_view.blayout = InferImplicitTileLayoutFromShape(shape);
+
+  if (memory_space.has_value()) {
+    switch (*memory_space) {
+      case MemorySpace::Mat:
+      case MemorySpace::Left:
+        implicit_view.blayout = TileLayout::col_major;
+        implicit_view.slayout = TileLayout::row_major;
+        break;
+      case MemorySpace::Right:
+        implicit_view.slayout = TileLayout::col_major;
+        break;
+      case MemorySpace::Acc:
+        implicit_view.blayout = TileLayout::col_major;
+        implicit_view.slayout = TileLayout::row_major;
+        implicit_view.fractal = 1024;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return implicit_view;
+}
+
+/// Return whether TileView matches the printer's raw TileView() defaults.
+inline bool IsDefaultPrintedTileView(const TileView& tile_view, const std::vector<ExprPtr>& shape) {
+  if (!tile_view.stride.empty() || tile_view.start_offset || tile_view.pad != PadValue::null) {
+    return false;
+  }
+
+  const std::vector<ExprPtr>& normalized_valid_shape =
+      tile_view.valid_shape.empty() ? shape : tile_view.valid_shape;
+  if (!ShapeExprListsEquivalent(normalized_valid_shape, shape)) {
+    return false;
+  }
+
+  TileView default_view;
+  return tile_view.blayout == default_view.blayout && tile_view.slayout == default_view.slayout &&
+         tile_view.fractal == default_view.fractal;
+}
+
+/// Return whether TileView matches the semantics of omitted Python syntax.
+inline bool IsImplicitPrintedTileView(const TileView& tile_view, const std::vector<ExprPtr>& shape,
+                                      const std::optional<MemorySpace>& memory_space = std::nullopt) {
+  if (!ShapeExprListsEquivalent(tile_view.valid_shape, shape)) {
+    return false;
+  }
+  if (!tile_view.stride.empty() || tile_view.start_offset || tile_view.pad != PadValue::null) {
+    return false;
+  }
+
+  TileView implicit_view = GetImplicitTileView(shape, memory_space);
+  return tile_view.blayout == implicit_view.blayout && tile_view.slayout == implicit_view.slayout &&
+         tile_view.fractal == implicit_view.fractal;
+}
+
+/// Normalize sparse/default TileView syntax to a comparable semantic form.
+inline TileView NormalizeImplicitTileView(const std::optional<TileView>& tile_view,
+                                          const std::vector<ExprPtr>& shape,
+                                          const std::optional<MemorySpace>& memory_space = std::nullopt,
+                                          bool fill_start_offset = false) {
+  TileView normalized = tile_view.value_or(TileView{});
+  if (normalized.valid_shape.empty()) {
+    normalized.valid_shape = shape;
+  }
+  if (!tile_view.has_value() || IsDefaultPrintedTileView(normalized, shape)) {
+    TileView implicit_view = GetImplicitTileView(shape, memory_space);
+    normalized.blayout = implicit_view.blayout;
+    normalized.slayout = implicit_view.slayout;
+    normalized.fractal = implicit_view.fractal;
+  }
+  if (fill_start_offset && !normalized.start_offset) {
+    normalized.start_offset = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+  }
+  return normalized;
+}
+
+/// Return whether explicit TileView() can be safely omitted in printed syntax.
+inline bool CanOmitExplicitEmptyTileView(const std::vector<ExprPtr>& shape,
+                                         const std::optional<MemorySpace>& memory_space = std::nullopt) {
+  TileView default_view;
+  TileView implicit_view = GetImplicitTileView(shape, memory_space);
+  return implicit_view.blayout == default_view.blayout && implicit_view.slayout == default_view.slayout &&
+         implicit_view.fractal == default_view.fractal;
+}
+
+/// Return the valid_shape the printer should materialize for tile operations.
+inline std::vector<ExprPtr> GetPrintedValidShape(const std::optional<TileView>& tile_view,
+                                                 const std::vector<ExprPtr>& shape) {
+  if (tile_view.has_value() && !tile_view->valid_shape.empty()) {
+    return tile_view->valid_shape;
+  }
+  return shape;
+}
+
+}  // namespace pypto::ir::tile_view_semantics
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_TILE_VIEW_SEMANTICS_H_

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -10,7 +10,7 @@
 """AST parsing for converting Python DSL to IR builder calls."""
 
 import ast
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -66,6 +66,105 @@ def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
     if upper_value is None or lower_value is None:
         return None
     return upper_value - lower_value
+
+
+def _shape_exprs_match(lhs: Sequence[ir.Expr], rhs: Sequence[ir.Expr]) -> bool:
+    """Return whether two shape-like expression lists are statically identical."""
+    if len(lhs) != len(rhs):
+        return False
+    for lhs_dim, rhs_dim in zip(lhs, rhs):
+        if lhs_dim is rhs_dim:
+            continue
+        lhs_value = _const_int_value(lhs_dim)
+        rhs_value = _const_int_value(rhs_dim)
+        if lhs_value is None or rhs_value is None or lhs_value != rhs_value:
+            return False
+    return True
+
+
+def _infer_implicit_tile_layout_from_shape(shape: Sequence[ir.Expr]) -> ir.TileLayout:
+    """Infer the block layout represented by omitted TileView syntax."""
+    if len(shape) != 2:
+        return ir.TileLayout.row_major
+    rows_value = _const_int_value(shape[0])
+    cols_value = _const_int_value(shape[1])
+    if rows_value is None or cols_value is None:
+        return ir.TileLayout.row_major
+    return ir.TileLayout.col_major if cols_value == 1 and rows_value > 1 else ir.TileLayout.row_major
+
+
+def _implicit_tile_view_defaults(
+    shape: Sequence[ir.Expr],
+    memory_space: ir.MemorySpace | None = None,
+) -> tuple[ir.TileLayout, ir.TileLayout, int]:
+    """Return the layout/fractal defaults implied by omitted TileView syntax."""
+    default_blayout = _infer_implicit_tile_layout_from_shape(shape)
+    default_slayout = ir.TileLayout.none_box
+    default_fractal = ir.TileView().fractal
+    if memory_space in (ir.MemorySpace.Mat, ir.MemorySpace.Left):
+        default_blayout = ir.TileLayout.col_major
+        default_slayout = ir.TileLayout.row_major
+    elif memory_space == ir.MemorySpace.Right:
+        default_slayout = ir.TileLayout.col_major
+    elif memory_space == ir.MemorySpace.Acc:
+        default_blayout = ir.TileLayout.col_major
+        default_slayout = ir.TileLayout.row_major
+        default_fractal = 1024
+    return default_blayout, default_slayout, default_fractal
+
+
+def _has_printable_tile_view(
+    tile_view: ir.TileView | None,
+    shape: Sequence[ir.Expr],
+    memory_space: ir.MemorySpace | None = None,
+) -> bool:
+    """Return whether a TileView carries non-default metadata in Python text form."""
+    if tile_view is None:
+        return False
+    if tile_view.valid_shape and not _shape_exprs_match(tile_view.valid_shape, shape):
+        return True
+    if tile_view.stride:
+        return True
+    if tile_view.start_offset is not None:
+        return True
+    default_blayout, default_slayout, default_fractal = _implicit_tile_view_defaults(shape, memory_space)
+    if tile_view.blayout != default_blayout:
+        return True
+    if tile_view.slayout != default_slayout:
+        return True
+    if tile_view.fractal != default_fractal:
+        return True
+    if tile_view.pad != ir.PadValue.null:
+        return True
+    return False
+
+
+def _normalize_type_for_syntax_match(type_: ir.Type | None) -> ir.Type | None:
+    """Normalize omitted default TileView metadata before syntax-level comparison."""
+    if isinstance(type_, ir.TileType):
+        tile_view = type_.tile_view
+        if tile_view is not None and not _has_printable_tile_view(tile_view, type_.shape, type_.memory_space):
+            tile_view = None
+        if tile_view is type_.tile_view:
+            return type_
+        return ir.TileType(type_.shape, type_.dtype, type_.memref, tile_view, type_.memory_space)
+
+    return type_
+
+
+def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
+    """Return whether two IR types are equivalent in parser-visible syntax."""
+    if lhs is rhs:
+        return True
+    if lhs is None or rhs is None:
+        return lhs is rhs
+    lhs = _normalize_type_for_syntax_match(lhs)
+    rhs = _normalize_type_for_syntax_match(rhs)
+    assert lhs is not None
+    assert rhs is not None
+    if type(lhs) is not type(rhs):
+        return False
+    return ir.python_print_type(lhs) == ir.python_print_type(rhs)
 
 
 class ASTParser:
@@ -441,7 +540,7 @@ class ASTParser:
             if (
                 not isinstance(value_type, ir.UnknownType)
                 and not isinstance(existing_var.type, ir.UnknownType)
-                and existing_var.type != value_type
+                and not _types_match(existing_var.type, value_type)
             ):
                 raise ParserTypeError(
                     f"Cannot reassign '{var_name}' with a different type: "

--- a/python/pypto/language/typing/tile.py
+++ b/python/pypto/language/typing/tile.py
@@ -16,31 +16,69 @@ from collections.abc import Sequence
 from typing import Any
 
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Expr, MemRef
+from pypto.pypto_core.ir import Expr, MemorySpace, MemRef, TileView
 
 
 class TileMeta(type):
     """Metaclass for Tile to enable subscript notation."""
 
     def __getitem__(cls, item: tuple) -> "Tile":
-        """Enable Tile[[shape], dtype] and Tile[[shape], dtype, memref] syntax.
+        """Enable Tile[[shape], dtype] annotation syntax.
 
         Args:
-            item: Tuple of (shape, dtype) or (shape, dtype, memref)
+            item: Tuple of:
+                - (shape, dtype)
+                - (shape, dtype, memory_space_or_tile_view)
+                - (shape, dtype, memref, memory_space)
+                - (shape, dtype, memref, memory_space, tile_view)
 
         Returns:
-            Tile instance with shape, dtype, and optional memref
+            Tile instance with shape, dtype, and optional memref / memory space / tile view
         """
-        if not isinstance(item, tuple) or len(item) not in (2, 3):
-            raise TypeError("Tile requires [shape, dtype] or [shape, dtype, memref] notation")
+        if not isinstance(item, tuple) or len(item) not in (2, 3, 4, 5):
+            raise TypeError(
+                "Tile requires [shape, dtype], [shape, dtype, memory_space_or_tile_view], "
+                "[shape, dtype, memref, memory_space], or "
+                "[shape, dtype, memref, memory_space, tile_view] notation"
+            )
 
-        if len(item) == 3:
-            shape, dtype, memref = item
-            if not isinstance(memref, MemRef):
-                raise TypeError(f"Tile 3rd argument must be a MemRef instance, got {type(memref).__name__}")
-            return cls(shape, dtype, memref=memref, _annotation_only=True)
-        shape, dtype = item
-        return cls(shape, dtype, _annotation_only=True)
+        shape, dtype, *extras = item
+        memref = None
+        memory_space = None
+        tile_view = None
+
+        for extra in extras:
+            if isinstance(extra, MemRef):
+                if memref is not None:
+                    raise TypeError("Tile annotation can contain at most one MemRef")
+                memref = extra
+                continue
+            if isinstance(extra, MemorySpace):
+                if memory_space is not None:
+                    raise TypeError("Tile annotation can contain at most one memory space")
+                memory_space = extra
+                continue
+            if isinstance(extra, TileView):
+                if tile_view is not None:
+                    raise TypeError("Tile annotation can contain at most one TileView")
+                tile_view = extra
+                continue
+            raise TypeError(
+                "Tile trailing arguments must be MemRef, MemorySpace, or TileView, "
+                f"got {type(extra).__name__}"
+            )
+
+        if memref is not None and memory_space is None:
+            raise TypeError("Tile annotation with MemRef must also specify an explicit MemorySpace")
+
+        return cls(
+            shape,
+            dtype,
+            memref=memref,
+            memory_space=memory_space,
+            tile_view=tile_view,
+            _annotation_only=True,
+        )
 
     def __call__(
         cls,
@@ -48,6 +86,8 @@ class TileMeta(type):
         dtype=None,
         expr: Expr | None = None,
         memref: "MemRef | None" = None,
+        memory_space: "MemorySpace | None" = None,
+        tile_view: "TileView | None" = None,
         _annotation_only: bool = False,
     ) -> "Tile":
         """Enable both Tile((shape), dtype) syntax and runtime wrapping."""
@@ -59,8 +99,26 @@ class TileMeta(type):
             and expr is None
         ):
             real_shape, real_dtype = shape
-            return type.__call__(cls, real_shape, real_dtype, None, memref, _annotation_only)
-        return type.__call__(cls, shape, dtype, expr, memref, _annotation_only)
+            return type.__call__(
+                cls,
+                real_shape,
+                real_dtype,
+                expr=None,
+                memref=memref,
+                memory_space=memory_space,
+                tile_view=tile_view,
+                _annotation_only=_annotation_only,
+            )
+        return type.__call__(
+            cls,
+            shape,
+            dtype,
+            expr=expr,
+            memref=memref,
+            memory_space=memory_space,
+            tile_view=tile_view,
+            _annotation_only=_annotation_only,
+        )
 
 
 class Tile(metaclass=TileMeta):
@@ -92,6 +150,8 @@ class Tile(metaclass=TileMeta):
         dtype: DataType | None = None,
         expr: Expr | None = None,
         memref: MemRef | None = None,
+        memory_space: MemorySpace | None = None,
+        tile_view: TileView | None = None,
         _annotation_only: bool = False,
     ):
         """Initialize Tile.
@@ -107,12 +167,16 @@ class Tile(metaclass=TileMeta):
             self.shape = shape
             self.dtype = dtype
             self.memref = memref
+            self.memory_space = memory_space
+            self.tile_view = tile_view
             self._expr = None
         elif expr is not None:
             self._expr = expr
             self.shape = None
             self.dtype = None
             self.memref = None
+            self.memory_space = None
+            self.tile_view = None
         else:
             raise ValueError(
                 "Tile must be initialized with either (shape, dtype) for "
@@ -145,9 +209,14 @@ class Tile(metaclass=TileMeta):
         """String representation."""
         if self._expr is not None:
             return f"Tile(expr={self._expr})"
+        parts = [f"[{self.shape}]", f"{self.dtype}"]
         if self.memref is not None:
-            return f"Tile[[{self.shape}], {self.dtype}, {self.memref}]"
-        return f"Tile[[{self.shape}], {self.dtype}]"
+            parts.append(f"{self.memref}")
+        if self.memory_space is not None:
+            parts.append(f"{self.memory_space}")
+        if self.tile_view is not None:
+            parts.append(f"{self.tile_view}")
+        return f"Tile[{', '.join(parts)}]"
 
 
 __all__ = ["Tile"]

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -28,6 +28,19 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+_DEFAULT_TILEVIEW_ANNOTATIONS_WITH_MEMORY = [
+    ("pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView()]", ir.MemorySpace.Vec),
+    ("pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView()]", ir.MemorySpace.Mat),
+    ("pl.Tile[[16, 128], pl.FP32, pl.Mem.Left, pl.TileView()]", ir.MemorySpace.Left),
+    ("pl.Tile[[16, 128], pl.FP32, pl.Mem.Right, pl.TileView()]", ir.MemorySpace.Right),
+    ("pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc, pl.TileView()]", ir.MemorySpace.Acc),
+]
+_DEFAULT_TILEVIEW_ANNOTATIONS = [annotation for annotation, _ in _DEFAULT_TILEVIEW_ANNOTATIONS_WITH_MEMORY]
+_NON_DEFAULT_TILEVIEW_ANNOTATION = (
+    "pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[16, 64])]"
+)
+
+
 def _make_resolver(
     closure_vars: dict | None = None, scope_lookup: "Callable[[str], Any | None] | None" = None
 ) -> TypeResolver:
@@ -152,6 +165,57 @@ class TestTypeResolver:
 
         with pytest.raises(ParserTypeError, match="Unknown shape variable"):
             resolver._parse_shape(node)
+
+    @pytest.mark.parametrize(
+        ("annotation", "expected_memory_space"),
+        _DEFAULT_TILEVIEW_ANNOTATIONS_WITH_MEMORY,
+    )
+    def test_tile_annotation_accepts_memory_space_and_tileview_without_memref(
+        self, annotation: str, expected_memory_space: ir.MemorySpace
+    ):
+        """Tile[...] accepts explicit MemorySpace + TileView() even without MemRef."""
+        resolved = eval(annotation, {"pl": pl})
+
+        assert resolved.memory_space == expected_memory_space
+        assert resolved.tile_view is not None
+        assert resolved.memref is None
+
+    @pytest.mark.parametrize("annotation", _DEFAULT_TILEVIEW_ANNOTATIONS)
+    def test_explicit_empty_tileview_prints_as_canonical_implicit_form(self, annotation: str):
+        """Redundant explicit TileView() prints back as canonical omitted syntax."""
+        resolver = _make_resolver()
+        resolved = resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+        assert isinstance(resolved, ir.TileType)
+
+        printed = ir.python_print_type(resolved)
+
+        assert "pl.TileView(" not in printed
+        assert printed == annotation.replace(", pl.TileView()", "")
+
+    def test_non_default_tileview_is_not_canonicalized_away(self):
+        """A non-default TileView must remain explicit in printed canonical syntax."""
+        resolver = _make_resolver()
+        annotation = _NON_DEFAULT_TILEVIEW_ANNOTATION
+
+        resolved = resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+        assert isinstance(resolved, ir.TileType)
+        printed = ir.python_print_type(resolved)
+
+        assert "pl.TileView(" in printed
+        assert "valid_shape=[16, 64]" in printed
+
+    @pytest.mark.parametrize("annotation", _DEFAULT_TILEVIEW_ANNOTATIONS)
+    def test_tile_type_text_roundtrip_is_stable_after_canonicalization(self, annotation: str):
+        """Once canonicalized, the printed tile type should parse and print stably."""
+        resolver = _make_resolver()
+        first = resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+        assert isinstance(first, ir.TileType)
+
+        printed = ir.python_print_type(first)
+        reparsed = resolver.resolve_type(ast.parse(printed, mode="eval").body)
+        assert isinstance(reparsed, ir.TileType)
+
+        assert ir.python_print_type(reparsed) == printed
 
 
 class TestTupleTypeResolver:


### PR DESCRIPTION
## Summary
- canonicalize parser-side Tile type comparison so omitted default TileView metadata does not break reassignment after print-parse roundtrip
- extend `pl.Tile[...]` annotation syntax to carry explicit `MemorySpace` and `TileView`, keeping printed tile types parseable by the language layer
- add a reusable TileView semantics helper for the default-layout rules this roundtrip work depends on

## Testing
- cmake --build build --parallel 14
- PYTHONPATH=$(pwd)/python .venv/bin/pytest tests/ut -v
- PATH=$(pwd)/.venv/bin:$PATH .venv/bin/python tests/lint/clang_tidy.py --jobs=$(nproc) --diff-base=upstream/main
