### PR TITLE
feat(pass): detect IterArg InOut parameters in OutlineIncoreScopes

### DIFF
--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -465,6 +465,30 @@ class ScopeOutliner : public IRMutator {
       }
     }
 
+    // --- Detect IterArg InOut parameters ---
+    // A tensor input whose base name matches a non-store output's base name
+    // represents a loop-carried variable (SSA pattern: input "acc" → body
+    // IterArg → output "acc__ssa_v0").  Mark the input as InOut so downstream
+    // passes (ConvertTensorToTileOps) store back to the same buffer.
+    // Note: store-target InOut is already handled by UpgradeWrittenTensorParamDirections
+    // in ConvertTensorToTileOps, so we only detect the IterArg case here.
+    std::unordered_map<std::string, const Var*> input_by_base;
+    for (const auto& in_var : input_vars) {
+      std::string base = auto_name::GetBaseName(in_var->name_hint_);
+      if (!base.empty()) {
+        input_by_base[base] = in_var.get();
+      }
+    }
+    std::unordered_set<const Var*> inout_set;
+    for (const auto& out_var : output_vars) {
+      if (store_output_set.count(out_var.get())) continue;  // skip store targets
+      std::string out_base = auto_name::GetBaseName(out_var->name_hint_);
+      auto it = input_by_base.find(out_base);
+      if (it != input_by_base.end()) {
+        inout_set.insert(it->second);
+      }
+    }
+
     std::sort(output_vars.begin(), output_vars.end(),
               [](const VarPtr& a, const VarPtr& b) { return a->name_hint_ < b->name_hint_; });
 
@@ -513,7 +537,8 @@ class ScopeOutliner : public IRMutator {
     for (const auto& input_var : input_vars) {
       auto param_var = std::make_shared<Var>(input_var->name_hint_, input_var->GetType(), op->span_);
       input_params.push_back(param_var);
-      input_param_directions.push_back(ParamDirection::In);
+      input_param_directions.push_back(inout_set.count(input_var.get()) ? ParamDirection::InOut
+                                                                        : ParamDirection::In);
       var_substitution_map[input_var.get()] = param_var;
     }
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1115,11 +1115,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
           << "Internal error: tuple element index " << elem.index << " out of range for " << call->op_->name_
           << " (has " << out_indices.size() << " Out/InOut params)";
       size_t param_idx = out_indices[static_cast<size_t>(elem.index)];
-      // InOut params are already the external tensor (modified in-place); no alias needed.
-      if (callee->param_directions_[param_idx] == ParamDirection::InOut) {
-        continue;
-      }
       std::string elem_name = ReserveVarEmitName(elem.var);
+      // EmitTensorAlias skips self-aliases (alias_name == out_arg), so InOut
+      // params that already match the output name emit nothing, while
+      // auto-outlined InOut returns get the alias they need.
       EmitTensorAlias(elem_name, call, param_idx);
     }
   }

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1361,6 +1361,16 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   std::vector<TypePtr> new_return_types;
   size_t num_added_outputs = 0;
 
+  // Collect InOut tensor params by base name for matching with return values.
+  // IterArg InOut returns are stored back to the existing InOut param instead
+  // of creating a new Out param.
+  std::unordered_map<std::string, VarPtr> inout_param_by_base;
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    if (func->param_directions_[i] == ParamDirection::InOut && As<TensorType>(func->params_[i]->GetType())) {
+      inout_param_by_base[auto_name::GetBaseName(func->params_[i]->name_hint_)] = func->params_[i];
+    }
+  }
+
   if (return_stmt) {
     std::vector<ExprPtr> new_return_exprs;
 
@@ -1376,11 +1386,26 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
             << "Internal error: return type " << i << " should be TensorType but got "
             << func->return_types_[i]->TypeName();
 
-        // Add output tensor parameter
-        std::string out_name = MakeOutParamName(num_added_outputs);
-        auto out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
-        new_params.push_back(out_param);
-        new_param_directions.push_back(ParamDirection::Out);
+        // Determine target param: reuse existing InOut param or create new Out param.
+        VarPtr out_param;
+        bool is_inout_return = false;
+        auto orig_ret_var = As<Var>(return_stmt->value_[i]);
+        if (orig_ret_var) {
+          std::string ret_base = auto_name::GetBaseName(orig_ret_var->name_hint_);
+          auto inout_it = inout_param_by_base.find(ret_base);
+          if (inout_it != inout_param_by_base.end()) {
+            out_param = inout_it->second;
+            is_inout_return = true;
+            inout_param_by_base.erase(inout_it);
+          }
+        }
+        if (!is_inout_return) {
+          // Add new output tensor parameter
+          std::string out_name = MakeOutParamName(num_added_outputs);
+          out_param = std::make_shared<Var>(out_name, orig_tensor_type, span);
+          new_params.push_back(out_param);
+          new_param_directions.push_back(ParamDirection::Out);
+        }
 
         if (auto loop_rewrite = RewriteReturnedAssembleLoopToStore(new_stmts, ret_expr, out_param,
                                                                    orig_tensor_type, op_registry)) {
@@ -1391,7 +1416,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
           }
           new_return_types.push_back(orig_tensor_type);
           new_return_exprs.push_back(loop_rewrite->new_return_var);
-          ++num_added_outputs;
+          if (!is_inout_return) ++num_added_outputs;
           continue;
         }
 
