### PR TITLE
fix(pass): store iter-arg returns to InOut params in ConvertTensorToTileOps

### DIFF
--- a/docs/en/dev/passes/12-init_memref.md
+++ b/docs/en/dev/passes/12-init_memref.md
@@ -120,7 +120,7 @@ Pass InitMemRef();
 
 - `NormalizeStmtStructure` is called internally before MemRef initialization
 - `InitMemRefMutator` reads `memory_space` from `TileType` and creates MemRef objects
-  - Handles MemRef sharing for view ops, reuse-input ops (`tile.store`, `matmul_acc`, `gemv_acc`), and ForStmt/IfStmt yield values
+  - Handles MemRef sharing for view ops, reuse-input ops (`tile.store`, `matmul_acc`, `gemv_acc`), tile aliases (`a = b`), and ForStmt/IfStmt yield values
 - `NonDDRMemRefCollector` collects unique non-DDR MemRefs
 - `CreateAllocStatement` / `InsertAllocsIntoBody` create and insert alloc ops
 

--- a/docs/en/dev/passes/15-memory_reuse.md
+++ b/docs/en/dev/passes/15-memory_reuse.md
@@ -138,7 +138,7 @@ Pass MemoryReuse();
 - `ComputeLifetimes` builds MemRef sharing groups and lifetime intervals
 - `IdentifyReuseOpportunities` finds reuse candidates
 - `ApplyMemRefSharing` updates MemRef pointers via `MemRefSharingMutator`
-- `YieldFixupMutator` fixes ForStmt/IfStmt yield/return_var MemRef mismatches after reuse
+- `YieldFixupMutator` fixes ForStmt/IfStmt yield/return_var MemRef mismatches after reuse (inserts `tile.move` when needed)
 - `UsedMemRefCollector` gathers still-referenced MemRef pointers after sharing
 - `RemoveUnusedAllocStatements` filters out redundant `tile.alloc` statements from `SeqStmts`
 

--- a/docs/zh-cn/dev/passes/12-init_memref.md
+++ b/docs/zh-cn/dev/passes/12-init_memref.md
@@ -120,7 +120,7 @@ Pass InitMemRef();
 
 - `NormalizeStmtStructure` 在 MemRef 初始化之前被内部调用
 - `InitMemRefMutator` 从 `TileType` 读取 `memory_space` 并创建 MemRef 对象
-  - 处理 view 操作、复用输入操作（`tile.store`、`matmul_acc`、`gemv_acc`）以及 ForStmt/IfStmt yield 值的 MemRef 共享
+  - 处理 view 操作、复用输入操作（`tile.store`、`matmul_acc`、`gemv_acc`）、tile 别名（`a = b`）以及 ForStmt/IfStmt yield 值的 MemRef 共享
 - `NonDDRMemRefCollector` 收集唯一的非 DDR MemRef
 - `CreateAllocStatement` / `InsertAllocsIntoBody` 创建并插入 alloc 操作
 

--- a/docs/zh-cn/dev/passes/15-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/15-memory_reuse.md
@@ -123,7 +123,7 @@ Pass MemoryReuse();
 - `ComputeLifetimes` 构建 MemRef 共享组和生命周期区间
 - `IdentifyReuseOpportunities` 查找复用候选
 - `ApplyMemRefSharing` 通过 `MemRefSharingMutator` 更新 MemRef 指针
-- `YieldFixupMutator` 修复 ForStmt/IfStmt 在复用后的 yield/return_var MemRef 不一致
+- `YieldFixupMutator` 修复 ForStmt/IfStmt 在复用后的 yield/return_var MemRef 不一致（必要时插入 `tile.move`）
 - `UsedMemRefCollector` 收集共享后仍被引用的 MemRef 指针
 - `RemoveUnusedAllocStatements` 从 `SeqStmts` 中过滤掉冗余的 `tile.alloc` 语句
 

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -215,6 +215,187 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
   return {};
 }
 
