### PR TITLE
fix(codegen): remove redundant pto.tmov from IfStmt emit_branch for tile returns

### DIFF
--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -137,14 +137,14 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     }
     Emit("}");
   } else {
-    // Like loops, keep tile return values out of scf.if results. Materialize
-    // them into pre-declared tile buffers inside each branch, and only use
-    // scf.if results for scalar-like SSA values.
+    // Like loops, keep tile return values out of scf.if results. Pre-declare
+    // tile buffers for return_vars using the canonical MemRef address (assigned
+    // by MemoryReuse), and only use scf.if results for scalar-like SSA values.
+    // MemoryReuse's YieldFixupMutator ensures all branch yields already share
+    // the return_var's canonical MemRef, so no codegen-level tmov is needed.
     std::vector<bool> returns_via_scf(op->return_vars_.size(), false);
     std::vector<std::string> scf_return_names;
     std::vector<std::string> scf_return_types;
-    std::vector<std::string> tile_return_targets(op->return_vars_.size());
-    std::vector<std::string> tile_return_types(op->return_vars_.size());
 
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
       const auto& return_var = op->return_vars_[i];
@@ -177,8 +177,6 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string ret_name =
             AllocNewTileBuf(tile_type_string, return_var->name_hint_, addr_ssa, valid_row_ssa, valid_col_ssa);
         BindVarToMlir(return_var, ret_name);
-        tile_return_targets[i] = ret_name;
-        tile_return_types[i] = tile_type_string;
       } else {
         INTERNAL_CHECK(false) << "Internal error: unsupported IfStmt return_var type for "
                               << return_var->name_hint_;
@@ -210,14 +208,9 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           scalar_yields.push_back(branch_yields[i]);
           continue;
         }
-        if (tile_return_targets[i].empty() || branch_yields[i].empty()) continue;
-        if (branch_yields[i] == tile_return_targets[i]) continue;
-
-        std::string src_type = GetSSATileBufType(branch_yields[i]);
-        INTERNAL_CHECK(!src_type.empty())
-            << "Internal error: missing tile type for IfStmt branch yield " << branch_yields[i];
-        Emit("pto.tmov ins(" + branch_yields[i] + " : " + src_type + ") outs(" + tile_return_targets[i] +
-             " : " + tile_return_types[i] + ")");
+        // Tile return_vars: MemoryReuse ensures branch yields share the return_var's
+        // canonical MemRef (same physical address). No codegen-level tmov needed —
+        // the IR-level tile.move (from MemoryReuse's YieldFixupMutator) handles the copy.
       }
 
       if (!scf_return_types.empty()) {

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1188,6 +1188,57 @@ def test_pto_codegen_if_stmt_tile_phi_preserves_dynamic_valid_shape():
     assert "v_col=?" in phi_alloc_line, f"Expected dynamic v_col in tile phi alloc, got: {phi_alloc_line}"
 
 
+def test_pto_codegen_if_stmt_tile_no_redundant_tmov():
+    """IfStmt emit_branch must not generate a codegen-level tmov for tile return_vars.
+
+    MemoryReuse's YieldFixupMutator inserts an IR-level tile.move in the else-branch
+    to unify its yield MemRef with the then-branch's canonical MemRef. The codegen
+    should emit exactly one pto.tmov (from that IR tile.move), not a second redundant
+    one from emit_branch (which would copy addr B → addr B, a no-op).
+    """
+
+    @pl.program
+    class IfTileNoRedundantTmovProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def repro(
+            self,
+            flag: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            seed: pl.Tile[[64, 64], pl.FP32] = pl.tile.create(
+                [64, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+            )
+            then_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.muls(seed, 2.0)
+            else_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.muls(seed, 3.0)
+            if flag == 0:
+                result = then_tile
+            else:
+                result = else_tile
+            final: pl.Tensor[[64, 64], pl.FP32] = pl.store(result, [0, 0], out)
+            return final
+
+    mlir_code = _generate_default_mlir(IfTileNoRedundantTmovProgram)
+    lines = _get_mlir_lines(mlir_code)
+
+    tmov_lines = _find_lines(lines, "pto.tmov")
+    # After the fix: exactly one tmov — the IR-level tile.move (else branch only).
+    # The then-branch has no tmov; the codegen-level tmov from emit_branch is removed.
+    assert len(tmov_lines) == 1, (
+        f"Expected exactly 1 pto.tmov (from IR tile.move), got {len(tmov_lines)}: {tmov_lines}"
+    )
+
+    # The single tmov copies from the else computation result to the canonical tile_buf.
+    tmov = tmov_lines[0]
+    assert "pto.tmov" in tmov, f"Expected a pto.tmov line, got: {tmov}"
+    # Verify the tmov targets are at different addresses (it's a real copy, not a no-op).
+    ins_match = re.search(r"ins\((%[\w\d_]+)", tmov)
+    outs_match = re.search(r"outs\((%[\w\d_]+)", tmov)
+    assert ins_match and outs_match, f"Expected ins/outs operands in tmov: {tmov}"
+    assert ins_match.group(1) != outs_match.group(1), (
+        f"tmov src and dst must differ (not a self-copy): {tmov}"
+    )
+
+
 def test_pto_codegen_if_stmt_scalar_result_preserves_integer_dtype():
     """IfStmt scalar results should use their real scalar dtype in scf.if results."""
 


### PR DESCRIPTION
MemoryReuse's YieldFixupMutator ensures all IfStmt branch yields and the return_var share the same canonical MemRef (same physical address). The codegen-level pto.tmov emitted by emit_branch was therefore always a no-op (addr B → addr B), wasting a cycle.

Remove the tmov generation from emit_branch. The pre-declared tile buffer for the return_var (via AllocNewTileBuf) is kept for SSA visibility after the scf.if block. The IR-level tile.move (inserted by YieldFixupMutator when then/else yields have different MemRefs) handles the actual copy.

Fixes #803