### PR TITLE
chore(skills): make code simplification decision automatic in git-commit

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -158,7 +158,7 @@ git add file && git commit --amend --no-edit   # Add forgotten file
 
 ## Checklist
 
-- [ ] Code simplification: ran (if code changes) or skipped with reason (if docs/config/trivial)
+- [ ] Code simplification: ran (for logic changes) or skipped with reason (if docs/config/mechanical)
 - [ ] Changed files analyzed (code vs docs/config only)
 - [ ] Code review completed
 - [ ] Tests passed (if code changed) or skipped (if docs/config only)


### PR DESCRIPTION
## Summary
- Changed Step 0 of the git-commit skill from always asking the user to an AI-driven automatic decision
- **Skip** code simplification for docs/rules/skills/config-only changes and purely mechanical edits
- **Run** code simplification for all logic-involving code changes (the common case)
- User can still override the automatic decision by explicitly requesting or declining

## Testing
- [ ] Skill file passes markdownlint
- [ ] Skill file stays within 200-line limit (currently 175 lines)
- [ ] Pre-commit hooks pass