### PR TITLE
fix(ir): substitute dynamic shape vars at cross-function call sites

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -203,6 +203,25 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
   }
 }
 
+/**
+ * @brief Deduce return types for a cross-function call by substituting dynamic
+ *        shape variables in the callee's return types with concrete values from
+ *        the actual call arguments.
+ *
+ * Builds a mapping from Var dimensions in callee param types to the
+ * corresponding dimensions in actual arg types, then substitutes those
+ * Vars in each return type.  Handles TensorType (shape + tensor_view),
+ * TileType (shape + tile_view), and TupleType (recursive).
+ *
+ * @param callee_params  Callee function parameter variables
+ * @param args           Actual call argument expressions
+ * @param return_types   Callee's declared return types
+ * @return Substituted return types (unchanged if no dynamic vars found)
+ */
+std::vector<TypePtr> DeduceCallReturnType(const std::vector<VarPtr>& callee_params,
+                                          const std::vector<ExprPtr>& args,
+                                          const std::vector<TypePtr>& return_types);
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -49,6 +49,7 @@
 #include "pypto/ir/transforms/utils/parent_stmt_analysis.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace nb = nanobind;
 
@@ -1325,6 +1326,12 @@ void BindIR(nb::module_& m) {
       "Deep-clone a statement subtree, creating fresh Var objects at definition sites.\n\n"
       "Returns a tuple of (cloned_body, var_map) where var_map is a list of\n"
       "(original_var, cloned_var) pairs for definition-site clones.");
+
+  // Cross-function call return type deduction
+  ir.def("deduce_call_return_type", &DeduceCallReturnType, nb::arg("callee_params"), nb::arg("args"),
+         nb::arg("return_types"),
+         "Deduce return types for a cross-function call by substituting "
+         "dynamic shape variables from callee params with actual arg shapes.");
 }
 
 }  // namespace python

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2147,6 +2147,12 @@ class ASTParser:
 
                     args = [self.parse_expression(arg) for arg in call.args]
                     return_types = func_obj.return_types if func_obj else []
