### PR TITLE
fix(build): add -DNDEBUG to RelWithDebInfo build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # Compiler flags
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -DNDEBUG")
 
 # Fix debug info paths when building in a temp directory (e.g., pip install)
 # This remaps paths in DWARF debug info so backtraces show clean relative paths

--- a/src/core/backtrace.cpp
+++ b/src/core/backtrace.cpp
@@ -74,7 +74,7 @@ Backtrace::Backtrace() {
 }
 
 void Backtrace::ErrorCallback(void* data, const char* msg, int errnum) {
-  // Log errors in backtrace generation to stderr for debugging
+  // Always report libbacktrace errors to stderr so failures in backtrace generation are not silent
   if (msg) {
     fprintf(stderr, "libbacktrace error: %s (errno: %d)\n", msg, errnum);
   }

--- a/src/core/backtrace.cpp
+++ b/src/core/backtrace.cpp
@@ -74,12 +74,10 @@ Backtrace::Backtrace() {
 }
 
 void Backtrace::ErrorCallback(void* data, const char* msg, int errnum) {
-#ifndef NDEBUG
   // Log errors in backtrace generation to stderr for debugging
   if (msg) {
     fprintf(stderr, "libbacktrace error: %s (errno: %d)\n", msg, errnum);
   }
-#endif
 }
 
 /// Clean up file paths from debug info that may contain temp build directory prefixes.


### PR DESCRIPTION
## Summary
- Add `-DNDEBUG` to `RelWithDebInfo` CMake flags, aligning it with `Release` for disabling debug-only code paths (e.g., default log level changes from DEBUG to ERROR)
- Remove `#ifndef NDEBUG` guards from `backtrace.cpp` `ErrorCallback` so libbacktrace errors are always reported to stderr regardless of build configuration
- `CHECK` and `INTERNAL_CHECK` macros are unaffected since they are unconditional

## Testing
- [x] All 3226 tests pass (15 skipped)
- [x] clang-tidy clean
- [x] Pre-commit hooks pass (clang-format, cpplint, headers)