### PR TITLE
fix(language): relax DSL call typing for literals

### DIFF
--- a/examples/ir_parser/batch_paged_attention_example.py
+++ b/examples/ir_parser/batch_paged_attention_example.py
@@ -489,7 +489,7 @@ def BuildBatchPagedAttentionProgram(
                         pij_b,
                         mij_b,
                         lij_b,
-                        1.0,  # type: ignore[reportArgumentType]
+                        1.0,
                         context_lens,
                         batch_cfg,
                         bn,

--- a/examples/ir_parser/dynamic_paged_attention_example.py
+++ b/examples/ir_parser/dynamic_paged_attention_example.py
@@ -289,16 +289,16 @@ def build_dynamic_paged_attention_program(
 
                     # Allocate zero-initialised accumulators for the online softmax state
                     oi_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
-                        [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                        [q_tile, head_dim_cfg],
                         dtype=pl.FP32,
                     )
                     li_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     mi_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     # Bind concrete tensor shapes to dynamic type annotations (no-op passthrough)
                     oi, li_update, mi_update = dyn_kernel_init_inplace(oi_buf, li_buf, mi_buf)
@@ -307,7 +307,7 @@ def build_dynamic_paged_attention_program(
                         # Slice the query tile for this head-tile and batch entry
                         qi: pl.Tensor[[q_tile, head_dim_cfg], pl.BF16] = pl.slice(
                             query,
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             [cur_offset, 0],
                         )
 
@@ -321,19 +321,19 @@ def build_dynamic_paged_attention_program(
                         # Slice the key block: key_cache is [KV_rows, head_dim]
                         kj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.slice(
                             key_cache,
-                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [block_size_cfg, head_dim_cfg],
                             [kv_block_row, 0],
                         )
                         # Slice the value block: value_cache is stored as [KV_rows, head_dim]
                         vj: pl.Tensor[[block_size_cfg, head_dim_cfg], pl.BF16] = pl.slice(
                             value_cache,
-                            [block_size_cfg, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [block_size_cfg, head_dim_cfg],
                             [kv_block_row, 0],
                         )
 
                         # Stage 1: QK matmul — sij[q_tile, block_size] = qi @ kj.T
                         sij_buf: pl.Tensor[[q_tile, block_size_cfg], pl.FP32] = pl.create_tensor(
-                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, block_size_cfg],
                             dtype=pl.FP32,
                         )
                         sij = dyn_kernel_qk_matmul(qi, kj, sij_buf)
@@ -342,53 +342,53 @@ def build_dynamic_paged_attention_program(
                         # including out-of-range tokens in the softmax
                         sij_valid: pl.Tensor[[q_tile, valid_len], pl.FP32] = pl.slice(
                             sij,
-                            [q_tile, valid_len],  # type: ignore[reportArgumentType]
+                            [q_tile, valid_len],
                             [0, 0],
                         )
 
                         # Stage 2: softmax prepare — scale, row_max (mi), exp, row_sum (li)
                         pij_f16_buf: pl.Tensor[[q_tile, block_size_cfg], pl.BF16] = pl.create_tensor(
-                            [q_tile, block_size_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, block_size_cfg],
                             dtype=pl.BF16,
                         )
                         mi_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         li_sm_buf: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         pij_f16, mi, li = dyn_kernel_softmax_prepare(
                             sij_valid,
-                            1.0,  # type: ignore[reportArgumentType]
+                            1.0,
                             pij_f16_buf,
                             mi_sm_buf,
-                            li_sm_buf,  # type: ignore[reportArgumentType]
+                            li_sm_buf,
                         )
 
                         # Stage 3: PV matmul — oi_tmp[q_tile, head_dim] = pij @ vj
                         oi_tmp_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.create_tensor(
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             dtype=pl.FP32,
                         )
                         oi_tmp = dyn_kernel_pv_matmul(pij_f16, vj, oi_tmp_buf)
 
                         # Determine position flags for the online softmax update kernel
                         if bn == 0:
-                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(1)
                         else:
-                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                            is_first: pl.Scalar[pl.INT64] = pl.yield_(0)
                         if bn == bn_this_batch - 1:
-                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)  # type: ignore[reportArgumentType]
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(1)
                         else:
-                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)  # type: ignore[reportArgumentType]
+                            is_last: pl.Scalar[pl.INT64] = pl.yield_(0)
 
                         # Stage 4: online update — merge (mij, lij, oi_new) into (mi, li, oi)
                         # and write final normalised output on the last block
                         out_view_buf: pl.Tensor[[q_tile, head_dim_cfg], pl.FP32] = pl.slice(
                             out,
-                            [q_tile, head_dim_cfg],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim_cfg],
                             [cur_offset, 0],
                         )
                         mi_update, li_update, oi, out_view = dyn_kernel_online_update(

--- a/examples/ir_parser/orchestration_example.py
+++ b/examples/ir_parser/orchestration_example.py
@@ -104,11 +104,11 @@ class ExampleOrchProgram:
 
         # Task 1: d = c + 1 (call kernel_add_scalar with output buffer d)
         d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
-        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+        d = self.kernel_add_scalar(c, 1.0, d)
 
         # Task 2: e = c + 2 (call kernel_add_scalar with output buffer e)
         e: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
-        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+        e = self.kernel_add_scalar(c, 2.0, e)
 
         # Task 3: f = d * e (call kernel_mul with output buffer)
         f_result = self.kernel_mul(d, e, f_result)

--- a/examples/ir_parser/paged_attention_example.py
+++ b/examples/ir_parser/paged_attention_example.py
@@ -370,7 +370,7 @@ def build_paged_attention_program(
                         # Softmax prepare (VECTOR) via shared module-level InCore kernel
                         pij_f16, mi, li = kernel_softmax_prepare(
                             sij_valid,
-                            1.0,  # type: ignore[reportArgumentType]
+                            1.0,
                             pij_f16_buf,
                             mi_sm_buf,
                             li_sm_buf,
@@ -512,7 +512,7 @@ def build_paged_attention_unaligned_program(
                         )
                         pij_f16, mi, li = kernel_softmax_prepare_unaligned(
                             sij,
-                            1.0,  # type: ignore[reportArgumentType]
+                            1.0,
                             valid_len,
                             pij_f16_buf,
                             mi_sm_buf,

--- a/examples/ir_parser/paged_attention_multi_config_example.py
+++ b/examples/ir_parser/paged_attention_multi_config_example.py
@@ -480,40 +480,40 @@ def build_paged_attention_multi_config_program(
                     cur_offset = b_idx * num_heads + q_idx * q_tile
 
                     oi: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
-                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        [q_tile, head_dim],
                         dtype=pl.FP32,
                     )
                     li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     oi, li_update, mi_update = _hub(oi, li_update, mi_update)
 
                     qi: pl.Tensor[[q_tile, head_dim], pl.BF16] = pl.slice(
                         query,
-                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        [q_tile, head_dim],
                         [cur_offset, 0],
                     )
 
                     # ── n_unroll loop over KV blocks ──────────
-                    for bn in pl.range(0, max_bn, n_unroll):  # type: ignore[reportArgumentType]
-                        n_blocks = pl.min(n_unroll, max_bn - bn)  # type: ignore[reportArgumentType]
+                    for bn in pl.range(0, max_bn, n_unroll):
+                        n_blocks = pl.min(n_unroll, max_bn - bn)
                         bt_offset = b_idx * max_num_blocks_per_req + bn
 
                         # Pre-extract block indices from block_table (multi-config)
                         block_indices: pl.Tensor[[n_unroll], pl.INT32] = pl.slice(
                             block_table,
-                            [n_unroll],  # type: ignore[reportArgumentType]
+                            [n_unroll],
                             [bt_offset],
                         )
 
                         # 1. QK matmul (CUBE)
                         sij_buf: pl.Tensor[[n_unroll_q, block_size], pl.FP32] = pl.create_tensor(
-                            [n_unroll_q, block_size],  # type: ignore[reportArgumentType]
+                            [n_unroll_q, block_size],
                             dtype=pl.FP32,
                         )
                         sij_buf = _qk(
@@ -526,29 +526,29 @@ def build_paged_attention_multi_config_program(
 
                         # 2. Softmax prepare (VECTOR)
                         pij_buf: pl.Tensor[[n_unroll_q, block_size], pl.BF16] = pl.create_tensor(
-                            [n_unroll_q, block_size],  # type: ignore[reportArgumentType]
+                            [n_unroll_q, block_size],
                             dtype=pl.BF16,
                         )
                         mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         pij_buf, mi, li = _sf(
                             sij_buf,
-                            1.0,  # type: ignore[reportArgumentType]
+                            1.0,
                             pij_buf,
                             mi,
                             li,
-                            n_blocks,  # type: ignore[reportArgumentType]
+                            n_blocks,
                         )
 
                         # 3. PV matmul (CUBE)
                         oi_new: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
-                            [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim],
                             dtype=pl.FP32,
                         )
                         oi_new = _pv(
@@ -572,7 +572,7 @@ def build_paged_attention_multi_config_program(
                         # 5. Online update (VECTOR)
                         out_view: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.slice(
                             out,
-                            [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim],
                             [cur_offset, 0],
                         )
                         mi_update, li_update, oi, out_view = _up(

--- a/examples/ir_parser/vector_example_dag.py
+++ b/examples/ir_parser/vector_example_dag.py
@@ -94,9 +94,9 @@ class VectorExampleProgram:
         c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
         c = self.kernel_add(a, b, c)
         d: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+        d = self.kernel_add_scalar(c, 1.0, d)
         e: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+        e = self.kernel_add_scalar(c, 2.0, e)
         g: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
         g = self.kernel_mul(d, e, g)
         f = self.kernel_add(g, c, f)

--- a/examples/language/intermediate/vector_dag.py
+++ b/examples/language/intermediate/vector_dag.py
@@ -87,9 +87,9 @@ class VectorDAGProgram:
         c: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
         c = self.kernel_add(a, b, c)
         d: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-        d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+        d = self.kernel_add_scalar(c, 1.0, d)
         e: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
-        e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+        e = self.kernel_add_scalar(c, 2.0, e)
         g: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], dtype=pl.FP32)
         g = self.kernel_mul(d, e, g)
         f = self.kernel_add(g, c, f)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -82,7 +82,7 @@ def _create_tile_binary_call(
 
 
 def create(
-    shape: Sequence[int] | _ir_core.MakeTuple,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
     span: Span | None = None,
@@ -338,7 +338,7 @@ def get_block_idx(span: Span | None = None) -> Call:
 
 
 def full(
-    shape: Sequence[int] | _ir_core.MakeTuple,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     dtype: DataType,
     value: int | float,
     span: Span | None = None,

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -149,7 +149,7 @@ def create(
     # create C++ binding accepts Sequence[int]; Expr elements from Scalar
     # unwrapping are valid at DSL parse time (parser reads the AST).
     call_expr = _ir_ops.create(
-        _normalize_intlike(shape),  # type: ignore[reportArgumentType]
+        _normalize_intlike(shape),
         dtype,
         target_memory,
     )

--- a/python/pypto/language/parser/decorator.pyi
+++ b/python/pypto/language/parser/decorator.pyi
@@ -1,0 +1,82 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Typing facade for DSL decorators.
+
+This stub intentionally models ``@pl.function``-decorated methods as permissive
+bound callables. The DSL parser accepts literal arguments like ``2.0`` at call
+sites and lowers them to IR constants, but plain Python type checking cannot
+express that coercion on arbitrary decorated methods without broadening the
+callable boundary.
+"""
+
+from ast import FunctionDef
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, overload
+
+from pypto.pypto_core import ir
+
+_R_co = TypeVar("_R_co", covariant=True)
+
+class InlineFunction:
+    """Stores AST and metadata for a function to be inlined at call sites."""
+
+    name: str
+    func_def: FunctionDef
+    param_names: list[str]
+    source_file: str
+    source_lines: list[str]
+    line_offset: int
+    col_offset: int
+    closure_vars: dict[str, Any]
+
+class DSLFunction(ir.Function, Generic[_R_co]):
+    """Typing-only view of a decorated DSL function.
+
+    At module scope, decorated functions behave like ``ir.Function`` objects.
+    When accessed as class attributes through an instance inside ``@pl.program``
+    bodies, treat them as permissive callables so pyright does not reject DSL
+    literal-to-scalar coercions at call sites. The return type of the decorated
+    function is preserved even though the argument list is intentionally broad.
+    """
+
+    @overload
+    def __get__(self, instance: None, owner: type[Any] | None = None) -> DSLFunction[_R_co]: ...
+    @overload
+    def __get__(self, instance: object, owner: type[Any] | None = None) -> Callable[..., _R_co]: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> _R_co: ...
+
+@overload
+def function(func: Callable[..., _R_co], /) -> DSLFunction[_R_co]: ...
+@overload
+def function(
+    *,
+    type: ir.FunctionType = ...,
+    level: ir.Level | None = ...,
+    role: ir.Role | None = ...,
+    strict_ssa: bool = ...,
+) -> Callable[[Callable[..., _R_co]], DSLFunction[_R_co]]: ...
+def function(
+    func: Callable[..., _R_co] | None = None,
+    *,
+    type: ir.FunctionType = ...,
+    level: ir.Level | None = ...,
+    role: ir.Role | None = ...,
+    strict_ssa: bool = ...,
+) -> DSLFunction[_R_co] | Callable[[Callable[..., _R_co]], DSLFunction[_R_co]]: ...
+def inline(func: Callable[..., Any]) -> InlineFunction: ...
+@overload
+def program(cls: type[Any], /, *, strict_ssa: bool = ...) -> ir.Program: ...
+@overload
+def program(cls: None = None, /, *, strict_ssa: bool = ...) -> Callable[[type[Any]], ir.Program]: ...
+def program(
+    cls: type[Any] | None = None,
+    *,
+    strict_ssa: bool = ...,
+) -> ir.Program | Callable[[type[Any]], ir.Program]: ...

--- a/tests/st/runtime/test_dyn_orch_shape.py
+++ b/tests/st/runtime/test_dyn_orch_shape.py
@@ -511,7 +511,7 @@ class DynOrchPagedAttentionTestCase(PTOTestCase):
                             )
                             pij_f16, mi, li = kernel_softmax_prepare(
                                 sij_valid,
-                                1.0,  # type: ignore[reportArgumentType]
+                                1.0,
                                 pij_f16_buf,
                                 mi_sm_buf,
                                 li_sm_buf,

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -370,9 +370,9 @@ class TestOrchestration:
                 c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
                 c = self.kernel_add(a, b, c)
                 d: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
-                d = self.kernel_add_scalar(c, 1.0, d)  # type: ignore[reportArgumentType]
+                d = self.kernel_add_scalar(c, 1.0, d)
                 e: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
-                e = self.kernel_add_scalar(c, 2.0, e)  # type: ignore[reportArgumentType]
+                e = self.kernel_add_scalar(c, 2.0, e)
                 g: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
                 g = self.kernel_mul(d, e, g)
                 f = self.kernel_add(g, c, f)

--- a/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
@@ -351,64 +351,64 @@ def build_paged_attention_multi_config_program(
 
                     oi: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
                         [q_tile, head_dim],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     li_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     mi_update: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                         [q_tile, 1],
-                        dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                        dtype=pl.FP32,
                     )
                     oi, li_update, mi_update = _hub(oi, li_update, mi_update)
 
                     qi: pl.Tensor[[q_tile, head_dim], pl.BF16] = pl.slice(
                         query,
-                        [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                        [q_tile, head_dim],
                         [cur_offset, 0],
                     )
 
-                    for bn in pl.range(0, max_bn, n_unroll):  # type: ignore[reportArgumentType]
-                        n_blocks = pl.min(n_unroll, max_bn - bn)  # type: ignore[reportArgumentType]
+                    for bn in pl.range(0, max_bn, n_unroll):
+                        n_blocks = pl.min(n_unroll, max_bn - bn)
                         bt_offset = b_idx * max_num_blocks_per_req + bn
 
                         block_indices: pl.Tensor[[n_unroll], pl.INT32] = pl.slice(
                             block_table,
-                            [n_unroll],  # type: ignore[reportArgumentType]
+                            [n_unroll],
                             [bt_offset],
                         )
 
                         sij_buf: pl.Tensor[[n_unroll_q, block_size], pl.FP32] = pl.create_tensor(
                             [n_unroll_q, block_size],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         sij_buf = _qk(qi, key_cache, sij_buf, block_indices, n_blocks)
 
                         pij_buf: pl.Tensor[[n_unroll_q, block_size], pl.BF16] = pl.create_tensor(
                             [n_unroll_q, block_size],
-                            dtype=pl.BF16,  # type: ignore[reportArgumentType]
+                            dtype=pl.BF16,
                         )
                         mi: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         li: pl.Tensor[[q_tile, 1], pl.FP32] = pl.create_tensor(
                             [q_tile, 1],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         pij_buf, mi, li = _sf(
                             sij_buf,
-                            1.0,  # type: ignore[reportArgumentType]
+                            1.0,
                             pij_buf,
                             mi,
-                            li,  # type: ignore[reportArgumentType]
-                            n_blocks,  # type: ignore[reportArgumentType]
+                            li,
+                            n_blocks,
                         )
 
                         oi_new: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.create_tensor(
                             [q_tile, head_dim],
-                            dtype=pl.FP32,  # type: ignore[reportArgumentType]
+                            dtype=pl.FP32,
                         )
                         oi_new = _pv(pij_buf, value_cache, oi_new, block_indices, n_blocks)
 
@@ -423,7 +423,7 @@ def build_paged_attention_multi_config_program(
 
                         out_view: pl.Tensor[[q_tile, head_dim], pl.FP32] = pl.slice(
                             out,
-                            [q_tile, head_dim],  # type: ignore[reportArgumentType]
+                            [q_tile, head_dim],
                             [cur_offset, 0],
                         )
                         mi_update, li_update, oi, out_view = _up(


### PR DESCRIPTION
## Summary
- add a typing-only facade for `@pl.function`-decorated methods so bound DSL calls accept literals without `reportArgumentType` suppressions while preserving return types
- widen `tile.create` and `tile.full` shape typing to accept `Expr`-backed dimensions
- remove now-unneeded `reportArgumentType` suppressions from examples and tests

## Testing
- `cmake --build build --parallel`
- `pyright -p .`
- `python -m pytest tests/ut/codegen/test_orchestration_codegen.py tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py -n auto --maxprocesses 8 -v`
