### PR TITLE
perf(parser): use structural_equal instead of string comparison in _types_match

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -115,7 +115,14 @@ def _normalize_type_for_syntax_match(type_: ir.Type | None) -> ir.Type | None:
 
 
 def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
-    """Return whether two IR types are equivalent in parser-visible syntax."""
+    """Return whether two IR types are structurally equal after TileView normalization.
+
+    Uses C++ ``structural_equal`` (via ``==``) instead of comparing printed
+    strings.  Note: ``structural_equal`` intentionally skips the ``memref``
+    field on TileType/TensorType — memref identity is not relevant for
+    parser-level type matching because the Var (not the Call) carries the
+    authoritative memref via ``override_type``.
+    """
     if lhs is rhs:
         return True
     if lhs is None or rhs is None:
@@ -126,7 +133,7 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     assert rhs is not None
     if type(lhs) is not type(rhs):
         return False
-    return ir.python_print_type(lhs) == ir.python_print_type(rhs)
+    return lhs == rhs
 
 
 def _normalize_inferred_type_for_annotation(


### PR DESCRIPTION
## Summary
- Replace `ir.python_print_type()` string comparison with direct `==` (C++ `structural_equal`) in `_types_match`
- The old approach spawned a `ruff format` subprocess for every call via the registered format callback, causing ~2,660 subprocess spawns in a single codegen test
- Reduces full test suite time from ~96s to ~32s (3x speedup)

## Testing
- [x] All 3309 tests pass, 16 skipped
- [x] Pre-commit hooks pass (ruff, pyright, etc.)
- [x] Profiled before/after: `test_tile_ops_codegen` drops from 14.1s to 4.3s (import-dominated)