### PR TITLE
feat(ir): add tensor.gather operator with codegen and DSL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(PYPTO_SOURCES
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp
     src/ir/op/tensor_ops/memory.cpp
+    src/ir/op/tensor_ops/gather.cpp
     src/ir/op/tensor_ops/scatter_update.cpp
     src/ir/op/tensor_ops/reduction.cpp
     src/ir/op/tensor_ops/transform.cpp

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -940,3 +940,34 @@ def scatter_update(
     op_args: list[Expr] = [input, index, src]
     kwargs: dict[str, Any] = {"dim": dim_val}
     return _ir_core.create_op_call("tensor.scatter_update", op_args, kwargs, actual_span)
+
+
+def gather(
+    input: Expr,
+    dim: int,
+    index: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Gather values from input tensor along the specified dimension using index tensor.
+
+    For a 3D tensor, the output is computed as:
+        output[i][j][k] = input[index[i][j][k]][j][k]  if dim=0
+        output[i][j][k] = input[i][index[i][j][k]][k]  if dim=1
+        output[i][j][k] = input[i][j][index[i][j][k]]  if dim=2
+
+    Args:
+        input: Input tensor to gather from
+        dim: Dimension along which to gather (supports negative indexing)
+        index: Index tensor (same rank as input, integer dtype).
+               Output shape equals index shape.
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the gathered tensor (same dtype as input, same shape as index)
+    """
+    actual_span = _get_span_or_capture(span)
+    args = [input, index]
+    # dim may arrive as a ConstInt when called from the DSL parser — extract the int value
+    dim_val = int(dim.value) if isinstance(dim, ConstInt) else int(dim)
+    kwargs: dict[str, Any] = {"dim": dim_val}
+    return _ir_core.create_op_call("tensor.gather", args, kwargs, actual_span)

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -86,7 +86,7 @@ from .op.system_ops import (
     tpush_to_aic,
     tpush_to_aiv,
 )
-from .op.tensor_ops import assemble, create_tensor, dim, full, scatter_update
+from .op.tensor_ops import assemble, create_tensor, dim, full, gather, scatter_update
 from .op.tile_ops import (
     MemRefType,
     abs,
@@ -328,6 +328,7 @@ __all__ = [
     "assemble",
     "dim",
     "full",
+    "gather",
     "scatter_update",
     "FunctionType",
     "ForKind",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -59,6 +59,7 @@ __all__ = [
     "reshape",
     "transpose",
     "scatter_update",
+    "gather",
 ]
 
 from pypto.ir.op import tensor_ops as _ir_ops
@@ -778,4 +779,29 @@ def scatter_update(
         Tensor wrapping the scatter_update operation
     """
     call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
+    return Tensor(expr=call_expr)
+
+
+def gather(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+) -> Tensor:
+    """Gather values from input tensor along the specified dimension using index tensor.
+
+    For a 3D tensor, the output is computed as:
+        output[i][j][k] = input[index[i][j][k]][j][k]  if dim=0
+        output[i][j][k] = input[i][index[i][j][k]][k]  if dim=1
+        output[i][j][k] = input[i][j][index[i][j][k]]  if dim=2
+
+    Args:
+        input: Input tensor to gather from
+        dim: Dimension along which to gather (supports negative indexing)
+        index: Index tensor (same rank as input, integer dtype).
+               Output shape equals index shape.
+
+    Returns:
+        Tensor wrapping the gather operation (same dtype as input, same shape as index)
+    """
+    call_expr = _ir_ops.gather(input.unwrap(), dim, index.unwrap())
     return Tensor(expr=call_expr)

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -19,6 +19,7 @@
 
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/orchestration_op_registry.h"
+#include "pypto/core/any_cast.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
@@ -347,6 +348,137 @@ REGISTER_ORCHESTRATION_OP(tensor_scatter_update, ("tensor.scatter_update")) {
   oss << "           " << d_var << " * " << elem_bytes << "ULL);\n";
   oss << "  }\n}\n";
   oss << "Tensor " << result_var << " = " << codegen.GetExternalTensorName(input_name) << ";";
+  return oss.str();
+}
+
+REGISTER_ORCHESTRATION_OP(tensor_gather, ("tensor.gather")) {
+  // tensor.gather(input, index, dim=D):
+  //   output[i0][i1]...[iN] = input[i0]...[index[i0..iN]]...[iN]
+  //   where the dim-th coordinate is replaced by the index value.
+  // Supports arbitrary N-D tensors.
+  CHECK(op->args_.size() == 2) << "tensor.gather requires 2 arguments";
+
+  std::string input_name = codegen.TryGetVarName(op->args_[0]);
+  CHECK(!input_name.empty()) << "tensor.gather: input must be a variable";
+  std::string index_name = codegen.TryGetVarName(op->args_[1]);
+  CHECK(!index_name.empty()) << "tensor.gather: index must be a variable";
+
+  auto input_type = As<TensorType>(op->args_[0]->GetType());
+  auto index_type = As<TensorType>(op->args_[1]->GetType());
+  INTERNAL_CHECK(input_type && index_type) << "Internal error: invalid types for tensor.gather";
+
+  // Extract dim from kwargs
+  int gather_dim = 0;
+  for (const auto& [key, val] : op->kwargs_) {
+    if (key == "dim") {
+      gather_dim = AnyCast<int>(val, "kwarg key: dim");
+    }
+  }
+  int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
+  if (gather_dim < 0) {
+    gather_dim += static_cast<int>(ndim);
+  }
+
+  std::string input_ptr = codegen.GetTensorDataPtr(input_name);
+  std::string index_ptr = codegen.GetTensorDataPtr(index_name);
+
+  std::string elem_cpp_type = input_type->dtype_.ToCTypeString();
+  std::string index_cpp_type = index_type->dtype_.ToCTypeString();
+  std::string result_var = codegen.GetCurrentResultTarget();
+
+  std::ostringstream oss;
+
+  // 1. Create output tensor (shape = index shape, dtype = input dtype)
+  oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
+  for (int64_t i = 0; i < ndim; ++i) {
+    if (i > 0) oss << ", ";
+    oss << "(uint32_t)(" << codegen.GenerateExprString(index_type->shape_[i]) << ")";
+  }
+  oss << "};\n";
+  oss << "Tensor " << result_var << " = make_tensor(" << result_var << "_shapes, " << ndim << ", "
+      << codegen.GetRuntimeDataTypeString(input_type->dtype_) << ");\n";
+
+  // 2. Declare typed pointers
+  std::string ip = "inp_" + result_var;
+  std::string xp = "idx_" + result_var;
+  std::string op_ptr = "out_" + result_var;
+  oss << "const " << elem_cpp_type << "* " << ip << " = static_cast<const " << elem_cpp_type << "*>("
+      << input_ptr << ");\n";
+  oss << "const " << index_cpp_type << "* " << xp << " = static_cast<const " << index_cpp_type << "*>("
+      << index_ptr << ");\n";
+  oss << elem_cpp_type << "* " << op_ptr << " = static_cast<" << elem_cpp_type << "*>(" << result_var
+      << ".data);\n";
+
+  // 3. Declare output shape and input shape arrays, compute strides and total
+  std::string osh = "osh_" + result_var;
+  std::string ish = "ish_" + result_var;
+  std::string ist = "ist_" + result_var;
+  std::string total = "tot_" + result_var;
+
+  oss << "size_t " << osh << "[" << ndim << "] = {";
+  for (int64_t i = 0; i < ndim; ++i) {
+    if (i > 0) oss << ", ";
+    oss << "(size_t)(" << codegen.GenerateExprString(index_type->shape_[i]) << ")";
+  }
+  oss << "};\n";
+
+  oss << "size_t " << ish << "[" << ndim << "] = {";
+  for (int64_t i = 0; i < ndim; ++i) {
+    if (i > 0) oss << ", ";
+    oss << "(size_t)(" << codegen.GenerateExprString(input_type->shape_[i]) << ")";
+  }
+  oss << "};\n";
+
+  // Input strides (row-major)
+  oss << "size_t " << ist << "[" << ndim << "];\n";
+  oss << ist << "[" << ndim - 1 << "] = 1;\n";
+  if (ndim > 1) {
+    std::string d_var = "sd_" + result_var;
+    oss << "for (int " << d_var << " = " << ndim - 2 << "; " << d_var << " >= 0; --" << d_var << ") {\n";
+    oss << "  " << ist << "[" << d_var << "] = " << ist << "[" << d_var << " + 1] * " << ish << "[" << d_var
+        << " + 1];\n";
+    oss << "}\n";
+  }
+
+  // Total elements
+  oss << "size_t " << total << " = 1;\n";
+  {
+    std::string d_var = "td_" + result_var;
+    oss << "for (size_t " << d_var << " = 0; " << d_var << " < " << ndim << "; ++" << d_var << ") {\n";
+    oss << "  " << total << " *= " << osh << "[" << d_var << "];\n";
+    oss << "}\n";
+  }
+
+  // 4. Main gather loop
+  std::string flat = "f_" + result_var;
+  std::string coords = "c_" + result_var;
+  std::string tmp = "t_" + result_var;
+  std::string in_idx = "ii_" + result_var;
+  std::string d_loop = "d_" + result_var;
+
+  oss << "for (size_t " << flat << " = 0; " << flat << " < " << total << "; ++" << flat << ") {\n";
+
+  // Decompose flat index to N-D coordinates
+  oss << "  size_t " << coords << "[" << ndim << "];\n";
+  oss << "  size_t " << tmp << " = " << flat << ";\n";
+  oss << "  for (int " << d_loop << " = " << ndim - 1 << "; " << d_loop << " >= 0; --" << d_loop << ") {\n";
+  oss << "    " << coords << "[" << d_loop << "] = " << tmp << " % " << osh << "[" << d_loop << "];\n";
+  oss << "    " << tmp << " /= " << osh << "[" << d_loop << "];\n";
+  oss << "  }\n";
+
+  // Replace dim coordinate with index value
+  oss << "  " << coords << "[" << gather_dim << "] = static_cast<size_t>(" << xp << "[" << flat << "]);\n";
+
+  // Compute input linear index
+  oss << "  size_t " << in_idx << " = 0;\n";
+  oss << "  for (int " << d_loop << " = 0; " << d_loop << " < " << ndim << "; ++" << d_loop << ") {\n";
+  oss << "    " << in_idx << " += " << coords << "[" << d_loop << "] * " << ist << "[" << d_loop << "];\n";
+  oss << "  }\n";
+
+  // Copy element
+  oss << "  " << op_ptr << "[" << flat << "] = " << ip << "[" << in_idx << "];\n";
+  oss << "}\n";
+
   return oss.str();
 }
 

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file gather.cpp
+ * @brief Gather tensor operation
+ *
+ * Implements tensor.gather, which extracts values from the input tensor along
+ * the specified dimension using the provided index tensor (PyTorch gather semantics).
+ *
+ * For a 3D tensor:
+ *   output[i][j][k] = input[index[i][j][k]][j][k]  if dim=0
+ *   output[i][j][k] = input[i][index[i][j][k]][k]  if dim=1
+ *   output[i][j][k] = input[i][j][index[i][j][k]]  if dim=2
+ */
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/any_cast.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.gather(input, index, dim=...) -> TensorType with index's shape and input's dtype
+  CHECK(args.size() == 2) << "tensor.gather requires exactly 2 arguments (input, index), got " << args.size();
+
+  auto input_type = As<TensorType>(args[0]->GetType());
+  CHECK(input_type) << "tensor.gather: input must be TensorType, got " << args[0]->GetType()->TypeName();
+
+  auto index_type = As<TensorType>(args[1]->GetType());
+  CHECK(index_type) << "tensor.gather: index must be TensorType, got " << args[1]->GetType()->TypeName();
+
+  CHECK(index_type->dtype_.IsInt()) << "tensor.gather: index dtype must be integer, got "
+                                    << index_type->dtype_.ToString();
+
+  int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
+  CHECK(ndim > 0) << "tensor.gather: input must have at least 1 dimension";
+
+  CHECK(static_cast<int64_t>(index_type->shape_.size()) == ndim)
+      << "tensor.gather: index rank (" << index_type->shape_.size() << ") must match input rank (" << ndim
+      << ")";
+
+  // Extract and validate dim
+  int dim = 0;
+  bool dim_found = false;
+  for (const auto& [key, val] : kwargs) {
+    if (key == "dim") {
+      dim = AnyCast<int>(val, "kwarg key: dim");
+      dim_found = true;
+    }
+  }
+  CHECK(dim_found) << "tensor.gather: dim attribute is required";
+  CHECK(dim >= -ndim && dim < ndim) << "tensor.gather: dim (" << dim << ") out of range for tensor with rank "
+                                    << ndim;
+  if (dim < 0) {
+    dim += static_cast<int>(ndim);
+  }
+
+  // Validate index.shape[i] <= input.shape[i] for i != dim (when shapes are statically known)
+  for (int64_t i = 0; i < ndim; ++i) {
+    if (i == dim) continue;
+    auto idx_dim = As<ConstInt>(index_type->shape_[i]);
+    auto inp_dim = As<ConstInt>(input_type->shape_[i]);
+    if (idx_dim && inp_dim) {
+      CHECK(idx_dim->value_ <= inp_dim->value_)
+          << "tensor.gather: index.shape[" << i << "] (" << idx_dim->value_ << ") must be <= input.shape["
+          << i << "] (" << inp_dim->value_ << ") for non-gather dimension";
+    }
+  }
+
+  return std::make_shared<TensorType>(index_type->shape_, input_type->dtype_);
+}
+
+REGISTER_OP("tensor.gather")
+    .set_op_category("TensorOp")
+    .set_description(
+        "Gather values from input tensor along the specified dimension using index tensor. "
+        "output[i][j][k] = input[i][index[i][j][k]][k] when dim=1 (3D example). "
+        "index must have the same rank as input, with index.shape[i] <= input.shape[i] for i != dim. "
+        "Output has the same shape as index and the same dtype as input.")
+    .add_argument("input", "Input tensor to gather from")
+    .add_argument("index", "Index tensor (same rank as input, integer dtype)")
+    .set_attr<int>("dim")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorGatherType(args, kwargs);
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/st/codegen/test_gather_codegen.py
+++ b/tests/st/codegen/test_gather_codegen.py
@@ -1,0 +1,271 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end test for tensor.gather orchestration codegen pipeline.
+
+Verifies the complete compilation pipeline: DSL → IR → PassManager → codegen
+for programs using tensor.gather in orchestration functions.
+
+Test scenarios:
+  1. 2D gather with dim=0 (row selection)
+  2. 2D gather with dim=1 (MoE top-k expert selection pattern)
+  3. 3D gather with dim=1 (batch attention pattern)
+  4. 3D gather with dim=2 (last-dim selection)
+  5. 2D gather with negative dim (dim=-1 → dim=1)
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import ir
+
+
+def _generate_orch_code(program) -> str:
+    """Generate orchestration code through the full pipeline."""
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(program)
+    for func in optimized.functions.values():
+        if func.func_type == ir.FunctionType.Orchestration:
+            result = codegen.generate_orchestration(optimized, func)
+            return result.code
+    raise ValueError("No orchestration function found in program")
+
+
+class TestGatherOrchCodegenPipeline:
+    """End-to-end tests for tensor.gather through the full codegen pipeline."""
+
+    def test_gather_2d_dim0_pipeline(self):
+        """Full pipeline: 2D gather with dim=0 (row selection).
+
+        Pattern: select specific rows from a table.
+        Input [8, 4], Index [3, 4] → Output [3, 4]
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherDim0:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                t: pl.Tensor[[3, 4], pl.FP32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                tile: pl.Tile[[3, 4], pl.FP32] = pl.load(t, [0, 0], [3, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[8, 4], pl.FP32],
+                idx: pl.Tensor[[3, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                gathered: pl.Tensor[[3, 4], pl.FP32] = pl.gather(inp, 0, idx)
+                out = self.kernel_process(gathered, out)
+                return out
+
+        code = _generate_orch_code(GatherDim0)
+
+        # Verify output tensor creation
+        assert "make_tensor(" in code
+        assert "DataType::FLOAT32" in code
+
+        # Verify pointer casts for input and index
+        assert "static_cast<const float*>" in code
+        assert "static_cast<const int32_t*>" in code
+        assert "static_cast<float*>" in code
+
+        # Verify gather loop structure
+        assert "for (size_t" in code
+
+        # Verify dim=0 coordinate replacement
+        assert "[0] = static_cast<size_t>" in code
+
+        # Verify kernel task submission
+        assert "pto2_rt_submit_aiv_task" in code
+
+    def test_gather_2d_dim1_moe_pipeline(self):
+        """Full pipeline: 2D gather with dim=1 (MoE top-k expert selection).
+
+        Pattern: weights [16, 64] (16 tokens, 64 experts),
+                 topk_ids [16, 4] → selected weights [16, 4]
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherMoE:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                t: pl.Tensor[[16, 4], pl.FP16],
+                out: pl.Out[pl.Tensor[[16, 4], pl.FP16]],
+            ) -> pl.Tensor[[16, 4], pl.FP16]:
+                tile: pl.Tile[[16, 4], pl.FP16] = pl.load(t, [0, 0], [16, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                weights: pl.Tensor[[16, 64], pl.FP16],
+                topk_ids: pl.Tensor[[16, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[16, 4], pl.FP16]],
+            ) -> pl.Tensor[[16, 4], pl.FP16]:
+                selected: pl.Tensor[[16, 4], pl.FP16] = pl.gather(weights, 1, topk_ids)
+                out = self.kernel_process(selected, out)
+                return out
+
+        code = _generate_orch_code(GatherMoE)
+
+        # Output tensor dtype matches input (FP16), not index (INT32)
+        assert "DataType::FLOAT16" in code
+
+        # Output tensor shape matches index [16, 4], not input [16, 64]
+        assert "{(uint32_t)(16), (uint32_t)(4)}" in code
+        assert "make_tensor(" in code
+
+        # Input shape [16, 64] used for stride computation (distinct from output)
+        assert "{(size_t)(16), (size_t)(64)}" in code
+
+        # Verify dim=1 coordinate replacement
+        assert "[1] = static_cast<size_t>" in code
+
+    def test_gather_3d_pipeline(self):
+        """Full pipeline: 3D gather with dim=1 (batch attention pattern).
+
+        Pattern: Input [4, 8, 16], Index [4, 3, 16] → Output [4, 3, 16]
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Gather3D:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                t: pl.Tensor[[4, 3, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 3, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 3, 16], pl.FP32]:
+                tile: pl.Tile[[4, 3, 16], pl.FP32] = pl.load(t, [0, 0, 0], [4, 3, 16])
+                return pl.store(tile, [0, 0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[4, 8, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3, 16], pl.INT64],
+                out: pl.Out[pl.Tensor[[4, 3, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 3, 16], pl.FP32]:
+                gathered: pl.Tensor[[4, 3, 16], pl.FP32] = pl.gather(inp, 1, idx)
+                out = self.kernel_process(gathered, out)
+                return out
+
+        code = _generate_orch_code(Gather3D)
+
+        # Verify 3D tensor handling
+        assert "[3]" in code  # 3-element shape/stride arrays
+
+        # Verify dim=1 coordinate replacement for 3D
+        assert "[1] = static_cast<size_t>" in code
+
+        # Verify INT64 index pointer cast
+        assert "static_cast<const int64_t*>" in code
+
+        # Verify stride computation loop for 3D
+        assert "ist_" in code
+
+    def test_gather_3d_dim2_pipeline(self):
+        """Full pipeline: 3D gather with dim=2 (last-dim selection).
+
+        Pattern: Input [4, 8, 16], Index [4, 8, 5] → Output [4, 8, 5]
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Gather3DDim2:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                t: pl.Tensor[[4, 8, 5], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8, 5], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 5], pl.FP32]:
+                tile: pl.Tile[[4, 8, 5], pl.FP32] = pl.load(t, [0, 0, 0], [4, 8, 5])
+                return pl.store(tile, [0, 0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[4, 8, 16], pl.FP32],
+                idx: pl.Tensor[[4, 8, 5], pl.INT32],
+                out: pl.Out[pl.Tensor[[4, 8, 5], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 5], pl.FP32]:
+                gathered: pl.Tensor[[4, 8, 5], pl.FP32] = pl.gather(inp, 2, idx)
+                out = self.kernel_process(gathered, out)
+                return out
+
+        code = _generate_orch_code(Gather3DDim2)
+
+        # Verify dim=2 coordinate replacement
+        assert "[2] = static_cast<size_t>" in code
+
+        # Verify output shape matches index [4, 8, 5], not input [4, 8, 16]
+        assert "{(uint32_t)(4), (uint32_t)(8), (uint32_t)(5)}" in code
+
+        # Verify input shape [4, 8, 16] used for stride computation
+        assert "{(size_t)(4), (size_t)(8), (size_t)(16)}" in code
+
+    def test_gather_negative_dim_pipeline(self):
+        """Full pipeline: 2D gather with dim=-1 (normalizes to dim=1).
+
+        Pattern: Input [8, 16], Index [8, 4] → Output [8, 4]
+        Verifies negative dim is correctly normalized through the pipeline.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherNegDim:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_process(
+                self,
+                t: pl.Tensor[[8, 4], pl.FP32],
+                out: pl.Out[pl.Tensor[[8, 4], pl.FP32]],
+            ) -> pl.Tensor[[8, 4], pl.FP32]:
+                tile: pl.Tile[[8, 4], pl.FP32] = pl.load(t, [0, 0], [8, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[8, 16], pl.FP32],
+                idx: pl.Tensor[[8, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[8, 4], pl.FP32]],
+            ) -> pl.Tensor[[8, 4], pl.FP32]:
+                gathered: pl.Tensor[[8, 4], pl.FP32] = pl.gather(inp, -1, idx)
+                out = self.kernel_process(gathered, out)
+                return out
+
+        code = _generate_orch_code(GatherNegDim)
+
+        # dim=-1 normalizes to dim=1 for 2D tensor
+        assert "[1] = static_cast<size_t>" in code
+
+        # Verify output shape matches index [8, 4]
+        assert "{(uint32_t)(8), (uint32_t)(4)}" in code
+
+        # Verify output dtype matches input (FP32)
+        assert "DataType::FLOAT32" in code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1653,5 +1653,122 @@ class TestTensorReadWriteOffsetCodegen:
         assert "params_t0.add_inout(ext_acc)" in code
 
 
+class TestTensorGatherCodegen:
+    """Tests for tensor.gather orchestration codegen."""
+
+    def test_gather_2d_dim0_codegen(self):
+        """tensor.gather with 2D tensors and dim=0 generates correct C++ code."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_noop(
+                self,
+                t: pl.Tensor[[3, 4], pl.FP32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                tile: pl.Tile[[3, 4], pl.FP32] = pl.load(t, [0, 0], [3, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[8, 4], pl.FP32],
+                idx: pl.Tensor[[3, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                gathered: pl.Tensor[[3, 4], pl.FP32] = pl.gather(inp, 0, idx)
+                out = self.kernel_noop(gathered, out)
+                return out
+
+        code = _generate_orch_code(GatherProgram)
+
+        # Output tensor creation with index shape
+        assert "make_tensor(" in code
+        # Typed pointer casts for input and index
+        assert "static_cast<const float*>" in code
+        assert "static_cast<const int32_t*>" in code
+        # Main gather loop
+        assert "for (size_t" in code
+        # Dim coordinate replacement (dim=0)
+        assert "[0] = static_cast<size_t>" in code
+
+    def test_gather_2d_dim1_codegen(self):
+        """tensor.gather with dim=1 generates dim replacement at index 1."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherDim1Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_noop(
+                self,
+                t: pl.Tensor[[16, 4], pl.FP16],
+                out: pl.Out[pl.Tensor[[16, 4], pl.FP16]],
+            ) -> pl.Tensor[[16, 4], pl.FP16]:
+                tile: pl.Tile[[16, 4], pl.FP16] = pl.load(t, [0, 0], [16, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                weights: pl.Tensor[[16, 64], pl.FP16],
+                topk_ids: pl.Tensor[[16, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[16, 4], pl.FP16]],
+            ) -> pl.Tensor[[16, 4], pl.FP16]:
+                selected: pl.Tensor[[16, 4], pl.FP16] = pl.gather(weights, 1, topk_ids)
+                out = self.kernel_noop(selected, out)
+                return out
+
+        code = _generate_orch_code(GatherDim1Program)
+
+        # Dim coordinate replacement should use index 1
+        assert "[1] = static_cast<size_t>" in code
+
+        # Output tensor dtype matches input (FP16), not index (INT32)
+        assert "DataType::FLOAT16" in code
+
+        # Output tensor shape matches index [16, 4], not input [16, 64]
+        assert "selected_shapes[2] = {(uint32_t)(16), (uint32_t)(4)}" in code
+        assert "make_tensor(selected_shapes, 2, DataType::FLOAT16)" in code
+
+        # Input shape [16, 64] is used for stride computation (distinct from output shape)
+        assert "ish_selected[2] = {(size_t)(16), (size_t)(64)}" in code
+
+    def test_gather_negative_dim_codegen(self):
+        """tensor.gather with negative dim normalizes to positive index in codegen."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GatherNegDimProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_noop(
+                self,
+                t: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                tile: pl.Tile[[4, 8], pl.FP32] = pl.load(t, [0, 0], [4, 8])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[4, 8], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.INT32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                gathered: pl.Tensor[[4, 8], pl.FP32] = pl.gather(inp, -1, idx)
+                out = self.kernel_noop(gathered, out)
+                return out
+
+        code = _generate_orch_code(GatherNegDimProgram)
+
+        # dim=-1 for 2D tensor normalizes to dim=1
+        assert "[1] = static_cast<size_t>" in code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1617,5 +1617,186 @@ def test_tensor_scatter_update_invalid_dim():
         ir.op.tensor.scatter_update(input_var, 0, index_var, src_var)
 
 
+# ── tensor.gather tests ──────────────────────────────────────────────────
+
+
+def test_tensor_gather_2d_dim0():
+    """Test tensor.gather with 2D tensors and dim=0."""
+    span = ir.Span.unknown()
+
+    rows = ir.ConstInt(8, DataType.INT32, span)
+    cols = ir.ConstInt(4, DataType.INT32, span)
+    idx_rows = ir.ConstInt(3, DataType.INT32, span)
+
+    input_type = ir.TensorType([rows, cols], DataType.FP32)
+    index_type = ir.TensorType([idx_rows, cols], DataType.INT32)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    call = ir.op.tensor.gather(input_var, 0, index_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 2
+    # Output shape == index shape
+    assert isinstance(result_type.shape[0], ir.ConstInt)
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[0].value == 3
+    assert result_type.shape[1].value == 4
+
+
+def test_tensor_gather_2d_dim1():
+    """Test tensor.gather with 2D tensors and dim=1 (MoE use case)."""
+    span = ir.Span.unknown()
+
+    batch = ir.ConstInt(16, DataType.INT32, span)
+    num_experts = ir.ConstInt(64, DataType.INT32, span)
+    topk = ir.ConstInt(4, DataType.INT32, span)
+
+    input_type = ir.TensorType([batch, num_experts], DataType.FP16)
+    index_type = ir.TensorType([batch, topk], DataType.INT32)
+
+    input_var = ir.Var("topk_weights", input_type, span)
+    index_var = ir.Var("topk_ids", index_type, span)
+
+    call = ir.op.tensor.gather(input_var, 1, index_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert len(result_type.shape) == 2
+    assert isinstance(result_type.shape[0], ir.ConstInt)
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[0].value == 16
+    assert result_type.shape[1].value == 4
+
+
+def test_tensor_gather_3d():
+    """Test tensor.gather with 3D tensors and dim=1."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+    d2 = ir.ConstInt(16, DataType.INT32, span)
+    idx_d1 = ir.ConstInt(3, DataType.INT32, span)
+
+    input_type = ir.TensorType([d0, d1, d2], DataType.FP32)
+    index_type = ir.TensorType([d0, idx_d1, d2], DataType.INT64)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    call = ir.op.tensor.gather(input_var, 1, index_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[1].value == 3
+
+
+def test_tensor_gather_negative_dim():
+    """Test tensor.gather with negative dim value."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([d0, d1], DataType.FP32)
+    index_type = ir.TensorType([d0, d1], DataType.INT32)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    # dim=-1 should be equivalent to dim=1 for a 2D tensor
+    call = ir.op.tensor.gather(input_var, -1, index_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+
+
+def test_tensor_gather_rank_mismatch():
+    """Test tensor.gather rejects rank mismatch between input and index."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+    d2 = ir.ConstInt(16, DataType.INT32, span)
+
+    input_type = ir.TensorType([d0, d1, d2], DataType.FP32)  # 3D
+    index_type = ir.TensorType([d0, d1], DataType.INT32)  # 2D
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    with pytest.raises(ValueError, match="index rank"):
+        ir.op.tensor.gather(input_var, 0, index_var)
+
+
+def test_tensor_gather_non_integer_index():
+    """Test tensor.gather rejects non-integer index dtype."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([d0, d1], DataType.FP32)
+    index_type = ir.TensorType([d0, d1], DataType.FP32)  # float, not int
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    with pytest.raises(ValueError, match="index dtype must be integer"):
+        ir.op.tensor.gather(input_var, 0, index_var)
+
+
+def test_tensor_gather_dim_out_of_range():
+    """Test tensor.gather rejects dim out of range."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([d0, d1], DataType.FP32)
+    index_type = ir.TensorType([d0, d1], DataType.INT32)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    with pytest.raises(ValueError, match="dim.*out of range"):
+        ir.op.tensor.gather(input_var, 2, index_var)
+
+
+def test_tensor_gather_index_shape_exceeds_input():
+    """Test tensor.gather rejects index shape larger than input on non-gather dims."""
+    span = ir.Span.unknown()
+
+    d0 = ir.ConstInt(4, DataType.INT32, span)
+    d1 = ir.ConstInt(8, DataType.INT32, span)
+    d1_big = ir.ConstInt(16, DataType.INT32, span)  # bigger than input's d1
+
+    input_type = ir.TensorType([d0, d1], DataType.FP32)
+    index_type = ir.TensorType([d0, d1_big], DataType.INT32)
+
+    input_var = ir.Var("inp", input_type, span)
+    index_var = ir.Var("idx", index_type, span)
+
+    # dim=0, so d1 (index 1) is a non-gather dim and index.shape[1]=16 > input.shape[1]=8
+    with pytest.raises(ValueError, match="must be <="):
+        ir.op.tensor.gather(input_var, 0, index_var)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/test_tensor_gather.py
+++ b/tests/ut/language/test_tensor_gather.py
@@ -1,0 +1,209 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for pl.gather DSL API (tensor.gather operation).
+
+Verifies that pl.gather() produces correct IR when used inside @pl.function,
+including type deduction and error handling.
+
+Test scenarios:
+  1. 2D gather with dim=0 (row selection)
+  2. 2D gather with dim=1 (MoE top-k pattern)
+  3. 3D gather with dim=1 (batch attention pattern)
+  4. 3D gather with dim=2 (last-dim selection)
+  5. 2D gather with negative dim
+  6. 3D gather with negative dim
+  7. Orchestration function integration
+  8. Round-trip print → parse
+  9. Error cases: rank mismatch, non-integer index, dim out of range
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.language.parser.diagnostics.exceptions import InvalidOperationError
+
+
+class TestGatherDSL:
+    """Tests for pl.gather() via the DSL layer."""
+
+    def test_gather_2d_dim0(self):
+        """pl.gather with 2D tensors and dim=0 produces correct IR."""
+
+        @pl.function
+        def func(
+            inp: pl.Tensor[[8, 4], pl.FP32],
+            idx: pl.Tensor[[3, 4], pl.INT32],
+        ) -> pl.Tensor[[3, 4], pl.FP32]:
+            result: pl.Tensor[[3, 4], pl.FP32] = pl.gather(inp, 0, idx)
+            return result
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    def test_gather_2d_dim1(self):
+        """pl.gather with dim=1 (MoE top-k pattern) produces correct output type."""
+
+        @pl.function
+        def func(
+            weights: pl.Tensor[[16, 64], pl.FP16],
+            topk_ids: pl.Tensor[[16, 4], pl.INT32],
+        ) -> pl.Tensor[[16, 4], pl.FP16]:
+            selected: pl.Tensor[[16, 4], pl.FP16] = pl.gather(weights, 1, topk_ids)
+            return selected
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    def test_gather_3d(self):
+        """pl.gather with 3D tensors produces correct output shape."""
+
+        @pl.function
+        def func(
+            inp: pl.Tensor[[4, 8, 16], pl.FP32],
+            idx: pl.Tensor[[4, 3, 16], pl.INT64],
+        ) -> pl.Tensor[[4, 3, 16], pl.FP32]:
+            result: pl.Tensor[[4, 3, 16], pl.FP32] = pl.gather(inp, 1, idx)
+            return result
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    def test_gather_3d_dim2(self):
+        """pl.gather with 3D tensors and dim=2 (last-dim selection)."""
+
+        @pl.function
+        def func(
+            inp: pl.Tensor[[4, 8, 16], pl.FP32],
+            idx: pl.Tensor[[4, 8, 5], pl.INT32],
+        ) -> pl.Tensor[[4, 8, 5], pl.FP32]:
+            result: pl.Tensor[[4, 8, 5], pl.FP32] = pl.gather(inp, 2, idx)
+            return result
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    def test_gather_negative_dim(self):
+        """pl.gather with negative dim normalizes correctly."""
+
+        @pl.function
+        def func(
+            inp: pl.Tensor[[4, 8], pl.FP32],
+            idx: pl.Tensor[[4, 8], pl.INT32],
+        ) -> pl.Tensor[[4, 8], pl.FP32]:
+            result: pl.Tensor[[4, 8], pl.FP32] = pl.gather(inp, -1, idx)
+            return result
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    def test_gather_3d_negative_dim(self):
+        """pl.gather with 3D tensors and negative dim (-2 normalizes to dim=1)."""
+
+        @pl.function
+        def func(
+            inp: pl.Tensor[[4, 8, 16], pl.FP32],
+            idx: pl.Tensor[[4, 3, 16], pl.INT32],
+        ) -> pl.Tensor[[4, 3, 16], pl.FP32]:
+            result: pl.Tensor[[4, 3, 16], pl.FP32] = pl.gather(inp, -2, idx)
+            return result
+
+        printed = str(func)
+        assert "tensor.gather" in printed
+
+    @pytest.mark.xfail(
+        reason="Known limitation: printer outputs dim as kwarg but parser re-interprets "
+        "positional args differently, causing 'multiple values for dim'. "
+        "Same issue affects scatter_update and other dim-kwarg tensor ops.",
+        strict=True,
+    )
+    def test_gather_roundtrip(self):
+        """pl.gather survives print → parse round-trip."""
+
+        @pl.function
+        def original(
+            inp: pl.Tensor[[8, 4], pl.FP32],
+            idx: pl.Tensor[[3, 4], pl.INT32],
+        ) -> pl.Tensor[[3, 4], pl.FP32]:
+            result: pl.Tensor[[3, 4], pl.FP32] = pl.gather(inp, 0, idx)
+            return result
+
+        printed = ir.python_print(original)
+        reparsed = pl.parse(printed)
+        ir.assert_structural_equal(original, reparsed)
+
+    def test_gather_in_orchestration(self):
+        """pl.gather works inside an orchestration function."""
+
+        @pl.program
+        class GatherProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_noop(
+                self,
+                t: pl.Tensor[[3, 4], pl.FP32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                tile: pl.Tile[[3, 4], pl.FP32] = pl.load(t, [0, 0], [3, 4])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inp: pl.Tensor[[8, 4], pl.FP32],
+                idx: pl.Tensor[[3, 4], pl.INT32],
+                out: pl.Out[pl.Tensor[[3, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 4], pl.FP32]:
+                gathered: pl.Tensor[[3, 4], pl.FP32] = pl.gather(inp, 0, idx)
+                out = self.kernel_noop(gathered, out)
+                return out
+
+        assert GatherProgram is not None
+        printed = str(GatherProgram)
+        assert "tensor.gather" in printed
+
+
+class TestGatherDSLErrors:
+    """Tests for pl.gather() error cases via DSL layer."""
+
+    def test_gather_rank_mismatch(self):
+        """pl.gather rejects rank mismatch between input and index."""
+        with pytest.raises(InvalidOperationError, match="index rank"):
+
+            @pl.function
+            def func(
+                inp: pl.Tensor[[4, 8, 16], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.INT32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                return pl.gather(inp, 0, idx)
+
+    def test_gather_non_integer_index(self):
+        """pl.gather rejects non-integer index dtype."""
+        with pytest.raises(InvalidOperationError, match="index dtype must be integer"):
+
+            @pl.function
+            def func(
+                inp: pl.Tensor[[4, 8], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.FP32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                return pl.gather(inp, 0, idx)
+
+    def test_gather_dim_out_of_range(self):
+        """pl.gather rejects dim out of valid range."""
+        with pytest.raises(InvalidOperationError, match="dim.*out of range"):
+
+            @pl.function
+            def func(
+                inp: pl.Tensor[[4, 8], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.INT32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                return pl.gather(inp, 5, idx)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Implement `tensor.gather` operator across all layers: C++ IR, Python IR, DSL language, and codegen
- Follows PyTorch gather semantics: `output[i][j][k] = input[i][index[i][j][k]][k]` (for dim=1)
- Supports negative dim indexing and validates rank/shape constraints

## Changes
- **C++ IR**: `src/ir/op/tensor_ops/gather.cpp` — op registration with shape inference
- **CMake**: register new source file
- **Python IR**: `python/pypto/ir/op/tensor_ops.py` — `gather()` function
- **DSL**: `python/pypto/language/op/tensor_ops.py` + `__init__.py` export
- **Codegen**: `src/codegen/tensor_op_codegen.cpp` — gather codegen emitter
- **Tests**: UT for IR ops, language DSL, codegen orchestration; ST for codegen

## Test plan
- [x] Unit tests for tensor.gather IR op (basic, 2D, 3D, negative dim, error cases)
- [x] Unit tests for DSL language layer gather
- [x] Unit tests for codegen orchestration
- [x] ST codegen tests for gather
- [x] All pre-commit hooks pass (pyright, ruff, clang-format, cpplint)