+                    if func_obj is not None and return_types:
+                        return_types = ir.deduce_call_return_type(
+                            list(func_obj.params),
+                            args,
+                            return_types,
+                        )
                     return self._make_call_with_return_type(gvar, args, return_types, span)
                 else:
                     raise UndefinedVariableError(
@@ -2373,7 +2379,12 @@ class ASTParser:
         args = [self.parse_expression(arg) for arg in call.args]
 
         gvar = ir.GlobalVar(func_name)
-        return self._make_call_with_return_type(gvar, args, ext_func.return_types, span)
+        return_types = ir.deduce_call_return_type(
+            list(ext_func.params),
+            args,
+            list(ext_func.return_types),
+        )
+        return self._make_call_with_return_type(gvar, args, return_types, span)
 
     @staticmethod
     def _is_docstring(stmt: ast.stmt) -> bool:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2946,6 +2946,25 @@ def deep_clone(body: Stmt) -> tuple[Stmt, list[tuple[Var, Var]]]:
         (original_var, cloned_var) pairs for definition-site clones.
     """
 
+def deduce_call_return_type(
+    callee_params: Sequence[Var],
+    args: Sequence[Expr],
+    return_types: Sequence[Type],
+) -> list[Type]:
+    """Deduce return types for a cross-function call.
+
+    Substitutes dynamic shape variables in callee return types
+    with concrete values from actual argument types.
+
+    Args:
+        callee_params: Callee function parameter variables
+        args: Actual call argument expressions
+        return_types: Callee's declared return types
+
+    Returns:
+        Substituted return types (unchanged if no dynamic vars found)
+    """
+
 class IRVisitor:
     """Read-only IR visitor. Subclass and override visit_* methods.
 

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -13,13 +13,18 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/transforms/printer.h"
@@ -258,6 +263,128 @@ std::string FormatShape(const std::vector<ExprPtr>& shape) {
   }
   oss << "]";
   return oss.str();
+}
+
+// ============================================================================
+// Cross-function call return type deduction
+// ============================================================================
+
+std::vector<TypePtr> DeduceCallReturnType(const std::vector<VarPtr>& callee_params,
+                                          const std::vector<ExprPtr>& args,
+                                          const std::vector<TypePtr>& return_types) {
+  if (return_types.empty()) return return_types;
+
+  // 1. Build Var* -> ExprPtr mapping from param shapes vs arg shapes
+  std::unordered_map<const Var*, ExprPtr> var_map;
+  size_t n = std::min(callee_params.size(), args.size());
+  for (size_t i = 0; i < n; ++i) {
+    auto param_type = callee_params[i]->GetType();
+    auto arg_type = args[i]->GetType();
+    if (!param_type || !arg_type) continue;
+    auto p_shaped = As<ShapedType>(param_type);
+    auto a_shaped = As<ShapedType>(arg_type);
+    if (!p_shaped || !a_shaped) continue;
+    size_t ndim = std::min(p_shaped->shape_.size(), a_shaped->shape_.size());
+    for (size_t d = 0; d < ndim; ++d) {
+      if (auto var = As<Var>(p_shaped->shape_[d])) {
+        auto [it, inserted] = var_map.emplace(var.get(), a_shaped->shape_[d]);
+        // Validate consistency only when both are statically known constants.
+        // Symbolic dims (Vars, exprs) may be equal at runtime — defer to runtime.
+        if (!inserted) {
+          auto existing_const = GetConstantDimension(it->second);
+          auto new_const = GetConstantDimension(a_shaped->shape_[d]);
+          if (existing_const && new_const) {
+            CHECK(*existing_const == *new_const)
+                << "Dynamic shape variable '" << var->name_hint_
+                << "' has conflicting bindings: " << FormatShape({it->second}) << " vs "
+                << FormatShape({a_shaped->shape_[d]}) << " (from argument " << i << ", dimension " << d
+                << ")";
+          }
+        }
+      }
+    }
+  }
+  if (var_map.empty()) return return_types;
+
+  // 2. Substitution helpers
+  auto subst_dim = [&](const ExprPtr& dim) -> ExprPtr {
+    if (auto var = As<Var>(dim)) {
+      auto it = var_map.find(var.get());
+      if (it != var_map.end()) return it->second;
+    }
+    return dim;
+  };
+
+  auto subst_dims = [&](const std::vector<ExprPtr>& dims) {
+    std::vector<ExprPtr> result;
+    result.reserve(dims.size());
+    bool changed = false;
+    for (const auto& d : dims) {
+      auto nd = subst_dim(d);
+      if (nd.get() != d.get()) changed = true;
+      result.push_back(nd);
+    }
+    return std::pair{std::move(result), changed};
+  };
+
+  std::function<TypePtr(const TypePtr&)> subst_type;
+  subst_type = [&](const TypePtr& type) -> TypePtr {
+    if (!type) return type;
+    if (auto t = As<TensorType>(type)) {
+      auto [new_shape, changed] = subst_dims(t->shape_);
+      std::optional<TensorView> new_tv = t->tensor_view_;
+      if (new_tv.has_value()) {
+        auto [new_stride, s_changed] = subst_dims(new_tv->stride);
+        auto [new_vs, vs_changed] = subst_dims(new_tv->valid_shape);
+        if (s_changed || vs_changed) {
+          new_tv->stride = std::move(new_stride);
+          new_tv->valid_shape = std::move(new_vs);
+          changed = true;
+        }
+      }
+      if (!changed) return type;
+      return std::make_shared<TensorType>(std::move(new_shape), t->dtype_, t->memref_, std::move(new_tv));
+    }
+    if (auto t = As<TileType>(type)) {
+      auto [new_shape, changed] = subst_dims(t->shape_);
+      std::optional<TileView> new_tv = t->tile_view_;
+      if (new_tv.has_value()) {
+        auto [new_vs, vs_changed] = subst_dims(new_tv->valid_shape);
+        auto [new_stride, s_changed] = subst_dims(new_tv->stride);
+        auto new_start = subst_dim(new_tv->start_offset);
+        bool so_changed = (new_start.get() != new_tv->start_offset.get());
+        if (vs_changed || s_changed || so_changed) {
+          new_tv->valid_shape = std::move(new_vs);
+          new_tv->stride = std::move(new_stride);
+          new_tv->start_offset = std::move(new_start);
+          changed = true;
+        }
+      }
+      if (!changed) return type;
+      return std::make_shared<TileType>(std::move(new_shape), t->dtype_, t->memref_, std::move(new_tv),
+                                        t->memory_space_);
+    }
+    if (auto t = As<TupleType>(type)) {
+      std::vector<TypePtr> new_types;
+      bool changed = false;
+      for (const auto& inner : t->types_) {
+        auto nt = subst_type(inner);
+        if (nt.get() != inner.get()) changed = true;
+        new_types.push_back(nt);
+      }
+      if (!changed) return type;
+      return std::make_shared<TupleType>(std::move(new_types));
+    }
+    return type;  // ScalarType, etc. — no shape dims
+  };
+
+  // 3. Apply to all return types
+  std::vector<TypePtr> result;
+  result.reserve(return_types.size());
+  for (const auto& rt : return_types) {
+    result.push_back(subst_type(rt));
+  }
+  return result;
 }
 
 }  // namespace ir

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -273,10 +273,13 @@ std::vector<TypePtr> DeduceCallReturnType(const std::vector<VarPtr>& callee_para
                                           const std::vector<ExprPtr>& args,
                                           const std::vector<TypePtr>& return_types) {
   if (return_types.empty()) return return_types;
+  CHECK(callee_params.size() == args.size())
+      << "DeduceCallReturnType: callee_params size (" << callee_params.size() << ") must match args size ("
+      << args.size() << ")";
 
   // 1. Build Var* -> ExprPtr mapping from param shapes vs arg shapes
   std::unordered_map<const Var*, ExprPtr> var_map;
-  size_t n = std::min(callee_params.size(), args.size());
+  size_t n = callee_params.size();
   for (size_t i = 0; i < n; ++i) {
     auto param_type = callee_params[i]->GetType();
     auto arg_type = args[i]->GetType();

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -1391,6 +1391,141 @@ class TestFunctionCallArgCountValidation:
                     return result
 
 
+class TestCrossFunctionDynamicShapeSubstitution:
+    """Tests for dynamic shape variable substitution at cross-function call sites (issue #864)."""
+
+    def test_cross_function_dynamic_shape_substitution(self):
+        """Callee with dynamic [M, N] shapes, caller passes [128, 128] → return type is [128, 128]."""
+        M = pl.dynamic("M")
+        N = pl.dynamic("N")
+
+        @pl.program
+        class DynShape:
+            @pl.function(type=pl.FunctionType.InCore)
+            def add_kernel(
+                self,
+                a: pl.Tensor[[M, N], pl.FP32],
+                b: pl.Tensor[[M, N], pl.FP32],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                result: pl.Tensor[[M, N], pl.FP32] = pl.add(a, b)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c: pl.Tensor[[128, 128], pl.FP32] = self.add_kernel(a, b)
+                return c
+
+        orch_func = DynShape.get_function("orchestrator")
+        assert orch_func is not None
+        body = orch_func.body
+        assert isinstance(body, ir.SeqStmts)
+        assign_stmt = body.stmts[0]
+        assert isinstance(assign_stmt, ir.AssignStmt)
+        call_expr = assign_stmt.value
+        assert isinstance(call_expr, ir.Call)
+        call_type = call_expr.type
+        assert isinstance(call_type, ir.TensorType)
+        # Verify shape dims are concrete ConstInt, not Var
+        for dim in call_type.shape:
+            assert isinstance(dim, ir.ConstInt), f"Expected ConstInt, got {type(dim).__name__}: {dim}"
+            assert dim.value == 128
+
+    def test_cross_function_dynamic_shape_partial(self):
+        """Callee has [M, 64] — only M should be substituted."""
+        M = pl.dynamic("M")
+
+        @pl.program
+        class PartialDyn:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[M, 64], pl.FP32],
+            ) -> pl.Tensor[[M, 64], pl.FP32]:
+                return a
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[256, 64], pl.FP32],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                c: pl.Tensor[[256, 64], pl.FP32] = self.kernel(a)
+                return c
+
+        orch_func = PartialDyn.get_function("orch")
+        assert orch_func is not None
+        assert isinstance(orch_func.body, ir.SeqStmts)
+        assign_stmt = orch_func.body.stmts[0]
+        assert isinstance(assign_stmt, ir.AssignStmt)
+        call_type = assign_stmt.value.type
+        assert isinstance(call_type, ir.TensorType)
+        # First dim should be 256 (substituted), second should be 64 (unchanged)
+        assert isinstance(call_type.shape[0], ir.ConstInt)
+        assert call_type.shape[0].value == 256
+        assert isinstance(call_type.shape[1], ir.ConstInt)
+        assert call_type.shape[1].value == 64
+
+    def test_cross_function_static_shapes_unchanged(self):
+        """All-static shapes → no substitution needed, return types unchanged."""
+
+        @pl.program
+        class StaticShape:
+            @pl.function
+            def helper(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function
+            def caller(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = self.helper(x)
+                return c
+
+        caller_func = StaticShape.get_function("caller")
+        assert caller_func is not None
+        assert isinstance(caller_func.body, ir.SeqStmts)
+        assign_stmt = caller_func.body.stmts[0]
+        assert isinstance(assign_stmt, ir.AssignStmt)
+        call_type = assign_stmt.value.type
+        assert isinstance(call_type, ir.TensorType)
+        assert isinstance(call_type.shape[0], ir.ConstInt)
+        assert call_type.shape[0].value == 64
+
+    def test_cross_function_dynamic_shape_mismatch_raises(self):
+        """Callee has [M, N], [M, N] but caller passes [128, 64], [127, 64] → M conflicts."""
+        M = pl.dynamic("M")
+        N = pl.dynamic("N")
+
+        with pytest.raises(Exception, match="conflicting bindings"):
+
+            @pl.program
+            class ShapeMismatch:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    a: pl.Tensor[[M, N], pl.FP32],
+                    b: pl.Tensor[[M, N], pl.FP32],
+                ) -> pl.Tensor[[M, N], pl.FP32]:
+                    result: pl.Tensor[[M, N], pl.FP32] = pl.add(a, b)
+                    return result
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def orch(
+                    self,
+                    a: pl.Tensor[[128, 64], pl.FP32],
+                    b: pl.Tensor[[127, 64], pl.FP32],
+                ) -> pl.Tensor[[128, 64], pl.FP32]:
+                    c: pl.Tensor[[128, 64], pl.FP32] = self.kernel(a, b)
+                    return c
+
+
 class TestExternalFunctionControlFlow:
     """Tests for external @pl.function calls with control flow and SSA patterns."""
 


### PR DESCRIPTION
## Summary
- Add `DeduceCallReturnType` to `type_inference.h/cpp` that maps callee parameter shape `Var` nodes to concrete argument shape expressions, then substitutes those Vars in return types
- Handle `TensorType` (shape + tensor_view), `TileType` (shape + tile_view), and `TupleType` (recursive)
- Validate consistency: if the same dynamic variable maps to different concrete values across arguments, raise an error with a clear message
- Expose via Python binding `ir.deduce_call_return_type` and call it at both cross-function (`self.method()`) and external function call sites in the parser

## Testing
- [x] 4 new tests: full dynamic substitution, partial substitution, static (no-op), and shape mismatch error
- [x] All 3312 existing tests pass
- [x] Clang-tidy clean
- [x] Reproduction script from issue produces correct `Tensor[[128, 128], FP32]` return type

Fixes #864