### PR TITLE
chore(skills): remove self-assign step from fix-issue workflow

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -23,13 +23,12 @@ Create tasks to track progress through this workflow:
 
 1. Check gh CLI authentication
 2. Fetch issue content
-3. Assign issue to me
-4. Create issue branch
-5. Enter plan mode to design fix
-6. Implement the fix
-7. Run tests (use `testing` skill)
-8. Commit changes (use `git-commit` skill)
-9. Create PR (optional, use `github-pr` skill)
+3. Create issue branch
+4. Enter plan mode to design fix
+5. Implement the fix
+6. Run tests (use `testing` skill)
+7. Commit changes (use `git-commit` skill)
+8. Create PR (optional, use `github-pr` skill)
 
 ## Step 1: Check gh CLI Authentication
 
@@ -58,27 +57,7 @@ Comments often contain clarifications, reproduction steps, or design decisions t
 
 **If issue is closed**: Ask user if they still want to work on it.
 
-## Step 3: Assign Issue to Me
-
-Before assigning, check if someone is already working on the issue:
-
-```bash
-gh issue view ISSUE_NUMBER --json assignees --jq '.assignees[].login'
-```
-
-**If assigned to current user**: Continue — already claimed.
-
-**If assigned to someone else**: Ask the user whether to proceed or pick a different issue.
-
-**If unassigned**: Assign to yourself (best-effort — skip gracefully if permissions are insufficient):
-
-```bash
-gh issue edit ISSUE_NUMBER --add-assignee @me
-```
-
-If the assignment fails due to permissions (common on forks or some org repos), continue with the workflow — do not block.
-
-## Step 4: Create Issue Branch
+## Step 3: Create Issue Branch
 
 **Branch naming**: `issue-{number}-{short-description}`
 
@@ -89,7 +68,7 @@ BRANCH_NAME="issue-${ISSUE_NUM}-fix-tensor-validation"
 git checkout -b "$BRANCH_NAME"
 ```
 
-## Step 5: Enter Plan Mode
+## Step 4: Enter Plan Mode
 
 Use `EnterPlanMode` to design the fix.
 
@@ -102,7 +81,7 @@ Use `EnterPlanMode` to design the fix.
 - Documentation updates
 - Cross-layer changes (C++, Python, type stubs)
 
-## Step 6: Implement the Fix
+## Step 5: Implement the Fix
 
 After plan approval, follow PyPTO conventions:
 
@@ -112,7 +91,7 @@ After plan approval, follow PyPTO conventions:
 4. Add/update tests
 5. Maintain cross-layer sync (C++, Python, type stubs)
 
-## Step 7: Run Tests
+## Step 6: Run Tests
 
 ```text
 /testing
@@ -120,7 +99,7 @@ After plan approval, follow PyPTO conventions:
 
 Fix any failures before committing.
 
-## Step 8: Commit Changes
+## Step 7: Commit Changes
 
 ```text
 /git-commit
@@ -136,7 +115,7 @@ Fixes #ISSUE_NUMBER
 Detailed explanation of the fix.
 ```
 
-## Step 9: Create PR (Optional)
+## Step 8: Create PR (Optional)
 
 ```text
 /github-pr
@@ -157,7 +136,6 @@ Detailed explanation of the fix.
 
 - [ ] gh CLI authenticated
 - [ ] Issue content fetched and understood
-- [ ] Issue assignment attempted (best-effort)
 - [ ] Issue branch created from latest main
 - [ ] Plan created and approved
 - [ ] Fix implemented following PyPTO rules


### PR DESCRIPTION
## Summary
- Remove the "Assign Issue to Me" step (old Step 3) from the fix-issue skill workflow
- Renumber subsequent steps (3→8 becomes 3→7) for consistency
- Remove assignment-related checklist item

## Testing
- [x] Verified step numbering is consistent across workflow list, step headers, and checklist
- [x] Confirmed no stale references to assignment/self-assign remain