### PR TITLE
fix(ir): stabilize type roundtrip in structural equality

### DIFF
--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -314,8 +314,7 @@ class ShapedType : public Type {
    * @param dtype Element data type
    * @param shape Shape dimensions
    */
-  ShapedType(DataType dtype, std::vector<ExprPtr> shape)
-      : dtype_(dtype), shape_(std::move(shape)), memref_(std::nullopt) {}
+  ShapedType(DataType dtype, std::vector<ExprPtr> shape);
 
   /**
    * @brief Create a shaped type with constant shape
@@ -332,8 +331,7 @@ class ShapedType : public Type {
    * @param shape Shape dimensions
    * @param memref Memory reference (shared pointer)
    */
-  ShapedType(DataType dtype, std::vector<ExprPtr> shape, MemRefPtr memref)
-      : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+  ShapedType(DataType dtype, std::vector<ExprPtr> shape, MemRefPtr memref);
 
   /**
    * @brief Create a shaped type with optional memory reference (shared_ptr)
@@ -342,8 +340,7 @@ class ShapedType : public Type {
    * @param shape Shape dimensions
    * @param memref Optional memory reference (shared pointer)
    */
-  ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRefPtr> memref)
-      : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+  ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRefPtr> memref);
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ShapedType; }
   [[nodiscard]] std::string TypeName() const override { return "ShapedType"; }

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -39,10 +39,31 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/structural_comparison.h"
+#include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
+
+namespace {
+
+std::optional<TileView> NormalizePrintedTileView(const TileTypePtr& tile_type) {
+  if (!tile_type || !tile_type->tile_view_.has_value()) {
+    return std::nullopt;
+  }
+  if (tile_view_semantics::IsImplicitPrintedTileView(tile_type->tile_view_.value(), tile_type->shape_,
+                                                     tile_type->memory_space_)) {
+    return std::nullopt;
+  }
+  return tile_type->tile_view_;
+}
+
+bool AreForSyntaxScalarDtypesEquivalent(const DataType& lhs, const DataType& rhs) {
+  return (lhs == DataType::INT64 && rhs == DataType::INDEX) ||
+         (lhs == DataType::INDEX && rhs == DataType::INT64);
+}
+
+}  // namespace
 
 /**
  * @brief Unified structural equality checker for IR nodes
@@ -559,6 +580,9 @@ class StructuralEqualImpl {
   // names so that their vector/map element accessors ([i] / ['key']) attach directly
   // to the parent field name, producing paths like body[1] instead of body.stmts[1].
   void PushFieldName(const char* name) {
+    if (transparent_depth_ == 0) {
+      field_name_stack_.emplace_back(name);
+    }
     if constexpr (AssertMode) {
       if (transparent_depth_ == 0) {
         path_.emplace_back(name);  // No dot prefix — ThrowMismatch adds '.' separators
@@ -567,6 +591,9 @@ class StructuralEqualImpl {
   }
 
   void PopFieldName() {
+    if (transparent_depth_ == 0) {
+      field_name_stack_.pop_back();
+    }
     if constexpr (AssertMode) {
       if (transparent_depth_ == 0) {
         path_.pop_back();
@@ -586,6 +613,13 @@ class StructuralEqualImpl {
   bool EqualMemRef(const MemRefPtr& lhs, const MemRefPtr& rhs);
   bool EqualIterArg(const IterArgPtr& lhs, const IterArgPtr& rhs);
   bool EqualType(const TypePtr& lhs, const TypePtr& rhs);
+  bool IsLoopVarFieldContext() const {
+    return !field_name_stack_.empty() && field_name_stack_.back() == "loop_var";
+  }
+  bool IsConstIntTypeContext() const {
+    return !node_type_stack_.empty() && node_type_stack_.back() == "ConstInt" && !field_name_stack_.empty() &&
+           field_name_stack_.back() == "type";
+  }
 
   /**
    * @brief Generic field-based equality check for IR nodes using FieldIterator
@@ -667,25 +701,25 @@ class StructuralEqualImpl {
   std::unordered_map<VarPtr, VarPtr> lhs_to_rhs_var_map_;
   std::unordered_map<VarPtr, VarPtr> rhs_to_lhs_var_map_;
   std::vector<std::string> path_;  // Only used in assert mode
-  int transparent_depth_ = 0;      // Depth inside transparent containers (Program/SeqStmts)
+  std::vector<std::string> field_name_stack_;
+  std::vector<std::string> node_type_stack_;
+  int transparent_depth_ = 0;  // Depth inside transparent containers (Program/SeqStmts)
 };
 
 // Type dispatch macro for generic field-based comparison.
 // Saves and resets transparent_depth_ to 0 before entering EqualWithFields so that
 // field names of this (non-transparent) node are always pushed into the path, even
 // when Equal() is called recursively from within a transparent container's field visit.
-#define EQUAL_DISPATCH(Type)                                               \
-  if (auto lhs_##Type = As<Type>(lhs)) {                                   \
-    auto rhs_##Type = As<Type>(rhs);                                       \
-    if constexpr (AssertMode) {                                            \
-      int saved_depth = transparent_depth_;                                \
-      transparent_depth_ = 0;                                              \
-      bool result = rhs_##Type && EqualWithFields(lhs_##Type, rhs_##Type); \
-      transparent_depth_ = saved_depth;                                    \
-      return result;                                                       \
-    } else {                                                               \
-      return rhs_##Type && EqualWithFields(lhs_##Type, rhs_##Type);        \
-    }                                                                      \
+#define EQUAL_DISPATCH(Type)                                             \
+  if (auto lhs_##Type = As<Type>(lhs)) {                                 \
+    auto rhs_##Type = As<Type>(rhs);                                     \
+    node_type_stack_.emplace_back(#Type);                                \
+    int saved_depth = transparent_depth_;                                \
+    transparent_depth_ = 0;                                              \
+    bool result = rhs_##Type && EqualWithFields(lhs_##Type, rhs_##Type); \
+    transparent_depth_ = saved_depth;                                    \
+    node_type_stack_.pop_back();                                         \
+    return result;                                                       \
   }
 
 // Dispatch macro for transparent container nodes (Program, SeqStmts).
@@ -694,10 +728,12 @@ class StructuralEqualImpl {
 // parent field name: e.g., body[1] instead of body.stmts[1].
 #define EQUAL_DISPATCH_TRANSPARENT(Type)                                 \
   if (auto lhs_##Type = As<Type>(lhs)) {                                 \
-    if constexpr (AssertMode) transparent_depth_++;                      \
+    transparent_depth_++;                                                \
     auto rhs_##Type = As<Type>(rhs);                                     \
+    node_type_stack_.emplace_back(#Type);                                \
     bool result = rhs_##Type && EqualWithFields(lhs_##Type, rhs_##Type); \
-    if constexpr (AssertMode) transparent_depth_--;                      \
+    node_type_stack_.pop_back();                                         \
+    transparent_depth_--;                                                \
     return result;                                                       \
   }
 
@@ -787,6 +823,10 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
         ThrowMismatch("Type cast failed for ScalarType", IRNodePtr(), IRNodePtr(), "", "");
       }
       return false;
+    }
+    if ((IsLoopVarFieldContext() || IsConstIntTypeContext()) &&
+        AreForSyntaxScalarDtypesEquivalent(lhs_scalar->dtype_, rhs_scalar->dtype_)) {
+      return true;
     }
     if (lhs_scalar->dtype_ != rhs_scalar->dtype_) {
       if constexpr (AssertMode) {
@@ -904,15 +944,17 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       if (!Equal(lhs_tile->shape_[i], rhs_tile->shape_[i])) return false;
     }
     // Compare tile_view
-    if (lhs_tile->tile_view_.has_value() != rhs_tile->tile_view_.has_value()) {
+    auto lhs_tile_view = NormalizePrintedTileView(lhs_tile);
+    auto rhs_tile_view = NormalizePrintedTileView(rhs_tile);
+    if (lhs_tile_view.has_value() != rhs_tile_view.has_value()) {
       if constexpr (AssertMode) {
         ThrowMismatch("TileType tile_view presence mismatch", IRNodePtr(), IRNodePtr(), "", "");
       }
       return false;
     }
-    if (lhs_tile->tile_view_.has_value()) {
-      const auto& lhs_tv = lhs_tile->tile_view_.value();
-      const auto& rhs_tv = rhs_tile->tile_view_.value();
+    if (lhs_tile_view.has_value()) {
+      const auto& lhs_tv = lhs_tile_view.value();
+      const auto& rhs_tv = rhs_tile_view.value();
       // Compare valid_shape
       if (lhs_tv.valid_shape.size() != rhs_tv.valid_shape.size()) {
         if constexpr (AssertMode) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -36,10 +36,33 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
+
+namespace {
+
+std::optional<TileView> NormalizePrintedTileView(const TileTypePtr& tile_type) {
+  if (!tile_type || !tile_type->tile_view_.has_value()) {
+    return std::nullopt;
+  }
+  if (tile_view_semantics::IsImplicitPrintedTileView(tile_type->tile_view_.value(), tile_type->shape_,
+                                                     tile_type->memory_space_)) {
+    return std::nullopt;
+  }
+  return tile_type->tile_view_;
+}
+
+DataType CanonicalizeForSyntaxScalarDtype(const DataType& dtype) {
+  if (dtype == DataType::INT64 || dtype == DataType::INDEX) {
+    return DataType::INDEX;
+  }
+  return dtype;
+}
+
+}  // namespace
 
 /**
  * @brief Hash combine using Boost-inspired algorithm
@@ -124,9 +147,16 @@ class StructuralHasher {
     visit_op();
   }
 
-  // No-op path tracking hooks (path tracking is only needed in StructuralEqualImpl<true>)
-  void PushFieldName([[maybe_unused]] const char* name) {}
-  void PopFieldName() {}
+  void PushFieldName(const char* name) {
+    if (transparent_depth_ == 0) {
+      field_name_stack_.emplace_back(name);
+    }
+  }
+  void PopFieldName() {
+    if (transparent_depth_ == 0) {
+      field_name_stack_.pop_back();
+    }
+  }
 
   result_type VisitLeafField(const int& field) { return static_cast<result_type>(std::hash<int>{}(field)); }
 
@@ -267,6 +297,13 @@ class StructuralHasher {
  private:
   result_type HashNode(const IRNodePtr& node);
   result_type HashType(const TypePtr& type);
+  bool IsLoopVarFieldContext() const {
+    return !field_name_stack_.empty() && field_name_stack_.back() == "loop_var";
+  }
+  bool IsConstIntTypeContext() const {
+    return !node_type_stack_.empty() && node_type_stack_.back() == "ConstInt" && !field_name_stack_.empty() &&
+           field_name_stack_.back() == "type";
+  }
 
   template <typename NodePtr>
   result_type HashNodeImpl(const NodePtr& node);
@@ -274,6 +311,9 @@ class StructuralHasher {
   bool enable_auto_mapping_;
   std::unordered_map<IRNodePtr, result_type> hash_value_map_;
   int64_t free_var_counter_ = 0;
+  std::vector<std::string> field_name_stack_;
+  std::vector<std::string> node_type_stack_;
+  int transparent_depth_ = 0;
 };
 
 template <typename NodePtr>
@@ -282,6 +322,20 @@ StructuralHasher::result_type StructuralHasher::HashNodeImpl(const NodePtr& node
 
   // Start with type discriminator
   result_type h = static_cast<result_type>(std::hash<std::string>{}(node->TypeName()));
+  node_type_stack_.emplace_back(node->TypeName());
+
+  // Mirror EQUAL_DISPATCH / EQUAL_DISPATCH_TRANSPARENT from structural_equal.cpp:
+  // - Transparent containers (Program, SeqStmts) suppress their own field names by
+  //   incrementing transparent_depth_, so PushFieldName skips them.
+  // - Non-transparent nodes reset transparent_depth_ to 0 so their fields are always
+  //   tracked, even when visited from within a transparent container.
+  constexpr bool is_transparent = std::is_same_v<NodeType, Program> || std::is_same_v<NodeType, SeqStmts>;
+  int saved_depth = transparent_depth_;
+  if constexpr (is_transparent) {
+    transparent_depth_++;
+  } else {
+    transparent_depth_ = 0;
+  }
 
   // Visit all fields using reflection
   auto descriptors = NodeType::GetFieldDescriptors();
@@ -293,6 +347,9 @@ StructuralHasher::result_type StructuralHasher::HashNodeImpl(const NodePtr& node
       },
       descriptors);
 
+  transparent_depth_ = saved_depth;
+  node_type_stack_.pop_back();
+
   return hash_combine(h, fields_hash);
 }
 
@@ -300,7 +357,11 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
   INTERNAL_CHECK(type) << "structural_hash encountered null TypePtr";
   result_type h = static_cast<result_type>(std::hash<std::string>{}(type->TypeName()));
   if (auto scalar_type = As<ScalarType>(type)) {
-    h = hash_combine(h, static_cast<result_type>(std::hash<uint8_t>{}(scalar_type->dtype_.Code())));
+    DataType dtype = scalar_type->dtype_;
+    if (IsLoopVarFieldContext() || IsConstIntTypeContext()) {
+      dtype = CanonicalizeForSyntaxScalarDtype(dtype);
+    }
+    h = hash_combine(h, static_cast<result_type>(std::hash<uint8_t>{}(dtype.Code())));
   } else if (auto tensor_type = As<TensorType>(type)) {
     h = hash_combine(h, static_cast<result_type>(std::hash<uint8_t>{}(tensor_type->dtype_.Code())));
     h = hash_combine(h, static_cast<result_type>(tensor_type->shape_.size()));
@@ -339,8 +400,9 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       h = hash_combine(h, HashNode(dim));
     }
     // Hash tile_view if present
-    if (tile_type->tile_view_.has_value()) {
-      const auto& tv = tile_type->tile_view_.value();
+    auto tile_view = NormalizePrintedTileView(tile_type);
+    if (tile_view.has_value()) {
+      const auto& tv = tile_view.value();
       h = hash_combine(h, static_cast<result_type>(1));  // indicate presence
       // Hash valid_shape
       h = hash_combine(h, static_cast<result_type>(tv.valid_shape.size()));

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -56,6 +56,9 @@ bool operator==(const TileView& lhs, const TileView& rhs) {
 
 bool operator!=(const TileView& lhs, const TileView& rhs) { return !(lhs == rhs); }
 
+ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape)
+    : dtype_(dtype), shape_(std::move(shape)), memref_(std::nullopt) {}
+
 std::string TensorLayoutToString(TensorLayout layout) {
   switch (layout) {
     case TensorLayout::ND:
@@ -110,6 +113,12 @@ ShapedType::ShapedType(DataType dtype, const std::vector<int64_t>& shape, std::o
     shape_.push_back(std::make_shared<ConstInt>(dim, DataType::INDEX, Span::unknown()));
   }
 }
+
+ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, MemRefPtr memref)
+    : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+
+ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRefPtr> memref)
+    : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
 
 TileType::TileType(const std::vector<int64_t>& shape, DataType dtype, std::optional<MemRefPtr> memref,
                    std::optional<TileView> tile_view, std::optional<MemorySpace> memory_space)

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -272,6 +272,26 @@ class TestTensorTypeWithMemRef:
         assert tensor_var.type.memref is not None
         assert tensor_var.type.memory_space == ir.MemorySpace.DDR
 
+    def test_tensor_type_preserves_const_shape_dim_dtype(self):
+        """TensorType preserves the original dtype of Expr-based shape dims."""
+        span = ir.Span.unknown()
+        shape = [
+            ir.ConstInt(10, DataType.INT64, span),
+            ir.ConstInt(20, DataType.INT32, span),
+        ]
+
+        tensor_type = ir.TensorType(shape, DataType.FP32)
+
+        assert len(tensor_type.shape) == 2
+        # Original dtypes are preserved; INT64/INDEX equivalence is handled by
+        # structural_equal, not by mutating the IR at construction time.
+        assert isinstance(tensor_type.shape[0], ir.ConstInt)
+        assert isinstance(tensor_type.shape[0].type, ir.ScalarType)
+        assert tensor_type.shape[0].type.dtype == DataType.INT64
+        assert isinstance(tensor_type.shape[1], ir.ConstInt)
+        assert isinstance(tensor_type.shape[1].type, ir.ScalarType)
+        assert tensor_type.shape[1].type.dtype == DataType.INT32
+
 
 class TestTileTypeWithMemRef:
     """Tests for TileType with MemRef and TileView."""
@@ -289,6 +309,26 @@ class TestTileTypeWithMemRef:
         assert len(tile_type.shape) == 2
         assert tile_type.memref is None
         assert tile_type.tile_view is None
+
+    def test_tile_type_preserves_const_shape_dim_dtype(self):
+        """TileType preserves the original dtype of Expr-based shape dims."""
+        span = ir.Span.unknown()
+        shape = [
+            ir.ConstInt(16, DataType.INT64, span),
+            ir.ConstInt(32, DataType.INT32, span),
+        ]
+
+        tile_type = ir.TileType(shape, DataType.FP32)
+
+        assert len(tile_type.shape) == 2
+        # Original dtypes are preserved; INT64/INDEX equivalence is handled by
+        # structural_equal, not by mutating the IR at construction time.
+        assert isinstance(tile_type.shape[0], ir.ConstInt)
+        assert isinstance(tile_type.shape[0].type, ir.ScalarType)
+        assert tile_type.shape[0].type.dtype == DataType.INT64
+        assert isinstance(tile_type.shape[1], ir.ConstInt)
+        assert isinstance(tile_type.shape[1].type, ir.ScalarType)
+        assert tile_type.shape[1].type.dtype == DataType.INT32
 
     def test_tile_type_with_memref(self):
         """Test TileType creation with MemRef."""


### PR DESCRIPTION
## Summary

Fix two categories of structural equality mismatches that cause print-parse roundtrip verification to fail, without mutating IR values at construction time.

### Problem

When the roundtrip verifier does `python_print(program) → parse() → assert_structural_equal(original, reparsed)`, two kinds of type information change representation across the cycle even though the semantics are identical:

1. **TileView implicit defaults**: The printer omits a `TileView` when it matches the memory-space-aware implicit default (e.g. raw defaults for `Vec`/`Bias`, but not for `Mat`/`Left`/`Right`/`Acc`). If the original IR carries an explicit `TileView` that happens to equal the implicit default, it becomes `nullopt` after roundtrip, causing `structural_equal` to report a mismatch.

2. **INT64 vs INDEX scalar dtype**: The printer outputs `ConstInt` shape dimensions as bare integers (no dtype); the parser always reads them back as `INDEX`. Loop variable types (`ForStmt.loop_var`) face the same issue. Pass/builder code sometimes constructs these with `INT64`, so after roundtrip the dtype changes.

### Fix

**`structural_equal.cpp` / `structural_hash.cpp`**

- `NormalizePrintedTileView()`: before comparing a `TileType`'s `tile_view` field, normalize away any `TileView` that `IsImplicitPrintedTileView()` (memory-space-aware, already defined in `tile_view_semantics.h` from #774) would consider implicit. Both sides are normalized before comparison.

- Context-aware `INT64`/`INDEX` equivalence: add `field_name_stack_` and `node_type_stack_` to both `StructuralEqualImpl` and `StructuralHasher` to track traversal context. When comparing a `ScalarType` in the context of a `ConstInt.type` field or a `loop_var` field, treat `INT64` and `INDEX` as equivalent.

**`type.h` / `type.cpp`**

Move three `ShapedType(ExprPtr shape...)` constructor bodies from inline in the header to `type.cpp`. No behavioral change; original dtypes are fully preserved in the IR.

### Design decision

Equivalence is handled at the comparison layer, not by mutating caller-provided values at construction time. This is the conservative choice: the IR carries the original representation, and only the equality semantics are widened to cover printer/parser round-trip invariants.

## Testing

- Existing unit tests pass under the updated `structural_equal` / `structural_hash`.
- Two new tests in `test_memref.py` document that `TensorType` / `TileType` preserve the original `ConstInt` dtype of Expr-based shape dims (INT64 stays INT64, INT32 stays INT32).

## Related Issues

Prerequisite for #402 (roundtrip verification mode).