### PR TITLE
feat(st,codegen): add pre-compilation caching pipeline and migrate to ChipStorageTaskArgs API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,12 @@ jobs:
 
       - name: Clone and install simpler repository (pinned)
         run: |
-          git clone --branch main https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
           cd $GITHUB_WORKSPACE/simpler
-          git checkout fe63325094dabed918eafa63edb1a2fc40c3be6f
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=012a8c22fd0121c59ec2462da2146c260266f63b
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest
@@ -153,9 +152,8 @@ jobs:
 
       - name: Clone and install simpler repository (pinned)
         run: |
-          git clone --branch main https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
           cd $GITHUB_WORKSPACE/simpler
-          git checkout fe63325094dabed918eafa63edb1a2fc40c3be6f
           pip install -v .
 
       - name: Run fuzz tests (sim mode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=256 --pto-isa-commit=012a8c22fd0121c59ec2462da2146c260266f63b
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=256
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,18 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
-      - name: Clone and install simpler repository (stable)
+      - name: Add Ascend tools to PATH
+        run: echo "/usr/local/Ascend/cann-8.5.0/bin" >> $GITHUB_PATH
+
+      - name: Clone and install simpler repository (pinned)
         run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          git clone --branch main https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
           cd $GITHUB_WORKSPACE/simpler
+          git checkout fe63325094dabed918eafa63edb1a2fc40c3be6f
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=256
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=256 --pto-isa-commit=012a8c22fd0121c59ec2462da2146c260266f63b
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest
@@ -147,10 +151,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -v .[dev]
 
-      - name: Clone and install simpler repository (stable)
+      - name: Clone and install simpler repository (pinned)
         run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
+          git clone --branch main https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
           cd $GITHUB_WORKSPACE/simpler
+          git checkout fe63325094dabed918eafa63edb1a2fc40c3be6f
           pip install -v .
 
       - name: Run fuzz tests (sim mode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=012a8c22fd0121c59ec2462da2146c260266f63b
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -100,10 +100,11 @@ uint32_t dn_shapes[2] = {orch_args.tensor(2).shapes[0], orch_args.tensor(2).shap
 Tensor ext_dn = make_tensor_external_2d_dn(orch_args.tensor(2).data_as<void>(), dn_shapes, 2, DataType::FLOAT32);
 
 // Phase 6: Internal tensors (from pl.create_tensor — intermediates only)
-// Two declarations are emitted: a TensorCreateInfo for add_output, and a null-addr Tensor placeholder.
+// Only TensorCreateInfo is emitted here. The Tensor variable is bound at the submit site:
+//   non-DN: const Tensor& tmp = outs_t0.get_ref(0);   (declared at submit)
+//   DN:     Tensor tmp = make_tensor_2d_dn(...);        (declared here, copy-assigned at submit)
 uint32_t tmp_ci_shapes[2] = {16, 16};
 TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
-Tensor tmp = make_tensor_external(nullptr, tmp_ci_shapes, 2, DataType::FLOAT32);
 ```
 
 ### Phase 7–9: Task Submission and Control Flow
@@ -117,7 +118,7 @@ PTO2_SCOPE() {
     params_t0.add_input(ext_b);
     params_t0.add_output(tmp_ci);            // add_output takes TensorCreateInfo for internal tensors
     TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-    tmp = outs_t0.get_ref(0);               // copy-assign from ring buffer allocation
+    const Tensor& tmp = outs_t0.get_ref(0); // non-DN: bind const ref at submit site
 
     // ForStmt example — plain for loop, no nested PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -134,7 +135,8 @@ PTO2_SCOPE() {
 | ---- | ------ | ---------------- | ------ |
 | External (ND) | Function parameters (`In`/`Out`/`InOut`) | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
 | External (DN) | Function parameters, DN layout | `make_tensor_external_2d_dn(orch_args.tensor(N).data_as<void>(), {...}, ...)` | `ext_<name>` |
-| Internal | `pl.create_tensor(...)` in function body | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | `<name>` (no prefix) |
+| Internal (non-DN) | `pl.create_tensor(...)` in function body | `TensorCreateInfo var_ci(...)` + `const Tensor& var` bound at submit | `<name>` (no prefix) |
+| Internal (DN) | `pl.create_tensor(...)` with DN layout | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_2d_dn(...)` | `<name>` (no prefix) |
 
 External tensors wrap device memory pointers passed from the host via `ChipStorageTaskArgs`. Internal tensors are allocated by the runtime from a ring buffer when passed to `add_output(var_ci)`.
 
@@ -144,14 +146,16 @@ The `ParamDirection` of each function parameter determines how it appears in tas
 
 | Direction | Python Annotation | C++ Task Param | Semantics |
 | --------- | ----------------- | -------------- | --------- |
-| `In` | `pl.Tensor[...]` (default) | `params.add_input(ext_x)` | Read-only |
+| `In` | `pl.Tensor[...]` (default) | `params.add_input(ext_x)` | Read-only; if the tensor is from `pl.create_tensor`, uses `add_output` for first-time allocation |
 | `Out` (external) | `pl.Out[pl.Tensor[...]]` (param) | `params.add_inout(ext_x)` | Pre-allocated buffer |
-| `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x_ci)` + `x = outs.get_ref(i)` | Runtime ring-buffer alloc |
+| `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)` (non-DN) or `x = outs.get_ref(i)` (DN) | Runtime ring-buffer alloc |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | Read-write |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | Scalar constant (separate scalar slot) |
 
-When `add_output` is used, the submit call returns `TaskOutputTensors` and each internal output
-tensor is copy-assigned from `outs.get_ref(i)` to bind the runtime-allocated address.
+When `add_output` is used, the submit call returns `TaskOutputTensors`. For non-DN tensors,
+a `const Tensor& var = outs.get_ref(i)` binding is declared at the submit site. For DN tensors,
+a `Tensor var = make_tensor_2d_dn(...)` placeholder (null data pointer, with logical view) is
+pre-declared at the `tensor.create` site and copy-assigned after submit.
 
 ### Scalar Parameter Encoding
 
@@ -179,7 +183,7 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 Arg params_t0;
 params_t0.add_inout(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
-Tensor& result = ext_output;  // alias — result refers to ext_output
+const Tensor& result = ext_output;  // alias — result refers to ext_output
 ```
 
 If the return name matches the `Out`/`InOut` arg name, no alias is needed.
@@ -229,7 +233,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR Operation | C++ Codegen | Description |
 | ------------ | ----------- | ----------- |
-| `tensor.create` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | Ring-buffer alloc info + null-addr placeholder |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` | Ring-buffer alloc info; non-DN: `const Tensor& var` bound at submit; DN: `Tensor var = make_tensor_2d_dn(...)` declared before submit |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | Read scalar from host tensor |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
@@ -281,10 +285,9 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // Internal tensor (intermediate) — TensorCreateInfo for add_output, null-addr Tensor for input uses
+    // Internal tensor (intermediate) — only TensorCreateInfo declared here
     uint32_t c_ci_shapes[2] = {16, 16};
     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
     PTO2_SCOPE() {
         // Task 0: kernel_add (a + b → c)
@@ -293,7 +296,7 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
         params_t0.add_input(ext_b);
         params_t0.add_output(c_ci);
         TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-        c = outs_t0.get_ref(0);
+        const Tensor& c = outs_t0.get_ref(0);  // non-DN: bind const ref at submit site
 
         // Task 1: kernel_add (c + b → d)
         Arg params_t1;

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -4,8 +4,8 @@
 
 The orchestration codegen generates PTO2 runtime C++ code that manages task-graph execution on Ascend hardware. While [PTO codegen](00-pto_codegen.md) produces InCore kernel code (tile-level compute), orchestration codegen produces the host-side code that:
 
-- Wraps device memory pointers (via `TaskArg`) into `Tensor` objects
-- Builds `PTOParam` objects and calls `add_input`/`add_output`/`add_inout`/`add_scalar` to classify parameters
+- Wraps device memory pointers (via `ChipStorageTaskArgs`) into `Tensor` objects
+- Builds `Arg` objects and calls `add_input`/`add_output`/`add_inout`/`add_scalar` to classify parameters
 - Submits tasks to AIC (CUBE) or AIV (VECTOR) cores via `pto2_rt_submit_*_task`
 - Handles control flow (loops, conditionals) with `PTO2_SCOPE`
 
@@ -78,33 +78,32 @@ static inline Tensor make_tensor_2d_dn(...) { ... }
 
 ```cpp
 // Phase 3: Config function — returns expected argument count
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
 // Phase 4: Entry function signature
-// A2/A3:
-void aicpu_orchestration_entry(TaskArg* orch,
-    int arg_count, int orch_thread_num, int orch_thread_index) {
-// A5 (Ascend950): PTO2Runtime* rt prepended
-// void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)
+void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
+    int orch_thread_num, int orch_thread_index) {
 ```
 
 ### Phase 5–6: Tensor Setup
 
 ```cpp
-// Phase 5: External tensors — ND layout via from_task_arg()
-Tensor ext_a = from_task_arg(orch[0]);
-Tensor ext_b = from_task_arg(orch[1]);
+// Phase 5: External tensors — ND layout via from_tensor_arg()
+Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
 
 // DN layout: pass logical shape — make_tensor_external_2d_dn handles axis transposition internally
-uint32_t dn_shapes[2] = {orch[2].tensor.shapes[0], orch[2].tensor.shapes[1]};
-Tensor ext_dn = make_tensor_external_2d_dn(orch[2].data<void>(), dn_shapes, 2, DataType::FLOAT32);
+uint32_t dn_shapes[2] = {orch_args.tensor(2).shapes[0], orch_args.tensor(2).shapes[1]};
+Tensor ext_dn = make_tensor_external_2d_dn(orch_args.tensor(2).data_as<void>(), dn_shapes, 2, DataType::FLOAT32);
 
 // Phase 6: Internal tensors (from pl.create_tensor — intermediates only)
-uint32_t tmp_shapes[2] = {16, 16};
-Tensor tmp = make_tensor(tmp_shapes, 2, DataType::FLOAT32);
+// Two declarations are emitted: a TensorCreateInfo for add_output, and a null-addr Tensor placeholder.
+uint32_t tmp_ci_shapes[2] = {16, 16};
+TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
+Tensor tmp = make_tensor_external(nullptr, tmp_ci_shapes, 2, DataType::FLOAT32);
 ```
 
 ### Phase 7–9: Task Submission and Control Flow
@@ -112,16 +111,13 @@ Tensor tmp = make_tensor(tmp_shapes, 2, DataType::FLOAT32);
 All task submission is wrapped in a top-level `PTO2_SCOPE()`:
 
 ```cpp
-// Phase 7–9: Top-level PTO2_SCOPE wraps all task submissions
-// A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
 PTO2_SCOPE() {
-    PTOParam params_t0;
+    Arg params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
-    params_t0.add_output(ext_output);
-    // A2/A3: pto2_rt_submit_aiv_task(0, params_t0)
-    // A5:    pto2_rt_submit_aiv_task(rt, 0, params_t0)
-    pto2_rt_submit_aiv_task(0, params_t0);
+    params_t0.add_output(tmp_ci);            // add_output takes TensorCreateInfo for internal tensors
+    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+    tmp = outs_t0.get_ref(0);               // copy-assign from ring buffer allocation
 
     // ForStmt example — plain for loop, no nested PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -136,11 +132,11 @@ PTO2_SCOPE() {
 
 | Type | Source | C++ Construction | Naming |
 | ---- | ------ | ---------------- | ------ |
-| External (ND) | Function parameters (`In`/`Out`/`InOut`) | `from_task_arg(orch[N])` | `ext_<name>` |
-| External (DN) | Function parameters, DN layout | `make_tensor_external_2d_dn(orch[N].data<void>(), {orch[N].tensor.shapes[0], orch[N].tensor.shapes[1]}, ...)` — axis ordering handled internally | `ext_<name>` |
-| Internal | `pl.create_tensor(...)` in function body | `make_tensor(shapes, ndims, dtype)` | `<name>` (no prefix) |
+| External (ND) | Function parameters (`In`/`Out`/`InOut`) | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
+| External (DN) | Function parameters, DN layout | `make_tensor_external_2d_dn(orch_args.tensor(N).data_as<void>(), {...}, ...)` | `ext_<name>` |
+| Internal | `pl.create_tensor(...)` in function body | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | `<name>` (no prefix) |
 
-External tensors wrap device memory pointers passed from the host via `TaskArg`. Internal tensors are temporary workspace allocated by the runtime.
+External tensors wrap device memory pointers passed from the host via `ChipStorageTaskArgs`. Internal tensors are allocated by the runtime from a ring buffer when passed to `add_output(var_ci)`.
 
 ### Parameter Direction
 
@@ -149,9 +145,25 @@ The `ParamDirection` of each function parameter determines how it appears in tas
 | Direction | Python Annotation | C++ Task Param | Semantics |
 | --------- | ----------------- | -------------- | --------- |
 | `In` | `pl.Tensor[...]` (default) | `params.add_input(ext_x)` | Read-only |
-| `Out` | `pl.Out[pl.Tensor[...]]` | `params.add_output(ext_x)` | Write-only |
+| `Out` (external) | `pl.Out[pl.Tensor[...]]` (param) | `params.add_inout(ext_x)` | Pre-allocated buffer |
+| `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x_ci)` + `x = outs.get_ref(i)` | Runtime ring-buffer alloc |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | Read-write |
-| Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | Scalar constant (after all tensors) |
+| Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | Scalar constant (separate scalar slot) |
+
+When `add_output` is used, the submit call returns `TaskOutputTensors` and each internal output
+tensor is copy-assigned from `outs.get_ref(i)` to bind the runtime-allocated address.
+
+### Scalar Parameter Encoding
+
+Scalar params occupy `ChipStorageTaskArgs` scalar slots (0-indexed, separate from tensor slots).
+Float scalars use `float_to_u64(f)` (bit-cast). Other integer/bool scalars are cast to `uint64_t`.
+At the receiving end, union-based type punning is used to reinterpret the `uint64_t` as the target C type:
+
+```cpp
+union { uint64_t u64; float val; } scale_conv;
+scale_conv.u64 = orch_args.scalar(0);
+float scale = scale_conv.val;
+```
 
 ### Alias Generation
 
@@ -164,25 +176,13 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 
 ```cpp
 // Generated C++
-PTOParam params_t0;
-params_t0.add_output(ext_output);
+Arg params_t0;
+params_t0.add_inout(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
 Tensor& result = ext_output;  // alias — result refers to ext_output
 ```
 
-If the return name matches the `Out`/`InOut` arg name, no alias is needed. `InOut` params are never aliased — they are already the external tensor.
-
-### Backend Differences (A5 / Ascend950)
-
-When targeting Ascend950 (`BackendType::Ascend950`), the generated C++ differs in three ways:
-
-| Element | A2/A3 | A5 |
-| ------- | ----- | -- |
-| Entry function | `aicpu_orchestration_entry(TaskArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)` |
-| Scope macro | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
-| Submit calls | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
-
-The `rt` parameter is an explicit `PTO2Runtime*` pointer that A5 passes through the call chain instead of relying on thread-local storage.
+If the return name matches the `Out`/`InOut` arg name, no alias is needed.
 
 ### Core Type Inference
 
@@ -204,11 +204,11 @@ pij, mij, lij = self.kernel_softmax(sij, scale, pij, mij, lij)
 
 ```cpp
 // Generated C++ — tensors first, then scalars
-PTOParam params_t0;
+Arg params_t0;
 params_t0.add_input(ext_sij);
-params_t0.add_output(ext_pij);
-params_t0.add_output(ext_mij);
-params_t0.add_output(ext_lij);
+params_t0.add_inout(ext_pij);
+params_t0.add_inout(ext_mij);
+params_t0.add_inout(ext_lij);
 params_t0.add_scalar(float_to_u64(scale));  // scalar after all tensors
 pto2_rt_submit_aiv_task(0, params_t0);
 ```
@@ -219,11 +219,9 @@ When a kernel uses both AIC and AIV cores (mixed kernel), the codegen generates 
 
 ```cpp
 // Group: mixed_kernel (AIC + AIV)
-PTOParam params_t0;
-// ... add_input / add_output / add_scalar calls ...
+Arg params_t0;
+// ... add_input / add_inout / add_scalar calls ...
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
-// A2/A3: pto2_rt_submit_task(mixed_0, params_t0)
-// A5:    pto2_rt_submit_task(rt, mixed_0, params_t0)
 pto2_rt_submit_task(mixed_0, params_t0);
 ```
 
@@ -231,11 +229,11 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR Operation | C++ Codegen | Description |
 | ------------ | ----------- | ----------- |
-| `tensor.create` | `make_tensor(shapes, ndims, dtype)` | Allocate internal tensor |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | Ring-buffer alloc info + null-addr placeholder |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | Read scalar from host tensor |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
-| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | Runtime dimension from TaskArg |
+| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | Runtime dimension from ChipStorageTaskArgs |
 
 ## Complete Example
 
@@ -268,43 +266,40 @@ static uint64_t float_to_u64(float f) { /* ... */ }
 
 extern "C" {
 
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
-void aicpu_orchestration_entry(TaskArg* orch,
-    int arg_count, int orch_thread_num, int orch_thread_index) {
-    // Note: A5 adds PTO2Runtime* rt as the first parameter
-    (void)arg_count;
+void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
+    int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
-    // External tensors (from TaskArg)
-    Tensor ext_a = from_task_arg(orch[0]);
-    Tensor ext_b = from_task_arg(orch[1]);
-    Tensor ext_d = from_task_arg(orch[2]);
+    // External tensors (from ChipStorageTaskArgs)
+    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
+    Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // Internal tensor (intermediate)
-    uint32_t c_shapes[2] = {16, 16};
-    Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
+    // Internal tensor (intermediate) — TensorCreateInfo for add_output, null-addr Tensor for input uses
+    uint32_t c_ci_shapes[2] = {16, 16};
+    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
-    // A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         // Task 0: kernel_add (a + b → c)
-        PTOParam params_t0;
+        Arg params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
-        params_t0.add_output(c);
-        // A2/A3: pto2_rt_submit_aiv_task(0, params_t0)
-        // A5:    pto2_rt_submit_aiv_task(rt, 0, params_t0)
-        pto2_rt_submit_aiv_task(0, params_t0);
+        params_t0.add_output(c_ci);
+        TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+        c = outs_t0.get_ref(0);
 
         // Task 1: kernel_add (c + b → d)
-        PTOParam params_t1;
+        Arg params_t1;
         params_t1.add_input(c);
         params_t1.add_input(ext_b);
-        params_t1.add_output(ext_d);
+        params_t1.add_inout(ext_d);
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }
@@ -332,8 +327,11 @@ names in the output), but never for identity decisions.
 | ------ | ------- | ------- |
 | External tensor | `ext_<name>` | `ext_a` |
 | Internal tensor | `<name>` (no prefix) | `c` |
+| Internal TensorCreateInfo | `<name>_ci` | `c_ci` |
 | Task params | `params_t<N>` | `params_t0` |
-| TaskArg index | `orch[N]` (N-th tensor parameter) | `orch[0]` |
+| TaskOutputTensors | `outs_t<N>` | `outs_t0` |
+| Tensor arg index | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
+| Scalar arg index | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 
 ## Control Flow Generation
 
@@ -349,8 +347,8 @@ for i in pl.range(0, 4):
 // Generated C++ (inside top-level PTO2_SCOPE)
 Tensor acc = ext_acc;  // iter_arg initialization
 for (int64_t i = 0; i < 4; i += 1) {
-    PTOParam params_t0;
-    // ... add_input / add_output calls ...
+    Arg params_t0;
+    // ... add_input / add_inout calls ...
     pto2_rt_submit_aiv_task(0, params_t0);
 }
 ```
@@ -370,16 +368,15 @@ else:
 ```cpp
 // Generated C++
 if (condition) {
-    // A2/A3: PTO2_SCOPE()   A5: PTO2_SCOPE(rt)
     PTO2_SCOPE() {
-        PTOParam params_t0;
-        // ... add_input / add_output calls ...
+        Arg params_t0;
+        // ... add_input / add_inout calls ...
         pto2_rt_submit_aiv_task(0, params_t0);
     }
 } else {
     PTO2_SCOPE() {
-        PTOParam params_t1;
-        // ... add_input / add_output calls ...
+        Arg params_t1;
+        // ... add_input / add_inout calls ...
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -100,10 +100,11 @@ uint32_t dn_shapes[2] = {orch_args.tensor(2).shapes[0], orch_args.tensor(2).shap
 Tensor ext_dn = make_tensor_external_2d_dn(orch_args.tensor(2).data_as<void>(), dn_shapes, 2, DataType::FLOAT32);
 
 // 阶段 6：内部张量（来自 pl.create_tensor — 仅中间变量）
-// 生成两条声明：TensorCreateInfo 用于 add_output，空地址 Tensor 作为占位符。
+// 此处仅生成 TensorCreateInfo。Tensor 变量在提交处绑定：
+//   non-DN: const Tensor& tmp = outs_t0.get_ref(0);  （提交处声明）
+//   DN:     Tensor tmp = make_tensor_2d_dn(...);       （此处声明，提交后 copy-assign）
 uint32_t tmp_ci_shapes[2] = {16, 16};
 TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
-Tensor tmp = make_tensor_external(nullptr, tmp_ci_shapes, 2, DataType::FLOAT32);
 ```
 
 ### 阶段 7–9：任务提交与控制流
@@ -117,7 +118,7 @@ PTO2_SCOPE() {
     params_t0.add_input(ext_b);
     params_t0.add_output(tmp_ci);            // add_output 接受 TensorCreateInfo（内部张量）
     TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-    tmp = outs_t0.get_ref(0);               // 从环形缓冲区分配结果赋值回 Tensor
+    const Tensor& tmp = outs_t0.get_ref(0); // non-DN：在提交处绑定 const 引用
 
     // ForStmt 示例 — 普通 for 循环，不嵌套独立的 PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -134,7 +135,8 @@ PTO2_SCOPE() {
 | ---- | ---- | ------------ | ---- |
 | 外部（ND） | 函数参数（`In`/`Out`/`InOut`） | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
 | 外部（DN） | 函数参数，DN 布局 | `make_tensor_external_2d_dn(orch_args.tensor(N).data_as<void>(), {...}, ...)` | `ext_<name>` |
-| 内部（Internal） | 函数体中的 `pl.create_tensor(...)` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | `<name>`（无前缀） |
+| 内部（non-DN） | 函数体中的 `pl.create_tensor(...)` | `TensorCreateInfo var_ci(...)` + 提交处 `const Tensor& var` 绑定 | `<name>`（无前缀） |
+| 内部（DN） | 函数体中的 `pl.create_tensor(...)`，DN 布局 | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_2d_dn(...)` | `<name>`（无前缀） |
 
 外部张量封装从主机通过 `ChipStorageTaskArgs` 传入的设备内存指针。内部张量在传入 `add_output(var_ci)` 时由运行时从环形缓冲区分配。
 
@@ -144,13 +146,15 @@ PTO2_SCOPE() {
 
 | 方向 | Python 注解 | C++ 任务参数 | 语义 |
 | ---- | ----------- | ------------ | ---- |
-| `In` | `pl.Tensor[...]`（默认） | `params.add_input(ext_x)` | 只读 |
+| `In` | `pl.Tensor[...]`（默认） | `params.add_input(ext_x)` | 只读；若为 `pl.create_tensor` 变量，首次使用改用 `add_output` 分配内存 |
 | `Out`（外部） | `pl.Out[pl.Tensor[...]]`（参数） | `params.add_inout(ext_x)` | 预分配缓冲区 |
-| `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x_ci)` + `x = outs.get_ref(i)` | 运行时环形缓冲区分配 |
+| `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)`（non-DN）或 `x = outs.get_ref(i)`（DN） | 运行时环形缓冲区分配 |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | 读写 |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | 标量常量（独立 scalar 槽位） |
 
-使用 `add_output` 时，提交调用返回 `TaskOutputTensors`，每个内部输出张量通过 `outs.get_ref(i)` 拷贝赋值以绑定运行时分配的地址。
+使用 `add_output` 时，提交调用返回 `TaskOutputTensors`。non-DN 张量在提交处声明
+`const Tensor& var = outs.get_ref(i)` 绑定；DN 张量在 `tensor.create` 处预先声明
+`Tensor var = make_tensor_2d_dn(...)`（空数据指针，附带逻辑视图），提交后 copy-assign。
 
 ### 标量参数编码
 
@@ -178,7 +182,7 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 Arg params_t0;
 params_t0.add_inout(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
-Tensor& result = ext_output;  // 别名 — result 引用 ext_output
+const Tensor& result = ext_output;  // 别名 — result 引用 ext_output
 ```
 
 如果返回名称与 `Out`/`InOut` 参数名称匹配，则不需要别名。
@@ -228,7 +232,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR 操作 | C++ 代码生成 | 描述 |
 | ------- | ------------ | ---- |
-| `tensor.create` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | 环形缓冲区分配信息 + 空地址占位符 |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` | 环形缓冲区分配信息；non-DN: 提交处 `const Tensor& var` 绑定；DN: 此处声明 `Tensor var = make_tensor_2d_dn(...)` |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | 从主机张量读取标量 |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
@@ -280,10 +284,9 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // 内部张量（中间变量）— TensorCreateInfo 用于 add_output，空地址 Tensor 用于输入及赋值目标
+    // 内部张量（中间变量）— 此处仅声明 TensorCreateInfo
     uint32_t c_ci_shapes[2] = {16, 16};
     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
     PTO2_SCOPE() {
         // 任务 0: kernel_add (a + b → c)
@@ -292,7 +295,7 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
         params_t0.add_input(ext_b);
         params_t0.add_output(c_ci);
         TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-        c = outs_t0.get_ref(0);
+        const Tensor& c = outs_t0.get_ref(0);  // non-DN：提交处绑定 const 引用
 
         // 任务 1: kernel_add (c + b → d)
         Arg params_t1;

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -4,8 +4,8 @@
 
 编排代码生成器（Orchestration Codegen）生成 PTO2 运行时 C++ 代码，用于管理昇腾硬件上的任务图执行。[PTO 代码生成](00-pto_codegen.md)产生 InCore 核函数代码（Tile 级计算），而编排代码生成器产生主机侧代码，负责：
 
-- 将设备内存指针（通过 `TaskArg`）封装为 `Tensor` 对象
-- 构建 `PTOParam` 对象，调用 `add_input`/`add_output`/`add_inout`/`add_scalar` 对参数分类
+- 将设备内存指针（通过 `ChipStorageTaskArgs`）封装为 `Tensor` 对象
+- 构建 `Arg` 对象，调用 `add_input`/`add_output`/`add_inout`/`add_scalar` 对参数分类
 - 通过 `pto2_rt_submit_*_task` 向 AIC（CUBE）或 AIV（VECTOR）核心提交任务
 - 处理控制流（循环、条件分支），使用 `PTO2_SCOPE`
 
@@ -78,33 +78,32 @@ static inline Tensor make_tensor_2d_dn(...) { ... }
 
 ```cpp
 // 阶段 3：配置函数 — 返回期望的参数数量
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
 // 阶段 4：入口函数签名
-// A2/A3：
-void aicpu_orchestration_entry(TaskArg* orch,
-    int arg_count, int orch_thread_num, int orch_thread_index) {
-// A5（Ascend950）：在参数列表前增加 PTO2Runtime* rt
-// void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)
+void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
+    int orch_thread_num, int orch_thread_index) {
 ```
 
 ### 阶段 5–6：张量设置
 
 ```cpp
-// 阶段 5：外部张量 — ND 布局直接调用 from_task_arg()
-Tensor ext_a = from_task_arg(orch[0]);
-Tensor ext_b = from_task_arg(orch[1]);
+// 阶段 5：外部张量 — ND 布局调用 from_tensor_arg()
+Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
 
 // DN 布局：传入逻辑形状 — make_tensor_external_2d_dn 内部处理轴转置
-uint32_t dn_shapes[2] = {orch[2].tensor.shapes[0], orch[2].tensor.shapes[1]};
-Tensor ext_dn = make_tensor_external_2d_dn(orch[2].data<void>(), dn_shapes, 2, DataType::FLOAT32);
+uint32_t dn_shapes[2] = {orch_args.tensor(2).shapes[0], orch_args.tensor(2).shapes[1]};
+Tensor ext_dn = make_tensor_external_2d_dn(orch_args.tensor(2).data_as<void>(), dn_shapes, 2, DataType::FLOAT32);
 
 // 阶段 6：内部张量（来自 pl.create_tensor — 仅中间变量）
-uint32_t tmp_shapes[2] = {16, 16};
-Tensor tmp = make_tensor(tmp_shapes, 2, DataType::FLOAT32);
+// 生成两条声明：TensorCreateInfo 用于 add_output，空地址 Tensor 作为占位符。
+uint32_t tmp_ci_shapes[2] = {16, 16};
+TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
+Tensor tmp = make_tensor_external(nullptr, tmp_ci_shapes, 2, DataType::FLOAT32);
 ```
 
 ### 阶段 7–9：任务提交与控制流
@@ -112,16 +111,13 @@ Tensor tmp = make_tensor(tmp_shapes, 2, DataType::FLOAT32);
 所有任务提交包裹在顶层 `PTO2_SCOPE()` 中：
 
 ```cpp
-// 阶段 7–9：顶层 PTO2_SCOPE 包裹所有任务提交
-// A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
 PTO2_SCOPE() {
-    PTOParam params_t0;
+    Arg params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
-    params_t0.add_output(ext_output);
-    // A2/A3：pto2_rt_submit_aiv_task(0, params_t0)
-    // A5：   pto2_rt_submit_aiv_task(rt, 0, params_t0)
-    pto2_rt_submit_aiv_task(0, params_t0);
+    params_t0.add_output(tmp_ci);            // add_output 接受 TensorCreateInfo（内部张量）
+    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+    tmp = outs_t0.get_ref(0);               // 从环形缓冲区分配结果赋值回 Tensor
 
     // ForStmt 示例 — 普通 for 循环，不嵌套独立的 PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -136,11 +132,11 @@ PTO2_SCOPE() {
 
 | 类型 | 来源 | C++ 构造方式 | 命名 |
 | ---- | ---- | ------------ | ---- |
-| 外部（ND） | 函数参数（`In`/`Out`/`InOut`） | `from_task_arg(orch[N])` | `ext_<name>` |
-| 外部（DN） | 函数参数，DN 布局 | `make_tensor_external_2d_dn(orch[N].data<void>(), {orch[N].tensor.shapes[0], orch[N].tensor.shapes[1]}, ...)` — 轴排序由函数内部处理 | `ext_<name>` |
-| 内部（Internal） | 函数体中的 `pl.create_tensor(...)` | `make_tensor(shapes, ndims, dtype)` | `<name>`（无前缀） |
+| 外部（ND） | 函数参数（`In`/`Out`/`InOut`） | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
+| 外部（DN） | 函数参数，DN 布局 | `make_tensor_external_2d_dn(orch_args.tensor(N).data_as<void>(), {...}, ...)` | `ext_<name>` |
+| 内部（Internal） | 函数体中的 `pl.create_tensor(...)` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | `<name>`（无前缀） |
 
-外部张量封装从主机通过 `TaskArg` 传入的设备内存指针。内部张量是运行时分配的临时工作空间。
+外部张量封装从主机通过 `ChipStorageTaskArgs` 传入的设备内存指针。内部张量在传入 `add_output(var_ci)` 时由运行时从环形缓冲区分配。
 
 ### 参数方向
 
@@ -149,9 +145,24 @@ PTO2_SCOPE() {
 | 方向 | Python 注解 | C++ 任务参数 | 语义 |
 | ---- | ----------- | ------------ | ---- |
 | `In` | `pl.Tensor[...]`（默认） | `params.add_input(ext_x)` | 只读 |
-| `Out` | `pl.Out[pl.Tensor[...]]` | `params.add_output(ext_x)` | 只写 |
+| `Out`（外部） | `pl.Out[pl.Tensor[...]]`（参数） | `params.add_inout(ext_x)` | 预分配缓冲区 |
+| `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x_ci)` + `x = outs.get_ref(i)` | 运行时环形缓冲区分配 |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | 读写 |
-| Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | 标量常量（所有张量之后） |
+| Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | 标量常量（独立 scalar 槽位） |
+
+使用 `add_output` 时，提交调用返回 `TaskOutputTensors`，每个内部输出张量通过 `outs.get_ref(i)` 拷贝赋值以绑定运行时分配的地址。
+
+### 标量参数编码
+
+标量参数占用 `ChipStorageTaskArgs` 的 scalar 槽位（从 0 开始独立索引，与张量槽位分离）。
+浮点标量使用 `float_to_u64(f)` 进行位转换，其他整数/bool 标量强制转换为 `uint64_t`。
+接收端使用联合体（union）进行类型双关，将 `uint64_t` 重新解释为目标 C 类型：
+
+```cpp
+union { uint64_t u64; float val; } scale_conv;
+scale_conv.u64 = orch_args.scalar(0);
+float scale = scale_conv.val;
+```
 
 ### 别名生成
 
@@ -164,25 +175,13 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 
 ```cpp
 // 生成的 C++
-PTOParam params_t0;
-params_t0.add_output(ext_output);
+Arg params_t0;
+params_t0.add_inout(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
 Tensor& result = ext_output;  // 别名 — result 引用 ext_output
 ```
 
-如果返回名称与 `Out`/`InOut` 参数名称匹配，则不需要别名。`InOut` 参数永不生成别名 — 其本身已是外部张量。
-
-### 后端差异（A5 / Ascend950）
-
-针对 Ascend950（`BackendType::Ascend950`）时，生成的 C++ 在三处有所不同：
-
-| 元素 | A2/A3 | A5 |
-| ---- | ----- | -- |
-| 入口函数 | `aicpu_orchestration_entry(TaskArg* orch, ...)` | `aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch, ...)` |
-| Scope 宏 | `PTO2_SCOPE()` | `PTO2_SCOPE(rt)` |
-| 提交调用 | `pto2_rt_submit_aiv_task(id, params)` | `pto2_rt_submit_aiv_task(rt, id, params)` |
-
-`rt` 参数是显式的 `PTO2Runtime*` 指针，A5 通过调用链传递，而非依赖线程局部存储。
+如果返回名称与 `Out`/`InOut` 参数名称匹配，则不需要别名。
 
 ### 核心类型推断
 
@@ -204,11 +203,11 @@ pij, mij, lij = self.kernel_softmax(sij, scale, pij, mij, lij)
 
 ```cpp
 // 生成的 C++ — 先张量后标量
-PTOParam params_t0;
+Arg params_t0;
 params_t0.add_input(ext_sij);
-params_t0.add_output(ext_pij);
-params_t0.add_output(ext_mij);
-params_t0.add_output(ext_lij);
+params_t0.add_inout(ext_pij);
+params_t0.add_inout(ext_mij);
+params_t0.add_inout(ext_lij);
 params_t0.add_scalar(float_to_u64(scale));  // 标量在所有张量之后
 pto2_rt_submit_aiv_task(0, params_t0);
 ```
@@ -219,11 +218,9 @@ pto2_rt_submit_aiv_task(0, params_t0);
 
 ```cpp
 // Group: mixed_kernel (AIC + AIV)
-PTOParam params_t0;
-// ... add_input / add_output / add_scalar 调用 ...
+Arg params_t0;
+// ... add_input / add_inout / add_scalar 调用 ...
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
-// A2/A3：pto2_rt_submit_task(mixed_0, params_t0)
-// A5：   pto2_rt_submit_task(rt, mixed_0, params_t0)
 pto2_rt_submit_task(mixed_0, params_t0);
 ```
 
@@ -231,11 +228,11 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR 操作 | C++ 代码生成 | 描述 |
 | ------- | ------------ | ---- |
-| `tensor.create` | `make_tensor(shapes, ndims, dtype)` | 分配内部张量 |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` + `Tensor var = make_tensor_external(nullptr, ...)` | 环形缓冲区分配信息 + 空地址占位符 |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | 从主机张量读取标量 |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
-| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch[N].tensor.shapes[axis]` | 从 TaskArg 获取运行时维度 |
+| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | 从 ChipStorageTaskArgs 获取运行时维度 |
 
 ## 完整示例
 
@@ -268,43 +265,40 @@ static uint64_t float_to_u64(float f) { /* ... */ }
 
 extern "C" {
 
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{ .expected_arg_count = 3 };
 }
 
-void aicpu_orchestration_entry(TaskArg* orch,
-    int arg_count, int orch_thread_num, int orch_thread_index) {
-    // 注意：A5 在参数列表前增加 PTO2Runtime* rt
-    (void)arg_count;
+void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args,
+    int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
-    // 外部张量（来自 TaskArg）
-    Tensor ext_a = from_task_arg(orch[0]);
-    Tensor ext_b = from_task_arg(orch[1]);
-    Tensor ext_d = from_task_arg(orch[2]);
+    // 外部张量（来自 ChipStorageTaskArgs）
+    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
+    Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // 内部张量（中间变量）
-    uint32_t c_shapes[2] = {16, 16};
-    Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
+    // 内部张量（中间变量）— TensorCreateInfo 用于 add_output，空地址 Tensor 用于输入及赋值目标
+    uint32_t c_ci_shapes[2] = {16, 16};
+    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
-    // A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
     PTO2_SCOPE() {
         // 任务 0: kernel_add (a + b → c)
-        PTOParam params_t0;
+        Arg params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
-        params_t0.add_output(c);
-        // A2/A3：pto2_rt_submit_aiv_task(0, params_t0)
-        // A5：   pto2_rt_submit_aiv_task(rt, 0, params_t0)
-        pto2_rt_submit_aiv_task(0, params_t0);
+        params_t0.add_output(c_ci);
+        TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+        c = outs_t0.get_ref(0);
 
         // 任务 1: kernel_add (c + b → d)
-        PTOParam params_t1;
+        Arg params_t1;
         params_t1.add_input(c);
         params_t1.add_input(ext_b);
-        params_t1.add_output(ext_d);
+        params_t1.add_inout(ext_d);
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }
@@ -331,8 +325,11 @@ void aicpu_orchestration_entry(TaskArg* orch,
 | ---- | ---- | ---- |
 | 外部张量 | `ext_<name>` | `ext_a` |
 | 内部张量 | `<name>`（无前缀） | `c` |
+| 内部 TensorCreateInfo | `<name>_ci` | `c_ci` |
 | 任务参数 | `params_t<N>` | `params_t0` |
-| TaskArg 索引 | `orch[N]`（第 N 个张量参数） | `orch[0]` |
+| TaskOutputTensors | `outs_t<N>` | `outs_t0` |
+| 张量参数索引 | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
+| 标量参数索引 | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 
 ## 控制流生成
 
@@ -348,8 +345,8 @@ for i in pl.range(0, 4):
 // 生成的 C++（位于顶层 PTO2_SCOPE 内部）
 Tensor acc = ext_acc;  // 迭代参数初始化
 for (int64_t i = 0; i < 4; i += 1) {
-    PTOParam params_t0;
-    // ... add_input / add_output 调用 ...
+    Arg params_t0;
+    // ... add_input / add_inout 调用 ...
     pto2_rt_submit_aiv_task(0, params_t0);
 }
 ```
@@ -369,16 +366,15 @@ else:
 ```cpp
 // 生成的 C++
 if (condition) {
-    // A2/A3：PTO2_SCOPE()   A5：PTO2_SCOPE(rt)
     PTO2_SCOPE() {
-        PTOParam params_t0;
-        // ... add_input / add_output 调用 ...
+        Arg params_t0;
+        // ... add_input / add_inout 调用 ...
         pto2_rt_submit_aiv_task(0, params_t0);
     }
 } else {
     PTO2_SCOPE() {
-        PTOParam params_t1;
-        // ... add_input / add_output 调用 ...
+        Arg params_t1;
+        // ... add_input / add_inout 调用 ...
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -276,7 +276,7 @@ def _generate_arg_unpacking(func: _ir_core.Function) -> tuple[str, list[str]]:
         c_type = param.type.dtype.to_c_type_string()
         lines.append(f"    // Unpack tensor: {param_name}")
         lines.append(
-            f"    __gm__ TensorData* {param_name}_tensor = reinterpret_cast<__gm__ TensorData*>(args[{i}]);"
+            f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);"
         )
         lines.append(
             f"    __gm__ {c_type}* {param_name} = "

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -275,9 +275,7 @@ def _generate_arg_unpacking(func: _ir_core.Function) -> tuple[str, list[str]]:
         assert isinstance(param.type, _ir_core.TensorType)
         c_type = param.type.dtype.to_c_type_string()
         lines.append(f"    // Unpack tensor: {param_name}")
-        lines.append(
-            f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);"
-        )
+        lines.append(f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);")
         lines.append(
             f"    __gm__ {c_type}* {param_name} = "
             f"reinterpret_cast<__gm__ {c_type}*>("

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -79,13 +79,18 @@ def _get_simpler_stamp() -> str:
         return _simpler_stamp_value
     try:
         import subprocess
+
         simpler_root = os.environ.get("SIMPLER_ROOT", "")
         if not simpler_root:
             _simpler_stamp_value = "unknown"
             return _simpler_stamp_value
         r = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],
-            capture_output=True, text=True, cwd=simpler_root, timeout=5,
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=simpler_root,
+            timeout=5,
         )
         _simpler_stamp_value = r.stdout.strip() if r.returncode == 0 else "unknown"
     except Exception:
@@ -139,6 +144,7 @@ def _save_inputs(result: list, path: Path) -> None:
         {"kind": "ctypes", "name": "size", "ctype": "c_int64", "value": 1024}
     """
     import ctypes
+
     import torch
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -147,16 +153,16 @@ def _save_inputs(result: list, path: Path) -> None:
         if isinstance(val, torch.Tensor):
             serialisable.append({"kind": "tensor", "name": name, "data": val})
         elif isinstance(val, ctypes._SimpleCData):
-            serialisable.append({
-                "kind": "ctypes",
-                "name": name,
-                "ctype": type(val).__name__,
-                "value": val.value,
-            })
-        else:
-            raise TypeError(
-                f"Cannot serialise arg {name!r}: unsupported type {type(val)}"
+            serialisable.append(
+                {
+                    "kind": "ctypes",
+                    "name": name,
+                    "ctype": type(val).__name__,
+                    "value": val.value,
+                }
             )
+        else:
+            raise TypeError(f"Cannot serialise arg {name!r}: unsupported type {type(val)}")
     torch.save(serialisable, path)
 
 
@@ -166,6 +172,7 @@ def _load_inputs(path: Path) -> list | None:
     Returns ``None`` if the file does not exist or cannot be read.
     """
     import ctypes
+
     import torch
 
     if not path.exists():
@@ -505,8 +512,9 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
     # --- KernelCompiler.compile_incore ---
     orig_incore = KernelCompiler.compile_incore
 
-    def _patched_incore(self, source_path, core_type="aiv", pto_isa_root=None,
-                        extra_include_dirs=None, build_dir=None):
+    def _patched_incore(
+        self, source_path, core_type="aiv", pto_isa_root=None, extra_include_dirs=None, build_dir=None
+    ):
         source = Path(source_path)
         # Only cache for the expected structure: work_dir/kernels/{core_type}/{name}.cpp
         if source.parent.parent.name == "kernels":
@@ -584,10 +592,10 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
                 sys.path.insert(0, p)
 
     code_runner_cls = importlib.import_module("code_runner").CodeRunner
-    
-    from code_runner import CodeRunner  # type: ignore[import]  # noqa: PLC0415,I001 — available after sys.path setup
-    from kernel_compiler import KernelCompiler  # type: ignore[import]  # noqa: PLC0415
-    from runtime_builder import RuntimeBuilder  # type: ignore[import]  # noqa: PLC0415
+
+    from code_runner import CodeRunner
+    from kernel_compiler import KernelCompiler
+    from runtime_builder import RuntimeBuilder
 
     _install_golden_inputs_patch(CodeRunner)
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -35,8 +35,11 @@ Typical usage::
     print(result)  # PASS / FAIL: ...
 """
 
+import ctypes
+import functools
 import importlib
 import os
+import subprocess
 import sys
 import time
 import traceback
@@ -45,6 +48,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import torch
 
 from pypto import ir
 from pypto.backend import BackendType, set_backend_type
@@ -57,13 +62,13 @@ from .tensor_spec import TensorSpec
 # Golden inputs pre-generation cache
 # ---------------------------------------------------------------------------
 # .pt files written by pregenerate_golden_inputs() (see test_runner.py) are
-# the persistent cache.  This flag just prevents re-patching CodeRunner in
+# the persistent cache.  These flags prevent re-patching CodeRunner in
 # the same process.
-_code_runner_patched: bool = False
-_binary_cache_patched: bool = False
-_simpler_stamp_value: str | None = None
+_code_runner_patched: list[bool] = [False]
+_binary_cache_patched: list[bool] = [False]
 
 
+@functools.lru_cache(maxsize=1)
 def _get_simpler_stamp() -> str:
     """Return Simpler's current git commit (short hash) as a cache-key stamp.
 
@@ -74,16 +79,10 @@ def _get_simpler_stamp() -> str:
 
     The value is computed once and cached in-process.
     """
-    global _simpler_stamp_value
-    if _simpler_stamp_value is not None:
-        return _simpler_stamp_value
+    simpler_root = os.environ.get("SIMPLER_ROOT", "")
+    if not simpler_root:
+        return "unknown"
     try:
-        import subprocess
-
-        simpler_root = os.environ.get("SIMPLER_ROOT", "")
-        if not simpler_root:
-            _simpler_stamp_value = "unknown"
-            return _simpler_stamp_value
         r = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],
             check=False,
@@ -92,10 +91,9 @@ def _get_simpler_stamp() -> str:
             cwd=simpler_root,
             timeout=5,
         )
-        _simpler_stamp_value = r.stdout.strip() if r.returncode == 0 else "unknown"
+        return r.stdout.strip() if r.returncode == 0 else "unknown"
     except Exception:
-        _simpler_stamp_value = "unknown"
-    return _simpler_stamp_value
+        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -143,10 +141,6 @@ def _save_inputs(result: list, path: Path) -> None:
         {"kind": "tensor", "name": "a",    "data": <torch.Tensor>}
         {"kind": "ctypes", "name": "size", "ctype": "c_int64", "value": 1024}
     """
-    import ctypes
-
-    import torch
-
     path.parent.mkdir(parents=True, exist_ok=True)
     serialisable = []
     for name, val in result:
@@ -171,10 +165,6 @@ def _load_inputs(path: Path) -> list | None:
 
     Returns ``None`` if the file does not exist or cannot be read.
     """
-    import ctypes
-
-    import torch
-
     if not path.exists():
         return None
     try:
@@ -194,8 +184,6 @@ def _load_inputs(path: Path) -> list | None:
 
 def _save_golden(golden: dict, path: Path) -> None:
     """Serialise pre-computed golden output tensors to *path*."""
-    import torch
-
     path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(golden, path)
 
@@ -205,8 +193,6 @@ def _load_golden(path: Path) -> dict | None:
 
     Returns ``None`` if the file does not exist or cannot be read.
     """
-    import torch
-
     if not path.exists():
         return None
     try:
@@ -216,9 +202,11 @@ def _load_golden(path: Path) -> dict | None:
 
 
 def _save_binary(data: bytes, path: Path) -> None:
-    """Save compiled binary bytes to *path*."""
+    """Save compiled binary bytes to *path* atomically."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(data)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
 
 
 def _load_binary(path: Path) -> bytes | None:
@@ -438,8 +426,7 @@ def _install_golden_inputs_patch(CodeRunner) -> None:
 
     Each ``torch.load`` produces fresh tensors, so no cloning is needed.
     """
-    global _code_runner_patched
-    if _code_runner_patched:
+    if _code_runner_patched[0]:
         return
 
     orig_init = CodeRunner.__init__
@@ -474,7 +461,7 @@ def _install_golden_inputs_patch(CodeRunner) -> None:
         self._golden_module.compute_golden = _cached_compute
 
     CodeRunner.__init__ = _patched_init
-    _code_runner_patched = True
+    _code_runner_patched[0] = True
 
 
 # Persistent runtime binary cache — shared across test cases and sessions.
@@ -505,8 +492,7 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
     Idempotent — safe to call multiple times. Cache miss triggers compilation
     and saves the result; subsequent calls serve from disk.
     """
-    global _binary_cache_patched
-    if _binary_cache_patched:
+    if _binary_cache_patched[0]:
         return
 
     # --- KernelCompiler.compile_incore ---
@@ -567,7 +553,7 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
         return result
 
     RuntimeBuilder.build = _patched_build
-    _binary_cache_patched = True
+    _binary_cache_patched[0] = True
 
 
 def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_id: int) -> None:
@@ -591,16 +577,14 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
             if p not in sys.path:
                 sys.path.insert(0, p)
 
-    code_runner_cls = importlib.import_module("code_runner").CodeRunner
-
-    from code_runner import CodeRunner
-    from kernel_compiler import KernelCompiler
-    from runtime_builder import RuntimeBuilder
+    CodeRunner = importlib.import_module("code_runner").CodeRunner
+    KernelCompiler = importlib.import_module("kernel_compiler").KernelCompiler
+    RuntimeBuilder = importlib.import_module("runtime_builder").RuntimeBuilder
 
     _install_golden_inputs_patch(CodeRunner)
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
-    code_runner_cls(
+    CodeRunner(
         kernels_dir=str(work_dir),
         golden_path=str(golden_path),
         platform=platform,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -239,6 +239,8 @@ class RunConfig:
             ``build_output/<program_name>_<timestamp>``.
         codegen_only: If ``True``, stop after code generation without executing
             on device.  Useful for validating compilation output.
+        pto_isa_commit: If set, pin the pto-isa clone to this specific git
+            commit (hash or tag).  ``None`` means use the latest remote HEAD.
     """
 
     __test__ = False  # Not a pytest test class
@@ -253,6 +255,7 @@ class RunConfig:
     save_kernels: bool = False
     save_kernels_dir: str | None = None
     codegen_only: bool = False
+    pto_isa_commit: str | None = None
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
@@ -396,7 +399,7 @@ def run(
         write_golden(tensor_specs, golden, golden_path, rtol=config.rtol, atol=config.atol)
 
         # 4. Execute via Simpler's CodeRunner
-        _execute_on_device(work_dir, golden_path, config.platform, config.device_id)
+        _execute_on_device(work_dir, golden_path, config.platform, config.device_id, config.pto_isa_commit)
 
         return RunResult(passed=True, execution_time=time.time() - start_time)
 
@@ -555,7 +558,13 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
     _binary_cache_patched[0] = True
 
 
-def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_id: int) -> None:
+def _execute_on_device(
+    work_dir: Path,
+    golden_path: Path,
+    platform: str,
+    device_id: int,
+    pto_isa_commit: str | None = None,
+) -> None:
     """Invoke Simpler's CodeRunner to compile, load, execute, and validate.
 
     Automatically adds SIMPLER_ROOT sub-paths to ``sys.path`` when the
@@ -568,6 +577,8 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
         platform: Target execution platform (``"a2a3sim"``, ``"a2a3"``,
             ``"a5sim"``, or ``"a5"``).
         device_id: Hardware device index.
+        pto_isa_commit: If set, pin the pto-isa clone to this specific git
+            commit (hash or tag).
     """
     simpler_root = os.environ.get("SIMPLER_ROOT")
     if simpler_root:
@@ -589,6 +600,7 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
         platform=platform,
         device_id=device_id,
         clone_protocol="https",
+        pto_isa_commit=pto_isa_commit,
     ).run()
 
 

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -53,6 +53,176 @@ from pypto.ir.pass_manager import OptimizationStrategy
 from .golden_writer import write_golden
 from .tensor_spec import TensorSpec
 
+# ---------------------------------------------------------------------------
+# Golden inputs pre-generation cache
+# ---------------------------------------------------------------------------
+# .pt files written by pregenerate_golden_inputs() (see test_runner.py) are
+# the persistent cache.  This flag just prevents re-patching CodeRunner in
+# the same process.
+_code_runner_patched: bool = False
+_binary_cache_patched: bool = False
+_simpler_stamp_value: str | None = None
+
+
+def _get_simpler_stamp() -> str:
+    """Return Simpler's current git commit (short hash) as a cache-key stamp.
+
+    The stamp is used to namespace the global runtime binary cache so that
+    stale binaries from an older Simpler version are never reused after an
+    update.  Falls back to ``"unknown"`` when git is unavailable or
+    ``SIMPLER_ROOT`` is not set.
+
+    The value is computed once and cached in-process.
+    """
+    global _simpler_stamp_value
+    if _simpler_stamp_value is not None:
+        return _simpler_stamp_value
+    try:
+        import subprocess
+        simpler_root = os.environ.get("SIMPLER_ROOT", "")
+        if not simpler_root:
+            _simpler_stamp_value = "unknown"
+            return _simpler_stamp_value
+        r = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, cwd=simpler_root, timeout=5,
+        )
+        _simpler_stamp_value = r.stdout.strip() if r.returncode == 0 else "unknown"
+    except Exception:
+        _simpler_stamp_value = "unknown"
+    return _simpler_stamp_value
+
+
+# ---------------------------------------------------------------------------
+# Cache file helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_dir(golden_path: Path) -> Path:
+    """Return the ``cache/`` subdirectory co-located with ``golden.py``."""
+    return golden_path.parent / "cache"
+
+
+def _inputs_cache_file(golden_path: Path, case_name: str) -> Path:
+    """Return the path for the pre-generated inputs ``.pt`` file.
+
+    All cache artefacts live under ``work_dir/cache/`` alongside the other
+    test-case outputs::
+
+        work_dir/
+          cache/
+            Default_inputs.pt
+            Default_golden.pt
+            Case1_inputs.pt
+            Case1_golden.pt
+          golden.py
+          kernels/
+          orchestration/
+    """
+    safe = case_name.replace("/", "_").replace(" ", "_")
+    return _cache_dir(golden_path) / f"{safe}_inputs.pt"
+
+
+def _golden_cache_file(golden_path: Path, case_name: str) -> Path:
+    """Return the path for the pre-computed golden outputs ``.pt`` file."""
+    safe = case_name.replace("/", "_").replace(" ", "_")
+    return _cache_dir(golden_path) / f"{safe}_golden.pt"
+
+
+def _save_inputs(result: list, path: Path) -> None:
+    """Serialise ``generate_inputs()`` result to *path* via ``torch.save``.
+
+    Each item in *result* is wrapped in a small dict so that ctypes scalars
+    can be reconstructed faithfully on load::
+
+        {"kind": "tensor", "name": "a",    "data": <torch.Tensor>}
+        {"kind": "ctypes", "name": "size", "ctype": "c_int64", "value": 1024}
+    """
+    import ctypes
+    import torch
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialisable = []
+    for name, val in result:
+        if isinstance(val, torch.Tensor):
+            serialisable.append({"kind": "tensor", "name": name, "data": val})
+        elif isinstance(val, ctypes._SimpleCData):
+            serialisable.append({
+                "kind": "ctypes",
+                "name": name,
+                "ctype": type(val).__name__,
+                "value": val.value,
+            })
+        else:
+            raise TypeError(
+                f"Cannot serialise arg {name!r}: unsupported type {type(val)}"
+            )
+    torch.save(serialisable, path)
+
+
+def _load_inputs(path: Path) -> list | None:
+    """Load and reconstruct a ``generate_inputs()`` result from *path*.
+
+    Returns ``None`` if the file does not exist or cannot be read.
+    """
+    import ctypes
+    import torch
+
+    if not path.exists():
+        return None
+    try:
+        items = torch.load(path, weights_only=False)
+        result = []
+        for item in items:
+            name = item["name"]
+            if item["kind"] == "tensor":
+                result.append((name, item["data"]))
+            elif item["kind"] == "ctypes":
+                ctype_cls = getattr(ctypes, item["ctype"])
+                result.append((name, ctype_cls(item["value"])))
+        return result
+    except Exception:
+        return None
+
+
+def _save_golden(golden: dict, path: Path) -> None:
+    """Serialise pre-computed golden output tensors to *path*."""
+    import torch
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(golden, path)
+
+
+def _load_golden(path: Path) -> dict | None:
+    """Load pre-computed golden output tensors from *path*.
+
+    Returns ``None`` if the file does not exist or cannot be read.
+    """
+    import torch
+
+    if not path.exists():
+        return None
+    try:
+        return torch.load(path, weights_only=False)
+    except Exception:
+        return None
+
+
+def _save_binary(data: bytes, path: Path) -> None:
+    """Save compiled binary bytes to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _load_binary(path: Path) -> bytes | None:
+    """Load compiled binary bytes from *path*. Returns ``None`` on miss."""
+    if not path.exists():
+        return None
+    try:
+        return path.read_bytes()
+    except Exception:
+        return None
+
 
 @dataclass
 class RunConfig:
@@ -248,6 +418,150 @@ def run(
 # ---------------------------------------------------------------------------
 
 
+def _install_golden_inputs_patch(CodeRunner) -> None:
+    """Monkey-patch CodeRunner.__init__ to serve generate_inputs and compute_golden from disk cache.
+
+    Idempotent — safe to call multiple times.  For each new CodeRunner instance:
+
+    - ``generate_inputs``: loads ``cache/{case}_inputs.pt`` when available,
+      falls through to the original on a cache miss.
+    - ``compute_golden``: copies cached output tensors from
+      ``cache/{case}_golden.pt`` into the tensors dict when available,
+      falls through to the original on a cache miss.
+
+    Each ``torch.load`` produces fresh tensors, so no cloning is needed.
+    """
+    global _code_runner_patched
+    if _code_runner_patched:
+        return
+
+    orig_init = CodeRunner.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        golden_path = self.golden_path  # Path, already resolved
+
+        # --- patch generate_inputs -------------------------------------------
+        orig_gen = self._golden_module.generate_inputs
+
+        def _cached_gen(params):
+            case_name = params.get("name", "Default")
+            result = _load_inputs(_inputs_cache_file(golden_path, case_name))
+            return result if result is not None else orig_gen(params)
+
+        self._golden_module.generate_inputs = _cached_gen
+
+        # --- patch compute_golden --------------------------------------------
+        orig_compute = self._golden_module.compute_golden
+
+        def _cached_compute(tensors, params):
+            case_name = params.get("name", "Default")
+            cached = _load_golden(_golden_cache_file(golden_path, case_name))
+            if cached is not None:
+                for name, val in cached.items():
+                    if name in tensors:
+                        tensors[name].copy_(val)
+                return
+            orig_compute(tensors, params)
+
+        self._golden_module.compute_golden = _cached_compute
+
+    CodeRunner.__init__ = _patched_init
+    _code_runner_patched = True
+
+
+# Persistent runtime binary cache — shared across test cases and sessions.
+# Root directory for persistent runtime binary cache.  Actual files live under
+# a Simpler-version subdirectory (see _get_simpler_stamp()) so that stale
+# binaries are automatically bypassed after a Simpler update.
+_BINARY_RUNTIME_CACHE = (
+    Path(__file__).parent.parent.parent.parent / "build_output" / "binary_cache" / "runtimes"
+)
+
+
+def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
+    """Monkey-patch KernelCompiler and RuntimeBuilder to serve compiled binaries from disk.
+
+    Patches three methods with write-through caches:
+
+    - ``KernelCompiler.compile_incore``: caches at
+      ``work_dir/cache/incore_{core_type}_{stem}.bin``
+      (derived from the kernel source path structure
+      ``work_dir/kernels/{core_type}/{name}.cpp``).
+    - ``KernelCompiler.compile_orchestration``: caches at
+      ``work_dir/cache/orch_{stem}.bin``
+      (derived from ``work_dir/orchestration/{name}.cpp``).
+    - ``RuntimeBuilder.build``: caches at
+      ``build_output/binary_cache/runtimes/{name}_{platform}_{target}.bin``
+      (global, shared across all test cases).
+
+    Idempotent — safe to call multiple times. Cache miss triggers compilation
+    and saves the result; subsequent calls serve from disk.
+    """
+    global _binary_cache_patched
+    if _binary_cache_patched:
+        return
+
+    # --- KernelCompiler.compile_incore ---
+    orig_incore = KernelCompiler.compile_incore
+
+    def _patched_incore(self, source_path, core_type="aiv", pto_isa_root=None,
+                        extra_include_dirs=None, build_dir=None):
+        source = Path(source_path)
+        # Only cache for the expected structure: work_dir/kernels/{core_type}/{name}.cpp
+        if source.parent.parent.name == "kernels":
+            cache_file = source.parent.parent.parent / "cache" / f"incore_{core_type}_{source.stem}.bin"
+            cached = _load_binary(cache_file)
+            if cached is not None:
+                return cached
+            result = orig_incore(self, source_path, core_type, pto_isa_root, extra_include_dirs, build_dir)
+            _save_binary(result, cache_file)
+            return result
+        return orig_incore(self, source_path, core_type, pto_isa_root, extra_include_dirs, build_dir)
+
+    KernelCompiler.compile_incore = _patched_incore
+
+    # --- KernelCompiler.compile_orchestration ---
+    orig_orch = KernelCompiler.compile_orchestration
+
+    def _patched_orch(self, runtime_name, source_path, extra_include_dirs=None, build_dir=None):
+        source = Path(source_path)
+        # Only cache for the expected structure: work_dir/orchestration/{name}.cpp
+        if source.parent.name == "orchestration":
+            cache_file = source.parent.parent / "cache" / f"orch_{source.stem}.bin"
+            cached = _load_binary(cache_file)
+            if cached is not None:
+                return cached
+            result = orig_orch(self, runtime_name, source_path, extra_include_dirs, build_dir)
+            _save_binary(result, cache_file)
+            return result
+        return orig_orch(self, runtime_name, source_path, extra_include_dirs, build_dir)
+
+    KernelCompiler.compile_orchestration = _patched_orch
+
+    # --- RuntimeBuilder.build ---
+    orig_build = RuntimeBuilder.build
+
+    def _patched_build(self, name, build_dir=None):
+        cache_dir = _BINARY_RUNTIME_CACHE / _get_simpler_stamp()
+        host_file = cache_dir / f"{name}_{self.platform}_host.bin"
+        aicpu_file = cache_dir / f"{name}_{self.platform}_aicpu.bin"
+        aicore_file = cache_dir / f"{name}_{self.platform}_aicore.bin"
+        host = _load_binary(host_file)
+        aicpu = _load_binary(aicpu_file)
+        aicore = _load_binary(aicore_file)
+        if host is not None and aicpu is not None and aicore is not None:
+            return (host, aicpu, aicore)
+        result = orig_build(self, name, build_dir)
+        _save_binary(result[0], host_file)
+        _save_binary(result[1], aicpu_file)
+        _save_binary(result[2], aicore_file)
+        return result
+
+    RuntimeBuilder.build = _patched_build
+    _binary_cache_patched = True
+
+
 def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_id: int) -> None:
     """Invoke Simpler's CodeRunner to compile, load, execute, and validate.
 
@@ -270,6 +584,13 @@ def _execute_on_device(work_dir: Path, golden_path: Path, platform: str, device_
                 sys.path.insert(0, p)
 
     code_runner_cls = importlib.import_module("code_runner").CodeRunner
+    
+    from code_runner import CodeRunner  # type: ignore[import]  # noqa: PLC0415,I001 — available after sys.path setup
+    from kernel_compiler import KernelCompiler  # type: ignore[import]  # noqa: PLC0415
+    from runtime_builder import RuntimeBuilder  # type: ignore[import]  # noqa: PLC0415
+
+    _install_golden_inputs_patch(CodeRunner)
+    _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
     code_runner_cls(
         kernels_dir=str(work_dir),

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -485,8 +485,8 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
     - ``KernelCompiler.compile_orchestration``: caches at
       ``work_dir/cache/orch_{stem}.bin``
       (derived from ``work_dir/orchestration/{name}.cpp``).
-    - ``RuntimeBuilder.build``: caches at
-      ``build_output/binary_cache/runtimes/{name}_{platform}_{target}.bin``
+    - ``RuntimeBuilder.get_binaries``: caches at
+      ``build_output/binary_cache/runtimes/{name}_{platform}_{host|aicpu|aicore}.bin``
       (global, shared across all test cases).
 
     Idempotent — safe to call multiple times. Cache miss triggers compilation
@@ -494,6 +494,8 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
     """
     if _binary_cache_patched[0]:
         return
+
+    RuntimeBinaries = getattr(sys.modules[RuntimeBuilder.__module__], "RuntimeBinaries")
 
     # --- KernelCompiler.compile_incore ---
     orig_incore = KernelCompiler.compile_incore
@@ -533,26 +535,23 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
 
     KernelCompiler.compile_orchestration = _patched_orch
 
-    # --- RuntimeBuilder.build ---
-    orig_build = RuntimeBuilder.build
+    # --- RuntimeBuilder.get_binaries ---
+    orig_get_binaries = RuntimeBuilder.get_binaries
 
-    def _patched_build(self, name, build_dir=None):
+    def _patched_get_binaries(self, name, build=False):
         cache_dir = _BINARY_RUNTIME_CACHE / _get_simpler_stamp()
         host_file = cache_dir / f"{name}_{self.platform}_host.bin"
         aicpu_file = cache_dir / f"{name}_{self.platform}_aicpu.bin"
         aicore_file = cache_dir / f"{name}_{self.platform}_aicore.bin"
-        host = _load_binary(host_file)
-        aicpu = _load_binary(aicpu_file)
-        aicore = _load_binary(aicore_file)
-        if host is not None and aicpu is not None and aicore is not None:
-            return (host, aicpu, aicore)
-        result = orig_build(self, name, build_dir)
-        _save_binary(result[0], host_file)
-        _save_binary(result[1], aicpu_file)
-        _save_binary(result[2], aicore_file)
+        if host_file.exists() and aicpu_file.exists() and aicore_file.exists():
+            return RuntimeBinaries(host_path=host_file, aicpu_path=aicpu_file, aicore_path=aicore_file)
+        result = orig_get_binaries(self, name, build=build)
+        _save_binary(result.host_path.read_bytes(), host_file)
+        _save_binary(result.aicpu_path.read_bytes(), aicpu_file)
+        _save_binary(result.aicore_path.read_bytes(), aicore_file)
         return result
 
-    RuntimeBuilder.build = _patched_build
+    RuntimeBuilder.get_binaries = _patched_get_binaries
     _binary_cache_patched[0] = True
 
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -494,14 +494,15 @@ std::string GenerateHelperFunctions() {
   return oss.str();
 }
 
-// Generate scalar variable declaration from TaskArg scalar slot.
-// Uses value_as<T>() for type-safe reinterpretation (memcpy-based type punning).
-std::string GenerateScalarUnpack(const std::string& var_name, int orch_index,
+// Generate scalar variable declaration from ChipStorageTaskArgs scalar slot.
+// Uses union-based type punning to reinterpret the uint64_t scalar as the target C type.
+std::string GenerateScalarUnpack(const std::string& var_name, int scalar_index,
                                  const ScalarTypePtr& scalar_type) {
   std::ostringstream oss;
   std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-  oss << "    " << cpp_type << " " << var_name << " = orch[" << orch_index << "].value_as<" << cpp_type
-      << ">();\n";
+  oss << "    union { uint64_t u64; " << cpp_type << " val; } " << var_name << "_conv;\n";
+  oss << "    " << var_name << "_conv.u64 = orch_args.scalar(" << scalar_index << ");\n";
+  oss << "    " << cpp_type << " " << var_name << " = " << var_name << "_conv.val;\n";
   return oss.str();
 }
 
@@ -513,13 +514,10 @@ static inline Tensor make_tensor_external_2d_dn(void* addr,
     int32_t version = 0) {
     debug_assert(ndims == 2);
     static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-    uint64_t total = 1;
-    for (uint32_t i = 0; i < ndims; i++) {
-        total *= shapes[i];
-    }
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-    return Tensor(addr, total * get_element_size(dtype),
-        raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+    uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+    Tensor base = make_tensor_external(addr, raw_shapes, ndims, dtype, false, version);
+    uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+    return base.view(logical_shapes, zero_offsets);
 }
 
 static inline Tensor make_tensor_2d_dn(
@@ -529,20 +527,17 @@ static inline Tensor make_tensor_2d_dn(
     int32_t version = 0) {
     debug_assert(ndims == 2);
     static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-    uint64_t total = 1;
-    for (uint32_t i = 0; i < ndims; i++) {
-        total *= shapes[i];
-    }
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-    return Tensor(0, total * get_element_size(dtype),
-        raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+    uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+    Tensor base = make_tensor_external(nullptr, raw_shapes, ndims, dtype, false, version);
+    uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+    return base.view(logical_shapes, zero_offsets);
 }
 )";
 
 std::string GenerateConfigFunction(int expected_arg_count) {
   std::ostringstream oss;
   oss << "__attribute__((visibility(\"default\")))\n";
-  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {\n";
+  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {\n";
   oss << "    (void)orch_args;\n";
   oss << "    return PTO2OrchestrationConfig{\n";
   oss << "        .expected_arg_count = " << expected_arg_count << ",\n";
@@ -557,18 +552,11 @@ std::string GenerateConfigFunction(int expected_arg_count) {
 // Returns true when targeting an A5 (Ascend950) backend.
 bool IsA5Backend() { return pypto::backend::GetBackendType() == pypto::backend::BackendType::Ascend950; }
 
-// Returns "rt, " for A5 backends (explicit PTO2Runtime* argument), "" otherwise (TLS-based).
-std::string RtArg() { return IsA5Backend() ? "rt, " : ""; }
-
-// Returns "rt" for A5 backends (PTO2_SCOPE(rt)), "" for A2/A3 (PTO2_SCOPE()).
-std::string ScopeArg() { return IsA5Backend() ? "rt" : ""; }
-
-// Returns the opening of a pto2_rt_submit_{aic,aiv}_task call up to (and including) any rt arg.
-// A2/A3: "pto2_rt_submit_aic_task("    caller appends: func_id << ", " << params << ");"
-// A5:    "pto2_rt_submit_aic_task(rt, " caller appends: func_id << ", " << params << ");"
+// Returns the opening of a pto2_rt_submit_{aic,aiv}_task call.
+// Caller appends: func_id << ", " << params << ");".
 std::string CoreTypeToSubmitPrefix(CoreType core_type) {
   std::string func = core_type == CoreType::CUBE ? "pto2_rt_submit_aic_task" : "pto2_rt_submit_aiv_task";
-  return func + "(" + RtArg();
+  return func + "(";
 }
 
 // Removed DataTypeToPTO2Enum — now uses DataTypeToString from dtype.h
@@ -585,14 +573,14 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
     size_t ndim = tensor_type->shape_.size();
     CHECK(ndim == 2) << "only support 2D tensor for DN layout now";
     oss << "    uint32_t " << var_name << "_shapes[2] = {"
-        << "orch[" << orch_index << "].tensor.shapes[1], "
-        << "orch[" << orch_index << "].tensor.shapes[0]};\n";
+        << "orch_args.tensor(" << orch_index << ").shapes[1], "
+        << "orch_args.tensor(" << orch_index << ").shapes[0]};\n";
     oss << "    Tensor ext_" << var_name << " = make_tensor_external_2d_dn("
-        << "orch[" << orch_index << "].data<void>(), " << var_name << "_shapes, " << ndim << ", "
+        << "orch_args.tensor(" << orch_index << ").data_as<void>(), " << var_name << "_shapes, " << ndim << ", "
         << codegen.GetRuntimeDataTypeString(tensor_type->dtype_) << ");\n";
   } else {
-    // ND layout: use from_task_arg() to convert TaskArg to Tensor
-    oss << "    Tensor ext_" << var_name << " = from_task_arg(orch[" << orch_index << "]);\n";
+    // ND layout: use from_tensor_arg() to convert ContinuousTensor to Tensor
+    oss << "    Tensor ext_" << var_name << " = from_tensor_arg(orch_args.tensor(" << orch_index << "));\n";
   }
 
   return oss.str();
@@ -678,7 +666,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   [[nodiscard]] std::string GetTensorDataPtr(const std::string& name) const override {
     auto it = param_name_to_orch_index_.find(name);
     if (it != param_name_to_orch_index_.end()) {
-      return "orch[" + std::to_string(it->second) + "].data<void>()";
+      return "orch_args.tensor(" + std::to_string(it->second) + ").data_as<void>()";
     }
     return name + ".data";
   }
@@ -686,7 +674,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   [[nodiscard]] std::string GetTensorShapeDim(const std::string& name, int64_t axis) const override {
     auto it = param_name_to_orch_index_.find(name);
     if (it != param_name_to_orch_index_.end()) {
-      return "(int64_t)orch[" + std::to_string(it->second) + "].tensor.shapes[" + std::to_string(axis) + "]";
+      return "(int64_t)orch_args.tensor(" + std::to_string(it->second) + ").shapes[" + std::to_string(axis) + "]";
     }
     // Fallback for non-parameter tensors (views, aliases, internal tensors):
     // read the shape from the runtime Tensor object directly.
@@ -720,7 +708,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
           << stop_expr << "; " << loop_var << " += " << step_expr << ") {\n";
     indent_ += 4;
-    code_ << Indent() << "PTO2_SCOPE(" << ScopeArg() << ") {\n";
+    code_ << Indent() << "PTO2_SCOPE() {\n";
     indent_ += 4;
 
     auto saved = current_return_vars_;
@@ -846,8 +834,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   struct ParamEntry {
-    std::string kind;  // "add_input", "add_output", "add_inout", "add_scalar"
-    std::string value;
+    std::string kind;     // "add_input", "add_output", "add_inout", "add_scalar"
+    std::string value;    // expression passed to the method
+    std::string out_var;  // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
   };
 
   std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
@@ -862,9 +851,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (auto scalar_type = As<ScalarType>(arg->GetType())) {
           std::string cpp_type = scalar_type->dtype_.ToCTypeString();
           if (cpp_type == "float") {
-            params.push_back({"add_scalar", "float_to_u64(" + var_name + ")"});
+            params.push_back({"add_scalar", "float_to_u64(" + var_name + ")", ""});
           } else {
-            params.push_back({"add_scalar", var_name});
+            params.push_back({"add_scalar", var_name, ""});
           }
           continue;
         }
@@ -877,26 +866,34 @@ class OrchestrationStmtCodegen : public CodegenBase {
             << callee_func->param_directions_.size() << ") for callee '" << callee_name << "'";
         ParamDirection dir = callee_func->param_directions_[arg_idx];
         if (dir == ParamDirection::Out) {
-          params.push_back({"add_output", ext_name});
+          if (tensor_create_var_names_.count(var_name)) {
+            // Internal tensor.create tensor (has TensorCreateInfo var_ci):
+            // runtime allocates memory from ring buffer via add_output.
+            params.push_back({"add_output", var_name + "_ci", var_name});
+          } else {
+            // External tensor (from orch args) or view tensor (already has address):
+            // use add_inout since the buffer is pre-allocated.
+            params.push_back({"add_inout", ext_name, ""});
+          }
         } else if (dir == ParamDirection::InOut) {
-          params.push_back({"add_inout", ext_name});
+          params.push_back({"add_inout", ext_name, ""});
         } else {
-          params.push_back({"add_input", ext_name});
+          params.push_back({"add_input", ext_name, ""});
         }
       } else if (auto const_int = As<ConstInt>(arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
-        params.push_back({"add_scalar", "(uint64_t)" + value});
+        params.push_back({"add_scalar", "(uint64_t)" + value, ""});
       } else if (auto const_float = As<ConstFloat>(arg)) {
         std::string cpp_type = const_float->dtype().ToCTypeString();
         std::string value = FormatConstFloatValue(const_float, cpp_type);
         if (cpp_type == "float") {
-          params.push_back({"add_scalar", "float_to_u64(" + value + "f)"});
+          params.push_back({"add_scalar", "float_to_u64(" + value + "f)", ""});
         } else {
-          params.push_back({"add_scalar", "(uint64_t)" + value});
+          params.push_back({"add_scalar", "(uint64_t)" + value, ""});
         }
       } else if (auto const_bool = As<ConstBool>(arg)) {
-        params.push_back({"add_scalar", const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+        params.push_back({"add_scalar", const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0", ""});
       }
     }
 
@@ -941,6 +938,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
       auto assemble_view = TryGenerateAssembleViewForCreate(call, assign_var.get(), emit_var);
       if (assemble_view.has_value()) {
         gen_code = *assemble_view;
+      } else {
+        // Non-assemble-view tensor.create: will generate TensorCreateInfo + null Tensor.
+        // Track the emit name so BuildTaskParams knows to use add_output(var_ci).
+        tensor_create_var_names_.insert(emit_var);
       }
     }
     if (gen_code.empty()) {
@@ -1008,15 +1009,36 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     std::string ind = Indent();
 
-    // Generate PTOParam object and submit_task
+    // Generate Arg object and submit_task
     std::string task_var = "params_t" + std::to_string(task_counter_);
     code_ << "\n";
     code_ << ind << "// Task " << task_counter_ << ": " << callee_name << "\n";
-    code_ << ind << "PTOParam " << task_var << ";\n";
+    code_ << ind << "Arg " << task_var << ";\n";
     for (const auto& p : params) {
       code_ << ind << task_var << "." << p.kind << "(" << p.value << ");\n";
     }
-    code_ << ind << CoreTypeToSubmitPrefix(core_type) << func_id << ", " << task_var << ");\n";
+
+    // Collect internal Out tensors that need to be bound from TaskOutputTensors.
+    std::vector<std::string> internal_out_vars;
+    for (const auto& p : params) {
+      if (p.kind == "add_output" && !p.out_var.empty()) {
+        internal_out_vars.push_back(p.out_var);
+      }
+    }
+
+    std::string submit_expr = CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    if (internal_out_vars.empty()) {
+      code_ << ind << submit_expr << ";\n";
+    } else {
+      // Capture TaskOutputTensors and copy-assign each internal output tensor.
+      // Copy-assignment updates the existing null-addr Tensor declared by tensor.create
+      // with the runtime-allocated address from the ring buffer.
+      std::string outs_var = "outs_t" + std::to_string(task_counter_);
+      code_ << ind << "TaskOutputTensors " << outs_var << " = " << submit_expr << ";\n";
+      for (size_t i = 0; i < internal_out_vars.size(); ++i) {
+        code_ << ind << internal_out_vars[i] << " = " << outs_var << ".get_ref(" << i << ");\n";
+      }
+    }
 
     task_counter_++;
   }
@@ -1056,14 +1078,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     code_ << "\n";
     code_ << ind << "// Group " << group_name << ": MixedKernels (AIC + AIV)\n";
-    code_ << ind << "PTOParam " << task_var << ";\n";
+    code_ << ind << "Arg " << task_var << ";\n";
     for (const auto& p : params) {
       code_ << ind << task_var << "." << p.kind << "(" << p.value << ");\n";
     }
     code_ << ind << "MixedKernels mixed_" << task_counter_ << " = {" << aic_id << ", " << aiv_id
           << ", INVALID_KERNEL_ID};\n";
-    code_ << ind << "pto2_rt_submit_task(" << RtArg() << "mixed_" << task_counter_ << ", " << task_var
-          << ");\n";
+
+    // Collect internal Out tensors that need to be bound from TaskOutputTensors.
+    std::vector<std::string> internal_out_vars;
+    for (const auto& p : params) {
+      if (p.kind == "add_output" && !p.out_var.empty()) {
+        internal_out_vars.push_back(p.out_var);
+      }
+    }
+
+    std::string submit_expr =
+        "pto2_rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";
+    if (internal_out_vars.empty()) {
+      code_ << ind << submit_expr << ";\n";
+    } else {
+      std::string outs_var = "outs_t" + std::to_string(task_counter_);
+      code_ << ind << "TaskOutputTensors " << outs_var << " = " << submit_expr << ";\n";
+      for (size_t i = 0; i < internal_out_vars.size(); ++i) {
+        code_ << ind << internal_out_vars[i] << " = " << outs_var << ".get_ref(" << i << ");\n";
+      }
+    }
 
     task_counter_++;
   }
@@ -1127,7 +1167,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   // Visit a branch body (then/else) inside a PTO2_SCOPE, with return vars scoped.
   void VisitScopedBranchBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
     indent_ += 4;
-    code_ << Indent() << "PTO2_SCOPE(" << ScopeArg() << ") {\n";
+    code_ << Indent() << "PTO2_SCOPE() {\n";
     indent_ += 4;
 
     auto saved = current_return_vars_;
@@ -1249,12 +1289,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::set<std::string> declared_var_names_;  // Tracks all emitted names to prevent collisions
   std::unordered_map<const Var*, const Var*> var_to_param_;
   std::set<std::string> param_name_set_;                 // For string-only contexts (op codegen callbacks)
-  std::map<std::string, int> param_name_to_orch_index_;  // emit_name → orch[] index
+  std::map<std::string, int> param_name_to_orch_index_;  // emit_name → orch_args.tensor() index (tensors only)
   std::unordered_map<const Var*, const Var*> buffer_root_map_;
   std::unordered_map<const Var*, AssembleViewInfo> assemble_view_infos_;
   std::unordered_set<const Var*> non_optimizable_assemble_roots_;
   // Roots whose tensor.create was rewritten to a target.view for tensor.assemble.
   std::unordered_set<const Var*> emitted_assemble_view_roots_;
+  // Names of variables declared via tensor.create (have a TensorCreateInfo var_ci).
+  // Used to distinguish runtime-allocated tensors (add_output) from view tensors (add_inout).
+  std::set<std::string> tensor_create_var_names_;
   std::ostringstream code_;
   int indent_ = 4;
   std::string current_result_var_;
@@ -1296,7 +1339,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   std::set<std::string> param_name_set;
   std::map<std::string, int> param_name_to_orch_index;
   int tensor_param_count = 0;
-  // Collect scalar params in declaration order for TaskArg assignment after tensors
+  // Collect scalar params in declaration order for ChipStorageTaskArgs scalar slot assignment
   struct ScalarParamInfo {
     std::string emit_name;
     ScalarTypePtr scalar_type;
@@ -1314,11 +1357,8 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  // Scalar params occupy TaskArg slots after all tensor params
-  int scalar_param_start = tensor_param_count;
-  for (size_t i = 0; i < scalar_params.size(); ++i) {
-    param_name_to_orch_index[scalar_params[i].emit_name] = scalar_param_start + static_cast<int>(i);
-  }
+  // Scalar params are handled separately via GenerateScalarUnpack (0-indexed in ChipStorageTaskArgs.scalars_).
+  // They are NOT inserted into param_name_to_orch_index since that map is for tensor slots only.
 
   // Step 4c: Lineage alias — map iter_args/return_vars to their param's emit name
   for (const auto& [body_var, param_var] : lineage.var_to_param) {
@@ -1349,11 +1389,8 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   // 5. Entry function
   oss << "__attribute__((visibility(\"default\")))\n";
-  std::string rt_param = IsA5Backend() ? "PTO2Runtime* rt, " : "";
-  oss << "void aicpu_orchestration_entry(" << rt_param
-      << "TaskArg* orch, int arg_count, "
+  oss << "void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args, "
          "int orch_thread_num, int orch_thread_index) {\n";
-  oss << "    (void)arg_count;\n";
   oss << "    (void)orch_thread_num;\n";
   oss << "    (void)orch_thread_index;\n\n";
 
@@ -1367,7 +1404,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.SetAssembleViewInfos(buffer_info.assemble_view_infos);
   stmt_codegen.SetNonOptimizableAssembleRoots(buffer_info.non_optimizable_assemble_roots);
 
-  // 6. External tensors (from TaskArg — all from params)
+  // 6. External tensors (from ChipStorageTaskArgs — all from params)
   oss << "    // External tensors\n";
   int orch_idx = 0;
   for (const auto& var : func->params_) {
@@ -1379,12 +1416,11 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  // 7. Scalar params (from TaskArg — slots after tensors)
+  // 7. Scalar params (from ChipStorageTaskArgs scalar slots — 0-indexed separately from tensors)
   if (!scalar_params.empty()) {
     oss << "\n    // Scalar params\n";
     for (size_t i = 0; i < scalar_params.size(); ++i) {
-      int scalar_orch_idx = scalar_param_start + static_cast<int>(i);
-      oss << GenerateScalarUnpack(scalar_params[i].emit_name, scalar_orch_idx, scalar_params[i].scalar_type);
+      oss << GenerateScalarUnpack(scalar_params[i].emit_name, static_cast<int>(i), scalar_params[i].scalar_type);
     }
   }
 
@@ -1393,7 +1429,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.VisitStmt(func->body_);
 
   // 10. Emit generated code inside PTO2_SCOPE (required by runtime: scope_stack_top must be >= 0)
-  oss << "\n    PTO2_SCOPE(" << ScopeArg() << ") {\n";
+  oss << "\n    PTO2_SCOPE() {\n";
   oss << stmt_codegen.GetGeneratedCode();
   oss << "    }\n";
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -819,9 +819,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   struct ParamEntry {
-    std::string kind;     // "add_input", "add_output", "add_inout", "add_scalar"
-    std::string value;    // expression passed to the method
-    std::string out_var;  // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
+    std::string kind;              // "add_input", "add_output", "add_inout", "add_scalar"
+    std::string value;             // expression passed to the method
+    std::string out_var;           // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
+    bool out_var_is_new_decl = false;  // true: emit "const Tensor& var = get_ref()" (non-DN);
+                                       // false: emit "var = get_ref()" (DN, pre-declared placeholder)
   };
 
   std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
@@ -854,16 +856,31 @@ class OrchestrationStmtCodegen : public CodegenBase {
           if (tensor_create_var_names_.count(var_name)) {
             // Internal tensor.create tensor (has TensorCreateInfo var_ci):
             // runtime allocates memory from ring buffer via add_output.
-            params.push_back({"add_output", var_name + "_ci", var_name});
+            // DN tensors have a pre-declared null placeholder (copy-assign at submit).
+            // Non-DN tensors declare const Tensor& at the submit site.
+            bool is_dn = false;
+            if (auto tt = As<TensorType>(arg->GetType())) {
+              is_dn = tt->tensor_view_.has_value() && tt->tensor_view_->layout == TensorLayout::DN;
+            }
+            params.push_back({"add_output", var_name + "_ci", var_name, /*out_var_is_new_decl=*/!is_dn});
           } else {
             // External tensor (from orch args) or view tensor (already has address):
             // use add_inout since the buffer is pre-allocated.
-            params.push_back({"add_inout", ext_name, ""});
+            params.push_back({"add_inout", ext_name, "", false});
           }
         } else if (dir == ParamDirection::InOut) {
           params.push_back({"add_inout", ext_name, ""});
         } else {
-          params.push_back({"add_input", ext_name, ""});
+          // Input direction: tensor.create vars still need runtime memory allocation.
+          if (tensor_create_var_names_.count(var_name)) {
+            bool is_dn = false;
+            if (auto tt = As<TensorType>(arg->GetType())) {
+              is_dn = tt->tensor_view_.has_value() && tt->tensor_view_->layout == TensorLayout::DN;
+            }
+            params.push_back({"add_output", var_name + "_ci", var_name, /*out_var_is_new_decl=*/!is_dn});
+          } else {
+            params.push_back({"add_input", ext_name, ""});
+          }
         }
       } else if (auto const_int = As<ConstInt>(arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
@@ -1004,10 +1021,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
 
     // Collect internal Out tensors that need to be bound from TaskOutputTensors.
-    std::vector<std::string> internal_out_vars;
+    struct InternalOutVar {
+      std::string name;
+      bool is_new_decl;
+    };
+    std::vector<InternalOutVar> internal_out_vars;
     for (const auto& p : params) {
       if (p.kind == "add_output" && !p.out_var.empty()) {
-        internal_out_vars.push_back(p.out_var);
+        internal_out_vars.push_back({p.out_var, p.out_var_is_new_decl});
       }
     }
 
@@ -1016,13 +1037,20 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (internal_out_vars.empty()) {
       code_ << ind << submit_expr << ";\n";
     } else {
-      // Capture TaskOutputTensors and copy-assign each internal output tensor.
-      // Copy-assignment updates the existing null-addr Tensor declared by tensor.create
-      // with the runtime-allocated address from the ring buffer.
+      // Capture TaskOutputTensors and bind each internal output tensor.
+      // Non-DN: declare const Tensor& at submit site (no prior null placeholder).
+      // DN: copy-assign to pre-declared null placeholder.
       std::string outs_var = "outs_t" + std::to_string(task_counter_);
       code_ << ind << "TaskOutputTensors " << outs_var << " = " << submit_expr << ";\n";
       for (size_t i = 0; i < internal_out_vars.size(); ++i) {
-        code_ << ind << internal_out_vars[i] << " = " << outs_var << ".get_ref(" << i << ");\n";
+        const auto& ov = internal_out_vars[i];
+        if (ov.is_new_decl) {
+          code_ << ind << "const Tensor& " << ov.name << " = " << outs_var << ".get_ref(" << i << ");\n";
+        } else {
+          code_ << ind << ov.name << " = " << outs_var << ".get_ref(" << i << ");\n";
+        }
+        // Mark as bound: subsequent uses should use add_input, not add_output.
+        tensor_create_var_names_.erase(ov.name);
       }
     }
 
@@ -1072,10 +1100,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
           << ", INVALID_KERNEL_ID};\n";
 
     // Collect internal Out tensors that need to be bound from TaskOutputTensors.
-    std::vector<std::string> internal_out_vars;
+    struct InternalOutVar {
+      std::string name;
+      bool is_new_decl;
+    };
+    std::vector<InternalOutVar> internal_out_vars;
     for (const auto& p : params) {
       if (p.kind == "add_output" && !p.out_var.empty()) {
-        internal_out_vars.push_back(p.out_var);
+        internal_out_vars.push_back({p.out_var, p.out_var_is_new_decl});
       }
     }
 
@@ -1087,7 +1119,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       std::string outs_var = "outs_t" + std::to_string(task_counter_);
       code_ << ind << "TaskOutputTensors " << outs_var << " = " << submit_expr << ";\n";
       for (size_t i = 0; i < internal_out_vars.size(); ++i) {
-        code_ << ind << internal_out_vars[i] << " = " << outs_var << ".get_ref(" << i << ");\n";
+        const auto& ov = internal_out_vars[i];
+        if (ov.is_new_decl) {
+          code_ << ind << "const Tensor& " << ov.name << " = " << outs_var << ".get_ref(" << i << ");\n";
+        } else {
+          code_ << ind << ov.name << " = " << outs_var << ".get_ref(" << i << ");\n";
+        }
+        // Mark as bound: subsequent uses should use add_input, not add_output.
+        tensor_create_var_names_.erase(ov.name);
       }
     }
 
@@ -1108,11 +1147,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return out_indices;
   }
 
-  // Emit "Tensor& alias = ext_source;" when alias differs from source.
+  // Emit "const Tensor& alias = ext_source;" when alias differs from source.
   void EmitTensorAlias(const std::string& alias_name, const CallPtr& call, size_t arg_idx) {
     std::string out_arg = TryGetVarName(call->args_[arg_idx]);
     if (!out_arg.empty() && alias_name != out_arg) {
-      code_ << Indent() << "Tensor& " << alias_name << " = " << GetExternalTensorName(out_arg) << ";\n";
+      code_ << Indent() << "const Tensor& " << alias_name << " = " << GetExternalTensorName(out_arg) << ";\n";
     }
   }
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -479,30 +479,14 @@ std::string GenerateIncludes() {
   return oss.str();
 }
 
-std::string GenerateHelperFunctions() {
-  std::ostringstream oss;
-  oss << "// Helper to encode float as uint64_t for scalar params\n";
-  oss << "static uint64_t float_to_u64(float f) {\n";
-  oss << "    union {\n";
-  oss << "        float f32;\n";
-  oss << "        uint64_t u64;\n";
-  oss << "    } conv;\n";
-  oss << "    conv.u64 = 0;  // Clear upper bits\n";
-  oss << "    conv.f32 = f;\n";
-  oss << "    return conv.u64;\n";
-  oss << "}\n\n";
-  return oss.str();
-}
-
 // Generate scalar variable declaration from ChipStorageTaskArgs scalar slot.
-// Uses union-based type punning to reinterpret the uint64_t scalar as the target C type.
+// Uses from_u64<T>() from data_type.h to safely reinterpret the uint64_t scalar as the target C type.
 std::string GenerateScalarUnpack(const std::string& var_name, int scalar_index,
                                  const ScalarTypePtr& scalar_type) {
   std::ostringstream oss;
   std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-  oss << "    union { uint64_t u64; " << cpp_type << " val; } " << var_name << "_conv;\n";
-  oss << "    " << var_name << "_conv.u64 = orch_args.scalar(" << scalar_index << ");\n";
-  oss << "    " << cpp_type << " " << var_name << " = " << var_name << "_conv.val;\n";
+  oss << "    " << cpp_type << " " << var_name << " = from_u64<" << cpp_type << ">(orch_args.scalar("
+      << scalar_index << "));\n";
   return oss.str();
 }
 
@@ -851,7 +835,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (auto scalar_type = As<ScalarType>(arg->GetType())) {
           std::string cpp_type = scalar_type->dtype_.ToCTypeString();
           if (cpp_type == "float") {
-            params.push_back({"add_scalar", "float_to_u64(" + var_name + ")", ""});
+            params.push_back({"add_scalar", "to_u64(" + var_name + ")", ""});
           } else {
             params.push_back({"add_scalar", var_name, ""});
           }
@@ -888,7 +872,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         std::string cpp_type = const_float->dtype().ToCTypeString();
         std::string value = FormatConstFloatValue(const_float, cpp_type);
         if (cpp_type == "float") {
-          params.push_back({"add_scalar", "float_to_u64(" + value + "f)", ""});
+          params.push_back({"add_scalar", "to_u64(" + value + "f)", ""});
         } else {
           params.push_back({"add_scalar", "(uint64_t)" + value, ""});
         }
@@ -1377,9 +1361,6 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   // 1. Includes
   oss << GenerateIncludes();
-
-  // 2. Helper functions
-  oss << GenerateHelperFunctions();
 
   // 3. extern "C" block
   oss << "extern \"C\" {\n\n";

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -819,9 +819,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   struct ParamEntry {
-    std::string kind;              // "add_input", "add_output", "add_inout", "add_scalar"
-    std::string value;             // expression passed to the method
-    std::string out_var;           // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
+    std::string kind;     // "add_input", "add_output", "add_inout", "add_scalar"
+    std::string value;    // expression passed to the method
+    std::string out_var;  // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
     bool out_var_is_new_decl = false;  // true: emit "const Tensor& var = get_ref()" (non-DN);
                                        // false: emit "var = get_ref()" (DN, pre-declared placeholder)
   };

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -560,8 +560,8 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
         << "orch_args.tensor(" << orch_index << ").shapes[1], "
         << "orch_args.tensor(" << orch_index << ").shapes[0]};\n";
     oss << "    Tensor ext_" << var_name << " = make_tensor_external_2d_dn("
-        << "orch_args.tensor(" << orch_index << ").data_as<void>(), " << var_name << "_shapes, " << ndim << ", "
-        << codegen.GetRuntimeDataTypeString(tensor_type->dtype_) << ");\n";
+        << "orch_args.tensor(" << orch_index << ").data_as<void>(), " << var_name << "_shapes, " << ndim
+        << ", " << codegen.GetRuntimeDataTypeString(tensor_type->dtype_) << ");\n";
   } else {
     // ND layout: use from_tensor_arg() to convert ContinuousTensor to Tensor
     oss << "    Tensor ext_" << var_name << " = from_tensor_arg(orch_args.tensor(" << orch_index << "));\n";
@@ -658,7 +658,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   [[nodiscard]] std::string GetTensorShapeDim(const std::string& name, int64_t axis) const override {
     auto it = param_name_to_orch_index_.find(name);
     if (it != param_name_to_orch_index_.end()) {
-      return "(int64_t)orch_args.tensor(" + std::to_string(it->second) + ").shapes[" + std::to_string(axis) + "]";
+      return "(int64_t)orch_args.tensor(" + std::to_string(it->second) + ").shapes[" + std::to_string(axis) +
+             "]";
     }
     // Fallback for non-parameter tensors (views, aliases, internal tensors):
     // read the shape from the runtime Tensor object directly.
@@ -1010,7 +1011,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
-    std::string submit_expr = CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    std::string submit_expr =
+        CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
     if (internal_out_vars.empty()) {
       code_ << ind << submit_expr << ";\n";
     } else {
@@ -1272,8 +1274,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_map<const Var*, std::string> emit_name_map_;
   std::set<std::string> declared_var_names_;  // Tracks all emitted names to prevent collisions
   std::unordered_map<const Var*, const Var*> var_to_param_;
-  std::set<std::string> param_name_set_;                 // For string-only contexts (op codegen callbacks)
-  std::map<std::string, int> param_name_to_orch_index_;  // emit_name → orch_args.tensor() index (tensors only)
+  std::set<std::string> param_name_set_;  // For string-only contexts (op codegen callbacks)
+  std::map<std::string, int>
+      param_name_to_orch_index_;  // emit_name → orch_args.tensor() index (tensors only)
   std::unordered_map<const Var*, const Var*> buffer_root_map_;
   std::unordered_map<const Var*, AssembleViewInfo> assemble_view_infos_;
   std::unordered_set<const Var*> non_optimizable_assemble_roots_;
@@ -1341,8 +1344,9 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  // Scalar params are handled separately via GenerateScalarUnpack (0-indexed in ChipStorageTaskArgs.scalars_).
-  // They are NOT inserted into param_name_to_orch_index since that map is for tensor slots only.
+  // Scalar params are handled separately via GenerateScalarUnpack (0-indexed in
+  // ChipStorageTaskArgs.scalars_). They are NOT inserted into param_name_to_orch_index since that map is for
+  // tensor slots only.
 
   // Step 4c: Lineage alias — map iter_args/return_vars to their param's emit name
   for (const auto& [body_var, param_var] : lineage.var_to_param) {
@@ -1401,7 +1405,8 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   if (!scalar_params.empty()) {
     oss << "\n    // Scalar params\n";
     for (size_t i = 0; i < scalar_params.size(); ++i) {
-      oss << GenerateScalarUnpack(scalar_params[i].emit_name, static_cast<int>(i), scalar_params[i].scalar_type);
+      oss << GenerateScalarUnpack(scalar_params[i].emit_name, static_cast<int>(i),
+                                  scalar_params[i].scalar_type);
     }
   }
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -59,7 +59,10 @@ static std::string CalculateTensorSizeExpr(const TensorTypePtr& tensor_type, Cod
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
-  // tensor.create -> uint32_t var_shapes[N] = {...}; Tensor var = make_tensor(var_shapes, N, DataType::XX);
+  // tensor.create emits:
+  //   1. TensorCreateInfo var_ci(...) — used for add_output() in kernel dispatch
+  //   2. Tensor var = make_tensor_external(nullptr, ...) — initial null-addr tensor for add_input() uses
+  //      After an add_output() submit, the Tensor is updated via: var = outs.get_ref(i);
   auto result_type = As<TensorType>(op->GetType());
   CHECK(result_type) << "tensor.create must return TensorType";
 
@@ -67,21 +70,27 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
   size_t ndim = result_type->shape_.size();
 
   std::ostringstream oss;
-  oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
+  oss << "uint32_t " << result_var << "_ci_shapes[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
     oss << codegen.GenerateExprString(result_type->shape_[i]);
   }
   oss << "};\n";
 
-  // check layout DN
-  std::string runtime_func = "make_tensor";
-  if (result_type->tensor_view_.has_value() && result_type->tensor_view_->layout == TensorLayout::DN) {
+  std::string dtype_str = codegen.GetRuntimeDataTypeString(result_type->dtype_);
+  oss << "TensorCreateInfo " << result_var << "_ci(" << result_var << "_ci_shapes, " << ndim << ", " << dtype_str
+      << ");\n";
+
+  // Also declare a null-addr Tensor for input uses and as target for copy-assignment after output submit.
+  bool is_dn = result_type->tensor_view_.has_value() && result_type->tensor_view_->layout == TensorLayout::DN;
+  if (is_dn) {
     CHECK(ndim == 2) << "only support 2D tensor for DN layout now";
-    runtime_func = "make_tensor_2d_dn";
+    oss << "Tensor " << result_var << " = make_tensor_2d_dn(" << result_var << "_ci_shapes, " << ndim << ", "
+        << dtype_str << ");";
+  } else {
+    oss << "Tensor " << result_var << " = make_tensor_external(nullptr, " << result_var << "_ci_shapes, " << ndim
+        << ", " << dtype_str << ");";
   }
-  oss << "Tensor " << result_var << " = " << runtime_func << "(" << result_var << "_shapes, " << ndim << ", "
-      << codegen.GetRuntimeDataTypeString(result_type->dtype_) << ");";
   return oss.str();
 }
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -78,8 +78,8 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
   oss << "};\n";
 
   std::string dtype_str = codegen.GetRuntimeDataTypeString(result_type->dtype_);
-  oss << "TensorCreateInfo " << result_var << "_ci(" << result_var << "_ci_shapes, " << ndim << ", " << dtype_str
-      << ");\n";
+  oss << "TensorCreateInfo " << result_var << "_ci(" << result_var << "_ci_shapes, " << ndim << ", "
+      << dtype_str << ");\n";
 
   // Also declare a null-addr Tensor for input uses and as target for copy-assignment after output submit.
   bool is_dn = result_type->tensor_view_.has_value() && result_type->tensor_view_->layout == TensorLayout::DN;
@@ -88,8 +88,8 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
     oss << "Tensor " << result_var << " = make_tensor_2d_dn(" << result_var << "_ci_shapes, " << ndim << ", "
         << dtype_str << ");";
   } else {
-    oss << "Tensor " << result_var << " = make_tensor_external(nullptr, " << result_var << "_ci_shapes, " << ndim
-        << ", " << dtype_str << ");";
+    oss << "Tensor " << result_var << " = make_tensor_external(nullptr, " << result_var << "_ci_shapes, "
+        << ndim << ", " << dtype_str << ");";
   }
   return oss.str();
 }

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -59,10 +59,11 @@ static std::string CalculateTensorSizeExpr(const TensorTypePtr& tensor_type, Cod
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
-  // tensor.create emits:
-  //   1. TensorCreateInfo var_ci(...) — used for add_output() in kernel dispatch
-  //   2. Tensor var = make_tensor_external(nullptr, ...) — initial null-addr tensor for add_input() uses
-  //      After an add_output() submit, the Tensor is updated via: var = outs.get_ref(i);
+  // tensor.create emits TensorCreateInfo for runtime memory allocation via add_output().
+  // For non-DN tensors, the Tensor binding is emitted at the task submission site:
+  //   const Tensor& var = outs_tN.get_ref(i);
+  // For DN tensors, a null-addr placeholder with view transformation is pre-declared here,
+  // and copy-assigned at the submission site (unchanged behavior).
   auto result_type = As<TensorType>(op->GetType());
   CHECK(result_type) << "tensor.create must return TensorType";
 
@@ -79,18 +80,16 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
 
   std::string dtype_str = codegen.GetRuntimeDataTypeString(result_type->dtype_);
   oss << "TensorCreateInfo " << result_var << "_ci(" << result_var << "_ci_shapes, " << ndim << ", "
-      << dtype_str << ");\n";
+      << dtype_str << ");";
 
-  // Also declare a null-addr Tensor for input uses and as target for copy-assignment after output submit.
+  // DN layout: pre-declare null Tensor with logical view (copy-assigned after submit).
   bool is_dn = result_type->tensor_view_.has_value() && result_type->tensor_view_->layout == TensorLayout::DN;
   if (is_dn) {
     CHECK(ndim == 2) << "only support 2D tensor for DN layout now";
-    oss << "Tensor " << result_var << " = make_tensor_2d_dn(" << result_var << "_ci_shapes, " << ndim << ", "
-        << dtype_str << ");";
-  } else {
-    oss << "Tensor " << result_var << " = make_tensor_external(nullptr, " << result_var << "_ci_shapes, "
-        << ndim << ", " << dtype_str << ");";
+    oss << "\nTensor " << result_var << " = make_tensor_2d_dn(" << result_var << "_ci_shapes, " << ndim
+        << ", " << dtype_str << ");";
   }
+  // Non-DN: no placeholder; const Tensor& var declared at submit site via outs_tN.get_ref(i).
   return oss.str();
 }
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -18,6 +18,7 @@ import inspect
 import os
 import random
 import re
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -42,6 +43,10 @@ from harness.core.environment import (  # noqa: E402
 from harness.core.test_runner import TestRunner  # noqa: E402
 from pypto import LogLevel, set_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
+
+# Temp directories created for pre-compilation (when --save-kernels is not set).
+# Cleaned up in pytest_sessionfinish.
+_temp_precompile_dirs: list[Path] = []
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -262,7 +267,12 @@ def pytest_collection_finish(session: pytest.Session) -> None:
       compile-on-demand path inside ``TestRunner.run()``.
     """
     from harness.core.harness import PTOTestCase
-    from harness.core.test_runner import _precompile_cache, precompile_test_cases, pregenerate_golden_inputs, prebuild_binaries
+    from harness.core.test_runner import (
+        _precompile_cache,
+        prebuild_binaries,
+        precompile_test_cases,
+        pregenerate_golden_inputs,
+    )
 
     if not session.items:
         return
@@ -341,6 +351,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         cache_dir.mkdir(parents=True, exist_ok=True)
     else:
         cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_"))
+        _temp_precompile_dirs.append(cache_dir)
 
     # ── compile in parallel ───────────────────────────────────────────────────
     test_cases = list(seen.values())
@@ -356,9 +367,14 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     # Only makes sense when there are successful pre-compilations (golden.py
     # files must exist before we can load and call generate_inputs).
     if n_ok > 0:
-        ok_cases = [tc for tc in test_cases if tc.get_name() in _precompile_cache
-                    and _precompile_cache[tc.get_name()][1] is None]
-        print(f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…")
+        ok_cases = [
+            tc
+            for tc in test_cases
+            if tc.get_name() in _precompile_cache and _precompile_cache[tc.get_name()][1] is None
+        ]
+        print(
+            f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…"
+        )
         n_gen = pregenerate_golden_inputs(ok_cases, cache_dir, max_workers=max_workers)
         print(f"[PyPTO] Golden inputs pre-generated — {n_gen} case(s) cached\n")
 
@@ -369,6 +385,14 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         # CodeRunner calls serve from disk without recompiling.
         if not session.config.getoption("--codegen-only"):
             platform: str = session.config.getoption("--platform")
-            print(f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…")
+            print(
+                f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…"
+            )
             n_built = prebuild_binaries(ok_cases, cache_dir, platform, max_workers=max_workers)
             print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
+    """Clean up temporary pre-compilation directories created during the session."""
+    for d in _temp_precompile_dirs:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -170,6 +170,12 @@ def pytest_addoption(parser):
         choices=["DEBUG", "INFO", "WARN", "ERROR", "FATAL", "EVENT", "NONE"],
         help="PyPTO C++ log level threshold (default: ERROR)",
     )
+    parser.addoption(
+        "--pto-isa-commit",
+        action="store",
+        default=None,
+        help="Pin the pto-isa clone to a specific git commit (hash or tag). Default: use latest remote HEAD.",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -193,6 +199,7 @@ def test_config(request) -> RunConfig:
         save_kernels_dir=save_kernels_dir,
         dump_passes=request.config.getoption("--dump-passes"),
         codegen_only=request.config.getoption("--codegen-only"),
+        pto_isa_commit=request.config.getoption("--pto-isa-commit"),
     )
 
 
@@ -403,6 +410,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         # CodeRunner calls serve from disk without recompiling.
         if not session.config.getoption("--codegen-only"):
             platform: str = session.config.getoption("--platform")
+            pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
             # Ensure SIMPLER_ROOT is available before prebuild_binaries checks it.
             # This hook runs before session fixtures, so setup_simpler_dependency
             # may not have set it yet.
@@ -411,7 +419,9 @@ def pytest_collection_finish(session: pytest.Session) -> None:
                 f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
                 f" in parallel (workers={workers_str})…"
             )
-            n_built = prebuild_binaries(ok_cases, cache_dir, platform, max_workers=max_workers)
+            n_built = prebuild_binaries(
+                ok_cases, cache_dir, platform, max_workers=max_workers, pto_isa_commit=pto_isa_commit
+            )
             print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")
 
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -40,13 +41,35 @@ from harness.core.environment import (  # noqa: E402
     get_simpler_python_path,
     get_simpler_scripts_path,
 )
-from harness.core.test_runner import TestRunner  # noqa: E402
+from harness.core.harness import PTOTestCase  # noqa: E402
+from harness.core.test_runner import (  # noqa: E402
+    TestRunner,
+    _precompile_cache,
+    prebuild_binaries,
+    precompile_test_cases,
+    pregenerate_golden_inputs,
+)
 from pypto import LogLevel, set_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
 
 # Temp directories created for pre-compilation (when --save-kernels is not set).
 # Cleaned up in pytest_sessionfinish.
 _temp_precompile_dirs: list[Path] = []
+
+
+def _init_simpler_root_if_needed() -> None:
+    """Populate SIMPLER_ROOT if not already set.
+
+    pytest_collection_finish runs before session fixtures, so
+    setup_simpler_dependency may not have set SIMPLER_ROOT yet when
+    prebuild_binaries is called.  This function bridges that gap.
+    """
+    if os.environ.get("SIMPLER_ROOT"):
+        return
+    try:
+        os.environ["SIMPLER_ROOT"] = str(ensure_simpler_available())
+    except Exception:
+        pass  # SIMPLER_ROOT unavailable; prebuild_binaries will bail out early
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -251,6 +274,53 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_a5)
 
 
+def _collect_test_case_from_item(item: pytest.Item, seen: dict[str, PTOTestCase]) -> None:
+    """Inspect *item* and add any newly discovered PTOTestCase instance to *seen*."""
+    if any(m.name == "skip" for m in item.iter_markers()):
+        return
+
+    module = item.module
+
+    # Collect PTOTestCase subclasses visible in this module.
+    testcase_classes: dict[str, type] = {}
+    for attr in dir(module):
+        obj = getattr(module, attr, None)
+        if (
+            obj is not None
+            and isinstance(obj, type)
+            and issubclass(obj, PTOTestCase)
+            and obj is not PTOTestCase
+        ):
+            testcase_classes[attr] = obj
+
+    if not testcase_classes:
+        return
+
+    # callspec params for @pytest.mark.parametrize (empty dict if none).
+    callspec = getattr(item, "callspec", None)
+    call_params: dict[str, Any] = callspec.params if callspec else {}
+
+    # Scan test function source to find which class name is referenced.
+    try:
+        source = inspect.getsource(item.function)
+    except (OSError, TypeError):
+        return
+
+    for cls_name, cls in testcase_classes.items():
+        if not re.search(r"\b" + re.escape(cls_name) + r"\s*\(", source):
+            continue
+        # Filter callspec params to those accepted by __init__.
+        try:
+            sig = inspect.signature(cls.__init__)
+            valid = {k: v for k, v in call_params.items() if k in sig.parameters}
+            instance = cls(**valid)
+        except Exception:
+            continue  # constructor mismatch — skip
+        name = instance.get_name()
+        if name not in seen:
+            seen[name] = instance
+
+
 def pytest_collection_finish(session: pytest.Session) -> None:
     """Phase 1: discover and pre-compile all test cases in parallel after collection.
 
@@ -266,14 +336,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     - Cases that cannot be discovered fall back to the original
       compile-on-demand path inside ``TestRunner.run()``.
     """
-    from harness.core.harness import PTOTestCase
-    from harness.core.test_runner import (
-        _precompile_cache,
-        prebuild_binaries,
-        precompile_test_cases,
-        pregenerate_golden_inputs,
-    )
-
     if not session.items:
         return
 
@@ -281,50 +343,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     seen: dict[str, PTOTestCase] = {}  # test_name → instance (deduped)
 
     for item in session.items:
-        # Skip items already marked as skip (e.g. hardware / a5 markers).
-        if any(m.name == "skip" for m in item.iter_markers()):
-            continue
-
-        module = item.module
-
-        # Collect PTOTestCase subclasses visible in this module.
-        testcase_classes: dict[str, type] = {}
-        for attr in dir(module):
-            obj = getattr(module, attr, None)
-            if (
-                obj is not None
-                and isinstance(obj, type)
-                and issubclass(obj, PTOTestCase)
-                and obj is not PTOTestCase
-            ):
-                testcase_classes[attr] = obj
-
-        if not testcase_classes:
-            continue
-
-        # callspec params for @pytest.mark.parametrize (empty dict if none).
-        callspec = getattr(item, "callspec", None)
-        call_params: dict[str, Any] = callspec.params if callspec else {}
-
-        # Scan test function source to find which class name is referenced.
-        try:
-            source = inspect.getsource(item.function)
-        except (OSError, TypeError):
-            continue
-
-        for cls_name, cls in testcase_classes.items():
-            if not re.search(r"\b" + re.escape(cls_name) + r"\s*\(", source):
-                continue
-            # Filter callspec params to those accepted by __init__.
-            try:
-                sig = inspect.signature(cls.__init__)
-                valid = {k: v for k, v in call_params.items() if k in sig.parameters}
-                instance = cls(**valid)
-            except Exception:
-                continue  # constructor mismatch — skip
-            name = instance.get_name()
-            if name not in seen:
-                seen[name] = instance
+        _collect_test_case_from_item(item, seen)
 
     if not seen:
         return
@@ -344,8 +363,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         if kernels_dir:
             cache_dir = Path(kernels_dir)
         else:
-            from datetime import datetime
-
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             cache_dir = _PROJECT_ROOT / "build_output" / f"precompile_{timestamp}"
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -373,7 +390,8 @@ def pytest_collection_finish(session: pytest.Session) -> None:
             if tc.get_name() in _precompile_cache and _precompile_cache[tc.get_name()][1] is None
         ]
         print(
-            f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…"
+            f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s)"
+            f" in parallel (workers={workers_str})…"
         )
         n_gen = pregenerate_golden_inputs(ok_cases, cache_dir, max_workers=max_workers)
         print(f"[PyPTO] Golden inputs pre-generated — {n_gen} case(s) cached\n")
@@ -385,8 +403,13 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         # CodeRunner calls serve from disk without recompiling.
         if not session.config.getoption("--codegen-only"):
             platform: str = session.config.getoption("--platform")
+            # Ensure SIMPLER_ROOT is available before prebuild_binaries checks it.
+            # This hook runs before session fixtures, so setup_simpler_dependency
+            # may not have set it yet.
+            _init_simpler_root_if_needed()
             print(
-                f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…"
+                f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
+                f" in parallel (workers={workers_str})…"
             )
             n_built = prebuild_binaries(ok_cases, cache_dir, platform, max_workers=max_workers)
             print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -14,10 +14,14 @@ This configuration sets up the testing environment using the internal
 harness package (migrated from pto-testing-framework).
 """
 
+import inspect
 import os
 import random
+import re
 import sys
+import tempfile
 from pathlib import Path
+from typing import Any
 
 # Add harness to path (internal package in tests/st/)
 _ST_DIR = Path(__file__).parent
@@ -36,6 +40,7 @@ from harness.core.environment import (  # noqa: E402
     get_simpler_scripts_path,
 )
 from harness.core.test_runner import TestRunner  # noqa: E402
+from pypto import LogLevel, set_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
 
 
@@ -123,6 +128,20 @@ def pytest_addoption(parser):
         default=False,
         help="Only generate code, skip runtime execution (default: False)",
     )
+    parser.addoption(
+        "--precompile-workers",
+        action="store",
+        default=None,
+        type=int,
+        help="Number of parallel threads for pre-compilation phase (default: min(32, cpu_count+4))",
+    )
+    parser.addoption(
+        "--pypto-log-level",
+        action="store",
+        default="ERROR",
+        choices=["DEBUG", "INFO", "WARN", "ERROR", "FATAL", "EVENT", "NONE"],
+        help="PyPTO C++ log level threshold (default: ERROR)",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -198,11 +217,19 @@ def tensor_shape(request):
 
 # Skip markers
 def pytest_configure(config):
-    """Register custom markers."""
+    """Register custom markers and apply early global settings."""
     config.addinivalue_line("markers", "hardware: mark test as requiring hardware (--platform=a2a3)")
     config.addinivalue_line("markers", "a5: mark test as requiring Ascend 950 (--platform=a5 or a5sim)")
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "fuzz: mark test as fuzz test")
+
+    # Set C++ log level as early as possible so it applies to collection too.
+    # Forked child processes inherit this setting via os.fork().
+    try:
+        level_name: str = config.getoption("--pypto-log-level")
+        set_log_level(LogLevel[level_name])
+    except (ValueError, KeyError):
+        pass  # option not yet registered (e.g. during --co --help)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -217,3 +244,131 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_hardware)
         if "a5" in item.keywords and not platform.startswith("a5"):
             item.add_marker(skip_a5)
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Phase 1: discover and pre-compile all test cases in parallel after collection.
+
+    After pytest finishes collecting tests, this hook inspects each test item to
+    find which PTOTestCase subclass it uses, instantiates those cases, and
+    compiles them all concurrently via a thread pool.
+
+    Discovery strategy (best-effort, no test file changes required):
+    - Find PTOTestCase subclasses in each collected item's module.
+    - Scan the test function source for ``ClassName(`` to identify which class
+      is used in that test.
+    - For parametrised tests, match ``callspec.params`` to ``__init__`` kwargs.
+    - Cases that cannot be discovered fall back to the original
+      compile-on-demand path inside ``TestRunner.run()``.
+    """
+    from harness.core.harness import PTOTestCase
+    from harness.core.test_runner import _precompile_cache, precompile_test_cases, pregenerate_golden_inputs, prebuild_binaries
+
+    if not session.items:
+        return
+
+    # ── discover PTOTestCase instances ───────────────────────────────────────
+    seen: dict[str, PTOTestCase] = {}  # test_name → instance (deduped)
+
+    for item in session.items:
+        # Skip items already marked as skip (e.g. hardware / a5 markers).
+        if any(m.name == "skip" for m in item.iter_markers()):
+            continue
+
+        module = item.module
+
+        # Collect PTOTestCase subclasses visible in this module.
+        testcase_classes: dict[str, type] = {}
+        for attr in dir(module):
+            obj = getattr(module, attr, None)
+            if (
+                obj is not None
+                and isinstance(obj, type)
+                and issubclass(obj, PTOTestCase)
+                and obj is not PTOTestCase
+            ):
+                testcase_classes[attr] = obj
+
+        if not testcase_classes:
+            continue
+
+        # callspec params for @pytest.mark.parametrize (empty dict if none).
+        callspec = getattr(item, "callspec", None)
+        call_params: dict[str, Any] = callspec.params if callspec else {}
+
+        # Scan test function source to find which class name is referenced.
+        try:
+            source = inspect.getsource(item.function)
+        except (OSError, TypeError):
+            continue
+
+        for cls_name, cls in testcase_classes.items():
+            if not re.search(r"\b" + re.escape(cls_name) + r"\s*\(", source):
+                continue
+            # Filter callspec params to those accepted by __init__.
+            try:
+                sig = inspect.signature(cls.__init__)
+                valid = {k: v for k, v in call_params.items() if k in sig.parameters}
+                instance = cls(**valid)
+            except Exception:
+                continue  # constructor mismatch — skip
+            name = instance.get_name()
+            if name not in seen:
+                seen[name] = instance
+
+    if not seen:
+        return
+
+    dump_passes: bool = session.config.getoption("--dump-passes")
+    max_workers: int | None = session.config.getoption("--precompile-workers")
+
+    # Without --precompile-workers the pre-compilation/cache phases are skipped
+    # entirely; each test compiles on demand inside TestRunner.run().
+    if max_workers is None:
+        return
+
+    # ── determine cache directory ─────────────────────────────────────────────
+    save_kernels: bool = session.config.getoption("--save-kernels")
+    kernels_dir: str | None = session.config.getoption("--kernels-dir")
+    if save_kernels:
+        if kernels_dir:
+            cache_dir = Path(kernels_dir)
+        else:
+            from datetime import datetime
+
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            cache_dir = _PROJECT_ROOT / "build_output" / f"precompile_{timestamp}"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_"))
+
+    # ── compile in parallel ───────────────────────────────────────────────────
+    test_cases = list(seen.values())
+    workers_str = str(max_workers) if max_workers is not None else "auto"
+    print(f"\n[PyPTO] Pre-compiling {len(test_cases)} test case(s) in parallel (workers={workers_str})…")
+    precompile_test_cases(test_cases, cache_dir, dump_passes=dump_passes, max_workers=max_workers)
+
+    n_ok = sum(1 for _, err in _precompile_cache.values() if err is None)
+    n_fail = len(_precompile_cache) - n_ok
+    print(f"[PyPTO] Pre-compilation done — {n_ok} ok, {n_fail} failed\n")
+
+    # ── Phase 0: pre-generate golden inputs ──────────────────────────────────
+    # Only makes sense when there are successful pre-compilations (golden.py
+    # files must exist before we can load and call generate_inputs).
+    if n_ok > 0:
+        ok_cases = [tc for tc in test_cases if tc.get_name() in _precompile_cache
+                    and _precompile_cache[tc.get_name()][1] is None]
+        print(f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…")
+        n_gen = pregenerate_golden_inputs(ok_cases, cache_dir, max_workers=max_workers)
+        print(f"[PyPTO] Golden inputs pre-generated — {n_gen} case(s) cached\n")
+
+        # ── Phase 2: pre-build binary artifacts ──────────────────────────────
+        # Compile incore kernels, orchestration .so, and runtime binaries in parallel.
+        # Results are saved to work_dir/cache/ and the global binary_cache/runtimes/
+        # directory. _execute_on_device installs a write-through patch so subsequent
+        # CodeRunner calls serve from disk without recompiling.
+        if not session.config.getoption("--codegen-only"):
+            platform: str = session.config.getoption("--platform")
+            print(f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s) in parallel (workers={workers_str})…")
+            n_built = prebuild_binaries(ok_cases, cache_dir, platform, max_workers=max_workers)
+            print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -627,7 +627,9 @@ class TestRunner:
                 )
 
             platform = _resolve_platform(self.config.platform, backend_type)
-            _execute_on_device(work_dir, golden_path, platform, self.config.device_id, self.config.pto_isa_commit)
+            _execute_on_device(
+                work_dir, golden_path, platform, self.config.device_id, self.config.pto_isa_commit
+            )
 
             return RunResult(
                 passed=True,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -351,6 +351,7 @@ def prebuild_binaries(
     platform: str,
     *,
     max_workers: int | None = None,
+    pto_isa_commit: str | None = None,
 ) -> int:
     """Phase 2: pre-compile binary artifacts for all test cases in parallel.
 
@@ -365,6 +366,8 @@ def prebuild_binaries(
         cache_dir: Root output directory used during precompilation.
         platform: Session platform string (e.g. ``"a2a3"``).
         max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
+        pto_isa_commit: If set, pin the pto-isa clone to this specific git
+            commit (hash or tag).  ``None`` means use latest remote HEAD.
 
     Returns:
         Number of test cases whose kernels and orchestration were successfully
@@ -391,7 +394,7 @@ def prebuild_binaries(
 
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
-    pto_isa_root = _ensure_pto_isa_root(verbose=False, clone_protocol="https")
+    pto_isa_root = _ensure_pto_isa_root(verbose=False, clone_protocol="https", commit=pto_isa_commit)
     if pto_isa_root is None:
         return 0
 
@@ -549,6 +552,7 @@ class TestRunner:
                     cached_dir / "golden.py",
                     platform,
                     self.config.device_id,
+                    self.config.pto_isa_commit,
                 )
                 return RunResult(
                     passed=True,
@@ -623,7 +627,7 @@ class TestRunner:
                 )
 
             platform = _resolve_platform(self.config.platform, backend_type)
-            _execute_on_device(work_dir, golden_path, platform, self.config.device_id)
+            _execute_on_device(work_dir, golden_path, platform, self.config.device_id, self.config.pto_isa_commit)
 
             return RunResult(
                 passed=True,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -202,7 +202,7 @@ def precompile_test_cases(
             ``os.cpu_count()``.
     """
     # Group by backend type so set_backend_type is called once per group.
-    groups: dict[BackendType, list["PTOTestCase"]] = {}
+    groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
         groups.setdefault(tc.get_backend_type(), []).append(tc)
 
@@ -265,8 +265,6 @@ def pregenerate_golden_inputs(
     from pypto.runtime.runner import (
         _golden_cache_file,
         _inputs_cache_file,
-        _load_golden,
-        _load_inputs,
         _save_golden,
         _save_inputs,
     )
@@ -321,9 +319,13 @@ def pregenerate_golden_inputs(
             # Compute golden: replicate the logic in CodeRunner.run()
             output_names = set(getattr(module, "__outputs__", []))
             tensors = {name: val for name, val in result if isinstance(val, torch.Tensor)}
-            golden = {name: tensors[name].clone() for name in output_names if name in tensors}
-            golden_with_inputs = {**{k: v for k, v in tensors.items() if k not in output_names}, **golden}
+            # Clone output tensors so compute_golden modifies the clones (not the originals)
+            golden_with_inputs = {
+                name: val.clone() if name in output_names else val for name, val in tensors.items()
+            }
             module.compute_golden(golden_with_inputs, params)
+            # Save only the output tensors (which now contain the computed values)
+            golden = {name: golden_with_inputs[name] for name in output_names if name in golden_with_inputs}
             _save_golden(golden, golden_file)
             return True
         except Exception:
@@ -374,14 +376,14 @@ def prebuild_binaries(
             sys.path.insert(0, p)
 
     try:
-        from kernel_compiler import KernelCompiler  # type: ignore[import]
-        from runtime_builder import RuntimeBuilder  # type: ignore[import]
         from code_runner import _ensure_pto_isa_root  # type: ignore[import]
+        from kernel_compiler import KernelCompiler  # type: ignore[import]
         from pypto.runtime.runner import (
             _BINARY_RUNTIME_CACHE,
             _get_simpler_stamp,
             _install_binary_cache_patch,
         )
+        from runtime_builder import RuntimeBuilder  # type: ignore[import]
     except ImportError:
         return 0
 
@@ -456,10 +458,7 @@ def prebuild_binaries(
         tc_kernel_futs: list[tuple[list, concurrent.futures.Future]] = []
         for tc, compiler, runtime_name, kernels, orch_source in case_configs:
             runtime_includes = compiler.get_orchestration_include_dirs(runtime_name)[:2]
-            kfuts = [
-                pool.submit(_compile_incore_task, compiler, k, runtime_includes)
-                for k in kernels
-            ]
+            kfuts = [pool.submit(_compile_incore_task, compiler, k, runtime_includes) for k in kernels]
             ofut = pool.submit(_compile_orch_task, compiler, runtime_name, orch_source)
             tc_kernel_futs.append((kfuts, ofut))
             all_futs.extend(kfuts)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -19,7 +19,11 @@ Orchestrates the full test execution pipeline:
 """
 
 import concurrent.futures
+import importlib.util
+import logging
+import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -28,10 +32,22 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
-from pypto.runtime.runner import RunConfig, RunResult, _execute_on_device
+from pypto.runtime.runner import (
+    _BINARY_RUNTIME_CACHE,
+    RunConfig,
+    RunResult,
+    _execute_on_device,
+    _get_simpler_stamp,
+    _golden_cache_file,
+    _inputs_cache_file,
+    _install_binary_cache_patch,
+    _save_golden,
+    _save_inputs,
+)
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
 from harness.core.harness import PTOTestCase
@@ -39,6 +55,7 @@ from harness.core.harness import PTOTestCase
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
 _PROJECT_ROOT = _ST_DIR.parent.parent
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Pre-compilation cache (Phase 1 / Phase 2 split)
@@ -260,14 +277,6 @@ def pregenerate_golden_inputs(
     Returns:
         Number of (test_case, case_name) pairs successfully pre-generated.
     """
-    import importlib.util
-
-    from pypto.runtime.runner import (
-        _golden_cache_file,
-        _inputs_cache_file,
-        _save_golden,
-        _save_inputs,
-    )
 
     def _load_module(path: Path, name: str):
         spec = importlib.util.spec_from_file_location(name, path)
@@ -308,8 +317,6 @@ def pregenerate_golden_inputs(
 
     # ── Generate in parallel (one task per (test_case, case_name) pair) ──────
     def _gen_case(module, golden_path: Path, case_name: str, params: dict) -> bool:
-        import torch
-
         inputs_file = _inputs_cache_file(golden_path, case_name)
         golden_file = _golden_cache_file(golden_path, case_name)
         try:
@@ -363,10 +370,6 @@ def prebuild_binaries(
         Number of test cases whose kernels and orchestration were successfully
         pre-built.
     """
-    import importlib.util
-    import os
-    import sys
-
     simpler_root = os.environ.get("SIMPLER_ROOT", "")
     if not simpler_root:
         return 0
@@ -376,16 +379,15 @@ def prebuild_binaries(
             sys.path.insert(0, p)
 
     try:
-        from code_runner import _ensure_pto_isa_root  # type: ignore[import]
-        from kernel_compiler import KernelCompiler  # type: ignore[import]
-        from pypto.runtime.runner import (
-            _BINARY_RUNTIME_CACHE,
-            _get_simpler_stamp,
-            _install_binary_cache_patch,
-        )
-        from runtime_builder import RuntimeBuilder  # type: ignore[import]
+        code_runner_mod = importlib.import_module("code_runner")
+        kernel_compiler_mod = importlib.import_module("kernel_compiler")
+        runtime_builder_mod = importlib.import_module("runtime_builder")
     except ImportError:
         return 0
+
+    _ensure_pto_isa_root = code_runner_mod._ensure_pto_isa_root
+    KernelCompiler = kernel_compiler_mod.KernelCompiler
+    RuntimeBuilder = runtime_builder_mod.RuntimeBuilder
 
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
@@ -464,13 +466,14 @@ def prebuild_binaries(
             all_futs.extend(kfuts)
             all_futs.append(ofut)
 
-        # Wait for everything; swallow individual failures (write-through patch
-        # simply won't cache on failure, test will fall back to live compilation)
+        # Wait for everything; individual failures are logged but non-fatal:
+        # the write-through patch simply won't cache on failure and the test
+        # falls back to live compilation.
         for fut in concurrent.futures.as_completed(all_futs):
             try:
                 fut.result()
-            except Exception:
-                pass
+            except Exception as e:
+                _log.debug("Pre-build task failed (will fall back to live compilation): %s", e)
 
     # Count test cases where all kernels AND orchestration succeeded
     n_ok = sum(

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -18,15 +18,17 @@ Orchestrates the full test execution pipeline:
 5. Validate results
 """
 
+import concurrent.futures
 import shutil
 import tempfile
+import threading
 import time
 import traceback
 from datetime import datetime
 from pathlib import Path
 
 import pytest
-from pypto.backend import BackendType, set_backend_type
+from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
 from pypto.runtime.runner import RunConfig, RunResult, _execute_on_device
@@ -37,6 +39,23 @@ from harness.core.harness import PTOTestCase
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
 _PROJECT_ROOT = _ST_DIR.parent.parent
+
+# ---------------------------------------------------------------------------
+# Pre-compilation cache (Phase 1 / Phase 2 split)
+# ---------------------------------------------------------------------------
+
+# Maps test_name → (work_dir, error_str | None).
+# Populated by precompile_test_cases() in the parent process during
+# pytest_collection_finish, before any test forks.  Forked children inherit
+# the populated dict via os.fork() copy-on-write and find their pre-compiled
+# artefacts on the filesystem under work_dir.
+_precompile_cache: dict[str, tuple[Path, str | None]] = {}
+
+# set_backend_type is called once per backend-type group before the thread pool
+# starts.  Only get_program() needs serialisation because the @pl.program
+# decorator is not thread-safe; compile_program() writes to isolated dirs and
+# runs concurrently.
+_get_program_lock = threading.Lock()
 
 # Map BackendType to the architecture prefix used by the platform string.
 # "a2a3" covers Ascend 910B; "a5" covers Ascend 950.
@@ -113,6 +132,356 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
     output_path.write_text(write_golden_src, encoding="utf-8")
 
 
+# ---------------------------------------------------------------------------
+# Pre-compilation helpers
+# ---------------------------------------------------------------------------
+
+
+def _compile_for_cache(test_case: "PTOTestCase", work_dir: Path, dump_passes: bool) -> None:
+    """Compile one test case into *work_dir* (called from thread pool).
+
+    The backend type MUST already be set by the caller before entering the pool.
+    Only ``get_program`` is serialised (via ``_get_program_lock``) because the
+    ``@pl.program`` decorator is not thread-safe; ``compile_program`` writes to
+    an isolated directory and runs concurrently.
+    """
+    backend_type = test_case.get_backend_type()
+    with _get_program_lock:
+        program = test_case.get_program()
+    if program is None:
+        raise ValueError(
+            f"Test case {test_case.get_name()} must implement get_program() "
+            "to return a @pl.program class or ir.Program"
+        )
+    compile_program(
+        program,
+        work_dir,
+        strategy=test_case.get_strategy(),
+        backend_type=backend_type,
+        dump_passes=dump_passes,
+    )
+    if not list((work_dir / "kernels").rglob("*.cpp")):
+        raise ValueError(f"No kernels generated for {test_case.get_name()}")
+    if not list((work_dir / "orchestration").glob("*.cpp")):
+        raise ValueError(
+            f"No orchestration generated for {test_case.get_name()}. "
+            "Ensure your @pl.program includes an orchestration function "
+            "(decorated with @pl.function(type=pl.FunctionType.Orchestration))."
+        )
+    _write_golden_for_test_case(test_case, work_dir / "golden.py")
+
+
+def precompile_test_cases(
+    test_cases: "list[PTOTestCase]",
+    cache_dir: Path,
+    *,
+    dump_passes: bool = False,
+    max_workers: int | None = None,
+) -> None:
+    """Compile all *test_cases* in parallel and populate :data:`_precompile_cache`.
+
+    This is **Phase 1** of the two-phase execution model.  Call this once in
+    the parent process (e.g. from a ``pytest_collection_finish`` hook) before
+    any test forks.  Forked child processes inherit the populated cache and the
+    pre-compiled artefacts on the filesystem.
+
+    Because ``set_backend_type`` is a one-time global setter (calling it again
+    with a *different* value raises ``ValueError``), test cases are grouped by
+    backend type.  Each group is compiled sequentially with the backend set once;
+    ``get_program()`` is serialised within the group (via ``_get_program_lock``)
+    while ``compile_program()`` runs in parallel.  The backend is reset between
+    groups via ``reset_for_testing()``.
+
+    Args:
+        test_cases: Instances to compile (should be deduplicated by ``get_name``
+            before calling).
+        cache_dir: Root output directory; each test case is compiled into
+            ``cache_dir / <test_name>``.
+        dump_passes: If ``True``, dump intermediate IR after each pass.
+        max_workers: Thread-pool size per backend group.  Defaults to
+            ``os.cpu_count()``.
+    """
+    # Group by backend type so set_backend_type is called once per group.
+    groups: dict[BackendType, list["PTOTestCase"]] = {}
+    for tc in test_cases:
+        groups.setdefault(tc.get_backend_type(), []).append(tc)
+
+    def _compile_one(tc: "PTOTestCase") -> tuple[str, Path, str | None]:
+        name = tc.get_name()
+        work_dir = cache_dir / name
+        work_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            _compile_for_cache(tc, work_dir, dump_passes)
+            return name, work_dir, None
+        except Exception as exc:
+            return name, work_dir, f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+
+    for backend_type, group in groups.items():
+        # Set the backend type once for the whole group (idempotent if already
+        # set to the same value; reset_for_testing() between groups handles reuse).
+        set_backend_type(backend_type)
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                futures = {pool.submit(_compile_one, tc): tc for tc in group}
+                for fut in concurrent.futures.as_completed(futures):
+                    name, work_dir, error = fut.result()
+                    _precompile_cache[name] = (work_dir, error)
+        finally:
+            # Reset so the next group can set a different backend type.
+            reset_for_testing()
+
+
+def pregenerate_golden_inputs(
+    test_cases: "list[PTOTestCase]",
+    cache_dir: Path,
+    *,
+    max_workers: int | None = None,
+) -> int:
+    """Phase 0: pre-generate golden inputs for all test cases in parallel.
+
+    Must be called AFTER :func:`precompile_test_cases` so that golden.py files
+    have been written to ``cache_dir / <test_name> / golden.py``.
+
+    For each test case the golden module is loaded with importlib (no simpler
+    dependency needed — generated golden.py only imports torch/ctypes) and
+    ``generate_inputs(params)`` is called for every entry in ``ALL_CASES``.
+    Results are stored in :data:`pypto.runtime.runner._golden_inputs_cache`
+    keyed by ``(resolved_golden_path_str, case_name)``.  Forked worker
+    processes inherit the populated cache via copy-on-write and the
+    :func:`pypto.runtime.runner._install_golden_inputs_patch` monkey-patch
+    makes each ``CodeRunner`` instance serve inputs from the cache, skipping
+    the (potentially expensive) ``generate_inputs`` call at test execution time.
+
+    Args:
+        test_cases: Test case instances (should be deduplicated by ``get_name``).
+        cache_dir: Root output directory used during precompilation.
+        max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
+
+    Returns:
+        Number of (test_case, case_name) pairs successfully pre-generated.
+    """
+    import importlib.util
+
+    from pypto.runtime.runner import (
+        _golden_cache_file,
+        _inputs_cache_file,
+        _load_golden,
+        _load_inputs,
+        _save_golden,
+        _save_inputs,
+    )
+
+    def _load_module(path: Path, name: str):
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    # ── Collect work items (main thread) ─────────────────────────────────────
+    # Each item is (module, golden_path, case_name, params) for cases whose
+    # .pt file does not yet exist.  Module loading happens here (single thread)
+    # to avoid importlib races.
+    work_items: list[tuple] = []
+    already_cached = 0
+
+    for tc in test_cases:
+        work_dir = cache_dir / tc.get_name()
+        golden_path = work_dir / "golden.py"
+        if not golden_path.exists():
+            continue
+        try:
+            module = _load_module(golden_path, f"_pregolden_{tc.get_name()}")
+        except Exception:
+            continue
+        if module is None:
+            continue
+
+        all_cases = getattr(module, "ALL_CASES", {"Default": {}})
+        for case_name, case_params in all_cases.items():
+            inputs_file = _inputs_cache_file(golden_path, case_name)
+            golden_file = _golden_cache_file(golden_path, case_name)
+            if inputs_file.exists() and golden_file.exists():
+                already_cached += 1
+                continue
+            params = {"name": case_name, **case_params}
+            work_items.append((module, golden_path, case_name, params))
+
+    # ── Generate in parallel (one task per (test_case, case_name) pair) ──────
+    def _gen_case(module, golden_path: Path, case_name: str, params: dict) -> bool:
+        import torch
+
+        inputs_file = _inputs_cache_file(golden_path, case_name)
+        golden_file = _golden_cache_file(golden_path, case_name)
+        try:
+            result = module.generate_inputs(params)
+            _save_inputs(result, inputs_file)
+
+            # Compute golden: replicate the logic in CodeRunner.run()
+            output_names = set(getattr(module, "__outputs__", []))
+            tensors = {name: val for name, val in result if isinstance(val, torch.Tensor)}
+            golden = {name: tensors[name].clone() for name in output_names if name in tensors}
+            golden_with_inputs = {**{k: v for k, v in tensors.items() if k not in output_names}, **golden}
+            module.compute_golden(golden_with_inputs, params)
+            _save_golden(golden, golden_file)
+            return True
+        except Exception:
+            return False  # fallback: live generation at test time
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futs = [pool.submit(_gen_case, *item) for item in work_items]
+        n_generated = sum(f.result() for f in concurrent.futures.as_completed(futs))
+
+    return already_cached + n_generated
+
+
+def prebuild_binaries(
+    test_cases: "list[PTOTestCase]",
+    cache_dir: Path,
+    platform: str,
+    *,
+    max_workers: int | None = None,
+) -> int:
+    """Phase 2: pre-compile binary artifacts for all test cases in parallel.
+
+    Must be called AFTER :func:`precompile_test_cases` so kernel/orchestration
+    C++ sources exist under ``work_dir``. Imports KernelCompiler/RuntimeBuilder
+    from Simpler and compiles incore kernels, the orchestration ``.so``, and
+    runtime binaries, saving results via the write-through binary cache patch
+    in :mod:`pypto.runtime.runner`.
+
+    Args:
+        test_cases: Test case instances (deduplicated by ``get_name``).
+        cache_dir: Root output directory used during precompilation.
+        platform: Session platform string (e.g. ``"a2a3"``).
+        max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
+
+    Returns:
+        Number of test cases whose kernels and orchestration were successfully
+        pre-built.
+    """
+    import importlib.util
+    import os
+    import sys
+
+    simpler_root = os.environ.get("SIMPLER_ROOT", "")
+    if not simpler_root:
+        return 0
+    for sub in ("examples/scripts", "python"):
+        p = str(Path(simpler_root) / sub)
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+    try:
+        from kernel_compiler import KernelCompiler  # type: ignore[import]
+        from runtime_builder import RuntimeBuilder  # type: ignore[import]
+        from code_runner import _ensure_pto_isa_root  # type: ignore[import]
+        from pypto.runtime.runner import (
+            _BINARY_RUNTIME_CACHE,
+            _get_simpler_stamp,
+            _install_binary_cache_patch,
+        )
+    except ImportError:
+        return 0
+
+    _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
+
+    pto_isa_root = _ensure_pto_isa_root(verbose=False, clone_protocol="https")
+    if pto_isa_root is None:
+        return 0
+
+    def _load_kc(work_dir: Path):
+        config_path = work_dir / "kernel_config.py"
+        if not config_path.exists():
+            return None
+        spec = importlib.util.spec_from_file_location(f"_prebin_{work_dir.name}", str(config_path))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    # ── Collect configs for all valid test cases ──────────────────────────────
+    # Load each kernel_config.py once in the main thread (not thread-safe to do
+    # it concurrently via importlib).
+    case_configs: list[tuple] = []  # (tc, compiler, runtime_name, kernels, orch_source)
+    seen_runtimes: set[tuple[str, str]] = set()
+
+    for tc in test_cases:
+        name = tc.get_name()
+        if name not in _precompile_cache or _precompile_cache[name][1] is not None:
+            continue
+        work_dir = _precompile_cache[name][0]
+        mod = _load_kc(work_dir)
+        if mod is None:
+            continue
+        tc_platform = _resolve_platform(platform, tc.get_backend_type())
+        runtime_name = getattr(mod, "RUNTIME_CONFIG", {}).get("runtime", "host_build_graph")
+        seen_runtimes.add((tc_platform, runtime_name))
+        compiler = KernelCompiler(platform=tc_platform)
+        case_configs.append((tc, compiler, runtime_name, mod.KERNELS, mod.ORCHESTRATION["source"]))
+
+    if not case_configs:
+        return 0
+
+    # ── Submit ALL tasks to a single flat pool ────────────────────────────────
+    # - One task per incore kernel (kernels across all test cases run in parallel)
+    # - One task per orchestration .so
+    # - One task per unique (platform, runtime_name) build
+    # This way runtime compilation overlaps with kernel/orch compilation, and
+    # with a single test case (common case) all kernels still run in parallel.
+    def _compile_incore_task(compiler, kernel, runtime_includes):
+        compiler.compile_incore(
+            kernel["source"],
+            core_type=kernel["core_type"],
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=runtime_includes,
+        )
+
+    def _compile_orch_task(compiler, runtime_name, orch_source):
+        compiler.compile_orchestration(runtime_name, orch_source)
+
+    def _build_runtime_task(tc_platform, runtime_name):
+        host_file = _BINARY_RUNTIME_CACHE / _get_simpler_stamp() / f"{runtime_name}_{tc_platform}_host.bin"
+        if not host_file.exists():
+            RuntimeBuilder(platform=tc_platform).build(runtime_name)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        all_futs: list = []
+
+        # Runtime builds (independent of test-case kernels)
+        for tc_platform, runtime_name in seen_runtimes:
+            all_futs.append(pool.submit(_build_runtime_task, tc_platform, runtime_name))
+
+        # Per-test-case: each kernel and orchestration as independent tasks
+        tc_kernel_futs: list[tuple[list, concurrent.futures.Future]] = []
+        for tc, compiler, runtime_name, kernels, orch_source in case_configs:
+            runtime_includes = compiler.get_orchestration_include_dirs(runtime_name)[:2]
+            kfuts = [
+                pool.submit(_compile_incore_task, compiler, k, runtime_includes)
+                for k in kernels
+            ]
+            ofut = pool.submit(_compile_orch_task, compiler, runtime_name, orch_source)
+            tc_kernel_futs.append((kfuts, ofut))
+            all_futs.extend(kfuts)
+            all_futs.append(ofut)
+
+        # Wait for everything; swallow individual failures (write-through patch
+        # simply won't cache on failure, test will fall back to live compilation)
+        for fut in concurrent.futures.as_completed(all_futs):
+            try:
+                fut.result()
+            except Exception:
+                pass
+
+    # Count test cases where all kernels AND orchestration succeeded
+    n_ok = sum(
+        1
+        for kfuts, ofut in tc_kernel_futs
+        if all(f.exception() is None for f in kfuts) and ofut.exception() is None
+    )
+    return n_ok
+
+
 class TestRunner:
     """Executes PTO test cases via simpler's CodeRunner.
 
@@ -148,6 +517,51 @@ class TestRunner:
         """
         start_time = time.time()
         test_name = test_case.get_name()
+
+        # --- Phase 2: pre-compiled artifacts available — skip compilation ---
+        if test_name in _precompile_cache:
+            cached_dir, cached_error = _precompile_cache[test_name]
+            if cached_error is not None:
+                return RunResult(
+                    passed=False,
+                    test_name=test_name,
+                    error=f"Pre-compilation failed: {cached_error}",
+                    execution_time=time.time() - start_time,
+                )
+            if self.config.codegen_only:
+                return RunResult(
+                    passed=True,
+                    test_name=test_name,
+                    execution_time=time.time() - start_time,
+                )
+            try:
+                backend_type = test_case.get_backend_type()
+                platform = _resolve_platform(self.config.platform, backend_type)
+                # Re-write golden.py with the actual test case's tolerances.
+                # The pre-compiled golden.py may have been written with default
+                # tolerances (1e-5) because pytest_collection_finish instantiates
+                # test cases without their RunConfig constructor args.
+                _write_golden_for_test_case(test_case, cached_dir / "golden.py")
+                _execute_on_device(
+                    cached_dir,
+                    cached_dir / "golden.py",
+                    platform,
+                    self.config.device_id,
+                )
+                return RunResult(
+                    passed=True,
+                    test_name=test_name,
+                    execution_time=time.time() - start_time,
+                )
+            except Exception as e:
+                return RunResult(
+                    passed=False,
+                    test_name=test_name,
+                    error=f"{type(e).__name__}: {e}\n{traceback.format_exc()}",
+                    execution_time=time.time() - start_time,
+                )
+
+        # --- Original path: no cache, compile + execute in one step ---
 
         # Determine work directory based on save_kernels configuration
         if self.config.save_kernels:

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1536,7 +1536,9 @@ class TestTensorReadWriteOffsetCodegen:
 
         code = _generate_orch_code(Prog)
         # The flat offset expression is generated (either inlined as 51 or as computed expression)
-        assert ("orch_args.tensor(0).data_as<void>())[51]" in code) or ("1 * 4 * 8" in code and "2 * 8" in code)
+        assert ("orch_args.tensor(0).data_as<void>())[51]" in code) or (
+            "1 * 4 * 8" in code and "2 * 8" in code
+        )
         assert "orch_args.tensor(0).data_as<void>())" in code
 
     def test_tensor_read_variable_index(self):

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -148,7 +148,6 @@ class TestOrchestration:
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-                    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 0: kernel_add
                     Arg params_t0;
@@ -156,7 +155,7 @@ class TestOrchestration:
                     params_t0.add_input(ext_b);
                     params_t0.add_output(c_ci);
                     TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-                    c = outs_t0.get_ref(0);
+                    const Tensor& c = outs_t0.get_ref(0);
 
                     // Task 1: kernel_add
                     Arg params_t1;
@@ -421,7 +420,6 @@ class TestOrchestration:
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-                    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 0: kernel_add
                     Arg params_t0;
@@ -429,10 +427,9 @@ class TestOrchestration:
                     params_t0.add_input(ext_b);
                     params_t0.add_output(c_ci);
                     TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-                    c = outs_t0.get_ref(0);
+                    const Tensor& c = outs_t0.get_ref(0);
                     uint32_t d_ci_shapes[2] = {16, 16};
                     TensorCreateInfo d_ci(d_ci_shapes, 2, DataType::FLOAT32);
-                    Tensor d = make_tensor_external(nullptr, d_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 1: kernel_add_scalar
                     Arg params_t1;
@@ -440,10 +437,9 @@ class TestOrchestration:
                     params_t1.add_output(d_ci);
                     params_t1.add_scalar(to_u64(1.000000f));
                     TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);
-                    d = outs_t1.get_ref(0);
+                    const Tensor& d = outs_t1.get_ref(0);
                     uint32_t e_ci_shapes[2] = {16, 16};
                     TensorCreateInfo e_ci(e_ci_shapes, 2, DataType::FLOAT32);
-                    Tensor e = make_tensor_external(nullptr, e_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 2: kernel_add_scalar
                     Arg params_t2;
@@ -451,10 +447,9 @@ class TestOrchestration:
                     params_t2.add_output(e_ci);
                     params_t2.add_scalar(to_u64(2.000000f));
                     TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);
-                    e = outs_t2.get_ref(0);
+                    const Tensor& e = outs_t2.get_ref(0);
                     uint32_t g_ci_shapes[2] = {16, 16};
                     TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
-                    Tensor g = make_tensor_external(nullptr, g_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 3: kernel_mul
                     Arg params_t3;
@@ -462,7 +457,7 @@ class TestOrchestration:
                     params_t3.add_input(e);
                     params_t3.add_output(g_ci);
                     TaskOutputTensors outs_t3 = pto2_rt_submit_aiv_task(2, params_t3);
-                    g = outs_t3.get_ref(0);
+                    const Tensor& g = outs_t3.get_ref(0);
 
                     // Task 4: kernel_add
                     Arg params_t4;
@@ -709,11 +704,12 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorCreateProgram)
 
-        # tensor.create generates TensorCreateInfo + null-addr Tensor
+        # tensor.create generates TensorCreateInfo; const Tensor& binding emitted at submit site
         # FP16 = DataType::FLOAT16
         assert "uint32_t buf_ci_shapes[2] = {32, 32};" in code
         assert "TensorCreateInfo buf_ci(buf_ci_shapes, 2, DataType::FLOAT16)" in code
-        assert "Tensor buf = make_tensor_external(nullptr, buf_ci_shapes, 2, DataType::FLOAT16)" in code
+        assert "const Tensor& buf = " in code
+        assert "make_tensor_external(nullptr, buf_ci_shapes, 2, DataType::FLOAT16)" not in code
 
     def test_inplace_tensor(self):
         """Test inplace tensors use make_inout_param when a tensor is both input and output.
@@ -1316,7 +1312,8 @@ class TestOrchestration:
         code = _generate_orch_code(transformed)
 
         assert "TensorCreateInfo row_ci(row_ci_shapes, 2, DataType::FLOAT32);" in code
-        assert "Tensor row = make_tensor_external(nullptr, row_ci_shapes, 2, DataType::FLOAT32);" in code
+        assert "const Tensor& row = " in code
+        assert "make_tensor_external(nullptr, row_ci_shapes, 2, DataType::FLOAT32)" not in code
         assert "Tensor row = ext_out.view(row_shapes, row_offsets);" not in code
 
     def test_tensor_assemble_slice_source_does_not_require_view_fast_path(self):
@@ -1440,8 +1437,8 @@ class TestOrchestration:
         assert code.count("TensorCreateInfo ret0__out_1_ci(") == 1
         assert "params_t0.add_output(ret0__out_ci)" in code
         assert "params_t1.add_output(ret0__out_1_ci)" in code
-        assert "Tensor& first = ret0__out;" in code
-        assert "Tensor& second = ret0__out_1;" in code
+        assert "const Tensor& first = ret0__out;" in code
+        assert "const Tensor& second = ret0__out_1;" in code
         assert "add_output(ret0)" not in code
 
     def test_scalar_taskarg(self):

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -58,7 +58,7 @@ class TestOrchestration:
     """Test orchestration codegen format."""
 
     def test_basic_structure(self):
-        """Test codegen produces PTO2 format: make_tensor_external, PTOParam, pto2_rt_submit_aiv_task."""
+        """Test codegen produces PTO2 format: make_tensor_external, Arg, pto2_rt_submit_aiv_task."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -112,7 +112,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -127,13 +127,10 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(addr, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(addr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             static inline Tensor make_tensor_2d_dn(
@@ -143,42 +140,40 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(0, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(nullptr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
-                (void)arg_count;
+            void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_a = from_task_arg(orch[0]);
-                Tensor ext_b = from_task_arg(orch[1]);
-                Tensor ext_d = from_task_arg(orch[2]);
+                Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+                Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
+                Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
                 PTO2_SCOPE() {
-                    uint32_t c_shapes[2] = {16, 16};
-                    Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
+                    uint32_t c_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+                    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 0: kernel_add
-                    PTOParam params_t0;
+                    Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c);
-                    pto2_rt_submit_aiv_task(0, params_t0);
+                    params_t0.add_output(c_ci);
+                    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+                    c = outs_t0.get_ref(0);
 
                     // Task 1: kernel_add
-                    PTOParam params_t1;
+                    Arg params_t1;
                     params_t1.add_input(c);
                     params_t1.add_input(ext_b);
-                    params_t1.add_output(ext_d);
+                    params_t1.add_inout(ext_d);
                     pto2_rt_submit_aiv_task(0, params_t1);
                 }
             }
@@ -188,7 +183,7 @@ class TestOrchestration:
         assert_code_equal(code, expected)
 
     def test_tensor_read(self):
-        """Test tensor.read uses orch[].data<void>(), not host_t."""
+        """Test tensor.read uses orch_args.tensor().data_as<void>(), not host_t."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -221,9 +216,9 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorReadProgram)
 
-        # tensor.read uses orch[0].data<void>(), not host_t
+        # tensor.read uses orch_args.tensor(0).data_as<void>(), not host_t
         assert "idx_val" in code
-        assert "static_cast<float*>(orch[0].data<void>())" in code
+        assert "static_cast<float*>(orch_args.tensor(0).data_as<void>())" in code
         assert "host_t" not in code
 
     def test_config_file(self):
@@ -298,7 +293,7 @@ class TestOrchestration:
         # Two return tensors: c and d are both external
         assert "ext_c" in code
         assert "ext_d" in code
-        assert "from_task_arg(" in code
+        assert "from_tensor_arg(" in code
 
         # Two tasks submitted
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -401,7 +396,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -416,13 +411,10 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(addr, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(addr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             static inline Tensor make_tensor_2d_dn(
@@ -432,69 +424,73 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(0, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(nullptr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
-                (void)arg_count;
+            void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_a = from_task_arg(orch[0]);
-                Tensor ext_b = from_task_arg(orch[1]);
-                Tensor ext_f = from_task_arg(orch[2]);
+                Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
+                Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
+                Tensor ext_f = from_tensor_arg(orch_args.tensor(2));
 
                 PTO2_SCOPE() {
-                    uint32_t c_shapes[2] = {16, 16};
-                    Tensor c = make_tensor(c_shapes, 2, DataType::FLOAT32);
+                    uint32_t c_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+                    Tensor c = make_tensor_external(nullptr, c_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 0: kernel_add
-                    PTOParam params_t0;
+                    Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c);
-                    pto2_rt_submit_aiv_task(0, params_t0);
-                    uint32_t d_shapes[2] = {16, 16};
-                    Tensor d = make_tensor(d_shapes, 2, DataType::FLOAT32);
+                    params_t0.add_output(c_ci);
+                    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
+                    c = outs_t0.get_ref(0);
+                    uint32_t d_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo d_ci(d_ci_shapes, 2, DataType::FLOAT32);
+                    Tensor d = make_tensor_external(nullptr, d_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 1: kernel_add_scalar
-                    PTOParam params_t1;
+                    Arg params_t1;
                     params_t1.add_input(c);
-                    params_t1.add_output(d);
+                    params_t1.add_output(d_ci);
                     params_t1.add_scalar(float_to_u64(1.000000f));
-                    pto2_rt_submit_aiv_task(1, params_t1);
-                    uint32_t e_shapes[2] = {16, 16};
-                    Tensor e = make_tensor(e_shapes, 2, DataType::FLOAT32);
+                    TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);
+                    d = outs_t1.get_ref(0);
+                    uint32_t e_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo e_ci(e_ci_shapes, 2, DataType::FLOAT32);
+                    Tensor e = make_tensor_external(nullptr, e_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 2: kernel_add_scalar
-                    PTOParam params_t2;
+                    Arg params_t2;
                     params_t2.add_input(c);
-                    params_t2.add_output(e);
+                    params_t2.add_output(e_ci);
                     params_t2.add_scalar(float_to_u64(2.000000f));
-                    pto2_rt_submit_aiv_task(1, params_t2);
-                    uint32_t g_shapes[2] = {16, 16};
-                    Tensor g = make_tensor(g_shapes, 2, DataType::FLOAT32);
+                    TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);
+                    e = outs_t2.get_ref(0);
+                    uint32_t g_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
+                    Tensor g = make_tensor_external(nullptr, g_ci_shapes, 2, DataType::FLOAT32);
 
                     // Task 3: kernel_mul
-                    PTOParam params_t3;
+                    Arg params_t3;
                     params_t3.add_input(d);
                     params_t3.add_input(e);
-                    params_t3.add_output(g);
-                    pto2_rt_submit_aiv_task(2, params_t3);
+                    params_t3.add_output(g_ci);
+                    TaskOutputTensors outs_t3 = pto2_rt_submit_aiv_task(2, params_t3);
+                    g = outs_t3.get_ref(0);
 
                     // Task 4: kernel_add
-                    PTOParam params_t4;
+                    Arg params_t4;
                     params_t4.add_input(g);
                     params_t4.add_input(c);
-                    params_t4.add_output(ext_f);
+                    params_t4.add_inout(ext_f);
                     pto2_rt_submit_aiv_task(0, params_t4);
                 }
             }
@@ -554,13 +550,13 @@ class TestOrchestration:
 
         code = _generate_orch_code(TupleIntermediateProgram)
 
-        # Tuple elements x, y are intermediate: make_tensor (not external)
-        assert "Tensor x = make_tensor(" in code
-        assert "Tensor y = make_tensor(" in code
+        # Tuple elements x, y are intermediate: TensorCreateInfo (not external)
+        assert "TensorCreateInfo x_ci(" in code
+        assert "TensorCreateInfo y_ci(" in code
         assert "DataType::FLOAT32" in code
 
         # Return tensor result is external
-        assert "from_task_arg(orch[2])" in code
+        assert "from_tensor_arg(orch_args.tensor(2))" in code
 
         # Two tasks: kernel_pair + kernel_add
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -604,11 +600,11 @@ class TestOrchestration:
 
         code = _generate_orch_code(TupleOutputProgram)
 
-        # Both x and y are return tensors: from_task_arg(orch[])
+        # Both x and y are return tensors: from_tensor_arg(orch_args.tensor())
         assert "ext_x" in code
         assert "ext_y" in code
-        assert "from_task_arg(orch[2])" in code
-        assert "from_task_arg(orch[3])" in code
+        assert "from_tensor_arg(orch_args.tensor(2))" in code
+        assert "from_tensor_arg(orch_args.tensor(3))" in code
 
         # Only one task: kernel_pair
         assert code.count("pto2_rt_submit_aiv_task") == 1
@@ -683,13 +679,13 @@ class TestOrchestration:
         code = _generate_orch_code(FourTupleProgram)
 
         # All orch params are external tensors (mij=0, lij=1, oi_new=2, mi_in=3, li_in=4, oi_in=5, dst_in=6, final=7)
-        assert "Tensor ext_mi_in = from_task_arg(orch[3])" in code
-        assert "Tensor ext_li_in = from_task_arg(orch[4])" in code
-        assert "Tensor ext_oi_in = from_task_arg(orch[5])" in code
-        assert "Tensor ext_dst_in = from_task_arg(orch[6])" in code
+        assert "Tensor ext_mi_in = from_tensor_arg(orch_args.tensor(3))" in code
+        assert "Tensor ext_li_in = from_tensor_arg(orch_args.tensor(4))" in code
+        assert "Tensor ext_oi_in = from_tensor_arg(orch_args.tensor(5))" in code
+        assert "Tensor ext_dst_in = from_tensor_arg(orch_args.tensor(6))" in code
 
         # Final return tensor is external
-        assert "Tensor ext_final = from_task_arg(orch[7])" in code
+        assert "Tensor ext_final = from_tensor_arg(orch_args.tensor(7))" in code
 
         # Two tasks: online_update + kernel_add
         assert code.count("pto2_rt_submit_aiv_task") == 2
@@ -697,17 +693,17 @@ class TestOrchestration:
         # online_update: 3 In + 3 InOut + 1 Out = 7 params
         assert "params_t0.add_input(ext_mij)" in code
         assert "params_t0.add_inout(ext_mi_in)" in code
-        assert "params_t0.add_output(ext_dst_in)" in code
+        assert "params_t0.add_inout(ext_dst_in)" in code
 
         # kernel_add: 2 In + 1 Out = 3 params
         assert "params_t1.add_input(ext_oi_in)" in code
-        assert "params_t1.add_output(ext_final)" in code
+        assert "params_t1.add_inout(ext_final)" in code
 
         # PTO2_SCOPE wraps all task submissions
         assert "PTO2_SCOPE" in code
 
     def test_tensor_create(self):
-        """Test tensor.create generates make_tensor with correct size."""
+        """Test tensor.create generates TensorCreateInfo with shape/dtype."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -735,10 +731,11 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorCreateProgram)
 
-        # tensor.create generates make_tensor with shape/dtype
+        # tensor.create generates TensorCreateInfo + null-addr Tensor
         # FP16 = DataType::FLOAT16
-        assert "uint32_t buf_shapes[2] = {32, 32};" in code
-        assert "Tensor buf = make_tensor(buf_shapes, 2, DataType::FLOAT16)" in code
+        assert "uint32_t buf_ci_shapes[2] = {32, 32};" in code
+        assert "TensorCreateInfo buf_ci(buf_ci_shapes, 2, DataType::FLOAT16)" in code
+        assert "Tensor buf = make_tensor_external(nullptr, buf_ci_shapes, 2, DataType::FLOAT16)" in code
 
     def test_inplace_tensor(self):
         """Test inplace tensors use make_inout_param when a tensor is both input and output.
@@ -820,7 +817,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 7,
@@ -835,13 +832,10 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(addr, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(addr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             static inline Tensor make_tensor_2d_dn(
@@ -851,41 +845,37 @@ class TestOrchestration:
                 int32_t version = 0) {
                 debug_assert(ndims == 2);
                 static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
-                uint64_t total = 1;
-                for (uint32_t i = 0; i < ndims; i++) {
-                    total *= shapes[i];
-                }
-                uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS] = {shapes[1], shapes[0]};
-                return Tensor(0, total * get_element_size(dtype),
-                    raw_shapes, shapes, zero_offsets, ndims, dtype, version, true, false);
+                uint32_t raw_shapes[2] = {shapes[1], shapes[0]};
+                Tensor base = make_tensor_external(nullptr, raw_shapes, ndims, dtype, false, version);
+                uint32_t logical_shapes[2] = {shapes[0], shapes[1]};
+                return base.view(logical_shapes, zero_offsets);
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(TaskArg* orch, int arg_count, int orch_thread_num, int orch_thread_index) {
-                (void)arg_count;
+            void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
                 (void)orch_thread_num;
                 (void)orch_thread_index;
 
                 // External tensors
-                Tensor ext_mij = from_task_arg(orch[0]);
-                Tensor ext_lij = from_task_arg(orch[1]);
-                Tensor ext_oi_new = from_task_arg(orch[2]);
-                Tensor ext_mi = from_task_arg(orch[3]);
-                Tensor ext_li = from_task_arg(orch[4]);
-                Tensor ext_oi = from_task_arg(orch[5]);
-                Tensor ext_dst = from_task_arg(orch[6]);
+                Tensor ext_mij = from_tensor_arg(orch_args.tensor(0));
+                Tensor ext_lij = from_tensor_arg(orch_args.tensor(1));
+                Tensor ext_oi_new = from_tensor_arg(orch_args.tensor(2));
+                Tensor ext_mi = from_tensor_arg(orch_args.tensor(3));
+                Tensor ext_li = from_tensor_arg(orch_args.tensor(4));
+                Tensor ext_oi = from_tensor_arg(orch_args.tensor(5));
+                Tensor ext_dst = from_tensor_arg(orch_args.tensor(6));
 
                 PTO2_SCOPE() {
 
                     // Task 0: online_update
-                    PTOParam params_t0;
+                    Arg params_t0;
                     params_t0.add_input(ext_mij);
                     params_t0.add_input(ext_lij);
                     params_t0.add_input(ext_oi_new);
                     params_t0.add_inout(ext_mi);
                     params_t0.add_inout(ext_li);
                     params_t0.add_inout(ext_oi);
-                    params_t0.add_output(ext_dst);
+                    params_t0.add_inout(ext_dst);
                     pto2_rt_submit_aiv_task(0, params_t0);
                 }
             }
@@ -983,7 +973,7 @@ class TestOrchestration:
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
         # tensor.read generates host pointer access
-        assert "static_cast<int64_t*>(orch[2].data<void>())" in code
+        assert "static_cast<int64_t*>(orch_args.tensor(2).data_as<void>())" in code
 
         # kernel_add task submitted inside loop
         assert "pto2_rt_submit_aiv_task" in code
@@ -1059,7 +1049,7 @@ class TestOrchestration:
     def test_multiple_tuple_calls(self):
         """Test that multiple tuple-returning calls produce correct per-call params.
 
-        When two different kernel calls both return tuples, each call's PTOParam
+        When two different kernel calls both return tuples, each call's Arg
         array should only contain outputs from that specific call, not outputs
         from other calls. Regression test for SSA base name collision in
         tuple_var_to_elements_ (all _tuple_tmp_N collapsed to _tuple_tmp).
@@ -1127,9 +1117,9 @@ class TestOrchestration:
         in_task0 = False
         in_task1 = False
         for line in lines:
-            if "PTOParam params_t0" in line:
+            if "Arg params_t0" in line:
                 in_task0 = True
-            elif "PTOParam params_t1" in line:
+            elif "Arg params_t1" in line:
                 in_task1 = True
             elif "pto2_rt_submit" in line:
                 in_task0 = False
@@ -1219,10 +1209,10 @@ class TestOrchestration:
         assert "a_acc = a_acc;" not in code
         assert "b_acc = b_acc;" not in code
 
-        # make_tensor declarations exist (exactly once each)
-        # a_acc is a return value → external (from_task_arg(orch[]))
-        assert code.count("Tensor ext_a_acc = from_task_arg(orch[1])") == 1
-        assert code.count("Tensor b_acc = make_tensor(") == 1
+        # TensorCreateInfo declarations exist (exactly once each)
+        # a_acc is a return value → external (from_tensor_arg(orch_args.tensor()))
+        assert code.count("Tensor ext_a_acc = from_tensor_arg(orch_args.tensor(1))") == 1
+        assert code.count("TensorCreateInfo b_acc_ci(") == 1
 
         # For loop exists with correct structure
         assert "for (int64_t i = 0; i < 4; i += 1)" in code
@@ -1269,11 +1259,11 @@ class TestOrchestration:
         # Inplace detection: output_tensor return var should match the param,
         # so only 2 orch arg slots (input_tensor + output_tensor), not 3
         assert "expected_arg_count = 2" in code
-        assert "from_task_arg(orch[0])" in code  # input_tensor
-        assert "from_task_arg(orch[1])" in code  # output_tensor
+        assert "from_tensor_arg(orch_args.tensor(0))" in code  # input_tensor
+        assert "from_tensor_arg(orch_args.tensor(1))" in code  # output_tensor
 
         # No third orch entry for the compound-named return var
-        assert "orch[2]" not in code
+        assert "orch_args.tensor(2)" not in code
 
         # Task params should use ext_output_tensor (the inplace param), not a separate buffer
         assert "ext_output_tensor)" in code
@@ -1316,7 +1306,7 @@ class TestOrchestration:
         code = _generate_orch_code(transformed)
 
         assert "Tensor row = ext_out.view(row_shapes, row_offsets);" in code
-        assert "params_t0.add_output(row)" in code
+        assert "params_t0.add_inout(row)" in code
         assert "Tensor row = make_tensor(" not in code
         assert "memcpy(" not in code
         assert "ext_out = out;" not in code
@@ -1358,7 +1348,8 @@ class TestOrchestration:
 
         code = _generate_orch_code(transformed)
 
-        assert "Tensor row = make_tensor(row_shapes, 2, DataType::FLOAT32);" in code
+        assert "TensorCreateInfo row_ci(row_ci_shapes, 2, DataType::FLOAT32);" in code
+        assert "Tensor row = make_tensor_external(nullptr, row_ci_shapes, 2, DataType::FLOAT32);" in code
         assert "Tensor row = ext_out.view(row_shapes, row_offsets);" not in code
 
     def test_tensor_assemble_slice_source_does_not_require_view_fast_path(self):
@@ -1429,9 +1420,9 @@ class TestOrchestration:
         code = _generate_orch_code(NumericSuffixProgram)
 
         # Each param must get a distinct orch index
-        assert "from_task_arg(orch[0])" in code  # x
-        assert "from_task_arg(orch[1])" in code  # out_0
-        assert "from_task_arg(orch[2])" in code  # out_1
+        assert "from_tensor_arg(orch_args.tensor(0))" in code  # x
+        assert "from_tensor_arg(orch_args.tensor(1))" in code  # out_0
+        assert "from_tensor_arg(orch_args.tensor(2))" in code  # out_1
 
         # No collapsed names
         assert "ARG_PTR" not in code
@@ -1478,16 +1469,16 @@ class TestOrchestration:
 
         code = _generate_orch_code(transformed)
 
-        assert code.count("Tensor ret0__out = make_tensor(") == 1
-        assert code.count("Tensor ret0__out_1 = make_tensor(") == 1
-        assert "params_t0.add_output(ret0__out)" in code
-        assert "params_t1.add_output(ret0__out_1)" in code
+        assert code.count("TensorCreateInfo ret0__out_ci(") == 1
+        assert code.count("TensorCreateInfo ret0__out_1_ci(") == 1
+        assert "params_t0.add_output(ret0__out_ci)" in code
+        assert "params_t1.add_output(ret0__out_1_ci)" in code
         assert "Tensor& first = ret0__out;" in code
         assert "Tensor& second = ret0__out_1;" in code
         assert "add_output(ret0)" not in code
 
     def test_scalar_taskarg(self):
-        """Scalar params (INT64, INT32, FP32) get TaskArg slots after tensors and use value_as<T>()."""
+        """Scalar params get ChipStorageTaskArgs scalar slots (0-indexed) with union-based type punning."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1520,12 +1511,12 @@ class TestOrchestration:
 
         code = _generate_orch_code(MultiScalarProgram)
 
-        # Tensors at orch[0..1], scalars at orch[2..4]
-        assert "from_task_arg(orch[0])" in code
-        assert "from_task_arg(orch[1])" in code
-        assert "int64_t factor = orch[2].value_as<int64_t>();" in code
-        assert "int32_t count = orch[3].value_as<int32_t>();" in code
-        assert "float scale = orch[4].value_as<float>();" in code
+        # Tensors at orch_args.tensor(0..1), scalars at orch_args.scalar(0..2)
+        assert "from_tensor_arg(orch_args.tensor(0))" in code
+        assert "from_tensor_arg(orch_args.tensor(1))" in code
+        assert "factor_conv.u64 = orch_args.scalar(0);" in code
+        assert "count_conv.u64 = orch_args.scalar(1);" in code
+        assert "scale_conv.u64 = orch_args.scalar(2);" in code
         assert ".expected_arg_count = 5," in code
 
 
@@ -1545,7 +1536,7 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        assert "static_cast<float*>(orch[0].data<void>())[3]" in code
+        assert "static_cast<float*>(orch_args.tensor(0).data_as<void>())[3]" in code
 
     def test_tensor_read_constant_2d(self):
         """2D tensor [4, 8], read(t, [1, 3]) -> flat offset 1*8+3=11 (computed correctly)."""
@@ -1561,8 +1552,8 @@ class TestTensorReadWriteOffsetCodegen:
 
         code = _generate_orch_code(Prog)
         # The flat offset expression 1*8+3=11 is generated (either inlined or via idx_val)
-        assert ("orch[0].data<void>())[11]" in code) or ("1 * 8 + 3" in code)
-        assert "orch[0].data<void>())" in code
+        assert ("orch_args.tensor(0).data_as<void>())[11]" in code) or ("1 * 8 + 3" in code)
+        assert "orch_args.tensor(0).data_as<void>())" in code
 
     def test_tensor_read_constant_3d(self):
         """3D tensor [2, 4, 8], read(t, [1, 2, 3]) -> flat offset 1*32+2*8+3=51."""
@@ -1578,8 +1569,8 @@ class TestTensorReadWriteOffsetCodegen:
 
         code = _generate_orch_code(Prog)
         # The flat offset expression is generated (either inlined as 51 or as computed expression)
-        assert ("orch[0].data<void>())[51]" in code) or ("1 * 4 * 8" in code and "2 * 8" in code)
-        assert "orch[0].data<void>())" in code
+        assert ("orch_args.tensor(0).data_as<void>())[51]" in code) or ("1 * 4 * 8" in code and "2 * 8" in code)
+        assert "orch_args.tensor(0).data_as<void>())" in code
 
     def test_tensor_read_variable_index(self):
         """2D tensor [4, 8], read(t, [i, j]) -> generates idx_val = i * 8 + j."""
@@ -1618,8 +1609,8 @@ class TestTensorReadWriteOffsetCodegen:
 
         code = _generate_orch_code(Prog)
         # Write generates flat offset 11 or the expression 1*8+3
-        assert ("orch[0].data<void>())[11]" in code) or ("1 * 8 + 3" in code)
-        assert "orch[0].data<void>())" in code
+        assert ("orch_args.tensor(0).data_as<void>())[11]" in code) or ("1 * 8 + 3" in code)
+        assert "orch_args.tensor(0).data_as<void>())" in code
 
     def test_infer_output_param_from_loop_carried_store(self):
         """Loop-carried store to a default-In tensor should emit output params."""
@@ -1655,7 +1646,7 @@ class TestTensorReadWriteOffsetCodegen:
         code = _generate_orch_code(transformed)
 
         assert "params_t0.add_input(ext_x)" in code
-        assert "params_t0.add_output(ext_out)" in code
+        assert "params_t0.add_inout(ext_out)" in code
 
     def test_infer_inout_param_from_loop_carried_read_modify_write(self):
         """Loop-carried read-modify-write should emit inout params."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -98,17 +98,6 @@ class TestOrchestration:
 
             #include "pto_orchestration_api.h"
 
-            // Helper to encode float as uint64_t for scalar params
-            static uint64_t float_to_u64(float f) {
-                union {
-                    float f32;
-                    uint64_t u64;
-                } conv;
-                conv.u64 = 0;  // Clear upper bits
-                conv.f32 = f;
-                return conv.u64;
-            }
-
             extern "C" {
 
             __attribute__((visibility("default")))
@@ -382,17 +371,6 @@ class TestOrchestration:
 
             #include "pto_orchestration_api.h"
 
-            // Helper to encode float as uint64_t for scalar params
-            static uint64_t float_to_u64(float f) {
-                union {
-                    float f32;
-                    uint64_t u64;
-                } conv;
-                conv.u64 = 0;  // Clear upper bits
-                conv.f32 = f;
-                return conv.u64;
-            }
-
             extern "C" {
 
             __attribute__((visibility("default")))
@@ -460,7 +438,7 @@ class TestOrchestration:
                     Arg params_t1;
                     params_t1.add_input(c);
                     params_t1.add_output(d_ci);
-                    params_t1.add_scalar(float_to_u64(1.000000f));
+                    params_t1.add_scalar(to_u64(1.000000f));
                     TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);
                     d = outs_t1.get_ref(0);
                     uint32_t e_ci_shapes[2] = {16, 16};
@@ -471,7 +449,7 @@ class TestOrchestration:
                     Arg params_t2;
                     params_t2.add_input(c);
                     params_t2.add_output(e_ci);
-                    params_t2.add_scalar(float_to_u64(2.000000f));
+                    params_t2.add_scalar(to_u64(2.000000f));
                     TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);
                     e = outs_t2.get_ref(0);
                     uint32_t g_ci_shapes[2] = {16, 16};
@@ -802,17 +780,6 @@ class TestOrchestration:
             #include <stdio.h>
 
             #include "pto_orchestration_api.h"
-
-            // Helper to encode float as uint64_t for scalar params
-            static uint64_t float_to_u64(float f) {
-                union {
-                    float f32;
-                    uint64_t u64;
-                } conv;
-                conv.u64 = 0;  // Clear upper bits
-                conv.f32 = f;
-                return conv.u64;
-            }
 
             extern "C" {
 
@@ -1478,7 +1445,7 @@ class TestOrchestration:
         assert "add_output(ret0)" not in code
 
     def test_scalar_taskarg(self):
-        """Scalar params get ChipStorageTaskArgs scalar slots (0-indexed) with union-based type punning."""
+        """Scalar params get ChipStorageTaskArgs scalar slots (0-indexed) via from_u64<T>()."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1514,9 +1481,9 @@ class TestOrchestration:
         # Tensors at orch_args.tensor(0..1), scalars at orch_args.scalar(0..2)
         assert "from_tensor_arg(orch_args.tensor(0))" in code
         assert "from_tensor_arg(orch_args.tensor(1))" in code
-        assert "factor_conv.u64 = orch_args.scalar(0);" in code
-        assert "count_conv.u64 = orch_args.scalar(1);" in code
-        assert "scale_conv.u64 = orch_args.scalar(2);" in code
+        assert "from_u64<int64_t>(orch_args.scalar(0))" in code
+        assert "from_u64<int32_t>(orch_args.scalar(1))" in code
+        assert "from_u64<float>(orch_args.scalar(2))" in code
         assert ".expected_arg_count = 5," in code
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -654,17 +654,17 @@ class TestGenerateArgUnpacking:
     def test_tensor_only(self):
         func = _make_func("test_fn", [("a", "tensor"), ("b", "tensor"), ("out", "tensor")])
         code, names = _generate_arg_unpacking(func)
-        assert "reinterpret_cast<__gm__ TensorData*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[1])" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[2])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[2])" in code
         assert names == ["a", "b", "out"]
 
     def test_mixed_tensor_scalar(self):
         func = _make_func("test_fn", [("input", "tensor"), ("scale", "scalar"), ("output", "tensor")])
         code, names = _generate_arg_unpacking(func)
         # Tensors-first: input=args[0], output=args[1], scale=args[2]
-        assert "reinterpret_cast<__gm__ TensorData*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ TensorData*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
         assert "scale_conv.u64 = args[2];" in code
         assert "float scale = scale_conv.val;" in code
         assert names == ["input", "output", "scale"]


### PR DESCRIPTION
## Summary

- **ST pre-compilation pipeline**: introduce a parallel pre-compilation
  phase and multi-level disk cache in the system test framework to
  significantly reduce test execution time
- **Orchestration codegen migration**: replace the `TaskArg*/PTOParam`
  interface with the unified `ChipStorageTaskArgs` API throughout
  orchestration codegen

## Changes

### ST Pre-compilation & Multi-level Caching (`runner.py`, `conftest.py`, `test_runner.py`)

- Add `pytest_collection_finish` hook that discovers all `PTOTestCase`
  subclasses after collection and pre-compiles them concurrently via a
  thread pool; `--precompile-workers` controls parallelism
- Add `--pypto-log-level` CLI option so forked child processes inherit
  the C++ log level
- Four transparent write-through cache layers:
  - `generate_inputs` → `work_dir/cache/{case}_inputs.pt`
  - `compute_golden`  → `work_dir/cache/{case}_golden.pt`
  - Compiled incore/orch kernels → `work_dir/cache/{incore|orch}_{stem}.bin`
  - Runtime binaries → `build_output/binary_cache/runtimes/` (global,
    shared across test cases and sessions)
- Fix golden data bug: clone output tensors before `compute_golden` so
  saved values reflect post-computation state
- Fix `mkdtemp` temp-dir leak: track dirs and clean up in
  `pytest_sessionfinish`
- Atomic cache writes via temp file + `os.replace()` to prevent
  corruption on interrupted writes
- Code quality: replace bare global bools with `lru_cache`, move inline
  imports to top level, extract helper functions to reduce complexity
- Expose --pto-isa-commit option for pytest and RunConfig
- 
### Orchestration Codegen Migration (`orchestration_codegen.cpp`, `pto_backend.py`)

- Entry function now takes `const ChipStorageTaskArgs& orch_args`
  instead of `TaskArg*`; config function signature updated to match
- Tensor access: `orch[N]` → `orch_args.tensor(N)`,
  `.data<void>()` → `.data_as<void>()`, `from_task_arg` → `from_tensor_arg`
- Scalar unpack: `value_as<T>()` → union punning via `orch_args.scalar(N)`
- Internal tensor creation uses `TensorCreateInfo` + `add_output` +
  `outs.get_ref(i)` pattern; external outputs use `add_inout`
- Remove A5-specific `RtArg()`/`ScopeArg()` helpers and `PTO2_SCOPE(rt)`;
  unified API no longer requires an explicit runtime pointer
- `TensorData` → `Tensor` in kernel wrapper arg unpacking (`pto_backend.py`)
- EN and ZH-CN docs updated in sync

