### PR TITLE
fix(ir): add K-dimension validation to tensor.matmul type deduction

### DIFF
--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -97,17 +97,50 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
 
   if (lhs_shape.size() == 1 && rhs_shape.size() == 1) {
     // Vector x vector (dot product): [K] x [K] -> scalar (0D tensor)
+    auto k_lhs_const = As<ConstInt>(lhs_shape[0]);
+    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
+    if (k_lhs_const && k_rhs_const) {
+      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+          << "tensor.matmul dot product requires matching dimensions, but got lhs K=" << k_lhs_const->value_
+          << " and rhs K=" << k_rhs_const->value_;
+    }
     output_shape = {};
   } else if (lhs_shape.size() == 2 && rhs_shape.size() == 1) {
     // Matrix x vector: [M, K] x [K] -> [M]
+    auto k_lhs_const = As<ConstInt>(lhs_shape[1]);
+    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
+    if (k_lhs_const && k_rhs_const) {
+      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
+          << " and rhs K=" << k_rhs_const->value_;
+    }
     output_shape = {lhs_shape[0]};
   } else if (lhs_shape.size() == 1 && rhs_shape.size() == 2) {
     // Vector x matrix: [K] x [K, N] -> [N]
+    auto k_lhs_const = As<ConstInt>(lhs_shape[0]);
+    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
+    if (k_lhs_const && k_rhs_const) {
+      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
+          << " and rhs K=" << k_rhs_const->value_;
+    }
     output_shape = {rhs_shape[1]};
   } else if (lhs_shape.size() == 2 && rhs_shape.size() == 2) {
     // 2D x 2D matrix multiplication
     ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
+    ExprPtr k_lhs = a_trans ? lhs_shape[0] : lhs_shape[1];
+    ExprPtr k_rhs = b_trans ? rhs_shape[1] : rhs_shape[0];
     ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
+
+    // Verify K dimensions match (when statically known)
+    auto k_lhs_const = As<ConstInt>(k_lhs);
+    auto k_rhs_const = As<ConstInt>(k_rhs);
+    if (k_lhs_const && k_rhs_const) {
+      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
+          << " and rhs K=" << k_rhs_const->value_;
+    }
+
     output_shape = {m_dim, n_dim};
   } else {
     // For higher-dimensional tensors (both must have at least 2 dimensions),
@@ -132,7 +165,19 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
 
     // Append matrix dimensions
     ExprPtr m_dim = a_trans ? lhs_shape[lhs_ndim - 1] : lhs_shape[lhs_ndim - 2];
+    ExprPtr k_lhs = a_trans ? lhs_shape[lhs_ndim - 2] : lhs_shape[lhs_ndim - 1];
+    ExprPtr k_rhs = b_trans ? rhs_shape[rhs_ndim - 1] : rhs_shape[rhs_ndim - 2];
     ExprPtr n_dim = b_trans ? rhs_shape[rhs_ndim - 2] : rhs_shape[rhs_ndim - 1];
+
+    // Verify K dimensions match (when statically known)
+    auto k_lhs_const = As<ConstInt>(k_lhs);
+    auto k_rhs_const = As<ConstInt>(k_rhs);
+    if (k_lhs_const && k_rhs_const) {
+      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+          << "tensor.matmul requires matching inner dimensions for batched matmul, but got lhs K="
+          << k_lhs_const->value_ << " and rhs K=" << k_rhs_const->value_;
+    }
+
     output_shape.push_back(m_dim);
     output_shape.push_back(n_dim);
   }

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -111,7 +111,9 @@ def test_tensor_unary_ops():
 
 def test_tensor_matmul_with_transpose():
     """tensor.matmul with a_trans/b_trans should emit .mT."""
-    a = _tensor_var("a", [64, 128])
+    # When a_trans=True, K is lhs_shape[0] and M is lhs_shape[1].
+    # a = [K=128, M=64], b = [K=128, N=64] -> output [M=64, N=64]
+    a = _tensor_var("a", [128, 64])
     b = _tensor_var("b", [128, 64])
     out = _tensor_var("out", [64, 64])
     call = _op_call("tensor.matmul", [a, b], {"a_trans": True, "b_trans": False, "c_matrix_nz": False})


### PR DESCRIPTION
## Summary

`DeduceTensorMatMulType` in `src/ir/op/tensor_ops/matmul.cpp` computed output shapes without validating that the inner (K) dimensions of lhs and rhs actually match. This allowed mathematically invalid matmul configurations (e.g., mismatched K when using `a_trans`/`b_trans`) to pass type deduction silently.

- Add K-dimension matching checks (when statically known) to **all branches** of `DeduceTensorMatMulType`: 1D×1D dot product, 2D×1D matrix-vector, 1D×2D vector-matrix, 2D×2D matrix multiply, and batched matmul
- This follows the same validation pattern already used by `tensor.matmul_acc` and all `tile.matmul` variants
- Fix `test_tensor_matmul_with_transpose` tensor shapes from `a=[64,128]` to `a=[128,64]` so that `K=128` matches `b=[128,64]` when `a_trans=True`

## Test plan

- [x] Full UT suite: 3306 passed, 16 skipped
- [x] Verified K-mismatch is correctly caught with old invalid shapes
- [x] Verified valid shapes still pass type deduction

Fixes #837