### PR TITLE
fix(verifier): check variable references in type expressions

### DIFF
--- a/src/ir/verifier/verify_use_after_def.cpp
+++ b/src/ir/verifier/verify_use_after_def.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -18,9 +19,11 @@
 
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verification_error.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -39,6 +42,75 @@ std::string ErrorTypeToString(ErrorType type) {
 }  // namespace use_after_def
 
 namespace {
+
+/**
+ * @brief Collects all Var pointers referenced in expression trees.
+ *
+ * Used to find type-dynamic variables embedded in parameter type annotations
+ * (shape, valid_shape, stride, etc.) that are not defined by any statement.
+ */
+class VarCollector : public IRVisitor {
+ public:
+  std::vector<const Var*> vars_;
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override {
+    if (op) vars_.push_back(op.get());
+    // Don't recurse into the var's type — prevents infinite traversal.
+  }
+};
+
+/**
+ * @brief Visit all expression fields in a type using the given visitor.
+ *
+ * Covers: TensorType shape_, tensor_view_.{valid_shape, stride};
+ *         TileType shape_, tile_view_.{valid_shape, stride, start_offset};
+ *         TupleType elements (recursively).
+ */
+static void VisitTypeExprFields(IRVisitor& visitor, const TypePtr& type) {
+  if (!type) return;
+
+  auto visit_exprs = [&visitor](const std::vector<ExprPtr>& exprs) {
+    for (const auto& e : exprs) {
+      if (e) visitor.VisitExpr(e);
+    }
+  };
+
+  if (auto tensor_type = As<TensorType>(type)) {
+    visit_exprs(tensor_type->shape_);
+    if (tensor_type->tensor_view_.has_value()) {
+      const auto& tv = tensor_type->tensor_view_.value();
+      visit_exprs(tv.valid_shape);
+      visit_exprs(tv.stride);
+    }
+  } else if (auto tile_type = As<TileType>(type)) {
+    visit_exprs(tile_type->shape_);
+    if (tile_type->tile_view_.has_value()) {
+      const auto& tv = tile_type->tile_view_.value();
+      visit_exprs(tv.valid_shape);
+      visit_exprs(tv.stride);
+      if (tv.start_offset) visitor.VisitExpr(tv.start_offset);
+    }
+  } else if (auto tuple_type = As<TupleType>(type)) {
+    for (const auto& elem : tuple_type->types_) {
+      VisitTypeExprFields(visitor, elem);
+    }
+  }
+}
+
+/**
+ * @brief Collect all Var pointers from a type's expression fields.
+ *
+ * Recursively walks expression trees in shape, valid_shape, stride, and
+ * start_offset to find all referenced Var nodes and registers them via callback.
+ */
+static void CollectTypeVars(const TypePtr& type, const std::function<void(const Var*)>& register_var) {
+  VarCollector collector;
+  VisitTypeExprFields(collector, type);
+  for (const auto* var : collector.vars_) {
+    register_var(var);
+  }
+}
 
 /**
  * @brief Visitor that checks every Var use is preceded by a definition.
@@ -67,7 +139,7 @@ class UseAfterDefChecker : public IRVisitor {
  protected:
   void VisitVarLike_(const VarPtr& op) override {
     if (!op) return;
-    if (in_scope_.find(op.get()) == in_scope_.end()) {
+    if (!in_scope_.count(op.get())) {
       std::ostringstream msg;
       msg << "Variable '" << op->name_hint_ << "' used before definition"
           << " in function '" << func_name_ << "'";
@@ -75,9 +147,15 @@ class UseAfterDefChecker : public IRVisitor {
                                 static_cast<int>(use_after_def::ErrorType::USE_BEFORE_DEF), msg.str(),
                                 op->span_);
     }
-    // Do not call IRVisitor::VisitVarLike_ — type shape expressions are not
-    // data-flow uses and dynamic shape vars embedded in types are not defined
-    // by any statement in the function body.
+    // Visit variable references in type expressions (valid_shape, stride, etc.)
+    // to detect undefined vars in type metadata.  Guard against recursion:
+    // vars found inside type expressions are typically scalars whose types
+    // don't contain further view expressions, but the flag ensures safety.
+    if (!visiting_type_) {
+      visiting_type_ = true;
+      VisitTypeExprFields(*this, op->GetType());
+      visiting_type_ = false;
+    }
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -204,6 +282,7 @@ class UseAfterDefChecker : public IRVisitor {
   std::unordered_set<const Var*> in_scope_;
   std::vector<Diagnostic>& diagnostics_;
   std::string func_name_;
+  bool visiting_type_ = false;
 };
 
 class UseAfterDefPropertyVerifierImpl : public PropertyVerifier {
@@ -221,6 +300,17 @@ class UseAfterDefPropertyVerifierImpl : public PropertyVerifier {
       // Function parameters are definitions visible throughout the body.
       for (const auto& param : func->params_) {
         if (param) checker.AddDefinition(param.get());
+      }
+
+      // Type-dynamic vars in this function's parameter and return types are
+      // implicitly in scope.  E.g., Tensor[[N, M], FP32] where N, M are
+      // dynamic shape vars that exist only in the function signature.
+      auto add_def = [&checker](const Var* v) { checker.AddDefinition(v); };
+      for (const auto& param : func->params_) {
+        if (param) CollectTypeVars(param->GetType(), add_def);
+      }
+      for (const auto& ret_type : func->return_types_) {
+        CollectTypeVars(ret_type, add_def);
       }
 
       if (func->body_) checker.VisitStmt(func->body_);

--- a/tests/ut/ir/transforms/test_verify_use_after_def.py
+++ b/tests/ut/ir/transforms/test_verify_use_after_def.py
@@ -185,6 +185,61 @@ def test_use_after_def_is_structural_property():
     assert structural.contains(passes.IRProperty.UseAfterDef)
 
 
+def test_invalid_undefined_var_in_tensor_view_valid_shape():
+    """Var in TensorView.valid_shape that is not defined should be flagged."""
+    span = ir.Span.unknown()
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+    # param 'a' has a plain tensor type (no TensorView, no dynamic vars)
+    plain_type = ir.TensorType([dim16, dim16], DataType.FP32)
+    a = ir.Var("a", plain_type, span)
+    # 'n' is a stale var — never defined by any statement or param type
+    n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+    tensor_view = ir.TensorView([], ir.TensorLayout.ND, [n, dim16])
+    view_type = ir.TensorType([dim16, dim16], DataType.FP32, None, tensor_view)
+    t = ir.Var("t", view_type, span)
+
+    # t is defined via assign, but n (in its type's valid_shape) is never defined
+    def_t = ir.AssignStmt(t, a, span)
+    ret = ir.ReturnStmt([t], span)
+    body = ir.SeqStmts([def_t, ret], span)
+    func = ir.Function("bad_type", [a], [plain_type], body, span)
+    program = ir.Program([func], "prog", span)
+
+    errors = _errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))
+    assert len(errors) >= 1
+    assert any("n" in d.message for d in errors)
+
+
+def test_valid_type_dynamic_var_in_param_shape():
+    """Var in parameter's TensorType shape should not be flagged (type-dynamic)."""
+    span = ir.Span.unknown()
+    n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+    tensor_type = ir.TensorType([n], DataType.FP32)
+    t = ir.Var("t", tensor_type, span)
+
+    body = ir.ReturnStmt([t], span)
+    func = ir.Function("dynamic_shape", [t], [tensor_type], body, span)
+    program = ir.Program([func], "prog", span)
+
+    assert len(_errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))) == 0
+
+
+def test_valid_type_dynamic_var_in_param_tensor_view():
+    """Var in parameter's TensorView.valid_shape should not be flagged (type-dynamic)."""
+    span = ir.Span.unknown()
+    n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+    tensor_view = ir.TensorView([], ir.TensorLayout.ND, [n])
+    tensor_type = ir.TensorType([dim16], DataType.FP32, None, tensor_view)
+    t = ir.Var("t", tensor_type, span)
+
+    body = ir.ReturnStmt([t], span)
+    func = ir.Function("dynamic_view", [t], [tensor_type], body, span)
+    program = ir.Program([func], "prog", span)
+
+    assert len(_errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))) == 0
+
+
 def test_valid_then_only_leak_visible_after_if():
     """Variable defined only in then-branch (no else, no return_vars) is visible after if.
 


### PR DESCRIPTION
## Summary

- The `UseAfterDefChecker` now traverses variable references inside type expression fields (`TensorView.valid_shape`, `TensorView.stride`, `TileView.valid_shape`, `TileView.stride`, `TileView.start_offset`). Previously these were silently skipped, allowing dangling/undefined Var references in type metadata to go undetected.
- Type-dynamic variables from function parameter and return type annotations are collected upfront and treated as implicitly in scope.
- Adds 3 new tests: undefined var in valid_shape (error expected), type-dynamic var in param shape (no error), type-dynamic var in param TensorView (no error).

Fixes #855

> **Dependencies:** This PR must be merged **after** #868 and #871, which fix pre-existing bugs in cross-function call type inference and InitMemRef that this verifier enhancement exposes.

## Test plan

- [x] All 12 UseAfterDef verifier tests pass (including 3 new)
- [x] Full test suite: 3337 passed, 16 skipped, 0 failed (on top of #871)