### PR TITLE
feat(runtime): add profiling support with swimlane JSON generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,11 @@ jobs:
       - name: Test system tests
         run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128
 
+      - name: Test swimlane output
+        run: |
+          pytest tests/st/runtime/test_perf_swimlane.py \
+            -v --device=$DEVICE_ID --platform=a2a3 --enable-profiling --forked
+
   fuzz-tests-sim:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/examples/models/02_vector_dag.py
+++ b/examples/models/02_vector_dag.py
@@ -32,6 +32,8 @@ Run:  python examples/models/02_vector_dag.py  (requires hardware)
 Next: examples/models/03_flash_attention.py
 """
 
+import argparse
+
 import pypto.language as pl
 import torch
 from pypto.backend import BackendType
@@ -187,6 +189,15 @@ def golden(tensors: dict, params: dict | None = None) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Vector DAG example")
+    parser.add_argument(
+        "--enable-profiling",
+        action="store_true",
+        default=False,
+        help="Enable runtime profiling and generate swimlane JSON",
+    )
+    args = parser.parse_args()
+
     tensor_specs = [
         TensorSpec("a", [128, 128], torch.float32, init_value=2.0),
         TensorSpec("b", [128, 128], torch.float32, init_value=3.0),
@@ -203,6 +214,7 @@ def main():
             backend_type=BackendType.Ascend910B,
             rtol=1e-5,
             atol=1e-5,
+            enable_profiling=args.enable_profiling,
         ),
     )
     print(f"Result: {result}")

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -33,6 +33,7 @@ Shared InCore kernels (module-level @pl.function):
 These can be imported and reused by other @pl.program definitions.
 """
 
+import argparse
 import struct
 
 import pypto.language as pl
@@ -591,6 +592,15 @@ def build_tensor_specs(
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Paged attention example")
+    parser.add_argument(
+        "--enable-profiling",
+        action="store_true",
+        default=False,
+        help="Enable runtime profiling and generate swimlane JSON",
+    )
+    args = parser.parse_args()
+
     batch = 64
     num_heads = 16
     head_dim = 128
@@ -630,6 +640,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
+            enable_profiling=args.enable_profiling,
         ),
     )
     print(f"Result: {result}")

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -19,6 +19,8 @@ accepts any batch size at runtime.
 # DSL function bodies are parsed as AST — dynamic var names look undefined to pyright.
 # pyright: reportUndefinedVariable=false
 
+import argparse
+
 import pypto.language as pl
 import torch
 from pypto.backend import BackendType
@@ -500,6 +502,15 @@ def main():
     blocks.  The program is built once via build_dynamic_paged_attention_program()
     and executed on the target device with tolerance atol/rtol=2e-2.
     """
+    parser = argparse.ArgumentParser(description="Dynamic paged attention example")
+    parser.add_argument(
+        "--enable-profiling",
+        action="store_true",
+        default=False,
+        help="Enable runtime profiling and generate swimlane JSON",
+    )
+    args = parser.parse_args()
+
     batch = 64
     num_heads = 16
     head_dim = 128
@@ -535,6 +546,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
+            enable_profiling=args.enable_profiling,
         ),
     )
     print(f"Result: {result}")

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -38,6 +38,7 @@ Factory functions for batch-dynamic kernels:
   make_kernel_pv_matmul(key_cache_rows)
 """
 
+import argparse
 import struct
 
 import pypto.language as pl
@@ -736,6 +737,15 @@ def build_tensor_specs_multi_config(
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Multi-config paged attention example")
+    parser.add_argument(
+        "--enable-profiling",
+        action="store_true",
+        default=False,
+        help="Enable runtime profiling and generate swimlane JSON",
+    )
+    args = parser.parse_args()
+
     batch = 4
     num_heads = 16
     head_dim = HEAD_DIM
@@ -774,6 +784,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
+            enable_profiling=args.enable_profiling,
         ),
     )
     print(f"Result: {result}")

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -66,6 +66,7 @@ from .tensor_spec import TensorSpec
 # the same process.
 _code_runner_patched: list[bool] = [False]
 _binary_cache_patched: list[bool] = [False]
+_OUTPUTS_DIR = Path("outputs")
 
 
 @functools.lru_cache(maxsize=1)
@@ -241,6 +242,8 @@ class RunConfig:
             on device.  Useful for validating compilation output.
         pto_isa_commit: If set, pin the pto-isa clone to this specific git
             commit (hash or tag).  ``None`` means use the latest remote HEAD.
