### PR TITLE
fix(pass): remove dead tile alias assignments in ConvertTensorToTileOps store sinking

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -425,6 +425,37 @@ ExprPtr ResolveTileAlias(const ExprPtr& expr, const TileAliasMap& alias_map) {
   return current;
 }
 
+/// Collect all Var pointers referenced within an expression tree (RHS uses only).
+/// Used to determine whether an alias variable is still live after yield replacement.
+void CollectExprVarRefs(const ExprPtr& expr, std::unordered_set<const Var*>& refs) {
+  if (!expr) return;
+  if (auto var = As<Var>(expr)) {
+    refs.insert(var.get());
+    return;
+  }
+  if (auto call = As<Call>(expr)) {
+    for (const auto& arg : call->args_) {
+      CollectExprVarRefs(arg, refs);
+    }
+  }
+}
+
+/// Collect all Var pointers used as RHS expressions across a flat statement list.
+/// Excludes LHS definitions — only captures actual uses.
+std::unordered_set<const Var*> CollectStmtVarUses(const std::vector<StmtPtr>& stmts) {
+  std::unordered_set<const Var*> uses;
+  for (const auto& s : stmts) {
+    if (auto assign = As<AssignStmt>(s)) {
+      CollectExprVarRefs(assign->value_, uses);
+    } else if (auto ys = As<YieldStmt>(s)) {
+      for (const auto& v : ys->value_) CollectExprVarRefs(v, uses);
+    } else if (auto es = As<EvalStmt>(s)) {
+      CollectExprVarRefs(es->expr_, uses);
+    }
+  }
+  return uses;
+}
+
 /// Find the index of the YieldStmt in a flat statement list (backward search).
 /// Returns stmts.size() if not found.
 size_t FindYieldIndex(const std::vector<StmtPtr>& stmts) {
@@ -1622,21 +1653,27 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
         then_stmts[then_yield_idx] = std::make_shared<YieldStmt>(new_then_yield_values, then_yield->span_);
         else_stmts[else_yield_idx] = std::make_shared<YieldStmt>(new_else_yield_values, else_yield->span_);
 
-        // Remove dead alias assignments for yield values replaced by store sinking.
-        // Safe because sink candidates are simple pass-through branches (alias + yield).
+        // Remove alias assignments for yield values replaced by store sinking,
+        // but only if the alias var has no remaining uses in the branch.
         auto remove_dead_aliases = [&sink_candidates](std::vector<StmtPtr>& stmts, const YieldStmtPtr& yield,
                                                       const TileAliasMap& alias_map) {
-          std::unordered_set<const Var*> dead_vars;
+          std::unordered_set<const Var*> candidates;
           for (const auto& cand : sink_candidates) {
             auto old_var = As<Var>(yield->value_[cand.ifstmt_rv_index]);
             if (old_var && alias_map.count(old_var.get())) {
-              dead_vars.insert(old_var.get());
+              candidates.insert(old_var.get());
             }
           }
+          if (candidates.empty()) return;
+
+          // Collect all var references from RHS expressions (after yield replacement).
+          // Only remove aliases whose var is truly unused.
+          auto used = CollectStmtVarUses(stmts);
           stmts.erase(std::remove_if(stmts.begin(), stmts.end(),
-                                     [&dead_vars](const StmtPtr& s) {
+                                     [&candidates, &used](const StmtPtr& s) {
                                        auto assign = As<AssignStmt>(s);
-                                       return assign && dead_vars.count(assign->var_.get()) > 0;
+                                       return assign && candidates.count(assign->var_.get()) > 0 &&
+                                              used.count(assign->var_.get()) == 0;
                                      }),
                       stmts.end());
         };

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1622,6 +1622,27 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
         then_stmts[then_yield_idx] = std::make_shared<YieldStmt>(new_then_yield_values, then_yield->span_);
         else_stmts[else_yield_idx] = std::make_shared<YieldStmt>(new_else_yield_values, else_yield->span_);
 
+        // Remove dead alias assignments for yield values replaced by store sinking.
+        // Safe because sink candidates are simple pass-through branches (alias + yield).
+        auto remove_dead_aliases = [&sink_candidates](std::vector<StmtPtr>& stmts, const YieldStmtPtr& yield,
+                                                      const TileAliasMap& alias_map) {
+          std::unordered_set<const Var*> dead_vars;
+          for (const auto& cand : sink_candidates) {
+            auto old_var = As<Var>(yield->value_[cand.ifstmt_rv_index]);
+            if (old_var && alias_map.count(old_var.get())) {
+              dead_vars.insert(old_var.get());
+            }
+          }
+          stmts.erase(std::remove_if(stmts.begin(), stmts.end(),
+                                     [&dead_vars](const StmtPtr& s) {
+                                       auto assign = As<AssignStmt>(s);
+                                       return assign && dead_vars.count(assign->var_.get()) > 0;
+                                     }),
+                      stmts.end());
+        };
+        remove_dead_aliases(then_stmts, then_yield, then_alias_map);
+        remove_dead_aliases(else_stmts, else_yield, else_alias_map);
+
         auto new_then_body = SeqStmts::Flatten(std::move(then_stmts), last_if_stmt->then_body_->span_);
         auto new_else_body = SeqStmts::Flatten(std::move(else_stmts), (*last_if_stmt->else_body_)->span_);
         auto new_if_stmt =

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -425,36 +425,24 @@ ExprPtr ResolveTileAlias(const ExprPtr& expr, const TileAliasMap& alias_map) {
   return current;
 }
 
-/// Collect all Var pointers referenced within an expression tree (RHS uses only).
-/// Used to determine whether an alias variable is still live after yield replacement.
-void CollectExprVarRefs(const ExprPtr& expr, std::unordered_set<const Var*>& refs) {
-  if (!expr) return;
-  if (auto var = As<Var>(expr)) {
-    refs.insert(var.get());
-    return;
-  }
-  if (auto call = As<Call>(expr)) {
-    for (const auto& arg : call->args_) {
-      CollectExprVarRefs(arg, refs);
-    }
-  }
-}
+/// Visitor that collects all Var pointers used as RHS expressions.
+/// Overrides AssignStmt handling to skip LHS definitions — only captures actual uses.
+/// Uses IRVisitor's built-in recursion to handle nested control flow (IfStmt, ForStmt, etc.).
+class VarUseCollector : public IRVisitor {
+ public:
+  const std::unordered_set<const Var*>& uses() const { return uses_; }
 
-/// Collect all Var pointers used as RHS expressions across a flat statement list.
-/// Excludes LHS definitions — only captures actual uses.
-std::unordered_set<const Var*> CollectStmtVarUses(const std::vector<StmtPtr>& stmts) {
-  std::unordered_set<const Var*> uses;
-  for (const auto& s : stmts) {
-    if (auto assign = As<AssignStmt>(s)) {
-      CollectExprVarRefs(assign->value_, uses);
-    } else if (auto ys = As<YieldStmt>(s)) {
-      for (const auto& v : ys->value_) CollectExprVarRefs(v, uses);
-    } else if (auto es = As<EvalStmt>(s)) {
-      CollectExprVarRefs(es->expr_, uses);
-    }
+ protected:
+  void VisitExpr_(const VarPtr& op) override { uses_.insert(op.get()); }
+  void VisitExpr_(const IterArgPtr& op) override { uses_.insert(op.get()); }
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // Only visit RHS value, not LHS var — definitions are not uses.
+    VisitExpr(op->value_);
   }
-  return uses;
-}
+
+ private:
+  std::unordered_set<const Var*> uses_;
+};
 
 /// Find the index of the YieldStmt in a flat statement list (backward search).
 /// Returns stmts.size() if not found.
@@ -1666,9 +1654,11 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func,
           }
           if (candidates.empty()) return;
 
-          // Collect all var references from RHS expressions (after yield replacement).
+          // Full IR walk to collect all var uses (handles nested control flow).
           // Only remove aliases whose var is truly unused.
-          auto used = CollectStmtVarUses(stmts);
+          VarUseCollector collector;
+          for (const auto& s : stmts) collector.VisitStmt(s);
+          const auto& used = collector.uses();
           stmts.erase(std::remove_if(stmts.begin(), stmts.end(),
                                      [&candidates, &used](const StmtPtr& s) {
                                        auto assign = As<AssignStmt>(s);

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1668,9 +1668,8 @@ class TestNestedControlFlow:
                 a__tile: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
                 b__tile: pl.Tile[[64], pl.FP32] = pl.load(b, [0], [64])
                 if n == 0:
-                    ra: pl.Tile[[64], pl.FP32] = a__tile  # noqa: F841
-                    rb: pl.Tile[[64], pl.FP32] = b__tile  # noqa: F841
                     # Alias resolved: store from a__tile / b__tile directly
+                    # (dead alias assignments ra=a__tile, rb=b__tile are removed)
                     ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(a__tile, [0], a)
                     ret1__store: pl.Tensor[[64], pl.FP32] = pl.store(b__tile, [0], b)
                     phi_a, phi_b = pl.yield_(ret0__store, ret1__store)


### PR DESCRIPTION
## Summary
- Phase 3a store sinking in `ConvertTensorToTileOps` resolves alias chains via `ResolveTileAlias` and creates `tile.store` using the resolved tile directly, but left the original alias assignments (e.g. `oi__ssa_v3 = oi_tmp__tile`) as dead code
- Add cleanup logic after yield replacement to erase dead alias `AssignStmt`s from both IfStmt branches
- Update test expected output to reflect the removal of dead aliases

## Testing
- [x] All 55 `test_convert_tensor_to_tile_ops` tests pass
- [x] All 897 transform tests pass (12 skipped)
- [x] clang-tidy clean
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)