### PR TITLE
feat(ir): Update reserve_buffer and import_peer_buffer to return ScalarType(INT32)

### DIFF
--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -15,7 +15,7 @@ System operations handle hardware synchronization and cross-core communication:
 - tpush_to_aiv / tpush_to_aic: Push tile data across cores
 - tpop_from_aic / tpop_from_aiv: Pop tile data from cross-core pipe
 - aic_initialize_pipe / aiv_initialize_pipe: Initialize cross-core pipes
-- reserve_buffer / import_peer_buffer: Cross-core buffer management
+- reserve_buffer / import_peer_buffer: Cross-core buffer management (i32 SSA results)
 """
 
 from pypto.pypto_core import ir as _ir_core
@@ -190,6 +190,8 @@ def aiv_initialize_pipe(
 def reserve_buffer(*, name: str, size: int, base: int = AUTO, span: Span | None = None) -> Call:
     """Reserve a named buffer for cross-core communication.
 
+    Result type is ``ScalarType(INT32)`` (PTO ``pto.reserve_buffer ... -> i32``).
+
     Args:
         name: Buffer name
         size: Buffer size in bytes
@@ -206,6 +208,8 @@ def reserve_buffer(*, name: str, size: int, base: int = AUTO, span: Span | None 
 
 def import_peer_buffer(*, name: str, peer_func: str, span: Span | None = None) -> Call:
     """Import a buffer from a peer function in the same group.
+
+    Result type is ``ScalarType(INT32)`` (PTO ``pto.import_reserved_buffer ... -> i32``).
 
     Args:
         name: Buffer name to import

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -34,6 +34,9 @@ from ..typing import Tile
 class ReservedBuffer:
     """Return value from pl.reserve_buffer(), providing access to buffer metadata.
 
+    The underlying IR node is a ``Call`` whose result type is ``ScalarType(INT32)``,
+    matching PTO ``pto.reserve_buffer ... -> i32``.
+
     Attributes:
         base: Base address in local SRAM (int literal or AUTO sentinel).
         size: Buffer size in bytes.
@@ -46,9 +49,17 @@ class ReservedBuffer:
         self.size = size
         self.base = base
 
+    @property
+    def call(self) -> Call:
+        """The ``system.reserve_buffer`` IR call (i32 SSA result)."""
+        return self._expr
+
 
 class ImportedBuffer:
     """Return value from pl.import_peer_buffer(), providing access to peer buffer metadata.
+
+    The underlying IR node is a ``Call`` whose result type is ``ScalarType(INT32)``,
+    matching PTO ``pto.import_reserved_buffer ... -> i32``.
 
     Attributes:
         base: Peer buffer base address (resolved by allocator if peer uses AUTO).
@@ -61,6 +72,11 @@ class ImportedBuffer:
         self.name = name
         self.peer_func = peer_func
         self.base: int = AUTO  # resolved by allocator pass
+
+    @property
+    def call(self) -> Call:
+        """The ``system.import_peer_buffer`` IR call (i32 SSA result)."""
+        return self._expr
 
 
 __all__ = [
@@ -155,7 +171,7 @@ def reserve_buffer(*, name: str, size: int, base: int = AUTO, span: Span | None 
         span: Optional source span.
 
     Returns:
-        ReservedBuffer with .base, .size, .name attributes.
+        ReservedBuffer with .base, .size, .name and .call (IR ``Call`` with INT32 scalar type).
     """
     call = _ir_ops.reserve_buffer(name=name, size=size, base=base, span=span)
     return ReservedBuffer(expr=call, name=name, size=size, base=base)
@@ -170,7 +186,7 @@ def import_peer_buffer(*, name: str, peer_func: str, span: Span | None = None) -
         span: Optional source span.
 
     Returns:
-        ImportedBuffer with .base, .name, .peer_func attributes.
+        ImportedBuffer with .base, .name, .peer_func and .call (IR ``Call`` with INT32 scalar type).
         The .base value is resolved by the allocator pass.
     """
     call = _ir_ops.import_peer_buffer(name=name, peer_func=peer_func, span=span)

--- a/src/ir/op/sync_ops/cross_core.cpp
+++ b/src/ir/op/sync_ops/cross_core.cpp
@@ -10,10 +10,12 @@
  */
 
 #include <any>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
@@ -26,6 +28,14 @@ namespace {
 TypePtr DeduceUnknownType(const std::vector<ExprPtr>& args,
                           const std::vector<std::pair<std::string, std::any>>& kwargs) {
   return GetUnknownType();
+}
+
+// PTO emits `pto.reserve_buffer` / `pto.import_reserved_buffer` with `-> i32` result.
+TypePtr DeduceI32ScalarType(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  (void)args;
+  (void)kwargs;
+  return std::make_shared<ScalarType>(DataType::INT32);
 }
 
 }  // namespace
@@ -79,7 +89,7 @@ REGISTER_OP("system.reserve_buffer")
     .set_attr<std::string>("name")
     .set_attr<int>("size")
     .set_attr<int>("base")
-    .f_deduce_type(DeduceUnknownType);
+    .f_deduce_type(DeduceI32ScalarType);
 
 // Import a peer function's buffer
 REGISTER_OP("system.import_peer_buffer")
@@ -88,7 +98,7 @@ REGISTER_OP("system.import_peer_buffer")
     .no_argument()
     .set_attr<std::string>("name")
     .set_attr<std::string>("peer_func")
-    .f_deduce_type(DeduceUnknownType);
+    .f_deduce_type(DeduceI32ScalarType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/op_registry.h"
@@ -285,33 +284,23 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
   AutomaticPipeSetup setup;
 
   if (dir_mask & core_affinity::kDirMaskV2C) {
+    const auto v2c_name = BuildPipeBufferName(func_name, core_affinity::PipeDirection::V2C);
+    auto v2c_reserve = CreateReserveBuffer(v2c_name, buffer_size, span);
     setup.aic_stmts.push_back(std::make_shared<AssignStmt>(
-        std::make_shared<Var>(BuildPipeBufferName(func_name, core_affinity::PipeDirection::V2C),
-                              GetUnknownType(), span),
-        CreateReserveBuffer(BuildPipeBufferName(func_name, core_affinity::PipeDirection::V2C), buffer_size,
-                            span),
-        span));
+        std::make_shared<Var>(v2c_name, v2c_reserve->GetType(), span), v2c_reserve, span));
+    auto v2c_import = CreateImportPeerBuffer(v2c_name, aic_name, span);
     setup.aiv_stmts.push_back(std::make_shared<AssignStmt>(
-        std::make_shared<Var>(BuildPipeBufferName(func_name, core_affinity::PipeDirection::V2C) + "_import",
-                              GetUnknownType(), span),
-        CreateImportPeerBuffer(BuildPipeBufferName(func_name, core_affinity::PipeDirection::V2C), aic_name,
-                               span),
-        span));
+        std::make_shared<Var>(v2c_name + "_import", v2c_import->GetType(), span), v2c_import, span));
   }
 
   if (dir_mask & core_affinity::kDirMaskC2V) {
+    const auto c2v_name = BuildPipeBufferName(func_name, core_affinity::PipeDirection::C2V);
+    auto c2v_reserve = CreateReserveBuffer(c2v_name, buffer_size, span);
     setup.aiv_stmts.push_back(std::make_shared<AssignStmt>(
-        std::make_shared<Var>(BuildPipeBufferName(func_name, core_affinity::PipeDirection::C2V),
-                              GetUnknownType(), span),
-        CreateReserveBuffer(BuildPipeBufferName(func_name, core_affinity::PipeDirection::C2V), buffer_size,
-                            span),
-        span));
+        std::make_shared<Var>(c2v_name, c2v_reserve->GetType(), span), c2v_reserve, span));
+    auto c2v_import = CreateImportPeerBuffer(c2v_name, aiv_name, span);
     setup.aic_stmts.push_back(std::make_shared<AssignStmt>(
-        std::make_shared<Var>(BuildPipeBufferName(func_name, core_affinity::PipeDirection::C2V) + "_import",
-                              GetUnknownType(), span),
-        CreateImportPeerBuffer(BuildPipeBufferName(func_name, core_affinity::PipeDirection::C2V), aiv_name,
-                               span),
-        span));
+        std::make_shared<Var>(c2v_name + "_import", c2v_import->GetType(), span), c2v_import, span));
   }
 
   setup.aic_stmts.push_back(std::make_shared<EvalStmt>(

--- a/tests/ut/ir/test_cross_core_ops.py
+++ b/tests/ut/ir/test_cross_core_ops.py
@@ -47,19 +47,21 @@ def test_initialize_pipe_ops():
 
 
 def test_reserve_buffer_op():
-    """Test reserve_buffer op accepts no args and returns UnknownType."""
+    """Test reserve_buffer op accepts no args and returns ScalarType(INT32)."""
     span = ir.Span.unknown()
     call = ir.create_op_call("system.reserve_buffer", [], {"name": "shared_buf", "size": 1024}, span)
-    assert isinstance(call.type, ir.UnknownType)
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.INT32
 
 
 def test_import_peer_buffer_op():
-    """Test import_peer_buffer op accepts no args and returns UnknownType."""
+    """Test import_peer_buffer op accepts no args and returns ScalarType(INT32)."""
     span = ir.Span.unknown()
     call = ir.create_op_call(
         "system.import_peer_buffer", [], {"name": "shared_buf", "peer_func": "aic_kernel"}, span
     )
-    assert isinstance(call.type, ir.UnknownType)
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.INT32
 
 
 def test_cross_core_ops_registered():


### PR DESCRIPTION
fix #802
Enhance the `reserve_buffer` and `import_peer_buffer` operations to explicitly return `ScalarType(INT32)` instead of `UnknownType`. Update documentation and type deduction logic accordingly. Add properties to `ReservedBuffer` and `ImportedBuffer` classes to expose the underlying IR call. Update unit tests to reflect these changes.