+// ============================================================================
+// Iter-arg mapping: return_index → call_arg_index for InCore functions
+// called inside ForStmt loops.
+// ============================================================================
+
+/**
+ * @brief Per-InCore function mapping: which return indices correspond to which
+ * call argument indices (iter-args that get yielded back).
+ *
+ * For example, if return[0] feeds back to iter_arg whose init is call arg[2],
+ * then return_to_arg[0] = 2.
+ */
+using IterArgMapping = std::unordered_map<size_t, size_t>;  // return_index → call_arg_index
+
+/**
+ * @brief Scan orchestration functions to build iter-arg mappings for InCore calls.
+ *
+ * For each ForStmt containing an InCore call, determines which call arguments are
+ * iter-args and which return values feed back to those iter-args via yield.
+ *
+ * Pattern recognized:
+ *   for idx, (a, b, c) in pl.range(N, init_values=(a0, b0, c0)):
+ *       result = incore_func(..., a, b, c, ...)
+ *       new_a = result[0]; new_b = result[1]; new_c = result[2]
+ *       yield_(new_a, new_b, new_c)
+ *
+ * Here result[0] → a (arg position of a), result[1] → b, result[2] → c.
+ */
+std::unordered_map<std::string, IterArgMapping> AnalyzeIterArgMappings(
+    const std::vector<FunctionPtr>& functions) {
+  std::unordered_map<std::string, IterArgMapping> result;
+
+  // Pre-build set of InCore function names for O(1) lookups
+  std::unordered_set<std::string> incore_func_names;
+  for (const auto& func : functions) {
+    if (func->func_type_ == FunctionType::InCore) {
+      incore_func_names.insert(func->name_);
+    }
+  }
+
+  for (const auto& func : functions) {
+    if (func->func_type_ == FunctionType::InCore) continue;
+
+    // Walk all ForStmts recursively using a stack of statement lists
+    std::vector<std::vector<StmtPtr>> worklist;
+    worklist.push_back(FlattenToStmts(func->body_));
+
+    while (!worklist.empty()) {
+      auto stmts = std::move(worklist.back());
+      worklist.pop_back();
+
+      for (const auto& stmt : stmts) {
+        // Recurse into nested control flow
+        if (auto seq = As<SeqStmts>(stmt)) {
+          worklist.push_back(seq->stmts_);
+          continue;
+        }
+        if (auto scope = As<ScopeStmt>(stmt)) {
+          worklist.push_back(FlattenToStmts(scope->body_));
+          continue;
+        }
+        if (auto if_stmt = As<IfStmt>(stmt)) {
+          worklist.push_back(FlattenToStmts(if_stmt->then_body_));
+          if (if_stmt->else_body_.has_value()) {
+            worklist.push_back(FlattenToStmts(*if_stmt->else_body_));
+          }
+          continue;
+        }
+
+        auto for_stmt = As<ForStmt>(stmt);
+        if (!for_stmt) {
+          if (auto while_stmt = As<WhileStmt>(stmt)) {
+            worklist.push_back(FlattenToStmts(while_stmt->body_));
+          }
+          continue;
+        }
+
+        // Flatten the ForStmt body once, reuse for both worklist and analysis
+        auto body_stmts = FlattenToStmts(for_stmt->body_);
+
+        // Always recurse into this ForStmt's body for nested loops
+        worklist.push_back(body_stmts);
+
+        if (for_stmt->iter_args_.empty()) continue;
+
+        // Collect ALL InCore call assignments in this ForStmt body.
+        // A loop body may contain multiple InCore calls (e.g. incore_2, _3, _4, _5
+        // in flash_attention's sb loop), and only the one whose returns feed back
+        // through yield to iter-args should get the mapping.
+        std::vector<AssignStmtPtr> incore_call_assigns;
+        for (const auto& body_stmt : body_stmts) {
+          auto assign = As<AssignStmt>(body_stmt);
+          if (!assign) continue;
+          auto call = As<Call>(assign->value_);
+          if (!call) continue;
+          auto gvar = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+          if (!gvar) continue;
+          if (incore_func_names.count(gvar->name_) > 0) {
+            incore_call_assigns.push_back(assign);
+          }
+        }
+        if (incore_call_assigns.empty()) continue;
+
+        // Build map: iter_arg pointer → iter_arg index
+        std::unordered_map<const Var*, size_t> iter_arg_index;
+        for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+          iter_arg_index[for_stmt->iter_args_[i].get()] = i;
+        }
+
+        // Find the yield in the loop body
+        auto yield = transform_utils::FindYieldStmt(for_stmt->body_);
+        if (!yield) continue;
+
+        // Build map: call result tuple var → set of (tuple_index, dest_var)
+        std::unordered_map<const Var*, std::unordered_map<size_t, const Var*>> tuple_extracts;
+        for (const auto& body_stmt : body_stmts) {
+          auto assign = As<AssignStmt>(body_stmt);
+          if (!assign) continue;
+          auto tgi = As<TupleGetItemExpr>(assign->value_);
+          if (!tgi) continue;
+          if (auto src_var = As<Var>(tgi->tuple_)) {
+            tuple_extracts[src_var.get()][static_cast<size_t>(tgi->index_)] = assign->var_.get();
+          }
+        }
+
+        // Try each InCore call to find one whose returns feed back as iter-args
+        for (const auto& call_assign : incore_call_assigns) {
+          auto call = As<Call>(call_assign->value_);
+          auto gvar = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+
+          // Find which call arg positions correspond to iter_args
+          std::unordered_map<size_t, size_t> iter_idx_to_arg;  // iter_arg_index → call_arg_index
+          for (size_t arg_i = 0; arg_i < call->args_.size(); ++arg_i) {
+            const Var* raw_ptr = nullptr;
+            if (auto var = As<Var>(call->args_[arg_i])) {
+              raw_ptr = var.get();
+            } else if (auto ia = As<IterArg>(call->args_[arg_i])) {
+              raw_ptr = ia.get();
+            }
+            if (raw_ptr) {
+              auto it = iter_arg_index.find(raw_ptr);
+              if (it != iter_arg_index.end()) {
+                iter_idx_to_arg[it->second] = arg_i;
+              }
+            }
+          }
+
+          // Check yield values: yield[j] should be result[i] from this call
+          IterArgMapping mapping;
+          auto call_result_var = call_assign->var_.get();
+
+          for (size_t yield_i = 0; yield_i < yield->value_.size(); ++yield_i) {
+            auto yielded = As<Var>(yield->value_[yield_i]);
+            if (!yielded) continue;
+
+            auto extract_it = tuple_extracts.find(call_result_var);
+            if (extract_it == tuple_extracts.end()) continue;
+
+            for (const auto& [ret_idx, dest_var] : extract_it->second) {
+              if (dest_var == yielded.get()) {
+                auto arg_it = iter_idx_to_arg.find(yield_i);
+                if (arg_it != iter_idx_to_arg.end()) {
+                  mapping[ret_idx] = arg_it->second;
+                }
+                break;
+              }
+            }
+          }
+
+          if (!mapping.empty()) {
+            result[gvar->name_] = std::move(mapping);
+            break;  // Found the right InCore call for this ForStmt
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 /**
  * @brief Info about a tensor.slice result that feeds into a tensor.matmul/tensor.matmul_acc operand.
  *
@@ -1291,7 +1472,8 @@ struct IncoreTransformResult {
   size_t num_added_outputs;
 };
 
-IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
+IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
+                                              const IterArgMapping& iter_arg_mapping) {
   auto& conv_registry = OpConversionRegistry::GetInstance();
   auto& op_registry = OpRegistry::GetInstance();
   const auto& span = func->span_;
@@ -1364,6 +1546,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   if (return_stmt) {
     std::vector<ExprPtr> new_return_exprs;
 
+    // Phase 3: Process each return value
     for (size_t i = 0; i < return_stmt->value_.size(); ++i) {
       auto ret_expr = SubstituteExpr(return_stmt->value_[i], tensor_to_tile);
 
@@ -1375,6 +1558,25 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
         INTERNAL_CHECK(orig_tensor_type)
             << "Internal error: return type " << i << " should be TensorType but got "
             << func->return_types_[i]->TypeName();
+
+        // Check if this return value has an iter-arg mapping: store to the
+        // existing In param (auto-promoted to InOut) instead of adding a new Out param.
+        auto map_it = iter_arg_mapping.find(i);
+        if (map_it != iter_arg_mapping.end()) {
+          size_t arg_idx = map_it->second;
+          INTERNAL_CHECK(arg_idx < new_params.size())
+              << "Internal error: iter-arg mapping arg_idx " << arg_idx << " exceeds param count "
+              << new_params.size();
+
+          auto in_param = new_params[arg_idx];
+          auto offsets = MakeZeroOffsets(orig_tensor_type->shape_.size(), span);
+          auto store_call = op_registry.Create("tile.store", {ret_expr, offsets, in_param}, span);
+          auto store_var = std::make_shared<Var>(MakeStoreResultName(i), store_call->GetType(), span);
+          new_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
+          new_return_types.push_back(store_call->GetType());
+          new_return_exprs.push_back(store_var);
+          continue;
+        }
 
         // Add output tensor parameter
         std::string out_name = MakeOutParamName(num_added_outputs);
@@ -1770,14 +1972,25 @@ namespace pass {
 
 Pass ConvertTensorToTileOps() {
   auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
+    // Phase 0: Analyze iter-arg mappings from orchestration call sites
+    std::vector<FunctionPtr> all_funcs;
+    all_funcs.reserve(program->functions_.size());
+    for (const auto& [gvar, func] : program->functions_) {
+      all_funcs.push_back(func);
+    }
+    auto iter_arg_mappings = AnalyzeIterArgMappings(all_funcs);
+
     // Phase 1: Transform InCore functions
     std::unordered_map<std::string, size_t> incore_added_outputs;
     std::unordered_map<std::string, FunctionPtr> transformed_incore_funcs;
     std::vector<FunctionPtr> functions_phase1;
+    const IterArgMapping empty_mapping;
 
     for (const auto& [gvar, func] : program->functions_) {
       if (func->func_type_ == FunctionType::InCore) {
-        auto result = TransformIncoreFunction(func);
+        auto mapping_it = iter_arg_mappings.find(func->name_);
+        const auto& mapping = (mapping_it != iter_arg_mappings.end()) ? mapping_it->second : empty_mapping;
+        auto result = TransformIncoreFunction(func, mapping);
         incore_added_outputs[func->name_] = result.num_added_outputs;
         transformed_incore_funcs[func->name_] = result.func;
         functions_phase1.push_back(result.func);

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -201,6 +201,24 @@ class InitMemRefMutator : public IRMutator {
     return std::static_pointer_cast<const Expr>(GetNewVar(var_ptr));
   }
 
+  /**
+   * @brief Share a MemRef from a source expression to the LHS variable of an assignment.
+   *
+   * Returns a new AssignStmt with the LHS type updated to share the source's MemRef,
+   * or nullptr if the source has no MemRef.
+   */
+  StmtPtr ShareMemRefFrom(const ExprPtr& source, const AssignStmtPtr& op, const ExprPtr& new_value) {
+    auto shared_memref = GetTypeMemRef(source->GetType());
+    if (!shared_memref.has_value()) return nullptr;
+
+    auto source_ms = ExtractMemorySpaceFromType(source->GetType());
+    TypePtr new_type = CloneTypeWithMemRefAndRemapExprs(
+        op->var_->GetType(), shared_memref, [this](const ExprPtr& e) { return VisitExpr(e); }, source_ms);
+    VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
+    var_map_[op->var_] = new_var;
+    return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
+  }
+
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     // First visit the value (RHS)
     auto new_value = VisitExpr(op->value_);
@@ -216,25 +234,12 @@ class InitMemRefMutator : public IRMutator {
         // Get the input tile (first argument) after mutation
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call) {
-          auto input_tile_arg = new_call->args_[0];
-
-          // Extract MemRef from input tile
-          auto shared_memref = GetTypeMemRef(input_tile_arg->GetType());
-
-          // Create new variable with shared MemRef
-          if (shared_memref.has_value()) {
+          auto result = ShareMemRefFrom(new_call->args_[0], op, new_value);
+          if (result) {
             LOG_DEBUG << "Sharing MemRef from input tile to " << op->var_->name_hint_;
-            auto source_memory_space = ExtractMemorySpaceFromType(input_tile_arg->GetType());
-            TypePtr new_type = CloneTypeWithMemRefAndRemapExprs(
-                op->var_->GetType(), shared_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
-                source_memory_space);
-            VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
-            var_map_[op->var_] = new_var;
-
-            return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
-          } else {
-            LOG_DEBUG << "Input tile has no MemRef yet";
+            return result;
           }
+          LOG_DEBUG << "Input tile has no MemRef yet";
         }
       }
 
@@ -243,20 +248,23 @@ class InitMemRefMutator : public IRMutator {
       if (reuse_arg_idx.has_value()) {
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && *reuse_arg_idx < new_call->args_.size()) {
-          auto input_arg = new_call->args_[*reuse_arg_idx];
-          auto shared_memref = GetTypeMemRef(input_arg->GetType());
-          if (shared_memref.has_value()) {
+          auto result = ShareMemRefFrom(new_call->args_[*reuse_arg_idx], op, new_value);
+          if (result) {
             LOG_DEBUG << "Reusing MemRef from input arg " << *reuse_arg_idx << " for "
                       << op->var_->name_hint_;
-            auto source_memory_space = ExtractMemorySpaceFromType(input_arg->GetType());
-            TypePtr new_type = CloneTypeWithMemRefAndRemapExprs(
-                op->var_->GetType(), shared_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
-                source_memory_space);
-            VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
-            var_map_[op->var_] = new_var;
-            return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
+            return result;
           }
         }
+      }
+    }
+
+    // Tile alias: a = b where b is a tile Var — share b's MemRef.
+    // Without this, the alias gets a fresh MemRef that is never written to,
+    // breaking IfStmt return_vars that inherit the alias's empty MemRef.
+    if (auto value_var = As<Var>(new_value)) {
+      if (As<TileType>(op->var_->GetType())) {
+        auto result = ShareMemRefFrom(value_var, op, new_value);
+        if (result) return result;
       }
     }
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -719,21 +719,9 @@ class YieldFixupMutator : public IRMutator {
 
       // MemRef mismatch — create tile.move to copy yield value into initValue's buffer
       auto target_memory = init_tile->GetMemorySpace();
-      INTERNAL_CHECK(target_memory.has_value())
-          << "Internal error: initValue TileType must have memory_space";
+      auto [moved_var, move_stmt] = CreateTileMove(yield_var, init_memref, target_memory);
 
-      auto& op_reg = OpRegistry::GetInstance();
-      std::vector<std::pair<std::string, std::any>> kwargs = {
-          {"target_memory", std::any(target_memory.value())}};
-      auto move_call = op_reg.Create("tile.move", {yield_var}, kwargs, yield_var->span_);
-
-      // Create moved var with initValue's MemRef
-      auto moved_type = CloneTypeWithMemRefAndRemapExprs(
-          yield_var->GetType(), init_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
-          target_memory);
-      auto moved_var = std::make_shared<Var>(yield_var->name_hint_ + "_mv", moved_type, yield_var->span_);
-
-      move_stmts.emplace_back(std::make_shared<AssignStmt>(moved_var, move_call, yield_var->span_));
+      move_stmts.emplace_back(std::move(move_stmt));
       moves_to_insert.emplace_back(i, moved_var);
     }
 
@@ -772,48 +760,93 @@ class YieldFixupMutator : public IRMutator {
     // Find yield statements in each branch
     auto then_yield = FindYieldStmt(if_stmt->then_body_);
     auto else_yield = if_stmt->else_body_.has_value() ? FindYieldStmt(if_stmt->else_body_.value()) : nullptr;
+    if (!then_yield && !else_yield) return result;
 
-    // Patch return_vars to match yield value's MemRef
-    bool changed = false;
+    // For each return_var position, check if the two branches yield tiles
+    // with different MemRefs.  When they differ, insert tile.move in the
+    // branch whose MemRef ≠ the canonical target (then-branch is canonical).
+    bool body_changed = false;
+    std::vector<std::pair<size_t, VarPtr>> else_moves;
+    std::vector<StmtPtr> else_move_stmts;
     std::vector<VarPtr> new_return_vars = if_stmt->return_vars_;
 
     for (size_t i = 0; i < new_return_vars.size(); ++i) {
-      // Get yield value's MemRef — try then-branch first, fall back to else-branch
-      VarPtr yield_var = nullptr;
-      if (then_yield && i < then_yield->value_.size()) {
-        yield_var = As<Var>(then_yield->value_[i]);
-      }
-      if (!yield_var && else_yield && i < else_yield->value_.size()) {
-        yield_var = As<Var>(else_yield->value_[i]);
-      }
-      if (!yield_var) continue;
+      VarPtr then_var =
+          (then_yield && i < then_yield->value_.size()) ? As<Var>(then_yield->value_[i]) : nullptr;
+      VarPtr else_var =
+          (else_yield && i < else_yield->value_.size()) ? As<Var>(else_yield->value_[i]) : nullptr;
 
-      auto yield_tile = GetTileTypeWithMemRef(yield_var->GetType());
-      if (!yield_tile) continue;
-      auto yield_memref = GetDefinedMemRef(yield_tile);
+      auto then_tile = then_var ? GetTileTypeWithMemRef(then_var->GetType()) : nullptr;
+      auto else_tile = else_var ? GetTileTypeWithMemRef(else_var->GetType()) : nullptr;
+      if (!then_tile && !else_tile) continue;
 
+      // Use then-branch MemRef as canonical target (fall back to else if then absent)
+      auto target_tile = then_tile ? then_tile : else_tile;
+      auto target_memref = GetDefinedMemRef(target_tile);
+      auto target_memory = target_tile->GetMemorySpace();
+
+      // Check else branch: if MemRef differs from target, insert tile.move
+      if (then_tile && else_tile) {
+        auto else_memref = GetDefinedMemRef(else_tile);
+        if (else_memref.get() != target_memref.get()) {
+          auto [moved_var, move_stmt] = CreateTileMove(else_var, target_memref, target_memory);
+          else_move_stmts.emplace_back(std::move(move_stmt));
+          else_moves.emplace_back(i, moved_var);
+          body_changed = true;
+        }
+      }
+
+      // Patch return_var to share target MemRef
       auto rv_tile = As<TileType>(new_return_vars[i]->GetType());
-      if (!rv_tile || !rv_tile->memref_.has_value()) continue;
-      auto rv_memref = GetDefinedMemRef(rv_tile);
-
-      if (rv_memref.get() != yield_memref.get()) {
-        auto new_rv_type = CloneTypeWithMemRefAndRemapExprs(
-            rv_tile, yield_memref, [this](const ExprPtr& e) { return VisitExpr(e); },
-            yield_tile->GetMemorySpace());
-        new_return_vars[i] =
-            std::make_shared<Var>(new_return_vars[i]->name_hint_, new_rv_type, new_return_vars[i]->span_);
-        var_remap_[if_stmt->return_vars_[i].get()] = new_return_vars[i];
-        changed = true;
+      if (rv_tile && rv_tile->memref_.has_value()) {
+        auto rv_memref = GetDefinedMemRef(rv_tile);
+        if (rv_memref.get() != target_memref.get()) {
+          auto new_rv_type = CloneTypeWithMemRefAndRemapExprs(
+              rv_tile, target_memref, [this](const ExprPtr& e) { return VisitExpr(e); }, target_memory);
+          new_return_vars[i] =
+              std::make_shared<Var>(new_return_vars[i]->name_hint_, new_rv_type, new_return_vars[i]->span_);
+          var_remap_[if_stmt->return_vars_[i].get()] = new_return_vars[i];
+          body_changed = true;
+        }
       }
     }
 
-    if (!changed) return result;
+    if (!body_changed) return result;
 
-    return std::make_shared<IfStmt>(if_stmt->condition_, if_stmt->then_body_, if_stmt->else_body_,
+    // Rebuild else body with tile.move stmts inserted before yield
+    auto new_else_body = if_stmt->else_body_;
+    if (!else_moves.empty() && else_yield && if_stmt->else_body_.has_value()) {
+      std::vector<ExprPtr> new_else_yield_values = else_yield->value_;
+      for (const auto& [idx, moved_var] : else_moves) {
+        new_else_yield_values[idx] = moved_var;
+      }
+      auto new_yield = std::make_shared<YieldStmt>(new_else_yield_values, else_yield->span_);
+      new_else_body = InsertMovesAndReplaceYield(if_stmt->else_body_.value(), new_yield, else_move_stmts);
+    }
+
+    return std::make_shared<IfStmt>(if_stmt->condition_, if_stmt->then_body_, new_else_body,
                                     std::move(new_return_vars), if_stmt->span_);
   }
 
  private:
+  // Create a tile.move operation that copies source into target_memref's buffer.
+  // Returns (moved_var, move_assign_stmt).
+  std::pair<VarPtr, StmtPtr> CreateTileMove(const VarPtr& source, const MemRefPtr& target_memref,
+                                            std::optional<MemorySpace> target_memory) {
+    INTERNAL_CHECK(target_memory.has_value())
+        << "Internal error: target TileType must have memory_space for tile.move";
+    auto& op_reg = OpRegistry::GetInstance();
+    std::vector<std::pair<std::string, std::any>> kwargs = {
+        {"target_memory", std::any(target_memory.value())}};
+    auto move_call = op_reg.Create("tile.move", {source}, kwargs, source->span_);
+    auto moved_type = CloneTypeWithMemRefAndRemapExprs(
+        source->GetType(), target_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
+        target_memory);
+    auto moved_var = std::make_shared<Var>(source->name_hint_ + "_mv", moved_type, source->span_);
+    auto move_stmt = std::make_shared<AssignStmt>(moved_var, move_call, source->span_);
+    return {moved_var, move_stmt};
+  }
+
   // Patch iter_args and return_vars to share initValue's MemRef.
   // Returns the original ForStmt if no patching is needed.
   StmtPtr PatchIterArgsAndReturnVars(const ForStmtPtr& for_stmt, const YieldStmtPtr& yield_stmt) {

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1604,6 +1604,99 @@ class TestNestedControlFlow:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_iter_arg_return_stores_to_inout_param(self):
+        """When InCore returns feed back as iter-args via ForStmt, tile.store targets
+        the existing In param (promoted to InOut) instead of adding a new Out param.
+
+        Pattern:
+          orchestration: for i, (a, b) in range(N, init=(a0, b0)):
+                           result = incore(a, b, n)
+                           new_a, new_b = result[0], result[1]
+                           yield_(new_a, new_b)
+          incore:        if n==0: yield_(a, b)      # alias pass-through
+                         else:    yield_(add(a,b), mul(a,b))
+                         return phi_a, phi_b
+
+        Expected: store to In params (InOut), no Out params, no tensor.create at call site.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INT64],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                if n == 0:
+                    ra: pl.Tensor[[64], pl.FP32] = a
+                    rb: pl.Tensor[[64], pl.FP32] = b
+                    phi_a, phi_b = pl.yield_(ra, rb)
+                else:
+                    ra: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                    rb: pl.Tensor[[64], pl.FP32] = pl.mul(a, b)
+                    phi_a, phi_b = pl.yield_(ra, rb)
+                return phi_a, phi_b
+
+            @pl.function
+            def main(
+                self,
+                a0: pl.Tensor[[64], pl.FP32],
+                b0: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INT64],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                for i, (a, b) in pl.range(3, init_values=(a0, b0)):
+                    result: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]] = self.main_incore_0(
+                        a, b, n
+                    )
+                    new_a: pl.Tensor[[64], pl.FP32] = result[0]
+                    new_b: pl.Tensor[[64], pl.FP32] = result[1]
+                    out_a, out_b = pl.yield_(new_a, new_b)
+                return out_a, out_b
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.InOut[pl.Tensor[[64], pl.FP32]],
+                b: pl.InOut[pl.Tensor[[64], pl.FP32]],
+                n: pl.Scalar[pl.INT64],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                a_tile: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
+                b_tile: pl.Tile[[64], pl.FP32] = pl.load(b, [0], [64])
+                if n == 0:
+                    ra_tile: pl.Tile[[64], pl.FP32] = a_tile
+                    rb_tile: pl.Tile[[64], pl.FP32] = b_tile
+                    phi_a, phi_b = pl.yield_(ra_tile, rb_tile)
+                else:
+                    ra_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(a_tile, b_tile)
+                    rb_tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(a_tile, b_tile)
+                    phi_a, phi_b = pl.yield_(ra_tile, rb_tile)
+                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_a, [0], a)
+                ret1__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_b, [0], b)
+                return ret0__store, ret1__store
+
+            @pl.function
+            def main(
+                self,
+                a0: pl.Tensor[[64], pl.FP32],
+                b0: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INT64],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                for i, (a, b) in pl.range(3, init_values=(a0, b0)):
+                    result: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]] = self.main_incore_0(
+                        a, b, n
+                    )
+                    new_a: pl.Tensor[[64], pl.FP32] = result[0]
+                    new_b: pl.Tensor[[64], pl.FP32] = result[1]
+                    out_a, out_b = pl.yield_(new_a, new_b)
+                return out_a, out_b
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestGmLocalTensorConversion:
     """Test gm_tensor vs local_tensor differentiated conversion."""

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -425,6 +425,40 @@ class TestYieldMemRef:
         assert isinstance(then_var.type, ir.TileType)
         assert cast(ir.TileType, rv.type).shares_memref_with(cast(ir.TileType, then_var.type))
 
+    def test_tile_alias_shares_source_memref(self):
+        """Tile alias (a = b) shares MemRef with source tile, not a fresh one."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32],
+                cond: pl.Scalar[pl.INDEX],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_tensor, [0, 0], [64, 64]
+                )
+                if cond < 2:
+                    alias_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = tile_a
+                    if_result = pl.yield_(alias_a)
+                else:
+                    tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(tile_a, tile_a)
+                    if_result = pl.yield_(tile_b)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(if_result, [0, 0], output)
+                return result
+
+        After = passes.init_mem_ref()(Before)
+        func = _first_function(After)
+
+        tile_types = _get_tile_types(func)
+        assert "tile_a" in tile_types
+        assert "alias_a" in tile_types
+
+        # alias_a must share MemRef with tile_a (not get a fresh one)
+        assert tile_types["alias_a"].shares_memref_with(tile_types["tile_a"])
+
 
 class TestEdgeCases:
     """Edge cases requiring raw IR construction."""

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -808,6 +808,64 @@ class TestYieldFixup:
                 "if_result should share MemRef with tile_b after YieldFixupMutator patches it"
             )
 
+    def test_if_stmt_tile_move_when_branch_memrefs_differ(self):
+        """When IfStmt branches yield tiles with different MemRefs,
+        tile.move is inserted in the else-branch to unify to the then-branch's MemRef."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                input_b: pl.Tensor[[64, 64], pl.FP32],
+                cond_param: pl.Scalar[pl.INDEX],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [64, 64])
+                tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_b, [0, 0], [64, 64])
+                if cond_param < 2:
+                    # then branch: alias (shares tile_a's memref)
+                    alias_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = tile_a
+                    if_result = pl.yield_(alias_a)
+                else:
+                    # else branch: chain of ops where tile_a stays alive,
+                    # so the yield value can't share tile_a's memref.
+                    t1: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(tile_a, tile_b)
+                    t2: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(t1, tile_a)
+                    t3: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(t2, tile_a)
+                    if_result = pl.yield_(t3)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(if_result, [0, 0], output)
+                return result
+
+        func = _run_memory_reuse(Before)
+
+        # Find the IfStmt and check return_var + else-branch tile.move
+        def _find_if_stmt(stmt):
+            if isinstance(stmt, ir.IfStmt):
+                return stmt
+            if isinstance(stmt, ir.SeqStmts):
+                for child in stmt.stmts:
+                    r = _find_if_stmt(child)
+                    if r:
+                        return r
+            return None
+
+        if_stmt = _find_if_stmt(func.body)
+        assert if_stmt is not None
+        assert if_stmt.else_body is not None
+        assert len(if_stmt.return_vars) == 1
+
+        rv = if_stmt.return_vars[0]
+        assert isinstance(rv.type, ir.TileType)
+
+        # return_var should share MemRef with then-branch yield (alias_a = tile_a)
+        alias_a_type = _get_var_type(func, "alias_a")
+        assert alias_a_type is not None
+        assert rv.type.shares_memref_with(alias_a_type), (
+            "return_var should share MemRef with then-branch yield"
+        )
+
 
 class TestControlFlow:
     """Tests for correct lifetime analysis across control flow boundaries."""


### PR DESCRIPTION
## Summary
- **ConvertTensorToTileOps**: for InCore returns that feed back as ForStmt iter-args, `tile.store` now targets the existing In param (auto-promoted to InOut) instead of adding new Out params. The store is placed outside the IfStmt, referencing the phi variable directly — no store sinking into branches needed.
- **InitMemRef**: tile alias assignments (`a = b`) now share the source's MemRef instead of allocating a fresh one, preventing empty-memref aliases in IfStmt branches.
- **MemoryReuse YieldFixupMutator**: when IfStmt branches yield tiles with different MemRefs, `tile.move` is inserted in the else branch to unify to the then-branch's canonical MemRef (mirroring the existing ForStmt pattern).