+        enable_profiling: If ``True``, enable runtime profiling and generate
+            ``swimlane.json`` after execution.
     """
 
     __test__ = False  # Not a pytest test class
@@ -256,6 +259,7 @@ class RunConfig:
     save_kernels_dir: str | None = None
     codegen_only: bool = False
     pto_isa_commit: str | None = None
+    enable_profiling: bool = False
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
@@ -268,6 +272,10 @@ class RunConfig:
         if not self.platform.startswith(expected_arch):
             sim_suffix = "sim" if self.platform.endswith("sim") else ""
             self.platform = f"{expected_arch}{sim_suffix}"
+        # Profiling requires kernel artefacts to be retained so swimlane files
+        # can reference kernel_config.py.  Enable save_kernels automatically.
+        if self.enable_profiling and not self.save_kernels:
+            self.save_kernels = True
 
 
 @dataclass
@@ -399,7 +407,14 @@ def run(
         write_golden(tensor_specs, golden, golden_path, rtol=config.rtol, atol=config.atol)
 
         # 4. Execute via Simpler's CodeRunner
-        _execute_on_device(work_dir, golden_path, config.platform, config.device_id, config.pto_isa_commit)
+        _execute_on_device(
+            work_dir,
+            golden_path,
+            config.platform,
+            config.device_id,
+            config.pto_isa_commit,
+            config.enable_profiling,
+        )
 
         return RunResult(passed=True, execution_time=time.time() - start_time)
 
@@ -564,6 +579,7 @@ def _execute_on_device(
     platform: str,
     device_id: int,
     pto_isa_commit: str | None = None,
+    enable_profiling: bool = False,
 ) -> None:
     """Invoke Simpler's CodeRunner to compile, load, execute, and validate.
 
