### PR TITLE
feat(codegen): add a2a3 cross-core pipe gm_slot_buffer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.16
-          PTOAS_SHA256=276e9a81dacffe269bf528eff0bbdf6b3acfe7bf93a26b16a4356135482e61e4
+          PTOAS_VERSION=v0.18
+          PTOAS_SHA256=e61022d990e3142084529621d21ae10ca1aeea86c25fe6ba46222c61060f40af
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -256,6 +256,20 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetImportBufferSSA() const;
 
   /**
+   * @brief Record the SSA name of the __gm_pipe_buffer function parameter
+   *
+   * On Ascend910B (a2a3), the GM slot buffer is a function parameter used as
+   * intermediary for cross-core pipe communication. The codegen emits it as
+   * a gm_slot_buffer operand in initialize_pipe instructions.
+   */
+  void RecordGMSlotBufferSSA(const std::string& ssa);
+
+  /**
+   * @brief Get the recorded GM slot buffer SSA name (empty if none)
+   */
+  [[nodiscard]] std::string GetGMSlotBufferSSA() const;
+
+  /**
    * @brief Get the split value for a tile var produced by a matching tpop operation
    * @param var Raw pointer to the tile variable
    * @param expected_tpop_op_name Expected originating tpop op name
@@ -428,6 +442,7 @@ class PTOCodegen : public CodegenBase {
 
     std::string reserve_buf_ssa;
     std::string import_buf_ssa;
+    std::string gm_slot_buffer_ssa;
 
     std::string current_expr_value;
     std::vector<std::string> yield_buffer;
@@ -469,6 +484,7 @@ class PTOCodegen : public CodegenBase {
 
       reserve_buf_ssa.clear();
       import_buf_ssa.clear();
+      gm_slot_buffer_ssa.clear();
 
       current_expr_value.clear();
       yield_buffer.clear();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -938,6 +938,19 @@ static std::string MakeTfreeToAivCodegenPTO(const CallPtr& op, codegen::CodegenB
   return "";
 }
 
+// Helper to format initialize_pipe operand list
+static void EmitInitializePipeOperands(std::ostringstream& oss, const std::string& gm_ssa,
+                                       const std::string& c2v_ssa, const std::string& v2c_ssa) {
+  if (!gm_ssa.empty()) {
+    oss << "\n      (gm_slot_buffer = " << gm_ssa << " : !pto.ptr<f32>"
+        << ", c2v_consumer_buf = " << c2v_ssa << " : i32"
+        << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
+  } else {
+    oss << " (c2v_consumer_buf = " << c2v_ssa << " : i32"
+        << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
+  }
+}
+
 // system.aic_initialize_pipe: Initialize cross-core pipe on Cube side
 static std::string MakeAicInitializePipeCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -954,9 +967,8 @@ static std::string MakeAicInitializePipeCodegenPTO(const CallPtr& op, codegen::C
   if (c2v_ssa.empty()) c2v_ssa = codegen.GetOrEmitI32Constant(0);
 
   std::ostringstream oss;
-  oss << "pto.aic_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}"
-      << " (c2v_consumer_buf = " << c2v_ssa << " : i32"
-      << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
+  oss << "pto.aic_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}";
+  EmitInitializePipeOperands(oss, codegen.GetGMSlotBufferSSA(), c2v_ssa, v2c_ssa);
   codegen.Emit(oss.str());
 
   return "";
@@ -978,9 +990,8 @@ static std::string MakeAivInitializePipeCodegenPTO(const CallPtr& op, codegen::C
   if (v2c_ssa.empty()) v2c_ssa = codegen.GetOrEmitI32Constant(0);
 
   std::ostringstream oss;
-  oss << "pto.aiv_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}"
-      << " (c2v_consumer_buf = " << c2v_ssa << " : i32"
-      << ", v2c_consumer_buf = " << v2c_ssa << " : i32)";
+  oss << "pto.aiv_initialize_pipe {dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}";
+  EmitInitializePipeOperands(oss, codegen.GetGMSlotBufferSSA(), c2v_ssa, v2c_ssa);
   codegen.Emit(oss.str());
 
   return "";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -345,6 +345,11 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
   for (const auto& var : func->params_) {
     if (auto tensor_type = As<TensorType>(var->GetType())) {
+      // Skip tensor view for GM slot buffer workspace parameter (raw pointer, no view needed)
+      if (var->name_hint_ == "__gm_pipe_buffer") {
+        RecordGMSlotBufferSSA(GetVarName(var));
+        continue;
+      }
       std::string tensor_view = NewNamedTemp(var->name_hint_ + "_view");
       BindTensorView(var, tensor_view);
 
@@ -464,6 +469,9 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
 void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
   for (const auto& param : func->params_) {
     if (auto tensor_type = As<TensorType>(param->GetType())) {
+      // Skip GM slot buffer workspace parameter (raw pointer, no view needed)
+      if (param->name_hint_ == "__gm_pipe_buffer") continue;
+
       std::string tensor_view = fs_.tensor_to_view.at(GetVarKey(param));
 
       bool layout_DN = false;
@@ -775,6 +783,10 @@ void PTOCodegen::RecordImportBufferSSA(const std::string& ssa) {
 }
 
 std::string PTOCodegen::GetImportBufferSSA() const { return fs_.import_buf_ssa; }
+
+void PTOCodegen::RecordGMSlotBufferSSA(const std::string& ssa) { fs_.gm_slot_buffer_ssa = ssa; }
+
+std::string PTOCodegen::GetGMSlotBufferSSA() const { return fs_.gm_slot_buffer_ssa; }
 
 int PTOCodegen::GetValidatedTpopSplit(const ir::Var* var, const std::string& expected_tpop_op_name,
                                       const std::string& tfree_op_name) const {

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -11,6 +11,7 @@
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -24,6 +25,7 @@
 #include "pypto/backend/common/backend.h"
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/core/any_cast.h"
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -851,6 +853,236 @@ bool GroupCallsFunction(const FunctionPtr& group_func, const std::string& callee
   return false;
 }
 
+// ============================================================================
+// GM Slot Buffer Injection (a2a3 only)
+// ============================================================================
+
+/// Well-known parameter name for the GM slot buffer.
+constexpr const char* kGMPipeBufferName = "__gm_pipe_buffer";
+
+/// Check if a statement list contains aic_initialize_pipe or aiv_initialize_pipe.
+bool HasInitializePipeOps(const std::vector<StmtPtr>& stmts) {
+  for (const auto& stmt : stmts) {
+    CallPtr call;
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      call = std::dynamic_pointer_cast<const Call>(assign->value_);
+    } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      call = std::dynamic_pointer_cast<const Call>(eval->expr_);
+    }
+    if (call) {
+      auto op = std::dynamic_pointer_cast<const Op>(call->op_);
+      if (op && (op->name_ == "system.aic_initialize_pipe" || op->name_ == "system.aiv_initialize_pipe")) {
+        return true;
+      }
+    }
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      if (HasInitializePipeOps(FlattenBody(for_stmt->body_))) return true;
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      if (HasInitializePipeOps(FlattenBody(if_stmt->then_body_))) return true;
+      if (if_stmt->else_body_.has_value()) {
+        if (HasInitializePipeOps(FlattenBody(if_stmt->else_body_.value()))) return true;
+      }
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      if (HasInitializePipeOps(FlattenBody(while_stmt->body_))) return true;
+    }
+  }
+  return false;
+}
+
+bool HasGMPipeBufferParam(const FunctionPtr& func) {
+  for (const auto& param : func->params_) {
+    if (param->name_hint_ == kGMPipeBufferName) return true;
+  }
+  return false;
+}
+
+void BuildCallGraphFromFunctions(const std::vector<FunctionPtr>& functions,
+                                 std::unordered_map<std::string, std::unordered_set<std::string>>& callers,
+                                 std::unordered_map<std::string, std::unordered_set<std::string>>& callees) {
+  std::unordered_set<std::string> func_names;
+  for (const auto& func : functions) func_names.insert(func->name_);
+  for (const auto& func : functions) {
+    std::function<void(const std::vector<StmtPtr>&)> walk = [&](const std::vector<StmtPtr>& stmts) {
+      for (const auto& stmt : stmts) {
+        CallPtr call;
+        if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+          call = std::dynamic_pointer_cast<const Call>(assign->value_);
+        } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+          call = std::dynamic_pointer_cast<const Call>(eval->expr_);
+        }
+        if (call) {
+          auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+          if (gv && func_names.count(gv->name_)) {
+            callees[func->name_].insert(gv->name_);
+            callers[gv->name_].insert(func->name_);
+          }
+        }
+        if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+          walk(FlattenBody(for_stmt->body_));
+        } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+          walk(FlattenBody(if_stmt->then_body_));
+          if (if_stmt->else_body_.has_value()) walk(FlattenBody(if_stmt->else_body_.value()));
+        } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+          walk(FlattenBody(while_stmt->body_));
+        }
+      }
+    };
+    if (func->body_) walk(FlattenBody(func->body_));
+  }
+}
+
+FunctionPtr AddGMSlotBufferParam(const FunctionPtr& func) {
+  auto gm_type =
+      std::make_shared<TensorType>(std::vector<int64_t>{1}, DataType::FP32, std::nullopt, std::nullopt);
+  auto gm_var = std::make_shared<Var>(kGMPipeBufferName, gm_type, func->span_);
+  auto new_params = func->params_;
+  new_params.push_back(gm_var);
+  auto new_directions = func->param_directions_;
+  new_directions.push_back(ParamDirection::In);
+  return std::make_shared<Function>(func->name_, new_params, new_directions, func->return_types_, func->body_,
+                                    func->span_, func->func_type_, func->level_, func->role_);
+}
+
+StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<std::string>& modified_funcs,
+                                const VarPtr& gm_param) {
+  auto stmts = FlattenBody(body);
+  std::vector<StmtPtr> new_stmts;
+  bool any_changed = false;
+  for (const auto& stmt : stmts) {
+    auto try_rewrite = [&](const CallPtr& call) -> CallPtr {
+      if (!call) return nullptr;
+      auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+      if (!gv || !modified_funcs.count(gv->name_)) return nullptr;
+      std::vector<ExprPtr> new_args = call->args_;
+      new_args.push_back(gm_param);
+      return call->GetType() ? std::make_shared<Call>(call->op_, new_args, call->GetType(), call->span_)
+                             : std::make_shared<Call>(call->op_, new_args, call->span_);
+    };
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_))) {
+        new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, rw, assign->span_));
+        any_changed = true;
+        continue;
+      }
+    } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_))) {
+        new_stmts.push_back(std::make_shared<EvalStmt>(rw, eval->span_));
+        any_changed = true;
+        continue;
+      }
+    }
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      auto nb = RewriteCallsForGMBuffer(for_stmt->body_, modified_funcs, gm_param);
+      if (nb != for_stmt->body_) {
+        new_stmts.push_back(std::make_shared<ForStmt>(
+            for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_, nb,
+            for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
+            for_stmt->chunk_policy_, for_stmt->loop_origin_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      auto nt = RewriteCallsForGMBuffer(if_stmt->then_body_, modified_funcs, gm_param);
+      std::optional<StmtPtr> ne;
+      if (if_stmt->else_body_.has_value()) {
+        ne = RewriteCallsForGMBuffer(if_stmt->else_body_.value(), modified_funcs, gm_param);
+      }
+      bool body_changed = (nt != if_stmt->then_body_);
+      if (!body_changed && ne.has_value() && if_stmt->else_body_.has_value()) {
+        body_changed = (ne.value() != if_stmt->else_body_.value());
+      }
+      if (body_changed) {
+        new_stmts.push_back(
+            std::make_shared<IfStmt>(if_stmt->condition_, nt, ne, if_stmt->return_vars_, if_stmt->span_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto nb = RewriteCallsForGMBuffer(while_stmt->body_, modified_funcs, gm_param);
+      if (nb != while_stmt->body_) {
+        new_stmts.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_, nb,
+                                                        while_stmt->return_vars_, while_stmt->span_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else {
+      new_stmts.push_back(stmt);
+    }
+  }
+  if (!any_changed) return body;
+  return SeqStmts::Flatten(std::move(new_stmts), body->span_);
+}
+
+/// Inject __gm_pipe_buffer into pipe-using functions and propagate through callers.
+void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
+  if (!backend::BackendConfig::IsConfigured() ||
+      backend::GetBackendType() != backend::BackendType::Ascend910B) {
+    return;
+  }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>> callers, callees;
+  BuildCallGraphFromFunctions(functions, callers, callees);
+
+  std::unordered_set<std::string> pipe_funcs;
+  for (const auto& func : functions) {
+    if (!HasGMPipeBufferParam(func) && func->body_ && HasInitializePipeOps(FlattenBody(func->body_))) {
+      pipe_funcs.insert(func->name_);
+    }
+  }
+  if (pipe_funcs.empty()) return;
+
+  // Propagate upward
+  std::unordered_set<std::string> needs_gm = pipe_funcs;
+  std::vector<std::string> worklist(pipe_funcs.begin(), pipe_funcs.end());
+  while (!worklist.empty()) {
+    std::string name = worklist.back();
+    worklist.pop_back();
+    auto it = callers.find(name);
+    if (it == callers.end()) continue;
+    for (const auto& c : it->second) {
+      if (needs_gm.insert(c).second) worklist.push_back(c);
+    }
+  }
+
+  // Add params then rewrite call sites
+  for (auto& func : functions) {
+    if (needs_gm.count(func->name_) && !HasGMPipeBufferParam(func)) {
+      func = AddGMSlotBufferParam(func);
+    }
+  }
+
+  for (auto& func : functions) {
+    if (!needs_gm.count(func->name_)) continue;
+
+    VarPtr gm_param;
+    for (const auto& p : func->params_) {
+      if (p->name_hint_ == kGMPipeBufferName) {
+        gm_param = p;
+        break;
+      }
+    }
+    INTERNAL_CHECK(gm_param) << "Internal error: " << func->name_ << " should have " << kGMPipeBufferName;
+
+    std::unordered_set<std::string> mod_callees;
+    auto ci = callees.find(func->name_);
+    if (ci != callees.end()) {
+      for (const auto& c : ci->second) {
+        if (needs_gm.count(c)) mod_callees.insert(c);
+      }
+    }
+
+    if (!mod_callees.empty()) {
+      auto nb = RewriteCallsForGMBuffer(func->body_, mod_callees, gm_param);
+      func =
+          std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
+                                     nb, func->span_, func->func_type_, func->level_, func->role_);
+    }
+  }
+}
+
 }  // namespace
 
 namespace pass {
@@ -934,6 +1166,10 @@ Pass ExpandMixedKernel() {
         }
       }
     }
+
+    // Phase 4: Inject GM slot buffer params for a2a3 cross-core pipe communication.
+    // On Ascend910B, cross-core pipes require a GM slot buffer as intermediary.
+    InjectGMSlotBufferInPlace(new_functions);
 
     return std::make_shared<Program>(new_functions, program->name_, program->span_);
   };

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -1,0 +1,147 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+a2a3 Cross-Core Communication (TPUSH/TPOP) System Test.
+
+Verifies that the a2a3 pipe mechanism (GM slot buffer intermediary) compiles
+correctly through the full Default pipeline and produces valid kernel artifacts.
+
+Program under test:
+  Vector (AIV): loads tiles a and b, computes (a+b) and (a-b), pushes both to Cube.
+  Cube  (AIC) : pops both tiles, performs matmul((a+b), (a-b)), stores result.
+  Golden      : output = (a + b) @ (a - b)
+
+Run (codegen-only, no device execution):
+    pytest tests/st/runtime/test_cross_core.py -v --forked --codegen-only --save-kernels
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+
+@pl.program
+class CrossCoreTpushTpopProgram:
+    """V2C unidirectional cross-core program.
+
+    Vector producer: loads tiles a and b, computes add and sub, pushes both to Cube.
+    Cube consumer: pops tiles, performs matmul, stores result.
+    """
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def vector_producer(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ):
+        v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+        pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer.base)
+
+        tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+        tile_b: pl.Tile[[16, 16], pl.FP16] = pl.load(b, [0, 0], [16, 16])
+        result_add: pl.Tile[[16, 16], pl.FP16] = pl.add(tile_a, tile_b)
+        result_sub: pl.Tile[[16, 16], pl.FP16] = pl.sub(tile_a, tile_b)
+
+        pl.tpush_to_aic(result_add, split=1)
+        pl.tpush_to_aic(result_sub, split=1)
+
+    @pl.function(type=pl.FunctionType.AIC)
+    def cube_consumer(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+        pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf.base)
+
+        # Chain 1: tpop -> move (use) -> tfree
+        received_add: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=1)
+        received_add_left = pl.move(received_add, target_memory=pl.Mem.Left)
+        pl.tfree_to_aiv(received_add)
+
+        # Chain 2: tpop -> move (use) -> tfree
+        received_sub: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=1)
+        received_sub_right = pl.move(received_sub, target_memory=pl.Mem.Right)
+        pl.tfree_to_aiv(received_sub)
+
+        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add_left, received_sub_right)
+
+        updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(mm_result, [0, 0], output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.Group)
+    def group_func(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ):
+        updated = self.cube_consumer(a, b, output)
+        self.vector_producer(a, b, output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        out = self.group_func(a, b, output)
+        return out
+
+
+class CrossCoreTpushTpop(PTOTestCase):
+    """a2a3 cross-core V2C: output = (a + b) @ (a - b)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_tpush_tpop_v2c_16x16"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [16, 16], DataType.FP16, init_value=torch.randn),
+            TensorSpec("b", [16, 16], DataType.FP16, init_value=torch.randn),
+            TensorSpec("output", [16, 16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return CrossCoreTpushTpopProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].float()
+        b = tensors["b"].float()
+        tensors["output"][:] = torch.matmul(a + b, a - b)
+
+
+class TestCrossCore:
+    """a2a3 cross-core communication system tests (codegen-only, no device execution)."""
+
+    def test_tpush_tpop_v2c(self, test_runner):
+        """V2C pipe: compile through full pipeline and verify kernel artifacts.
+
+        Uses --codegen-only mode: compiles and generates kernel code but does
+        not execute on device. Use --save-kernels to persist the output.
+        """
+        test_case = CrossCoreTpushTpop()
+        # Force codegen-only: skip device execution, just verify compilation succeeds
+        test_runner.config.codegen_only = True
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core V2C compilation failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
feat(codegen): add a2a3 cross-core pipe gm_slot_buffer support
  
  On Ascend910B (a2a3), cross-core pipe communication between AIC and
  AIV requires a Global Memory slot buffer as intermediary, unlike Ascend950
  (a5) which has direct UB↔L1 hardware paths.

  Changes:
  - ExpandMixedKernel pass (Phase 4): detect pipe-using functions on Ascend910B, inject __gm_pipe_buffer tensor parameter, and propagate it through the call chain (AIC/AIV → Group → Main)
  - PTO codegen: emit gm_slot_buffer operand in aic/aiv_initialize_pipe, skip make_tensor_view for the workspace parameter
  - Add ST compilation test for cross-core tpush/tpop on a2a3