### PR TITLE
test(codegen): add dynamic valid_shape and SSA scope matmul loop tests

### DIFF
--- a/examples/kernels/09_dyn_valid_shape.py
+++ b/examples/kernels/09_dyn_valid_shape.py
@@ -1,0 +1,171 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Dynamic valid_shape examples — if/else and loop patterns.
+
+Demonstrates DSL patterns where the valid length of a tile is computed
+dynamically via if/else branches or loops, then used in a single
+load+fillpad:
+
+Pattern 1 (if/else)::
+
+    if is_last:
+        vlen = last_valid_len      # partial block
+    else:
+        vlen = full_len            # full block
+    tile = pl.load(..., valid_shapes=[rows, vlen])
+    padded = pl.tile.fillpad(tile, pad_value=PadValue.min)
+
+Pattern 2 (loop + if/else)::
+
+    for i in range(n_blocks):
+        if i == n_blocks - 1:
+            vlen = last_valid_len  # partial (last block)
+        else:
+            vlen = block_size      # full
+        tile = pl.load(..., valid_shapes=[Q_TILE, vlen])
+        padded = pl.tile.fillpad(tile, pad_value=PadValue.min)
+
+Use ``build_if_else_program()`` and ``build_loop_program()`` to obtain
+``@pl.program`` classes for these patterns.
+"""
+
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+
+# Tile / tensor dimensions
+Q_TILE = 64
+BLOCK_COL = 64
+N_ROW = 128  # sij_buf rows = Q_TILE * max_blocks(2)
+
+
+# ── Shared InCore kernels ────────────────────────────────────────────────────
+
+
+@pl.function(type=pl.FunctionType.InCore)
+def kernel_dyn_valid_shape(
+    data: pl.Tensor[[64, 64], pl.FP32],
+    scale: pl.Scalar[pl.FP32],
+    is_last: pl.Scalar[pl.BOOL],
+    valid_len: pl.Scalar[pl.INDEX],
+    full_len: pl.Scalar[pl.INDEX],
+    output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+) -> pl.Tensor[[64, 64], pl.FP32]:
+    """Load with dynamic valid_shape selected via if/else, fillpad, then scale."""
+    if is_last:
+        vlen: pl.Scalar[pl.INDEX] = valid_len
+    else:
+        vlen: pl.Scalar[pl.INDEX] = full_len
+    s_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+        data, [0, 0], [64, 64], valid_shapes=[64, vlen], target_memory=pl.MemorySpace.Vec
+    )
+    s_padded: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+    scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(s_padded, scale)
+    out: pl.Tensor[[64, 64], pl.FP32] = pl.store(scaled, [0, 0], output)
+    return out
+
+
+@pl.function(type=pl.FunctionType.InCore)
+def kernel_loop_dyn_valid(
+    sij_buf: pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32],
+    scale: pl.Scalar[pl.FP32],
+    n_blocks: pl.Scalar[pl.INDEX],
+    last_valid_len: pl.Scalar[pl.INDEX],
+    block_size: pl.Scalar[pl.INDEX],
+    output: pl.Out[pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32]],
+) -> pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32]:
+    """Loop over blocks; last block uses partial valid_shape, others use full."""
+    for i, (out,) in pl.range(n_blocks, init_values=(output,)):
+        if i == n_blocks - 1:
+            vlen: pl.Scalar[pl.INDEX] = last_valid_len
+        else:
+            vlen: pl.Scalar[pl.INDEX] = block_size
+        s_tile: pl.Tile[[Q_TILE, BLOCK_COL], pl.FP32] = pl.load(
+            sij_buf,
+            [i * Q_TILE, 0],
+            [Q_TILE, BLOCK_COL],
+            valid_shapes=[Q_TILE, vlen],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        s_padded: pl.Tile[[Q_TILE, BLOCK_COL], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+        scaled: pl.Tile[[Q_TILE, BLOCK_COL], pl.FP32] = pl.mul(s_padded, scale)
+        updated: pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32] = pl.store(scaled, [i * Q_TILE, 0], out)
+        loop_result = pl.yield_(updated)
+    return loop_result
+
+
+# ── Program builders ─────────────────────────────────────────────────────────
+
+
+def build_if_else_program():
+    """Build a program that selects valid_shape via if/else, then load+fillpad.
+
+    Returns:
+        A @pl.program class with an orchestration function that reads scalar
+        configs from 1-element tensors and calls kernel_dyn_valid_shape.
+    """
+
+    @pl.program
+    class DynValidShapeIfElse:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            data: pl.Tensor[[64, 64], pl.FP32],
+            scale_cfg: pl.Tensor[[1], pl.FP32],
+            flag_cfg: pl.Tensor[[1], pl.INT64],
+            valid_len_cfg: pl.Tensor[[1], pl.INT64],
+            full_len_cfg: pl.Tensor[[1], pl.INT64],
+            output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            scale: pl.Scalar[pl.FP32] = pl.tensor.read(scale_cfg, [0])
+            is_last: pl.Scalar[pl.INT64] = pl.tensor.read(flag_cfg, [0])
+            valid_len: pl.Scalar[pl.INT64] = pl.tensor.read(valid_len_cfg, [0])
+            full_len: pl.Scalar[pl.INT64] = pl.tensor.read(full_len_cfg, [0])
+            output = kernel_dyn_valid_shape(data, scale, is_last, valid_len, full_len, output)
+            return output
+
+    return DynValidShapeIfElse
+
+
+def build_loop_program():
+    """Build a program that loops over blocks with dynamic valid_shape per iteration.
+
+    Returns:
+        A @pl.program class with an orchestration function that reads scalar
+        configs from 1-element tensors and calls kernel_loop_dyn_valid.
+    """
+
+    @pl.program
+    class LoopDynValid:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            sij_buf: pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32],
+            scale_cfg: pl.Tensor[[1], pl.FP32],
+            n_blocks_cfg: pl.Tensor[[1], pl.INT64],
+            last_valid_len_cfg: pl.Tensor[[1], pl.INT64],
+            block_size_cfg: pl.Tensor[[1], pl.INT64],
+            output: pl.Out[pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32]],
+        ) -> pl.Tensor[[N_ROW, BLOCK_COL], pl.FP32]:
+            scale: pl.Scalar[pl.FP32] = pl.tensor.read(scale_cfg, [0])
+            n_blocks: pl.Scalar[pl.INT64] = pl.tensor.read(n_blocks_cfg, [0])
+            last_valid_len: pl.Scalar[pl.INT64] = pl.tensor.read(last_valid_len_cfg, [0])
+            block_size: pl.Scalar[pl.INT64] = pl.tensor.read(block_size_cfg, [0])
+            output = kernel_loop_dyn_valid(sij_buf, scale, n_blocks, last_valid_len, block_size, output)
+            return output
+
+    return LoopDynValid
+
+
+if __name__ == "__main__":
+    print("=== If/Else Dynamic Valid Shape ===")
+    print(build_if_else_program().as_python())
+    print("\n=== Loop Dynamic Valid Shape ===")
+    print(build_loop_program().as_python())

--- a/examples/kernels/__init__.py
+++ b/examples/kernels/__init__.py
@@ -18,6 +18,7 @@ Kernel examples — single-kernel programs, ordered by complexity.
   06_softmax.py        — numerically stable row-wise softmax
   07_normalization.py  — RMSNorm, LayerNorm
   08_assemble.py       — tile assembly patterns (Acc->Mat, Vec->Vec)
+  09_dyn_valid_shape.py — dynamic valid_shape via if/else and loop patterns
 """
 
 import importlib