@@ -579,6 +595,8 @@ def _execute_on_device(
         device_id: Hardware device index.
         pto_isa_commit: If set, pin the pto-isa clone to this specific git
             commit (hash or tag).
+        enable_profiling: If ``True``, enable runtime profiling and generate
+            ``swimlane.json`` after execution.
     """
     simpler_root = os.environ.get("SIMPLER_ROOT")
     if simpler_root:
@@ -594,6 +612,23 @@ def _execute_on_device(
     _install_golden_inputs_patch(CodeRunner)
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
+    # Snapshot existing device logs before run so we can identify the new one
+    # (CANN writes device logs asynchronously after execution).
+    # Device logs are only available on real hardware, not on simulators.
+    pre_run_logs: set[Path] = set()
+    device_log_dir: Path | None = None
+    if enable_profiling and not platform.endswith("sim"):
+        device_log_dir = _get_device_log_dir(device_id)
+        if device_log_dir.exists():
+            pre_run_logs = set(device_log_dir.glob("*.log"))
+
+    # Snapshot existing perf_swimlane files so we can identify the new one
+    # produced by CodeRunner (written to _OUTPUTS_DIR).
+    pre_run_perf_files: set[Path] = set()
+    if enable_profiling:
+        _OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
+        pre_run_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json"))
+
     CodeRunner(
         kernels_dir=str(work_dir),
         golden_path=str(golden_path),
@@ -601,7 +636,124 @@ def _execute_on_device(
         device_id=device_id,
         clone_protocol="https",
         pto_isa_commit=pto_isa_commit,
+        enable_profiling=enable_profiling,
     ).run()
+
+    if enable_profiling:
+        swimlane_dir = work_dir / "swimlane_data"
+        swimlane_dir.mkdir(parents=True, exist_ok=True)
+
+        # Move the newly created perf_swimlane_*.json into swimlane_data/.
+        new_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json")) - pre_run_perf_files
+        perf_file: Path | None = None
+        if new_perf_files:
+            perf_file = max(new_perf_files, key=lambda p: p.stat().st_mtime)
+            dest = swimlane_dir / perf_file.name
+            perf_file.rename(dest)
+            perf_file = dest
+            # Remove outputs/ if it is now empty (it is only a staging area).
+            try:
+                _OUTPUTS_DIR.rmdir()
+            except OSError:
+                pass
+
+        if not platform.endswith("sim"):
+            _generate_swimlane(
+                work_dir, device_id, device_log_dir, pre_run_logs, simpler_root, swimlane_dir, perf_file
+            )
+
+
+def _get_device_log_dir(device_id: int) -> Path:
+    """Return the CANN device log directory for *device_id*."""
+    ascend_work_path = os.environ.get("ASCEND_WORK_PATH")
+    if ascend_work_path:
+        root = Path(ascend_work_path).expanduser() / "log" / "debug"
+        if root.exists():
+            return root / f"device-{device_id}"
+    return Path.home() / "ascend" / "log" / "debug" / f"device-{device_id}"
+
+
+def _wait_for_new_device_log(
+    log_dir: Path, pre_run_logs: set[Path], timeout: float = 15, interval: float = 0.5
+) -> Path | None:
+    """Wait for a new ``*.log`` file in *log_dir* that wasn't present before the run.
+
+    CANN dlog writes device logs asynchronously, so the file may appear
+    a few seconds after execution completes.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if log_dir.exists():
+            new_logs = set(log_dir.glob("*.log")) - pre_run_logs
+            if new_logs:
+                return max(new_logs, key=lambda p: p.stat().st_mtime)
+        time.sleep(interval)
+    return None
+
+
+def _generate_swimlane(
+    work_dir: Path,
+    device_id: int,
+    device_log_dir: Path | None,
+    pre_run_logs: set[Path],
+    simpler_root: str | None,
+    swimlane_dir: Path,
+    perf_file: Path | None,
+) -> None:
+    """Run Simpler's swimlane_converter.py to generate ``merged_swimlane_*.json``.
+
+    Output is written to *swimlane_dir* alongside the input ``perf_swimlane_*.json``.
+
+    Args:
+        work_dir: Directory containing ``kernel_config.py``.
+        device_id: Hardware device index (fallback when no device log found).
+        device_log_dir: CANN device log directory snapshotted before the run.
+        pre_run_logs: Set of log files that existed before the run.
+        simpler_root: Path to the Simpler repository root.
+        swimlane_dir: Directory where swimlane JSON files are written.
+        perf_file: Path to the ``perf_swimlane_*.json`` file produced by
+            CodeRunner and already moved into *swimlane_dir*.  When ``None``,
+            swimlane conversion is skipped.
+    """
+    if not simpler_root:
+        return
+
+    swimlane_script = Path(simpler_root) / "tools" / "swimlane_converter.py"
+    if not swimlane_script.exists():
+        return
+
+    if perf_file is None:
+        print("No perf_swimlane_*.json found, skipping swimlane conversion")
+        return
+
+    kernel_config_path = work_dir / "kernel_config.py"
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = swimlane_dir / f"merged_swimlane_{timestamp}.json"
+
+    cmd = [
+        sys.executable,
+        str(swimlane_script),
+        str(perf_file),
+        "-o",
+        str(output_path),
+        "-k",
+        str(kernel_config_path),
+    ]
+
+    if device_log_dir is not None:
+        device_log_file = _wait_for_new_device_log(device_log_dir, pre_run_logs)
+        if device_log_file:
+            cmd += ["--device-log", str(device_log_file)]
+        else:
+            cmd += ["-d", str(device_id)]
+    else:
+        cmd += ["-d", str(device_id)]
+
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"Swimlane JSON written to: {output_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"swimlane_converter.py failed (exit {e.returncode}), no swimlane generated")
 
 
 def _patch_orchestration_headers(work_dir: Path) -> None:

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -176,6 +176,12 @@ def pytest_addoption(parser):
         default=None,
         help="Pin the pto-isa clone to a specific git commit (hash or tag). Default: use latest remote HEAD.",
     )
