### PR TITLE
feat(ir): add function-level attrs system, migrate split to attr

### DIFF
--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -88,7 +88,7 @@ class IRBuilder {
    */
   void BeginFunction(const std::string& name, const Span& span, FunctionType type = FunctionType::Opaque,
                      std::optional<Level> level = std::nullopt, std::optional<Role> role = std::nullopt,
-                     std::optional<SplitMode> split = std::nullopt);
+                     std::vector<std::pair<std::string, std::any>> attrs = {});
 
   /**
    * @brief Add a function parameter
@@ -534,13 +534,13 @@ class FunctionContext : public BuildContext {
  public:
   FunctionContext(std::string name, Span span, FunctionType func_type = FunctionType::Opaque,
                   std::optional<Level> level = std::nullopt, std::optional<Role> role = std::nullopt,
-                  std::optional<SplitMode> split = std::nullopt)
+                  std::vector<std::pair<std::string, std::any>> attrs = {})
       : BuildContext(Type::FUNCTION, std::move(span)),
         name_(std::move(name)),
         func_type_(func_type),
         level_(level),
         role_(role),
-        split_(split) {}
+        attrs_(std::move(attrs)) {}
 
   void AddParam(const VarPtr& param, ParamDirection direction = ParamDirection::In) {
     params_.push_back(param);
@@ -556,14 +556,14 @@ class FunctionContext : public BuildContext {
   [[nodiscard]] FunctionType GetFuncType() const { return func_type_; }
   [[nodiscard]] std::optional<Level> GetLevel() const { return level_; }
   [[nodiscard]] std::optional<Role> GetRole() const { return role_; }
-  [[nodiscard]] std::optional<SplitMode> GetSplit() const { return split_; }
+  [[nodiscard]] const std::vector<std::pair<std::string, std::any>>& GetAttrs() const { return attrs_; }
 
  private:
   std::string name_;
   FunctionType func_type_;
   std::optional<Level> level_;
   std::optional<Role> role_;
-  std::optional<SplitMode> split_;
+  std::vector<std::pair<std::string, std::any>> attrs_;
   std::vector<VarPtr> params_;
   std::vector<ParamDirection> param_directions_;
   std::vector<TypePtr> return_types_;

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_IR_BUILDER_H_
 #define PYPTO_IR_BUILDER_H_
 
+#include <any>
 #include <map>
 #include <memory>
 #include <optional>

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -427,6 +427,8 @@ class Function : public IRNode {
     if (!HasAttr("split")) return std::nullopt;
     int val = GetAttr<int>("split", 0);
     if (val == 0) return std::nullopt;
+    CHECK(val >= 0 && val <= static_cast<int>(SplitMode::LeftRight))
+        << "Invalid split mode value in attrs: " << val;
     return static_cast<SplitMode>(val);
   }
 };

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -12,6 +12,8 @@
 #ifndef PYPTO_IR_FUNCTION_H_
 #define PYPTO_IR_FUNCTION_H_
 
+#include <algorithm>
+#include <any>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -332,12 +334,12 @@ class Function : public IRNode {
    * @param type Function type (default: Opaque)
    * @param level Hierarchy level (default: nullopt — unspecified)
    * @param role Function role (default: nullopt)
-   * @param split Split mode for cross-core transfer (default: nullopt)
+   * @param attrs Function-level attributes (default: empty)
    */
   Function(std::string name, std::vector<VarPtr> params, std::vector<ParamDirection> param_directions,
            std::vector<TypePtr> return_types, StmtPtr body, Span span,
            FunctionType type = FunctionType::Opaque, std::optional<Level> level = std::nullopt,
-           std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt)
+           std::optional<Role> role = std::nullopt, std::vector<std::pair<std::string, std::any>> attrs = {})
       : IRNode(std::move(span)),
         name_(std::move(name)),
         params_(std::move(params)),
@@ -347,7 +349,7 @@ class Function : public IRNode {
         func_type_(type),
         level_(level),
         role_(role),
-        split_(split) {
+        attrs_(std::move(attrs)) {
     CHECK(params_.size() == param_directions_.size())
         << "params and param_directions must have same size, got " << params_.size() << " vs "
         << param_directions_.size();
@@ -359,7 +361,7 @@ class Function : public IRNode {
   /**
    * @brief Get field descriptors for reflection-based visitation
    *
-   * @return Tuple of field descriptors (params as DEF field, func_type, level, role, split,
+   * @return Tuple of field descriptors (params as DEF field, func_type, level, role, attrs,
    *         return_types and body as USUAL fields, name as an IGNORE field)
    */
   static constexpr auto GetFieldDescriptors() {
@@ -370,22 +372,63 @@ class Function : public IRNode {
                         reflection::UsualField(&Function::func_type_, "func_type"),
                         reflection::UsualField(&Function::level_, "level"),
                         reflection::UsualField(&Function::role_, "role"),
-                        reflection::UsualField(&Function::split_, "split"),
+                        reflection::UsualField(&Function::attrs_, "attrs"),
                         reflection::UsualField(&Function::return_types_, "return_types"),
                         reflection::UsualField(&Function::body_, "body"),
                         reflection::IgnoreField(&Function::name_, "name")));
   }
 
  public:
-  std::string name_;                // Function name
-  FunctionType func_type_;          // Function type (Opaque, Orchestration, InCore, AIC, AIV, or Group)
-  std::optional<Level> level_;      // Hierarchy level (nullopt = infer from func_type)
-  std::optional<Role> role_;        // Function role (nullopt = default per level)
-  std::optional<SplitMode> split_;  // Split mode for cross-core transfer (nullopt = no split)
-  std::vector<VarPtr> params_;      // Parameter variables
-  std::vector<ParamDirection> param_directions_;  // Parameter directions (same length as params_)
-  std::vector<TypePtr> return_types_;             // Return types
-  StmtPtr body_;                                  // Function body statement
+  std::string name_;            // Function name
+  FunctionType func_type_;      // Function type (Opaque, Orchestration, InCore, AIC, AIV, or Group)
+  std::optional<Level> level_;  // Hierarchy level (nullopt = infer from func_type)
+  std::optional<Role> role_;    // Function role (nullopt = default per level)
+  std::vector<std::pair<std::string, std::any>> attrs_;  // Function-level attributes (key-value metadata)
+  std::vector<VarPtr> params_;                           // Parameter variables
+  std::vector<ParamDirection> param_directions_;         // Parameter directions (same length as params_)
+  std::vector<TypePtr> return_types_;                    // Return types
+  StmtPtr body_;                                         // Function body statement
+
+  /**
+   * @brief Get a typed attribute value
+   * @tparam T Expected type of the attribute value
+   * @param key Attribute key
+   * @param default_value Default value if key doesn't exist
+   * @return The attribute value or default
+   */
+  template <typename T>
+  [[nodiscard]] T GetAttr(const std::string& key, const T& default_value = T{}) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) return AnyCast<T>(v, "func attr key: " + key);
+    }
+    return default_value;
+  }
+
+  /**
+   * @brief Check if an attribute exists
+   * @param key Attribute key
+   * @return true if the attribute exists
+   */
+  [[nodiscard]] bool HasAttr(const std::string& key) const {
+    return std::any_of(attrs_.begin(), attrs_.end(), [&key](const auto& pair) { return pair.first == key; });
+  }
+
+  /**
+   * @brief Get all attributes
+   * @return Vector of key-value attribute pairs
+   */
+  [[nodiscard]] const std::vector<std::pair<std::string, std::any>>& GetAttrs() const { return attrs_; }
+
+  /**
+   * @brief Convenience: extract SplitMode from attrs
+   * @return SplitMode if "split" attr is set and non-zero, nullopt otherwise
+   */
+  [[nodiscard]] std::optional<SplitMode> GetSplitMode() const {
+    if (!HasAttr("split")) return std::nullopt;
+    int val = GetAttr<int>("split", 0);
+    if (val == 0) return std::nullopt;
+    return static_cast<SplitMode>(val);
+  }
 };
 
 using FunctionPtr = std::shared_ptr<const Function>;

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_TRANSFORMS_UTILS_SCOPE_OUTLINE_UTILS_H_
 
 #include <algorithm>
