### PR TITLE
fix(codegen): use fixed indent for constants in generated .pto files

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -383,6 +383,7 @@ class PTOCodegen : public CodegenBase {
   struct FunctionState {
     std::ostringstream constants_section;
     std::ostringstream body_section;
+    std::string constants_indent;  ///< Fixed indent for constants_section (set once per function)
 
     std::map<const ir::Var*, std::string> var_to_mlir;
     std::map<const ir::Var*, std::string> tensor_to_view;
@@ -430,6 +431,7 @@ class PTOCodegen : public CodegenBase {
       constants_section.clear();
       body_section.str("");
       body_section.clear();
+      constants_indent.clear();
 
       var_to_mlir.clear();
       tensor_to_view.clear();

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -331,6 +331,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   }
   stream_ << " {\n";
   indent_level_++;
+  fs_.constants_indent = GetIndent();
 
   // Pre-emit i64 address constants now that indent_level_ is set
   for (const auto& [tile_var, tile_type] : fs_.tile_var_allocs) {
@@ -682,7 +683,7 @@ std::string PTOCodegen::GetOrEmitIndexConstant(int64_t value) {
   } else {
     name = NewTemp();
   }
-  fs_.constants_section << GetIndent() << name << " = arith.constant " << value << " : index\n";
+  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : index\n";
   fs_.emitted_constants[value] = name;
   return name;
 }
@@ -708,7 +709,7 @@ std::string PTOCodegen::GetOrEmitI64Constant(int64_t value) {
   } else {
     name = NewTemp();
   }
-  fs_.constants_section << GetIndent() << name << " = arith.constant " << value << " : i64\n";
+  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : i64\n";
   fs_.emitted_i64_constants[value] = name;
   return name;
 }
@@ -734,7 +735,7 @@ std::string PTOCodegen::GetOrEmitI32Constant(int32_t value) {
   } else {
     name = NewTemp();
   }
-  fs_.constants_section << GetIndent() << name << " = arith.constant " << value << " : i32\n";
+  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : i32\n";
   fs_.emitted_i32_constants[value] = name;
   return name;
 }
@@ -1050,7 +1051,7 @@ std::string PTOCodegen::GetOrEmitFloatConstant(double value, const std::string& 
     std::ostringstream val_str;
     val_str << std::scientific << std::setprecision(6) << value;
 
-    fs_.constants_section << GetIndent() << name << " = arith.constant " << val_str.str() << " : "
+    fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << val_str.str() << " : "
                           << mlir_type << "\n";
     fs_.emitted_float_constants.insert(value);
     fs_.float_const_names[value] = name;

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1394,5 +1394,40 @@ class TestColumnVectorCodegen:
         assert "layout = #pto.layout<nd>" in row_view
 
 
+def test_pto_codegen_constant_indent_consistency():
+    """All arith.constant lines must have consistent 2-space indent.
+
+    Regression test for #812: constants first encountered inside a nested scope
+    (for loop) used the loop's deeper indent level instead of the function-body
+    indent level.
+    """
+
+    @pl.program
+    class NestedConstantProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def nested_const(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            output: pl.Tensor[[128, 128], pl.FP32],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            for i, (out_iter,) in pl.range(2, init_values=(output,)):
+                offset_i: pl.Scalar[pl.INDEX] = i * 64
+                tile: pl.Tile[[64, 128], pl.FP32] = pl.load(a, [offset_i, 0], [64, 128])
+                updated: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile, [offset_i, 0], out_iter)
+                result = pl.yield_(updated)
+            return result
+
+    mlir_code = _generate_default_mlir(NestedConstantProgram)
+
+    # Collect all arith.constant lines with original indentation
+    const_lines = [line for line in mlir_code.splitlines() if "arith.constant" in line]
+    assert len(const_lines) >= 2, f"Expected at least 2 arith.constant lines, got {len(const_lines)}"
+
+    # All should have exactly 2-space indent (function-body level)
+    for line in const_lines:
+        leading_spaces = len(line) - len(line.lstrip())
+        assert leading_spaces == 2, f"arith.constant has {leading_spaces}-space indent (expected 2): {line!r}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fix inconsistent indentation of `arith.constant` lines in generated `.pto` files
- Constants first encountered inside nested scopes (for loops, if statements) used the deeper indent level instead of the function-body indent level
- Capture function-body indent once in `FunctionState::constants_indent` and use it in all four constant emission functions (index, i64, i32, float)

## Testing
- [x] All tests pass (3293 passed, 0 failed)
- [x] Code review completed
- [x] Clang-tidy passed
- [x] Regression test added (`test_pto_codegen_constant_indent_consistency`)

## Related Issues
Fixes #812