@@ -32,6 +33,7 @@ _ALIASES = {
     "softmax": "06_softmax",
     "normalization": "07_normalization",
     "assemble": "08_assemble",
+    "dyn_valid_shape": "09_dyn_valid_shape",
 }
 
 for _alias, _numbered in _ALIASES.items():

--- a/tests/st/codegen/test_dyn_valid_shape_loop.py
+++ b/tests/st/codegen/test_dyn_valid_shape_loop.py
@@ -1,0 +1,188 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Integration test for dynamic valid_shape in a loop with if/else branches.
+
+Verifies the PTO-level pattern from the paged-attention design discussion:
+
+  tile = alloc_tile<row=R, col=C, v_row=?, v_col=?, pad=min>
+  for i in range(n_blocks):
+      if i == n_blocks - 1:
+          set_validshape(tile, vrow1, vcol1)   # partial (last block)
+      else:
+          set_validshape(tile, vrow2, vcol2)   # full
+
+At the DSL level this translates to computing vlen in the if/else, then
+performing a single load+fillpad(pad_value=min) with that computed length.
+
+Test scenarios:
+  1. n_blocks=2: block 0 is full (64 cols), block 1 is partial (48 valid cols)
+  2. n_blocks=1: single block that is also the last → partial (48 valid cols)
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from examples.kernels.dyn_valid_shape import BLOCK_COL, N_ROW
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# ---------------------------------------------------------------------------
+# Test case 1: 2 blocks — block 0 full, block 1 partial (48 valid cols)
+# ---------------------------------------------------------------------------
+
+
+class LoopDynValidTwoBlocksTestCase(PTOTestCase):
+    """n_blocks=2, block_size=64, last_valid_len=48.
+
+    Expected:
+      rows 0-63  (block 0, full):    input * scale
+      rows 64-127 (block 1, last):   cols 0-47 = input * scale, cols 48-63 = -inf
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "loop_dyn_valid_two_blocks"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("sij_buf", [N_ROW, BLOCK_COL], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scale_cfg", [1], DataType.FP32, init_value=2.0),
+            TensorSpec(
+                "n_blocks_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([2], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "last_valid_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([48], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "block_size_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([64], dtype=torch.int64),
+            ),
+            TensorSpec("output", [N_ROW, BLOCK_COL], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        from examples.kernels.dyn_valid_shape import build_loop_program  # noqa: PLC0415
+
+        return build_loop_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], _params=None) -> None:
+        scale = float(tensors["scale_cfg"][0].item())
+        data = tensors["sij_buf"].clone()
+        expected = torch.full((128, 64), float("-inf"), dtype=torch.float32)
+        # Block 0 (full): all 64 cols valid
+        expected[:64, :] = data[:64, :] * scale
+        # Block 1 (last): cols 0-47 valid, cols 48-63 = -inf (pad.min * scale = -inf)
+        expected[64:, :48] = data[64:, :48] * scale
+        tensors["output"][:] = expected
+
+
+# ---------------------------------------------------------------------------
+# Test case 2: 1 block — single block is also the last → partial valid
+# ---------------------------------------------------------------------------
+
+
+class LoopDynValidOneBlockTestCase(PTOTestCase):
+    """n_blocks=1, block_size=64, last_valid_len=48.
+
+    Expected:
+      rows 0-63 (block 0, also last): cols 0-47 = input * scale, cols 48-63 = -inf
+      rows 64-127: untouched (zero-initialized output)
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "loop_dyn_valid_one_block"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("sij_buf", [N_ROW, BLOCK_COL], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scale_cfg", [1], DataType.FP32, init_value=2.0),
+            TensorSpec(
+                "n_blocks_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([1], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "last_valid_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([48], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "block_size_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([64], dtype=torch.int64),
+            ),
+            TensorSpec("output", [N_ROW, BLOCK_COL], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        from examples.kernels.dyn_valid_shape import build_loop_program  # noqa: PLC0415
+
+        return build_loop_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], _params=None) -> None:
+        scale = float(tensors["scale_cfg"][0].item())
+        data = tensors["sij_buf"].clone()
+        # Output is zero-initialized; only block 0 is written
+        expected = torch.zeros((128, 64), dtype=torch.float32)
+        # Block 0 (also last): cols 0-47 valid, cols 48-63 = -inf
+        expected[:64, :48] = data[:64, :48] * scale
+        expected[:64, 48:] = float("-inf")
+        tensors["output"][:] = expected
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoopDynValidShape:
+    """Verify loop + if/else dynamic valid_shape produces correct results."""
+
+    def test_two_blocks(self, test_runner):
+        """2 blocks: block 0 full, block 1 partial (48 valid cols padded with -inf)."""
+        result = test_runner.run(LoopDynValidTwoBlocksTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_one_block(self, test_runner):
+        """1 block: single block is the last → partial valid (48 cols), rest -inf."""
+        result = test_runner.run(LoopDynValidOneBlockTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/codegen/test_dynamic_valid_shape_if_else.py
+++ b/tests/st/codegen/test_dynamic_valid_shape_if_else.py
@@ -1,0 +1,177 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Integration tests for dynamic valid_shape across if/else branches.
+
+Verifies the PTO pattern where a tile buffer has dynamic valid shape and
+the valid length is computed in an if/else:
+
+  if is_last:
+      vlen = last_valid_len   (partial block)
+  else:
+      vlen = full_len         (full block)
+  tile = load(..., valid_shapes=[rows, vlen])
+  padded = fillpad(tile, pad_value=PadValue.min)
+
+Test scenarios:
+  1. is_last=True  → valid_len=48 < 64: cols 48-63 padded with -inf, then scaled
+  2. is_last=False → valid_len=64 = 64: no padding needed, then scaled
+  3. Loop variant: iterate over 2 blocks, last block has reduced valid length
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# ---------------------------------------------------------------------------
+# Test case 1: is_last=True — partial valid_len, padding region filled with -inf
+# ---------------------------------------------------------------------------
+
+
+class DynValidShapeLastBlockTestCase(PTOTestCase):
+    """Test: is_last=True, valid_len=48, full_len=64.
+
+    Expected: cols 0-47 = input * scale, cols 48-63 = -inf (padded with min, then scaled).
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "dyn_valid_shape_last_block"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("data", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scale_cfg", [1], DataType.FP32, init_value=2.0),
+            TensorSpec(
+                "flag_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([1], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "valid_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([48], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "full_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([64], dtype=torch.int64),
+            ),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        from examples.kernels.dyn_valid_shape import build_if_else_program  # noqa: PLC0415
+
+        return build_if_else_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], _params=None) -> None:
+        scale = float(tensors["scale_cfg"][0].item())
+        data = tensors["data"].clone()
+        expected = torch.full((64, 64), float("-inf"), dtype=torch.float32)
+        expected[:, :48] = data[:, :48] * scale
+        # cols 48-63 remain -inf (pad.min * scale = -inf)
+        tensors["output"][:] = expected
+
+
+# ---------------------------------------------------------------------------
+# Test case 2: is_last=False — full valid, fillpad is no-op
+# ---------------------------------------------------------------------------
+
+
+class DynValidShapeFullBlockTestCase(PTOTestCase):
+    """Test: is_last=False, valid_len=48, full_len=64.
+
+    Expected: all cols = input * scale (fillpad is no-op when valid == physical).
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "dyn_valid_shape_full_block"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("data", [64, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scale_cfg", [1], DataType.FP32, init_value=2.0),
+            TensorSpec(
+                "flag_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([0], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "valid_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([48], dtype=torch.int64),
+            ),
+            TensorSpec(
+                "full_len_cfg",
+                [1],
+                DataType.INT64,
+                init_value=torch.tensor([64], dtype=torch.int64),
+            ),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        from examples.kernels.dyn_valid_shape import build_if_else_program  # noqa: PLC0415
+
+        return build_if_else_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], _params=None) -> None:
+        scale = float(tensors["scale_cfg"][0].item())
+        data = tensors["data"].clone()
+        tensors["output"][:] = data * scale
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDynValidShapeIfElse:
+    """Verify dynamic valid_shape selection via if/else produces correct results."""
+
+    def test_last_block(self, test_runner):
+        """is_last=True: partial valid region, padding cols filled with -inf then scaled."""
+        test_case = DynValidShapeLastBlockTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_full_block(self, test_runner):
+        """is_last=False: full valid region, fillpad is no-op, all cols scaled."""
+        test_case = DynValidShapeFullBlockTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
+++ b/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
@@ -1,0 +1,206 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for dynamic valid_shape across if/else branches.
+
+Verifies the pattern described in the paged-attention design discussion:
+
+At the PTO level the pattern is:
+  tile = alloc_tile<row=R, col=C, v_row=?, v_col=?, pad=min>
+  if (...) { set_validshape(tile, vrow1, vcol1) }
+  else     { set_validshape(tile, vrow2, vcol2) }
+
+In the DSL, this translates to computing the valid length as a scalar in the
+if/else, then performing a single load+fillpad with that computed length:
+  if is_last:
+      vlen = last_valid_len
+  else:
+      vlen = full_len
+  s_tile = pl.load(..., valid_shapes=[rows, vlen])
+  s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+
+The tile buffer type is uniform (same v_row=?, v_col=?, pad=min) regardless
+of which branch executed. Only the runtime valid-shape value differs.
+"""
+
+# DSL function bodies are parsed as AST, not executed — suppress pyright errors
+# from type-checking annotations that reference module-level names.
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+import pytest
+from pypto import backend, ir
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import codegen
+
+# ---------------------------------------------------------------------------
+# Program 1: Simple if/else with different valid_shapes (no loop)
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class DynValidShapeIfElse:
+    """Compute valid length in if/else, then load+fillpad with uniform tile type.
+
+    The if/else only selects the scalar valid length. The load and fillpad
+    happen once, producing a single tile type with dynamic valid_shape and pad.min.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        data: pl.Tensor[[64, 64], pl.FP32],
+        scale: pl.Scalar[pl.FP32],
+        is_last: pl.Scalar[pl.BOOL],
+        valid_len: pl.Scalar[pl.INDEX],
+        full_len: pl.Scalar[pl.INDEX],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        if is_last:
+            vlen: pl.Scalar[pl.INDEX] = valid_len
+        else:
+            vlen: pl.Scalar[pl.INDEX] = full_len
+        s_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            data, [0, 0], [64, 64], valid_shapes=[64, vlen], target_memory=pl.MemorySpace.Vec
+        )
+        s_padded: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+        scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(s_padded, scale)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(scaled, [0, 0], output)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Program 2: Loop with if/else — the full paged-attention conversation pattern
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class DynValidShapeLoopIfElse:
+    """Loop over blocks, selecting valid length per iteration via if/else.
+
+    On the last iteration: vlen = last_valid_len (partial block)
+    On other iterations:   vlen = block_size     (full block)
+
+    After the if/else, the single load+fillpad uses the computed vlen.
+    This produces a uniform tile type across all iterations.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        sij_buf: pl.Tensor[[128, 64], pl.FP32],
+        scale: pl.Scalar[pl.FP32],
+        n_blocks: pl.Scalar[pl.INDEX],
+        last_valid_len: pl.Scalar[pl.INDEX],
+        block_size: pl.Scalar[pl.INDEX],
+        output: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+    ) -> pl.Tensor[[128, 64], pl.FP32]:
+        for i, (out,) in pl.range(n_blocks, init_values=(output,)):
+            if i == n_blocks - 1:
+                vlen: pl.Scalar[pl.INDEX] = last_valid_len
+            else:
+                vlen: pl.Scalar[pl.INDEX] = block_size
+            s_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+                sij_buf, [i * 64, 0], [64, 64], valid_shapes=[64, vlen], target_memory=pl.MemorySpace.Vec
+            )
+            s_padded: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+            scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(s_padded, scale)
+            updated: pl.Tensor[[128, 64], pl.FP32] = pl.store(scaled, [i * 64, 0], out)
+            loop_result = pl.yield_(updated)
+        return loop_result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _compile_and_codegen(program_cls, func_name: str) -> str:
+    """Run pass pipeline + PTO codegen on a single function, return MLIR string."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(program_cls)
+
+    func = None
+    for f in optimized.functions.values():
+        if f.name == func_name:
+            func = f
+            break
+    assert func is not None, f"Function '{func_name}' not found in optimized program"
+
+    single_func_program = ir.Program([func], func_name, optimized.span)
+    gen = codegen.PTOCodegen()
+    return gen.generate(single_func_program)
+
+
+@pytest.fixture(scope="module")
+def if_else_mlir() -> str:
+    """Compile if/else program once for all tests in this module."""
+    return _compile_and_codegen(DynValidShapeIfElse, "kernel")
+
+
+@pytest.fixture(scope="module")
+def loop_mlir() -> str:
+    """Compile loop program once for all tests in this module."""
+    return _compile_and_codegen(DynValidShapeLoopIfElse, "kernel")
+
+
+def test_if_else_dyn_valid_shape_compiles(if_else_mlir: str):
+    """Verify that if/else with dynamic valid_shape compiles through the pipeline."""
+    assert if_else_mlir, "Generated MLIR code should not be empty"
+
+
+def test_if_else_dyn_valid_shape_has_dynamic_alloc(if_else_mlir: str):
+    """Verify the generated code has dynamic valid-shape tile allocations."""
+    alloc_lines = [line.strip() for line in if_else_mlir.split("\n") if "pto.alloc_tile" in line]
+    s_tile_allocs = [line for line in alloc_lines if "s_tile" in line]
+    assert len(s_tile_allocs) >= 1, f"Expected s_tile alloc, got alloc_lines: {alloc_lines}"
+    assert "v_col=?" in s_tile_allocs[0], f"Expected dynamic v_col=? in s_tile alloc: {s_tile_allocs[0]}"
+
+
+def test_if_else_dyn_valid_shape_has_set_validshape(if_else_mlir: str):
+    """Verify the generated code emits pto.set_validshape for fillpad-consumed tiles."""
+    assert "pto.set_validshape" in if_else_mlir, (
+        f"Expected pto.set_validshape in MLIR output:\n{if_else_mlir}"
+    )
+
+
+def test_if_else_dyn_valid_shape_has_fillpad(if_else_mlir: str):
+    """Verify the generated code emits pto.fillpad with pad=min."""
+    assert "pto.tfillpad" in if_else_mlir, f"Expected pto.tfillpad in MLIR output:\n{if_else_mlir}"
+
+
+def test_if_else_dyn_valid_shape_padded_alloc_has_pad_min(if_else_mlir: str):
+    """Verify the padded tile alloc has pad=3 (PadValue.min)."""
+    alloc_lines = [line.strip() for line in if_else_mlir.split("\n") if "pto.alloc_tile" in line]
+    padded_allocs = [line for line in alloc_lines if "s_padded" in line]
+    assert len(padded_allocs) >= 1, f"Expected s_padded alloc, got alloc_lines: {alloc_lines}"
+    assert "pad=3>" in padded_allocs[0], f"Expected pad=3 (PadValue.min) in padded alloc: {padded_allocs[0]}"
+
+
+def test_loop_if_else_dyn_valid_shape_compiles(loop_mlir: str):
+    """Verify the loop + if/else pattern with dynamic valid_shapes compiles."""
+    assert loop_mlir, "Generated MLIR code should not be empty"
+
+
+def test_loop_if_else_dyn_valid_shape_has_scf_for(loop_mlir: str):
+    """Verify the loop generates scf.for in the MLIR output."""
+    assert "scf.for" in loop_mlir, f"Expected scf.for loop in MLIR output:\n{loop_mlir}"
+
+
+def test_loop_if_else_dyn_valid_shape_has_scf_if(loop_mlir: str):
+    """Verify the if/else generates scf.if in the MLIR output."""
+    assert "scf.if" in loop_mlir, f"Expected scf.if in MLIR output:\n{loop_mlir}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add UT and ST coverage for dynamic valid_shape selection via if/else branches (with and without loop)

## Test plan
- [ ] UT: `pytest tests/ut/codegen/test_dynamic_valid_shape_if_else.py -v`
- [ ] ST: `pytest tests/st/codegen/test_dynamic_valid_shape_if_else.py -v`
- [ ] ST: `pytest tests/st/codegen/test_dyn_valid_shape_loop.py -v`