### PR TITLE
fix(typing): make DynVar a Scalar subclass to fix TensorView type stubs

### DIFF
--- a/python/pypto/ir/type.py
+++ b/python/pypto/ir/type.py
@@ -108,10 +108,20 @@ TileType.__init__ = _tile_type_init_wrapper
 
 
 def _normalize_seq(seq: Sequence[Expr | int] | None) -> list[Expr]:
-    """Normalize a sequence of Expr or int to a list of Expr."""
+    """Normalize a sequence of Expr, int, or Scalar/DynVar to a list of Expr."""
+    from pypto.language.typing.scalar import Scalar  # noqa: PLC0415  # lazy: circular import
+
     if not seq:
         return []
-    return [_normalize_expr(v) if isinstance(v, int) else v for v in seq]
+    result: list[Expr] = []
+    for v in seq:
+        if isinstance(v, int):
+            result.append(_normalize_expr(v))
+        elif isinstance(v, Scalar):
+            result.append(v.unwrap())
+        else:
+            result.append(v)
+    return result
 
 
 class _TensorViewMeta(type):

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -37,6 +37,7 @@ Typical usage:
         return x
 """
 
+from pypto.ir import TensorView, TileView
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import (
     ForKind,
@@ -49,9 +50,7 @@ from pypto.pypto_core.ir import (
     Role,
     SplitMode,
     TensorLayout,
-    TensorView,
     TileLayout,
-    TileView,
 )
 
 from . import parser

--- a/python/pypto/language/typing/dynamic.py
+++ b/python/pypto/language/typing/dynamic.py
@@ -9,16 +9,20 @@
 
 """Dynamic shape variables for use in type annotations."""
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    pass
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import Expr, ScalarType, Span, Var
+
+from .scalar import Scalar
 
 
-class DynVar:
+class DynVar(Scalar):
     """Dynamic shape variable for use in type annotations.
 
     Creates a symbolic dimension that becomes an ir.Var node in the IR shape.
+    Inherits from Scalar so that DynVar is accepted wherever Scalar/IntLike
+    is expected (e.g. shape parameters, TensorView valid_shape).
 
     Example:
         M = pl.dynamic("M")
@@ -37,6 +41,23 @@ class DynVar:
         # that encounter this DynVar object share the same ir.Var instance,
         # ensuring structural equality across @pl.function boundaries.
         self._ir_var: Any = None
+        # Bypass Scalar.__init__ (which requires dtype or expr) and set
+        # its fields directly.  The actual expr is provided lazily via unwrap().
+        self.dtype = None
+        self.expr = None
+        self._annotation_only = False
+
+    def unwrap(self) -> Expr:
+        """Return the underlying ir.Var, creating it eagerly if needed.
+
+        This allows DynVar to participate in _normalize_intlike() and other
+        Scalar-consuming paths without requiring prior TypeResolver resolution.
+        """
+        if self._ir_var is None:
+            self._ir_var = Var(self.name, ScalarType(DataType.INDEX), Span.unknown())
+        # Keep Scalar.expr in sync so direct .expr access returns a valid value.
+        self.expr = self._ir_var
+        return self._ir_var
 
     def __repr__(self) -> str:
         return f"DynVar({self.name!r})"
@@ -51,7 +72,7 @@ def dynamic(name: str) -> DynVar:
     Returns:
         DynVar that can be used in shape annotations
     """
-    return DynVar(name)
+    return DynVar(name)  # type: ignore[return-value]  # metaclass __call__ typed as -> Scalar
 
 
 __all__ = ["DynVar", "dynamic"]

--- a/python/pypto/language/typing/dynamic.py
+++ b/python/pypto/language/typing/dynamic.py
@@ -43,7 +43,7 @@ class DynVar(Scalar):
         self._ir_var: Any = None
         # Bypass Scalar.__init__ (which requires dtype or expr) and set
         # its fields directly.  The actual expr is provided lazily via unwrap().
-        self.dtype = None
+        self.dtype = DataType.INDEX
         self.expr = None
         self._annotation_only = False
 

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -57,6 +57,11 @@ class ScalarMeta(type):
         Returns:
             Scalar instance
         """
+        # Subclasses (e.g. DynVar) bypass Scalar's arg reinterpretation logic
+        # and delegate directly to their own __init__.
+        if cls is not Scalar:
+            return cast("Scalar", type.__call__(cls, *args, **kwargs))
+
         _validate_scalar_meta_call(args, kwargs)
 
         # When called with just dtype (legacy notation), treat it as annotation mode

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -10,9 +10,12 @@
 
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Final, overload
+from typing import TYPE_CHECKING, Any, Final, overload
 
 from pypto import DataType
+
+if TYPE_CHECKING:
+    from pypto.language.typing.scalar import Scalar
 
 class Span:
     """Source location information tracking file, line, and column positions."""
@@ -381,14 +384,14 @@ class TensorView:
     @overload
     def __init__(
         self,
-        stride: Sequence[Expr | int],
+        stride: Sequence[Expr | int | Scalar],
         layout: TensorLayout,
-        valid_shape: Sequence[Expr | int] = ...,
+        valid_shape: Sequence[Expr | int | Scalar] = ...,
     ) -> None:
         """Create a tensor view with stride, layout and optional valid shape.
 
         Args:
-            stride: Stride for each dimension (Expr or int, ints auto-converted to ConstInt)
+            stride: Stride for each dimension (Expr, int, or Scalar/DynVar)
             layout: Tensor layout type (ND, DN, or NZ)
             valid_shape: Valid shape for each dimension (optional, defaults to empty)
         """


### PR DESCRIPTION
## Summary

Fixes #856 — `pl.TensorView(valid_shape=[8, M])` where `M = pl.dynamic("M")` was rejected by pyright because `DynVar` was neither `Expr` nor `int`.

- Make `DynVar` inherit from `Scalar`, so it is automatically accepted wherever `Scalar` or `IntLike` (`int | Scalar | Expr`) is expected
- Add `ScalarMeta.__call__` bypass for subclasses so `DynVar("M")` construction isn't broken by the metaclass's arg reinterpretation
- Override `DynVar.unwrap()` to eagerly create an `ir.Var(name, ScalarType(INDEX))` when needed, enabling `_normalize_intlike()` and other Scalar-consuming paths
- Widen `TensorView` type stubs to accept `Scalar` (under `TYPE_CHECKING` guard)

As a bonus, `DynVar` now inherits Scalar's arithmetic operators — `M + N`, `M * 2`, etc. all work.

## Testing

- [x] All 3309 unit tests pass (0 failures)
- [x] Dynamic shape codegen tests pass
- [x] Pre-commit hooks pass (ruff, pyright, clang-format)
- [x] Smoke-tested `isinstance(M, pl.Scalar)`, `M.unwrap()`, `M + N`

## Related Issues

Fixes #856