### PR TITLE
fix(pass): rebuild call type after InferTileMemorySpace rewrites (#777)

### DIFF
--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -279,7 +279,7 @@ class TileMemorySpaceMutator : public IRMutator {
     }
 
     if (!changed) return op;
-    return std::make_shared<Call>(op->op_, std::move(new_args), op->kwargs_, op->GetType(), op->span_);
+    return OpRegistry::GetInstance().Create(op->op_->name_, new_args, op->kwargs_, op->span_);
   }
 
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -840,6 +840,15 @@ class TestAutoMoveInsertion:
         assert "pl.tile.write(x_tile_Vec, [0, 0], value)" in printed
         assert printed.count("pl.tile.move") == 1
 
+        incore_func = After.get_function("main_incore_0")
+        assert incore_func is not None
+        assert isinstance(incore_func.body, ir.SeqStmts)
+        write_stmt = incore_func.body.stmts[2]
+        assert isinstance(write_stmt, ir.EvalStmt)
+        assert isinstance(write_stmt.expr, ir.Call)
+        assert isinstance(write_stmt.expr.type, ir.TileType)
+        assert write_stmt.expr.type.memory_space == ir.MemorySpace.Vec
+
     def test_store_no_move_for_vec(self):
         """tile.store accepts Vec — no move needed for Vec tile."""
 


### PR DESCRIPTION
## Summary
- rebuild Call type when InferTileMemorySpace rewrites call arguments
- add a regression test that checks the rewritten tile.write call carries Vec memory space in its expr.type

## Testing
- cmake --build build --parallel 14
- PYTHONPATH=$(pwd)/python .venv/bin/python -m pytest tests/ut/ir/transforms/test_infer_tile_memory_space.py::TestAutoMoveInsertion::test_eval_stmt_consumer_collects_and_inserts_move -v
- PYTHONPATH=$(pwd)/python .venv/bin/python -m pytest tests/ut/ir/transforms/test_infer_tile_memory_space.py -v

## Notes
- split out from the broader roundtrip work so this pass bug can be reviewed independently