### PR TITLE
fix(typing): accept DynVar in TensorView/TileView type stubs and IntLike

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -2,7 +2,7 @@
 
 All operations are accessed via `import pypto.language as pl`.
 
-**Notation:** `T` = `Tensor` or `Tile` (unified dispatch). `IntLike` = `int | Scalar | Expr`. `Mem` = `MemorySpace` (short alias; both `pl.Mem` and `pl.MemorySpace` work).
+**Notation:** `T` = `Tensor` or `Tile` (unified dispatch). `IntLike` = `int | Scalar | Expr | DynVar`. `Mem` = `MemorySpace` (short alias; both `pl.Mem` and `pl.MemorySpace` work).
 
 ## Unified Dispatch (`pl.*`)
 

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -2,7 +2,7 @@
 
 所有操作通过 `import pypto.language as pl` 访问。
 
-**符号说明：** `T` = `Tensor` 或 `Tile`（统一分发）。`IntLike` = `int | Scalar | Expr`。`Mem` = `pl.Mem`（`pl.MemorySpace` 的简写别名，两者等价）。
+**符号说明：** `T` = `Tensor` 或 `Tile`（统一分发）。`IntLike` = `int | Scalar | Expr | DynVar`。`Mem` = `pl.Mem`（`pl.MemorySpace` 的简写别名，两者等价）。
 
 ## 统一分发（`pl.*`）
 

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -26,7 +26,7 @@ from pypto.language.typing.tile import Tile
 from pypto.language.typing.tuple import Tuple
 from pypto.pypto_core.ir import Expr
 
-IntLike: TypeAlias = int | Scalar | Expr
-"""Type alias for shape/offset parameters that accept int literals, Scalar DSL values, or raw Expr."""
+IntLike: TypeAlias = int | Scalar | Expr | DynVar
+"""Type alias for shape/offset parameters that accept int literals, Scalar DSL values, raw Expr, or DynVar."""
 
 __all__ = ["DynVar", "InOut", "IntLike", "Out", "Scalar", "Tensor", "Tile", "Tuple", "dynamic"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -13,6 +13,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Final, overload
 
 from pypto import DataType
+from pypto.language.typing.dynamic import DynVar
 
 class Span:
     """Source location information tracking file, line, and column positions."""
@@ -381,16 +382,16 @@ class TensorView:
     @overload
     def __init__(
         self,
-        stride: Sequence[Expr | int],
+        stride: Sequence[Expr | int | DynVar],
         layout: TensorLayout,
-        valid_shape: Sequence[Expr | int] = ...,
+        valid_shape: Sequence[Expr | int | DynVar] = ...,
     ) -> None:
         """Create a tensor view with stride, layout and optional valid shape.
 
         Args:
-            stride: Stride for each dimension (Expr or int, ints auto-converted to ConstInt)
+            stride: Stride for each dimension (Expr, int, or DynVar)
             layout: Tensor layout type (ND, DN, or NZ)
-            valid_shape: Valid shape for each dimension (optional, defaults to empty)
+            valid_shape: Valid shape for each dimension (Expr, int, or DynVar; optional, defaults to empty)
         """
 
 class TensorType(ShapedType):
@@ -502,9 +503,9 @@ class TileView:
     @overload
     def __init__(
         self,
-        valid_shape: Sequence[Expr | int],
-        stride: Sequence[Expr | int],
-        start_offset: Expr | int,
+        valid_shape: Sequence[Expr | int | DynVar],
+        stride: Sequence[Expr | int | DynVar],
+        start_offset: Expr | int | DynVar,
         blayout: TileLayout = ...,
         slayout: TileLayout = ...,
         fractal: int = ...,
@@ -513,9 +514,9 @@ class TileView:
         """Create a tile view with all parameters.
 
         Args:
-            valid_shape: Valid shape dimensions (Expr or int, ints auto-converted to ConstInt)
-            stride: Stride for each dimension (Expr or int, ints auto-converted to ConstInt)
-            start_offset: Starting offset (Expr or int, int auto-converted to ConstInt)
+            valid_shape: Valid shape dimensions (Expr, int, or DynVar)
+            stride: Stride for each dimension (Expr, int, or DynVar)
+            start_offset: Starting offset (Expr, int, or DynVar)
             blayout: Block layout (default: row_major)
             slayout: Scatter layout (default: none_box)
             fractal: Fractal size (default: 512)


### PR DESCRIPTION
## Summary
- Add `DynVar` to `TensorView.__init__` and `TileView.__init__` type stub unions (`stride`, `valid_shape`, `start_offset`)
- Add `DynVar` to `IntLike` type alias
- Update docstrings in `ir.pyi` and `IntLike` docs (en + zh-cn) to reflect the wider types

## Related Issues
Fixes #856

## Testing
- [x] All tests pass (3329 passed, 0 failed)
- [x] Pre-commit hooks pass (pyright, ruff, markdownlint)
- [x] No circular import (`dynamic.py` does not import from `ir`)