+#include <any>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -598,10 +599,14 @@ class ScopeOutliner : public IRMutator {
       outlined_body = std::make_shared<SeqStmts>(body_stmts, op->span_);
     }
 
-    // Register the outlined function (propagate level/role/split from ScopeStmt)
-    auto outlined_func = std::make_shared<Function>(outlined_func_name, input_params, input_param_directions,
-                                                    return_types, outlined_body, op->span_,
-                                                    outlined_func_type_, op->level_, op->role_, op->split_);
+    // Register the outlined function (propagate level/role from ScopeStmt, convert split to attrs)
+    std::vector<std::pair<std::string, std::any>> outlined_attrs;
+    if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
+      outlined_attrs.emplace_back("split", static_cast<int>(op->split_.value()));
+    }
+    auto outlined_func = std::make_shared<Function>(
+        outlined_func_name, input_params, input_param_directions, return_types, outlined_body, op->span_,
+        outlined_func_type_, op->level_, op->role_, std::move(outlined_attrs));
     outlined_functions_.push_back(outlined_func);
 
     // Build the call site in the parent function

--- a/python/bindings/module.h
+++ b/python/bindings/module.h
@@ -23,8 +23,23 @@
 
 #include <nanobind/nanobind.h>
 
+#include <any>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace pypto {
 namespace python {
+
+/**
+ * @brief Convert a Python dict to a vector of (key, value) pairs with std::any values
+ *
+ * Handles common types: int, bool, str, double, DataType, MemorySpace, etc.
+ *
+ * @param kwargs_dict Python dictionary of keyword arguments
+ * @return Vector of key-value pairs
+ */
+std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nanobind::dict& kwargs_dict);
 
 /**
  * @brief Register error exception types and exception translator

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -118,6 +118,9 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<CoreType>(item.second)) {
       // Cast enum to int for storage
       kwargs.emplace_back(key, static_cast<int>(nb::cast<CoreType>(item.second)));
+    } else if (nb::isinstance<SplitMode>(item.second)) {
+      // Cast enum to int for storage
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<SplitMode>(item.second)));
     } else if (nb::isinstance<PadValue>(item.second)) {
       kwargs.emplace_back(key, nb::cast<PadValue>(item.second));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
@@ -916,7 +919,7 @@ void BindIR(nb::module_& m) {
       "__init__",
       [](Function* self, const std::string& name, const nb::list& params,
          const std::vector<TypePtr>& return_types, const StmtPtr& body, const Span& span, FunctionType type,
-         std::optional<Level> level, std::optional<Role> role, std::optional<SplitMode> split) {
+         std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none) {
         std::vector<VarPtr> param_vars;
         std::vector<ParamDirection> param_dirs;
         param_vars.reserve(nb::len(params));
@@ -935,13 +938,58 @@ void BindIR(nb::module_& m) {
             param_dirs.push_back(ParamDirection::In);
           }
         }
+        // Build attrs vector from attrs dict
+        std::vector<std::pair<std::string, std::any>> attrs;
+        if (!attrs_or_none.is_none()) {
+          attrs = ConvertKwargsDict(nb::cast<nb::dict>(attrs_or_none));
+        }
         new (self) Function(name, std::move(param_vars), std::move(param_dirs), return_types, body, span,
-                            type, level, role, split);
+                            type, level, role, std::move(attrs));
       },
       nb::arg("name"), nb::arg("params"), nb::arg("return_types"), nb::arg("body"), nb::arg("span"),
       nb::arg("type") = FunctionType::Opaque, nb::arg("level") = nb::none(), nb::arg("role") = nb::none(),
-      nb::arg("split") = nb::none(), "Create a function definition");
+      nb::arg("attrs") = nb::none(), "Create a function definition");
   BindFields<Function>(function_class);
+  // Custom attrs property: convert vector<pair<string, any>> to Python dict
+  function_class.def_prop_ro(
+      "attrs",
+      [](const FunctionPtr& self) {
+        nb::dict result;
+        for (const auto& [key, value] : self->attrs_) {
+          if (value.type() == typeid(int)) {
+            result[key.c_str()] = AnyCast<int>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(bool)) {
+            result[key.c_str()] = AnyCast<bool>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(std::string)) {
+            result[key.c_str()] = AnyCast<std::string>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(double)) {
+            result[key.c_str()] = AnyCast<double>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(float)) {
+            result[key.c_str()] = AnyCast<float>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(DataType)) {
+            result[key.c_str()] = AnyCast<DataType>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(MemorySpace)) {
+            result[key.c_str()] = AnyCast<MemorySpace>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(TensorLayout)) {
+            result[key.c_str()] = AnyCast<TensorLayout>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(TileLayout)) {
+            result[key.c_str()] = AnyCast<TileLayout>(value, "converting to Python: " + key);
+          } else if (value.type() == typeid(PadValue)) {
+            result[key.c_str()] = AnyCast<PadValue>(value, "converting to Python: " + key);
+          }
+        }
+        return result;
+      },
+      "Function-level attributes as a dictionary");
+  // Backward-compat split property: extract SplitMode from attrs
+  function_class.def_prop_ro(
+      "split",
+      [](const FunctionPtr& self) -> nb::object {
+        auto mode = self->GetSplitMode();
+        if (!mode.has_value()) return nb::none();
+        return nb::cast(*mode);
+      },
+      "Split mode for cross-core transfer (convenience accessor into attrs)");
 
   // Program - const shared_ptr
   auto program_class =

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -15,6 +15,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "../module.h"
@@ -45,20 +47,29 @@ void BindIRBuilder(nb::module_& m) {
       .def(nb::init<>(), "Create a new IR builder")
 
       // Function building
-      .def("begin_function", &IRBuilder::BeginFunction, nb::arg("name"), nb::arg("span"),
-           nb::arg("type") = FunctionType::Opaque, nb::arg("level") = nb::none(),
-           nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
-           "Begin building a function.\n\n"
-           "Creates a new function context. Must be closed with end_function().\n\n"
-           "Args:\n"
-           "    name: Function name\n"
-           "    span: Source location for function definition\n"
-           "    type: Function type (default: Opaque)\n"
-           "    level: Hierarchy level (default: None)\n"
-           "    role: Function role (default: None)\n"
-           "    split: Split mode (default: None)\n\n"
-           "Raises:\n"
-           "    RuntimeError: If already inside a function (nested functions not allowed)")
+      .def(
+          "begin_function",
+          [](IRBuilder& self, const std::string& name, const Span& span, FunctionType type,
+             std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none) {
+            std::vector<std::pair<std::string, std::any>> attrs;
+            if (!attrs_or_none.is_none()) {
+              attrs = ConvertKwargsDict(nb::cast<nb::dict>(attrs_or_none));
+            }
+            self.BeginFunction(name, span, type, level, role, std::move(attrs));
+          },
+          nb::arg("name"), nb::arg("span"), nb::arg("type") = FunctionType::Opaque,
+          nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("attrs") = nb::none(),
+          "Begin building a function.\n\n"
+          "Creates a new function context. Must be closed with end_function().\n\n"
+          "Args:\n"
+          "    name: Function name\n"
+          "    span: Source location for function definition\n"
+          "    type: Function type (default: Opaque)\n"
+          "    level: Hierarchy level (default: None)\n"
+          "    role: Function role (default: None)\n"
+          "    attrs: Function-level attributes dict (default: None)\n\n"
+          "Raises:\n"
+          "    RuntimeError: If already inside a function (nested functions not allowed)")
 
       .def("func_arg", &IRBuilder::FuncArg, nb::arg("name"), nb::arg("type"), nb::arg("span"),
            nb::arg("direction") = ParamDirection::In,

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -18,6 +18,7 @@ import builtins
 import inspect
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from typing import Any
 
 from pypto.pypto_core import DataType, ir
 from pypto.pypto_core.ir import IRBuilder as CppIRBuilder
@@ -61,7 +62,7 @@ class IRBuilder:
         type: ir.FunctionType = ir.FunctionType.Opaque,
         level: ir.Level | None = None,
         role: ir.Role | None = None,
-        split: ir.SplitMode | None = None,
+        attrs: dict[str, Any] | None = None,
     ) -> Iterator["FunctionBuilder"]:
         """Context manager for building functions.
 
@@ -71,7 +72,7 @@ class IRBuilder:
             type: Function type (default: Opaque)
             level: Hierarchy level (default: None)
             role: Function role (default: None)
-            split: Split mode for cross-core transfer (default: None)
+            attrs: Function-level attributes dict (default: None)
 
         Yields:
             FunctionBuilder: Helper object for building the function
@@ -89,7 +90,7 @@ class IRBuilder:
         self._ctx_counter += 1
         self._begin_spans[ctx_id] = begin_span
 
-        self._builder.begin_function(name, begin_span, type, level, role, split)
+        self._builder.begin_function(name, begin_span, type, level, role, attrs or {})
         builder_obj = FunctionBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -302,7 +302,7 @@ class ASTParser:
         func_type: ir.FunctionType = ir.FunctionType.Opaque,
         func_level: ir.Level | None = None,
         func_role: ir.Role | None = None,
-        func_split: ir.SplitMode | None = None,
+        func_attrs: dict[str, Any] | None = None,
     ) -> ir.Function:
         """Parse function definition and build IR.
 
@@ -311,7 +311,7 @@ class ASTParser:
             func_type: Function type (default: Opaque)
             func_level: Hierarchy level (default: None)
             func_role: Function role (default: None)
-            func_split: Split mode (default: None)
+            func_attrs: Function-level attributes dict (default: None)
 
         Returns:
             IR Function object
@@ -325,7 +325,7 @@ class ASTParser:
 
         # Begin building function
         with self.builder.function(
-            func_name, func_span, type=func_type, level=func_level, role=func_role, split=func_split
+            func_name, func_span, type=func_type, level=func_level, role=func_role, attrs=func_attrs
         ) as f:
             # Parse parameters (skip 'self' if it's the first parameter without annotation)
             for arg in func_def.args.args:

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -210,12 +210,28 @@ _FUNCTION_TYPE_MAP: dict[str, ir.FunctionType] = {
 }
 
 
+def _find_function_decorator_call(node: ast.FunctionDef) -> ast.Call | None:
+    """Find the @pl.function(...) Call decorator on a FunctionDef, if present.
+
+    Args:
+        node: AST FunctionDef node to search
+
+    Returns:
+        The ast.Call node for the @pl.function(...) decorator, or None
+    """
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        func = decorator.func
+        if (isinstance(func, ast.Attribute) and func.attr == "function") or (
+            isinstance(func, ast.Name) and func.id == "function"
+        ):
+            return decorator
+    return None
+
+
 def _extract_function_type_from_decorator(node: ast.FunctionDef) -> ir.FunctionType:
     """Extract function type from @pl.function(type=...) decorator.
-
-    Searches through the function's decorators to find @pl.function(type=...)
-    and extracts the FunctionType value. If no type parameter is found,
-    returns FunctionType.Opaque as the default.
 
     Args:
         node: AST FunctionDef node to extract function type from
@@ -223,48 +239,37 @@ def _extract_function_type_from_decorator(node: ast.FunctionDef) -> ir.FunctionT
     Returns:
         FunctionType extracted from decorator, or FunctionType.Opaque if not specified
     """
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call):
-            continue
+    decorator = _find_function_decorator_call(node)
+    if decorator is None:
+        return ir.FunctionType.Opaque
 
-        # Check if it's a pl.function or function call
-        is_function_call = (
-            isinstance(decorator.func, ast.Attribute) and decorator.func.attr == "function"
-        ) or (isinstance(decorator.func, ast.Name) and decorator.func.id == "function")
-
-        if not is_function_call:
-            continue
-
-        # Look for type= keyword argument
-        for keyword in decorator.keywords:
-            if keyword.arg is None:
-                raise ParserSyntaxError(
-                    "Unsupported `@pl.function(**kwargs)` in `@pl.program`",
-                    hint="Use a literal type=pl.FunctionType.<name>.",
-                )
-            if keyword.arg != "type":
-                continue
-
-            value = keyword.value
-            if not isinstance(value, ast.Attribute):
-                raise ParserSyntaxError(
-                    "Unsupported `@pl.function`(type=...) value",
-                    hint="Use pl.FunctionType.<name>.",
-                )
-            is_function_type_attr = (
-                isinstance(value.value, ast.Name) and value.value.id == "FunctionType"
-            ) or (
-                isinstance(value.value, ast.Attribute)
-                and isinstance(value.value.value, ast.Name)
-                and value.value.value.id == "pl"
-                and value.value.attr == "FunctionType"
+    for keyword in decorator.keywords:
+        if keyword.arg is None:
+            raise ParserSyntaxError(
+                "Unsupported `@pl.function(**kwargs)` in `@pl.program`",
+                hint="Use a literal type=pl.FunctionType.<name>.",
             )
-            if not is_function_type_attr or value.attr not in _FUNCTION_TYPE_MAP:
-                raise ParserSyntaxError(
-                    "Unsupported `@pl.function`(type=...) value",
-                    hint="Use pl.FunctionType.<name>.",
-                )
-            return _FUNCTION_TYPE_MAP[value.attr]
+        if keyword.arg != "type":
+            continue
+
+        value = keyword.value
+        if not isinstance(value, ast.Attribute):
+            raise ParserSyntaxError(
+                "Unsupported `@pl.function`(type=...) value",
+                hint="Use pl.FunctionType.<name>.",
+            )
+        is_function_type_attr = (isinstance(value.value, ast.Name) and value.value.id == "FunctionType") or (
+            isinstance(value.value, ast.Attribute)
+            and isinstance(value.value.value, ast.Name)
+            and value.value.value.id == "pl"
+            and value.value.attr == "FunctionType"
+        )
+        if not is_function_type_attr or value.attr not in _FUNCTION_TYPE_MAP:
+            raise ParserSyntaxError(
+                "Unsupported `@pl.function`(type=...) value",
+                hint="Use pl.FunctionType.<name>.",
+            )
+        return _FUNCTION_TYPE_MAP[value.attr]
 
     return ir.FunctionType.Opaque
 
@@ -280,53 +285,85 @@ def _extract_function_level_role_from_decorator(
     Returns:
         Tuple of (level, role), either or both may be None
     """
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call):
+    decorator = _find_function_decorator_call(node)
+    if decorator is None:
+        return None, None
+
+    level = None
+    role = None
+    for keyword in decorator.keywords:
+        if keyword.arg == "level":
+            if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
+                level = None
+            else:
+                level = extract_enum_value(keyword.value, LEVEL_MAP, "Level", "pl.Level")
+        elif keyword.arg == "role":
+            if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
+                role = None
+            else:
+                role = extract_enum_value(keyword.value, ROLE_MAP, "Role", "pl.Role")
+    return level, role
+
+
+def _normalize_attrs(attrs: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize function attrs: convert SplitMode enums to int values for C++ storage.
+
+    SplitMode.NONE entries are dropped (equivalent to no split).
+    Returns None if the result is empty.
+    """
+    if not attrs:
+        return None
+    result: dict[str, Any] = {}
+    for key, value in attrs.items():
+        if isinstance(value, ir.SplitMode):
+            if value != ir.SplitMode.NONE:
+                result[key] = value.value
+        else:
+            result[key] = value
+    return result or None
+
+
+def _extract_function_attrs_from_decorator(node: ast.FunctionDef) -> dict[str, Any]:
+    """Extract function attrs from @pl.function(attrs={...}) decorator.
+
+    Supports attrs={"split": pl.SplitMode.UP_DOWN, ...} syntax.
+    Returns a normalized dict with enum values converted to ints.
+    """
+    decorator = _find_function_decorator_call(node)
+    if decorator is None:
+        return {}
+
+    for keyword in decorator.keywords:
+        if keyword.arg != "attrs":
             continue
-
-        is_function_call = (
-            isinstance(decorator.func, ast.Attribute) and decorator.func.attr == "function"
-        ) or (isinstance(decorator.func, ast.Name) and decorator.func.id == "function")
-
-        if not is_function_call:
-            continue
-
-        level = None
-        role = None
-        for keyword in decorator.keywords:
-            if keyword.arg == "level":
-                if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
-                    level = None
-                else:
-                    level = extract_enum_value(keyword.value, LEVEL_MAP, "Level", "pl.Level")
-            elif keyword.arg == "role":
-                if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
-                    role = None
-                else:
-                    role = extract_enum_value(keyword.value, ROLE_MAP, "Role", "pl.Role")
-        return level, role
-    return None, None
-
-
-def _extract_function_split_from_decorator(node: ast.FunctionDef) -> ir.SplitMode | None:
-    """Extract split mode from @pl.function(split=...) decorator."""
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call):
-            continue
-
-        is_function_call = (
-            isinstance(decorator.func, ast.Attribute) and decorator.func.attr == "function"
-        ) or (isinstance(decorator.func, ast.Name) and decorator.func.id == "function")
-
-        if not is_function_call:
-            continue
-
-        for keyword in decorator.keywords:
-            if keyword.arg == "split":
-                if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
-                    return None
-                return extract_enum_value(keyword.value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
-    return None
+        if isinstance(keyword.value, ast.Constant) and keyword.value.value is None:
+            return {}
+        if not isinstance(keyword.value, ast.Dict):
+            raise ParserSyntaxError(
+                "Unsupported `@pl.function(attrs=...)` value",
+                hint='Use a dict literal, e.g. attrs={"split": pl.SplitMode.UP_DOWN}.',
+            )
+        attrs: dict[str, Any] = {}
+        for k, v in zip(keyword.value.keys, keyword.value.values):
+            if k is None:
+                raise ParserSyntaxError(
+                    "Unsupported `**` unpacking in `@pl.function(attrs={...})`",
+                    hint="Use only string literal keys in the attrs dict.",
+                )
+            if not isinstance(k, ast.Constant) or not isinstance(k.value, str):
+                raise ParserSyntaxError(
+                    f"Attrs dict key must be a string literal, got {ast.dump(k)}",
+                    hint='Use string literal keys, e.g. attrs={"split": ...}.',
+                )
+            attr_key = k.value
+            if attr_key == "split":
+                split_mode = extract_enum_value(v, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
+                if split_mode != ir.SplitMode.NONE:
+                    attrs["split"] = split_mode.value
+            elif isinstance(v, ast.Constant):
+                attrs[attr_key] = v.value
+        return attrs
+    return {}
 
 
 def _prescan_reserve_buffers(
@@ -550,7 +587,7 @@ def function(
     type: ir.FunctionType = ir.FunctionType.Opaque,
     level: ir.Level | None = None,
     role: ir.Role | None = None,
-    split: ir.SplitMode | None = None,
+    attrs: dict[str, Any] | None = None,
     strict_ssa: bool = False,
 ) -> ir.Function: ...
 
@@ -562,7 +599,7 @@ def function(
     type: ir.FunctionType = ir.FunctionType.Opaque,
     level: ir.Level | None = None,
     role: ir.Role | None = None,
-    split: ir.SplitMode | None = None,
+    attrs: dict[str, Any] | None = None,
     strict_ssa: bool = False,
 ) -> FunctionDecorator: ...
 
@@ -573,7 +610,7 @@ def function(
     type: ir.FunctionType = ir.FunctionType.Opaque,
     level: ir.Level | None = None,
     role: ir.Role | None = None,
-    split: ir.SplitMode | None = None,
+    attrs: dict[str, Any] | None = None,
     strict_ssa: bool = False,
 ) -> ir.Function | FunctionDecorator:
     """Decorator that parses a DSL function and returns IR Function.
@@ -587,6 +624,7 @@ def function(
         type: Function type (Opaque, Orchestration, or InCore)
         level: Hierarchy level (e.g. pl.Level.HOST)
         role: Function role (e.g. pl.Role.Worker)
+        attrs: Function-level attributes dict (e.g. {"split": pl.SplitMode.UP_DOWN})
         strict_ssa: If True, enforce SSA (single assignment per variable).
                    If False (default), allow variable reassignment (non-SSA mode).
 
@@ -644,8 +682,17 @@ def function(
                 closure_vars=closure_vars,
             )
 
+            # Normalize attrs: convert enum values to ints for storage
+            func_attrs = _normalize_attrs(attrs) if attrs else None
+
             try:
-                ir_func = parser.parse_function(func_def, func_type=type, func_level=level, func_role=role)
+                ir_func = parser.parse_function(
+                    func_def,
+                    func_type=type,
+                    func_level=level,
+                    func_role=role,
+                    func_attrs=func_attrs,
+                )
             except ParserError:
                 # Re-raise ParserError as-is, it already has source lines
                 raise
@@ -821,10 +868,10 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
             dyn_var_cache: dict[str, ir.Var] = {}
 
             for func_def in func_defs:
-                # Extract function type, level/role, and split from decorator
+                # Extract function type, level/role, and attrs from decorator
                 func_type = _extract_function_type_from_decorator(func_def)
                 func_level, func_role = _extract_function_level_role_from_decorator(func_def)
-                func_split = _extract_function_split_from_decorator(func_def)
+                func_attrs = _extract_function_attrs_from_decorator(func_def)
 
                 # Strip 'self' parameter if present (must be done before parsing)
                 func_def_to_parse = _strip_self_parameter(func_def)
@@ -849,7 +896,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                         func_type=func_type,
                         func_level=func_level,
                         func_role=func_role,
-                        func_split=func_split,
+                        func_attrs=func_attrs or None,
                     )
                 except ParserError:
                     raise

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1865,8 +1865,11 @@ class Function(IRNode):
     role: Final[Role | None]
     """Function role (None = unspecified)."""
 
+    attrs: Final[dict[str, Any]]
+    """Function-level attributes (key-value metadata)."""
+
     split: Final[SplitMode | None]
-    """Split mode for cross-core transfer (None = no split)."""
+    """Split mode for cross-core transfer (convenience accessor into attrs)."""
 
     params: Final[list[Var]]
     """Parameter variables."""
@@ -1890,7 +1893,7 @@ class Function(IRNode):
         type: FunctionType = FunctionType.Opaque,
         level: Level | None = None,
         role: Role | None = None,
-        split: SplitMode | None = None,
+        attrs: dict[str, Any] | None = None,
     ) -> None:
         """Create a function definition.
 
@@ -1903,7 +1906,7 @@ class Function(IRNode):
             type: Function type (default: Opaque)
             level: Hierarchy level (default: None — unspecified)
             role: Function role (default: None — unspecified)
-            split: Split mode for cross-core transfer (default: None)
+            attrs: Function-level attributes dict (default: None)
         """
 
     def __str__(self) -> str:
@@ -2323,6 +2326,7 @@ class IRBuilder:
         type: FunctionType = FunctionType.Opaque,
         level: Level | None = None,
         role: Role | None = None,
+        attrs: dict[str, Any] | None = None,
     ) -> None:
         """Begin building a function.
 
@@ -2332,6 +2336,7 @@ class IRBuilder:
             type: Function type (default: Opaque)
             level: Hierarchy level (default: None)
             role: Function role (default: None)
+            attrs: Function-level attributes dict (default: None)
         """
 
     def func_arg(

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/ir/builder.h"
 
+#include <any>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -38,14 +39,15 @@ IRBuilder::IRBuilder() = default;
 
 void IRBuilder::BeginFunction(const std::string& name, const Span& span, FunctionType type,
                               std::optional<Level> level, std::optional<Role> role,
-                              std::optional<SplitMode> split) {
+                              std::vector<std::pair<std::string, std::any>> attrs) {
   if (InFunction()) {
     throw pypto::RuntimeError("Cannot begin function '" + name + "': already inside function '" +
                               static_cast<FunctionContext*>(CurrentContext())->GetName() + "' at " +
                               CurrentContext()->GetBeginSpan().to_string());
   }
 
-  context_stack_.push_back(std::make_unique<FunctionContext>(name, span, type, level, role, split));
+  context_stack_.push_back(
+      std::make_unique<FunctionContext>(name, span, type, level, role, std::move(attrs)));
 }
 
 VarPtr IRBuilder::FuncArg(const std::string& name, const TypePtr& type, const Span& span,
@@ -80,7 +82,7 @@ FunctionPtr IRBuilder::EndFunction(const Span& end_span) {
   auto func =
       std::make_shared<Function>(func_ctx->GetName(), func_ctx->GetParams(), func_ctx->GetParamDirections(),
                                  func_ctx->GetReturnTypes(), body, combined_span, func_ctx->GetFuncType(),
-                                 func_ctx->GetLevel(), func_ctx->GetRole(), func_ctx->GetSplit());
+                                 func_ctx->GetLevel(), func_ctx->GetRole(), func_ctx->GetAttrs());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -653,17 +653,26 @@ static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack:
     role = static_cast<Role>(role_obj->via.u64);
   }
 
-  // Deserialize optional split mode
-  std::optional<SplitMode> split = std::nullopt;
-  auto split_obj = GetOptionalFieldObj(fields_obj, "split", ctx);
-  if (split_obj.has_value() && split_obj->type != msgpack::type::NIL) {
-    split = static_cast<SplitMode>(split_obj->via.u64);
+  // Deserialize function attrs (new format), with backward compat for old "split" field
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_obj = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_obj.has_value() && attrs_obj->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_obj, "attrs");
+  } else {
+    // Legacy backward compat: convert old "split" field to attrs
+    auto split_obj = GetOptionalFieldObj(fields_obj, "split", ctx);
+    if (split_obj.has_value() && split_obj->type != msgpack::type::NIL) {
+      int split_val = static_cast<int>(split_obj->via.u64);
+      if (split_val != 0) {
+        attrs.emplace_back("split", split_val);
+      }
+    }
   }
 
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
   return std::make_shared<Function>(name, params, param_directions, return_types, body, span, func_type,
-                                    level, role, split);
+                                    level, role, std::move(attrs));
 }
 
 // Deserialize Program

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -437,7 +437,7 @@ FunctionPtr TransformAllocateMemoryAddr(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1631,7 +1631,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
   auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
   auto new_func =
       std::make_shared<Function>(func->name_, new_params, new_param_directions, new_return_types, new_body,
-                                 span, FunctionType::InCore, func->level_, func->role_, func->split_);
+                                 span, FunctionType::InCore, func->level_, func->role_, func->attrs_);
 
   return {new_func, num_added_outputs};
 }
@@ -1967,7 +1967,7 @@ FunctionPtr UpdateCallSites(const FunctionPtr& func,
   auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, span, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -260,7 +260,7 @@ class SSAConverter {
     StmtPtr new_body = func->body_ ? ConvertStmt(func->body_) : nullptr;
 
     return std::make_shared<Function>(func->name_, new_params, new_dirs, func->return_types_, new_body,
-                                      func->span_, func->func_type_, func->level_, func->role_, func->split_);
+                                      func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
   }
 
  private:

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -799,7 +799,7 @@ FunctionPtr TransformCtrlFlow(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -940,7 +940,7 @@ FunctionPtr AddGMSlotBufferParam(const FunctionPtr& func) {
   auto new_directions = func->param_directions_;
   new_directions.push_back(ParamDirection::In);
   return std::make_shared<Function>(func->name_, new_params, new_directions, func->return_types_, func->body_,
-                                    func->span_, func->func_type_, func->level_, func->role_);
+                                    func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
 }
 
 StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<std::string>& modified_funcs,
@@ -1076,9 +1076,9 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
 
     if (!mod_callees.empty()) {
       auto nb = RewriteCallsForGMBuffer(func->body_, mod_callees, gm_param);
-      func =
-          std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                     nb, func->span_, func->func_type_, func->level_, func->role_);
+      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                        func->return_types_, nb, func->span_, func->func_type_, func->level_,
+                                        func->role_, func->attrs_);
     }
   }
 }

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -588,7 +588,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   (void)aic_clone_map_unused;
   auto aic_func = std::make_shared<Function>(aic_name, aic_params, func->param_directions_,
                                              std::vector<TypePtr>{}, aic_cloned_body, func->span_,
-                                             FunctionType::AIC, std::nullopt, std::nullopt, func->split_);
+                                             FunctionType::AIC, std::nullopt, std::nullopt, func->attrs_);
 
   // Create AIV function with deep clone (fresh Vars for all params and locals,
   // ensuring no shared Var pointers with AIC for structural equality)
@@ -727,7 +727,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   (void)aiv_clone_map_unused;
   auto aiv_func = std::make_shared<Function>(aiv_name, aiv_params, func->param_directions_,
                                              func->return_types_, aiv_cloned_body, func->span_,
-                                             FunctionType::AIV, std::nullopt, std::nullopt, func->split_);
+                                             FunctionType::AIV, std::nullopt, std::nullopt, func->attrs_);
 
   if (!create_group) {
     return {aic_func, aiv_func, std::nullopt};
@@ -1138,7 +1138,7 @@ Pass ExpandMixedKernel() {
         FunctionType new_type = (combined == CoreAffinity::CUBE) ? FunctionType::AIC : FunctionType::AIV;
         auto converted = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                                     func->return_types_, func->body_, func->span_, new_type,
-                                                    std::nullopt, std::nullopt, func->split_);
+                                                    std::nullopt, std::nullopt, func->attrs_);
         new_functions.push_back(converted);
         continue;
       }

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -347,7 +347,7 @@ FunctionPtr TransformFlattenCallExpr(const FunctionPtr& func) {
   auto new_body = mutator.VisitStmt(func->body_);
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -658,7 +658,7 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
   // and this pass only flattens tile ops. Tensor types are never modified.
   auto result =
       std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                 new_body, span, func->func_type_, func->level_, func->role_, func->split_);
+                                 new_body, span, func->func_type_, func->level_, func->role_, func->attrs_);
   return result;
 }
 

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -414,7 +414,7 @@ FunctionPtr TransformInferTileMemorySpace(const FunctionPtr& func) {
 
   auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                            func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->split_);
+                                           func->level_, func->role_, func->attrs_);
   return result;
 }
 

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -509,7 +509,7 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
   auto result_func = std::make_shared<Function>(
       normalized_func->name_, new_params, normalized_func->param_directions_, normalized_func->return_types_,
       new_body, normalized_func->span_, normalized_func->func_type_, normalized_func->level_,
-      normalized_func->role_, normalized_func->split_);
+      normalized_func->role_, normalized_func->attrs_);
 
   // Step 3: Collect non-DDR MemRefs and create alloc statements
   NonDDRMemRefCollector collector;
@@ -533,7 +533,7 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
   return std::make_shared<Function>(result_func->name_, new_params, result_func->param_directions_,
                                     result_func->return_types_, final_body, result_func->span_,
                                     result_func->func_type_, result_func->level_, result_func->role_,
-                                    result_func->split_);
+                                    result_func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -317,7 +317,7 @@ class SyncInserter {
 
     return std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                       func->return_types_, new_body, func->span_, func->func_type_,
-                                      func->level_, func->role_, func->split_);
+                                      func->level_, func->role_, func->attrs_);
   }
 
  private:

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -775,7 +775,7 @@ FunctionPtr TransformInterchangeChunkLoops(const FunctionPtr& func) {
 
   auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                            func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->split_);
+                                           func->level_, func->role_, func->attrs_);
   return result;
 }
 

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -138,7 +138,7 @@ FunctionPtr IRMutator::VisitFunction(const FunctionPtr& func) {
   }
   return std::make_shared<const Function>(func->name_, func->params_, func->param_directions_,
                                           func->return_types_, std::move(new_body), func->span_,
-                                          func->func_type_, func->level_, func->role_);
+                                          func->func_type_, func->level_, func->role_, func->attrs_);
 }
 
 ExprPtr IRMutator::VisitExpr(const ExprPtr& expr) { return ExprFunctor<ExprPtr>::VisitExpr(expr); }

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -74,7 +74,7 @@ Pass OutlineClusterScopes() {
 
       auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                                  func->return_types_, new_body, func->span_, func->func_type_,
-                                                 func->level_, func->role_, func->split_);
+                                                 func->level_, func->role_, func->attrs_);
       new_functions.push_back(new_func);
 
       const auto& outlined = outliner.GetOutlinedFunctions();

--- a/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
+++ b/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
@@ -79,7 +79,7 @@ Pass OutlineHierarchyScopes() {
       // Preserve parent function type (don't promote — hierarchy is orthogonal to FunctionType)
       auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                                  func->return_types_, new_body, func->span_, func->func_type_,
-                                                 func->level_, func->role_, func->split_);
+                                                 func->level_, func->role_, func->attrs_);
       new_functions.push_back(new_func);
 
       const auto& outlined = outliner.GetOutlinedFunctions();

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -83,7 +83,7 @@ Pass OutlineIncoreScopes() {
       FunctionType new_func_type = outlined.empty() ? func->func_type_ : FunctionType::Orchestration;
       auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                                  func->return_types_, new_body, func->span_, new_func_type,
-                                                 func->level_, func->role_, func->split_);
+                                                 func->level_, func->role_, func->attrs_);
       new_functions.push_back(new_func);
 
       // Collect outlined functions (prepend before parent so inner functions come first)

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1216,7 +1216,10 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
     bool has_type = func->func_type_ != FunctionType::Opaque;
     bool has_level = func->level_.has_value();
     bool has_role = func->role_.has_value();
-    bool has_split = func->split_.has_value() && func->split_.value() != SplitMode::None;
+    // NOTE: Currently only the "split" attr is printed. Other attrs in func->attrs_
+    // will be silently dropped during printing. Extend here when new attrs are added.
+    auto func_split_mode = func->GetSplitMode();
+    bool has_split = func_split_mode.has_value();
     if (has_type || has_level || has_role || has_split) {
       stream_ << "(";
       bool first = true;
@@ -1236,7 +1239,8 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
       }
       if (has_split) {
         if (!first) stream_ << ", ";
-        stream_ << "split=" << prefix_ << ".SplitMode." << SplitModeToPythonString(func->split_.value());
+        stream_ << "attrs={\"split\": " << prefix_ << ".SplitMode."
+                << SplitModeToPythonString(*func_split_mode) << "}";
       }
       stream_ << ")";
     }

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -234,7 +234,7 @@ FunctionPtr RewriteFunction(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/resolve_transpose_layout_pass.cpp
+++ b/src/ir/transforms/resolve_transpose_layout_pass.cpp
@@ -137,7 +137,7 @@ FunctionPtr TransformIncoreParams(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/simplify_expr_pass.cpp
+++ b/src/ir/transforms/simplify_expr_pass.cpp
@@ -171,7 +171,7 @@ FunctionPtr TransformSimplifyExpr(const FunctionPtr& func) {
   if (new_body.get() == func->body_.get()) return func;
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -579,7 +579,7 @@ FunctionPtr TransformSplitChunkedLoops(const FunctionPtr& func) {
 
   auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                            func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->split_);
+                                           func->level_, func->role_, func->attrs_);
   return result;
 }
 

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -335,11 +335,12 @@ std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode m
 }
 
 FunctionPtr ProcessFunction(const FunctionPtr& func) {
-  if (!func->split_.has_value() || func->split_.value() == SplitMode::None) {
+  auto split_mode = func->GetSplitMode();
+  if (!split_mode.has_value()) {
     return func;
   }
 
-  SplitMode mode = func->split_.value();
+  SplitMode mode = *split_mode;
   int split_int = static_cast<int>(mode);
   int split_dim = SplitDimension(mode);
   bool is_aiv = (func->func_type_ == FunctionType::AIV);
@@ -392,7 +393,7 @@ FunctionPtr ProcessFunction(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace
@@ -407,7 +408,7 @@ Pass SplitVectorKernel() {
     for (const auto& [gvar, func] : program->functions_) {
       // Only process AIC and AIV functions that have a non-None split mode
       if ((func->func_type_ == FunctionType::AIV || func->func_type_ == FunctionType::AIC) &&
-          func->split_.has_value() && func->split_.value() != SplitMode::None) {
+          func->GetSplitMode().has_value()) {
         auto new_func = ProcessFunction(func);
         new_functions.push_back(new_func);
         changed = true;

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -152,7 +152,7 @@ FunctionPtr TransformUnrollLoops(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace

--- a/src/ir/transforms/utils/normalize_stmt_structure.cpp
+++ b/src/ir/transforms/utils/normalize_stmt_structure.cpp
@@ -160,7 +160,7 @@ FunctionPtr NormalizeStmtStructure(const FunctionPtr& func) {
 
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->split_);
+                                    func->attrs_);
 }
 
 }  // namespace pypto::ir

--- a/tests/ut/ir/core/test_function_attrs.py
+++ b/tests/ut/ir/core/test_function_attrs.py
@@ -141,7 +141,7 @@ class TestFunctionAttrsPrinterRoundtrip:
             def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
                 return x
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ir.assert_structural_equal(A, B)
 
 

--- a/tests/ut/ir/core/test_function_attrs.py
+++ b/tests/ut/ir/core/test_function_attrs.py
@@ -1,0 +1,149 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for Function-level attributes (attrs) system."""
+
+import pypto.language as pl
+import pypto.pypto_core as pc
+import pytest
+from pypto.pypto_core import ir
+
+
+def _make_nop_body() -> ir.Stmt:
+    """Create a minimal function body (pass statement)."""
+    span = ir.Span.unknown()
+    return ir.EvalStmt(ir.ConstInt(0, pc.DataType.INT64, span), span)
+
+
+class TestFunctionAttrsBinding:
+    """Test Function attrs via Python bindings."""
+
+    def test_empty_attrs(self):
+        span = ir.Span.unknown()
+        body = _make_nop_body()
+        func = ir.Function("f", [], [], body, span)
+        assert func.attrs == {}
+        assert func.split is None
+
+    def test_split_via_attrs_param(self):
+        span = ir.Span.unknown()
+        body = _make_nop_body()
+        func = ir.Function("f", [], [], body, span, attrs={"split": 1})
+        assert func.attrs == {"split": 1}
+        assert func.split == ir.SplitMode.UP_DOWN
+
+    def test_left_right_via_attrs(self):
+        span = ir.Span.unknown()
+        body = _make_nop_body()
+        func = ir.Function("f", [], [], body, span, attrs={"split": 2})
+        assert func.attrs == {"split": 2}
+        assert func.split == ir.SplitMode.LEFT_RIGHT
+
+    def test_custom_attrs(self):
+        span = ir.Span.unknown()
+        body = _make_nop_body()
+        func = ir.Function("f", [], [], body, span, attrs={"split": 1, "pipeline_depth": 2})
+        assert func.attrs["split"] == 1
+        assert func.attrs["pipeline_depth"] == 2
+        assert func.split == ir.SplitMode.UP_DOWN
+
+    def test_no_attrs_means_no_split(self):
+        span = ir.Span.unknown()
+        body = _make_nop_body()
+        func = ir.Function("f", [], [], body, span)
+        assert func.attrs == {}
+        assert func.split is None
+
+
+class TestFunctionAttrsDSL:
+    """Test Function attrs via the @pl.function / @pl.program DSL decorators."""
+
+    def test_program_split_up_down(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        func = Prog["main"]
+        assert func is not None
+        assert func.split == ir.SplitMode.UP_DOWN
+        assert func.attrs["split"] == 1
+
+    def test_program_no_attrs(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        func = Prog["main"]
+        assert func is not None
+        assert func.split is None
+        assert func.attrs == {}
+
+    def test_standalone_function_attrs(self):
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def my_func(x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+            return x
+
+        assert my_func.split == ir.SplitMode.LEFT_RIGHT
+        assert my_func.attrs["split"] == 2
+
+
+class TestFunctionAttrsPrinterRoundtrip:
+    """Test that Function attrs survive print -> parse round-trip."""
+
+    @pytest.mark.skip(reason="pl.program_from_string not yet implemented")
+    def test_split_roundtrip(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        printed = ir.python_print(Before)
+        After = pl.program_from_string(printed)  # type: ignore[attr-defined]
+        func = After["main"]
+        assert func.split == ir.SplitMode.UP_DOWN
+
+    def test_structural_equality_with_attrs(self):
+        @pl.program
+        class A:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        @pl.program
+        class B:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        ir.assert_structural_equal(A, B)
+
+    def test_structural_inequality_different_split(self):
+        @pl.program
+        class A:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        @pl.program
+        class B:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+            def main(self, x: pl.Tensor[[16, 128], pl.FP16]) -> pl.Tensor[[16, 128], pl.FP16]:
+                return x
+
+        with pytest.raises(Exception):
+            ir.assert_structural_equal(A, B)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -47,7 +47,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Before:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -56,7 +56,7 @@ class TestSplitVectorKernelUpDown:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=0)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
@@ -66,7 +66,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Expected:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -75,7 +75,7 @@ class TestSplitVectorKernelUpDown:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=1)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INT64] = pl.tile.get_subblock_idx()
                 z_vec: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
@@ -89,7 +89,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Before:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -98,7 +98,7 @@ class TestSplitVectorKernelUpDown:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=0)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
@@ -114,7 +114,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Expected:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -123,7 +123,7 @@ class TestSplitVectorKernelUpDown:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=1)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
@@ -164,7 +164,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Before:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16]):
                 a_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat, pl.TileView()] = pl.tpop_from_aiv(
                     split=0
@@ -173,7 +173,7 @@ class TestSplitVectorKernelUpDown:
 
         @pl.program
         class Expected:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.UP_DOWN)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16]):
                 a_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat, pl.TileView()] = pl.tpop_from_aiv(
                     split=1
@@ -191,7 +191,7 @@ class TestSplitVectorKernelLeftRight:
 
         @pl.program
         class Before:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -200,7 +200,7 @@ class TestSplitVectorKernelLeftRight:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=0)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
@@ -210,7 +210,7 @@ class TestSplitVectorKernelLeftRight:
 
         @pl.program
         class Expected:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -219,7 +219,7 @@ class TestSplitVectorKernelLeftRight:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=2)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INT64] = pl.tile.get_subblock_idx()
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=2)
@@ -235,7 +235,7 @@ class TestSplitVectorKernelLeftRight:
 
         @pl.program
         class Before:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -244,7 +244,7 @@ class TestSplitVectorKernelLeftRight:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=0)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
@@ -260,7 +260,7 @@ class TestSplitVectorKernelLeftRight:
 
         @pl.program
         class Expected:
-            @pl.function(type=pl.FunctionType.AIC, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
@@ -269,7 +269,7 @@ class TestSplitVectorKernelLeftRight:
                 z_tile = pl.matmul(x_left, y_right)
                 pl.tpush_to_aiv(z_tile, split=2)
 
-            @pl.function(type=pl.FunctionType.AIV, split=pl.SplitMode.LEFT_RIGHT)
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:


### PR DESCRIPTION
## Summary

Implements #819 — adds a generic function-level attribute system to `Function`, replacing the dedicated `split_` field with an extensible `attrs_` map.

- **New `attrs_` field** on `Function` (`vector<pair<string, any>>`), reusing the same type as `Call::kwargs_` — zero new serialization/equality/hashing code needed
- **SplitMode stored as `int`** inside attrs, accessed via `GetSplitMode()` convenience method
- **Breaking change**: `@pl.function(split=pl.SplitMode.UP_DOWN)` → `@pl.function(attrs={"split": pl.SplitMode.UP_DOWN})`
- **Backward-compatible deserialization**: old serialized `"split"` field automatically converted to attrs
- **Bug fix**: `IRMutator::VisitFunction` was silently dropping the `split_` field — now correctly propagates `attrs_`

### Key changes across layers

| Layer | Files | Change |
|-------|-------|--------|
| C++ IR | `function.h`, `builder.h`, `builder.cpp` | `split_` → `attrs_`, add `GetAttr<T>()`, `HasAttr()`, `GetSplitMode()` |
| Passes | ~25 files in `src/ir/transforms/` | Mechanical `func->split_` → `func->attrs_` |
| Printer | `python_printer.cpp` | Prints `attrs={"split": pl.SplitMode.X}` |
| Serialization | `type_deserializers.cpp` | Backward compat: old `"split"` field → attrs |
| Bindings | `ir.cpp`, `ir_builder.cpp`, `module.h` | `attrs` param, `attrs`/`split` properties |
| Python DSL | `decorator.py`, `ast_parser.py`, `builder.py` | `attrs=` decorator, `_extract_function_attrs_from_decorator` |
| Type stubs | `ir.pyi` | Updated signatures |
| Tests | `test_function_attrs.py`, `test_split_vector_kernel.py` | New attrs tests, migrated split tests |

## Testing

- [x] All 3272 tests pass (3271 passed, 1 skipped, 0 failed)
- [x] Code review completed
- [x] Clang-tidy passed (only pre-existing warnings)
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

Closes #819