@@ -1399,13 +1424,12 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
         auto offsets = MakeZeroOffsets(tile_type->shape_.size(), span);
         auto store_call = op_registry.Create("tile.store", {ret_expr, offsets, out_param}, span);
 
-        auto store_var =
-            std::make_shared<Var>(MakeStoreResultName(num_added_outputs), store_call->GetType(), span);
+        auto store_var = std::make_shared<Var>(MakeStoreResultName(i), store_call->GetType(), span);
         new_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
 
         new_return_types.push_back(store_call->GetType());
         new_return_exprs.push_back(store_var);
-        ++num_added_outputs;
+        if (!is_inout_return) ++num_added_outputs;
       } else {
         // Non-tile return values pass through
         new_return_types.push_back(ret_expr->GetType());

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2349,5 +2349,42 @@ class TestTensorFullConversion:
         assert "tensor.full" not in ir_str
 
 
+class TestInOutParamHandling:
+    """Tests for InOut parameter handling in ConvertTensorToTileOps."""
+
+    def test_inout_param_reuses_existing_param_for_tile_store(self):
+        """InOut param from outlining: tile.store targets existing InOut param, no new Out param.
+
+        End-to-end: outline detects IterArg InOut, then convert reuses the
+        InOut param for tile.store instead of adding a new Out param.
+        """
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.incore():
+                    for i in pl.range(10):
+                        x = pl.add(x, x)
+                return x
+
+        # Run outline (which marks x as InOut), then convert
+        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
+        with ctx:
+            prog = passes.convert_to_ssa()(Input)
+            prog = passes.outline_incore_scopes()(prog)
+            prog = passes.ctrl_flow_transform()(prog)
+            After = passes.convert_tensor_to_tile_ops()(prog)
+
+        incore_func = After.get_function("main_incore_0")
+        assert incore_func is not None
+
+        # The InOut param should remain — no additional Out param added
+        inout_count = sum(1 for d in incore_func.param_directions if d == ir.ParamDirection.InOut)
+        out_count = sum(1 for d in incore_func.param_directions if d == ir.ParamDirection.Out)
+        assert inout_count == 1, f"Expected 1 InOut param, got {inout_count}"
+        assert out_count == 0, f"Expected 0 Out params (reused InOut), got {out_count}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_ctrl_flow_transform.py
+++ b/tests/ut/ir/transforms/test_ctrl_flow_transform.py
@@ -2029,7 +2029,7 @@ def test_pipeline_integration():
     @pl.program
     class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
-        def main_incore_0(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        def main_incore_0(self, x_0: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -552,6 +552,132 @@ class TestOutlineIncoreScopes:
             "outer loop's init value 'init' must NOT be a parameter of the incore function"
         )
 
+    def test_outline_scope_iterarg_inout_detection(self):
+        """IterArg InOut: loop-carried tensor input gets InOut direction.
+
+        When a tensor is both an input (initial value) and an output (final loop value)
+        of an incore scope — linked via ForStmt IterArgs — the parameter should be
+        marked as InOut rather than In.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.incore():
+                    for _i__idx_v0, (x__iter_v1,) in pl.range(10, init_values=(x__ssa_v0,)):
+                        x__ssa_v3: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x__iter_v1, x__iter_v1)
+                        x__rv_v2: pl.Tensor[[64], pl.FP32] = pl.yield_(x__ssa_v3)
+                return x__rv_v2
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main_incore_0(
+                self, x__ssa_v0: pl.InOut[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for _i__idx_v0, (x__iter_v1,) in pl.range(10, init_values=(x__ssa_v0,)):
+                    x__ssa_v3: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x__iter_v1, x__iter_v1)
+                    x__rv_v2: pl.Tensor[[64], pl.FP32] = pl.yield_(x__ssa_v3)
+                return x__rv_v2
+
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                x__rv_v2: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x__ssa_v0)
+                return x__rv_v2
+
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_scope_iterarg_inout_with_separate_input(self):
+        """IterArg InOut with a separate read-only input: only the loop-carried tensor gets InOut.
+
+        When an incore scope has both a loop-carried accumulator (InOut) and a
+        read-only tensor (In), only the accumulator should be marked InOut.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(
+                self, x__ssa_v0: pl.Tensor[[64], pl.FP32], y__ssa_v0: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.incore():
+                    for _i__idx_v0, (x__iter_v1,) in pl.range(5, init_values=(x__ssa_v0,)):
+                        x__ssa_v3: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x__iter_v1, y__ssa_v0)
+                        x__rv_v2: pl.Tensor[[64], pl.FP32] = pl.yield_(x__ssa_v3)
+                return x__rv_v2
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main_incore_0(
+                self,
+                x__ssa_v0: pl.InOut[pl.Tensor[[64], pl.FP32]],
+                y__ssa_v0: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for _i__idx_v0, (x__iter_v1,) in pl.range(5, init_values=(x__ssa_v0,)):
+                    x__ssa_v3: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x__iter_v1, y__ssa_v0)
+                    x__rv_v2: pl.Tensor[[64], pl.FP32] = pl.yield_(x__ssa_v3)
+                return x__rv_v2
+
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def main(
+                self, x__ssa_v0: pl.Tensor[[64], pl.FP32], y__ssa_v0: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x__rv_v2: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x__ssa_v0, y__ssa_v0)
+                return x__rv_v2
+
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_scope_store_target_not_affected_by_iterarg_inout(self):
+        """Store targets remain separate In+Out even when IterArg InOut is detected.
+
+        Store-target InOut is handled by UpgradeWrittenTensorParamDirections in
+        ConvertTensorToTileOps, not by OutlineIncoreScopes.  Verify that the
+        store target handling is preserved when IterArg InOut detection is active.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x__ssa_v0: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf__ssa_v0: pl.Tensor[[16, 128], pl.FP32] = pl.tensor.create(
+                    [16, 128], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                with pl.incore():
+                    tile__ssa_v0: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                        [16, 128], dtype=pl.FP32, value=0.0
+                    )
+                    pl.tile.store(tile__ssa_v0, [0, 0], buf__ssa_v0)
+                result__ssa_v0: pl.Tensor[[16, 128], pl.FP32] = pl.tensor.add(buf__ssa_v0, x__ssa_v0)
+                return result__ssa_v0
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main_incore_0(
+                self, buf__ssa_v0: pl.Tensor[[16, 128], pl.FP32]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                tile__ssa_v0: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                    [16, 128], dtype=pl.FP32, value=0.0
+                )
+                buf__store: pl.Tensor[[16, 128], pl.FP32] = pl.tile.store(tile__ssa_v0, [0, 0], buf__ssa_v0)
+                return buf__store
+
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def main(self, x__ssa_v0: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf__ssa_v0: pl.Tensor[[16, 128], pl.FP32] = pl.tensor.create(
+                    [16, 128], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                buf__ssa_v1: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(buf__ssa_v0)
+                result__ssa_v0: pl.Tensor[[16, 128], pl.FP32] = pl.tensor.add(buf__ssa_v1, x__ssa_v0)
+                return result__ssa_v0
+
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestSplitIncoreOrchVerifier:
     """Regression tests for the SplitIncoreOrch property verifier."""


### PR DESCRIPTION
## Summary
- Detect loop-carried tensor variables as InOut parameters at outline time, so `ConvertTensorToTileOps` stores back to the same buffer instead of creating a redundant Out parameter with `tensor.create` at call sites
- `OutlineIncoreScopes`: match input/output base names via `auto_name::GetBaseName` to detect the IterArg InOut pattern (e.g., input `acc` ↔ output `acc__ssa_v0`), mark matched inputs as `ParamDirection::InOut`
- `ConvertTensorToTileOps`: reuse existing InOut param for `tile.store` instead of adding a new Out param; skip `num_added_outputs` increment so call sites don't get spurious `tensor.create`
- Orchestration codegen: remove blanket InOut alias skip in `GenerateTupleReturnAliases`, rely on `EmitTensorAlias` self-alias check for correct behavior in both hand-written and auto-outlined InOut cases

## Testing
- [x] All 3228 unit tests pass
- [x] 3 new outline tests (IterArg InOut detection, mixed In+InOut, store target non-interference)
- [x] 1 new end-to-end convert test (InOut param reuse across outline → convert pipeline)
- [x] 1 updated test expectation (`test_pipeline_integration` now expects InOut)
- [x] clang-tidy clean
- [x] clang-format, cpplint, ruff, pyright all pass

## Related Issues
Fixes #741