### PR TITLE
fix(printer): use PythonPrint in FormatShape for readable error messages

### DIFF
--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -22,6 +22,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -253,7 +254,7 @@ std::string FormatShape(const std::vector<ExprPtr>& shape) {
     if (i > 0) {
       oss << ", ";
     }
-    oss << shape[i];
+    oss << PythonPrint(shape[i]);
   }
   oss << "]";
   return oss.str();

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1617,5 +1617,43 @@ def test_tensor_scatter_update_invalid_dim():
         ir.op.tensor.scatter_update(input_var, 0, index_var, src_var)
 
 
+class TestTensorFormatShapeError:
+    """Regression tests for issue #824: FormatShape prints readable shapes, not pointer addresses."""
+
+    def test_tensor_add_shape_mismatch_shows_readable_dims(self):
+        """Test that tensor shape mismatch errors show readable dimensions."""
+        span = ir.Span.unknown()
+
+        dim4 = ir.ConstInt(4, DataType.DEFAULT_CONST_INT, span)
+        dim8 = ir.ConstInt(8, DataType.DEFAULT_CONST_INT, span)
+        dim3 = ir.ConstInt(3, DataType.DEFAULT_CONST_INT, span)
+
+        tensor_type1 = ir.TensorType([dim4, dim8], DataType.FP32)
+        tensor_type2 = ir.TensorType([dim3, dim8], DataType.FP32)
+
+        tensor_a = ir.Var("a", tensor_type1, span)
+        tensor_b = ir.Var("b", tensor_type2, span)
+
+        with pytest.raises(ValueError, match=r"\[4, 8\].*\[3, 8\]"):
+            ir.op.tensor.add(tensor_a, tensor_b)
+
+    def test_tensor_add_symbolic_shape_mismatch_shows_var_names(self):
+        """Test that symbolic tensor shape mismatch errors show variable names."""
+        span = ir.Span.unknown()
+
+        sym_m = ir.Var("M", ir.ScalarType(DataType.INT32), span)
+        sym_n = ir.Var("N", ir.ScalarType(DataType.INT32), span)
+        dim8 = ir.ConstInt(8, DataType.DEFAULT_CONST_INT, span)
+
+        tensor_type1 = ir.TensorType([sym_m, dim8], DataType.FP32)
+        tensor_type2 = ir.TensorType([sym_n, dim8], DataType.FP32)
+
+        tensor_a = ir.Var("a", tensor_type1, span)
+        tensor_b = ir.Var("b", tensor_type2, span)
+
+        with pytest.raises(ValueError, match=r"\[M, 8\].*\[N, 8\]"):
+            ir.op.tensor.add(tensor_a, tensor_b)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2083,5 +2083,59 @@ class TestTileConcatOps:
             tile.concat(t0_var, t1_var)
 
 
+class TestTileFormatShapeError:
+    """Regression tests for issue #824: FormatShape prints readable shapes, not pointer addresses."""
+
+    def test_tile_add_shape_mismatch_shows_readable_dims(self):
+        """Test that shape mismatch errors show readable dimensions, not pointer addresses."""
+        span = ir.Span.unknown()
+
+        dim16 = ir.ConstInt(16, DataType.DEFAULT_CONST_INT, span)
+        dim32 = ir.ConstInt(32, DataType.DEFAULT_CONST_INT, span)
+
+        tile_type1 = ir.TileType([dim16, dim16], DataType.FP32)
+        tile_type2 = ir.TileType([dim32, dim16], DataType.FP32)
+
+        tile_a = ir.Var("a", tile_type1, span)
+        tile_b = ir.Var("b", tile_type2, span)
+
+        with pytest.raises(ValueError, match=r"\[16, 16\].*\[32, 16\]"):
+            tile.add(tile_a, tile_b)
+
+    def test_tile_mul_shape_mismatch_shows_readable_dims(self):
+        """Test that tile.mul shape mismatch shows readable shapes."""
+        span = ir.Span.unknown()
+
+        dim8 = ir.ConstInt(8, DataType.DEFAULT_CONST_INT, span)
+        dim16 = ir.ConstInt(16, DataType.DEFAULT_CONST_INT, span)
+        dim32 = ir.ConstInt(32, DataType.DEFAULT_CONST_INT, span)
+
+        tile_type1 = ir.TileType([dim8, dim16], DataType.FP32)
+        tile_type2 = ir.TileType([dim32, dim16], DataType.FP32)
+
+        tile_a = ir.Var("a", tile_type1, span)
+        tile_b = ir.Var("b", tile_type2, span)
+
+        with pytest.raises(ValueError, match=r"\[8, 16\].*\[32, 16\]"):
+            tile.mul(tile_a, tile_b)
+
+    def test_tile_add_symbolic_shape_mismatch_shows_var_names(self):
+        """Test that symbolic shape mismatch errors show variable names."""
+        span = ir.Span.unknown()
+
+        sym_m = ir.Var("M", ir.ScalarType(DataType.INT32), span)
+        sym_n = ir.Var("N", ir.ScalarType(DataType.INT32), span)
+        dim16 = ir.ConstInt(16, DataType.DEFAULT_CONST_INT, span)
+
+        tile_type1 = ir.TileType([sym_m, dim16], DataType.FP32)
+        tile_type2 = ir.TileType([sym_n, dim16], DataType.FP32)
+
+        tile_a = ir.Var("a", tile_type1, span)
+        tile_b = ir.Var("b", tile_type2, span)
+
+        with pytest.raises(ValueError, match=r"\[M, 16\].*\[N, 16\]"):
+            tile.add(tile_a, tile_b)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fix `FormatShape` in `type_inference.cpp` to use `PythonPrint` instead of streaming `ExprPtr` directly, which printed raw pointer addresses
- Error messages now show readable shapes like `[64, 128]` or `[N, M]` instead of `[0x7f..., 0x7f...]`
- Add regression tests for both tile and tensor shape mismatch errors, including symbolic shape cases

## Testing
- [x] All 3266 unit tests pass
- [x] Code review completed
- [x] Clang-tidy passing (include added)
- [x] 5 new regression tests added

## Related Issues
Fixes #824