+    parser.addoption(
+        "--enable-profiling",
+        action="store_true",
+        default=False,
+        help="Enable runtime profiling and generate swimlane.json after execution.",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -200,6 +206,7 @@ def test_config(request) -> RunConfig:
         dump_passes=request.config.getoption("--dump-passes"),
         codegen_only=request.config.getoption("--codegen-only"),
         pto_isa_commit=request.config.getoption("--pto-isa-commit"),
+        enable_profiling=request.config.getoption("--enable-profiling"),
     )
 
 

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -628,7 +628,12 @@ class TestRunner:
 
             platform = _resolve_platform(self.config.platform, backend_type)
             _execute_on_device(
-                work_dir, golden_path, platform, self.config.device_id, self.config.pto_isa_commit
+                work_dir,
+                golden_path,
+                platform,
+                self.config.device_id,
+                self.config.pto_isa_commit,
+                self.config.enable_profiling,
             )
 
             return RunResult(

--- a/tests/st/runtime/test_perf_swimlane.py
+++ b/tests/st/runtime/test_perf_swimlane.py
@@ -1,0 +1,154 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Swimlane JSON output validation tests.
+
+Runs matmul 64x64x64 (PTO backend) with profiling and validates the
+generated perf_swimlane_*.json in build_output/<run_dir>/swimlane_data/.
+
+Requires --enable-profiling and real hardware (--platform=a2a3).
+All tests in this file are skipped automatically when --enable-profiling
+is not passed.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+_BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "build_output"
+
+
+class _MatmulPTO(PTOTestCase):
+    """Matmul 64x64x64 with PTO backend — vehicle for swimlane generation."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "matmul_pto_64x64x64"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = 64, 64, 64
+
+        @pl.program
+        class MatmulProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                tile_a_l1 = pl.load(a, offsets=[0, 0], shapes=[M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                out_c = pl.store(tile_c_l0c, offsets=[0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c = self.matmul(a, b, out_c)
+                return out_c
+
+        return MatmulProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
+
+
+@pytest.fixture(scope="session")
+def swimlane_file(test_runner) -> Path:
+    """Run matmul once with profiling and return the generated swimlane file.
+
+    Skips the entire test session (all dependent tests) when
+    --enable-profiling is not passed.
+    """
+    if not test_runner.config.enable_profiling:
+        pytest.skip("pass --enable-profiling to run swimlane tests")
+
+    before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/swimlane_data/perf_swimlane_*.json"))
+
+    result = test_runner.run(_MatmulPTO())
+    assert result.passed, f"Matmul execution failed: {result.error}"
+
+    after: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/swimlane_data/perf_swimlane_*.json"))
+    new_files = after - before
+    assert new_files, "No perf_swimlane_*.json was generated in build_output/*/swimlane_data/"
+
+    return max(new_files, key=lambda p: p.stat().st_mtime)
+
+
+@pytest.fixture(scope="session")
+def swimlane_data(swimlane_file: Path) -> dict:
+    return json.loads(swimlane_file.read_text())
+
+
+class TestSwimlaneOutput:
+    """Validate the structure and content of perf_swimlane_*.json."""
+
+    def test_file_generated(self, swimlane_file: Path):
+        """A perf_swimlane_*.json file is created in build_output/*/swimlane_data/."""
+        assert swimlane_file.exists(), f"Swimlane file not found: {swimlane_file}"
+
+    def test_top_level_structure(self, swimlane_data: dict):
+        """Top-level 'version' and 'tasks' fields are present and non-empty."""
+        assert "version" in swimlane_data, "Missing top-level field: 'version'"
+        assert "tasks" in swimlane_data, "Missing top-level field: 'tasks'"
+        assert len(swimlane_data["tasks"]) > 0, "tasks list is empty"
+
+    def test_task_required_fields(self, swimlane_data: dict):
+        """Each task contains all required fields with the correct types."""
+        required: dict[str, type | tuple] = {
+            "task_id": int,
+            "func_id": int,
+            "core_id": int,
+            "core_type": str,
+            "start_time_us": (int, float),
+            "end_time_us": (int, float),
+            "duration_us": (int, float),
+            "fanout": list,
+            "fanout_count": int,
+        }
+        for task in swimlane_data["tasks"]:
+            for field, expected_type in required.items():
+                assert field in task, f"task_id={task.get('task_id')}: missing field '{field}'"
+                assert isinstance(task[field], expected_type), (
+                    f"task_id={task.get('task_id')}: field '{field}' has type "
+                    f"{type(task[field]).__name__}, expected {expected_type}"
+                )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add `enable_profiling` flag to `RunConfig` and `_execute_on_device`.
When enabled on real hardware, passes the flag through to CodeRunner
(which writes `outputs/perf_swimlane_*.json`), then post-processes it
via Simpler's `swimlane_converter.py` to produce
`outputs/merged_swimlane_<timestamp>.json`.

- `runner.py`: add `_get_device_log_dir`, `_wait_for_new_device_log`,
  and `_generate_swimlane` helpers; snapshot CANN device logs before
  execution and run the converter after; wire `enable_profiling` into
  `run()` and `_execute_on_device()`
- `conftest.py` / `test_runner.py`: expose `--enable-profiling` CLI
  option and propagate it through to `RunConfig`
- `test_perf_swimlane.py`: new ST test that runs matmul 64×64×64 with
  profiling and validates the generated `perf_swimlane_*.json`
  structure and required task fields; skipped when `--enable-profiling`
  is not passed
- `ci.yml`: add CI step to run swimlane tests on a2a3 hardware