### PR TITLE
feat(op): add sort32, gather, gather_mask, and mrgsort tile operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(PYPTO_SOURCES
     src/ir/op/tile_ops/transform.cpp
     src/ir/op/tile_ops/unary.cpp
     src/ir/op/tile_ops/cross_core.cpp
+    src/ir/op/tile_ops/sort.cpp
     src/ir/op/sync_ops/sync.cpp
     src/ir/op/sync_ops/cross_core.cpp
     src/ir/op/tensor_ops/broadcast.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(PYPTO_SOURCES
     src/ir/op/tile_ops/unary.cpp
     src/ir/op/tile_ops/cross_core.cpp
     src/ir/op/tile_ops/sort.cpp
+    src/ir/op/tile_ops/gather.cpp
     src/ir/op/sync_ops/sync.cpp
     src/ir/op/sync_ops/cross_core.cpp
     src/ir/op/tensor_ops/broadcast.cpp

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -128,6 +128,19 @@ class PTOCodegen : public CodegenBase {
    */
   std::string EmitCastToIndex(const ir::VarPtr& var, const std::string& mlir_name);
 
+  /**
+   * @brief Emit arith.index_cast if expression is not already i32 type
+   *
+   * PTO ISA instructions like pto.tmrgsort require i32 operands. When the
+   * operand is a runtime variable (e.g., loop induction variable typed as
+   * index), this emits the necessary cast.
+   *
+   * @param expr IR expression whose type determines the cast
+   * @param mlir_name Current MLIR SSA name for the expression value
+   * @return SSA name of the i32-typed value (original if already i32)
+   */
+  std::string EmitCastToI32(const ir::ExprPtr& expr, const std::string& mlir_name);
+
   /// Check if a tile variable is consumed by a tile.fillpad operation.
   bool HasFillpadConsumer(const ir::Var* var) const;
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2017,8 +2017,7 @@ def gather(
         return _ir_core.create_op_call("tile.gather_mask", [src], kwargs, actual_span)
     if indices is None or tmp is None:
         raise ValueError(
-            "gather() requires either (indices, tmp) for index form, "
-            "or mask_pattern=<int> for mask form"
+            "gather() requires either (indices, tmp) for index form, or mask_pattern=<int> for mask form"
         )
     return _ir_core.create_op_call("tile.gather", [src, indices, tmp], {}, actual_span)
 
@@ -2038,6 +2037,8 @@ def gather_mask(src: Expr, mask_pattern: int, span: Span | None = None) -> Call:
         Call expression returning gathered tile
     """
     return gather(src, mask_pattern=mask_pattern, span=span)
+
+
 # ============================================================================
 # Merge Sort Operations
 # ============================================================================
@@ -2049,7 +2050,7 @@ def mrgsort(
     src2: Expr | None = None,
     src3: Expr | None = None,
     tmp: Expr | None = None,
-    excuted: Expr | None = None,
+    executed: Expr | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Expr | None = None,
@@ -2067,7 +2068,7 @@ def mrgsort(
         src2: (format2) Third sorted input tile.
         src3: (format2) Fourth sorted input tile.
         tmp: (format2) Temporary workspace tile.
-        excuted: (format2) Exhaustion status tile (written by hardware).
+        executed: (format2) Exhaustion status tile (written by hardware).
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
         span: Optional source span for debugging.
@@ -2088,12 +2089,37 @@ def mrgsort(
             block_len_expr = _ir_core.ConstInt(block_len, DataType.INT32, actual_span)
         return _ir_core.create_op_call("tile.mrgsort_format1", [src0, block_len_expr], {}, actual_span)
     # format2: 4-way merge (pto.tmrgsort format2)
-    if src1 is None or src2 is None or src3 is None or tmp is None or excuted is None:
+    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, excuted) for format2"
+            "or (src0, src1, src2, src3, tmp, executed) for format2"
         )
     kwargs: dict[str, Any] = {"exhausted": exhausted}
     return _ir_core.create_op_call(
-        "tile.mrgsort_format2", [src0, src1, src2, src3, tmp, excuted], kwargs, actual_span
+        "tile.mrgsort_format2", [src0, src1, src2, src3, tmp, executed], kwargs, actual_span
     )
+
+
+def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None) -> Call:
+    """Single-list merge sort (format1). Used by the parser for roundtrip fidelity.
+
+    Prefer ``mrgsort(src, block_len=...)`` in user code.
+    """
+    return mrgsort(src0, block_len=block_len, span=span)
+
+
+def mrgsort_format2(
+    src0: Expr,
+    src1: Expr,
+    src2: Expr,
+    src3: Expr,
+    tmp: Expr,
+    executed: Expr,
+    exhausted: bool = False,
+    span: Span | None = None,
+) -> Call:
+    """4-way merge sort (format2). Used by the parser for roundtrip fidelity.
+
+    Prefer ``mrgsort(src0, src1, src2, src3, tmp, executed)`` in user code.
+    """
+    return mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=exhausted, span=span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2011,6 +2011,11 @@ def gather(
     """
     actual_span = _get_span_or_capture(span)
     if mask_pattern is not None:
+        if indices is not None or tmp is not None:
+            raise ValueError(
+                "gather() mask form (mask_pattern=...) and index form (indices, tmp) "
+                "are mutually exclusive; do not pass indices or tmp with mask_pattern"
+            )
         kwargs: dict[str, Any] = {"mask_pattern": mask_pattern}
         if output_dtype is not None:
             kwargs["output_dtype"] = output_dtype  # int | DataType, C++ handles both
@@ -2079,6 +2084,11 @@ def mrgsort(
     actual_span = _get_span_or_capture(span)
     if block_len is not None:
         # format1: single-list merge sort (pto.tmrgsort format1)
+        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+            raise ValueError(
+                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "are mutually exclusive; do not pass format2 arguments with block_len"
+            )
         # PTO ISA requires block_len as i32. The parser may emit ConstInt with INDEX dtype,
         # so always extract the integer value and create a fresh INT32 constant.
         if isinstance(block_len, _ir_core.ConstInt):

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1950,3 +1950,26 @@ def tpop_from_aiv(
         op = _ir_core.get_op("tile.tpop_from_aiv")
         return _ir_core.Call(op, [], {"split": split}, resolved_type, actual_span)
     return _ir_core.create_op_call("tile.tpop_from_aiv", [], {"split": split}, actual_span)
+
+
+# ============================================================================
+# Sorting Operations
+# ============================================================================
+
+
+def sort32(src: Expr, idx: Expr, span: Span | None = None) -> Call:
+    """Sort fixed 32-element blocks with explicit index tile.
+
+    Sorts 32-element blocks in src and permutes idx accordingly.
+    Output tile stores sorted value-index pairs with doubled last dimension.
+
+    Args:
+        src: Input value tile (TileType, FP16 or FP32, Vec memory)
+        idx: Input index tile (TileType, Vec memory) with sequential offsets
+        span: Optional source span for debugging
+
+    Returns:
+        Call expression returning sorted tile with doubled last dimension
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.sort32", [src, idx], {}, actual_span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1986,6 +1986,7 @@ def gather(
     tmp: Expr | None = None,
     *,
     mask_pattern: int | None = None,
+    output_dtype: int | DataType | None = None,
     span: Span | None = None,
 ) -> Call:
     """Gather elements from src, using either indices or a fixed mask pattern.
@@ -1999,6 +2000,10 @@ def gather(
         tmp: Temporary workspace tile (INT32). Required for index form.
         mask_pattern: Mask pattern selector (1-7), keyword-only. Use for mask form.
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
+        output_dtype: Optional output dtype for mask form (keyword-only). When provided,
+            the result tile has this dtype instead of src's dtype. The hardware only
+            requires sizeof(dst_dtype) == sizeof(src_dtype). Useful for extracting
+            UINT32 index bits from FP32 sort32 output (bit reinterpretation).
         span: Optional source span
 
     Returns:
@@ -2007,6 +2012,8 @@ def gather(
     actual_span = _get_span_or_capture(span)
     if mask_pattern is not None:
         kwargs: dict[str, Any] = {"mask_pattern": mask_pattern}
+        if output_dtype is not None:
+            kwargs["output_dtype"] = output_dtype  # int | DataType, C++ handles both
         return _ir_core.create_op_call("tile.gather_mask", [src], kwargs, actual_span)
     if indices is None or tmp is None:
         raise ValueError(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2031,3 +2031,62 @@ def gather_mask(src: Expr, mask_pattern: int, span: Span | None = None) -> Call:
         Call expression returning gathered tile
     """
     return gather(src, mask_pattern=mask_pattern, span=span)
+# ============================================================================
+# Merge Sort Operations
+# ============================================================================
+
+
+def mrgsort(
+    src0: Expr,
+    src1: Expr | None = None,
+    src2: Expr | None = None,
+    src3: Expr | None = None,
+    tmp: Expr | None = None,
+    excuted: Expr | None = None,
+    exhausted: bool = False,
+    *,
+    block_len: int | Expr | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Merge sort — format1 (single-list) or format2 (4-way merge).
+
+    Format1 (block_len form): sorts a tile containing multiple pre-sorted runs.
+    Format2 (4-way form): merges 4 pre-sorted input tiles into one sorted output.
+
+    Args:
+        src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
+              For format2: first sorted input tile.
+        src1: (format2) Second sorted input tile.
+        src2: (format2) Third sorted input tile.
+        src3: (format2) Fourth sorted input tile.
+        tmp: (format2) Temporary workspace tile.
+        excuted: (format2) Exhaustion status tile (written by hardware).
+        exhausted: (format2) If True, marks inputs as exhausted (default: False).
+        block_len: (format1, keyword-only) Run length, must be multiple of 64.
+        span: Optional source span for debugging.
+
+    Returns:
+        Call expression returning merged sorted tile.
+    """
+    actual_span = _get_span_or_capture(span)
+    if block_len is not None:
+        # format1: single-list merge sort (pto.tmrgsort format1)
+        # PTO ISA requires block_len as i32. The parser may emit ConstInt with INDEX dtype,
+        # so always extract the integer value and create a fresh INT32 constant.
+        if isinstance(block_len, _ir_core.ConstInt):
+            block_len_expr = _ir_core.ConstInt(block_len.value, DataType.INT32, actual_span)
+        elif isinstance(block_len, Expr):
+            block_len_expr = block_len
+        else:
+            block_len_expr = _ir_core.ConstInt(block_len, DataType.INT32, actual_span)
+        return _ir_core.create_op_call("tile.mrgsort_format1", [src0, block_len_expr], {}, actual_span)
+    # format2: 4-way merge (pto.tmrgsort format2)
+    if src1 is None or src2 is None or src3 is None or tmp is None or excuted is None:
+        raise ValueError(
+            "mrgsort() requires either block_len=<int> for format1, "
+            "or (src0, src1, src2, src3, tmp, excuted) for format2"
+        )
+    kwargs: dict[str, Any] = {"exhausted": exhausted}
+    return _ir_core.create_op_call(
+        "tile.mrgsort_format2", [src0, src1, src2, src3, tmp, excuted], kwargs, actual_span
+    )

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1973,3 +1973,61 @@ def sort32(src: Expr, idx: Expr, span: Span | None = None) -> Call:
     """
     actual_span = _get_span_or_capture(span)
     return _ir_core.create_op_call("tile.sort32", [src, idx], {}, actual_span)
+
+
+# ============================================================================
+# Gather Operations
+# ============================================================================
+
+
+def gather(
+    src: Expr,
+    indices: Expr | None = None,
+    tmp: Expr | None = None,
+    *,
+    mask_pattern: int | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Gather elements from src, using either indices or a fixed mask pattern.
+
+    Index form: dst[i, j] = src[indices[i, j]]. Requires indices and tmp workspace.
+    Mask form: selects elements by a hardware mask pattern.
+
+    Args:
+        src: Source tile (FP16, FP32, INT16, or INT32)
+        indices: Index tile (INT32). Required for index form.
+        tmp: Temporary workspace tile (INT32). Required for index form.
+        mask_pattern: Mask pattern selector (1-7), keyword-only. Use for mask form.
+            1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
+        span: Optional source span
+
+    Returns:
+        Call expression returning gathered tile
+    """
+    actual_span = _get_span_or_capture(span)
+    if mask_pattern is not None:
+        kwargs: dict[str, Any] = {"mask_pattern": mask_pattern}
+        return _ir_core.create_op_call("tile.gather_mask", [src], kwargs, actual_span)
+    if indices is None or tmp is None:
+        raise ValueError(
+            "gather() requires either (indices, tmp) for index form, "
+            "or mask_pattern=<int> for mask form"
+        )
+    return _ir_core.create_op_call("tile.gather", [src, indices, tmp], {}, actual_span)
+
+
+def gather_mask(src: Expr, mask_pattern: int, span: Span | None = None) -> Call:
+    """Gather elements from src using a fixed mask pattern.
+
+    .. deprecated::
+        Use ``gather(src, mask_pattern=<value>)`` instead.
+
+    Args:
+        src: Source tile (FP16, FP32, INT16, or INT32)
+        mask_pattern: Mask pattern selector (1-7)
+        span: Optional source span
+
+    Returns:
+        Call expression returning gathered tile
+    """
+    return gather(src, mask_pattern=mask_pattern, span=span)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1596,7 +1596,14 @@ def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile: ...
 def gather(src: Tile, *, mask_pattern: int, output_dtype: int | DataType | None = None) -> Tile: ...
 
 
-def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, mask_pattern: int | None = None, output_dtype: int | DataType | None = None) -> Tile:
+def gather(
+    src: Tile,
+    indices: Tile | None = None,
+    tmp: Tile | None = None,
+    *,
+    mask_pattern: int | None = None,
+    output_dtype: int | DataType | None = None,
+) -> Tile:
     """Gather elements from src tile, using either indices or a fixed mask pattern.
 
     Index form: dst[i, j] = src[indices[i, j]]. Requires indices and tmp workspace.
@@ -1635,8 +1642,7 @@ def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, m
         raise ValueError("output_dtype is only valid for the mask form of gather(); use mask_pattern=<int>")
     if indices is None or tmp is None:
         raise ValueError(
-            "gather() requires either (indices, tmp) for index form, "
-            "or mask_pattern=<int> for mask form"
+            "gather() requires either (indices, tmp) for index form, or mask_pattern=<int> for mask form"
         )
     call_expr = _ir_ops.gather(src.unwrap(), indices.unwrap(), tmp.unwrap())
     return Tile(expr=call_expr)
@@ -1653,7 +1659,7 @@ def mrgsort(
     src2: Tile,
     src3: Tile,
     tmp: Tile,
-    excuted: Tile,
+    executed: Tile,
     exhausted: bool = ...,
 ) -> Tile: ...
 
@@ -1664,7 +1670,7 @@ def mrgsort(
     src2: Tile | None = None,
     src3: Tile | None = None,
     tmp: Tile | None = None,
-    excuted: Tile | None = None,
+    executed: Tile | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Scalar | None = None,
@@ -1678,8 +1684,8 @@ def mrgsort(
         out = mrgsort(src, block_len=64)
 
     Format2 usage (6 positional args):
-        out = mrgsort(src0, src1, src2, src3, tmp, excuted)
-        out = mrgsort(src0, src1, src2, src3, tmp, excuted, exhausted=True)
+        out = mrgsort(src0, src1, src2, src3, tmp, executed)
+        out = mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=True)
 
     Args:
         src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
@@ -1688,7 +1694,7 @@ def mrgsort(
         src2: (format2) Third sorted input tile.
         src3: (format2) Fourth sorted input tile.
         tmp: (format2) Temporary workspace tile.
-        excuted: (format2) Exhaustion status tile (written by hardware).
+        executed: (format2) Exhaustion status tile (written by hardware).
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
 
@@ -1701,10 +1707,10 @@ def mrgsort(
         call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
         return Tile(expr=call_expr)
     # format2: 4-way merge
-    if src1 is None or src2 is None or src3 is None or tmp is None or excuted is None:
+    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, excuted) for format2"
+            "or (src0, src1, src2, src3, tmp, executed) for format2"
         )
     call_expr = _ir_ops.mrgsort(
         src0.unwrap(),
@@ -1712,7 +1718,7 @@ def mrgsort(
         src2.unwrap(),
         src3.unwrap(),
         tmp.unwrap(),
-        excuted.unwrap(),
+        executed.unwrap(),
         exhausted,
     )
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1634,8 +1634,11 @@ def gather(
         out = gather(src, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32)
     """
     if mask_pattern is not None:
-        if output_dtype is not None and (indices is not None or tmp is not None):
-            raise ValueError("output_dtype is only valid for the mask form of gather()")
+        if indices is not None or tmp is not None:
+            raise ValueError(
+                "gather() mask form (mask_pattern=...) and index form (indices, tmp) "
+                "are mutually exclusive; do not pass indices or tmp with mask_pattern"
+            )
         call_expr = _ir_ops.gather(src.unwrap(), mask_pattern=mask_pattern, output_dtype=output_dtype)
         return Tile(expr=call_expr)
     if output_dtype is not None:
@@ -1703,6 +1706,11 @@ def mrgsort(
     """
     if block_len is not None:
         # format1: single-list merge sort
+        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+            raise ValueError(
+                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "are mutually exclusive; do not pass format2 arguments with block_len"
+            )
         block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
         call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
         return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -111,6 +111,7 @@ __all__ = [
     "sort32",
     "gather",
     "MaskPattern",
+    "mrgsort",
 ]
 
 from pypto.ir.op import tile_ops as _ir_ops
@@ -1627,4 +1628,80 @@ def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, m
             "or mask_pattern=<int> for mask form"
         )
     call_expr = _ir_ops.gather(src.unwrap(), indices.unwrap(), tmp.unwrap())
+    return Tile(expr=call_expr)
+
+
+@overload
+def mrgsort(src0: Tile, *, block_len: int | Scalar) -> Tile: ...
+
+
+@overload
+def mrgsort(
+    src0: Tile,
+    src1: Tile,
+    src2: Tile,
+    src3: Tile,
+    tmp: Tile,
+    excuted: Tile,
+    exhausted: bool = ...,
+) -> Tile: ...
+
+
+def mrgsort(
+    src0: Tile,
+    src1: Tile | None = None,
+    src2: Tile | None = None,
+    src3: Tile | None = None,
+    tmp: Tile | None = None,
+    excuted: Tile | None = None,
+    exhausted: bool = False,
+    *,
+    block_len: int | Scalar | None = None,
+) -> Tile:
+    """Merge sort — format1 (single-list) or format2 (4-way merge).
+
+    Format1: sorts a tile containing multiple pre-sorted runs of length block_len.
+    Format2: performs a 4-way merge of 4 pre-sorted input tiles.
+
+    Format1 usage (keyword block_len):
+        out = mrgsort(src, block_len=64)
+
+    Format2 usage (6 positional args):
+        out = mrgsort(src0, src1, src2, src3, tmp, excuted)
+        out = mrgsort(src0, src1, src2, src3, tmp, excuted, exhausted=True)
+
+    Args:
+        src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
+              For format2: first sorted input tile.
+        src1: (format2) Second sorted input tile.
+        src2: (format2) Third sorted input tile.
+        src3: (format2) Fourth sorted input tile.
+        tmp: (format2) Temporary workspace tile.
+        excuted: (format2) Exhaustion status tile (written by hardware).
+        exhausted: (format2) If True, marks inputs as exhausted (default: False).
+        block_len: (format1, keyword-only) Run length, must be multiple of 64.
+
+    Returns:
+        Tile with merged sorted elements
+    """
+    if block_len is not None:
+        # format1: single-list merge sort
+        block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
+        call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
+        return Tile(expr=call_expr)
+    # format2: 4-way merge
+    if src1 is None or src2 is None or src3 is None or tmp is None or excuted is None:
+        raise ValueError(
+            "mrgsort() requires either block_len=<int> for format1, "
+            "or (src0, src1, src2, src3, tmp, excuted) for format2"
+        )
+    call_expr = _ir_ops.mrgsort(
+        src0.unwrap(),
+        src1.unwrap(),
+        src2.unwrap(),
+        src3.unwrap(),
+        tmp.unwrap(),
+        excuted.unwrap(),
+        exhausted,
+    )
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -108,6 +108,7 @@ __all__ = [
     "tpush_to_aic",
     "tpop_from_aic",
     "tpop_from_aiv",
+    "sort32",
 ]
 
 from pypto.ir.op import tile_ops as _ir_ops
@@ -1546,4 +1547,24 @@ def sels(lhs: Tile, rhs: Tile, select_mode: int | float | Expr | Scalar) -> Tile
     """
     select_mode_expr = select_mode.unwrap() if isinstance(select_mode, Scalar) else select_mode
     call_expr = _ir_ops.sels(lhs.unwrap(), rhs.unwrap(), select_mode_expr)
+    return Tile(expr=call_expr)
+
+
+def sort32(src: Tile, idx: Tile) -> Tile:
+    """Sort fixed 32-element blocks with explicit index tile.
+
+    Sorts 32-element blocks in src, permuting idx alongside.
+    Returns sorted value-index pairs tile with doubled last dimension.
+
+    For FP16 src: initialize idx with [0, 1, 2, ..., 31] per block.
+    For FP32 src: initialize idx with [0, 2, 4, ..., 62] per block.
+
+    Args:
+        src: Input value tile (FP16 or FP32)
+        idx: Input index tile with sequential offsets
+
+    Returns:
+        Tile wrapping the sort32 operation (last dim doubled)
+    """
+    call_expr = _ir_ops.sort32(src.unwrap(), idx.unwrap())
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1593,10 +1593,10 @@ def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile: ...
 
 
 @overload
-def gather(src: Tile, *, mask_pattern: int) -> Tile: ...
+def gather(src: Tile, *, mask_pattern: int, output_dtype: int | DataType | None = None) -> Tile: ...
 
 
-def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, mask_pattern: int | None = None) -> Tile:
+def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, mask_pattern: int | None = None, output_dtype: int | DataType | None = None) -> Tile:
     """Gather elements from src tile, using either indices or a fixed mask pattern.
 
     Index form: dst[i, j] = src[indices[i, j]]. Requires indices and tmp workspace.
@@ -1608,6 +1608,10 @@ def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, m
         tmp: Temporary workspace tile (INT32). Required for index form.
         mask_pattern: Mask pattern selector (1-7), keyword-only. Use for mask form.
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
+        output_dtype: Optional output dtype for mask form only. When provided, the result
+            tile has this dtype instead of src's dtype (bit reinterpretation, no conversion).
+            Hardware requires sizeof(dst_dtype) == sizeof(src_dtype). Example: use
+            output_dtype=pl.UINT32 to extract sort32 index bits from FP32 memory.
 
     Returns:
         Tile with gathered elements
@@ -1616,12 +1620,19 @@ def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, m
         # Index form
         out = gather(src, indices, tmp)
 
-        # Mask form
+        # Mask form (same dtype)
         out = gather(src, mask_pattern=1)
+
+        # Mask form with cross-type output (FP32 bits → UINT32)
+        out = gather(src, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32)
     """
     if mask_pattern is not None:
-        call_expr = _ir_ops.gather_mask(src.unwrap(), mask_pattern)
+        if output_dtype is not None and (indices is not None or tmp is not None):
+            raise ValueError("output_dtype is only valid for the mask form of gather()")
+        call_expr = _ir_ops.gather(src.unwrap(), mask_pattern=mask_pattern, output_dtype=output_dtype)
         return Tile(expr=call_expr)
+    if output_dtype is not None:
+        raise ValueError("output_dtype is only valid for the mask form of gather(); use mask_pattern=<int>")
     if indices is None or tmp is None:
         raise ValueError(
             "gather() requires either (indices, tmp) for index form, "

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -109,6 +109,8 @@ __all__ = [
     "tpop_from_aic",
     "tpop_from_aiv",
     "sort32",
+    "gather",
+    "MaskPattern",
 ]
 
 from pypto.ir.op import tile_ops as _ir_ops
@@ -134,6 +136,21 @@ class MemRefType:
     (``mem_vec_0: pl.MemRefType = pl.tile.alloc(...)``) is valid Python that
     pyright and the text-parser can process.
     """
+
+
+class MaskPattern:
+    """Hardware mask pattern selectors for tile.gather_mask.
+
+    Bit patterns are read right-to-left; lower bits correspond to lower indices.
+    """
+
+    P0101 = 1  # stride-2: select positions 0, 2, 4, ...
+    P1010 = 2  # stride-2: select positions 1, 3, 5, ...
+    P0001 = 3  # stride-4: select positions 0, 4, 8, ...
+    P0010 = 4  # stride-4: select positions 1, 5, 9, ...
+    P0100 = 5  # stride-4: select positions 2, 6, 10, ...
+    P1000 = 6  # stride-4: select positions 3, 7, 11, ...
+    P1111 = 7  # select all positions
 
 
 def alloc(
@@ -1567,4 +1584,47 @@ def sort32(src: Tile, idx: Tile) -> Tile:
         Tile wrapping the sort32 operation (last dim doubled)
     """
     call_expr = _ir_ops.sort32(src.unwrap(), idx.unwrap())
+    return Tile(expr=call_expr)
+
+
+@overload
+def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile: ...
+
+
+@overload
+def gather(src: Tile, *, mask_pattern: int) -> Tile: ...
+
+
+def gather(src: Tile, indices: Tile | None = None, tmp: Tile | None = None, *, mask_pattern: int | None = None) -> Tile:
+    """Gather elements from src tile, using either indices or a fixed mask pattern.
+
+    Index form: dst[i, j] = src[indices[i, j]]. Requires indices and tmp workspace.
+    Mask form: selects elements by a hardware mask pattern. No indices or tmp needed.
+
+    Args:
+        src: Source tile (FP16, FP32, INT16, or INT32)
+        indices: Index tile (INT32). Required for index form.
+        tmp: Temporary workspace tile (INT32). Required for index form.
+        mask_pattern: Mask pattern selector (1-7), keyword-only. Use for mask form.
+            1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
+
+    Returns:
+        Tile with gathered elements
+
+    Examples:
+        # Index form
+        out = gather(src, indices, tmp)
+
+        # Mask form
+        out = gather(src, mask_pattern=1)
+    """
+    if mask_pattern is not None:
+        call_expr = _ir_ops.gather_mask(src.unwrap(), mask_pattern)
+        return Tile(expr=call_expr)
+    if indices is None or tmp is None:
+        raise ValueError(
+            "gather() requires either (indices, tmp) for index form, "
+            "or mask_pattern=<int> for mask form"
+        )
+    call_expr = _ir_ops.gather(src.unwrap(), indices.unwrap(), tmp.unwrap())
     return Tile(expr=call_expr)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1994,6 +1994,8 @@ class ASTParser:
             ast.Div: ir.truediv,
             ast.FloorDiv: ir.floordiv,
             ast.Mod: ir.mod,
+            ast.LShift: ir.bit_shift_left,
+            ast.RShift: ir.bit_shift_right,
         }
 
         op_type = type(binop.op)
@@ -2001,7 +2003,7 @@ class ASTParser:
             raise UnsupportedFeatureError(
                 f"Unsupported binary operator: {op_type.__name__}",
                 span=self.span_tracker.get_span(binop),
-                hint="Use supported operators: +, -, *, /, //, %",
+                hint="Use supported operators: +, -, *, /, //, %, <<, >>",
             )
 
         return op_map[op_type](left, right, span)

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -200,6 +200,18 @@ class Scalar(metaclass=ScalarMeta):
     def __mod__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() % (other.unwrap() if isinstance(other, Scalar) else other))
 
+    def __lshift__(self, other: "int | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() << (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __rlshift__(self, other: int) -> "Scalar":
+        return Scalar(expr=other << self.unwrap())
+
+    def __rshift__(self, other: "int | Scalar") -> "Scalar":
+        return Scalar(expr=self.unwrap() >> (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __rrshift__(self, other: int) -> "Scalar":
+        return Scalar(expr=other >> self.unwrap())
+
     # ------------------------------------------------------------------
     # Comparison operators — return Scalar wrapping the IR comparison node.
     # ------------------------------------------------------------------

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -261,7 +261,7 @@ def _tensor_literal_expr(tensor: torch.Tensor, shape_str: str, dtype_str: str) -
             return f"torch.eye({tensor.shape[0]}, dtype={dtype_str})"
 
     # Tensor small enough to inline as a list literal
-    if tensor.numel() <= 10000:
+    if tensor.numel() <= 100:
         return f"torch.tensor({tensor.tolist()!r}, dtype={dtype_str})"
 
     raise ValueError(

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -260,8 +260,8 @@ def _tensor_literal_expr(tensor: torch.Tensor, shape_str: str, dtype_str: str) -
         if torch.allclose(tensor.float(), torch.eye(tensor.shape[0])):
             return f"torch.eye({tensor.shape[0]}, dtype={dtype_str})"
 
-    # Small tensor: inline list literal
-    if tensor.numel() <= 100:
+    # Tensor small enough to inline as a list literal
+    if tensor.numel() <= 10000:
         return f"torch.tensor({tensor.tolist()!r}, dtype={dtype_str})"
 
     raise ValueError(

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -459,10 +459,15 @@ static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
-  // blockLen must be i32 per PTO ISA. Extract value from ConstInt and emit i32 constant.
-  auto const_int = ir::As<ir::ConstInt>(op->args_[1]);
-  INTERNAL_CHECK(const_int) << "tile.mrgsort_format1 block_len must be a ConstInt";
-  std::string block_len = codegen.GetOrEmitI32Constant(static_cast<int32_t>(const_int->value_));
+  // blockLen must be i32 per PTO ISA. Constants use the optimized dedup path;
+  // runtime variables (e.g., loop-carried block_len) go through GetExprAsCode + cast.
+  std::string block_len;
+  if (auto const_int = ir::As<ir::ConstInt>(op->args_[1])) {
+    block_len = codegen.GetOrEmitI32Constant(static_cast<int32_t>(const_int->value_));
+  } else {
+    block_len = codegen.GetExprAsCode(op->args_[1]);
+    block_len = codegen.EmitCastToI32(op->args_[1], block_len);
+  }
 
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -402,14 +402,83 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
   return "";
 }
 
-// TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
-// Helper function for MrgSort
+// Helper function for MrgSort format2: emits pto.tmrgsort
+// format2: ins(src0, src1, src2, src3 {exhausted = <bool>} : types...)
+//          outs(dst, tmp, excuted : dst_type, tmp_type, vector<4xi16>)
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments, but got "
+  CHECK(op->args_.size() == 6) << "Operation:[" << pto_op_name
+                               << "] requires 6 arguments (src0, src1, src2, src3, tmp, excuted), but got "
                                << op->args_.size();
-  codegen.Emit(pto_op_name);
+
+  // ins: src0, src1, src2, src3 (args 0-3)
+  std::string src0 = codegen.GetExprAsCode(op->args_[0]);
+  std::string src1 = codegen.GetExprAsCode(op->args_[1]);
+  std::string src2 = codegen.GetExprAsCode(op->args_[2]);
+  std::string src3 = codegen.GetExprAsCode(op->args_[3]);
+  std::string s0t = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string s1t = codegen.GetExprTypeAnnotation(op->args_[1]);
+  std::string s2t = codegen.GetExprTypeAnnotation(op->args_[2]);
+  std::string s3t = codegen.GetExprTypeAnnotation(op->args_[3]);
+
+  // outs: dst (result target), tmp (arg4), excuted (arg5)
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+  std::string tmp = codegen.GetExprAsCode(op->args_[4]);
+  std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[4]);
+  std::string excuted = codegen.GetExprAsCode(op->args_[5]);
+
+  bool exhausted = op->GetKwarg<bool>("exhausted", false);
+  std::string exhausted_attr = exhausted ? "{exhausted = true}" : "{exhausted = false}";
+
+  std::ostringstream oss;
+  oss << pto_op_name << " ins(" << src0 << ", " << src1 << ", " << src2 << ", " << src3 << " " << exhausted_attr;
+  if (!s0t.empty() || !s1t.empty() || !s2t.empty() || !s3t.empty()) {
+    oss << " : " << s0t << ", " << s1t << ", " << s2t << ", " << s3t;
+  }
+  oss << ") outs(" << dst << ", " << tmp << ", " << excuted;
+  if (!dst_type.empty() || !tmp_type.empty()) {
+    oss << " : " << dst_type << ", " << tmp_type << ", vector<4xi16>";
+  }
+  oss << ")";
+
+  codegen.Emit(oss.str());
+  return "";
+}
+
+// Helper function for MrgSort1 format1: emits pto.tmrgsort
+// format1: ins(src, blockLen : src_type, i32) outs(dst : dst_type)
+static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const CallPtr& op,
+                                          codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
+                               << "] requires 2 arguments (src, block_len), but got "
+                               << op->args_.size();
+
+  std::string src = codegen.GetExprAsCode(op->args_[0]);
+  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+
+  // blockLen must be i32 per PTO ISA. Extract value from ConstInt and emit i32 constant.
+  auto const_int = ir::As<ir::ConstInt>(op->args_[1]);
+  INTERNAL_CHECK(const_int) << "tile.mrgsort_format1 block_len must be a ConstInt";
+  std::string block_len = codegen.GetOrEmitI32Constant(static_cast<int32_t>(const_int->value_));
+
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream oss;
+  oss << pto_op_name << " ins(" << src << ", " << block_len;
+  if (!src_type.empty()) {
+    oss << " : " << src_type << ", i32";
+  }
+  oss << ") outs(" << dst;
+  if (!dst_type.empty()) {
+    oss << " : " << dst_type;
+  }
+  oss << ")";
+
+  codegen.Emit(oss.str());
   return "";
 }
 
@@ -1296,10 +1365,27 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.gather_mask", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGatherMaskCodegenPTO(op, codegen);
   });
-  // TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
-  reg("tile.mrgsort", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-    return MakeMrgSortCodegenPTO("pto.tmrgsort", op, codegen);
-  });
+  // tile.mrgsort_format2 (TMRGSORT format2): all inputs and output must be row_major per ISA
+  if (exclude_ops.count("tile.mrgsort_format2") == 0) {
+    backend.RegisterOp("tile.mrgsort_format2")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          return MakeMrgSortCodegenPTO("pto.tmrgsort", op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_input_layout(1, ir::TileLayout::row_major)
+        .set_input_layout(2, ir::TileLayout::row_major)
+        .set_input_layout(3, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
+  // tile.mrgsort_format1 (TMRGSORT format1): src and output must be row_major per ISA
+  if (exclude_ops.count("tile.mrgsort_format1") == 0) {
+    backend.RegisterOp("tile.mrgsort_format1")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          return MakeMrgSort1CodegenPTO("pto.tmrgsort", op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
   reg("tile.print", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakePrintCodegenPTO("pto.tprint", op, codegen);
   });

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -343,8 +343,8 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
 static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                         codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments (src, idx), but got "
-                               << op->args_.size();
+  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
+                               << "] requires 2 arguments (src, idx), but got " << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string idx = codegen.GetExprAsCode(op->args_[1]);
@@ -388,7 +388,8 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
 
   std::ostringstream oss;
-  oss << "pto.tgather ins(" << src << ", {maskPattern = #pto.mask_pattern<" << mask_patterns.at(pattern) << ">}";
+  oss << "pto.tgather ins(" << src << ", {maskPattern = #pto.mask_pattern<" << mask_patterns.at(pattern)
+      << ">}";
   if (!src_type.empty()) {
     oss << " : " << src_type;
   }
@@ -404,12 +405,12 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 
 // Helper function for MrgSort format2: emits pto.tmrgsort
 // format2: ins(src0, src1, src2, src3 {exhausted = <bool>} : types...)
-//          outs(dst, tmp, excuted : dst_type, tmp_type, vector<4xi16>)
+//          outs(dst, tmp, executed : dst_type, tmp_type, vector<4xi16>)
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 6) << "Operation:[" << pto_op_name
-                               << "] requires 6 arguments (src0, src1, src2, src3, tmp, excuted), but got "
+                               << "] requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
                                << op->args_.size();
 
   // ins: src0, src1, src2, src3 (args 0-3)
@@ -422,22 +423,23 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
   std::string s2t = codegen.GetExprTypeAnnotation(op->args_[2]);
   std::string s3t = codegen.GetExprTypeAnnotation(op->args_[3]);
 
-  // outs: dst (result target), tmp (arg4), excuted (arg5)
+  // outs: dst (result target), tmp (arg4), executed (arg5)
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
   std::string tmp = codegen.GetExprAsCode(op->args_[4]);
   std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[4]);
-  std::string excuted = codegen.GetExprAsCode(op->args_[5]);
+  std::string executed = codegen.GetExprAsCode(op->args_[5]);
 
   bool exhausted = op->GetKwarg<bool>("exhausted", false);
   std::string exhausted_attr = exhausted ? "{exhausted = true}" : "{exhausted = false}";
 
   std::ostringstream oss;
-  oss << pto_op_name << " ins(" << src0 << ", " << src1 << ", " << src2 << ", " << src3 << " " << exhausted_attr;
+  oss << pto_op_name << " ins(" << src0 << ", " << src1 << ", " << src2 << ", " << src3 << " "
+      << exhausted_attr;
   if (!s0t.empty() || !s1t.empty() || !s2t.empty() || !s3t.empty()) {
     oss << " : " << s0t << ", " << s1t << ", " << s2t << ", " << s3t;
   }
-  oss << ") outs(" << dst << ", " << tmp << ", " << excuted;
+  oss << ") outs(" << dst << ", " << tmp << ", " << executed;
   if (!dst_type.empty() || !tmp_type.empty()) {
     oss << " : " << dst_type << ", " << tmp_type << ", vector<4xi16>";
   }
@@ -453,8 +455,7 @@ static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const 
                                           codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
-                               << "] requires 2 arguments (src, block_len), but got "
-                               << op->args_.size();
+                               << "] requires 2 arguments (src, block_len), but got " << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -335,14 +335,37 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
   return "";
 }
 
-// TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
-// Helper function for Sort32
+// Helper function for Sort32: emits pto.tsort32
+// PTOAS expects: ins(src, idx : src_type, idx_type) outs(dst : dst_type)
 static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                         codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 1) << "Operation:[" << pto_op_name << "] requires 1 argument, but got "
+  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments (src, idx), but got "
                                << op->args_.size();
-  codegen.Emit(pto_op_name);
+
+  std::string src = codegen.GetExprAsCode(op->args_[0]);
+  std::string idx = codegen.GetExprAsCode(op->args_[1]);
+  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string idx_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream oss;
+  oss << pto_op_name;
+  // ins clause: src, idx
+  oss << " ins(" << src << ", " << idx;
+  if (!src_type.empty() || !idx_type.empty()) {
+    oss << " : " << src_type << ", " << idx_type;
+  }
+  // outs clause: dst only (idx is modified in-place by hardware)
+  oss << ") outs(" << dst;
+  if (!dst_type.empty()) {
+    oss << " : " << dst_type;
+  }
+  oss << ")";
+
+  codegen.Emit(oss.str());
   return "";
 }
 
@@ -1226,10 +1249,16 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.ci", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeCiCodegenPTO("pto.tci", op, codegen);
   });
-  // TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
-  reg("tile.sort32", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-    return MakeSort32CodegenPTO("pto.tsort32", op, codegen);
-  });
+  // tile.sort32 (TSORT32): all inputs and output must be row_major per ISA
+  if (exclude_ops.count("tile.sort32") == 0) {
+    backend.RegisterOp("tile.sort32")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          return MakeSort32CodegenPTO("pto.tsort32", op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_input_layout(1, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
   // TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
   reg("tile.mrgsort", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeMrgSortCodegenPTO("pto.tmrgsort", op, codegen);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -107,6 +107,9 @@ static void CheckSafeIdentifier(const std::string& value, const std::string& att
 static const std::vector<std::string> cmp_modes = {"eq", "ne", "lt", "le", "gt", "ge"};
 static const std::vector<std::string> round_modes = {"NONE", "RINT",  "ROUND", "FLOOR",
                                                      "CEIL", "TRUNC", "ODD",   "CAST_RINT"};
+// Mask pattern names for pto.tgather mask form (index 0 unused, patterns 1-7)
+static const std::vector<std::string> mask_patterns = {"",      "P0101", "P1010", "P0001",
+                                                       "P0010", "P0100", "P1000", "P1111"};
 
 // Helper function for input & output generation (with type annotations)
 static std::string GenerateInsOutsClause(const CallPtr& op, codegen::PTOCodegen& codegen,
@@ -359,6 +362,36 @@ static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const Ca
     oss << " : " << src_type << ", " << idx_type;
   }
   // outs clause: dst only (idx is modified in-place by hardware)
+  oss << ") outs(" << dst;
+  if (!dst_type.empty()) {
+    oss << " : " << dst_type;
+  }
+  oss << ")";
+
+  codegen.Emit(oss.str());
+  return "";
+}
+
+// Helper function for GatherMask: emits pto.tgather with maskPattern attribute
+// PTOAS expects: ins(src, {maskPattern = #pto.mask_pattern<Pxxxx>} : src_type) outs(dst : dst_type)
+static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 1) << "tile.gather_mask requires 1 argument (src), but got " << op->args_.size();
+
+  int pattern = op->GetKwarg<int>("mask_pattern");
+  CHECK(pattern >= 1 && pattern < static_cast<int>(mask_patterns.size()))
+      << "mask_pattern out of range: " << pattern;
+
+  std::string src = codegen.GetExprAsCode(op->args_[0]);
+  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream oss;
+  oss << "pto.tgather ins(" << src << ", {maskPattern = #pto.mask_pattern<" << mask_patterns.at(pattern) << ">}";
+  if (!src_type.empty()) {
+    oss << " : " << src_type;
+  }
   oss << ") outs(" << dst;
   if (!dst_type.empty()) {
     oss << " : " << dst_type;
@@ -1138,7 +1171,7 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.transpose",       "pto.ttrans",           3},
     {"tile.extract",         "pto.textract",         3},
     // Gather/scatter operations
-    {"tile.gather",          "pto.tgather",          2},
+    {"tile.gather",          "pto.tgather",          3},
     {"tile.gatherb",         "pto.tgatherb",         2},
     {"tile.scatter",         "pto.tscatter",         2},
     // Partial reduction operations
@@ -1259,6 +1292,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
         .set_input_layout(1, ir::TileLayout::row_major)
         .set_output_layout(ir::TileLayout::row_major);
   }
+  // tile.gather_mask (TGATHER mask form): only src operand + maskPattern attribute
+  reg("tile.gather_mask", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeGatherMaskCodegenPTO(op, codegen);
+  });
   // TODO(guoliwei): Sorting operations typically have multiple outputs, which has not yet been addressed.
   reg("tile.mrgsort", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeMrgSortCodegenPTO("pto.tmrgsort", op, codegen);

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -274,9 +274,8 @@ std::string PTOCodegen::EmitCastToIndex(const ir::VarPtr& var, const std::string
 
 std::string PTOCodegen::EmitCastToI32(const ir::ExprPtr& expr, const std::string& mlir_name) {
   if (auto scalar_type = As<ScalarType>(expr->GetType())) {
-    CHECK(!scalar_type->dtype_.IsFloat())
-        << "EmitCastToI32 does not support floating-point types (got " << GetTypeString(scalar_type->dtype_)
-        << ")";
+    CHECK(!scalar_type->dtype_.IsFloat()) << "EmitCastToI32 does not support floating-point types (got "
+                                          << GetTypeString(scalar_type->dtype_) << ")";
     if (scalar_type->dtype_ != DataType::INT32) {
       std::string i32_name = NewTemp();
       std::string src_type = GetTypeString(scalar_type->dtype_);

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -272,6 +272,21 @@ std::string PTOCodegen::EmitCastToIndex(const ir::VarPtr& var, const std::string
   return mlir_name;
 }
 
+std::string PTOCodegen::EmitCastToI32(const ir::ExprPtr& expr, const std::string& mlir_name) {
+  if (auto scalar_type = As<ScalarType>(expr->GetType())) {
+    CHECK(!scalar_type->dtype_.IsFloat())
+        << "EmitCastToI32 does not support floating-point types (got " << GetTypeString(scalar_type->dtype_)
+        << ")";
+    if (scalar_type->dtype_ != DataType::INT32) {
+      std::string i32_name = NewTemp();
+      std::string src_type = GetTypeString(scalar_type->dtype_);
+      Emit(i32_name + " = arith.index_cast " + mlir_name + " : " + src_type + " to i32");
+      return i32_name;
+    }
+  }
+  return mlir_name;
+}
+
 bool PTOCodegen::HasFillpadConsumer(const ir::Var* var) const {
   return fs_.fillpad_input_vars.count(var) > 0;
 }

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -279,7 +279,16 @@ std::string PTOCodegen::EmitCastToI32(const ir::ExprPtr& expr, const std::string
     if (scalar_type->dtype_ != DataType::INT32) {
       std::string i32_name = NewTemp();
       std::string src_type = GetTypeString(scalar_type->dtype_);
-      Emit(i32_name + " = arith.index_cast " + mlir_name + " : " + src_type + " to i32");
+      // Use arith.index_cast for index→i32, arith.trunci/extui for int→int
+      std::string mlir_op;
+      if (scalar_type->dtype_ == DataType::INDEX) {
+        mlir_op = "arith.index_cast";
+      } else if (scalar_type->dtype_.GetBit() > 32) {
+        mlir_op = "arith.trunci";
+      } else {
+        mlir_op = scalar_type->dtype_.IsUnsignedInt() ? "arith.extui" : "arith.extsi";
+      }
+      Emit(i32_name + " = " + mlir_op + " " + mlir_name + " : " + src_type + " to i32");
       return i32_name;
     }
   }

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -37,6 +37,8 @@ std::string DataTypeToMLIR(DataType dtype) {
     return "bf16";
   } else if (dtype == DataType::INT32) {
     return "i32";
+  } else if (dtype == DataType::UINT32) {
+    return "ui32";
   } else if (dtype == DataType::INDEX) {
     return "index";
   } else if (dtype == DataType::INT64) {

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
@@ -156,7 +157,33 @@ static TypePtr DeduceTileGatherMaskType(const std::vector<ExprPtr>& args,
   TileView tile_view;
   tile_view.valid_shape = out_shape;
   InheritTileViewLayout(tile_view, src_type);
-  return std::make_shared<TileType>(out_shape, src_type->dtype_, std::nullopt, tile_view);
+
+  // Read optional output_dtype kwarg for cross-type bit extraction (e.g. FP32→UINT32).
+  // Hardware TGATHER mask form only requires sizeof(dst) == sizeof(src), not same type.
+  bool has_output_dtype = false;
+  DataType out_dtype;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "output_dtype") {
+      if (value.type() == typeid(DataType)) {
+        out_dtype = AnyCast<DataType>(value, "kwarg key: output_dtype");
+      } else if (value.type() == typeid(int)) {
+        out_dtype = static_cast<DataType>(AnyCast<int>(value, "kwarg key: output_dtype"));
+      }
+      has_output_dtype = true;
+      break;
+    }
+  }
+  if (!has_output_dtype) {
+    out_dtype = src_type->dtype_;
+  } else {
+    CHECK(out_dtype.GetBit() == src_type->dtype_.GetBit())
+        << "The operator " << op_name
+        << " output_dtype must have the same bit width as src dtype ("
+        << src_type->dtype_.ToString() << " = " << src_type->dtype_.GetBit()
+        << " bits), but got " << out_dtype.ToString() << " = " << out_dtype.GetBit() << " bits";
+  }
+
+  return std::make_shared<TileType>(out_shape, out_dtype, std::nullopt, tile_view);
 }
 
 REGISTER_OP("tile.gather_mask")
@@ -164,6 +191,7 @@ REGISTER_OP("tile.gather_mask")
     .set_description("Gather elements by mask pattern (maps to pto.tgather with maskPattern)")
     .add_argument("src", "Source tile (FP16, FP32, INT16, or INT32)")
     .set_attr<int>("mask_pattern")
+    .set_attr<DataType>("output_dtype")  // optional: cross-type output (sizeof equality required)
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -105,8 +105,8 @@ REGISTER_OP("tile.gather")
 static TypePtr DeduceTileGatherMaskType(const std::vector<ExprPtr>& args,
                                         const std::vector<std::pair<std::string, std::any>>& kwargs,
                                         const std::string& op_name) {
-  CHECK(args.size() == 1) << "The operator " << op_name
-                          << " requires 1 argument (src), but got " << args.size();
+  CHECK(args.size() == 1) << "The operator " << op_name << " requires 1 argument (src), but got "
+                          << args.size();
 
   auto src_type = As<TileType>(args[0]->GetType());
   CHECK(src_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
@@ -177,10 +177,9 @@ static TypePtr DeduceTileGatherMaskType(const std::vector<ExprPtr>& args,
     out_dtype = src_type->dtype_;
   } else {
     CHECK(out_dtype.GetBit() == src_type->dtype_.GetBit())
-        << "The operator " << op_name
-        << " output_dtype must have the same bit width as src dtype ("
-        << src_type->dtype_.ToString() << " = " << src_type->dtype_.GetBit()
-        << " bits), but got " << out_dtype.ToString() << " = " << out_dtype.GetBit() << " bits";
+        << "The operator " << op_name << " output_dtype must have the same bit width as src dtype ("
+        << src_type->dtype_.ToString() << " = " << src_type->dtype_.GetBit() << " bits), but got "
+        << out_dtype.ToString() << " = " << out_dtype.GetBit() << " bits";
   }
 
   return std::make_shared<TileType>(out_shape, out_dtype, std::nullopt, tile_view);

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -63,13 +63,16 @@ static TypePtr DeduceTileGatherType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires indices dtype to be INT32, but got "
       << idx_type->dtype_.ToString();
 
-  // Third arg: tmp workspace tile (must be i32, same as indices)
+  // Third arg: tmp workspace tile (must be i32, same shape as indices)
   auto tmp_type = As<TileType>(args[2]->GetType());
   CHECK(tmp_type) << "The operator " << op_name << " requires third argument to be a TileType, but got "
                   << args[2]->GetType()->TypeName();
   CHECK(tmp_type->dtype_ == DataType::INT32)
       << "The operator " << op_name << " requires tmp dtype to be INT32, but got "
       << tmp_type->dtype_.ToString();
+  CHECK(tmp_type->shape_.size() == idx_type->shape_.size())
+      << "The operator " << op_name << " requires tmp shape rank to match indices rank ("
+      << idx_type->shape_.size() << "), but got " << tmp_type->shape_.size();
 
   // Output: shape from indices tile, dtype from src tile, propagate tile_view
   TileView tile_view;

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file gather.cpp
+ * @brief Gather tile operations
+ *
+ * This file implements gather operators:
+ * - tile.gather: index-based element gathering (pto.tgather index form)
+ * - tile.gather_mask: mask-pattern element selection (pto.tgather mask form)
+ */
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+
+static TypePtr DeduceTileGatherType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  CHECK(args.size() == 3) << "The operator " << op_name
+                          << " requires 3 arguments (src, indices, tmp), but got " << args.size();
+
+  // First arg: src tile (f16, f32, i16, or i32)
+  auto src_type = As<TileType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32 ||
+        src_type->dtype_ == DataType::INT16 || src_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name << " requires src dtype to be FP16, FP32, INT16, or INT32, but got "
+      << src_type->dtype_.ToString();
+
+  // Second arg: indices tile (must be i32)
+  auto idx_type = As<TileType>(args[1]->GetType());
+  CHECK(idx_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
+                  << args[1]->GetType()->TypeName();
+  CHECK(idx_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name << " requires indices dtype to be INT32, but got "
+      << idx_type->dtype_.ToString();
+
+  // Third arg: tmp workspace tile (must be i32, same as indices)
+  auto tmp_type = As<TileType>(args[2]->GetType());
+  CHECK(tmp_type) << "The operator " << op_name << " requires third argument to be a TileType, but got "
+                  << args[2]->GetType()->TypeName();
+  CHECK(tmp_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name << " requires tmp dtype to be INT32, but got "
+      << tmp_type->dtype_.ToString();
+
+  // Output: shape from indices tile, dtype from src tile, propagate tile_view
+  TileView tile_view;
+  tile_view.valid_shape = idx_type->shape_;
+  InheritTileViewLayout(tile_view, src_type);
+  return std::make_shared<TileType>(idx_type->shape_, src_type->dtype_, std::nullopt, tile_view);
+}
+
+// ============================================================================
+// Registration for Gather Operations
+// ============================================================================
+
+REGISTER_OP("tile.gather")
+    .set_op_category("TileOp")
+    .set_description("Gather elements by index (maps to pto.tgather)")
+    .add_argument("src", "Source tile (FP16, FP32, INT16, or INT32)")
+    .add_argument("indices", "Index tile (INT32)")
+    .add_argument("tmp", "Temporary workspace tile (INT32)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    .set_input_memory(2, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGatherType(args, kwargs, "tile.gather");
+    });
+
+// ============================================================================
+// Gather Mask: mask-pattern form of pto.tgather
+// ============================================================================
+
+static TypePtr DeduceTileGatherMaskType(const std::vector<ExprPtr>& args,
+                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                        const std::string& op_name) {
+  CHECK(args.size() == 1) << "The operator " << op_name
+                          << " requires 1 argument (src), but got " << args.size();
+
+  auto src_type = As<TileType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32 ||
+        src_type->dtype_ == DataType::INT16 || src_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name << " requires src dtype to be FP16, FP32, INT16, or INT32, but got "
+      << src_type->dtype_.ToString();
+
+  // Validate mask_pattern kwarg (values 1-7 per PTOAS MaskPattern enum)
+  int pattern = -1;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "mask_pattern") {
+      pattern = std::any_cast<int>(value);
+      break;
+    }
+  }
+  CHECK(pattern >= 1 && pattern <= 7)
+      << "The operator " << op_name << " requires mask_pattern in range [1, 7], but got " << pattern;
+
+  // Output shape: mask selects a subset of columns per row, producing a compacted tile.
+  //   P0101 (1), P1010 (2) — stride 2: each row contributes cols/2 elements
+  //   P0001 (3)..P1000 (6) — stride 4: each row contributes cols/4 elements
+  //   P1111 (7)            — no stride: all cols kept
+  const auto& src_shape = src_type->shape_;
+  INTERNAL_CHECK(src_shape.size() == 2)
+      << "Internal error: tile.gather_mask requires 2D src shape, got rank " << src_shape.size();
+
+  const ExprPtr& col_expr = src_shape[1];
+  ExprPtr out_col_expr;
+  if (pattern == 7) {
+    out_col_expr = col_expr;  // P1111: all cols
+  } else {
+    int64_t divisor = (pattern <= 2) ? 2 : 4;
+    if (auto const_col = As<ConstInt>(col_expr)) {
+      int64_t out_cols = const_col->value_ / divisor;
+      CHECK(const_col->value_ % divisor == 0)
+          << "The operator " << op_name << " with mask_pattern=" << pattern
+          << " requires src columns divisible by " << divisor << ", got " << const_col->value_;
+      out_col_expr = std::make_shared<ConstInt>(out_cols, DataType::INDEX, Span::unknown());
+    } else {
+      auto div_expr = std::make_shared<ConstInt>(divisor, DataType::INDEX, Span::unknown());
+      out_col_expr = std::make_shared<FloorDiv>(col_expr, div_expr, DataType::INDEX, Span::unknown());
+    }
+  }
+
+  std::vector<ExprPtr> out_shape = {src_shape[0], out_col_expr};
+  TileView tile_view;
+  tile_view.valid_shape = out_shape;
+  InheritTileViewLayout(tile_view, src_type);
+  return std::make_shared<TileType>(out_shape, src_type->dtype_, std::nullopt, tile_view);
+}
+
+REGISTER_OP("tile.gather_mask")
+    .set_op_category("TileOp")
+    .set_description("Gather elements by mask pattern (maps to pto.tgather with maskPattern)")
+    .add_argument("src", "Source tile (FP16, FP32, INT16, or INT32)")
+    .set_attr<int>("mask_pattern")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGatherMaskType(args, kwargs, "tile.gather_mask");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -11,10 +11,11 @@
 
 /**
  * @file sort.cpp
- * @brief Sorting tile operations (Sort32)
+ * @brief Sorting tile operations (Sort32, MrgSort)
  *
  * This file implements sort operations for tile-level programming.
  * Sort32 sorts fixed-size 32-element blocks and maps to pto.tsort32.
+ * MrgSort merges 4 pre-sorted lists and maps to pto.tmrgsort (format2).
  */
 
 #include <any>
@@ -23,6 +24,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <optional>
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
@@ -35,6 +38,21 @@
 
 namespace pypto {
 namespace ir {
+
+// Helper to get kwargs value with optional default
+template <typename T>
+static T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
+                  const std::optional<T>& default_value = std::nullopt) {
+  for (const auto& [k, v] : kwargs) {
+    if (k == key) {
+      return AnyCast<T>(v, "kwarg key: " + key);
+    }
+  }
+  if (default_value) {
+    return *default_value;
+  }
+  throw ValueError("Missing kwarg: " + key);
+}
 
 TypePtr DeduceTileSort32Type(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -91,6 +109,122 @@ REGISTER_OP("tile.sort32")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileSort32Type(args, kwargs, "tile.sort32");
+    });
+
+// ============================================================================
+// MrgSort: 4-way merge sort (format2) — maps to pto.tmrgsort
+// ============================================================================
+
+TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  CHECK(args.size() == 6) << "The operator " << op_name
+                          << " requires 6 arguments (src0, src1, src2, src3, tmp, excuted), but got "
+                          << args.size();
+
+  // First 4 args: sorted input tiles (f16 or f32, matching dtype)
+  auto src0_type = As<TileType>(args[0]->GetType());
+  CHECK(src0_type) << "The operator " << op_name << " requires argument 0 to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+  CHECK(src0_type->dtype_ == DataType::FP16 || src0_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src0_type->dtype_.ToString();
+
+  for (size_t i = 1; i < 4; ++i) {
+    auto src_type = As<TileType>(args[i]->GetType());
+    CHECK(src_type) << "The operator " << op_name << " requires argument " << i
+                    << " to be a TileType, but got " << args[i]->GetType()->TypeName();
+    CHECK(src_type->dtype_ == src0_type->dtype_)
+        << "The operator " << op_name << " requires all src tiles to have matching dtype, but argument " << i
+        << " has " << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString() << ")";
+  }
+
+  // arg4: tmp workspace tile
+  auto tmp_type = As<TileType>(args[4]->GetType());
+  CHECK(tmp_type) << "The operator " << op_name << " requires argument 4 (tmp) to be a TileType, but got "
+                  << args[4]->GetType()->TypeName();
+
+  // arg5: excuted status tile
+  auto exc_type = As<TileType>(args[5]->GetType());
+  CHECK(exc_type) << "The operator " << op_name
+                  << " requires argument 5 (excuted) to be a TileType, but got "
+                  << args[5]->GetType()->TypeName();
+
+  // kwarg: exhausted (bool, default false)
+  [[maybe_unused]] bool exhausted = GetKwarg<bool>(kwargs, "exhausted", false);
+
+  // Output shape matches tmp tile (the merge destination buffer)
+  TileView tile_view;
+  tile_view.valid_shape = tmp_type->shape_;
+  return std::make_shared<TileType>(tmp_type->shape_, src0_type->dtype_, std::nullopt, tile_view);
+}
+
+REGISTER_OP("tile.mrgsort_format2")
+    .set_op_category("TileOp")
+    .set_description("Merge sort 4 sorted lists, format2 (maps to pto.tmrgsort)")
+    .add_argument("src0", "First sorted input tile (FP16 or FP32)")
+    .add_argument("src1", "Second sorted input tile")
+    .add_argument("src2", "Third sorted input tile")
+    .add_argument("src3", "Fourth sorted input tile")
+    .add_argument("tmp", "Temporary workspace tile")
+    .add_argument("excuted", "Exhaustion status output tile")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    .set_input_memory(2, MemorySpace::Vec)
+    .set_input_memory(3, MemorySpace::Vec)
+    .set_input_memory(4, MemorySpace::Vec)
+    .set_input_memory(5, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileMrgSortType(args, kwargs, "tile.mrgsort_format2");
+    });
+
+// ============================================================================
+// MrgSort1: single-list merge sort (format1) — maps to pto.tmrgsort
+// ============================================================================
+
+TypePtr DeduceTileMrgSort1Type(const std::vector<ExprPtr>& args,
+                                const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name
+                          << " requires 2 arguments (src, block_len), but got " << args.size();
+
+  // arg0: src tile (f16 or f32)
+  auto src_type = As<TileType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name << " requires argument 0 to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src_type->dtype_.ToString();
+
+  // arg1: block_len (integer scalar)
+  auto block_len_type = As<ScalarType>(args[1]->GetType());
+  CHECK(block_len_type) << "The operator " << op_name
+                        << " requires argument 1 (block_len) to be a ScalarType, but got "
+                        << args[1]->GetType()->TypeName();
+  CHECK(block_len_type->dtype_.IsInt())
+      << "The operator " << op_name << " requires block_len to be an integer type, but got "
+      << block_len_type->dtype_.ToString();
+
+  // Output shape matches src (merge destination has same dimensions as input)
+  TileView tile_view;
+  tile_view.valid_shape = src_type->shape_;
+  return std::make_shared<TileType>(src_type->shape_, src_type->dtype_, std::nullopt, tile_view);
+}
+
+REGISTER_OP("tile.mrgsort_format1")
+    .set_op_category("TileOp")
+    .set_description("Single-list merge sort, format1 (maps to pto.tmrgsort format1)")
+    .add_argument("src", "Input tile containing pre-sorted runs (FP16 or FP32)")
+    .add_argument("block_len", "Run length for merge sort (integer scalar, multiple of 64)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileMrgSort1Type(args, kwargs, "tile.mrgsort_format1");
     });
 
 }  // namespace ir

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -147,8 +147,7 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
 
   // arg5: executed status tile
   auto exc_type = As<TileType>(args[5]->GetType());
-  CHECK(exc_type) << "The operator " << op_name
-                  << " requires argument 5 (executed) to be a TileType, but got "
+  CHECK(exc_type) << "The operator " << op_name << " requires argument 5 (executed) to be a TileType, but got "
                   << args[5]->GetType()->TypeName();
 
   // kwarg: exhausted (bool, default false)

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -19,16 +19,17 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <optional>
-
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
@@ -57,8 +58,8 @@ static T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, c
 TypePtr DeduceTileSort32Type(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs,
                              const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name
-                          << " requires 2 arguments (src, idx), but got " << args.size();
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (src, idx), but got "
+                          << args.size();
 
   // First arg: src tile (f16 or f32)
   auto src_type = As<TileType>(args[0]->GetType());
@@ -116,10 +117,10 @@ REGISTER_OP("tile.sort32")
 // ============================================================================
 
 TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
-                               const std::vector<std::pair<std::string, std::any>>& kwargs,
-                               const std::string& op_name) {
+                              const std::vector<std::pair<std::string, std::any>>& kwargs,
+                              const std::string& op_name) {
   CHECK(args.size() == 6) << "The operator " << op_name
-                          << " requires 6 arguments (src0, src1, src2, src3, tmp, excuted), but got "
+                          << " requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
                           << args.size();
 
   // First 4 args: sorted input tiles (f16 or f32, matching dtype)
@@ -144,10 +145,10 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
   CHECK(tmp_type) << "The operator " << op_name << " requires argument 4 (tmp) to be a TileType, but got "
                   << args[4]->GetType()->TypeName();
 
-  // arg5: excuted status tile
+  // arg5: executed status tile
   auto exc_type = As<TileType>(args[5]->GetType());
   CHECK(exc_type) << "The operator " << op_name
-                  << " requires argument 5 (excuted) to be a TileType, but got "
+                  << " requires argument 5 (executed) to be a TileType, but got "
                   << args[5]->GetType()->TypeName();
 
   // kwarg: exhausted (bool, default false)
@@ -167,7 +168,7 @@ REGISTER_OP("tile.mrgsort_format2")
     .add_argument("src2", "Third sorted input tile")
     .add_argument("src3", "Fourth sorted input tile")
     .add_argument("tmp", "Temporary workspace tile")
-    .add_argument("excuted", "Exhaustion status output tile")
+    .add_argument("executed", "Exhaustion status output tile")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
@@ -186,10 +187,10 @@ REGISTER_OP("tile.mrgsort_format2")
 // ============================================================================
 
 TypePtr DeduceTileMrgSort1Type(const std::vector<ExprPtr>& args,
-                                const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name
-                          << " requires 2 arguments (src, block_len), but got " << args.size();
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (src, block_len), but got "
+                          << args.size();
 
   // arg0: src tile (f16 or f32)
   auto src_type = As<TileType>(args[0]->GetType());

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file sort.cpp
+ * @brief Sorting tile operations (Sort32)
+ *
+ * This file implements sort operations for tile-level programming.
+ * Sort32 sorts fixed-size 32-element blocks and maps to pto.tsort32.
+ */
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+TypePtr DeduceTileSort32Type(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& kwargs,
+                             const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name
+                          << " requires 2 arguments (src, idx), but got " << args.size();
+
+  // First arg: src tile (f16 or f32)
+  auto src_type = As<TileType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src_type->dtype_.ToString();
+
+  // Second arg: idx tile
+  auto idx_type = As<TileType>(args[1]->GetType());
+  CHECK(idx_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
+                  << args[1]->GetType()->TypeName();
+
+  // Build output shape: double the last dimension for value-index pairs
+  const auto& input_shape = src_type->shape_;
+  CHECK(!input_shape.empty()) << "The operator " << op_name << " requires non-empty input shape";
+
+  std::vector<ExprPtr> output_shape(input_shape.begin(), input_shape.end() - 1);
+  auto last_dim = input_shape.back();
+  // Try constant evaluation for the common case (sort32 always uses cols=32 -> 64)
+  if (auto const_dim = As<ConstInt>(last_dim)) {
+    int64_t doubled = const_dim->value_ * 2;
+    output_shape.push_back(std::make_shared<ConstInt>(doubled, DataType::INDEX, Span::unknown()));
+  } else {
+    auto two = std::make_shared<ConstInt>(2, DataType::INDEX, Span::unknown());
+    output_shape.push_back(std::make_shared<Mul>(last_dim, two, DataType::INDEX, Span::unknown()));
+  }
+
+  TileView tile_view;
+  tile_view.valid_shape = output_shape;
+  return std::make_shared<TileType>(output_shape, src_type->dtype_, std::nullopt, tile_view);
+}
+
+// ============================================================================
+// Registration for Sort Operations
+// ============================================================================
+
+REGISTER_OP("tile.sort32")
+    .set_op_category("TileOp")
+    .set_description("Sort fixed 32-element blocks (maps to pto.tsort32)")
+    .add_argument("src", "Input value tile (TileType, f16 or f32)")
+    .add_argument("idx", "Input index tile (TileType)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileSort32Type(args, kwargs, "tile.sort32");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -91,6 +92,7 @@ TypePtr DeduceTileSort32Type(const std::vector<ExprPtr>& args,
 
   TileView tile_view;
   tile_view.valid_shape = output_shape;
+  InheritTileViewLayout(tile_view, src_type);
   return std::make_shared<TileType>(output_shape, src_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -147,7 +149,8 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
 
   // arg5: executed status tile
   auto exc_type = As<TileType>(args[5]->GetType());
-  CHECK(exc_type) << "The operator " << op_name << " requires argument 5 (executed) to be a TileType, but got "
+  CHECK(exc_type) << "The operator " << op_name
+                  << " requires argument 5 (executed) to be a TileType, but got "
                   << args[5]->GetType()->TypeName();
 
   // kwarg: exhausted (bool, default false)
@@ -156,6 +159,7 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
   // Output shape matches tmp tile (the merge destination buffer)
   TileView tile_view;
   tile_view.valid_shape = tmp_type->shape_;
+  InheritTileViewLayout(tile_view, src0_type);
   return std::make_shared<TileType>(tmp_type->shape_, src0_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -168,6 +172,7 @@ REGISTER_OP("tile.mrgsort_format2")
     .add_argument("src3", "Fourth sorted input tile")
     .add_argument("tmp", "Temporary workspace tile")
     .add_argument("executed", "Exhaustion status output tile")
+    .set_attr<bool>("exhausted")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
@@ -208,9 +213,17 @@ TypePtr DeduceTileMrgSort1Type(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires block_len to be an integer type, but got "
       << block_len_type->dtype_.ToString();
 
+  // Validate constant block_len: must be a positive multiple of 64
+  if (auto const_val = As<ConstInt>(args[1])) {
+    CHECK(const_val->value_ > 0 && const_val->value_ % 64 == 0)
+        << "The operator " << op_name << " requires block_len to be a positive multiple of 64, but got "
+        << const_val->value_;
+  }
+
   // Output shape matches src (merge destination has same dimensions as input)
   TileView tile_view;
   tile_view.valid_shape = src_type->shape_;
+  InheritTileViewLayout(tile_view, src_type);
   return std::make_shared<TileType>(src_type->shape_, src_type->dtype_, std::nullopt, tile_view);
 }
 

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -34,6 +34,7 @@ class DataType(Enum):
     FP32 = "fp32"
     FP16 = "fp16"
     INT32 = "int32"
+    UINT32 = "uint32"
     INT64 = "int64"
     BOOL = "bool"
 
@@ -45,6 +46,7 @@ class DataType(Enum):
             DataType.FP32: torch.float32,
             DataType.FP16: torch.float16,
             DataType.INT32: torch.int32,
+            DataType.UINT32: torch.int32,  # PyTorch has no uint32; use int32 (same bits)
             DataType.INT64: torch.int64,
             DataType.BOOL: torch.bool,
         }

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -18,6 +18,8 @@ interleaved (value, index) pairs:
 
 To read back indices as integers on the host side, use:
     values, indices = extract_sort32_results(output_f32)
+
+Also tests tile.gather_mask (mask-pattern form of pto.tgather).
 """
 
 from typing import Any
@@ -85,11 +87,163 @@ class Sort32FP32Program:
         return output
 
 
+@pl.program
+class Sort32GatherFP32Program:
+    """Sort 32-element blocks, then gather to separate values and indices."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def sort32_gather_kernel(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        val_gather_idx: pl.Tensor[[8, 32], pl.INT32],
+        idx_gather_idx: pl.Tensor[[8, 32], pl.INT32],
+        gather_tmp: pl.Tensor[[8, 32], pl.INT32],
+        val_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> tuple[pl.Tensor[[8, 32], pl.FP32], pl.Tensor[[8, 32], pl.FP32]]:
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
+            idx_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+
+        val_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(
+            val_gather_idx, offsets=[0, 0], shapes=[8, 32]
+        )
+        idx_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(
+            idx_gather_idx, offsets=[0, 0], shapes=[8, 32]
+        )
+        tmp_tile: pl.Tile[[8, 32], pl.INT32] = pl.load(
+            gather_tmp, offsets=[0, 0], shapes=[8, 32]
+        )
+
+        val_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
+            sorted_tile, val_gidx, tmp_tile
+        )
+        # Index bits are stored as raw uint32 in f32 memory by sort32.
+        # Keep as FP32 — host will .view(torch.int32) to reinterpret bits.
+        idx_tile_fp32: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
+            sorted_tile, idx_gidx, tmp_tile
+        )
+
+        val_out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
+            val_tile, offsets=[0, 0], output_tensor=val_output
+        )
+        idx_out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
+            idx_tile_fp32, offsets=[0, 0], output_tensor=idx_output
+        )
+        return val_out, idx_out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        val_gather_idx: pl.Tensor[[8, 32], pl.INT32],
+        idx_gather_idx: pl.Tensor[[8, 32], pl.INT32],
+        gather_tmp: pl.Tensor[[8, 32], pl.INT32],
+        val_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> tuple[pl.Tensor[[8, 32], pl.FP32], pl.Tensor[[8, 32], pl.FP32]]:
+        val_output, idx_output = self.sort32_gather_kernel(
+            src_tensor, idx_tensor, val_gather_idx, idx_gather_idx,
+            gather_tmp, val_output, idx_output
+        )
+        return val_output, idx_output
+
+
+@pl.program
+class Sort32GatherMaskFP32Program:
+    """Sort 32-element blocks, then extract values via P0101 gather_mask."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def sort32_gather_mask_kernel(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> pl.Tensor[[8, 32], pl.FP32]:
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
+            idx_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+        # P0101 selects every other element (stride=2): columns 0,2,4,...
+        # sort32 layout is [val0, idx0, val1, idx1, ...], so P0101 extracts values.
+        # Output shape: [8, 64/2] = [8, 32]
+        gathered: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
+            sorted_tile, mask_pattern=pl.tile.MaskPattern.P0101
+        )
+        out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
+            gathered, offsets=[0, 0], output_tensor=output
+        )
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> pl.Tensor[[8, 32], pl.FP32]:
+        output = self.sort32_gather_mask_kernel(src_tensor, idx_tensor, output)
+        return output
+
+
+
+@pl.program
+class GatherMaskFP32Program:
+    """Gather elements using a fixed mask pattern (P1111 = all elements)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def gather_mask_kernel(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> pl.Tensor[[8, 32], pl.FP32]:
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        gathered: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
+            src_tile, mask_pattern=pl.tile.MaskPattern.P1111
+        )
+        out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
+            gathered, offsets=[0, 0], output_tensor=output
+        )
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+    ) -> pl.Tensor[[8, 32], pl.FP32]:
+        output = self.gather_mask_kernel(src_tensor, output)
+        return output
+
+
 # --- Test Cases ---
 
 
 # Pre-compute idx tensor: [0, 1, 2, ..., 31] per row (logical indices)
 _IDX_TENSOR_FP32 = torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).expand(8, -1).contiguous()
+
+# Pre-compute gather index tensors for separating interleaved (val, idx) pairs.
+# sort32 output layout: [val0, idx0, val1, idx1, ...] → 64 elements per row.
+# pto.tgather uses FLAT element indices into the entire source tile, so each row
+# needs a row-specific offset: row i uses base offset i*64.
+_ROW_OFFSETS = (torch.arange(0, 8, dtype=torch.int32) * 64).unsqueeze(1)  # [8, 1]
+_VAL_GATHER_IDX = (
+    (torch.arange(0, 32, dtype=torch.int32) * 2).unsqueeze(0) + _ROW_OFFSETS
+).contiguous()  # [8, 32]
+_IDX_GATHER_IDX = (
+    (torch.arange(0, 32, dtype=torch.int32) * 2 + 1).unsqueeze(0) + _ROW_OFFSETS
+).contiguous()  # [8, 32]
 
 
 class Sort32FP32TestCase(PTOTestCase):
@@ -119,7 +273,12 @@ class Sort32FP32TestCase(PTOTestCase):
         return Sort32FP32Program
 
     def compute_expected(self, tensors, params=None):
-        """Expected: descending sort, interleaved [val, idx_as_f32, ...] layout."""
+        """Expected: descending sort, interleaved [val, idx_as_f32, ...] layout.
+
+        Hardware TSORT32 stores uint32 index bits directly in f32 memory
+        (bit reinterpretation, not value conversion).  The sim TSORT32
+        does value conversion instead — this is a known sim discrepancy.
+        """
         src = tensors["src_tensor"]  # [8, 32]
         expected = torch.zeros(8, 64, dtype=torch.float32)
         for row in range(8):
@@ -128,6 +287,116 @@ class Sort32FP32TestCase(PTOTestCase):
             expected[row, 0::2] = sorted_vals
             expected[row, 1::2] = idx_as_f32
         tensors["output"][:] = expected
+
+
+class Sort32GatherFP32TestCase(PTOTestCase):
+    """Test sort32 + gather: separate values and indices from interleaved output.
+
+    Pipeline: sort32 → gather(even positions) → val_output [FP32]
+              sort32 → gather(odd positions) → idx_output [FP32, host reinterprets as int32]
+    """
+
+    def get_name(self) -> str:
+        return "sort32_gather_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
+            TensorSpec("val_gather_idx", [8, 32], DataType.INT32, init_value=_VAL_GATHER_IDX),
+            TensorSpec("idx_gather_idx", [8, 32], DataType.INT32, init_value=_IDX_GATHER_IDX),
+            TensorSpec("gather_tmp", [8, 32], DataType.INT32, init_value=0),
+            TensorSpec("val_output", [8, 32], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [8, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Sort32GatherFP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: sorted values (FP32) and index bits as FP32 (host reinterprets)."""
+        src = tensors["src_tensor"]  # [8, 32]
+        val_expected = torch.zeros(8, 32, dtype=torch.float32)
+        idx_expected = torch.zeros(8, 32, dtype=torch.float32)
+        for row in range(8):
+            sorted_vals, sorted_indices = torch.sort(src[row], descending=True)
+            # uint32 index bits reinterpreted as f32 (matches hardware sort32 output)
+            idx_as_f32 = sorted_indices.int().view(torch.float32)
+            val_expected[row] = sorted_vals
+            idx_expected[row] = idx_as_f32
+        tensors["val_output"][:] = val_expected
+        tensors["idx_output"][:] = idx_expected
+
+
+class Sort32GatherMaskFP32TestCase(PTOTestCase):
+    """Test sort32 + gather_mask: extract values with P0101 from interleaved output.
+
+    sort32 output layout: [val0, idx0, val1, idx1, ...] (64 elements per row).
+    P0101 selects columns 0,2,4,... (stride=2) → [8, 32] of sorted values.
+    """
+
+    def get_name(self) -> str:
+        return "sort32_gather_mask_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
+            TensorSpec("output", [8, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Sort32GatherMaskFP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """P0101 selects even-column positions from interleaved output = sorted values."""
+        src = tensors["src_tensor"]  # [8, 32]
+        expected = torch.zeros(8, 32, dtype=torch.float32)
+        for row in range(8):
+            sorted_vals, _ = torch.sort(src[row], descending=True)
+            expected[row] = sorted_vals
+        tensors["output"][:] = expected
+
+
+class GatherMaskFP32TestCase(PTOTestCase):
+    """Test gather_mask with P1111 pattern on FP32 data.
+
+    P1111 selects all elements, so output should match input exactly.
+    """
+
+    def get_name(self) -> str:
+        return "gather_mask_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [8, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherMaskFP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """P1111 selects all elements — output equals input."""
+        tensors["output"][:] = tensors["src_tensor"]
 
 
 # --- Tests ---
@@ -145,6 +414,32 @@ class TestSort:
             # indices: [8, 32] int32 — original positions
         """
         test_case = Sort32FP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_sort32_gather_fp32(self, test_runner):
+        """Test sort32 + gather: separate values and indices into distinct tensors.
+
+        Pipeline: sort32 → gather(even) → val_output [8,32] FP32
+                  sort32 → gather(odd) → idx_output [8,32] FP32 (host reinterprets)
+        """
+        test_case = Sort32GatherFP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_sort32_gather_mask_fp32(self, test_runner):
+        """Test sort32 + gather_mask: extract sorted values with P0101 mask.
+
+        Pipeline: sort32 → gather(mask_pattern=P0101) → output [8,32] FP32
+        P0101 selects columns 0,2,4,... (stride=2) from [8,64] interleaved output.
+        """
+        test_case = Sort32GatherMaskFP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_gather_mask_fp32(self, test_runner):
+        """Test gather_mask with P1111 pattern: output should match input."""
+        test_case = GatherMaskFP32TestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -318,28 +318,44 @@ class MrgSort1DynFP32Program:
 # --- Test Cases ---
 
 
-# Pre-compute idx tensor: [0, 1, 2, ..., 31] per row (logical indices)
-_IDX_TENSOR_FP32 = torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).expand(8, -1).contiguous()
+# Factory functions for init_value tensors (golden_writer requires callables for large tensors).
 
-# Pre-compute gather index tensors for separating interleaved (val, idx) pairs.
-# sort32 output layout: [val0, idx0, val1, idx1, ...] → 64 elements per row.
-# pto.tgather uses FLAT element indices into the entire source tile, so each row
-# needs a row-specific offset: row i uses base offset i*64.
-_ROW_OFFSETS = (torch.arange(0, 8, dtype=torch.int32) * 64).unsqueeze(1)  # [8, 1]
-_VAL_GATHER_IDX = (
-    (torch.arange(0, 32, dtype=torch.int32) * 2).unsqueeze(0) + _ROW_OFFSETS
-).contiguous()  # [8, 32]
-_IDX_GATHER_IDX = (
-    (torch.arange(0, 32, dtype=torch.int32) * 2 + 1).unsqueeze(0) + _ROW_OFFSETS
-).contiguous()  # [8, 32]
 
-# Pre-compute tensors for mrgsort format1 test (sort32 → mrgsort → gather pipeline).
-# Global indices [0, 1, 2, ..., 127] — sort32 idx is just an index mapping.
-_IDX_1x128 = torch.arange(0, 128, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 128]
+def _make_idx_8x32():
+    """[0, 1, 2, ..., 31] per row — logical indices for sort32 idx input."""
+    return torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).expand(8, -1).contiguous()
 
-# Pre-compute tensors for mrgsort format1 dynamic block_len test (2048 elements).
-# Global indices [0, 1, 2, ..., 2047] — sort32 idx is just an index mapping.
-_IDX_1x2048 = torch.arange(0, 2048, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 2048]
+
+def _make_val_gather_idx():
+    """Flat even-position indices into [8, 64] sort32 output — selects values."""
+    row_offsets = (torch.arange(0, 8, dtype=torch.int32) * 64).unsqueeze(1)
+    return ((torch.arange(0, 32, dtype=torch.int32) * 2).unsqueeze(0) + row_offsets).contiguous()
+
+
+def _make_idx_gather_idx():
+    """Flat odd-position indices into [8, 64] sort32 output — selects indices."""
+    row_offsets = (torch.arange(0, 8, dtype=torch.int32) * 64).unsqueeze(1)
+    return ((torch.arange(0, 32, dtype=torch.int32) * 2 + 1).unsqueeze(0) + row_offsets).contiguous()
+
+
+def _make_idx_1x128():
+    """Global indices [0..127] for mrgsort format1 test."""
+    return torch.arange(0, 128, dtype=torch.int32).unsqueeze(0).contiguous()
+
+
+def _make_src_1x128():
+    """Random [1, 128] FP32 source for mrgsort format1 test."""
+    return torch.randn(128).unsqueeze(0).contiguous()
+
+
+def _make_idx_1x2048():
+    """Global indices [0..2047] for mrgsort dynamic block_len test."""
+    return torch.arange(0, 2048, dtype=torch.int32).unsqueeze(0).contiguous()
+
+
+def _make_src_1x2048():
+    """Random [1, 2048] FP32 source for mrgsort dynamic block_len test."""
+    return torch.randn(2048).unsqueeze(0).contiguous()
 
 
 class MrgSort1FP32TestCase(PTOTestCase):
@@ -360,10 +376,9 @@ class MrgSort1FP32TestCase(PTOTestCase):
         return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
-        src = torch.randn(128).unsqueeze(0).contiguous()  # [1, 128] random FP32
         return [
-            TensorSpec("src_tensor", [1, 128], DataType.FP32, init_value=src),
-            TensorSpec("idx_tensor", [1, 128], DataType.UINT32, init_value=_IDX_1x128),
+            TensorSpec("src_tensor", [1, 128], DataType.FP32, init_value=_make_src_1x128),
+            TensorSpec("idx_tensor", [1, 128], DataType.UINT32, init_value=_make_idx_1x128),
             TensorSpec("val_output", [1, 128], DataType.FP32, is_output=True),
             TensorSpec("idx_output", [1, 128], DataType.UINT32, is_output=True),
         ]
@@ -401,10 +416,9 @@ class MrgSort1DynFP32TestCase(PTOTestCase):
         return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
-        src = torch.randn(2048).unsqueeze(0).contiguous()  # [1, 2048] random FP32
         return [
-            TensorSpec("src_tensor", [1, 2048], DataType.FP32, init_value=src),
-            TensorSpec("idx_tensor", [1, 2048], DataType.UINT32, init_value=_IDX_1x2048),
+            TensorSpec("src_tensor", [1, 2048], DataType.FP32, init_value=_make_src_1x2048),
+            TensorSpec("idx_tensor", [1, 2048], DataType.UINT32, init_value=_make_idx_1x2048),
             TensorSpec("val_output", [1, 2048], DataType.FP32, is_output=True),
             TensorSpec("idx_output", [1, 2048], DataType.UINT32, is_output=True),
         ]
@@ -444,7 +458,7 @@ class Sort32FP32TestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
-            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
             TensorSpec("output", [8, 64], DataType.FP32, is_output=True),
         ]
 
@@ -487,9 +501,9 @@ class Sort32GatherFP32TestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
-            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
-            TensorSpec("val_gather_idx", [8, 32], DataType.INT32, init_value=_VAL_GATHER_IDX),
-            TensorSpec("idx_gather_idx", [8, 32], DataType.INT32, init_value=_IDX_GATHER_IDX),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
+            TensorSpec("val_gather_idx", [8, 32], DataType.INT32, init_value=_make_val_gather_idx),
+            TensorSpec("idx_gather_idx", [8, 32], DataType.INT32, init_value=_make_idx_gather_idx),
             TensorSpec("gather_tmp", [8, 32], DataType.INT32, init_value=0),
             TensorSpec("val_output", [8, 32], DataType.FP32, is_output=True),
             TensorSpec("idx_output", [8, 32], DataType.FP32, is_output=True),
@@ -532,7 +546,7 @@ class Sort32GatherMaskFP32TestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
-            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
             TensorSpec("output", [8, 32], DataType.FP32, is_output=True),
         ]
 

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -21,8 +21,6 @@ TMRGSORT format2 merges 4 pre-sorted lists into a single sorted output:
 
 To read back indices as integers on the host side, use:
     values, indices = extract_sort32_results(output_f32)
-
-Also tests tile.gather_mask (mask-pattern form of pto.tgather).
 """
 
 from typing import Any
@@ -257,33 +255,64 @@ class MrgSort1FP32Program:
 
 
 @pl.program
-class GatherMaskFP32Program:
-    """Gather elements using a fixed mask pattern (P1111 = all elements)."""
+class MrgSort1DynFP32Program:
+    """Sort 64×32-element blocks (2048 values) with sort32, then merge with
+    3 iterations of mrgsort format1 using dynamic block_len computed from loop index.
+
+    Pipeline: sort32 → for i in range(3) { mrgsort(1 << (6+2*i)) } → gather
+    block_len = 1<<6=64, 1<<8=256, 1<<10=1024.
+    """
+
     @pl.function(type=pl.FunctionType.InCore)
-    def gather_mask_kernel(
+    def mrgsort1_dyn_kernel(
         self,
-        src_tensor: pl.Tensor[[8, 32], pl.FP32],
-        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
-    ) -> pl.Tensor[[8, 32], pl.FP32]:
-        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[8, 32]
+        src_tensor: pl.Tensor[[1, 2048], pl.FP32],
+        idx_tensor: pl.Tensor[[1, 2048], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 2048], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
+        src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[1, 2048]
         )
-        gathered: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
-            src_tile, mask_pattern=pl.tile.MaskPattern.P1111
+        idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(
+            idx_tensor, offsets=[0, 0], shapes=[1, 2048]
         )
-        out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
-            gathered, offsets=[0, 0], output_tensor=output
+        # Sort each 32-element block descending → [1, 4096] interleaved (val+idx pairs)
+        sorted_tile: pl.Tile[[1, 4096], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+        # Iterative 4-way merge: block_len = 1<<(6+2*i) = 64, 256, 1024
+        # Only tile in init_values → no scalar iter_args → ptoas compatible
+        for i, (tile_iter,) in pl.range(3, init_values=(sorted_tile,)):
+            block_len = 1 << (6 + i * 2)
+            merged: pl.Tile[[1, 4096], pl.FP32] = pl.tile.mrgsort(tile_iter, block_len=block_len)
+            result = pl.yield_(merged)
+        # Extract sorted values (even positions, FP32)
+        vals: pl.Tile[[1, 2048], pl.FP32] = pl.tile.gather(
+            result, mask_pattern=pl.tile.MaskPattern.P0101
         )
-        return out
+        # Extract indices (odd positions): bit-reinterpret FP32 → UINT32
+        idx: pl.Tile[[1, 2048], pl.UINT32] = pl.tile.gather(
+            result, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
+        )
+        out_val: pl.Tensor[[1, 2048], pl.FP32] = pl.store(
+            vals, offsets=[0, 0], output_tensor=val_output
+        )
+        out_idx: pl.Tensor[[1, 2048], pl.UINT32] = pl.store(
+            idx, offsets=[0, 0], output_tensor=idx_output
+        )
+        return out_val, out_idx
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
+    def orchestrator_dyn(
         self,
-        src_tensor: pl.Tensor[[8, 32], pl.FP32],
-        output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
-    ) -> pl.Tensor[[8, 32], pl.FP32]:
-        output = self.gather_mask_kernel(src_tensor, output)
-        return output
+        src_tensor: pl.Tensor[[1, 2048], pl.FP32],
+        idx_tensor: pl.Tensor[[1, 2048], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 2048], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
+        val_output, idx_output = self.mrgsort1_dyn_kernel(
+            src_tensor, idx_tensor, val_output, idx_output
+        )
+        return val_output, idx_output
 
 
 # --- Test Cases ---
@@ -304,20 +333,13 @@ _IDX_GATHER_IDX = (
     (torch.arange(0, 32, dtype=torch.int32) * 2 + 1).unsqueeze(0) + _ROW_OFFSETS
 ).contiguous()  # [8, 32]
 
-# Pre-compute tensors for single-row mrgsort format2 test.
-# sort32 idx: [0, 1, 2, ..., 31] for 1 row
-_IDX_1x32 = torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 32]
-# Gather indices for extracting values from sort32 [1,64] interleaved output.
-# For rows=1, flat indices = column positions: even positions [0, 2, 4, ..., 62]
-_VAL_GIDX_1x32 = (
-    torch.arange(0, 32, dtype=torch.int32) * 2
-).unsqueeze(0).contiguous()  # [1, 32]
-
 # Pre-compute tensors for mrgsort format1 test (sort32 → mrgsort → gather pipeline).
-# 4 groups × 32 FP32 values: idx per group = [0, 2, 4, ..., 62] (FP32 sort32 stride-2 convention)
-_IDX_1x128 = torch.cat([
-    torch.arange(0, 32, dtype=torch.int32) * 2 for _ in range(4)
-]).unsqueeze(0).contiguous()  # [1, 128]
+# Global indices [0, 1, 2, ..., 127] — sort32 idx is just an index mapping.
+_IDX_1x128 = torch.arange(0, 128, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 128]
+
+# Pre-compute tensors for mrgsort format1 dynamic block_len test (2048 elements).
+# Global indices [0, 1, 2, ..., 2047] — sort32 idx is just an index mapping.
+_IDX_1x2048 = torch.arange(0, 2048, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 2048]
 
 
 class MrgSort1FP32TestCase(PTOTestCase):
@@ -325,7 +347,7 @@ class MrgSort1FP32TestCase(PTOTestCase):
 
     4×32-element FP32 blocks are sorted by sort32, merged by mrgsort format1
     (block_len=64, repeatTimes=1), then split into sorted values and permuted indices.
-    idx_output is UINT32 — index bits are extracted directly via cross-type gather_mask.
+    idx_output is UINT32 holding the global index of each element in sorted order.
     """
 
     def get_name(self) -> str:
@@ -350,22 +372,57 @@ class MrgSort1FP32TestCase(PTOTestCase):
         return MrgSort1FP32Program
 
     def compute_expected(self, tensors, params=None):
-        """Compute expected val and idx outputs.
-
-        val_output: all 128 values sorted descending.
-        idx_output: within-group position × 2 as UINT32, sorted by value.
-            For FP32 sort32: each idx = 2 × (original position within its 32-element group).
-        """
+        """Compute expected val and idx outputs for 128-element sort."""
         src = tensors["src_tensor"].flatten()  # [128]
+        idx = tensors["idx_tensor"].flatten()  # [0, 1, 2, ..., 127]
         _, global_order = torch.sort(src, descending=True)
 
         # Expected sorted values
         tensors["val_output"][:] = src[global_order].unsqueeze(0)
 
-        # Expected idx: within-group position × 2 as UINT32 (int32 in PyTorch, same bits)
-        within_group_pos = global_order % 32
-        expected_idx_u32 = (within_group_pos * 2).to(torch.int32)
-        tensors["idx_output"][:] = expected_idx_u32.unsqueeze(0)
+        # Expected idx: the original index mapping permuted by sort order
+        tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
+
+
+class MrgSort1DynFP32TestCase(PTOTestCase):
+    """Test sort32 → mrgsort format1 with dynamic block_len → gather pipeline.
+
+    64×32-element FP32 blocks sorted by sort32, iteratively merged by mrgsort
+    format1 with block_len quadrupling each iteration (64 → 256 → 1024).
+    """
+
+    def get_name(self) -> str:
+        return "mrgsort1_dyn_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        src = torch.randn(2048).unsqueeze(0).contiguous()  # [1, 2048] random FP32
+        return [
+            TensorSpec("src_tensor", [1, 2048], DataType.FP32, init_value=src),
+            TensorSpec("idx_tensor", [1, 2048], DataType.UINT32, init_value=_IDX_1x2048),
+            TensorSpec("val_output", [1, 2048], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [1, 2048], DataType.UINT32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MrgSort1DynFP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """Compute expected val and idx outputs for 2048-element sort."""
+        src = tensors["src_tensor"].flatten()  # [2048]
+        idx = tensors["idx_tensor"].flatten()  # [0, 1, 2, ..., 2047]
+        _, global_order = torch.sort(src, descending=True)
+
+        # Expected sorted values
+        tensors["val_output"][:] = src[global_order].unsqueeze(0)
+
+        # Expected idx: the original index mapping permuted by sort order
+        tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
 
 
 class Sort32FP32TestCase(PTOTestCase):
@@ -492,35 +549,6 @@ class Sort32GatherMaskFP32TestCase(PTOTestCase):
         tensors["output"][:] = expected
 
 
-class GatherMaskFP32TestCase(PTOTestCase):
-    """Test gather_mask with P1111 pattern on FP32 data.
-
-    P1111 selects all elements, so output should match input exactly.
-    """
-
-    def get_name(self) -> str:
-        return "gather_mask_fp32"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
-            TensorSpec("output", [8, 32], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return GatherMaskFP32Program
-
-    def compute_expected(self, tensors, params=None):
-        """P1111 selects all elements — output equals input."""
-        tensors["output"][:] = tensors["src_tensor"]
-
-
 # --- Tests ---
 
 
@@ -559,15 +587,15 @@ class TestSort:
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_gather_mask_fp32(self, test_runner):
-        """Test gather_mask with P1111 pattern: output should match input."""
-        test_case = GatherMaskFP32TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
-
     def test_mrgsort1_fp32(self, test_runner):
         """Test tmrgsort format1: merge 4 pre-sorted 64-element runs into single sorted list."""
         test_case = MrgSort1FP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_mrgsort1_dyn_fp32(self, test_runner):
+        """Test tmrgsort format1 with dynamic block_len: sort 2048 elements via iterative merge."""
+        test_case = MrgSort1DynFP32TestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -8,13 +8,16 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """
-Test sort32 operation for fixed 32-element block sorting.
+Test sort32 and mrgsort operations for tile-level sorting.
 
 TSORT32 sorts 32-element blocks descending. The result is written to dst as
 interleaved (value, index) pairs:
   - float: dst cols = src cols × 2, layout [val_f32, idx_u32, val_f32, idx_u32, ...]
   - idx is INPUT only — it is NOT modified by the sort.
   - Sorted indices are stored inside dst at odd positions (u32 bits in f32 memory).
+
+TMRGSORT format2 merges 4 pre-sorted lists into a single sorted output:
+  - ins(src0, src1, src2, src3 {exhausted}) outs(dst, tmp, excuted)
 
 To read back indices as integers on the host side, use:
     values, indices = extract_sort32_results(output_f32)
@@ -197,9 +200,63 @@ class Sort32GatherMaskFP32Program:
 
 
 @pl.program
+class MrgSort1FP32Program:
+    """Sort 4×32-element blocks with sort32, then merge with mrgsort format1.
+
+    Pipeline: sort32 → mrgsort(block_len=64) → gather(P0101) val + gather(P1010) idx
+    idx output is FP32 holding UINT32 bit patterns (sort32 convention).
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def mrgsort1_kernel(
+        self,
+        src_tensor: pl.Tensor[[1, 128], pl.FP32],
+        idx_tensor: pl.Tensor[[1, 128], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.FP32]]:
+        src_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[1, 128]
+        )
+        idx_tile: pl.Tile[[1, 128], pl.UINT32] = pl.load(
+            idx_tensor, offsets=[0, 0], shapes=[1, 128]
+        )
+        # Sort each 32-element block descending → [1, 256] interleaved (val+idx pairs)
+        sorted_tile: pl.Tile[[1, 256], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+        # Merge the 4 sorted 64-col runs into one sorted sequence (block_len=64, repeatTimes=1)
+        merged: pl.Tile[[1, 256], pl.FP32] = pl.tile.mrgsort(sorted_tile, block_len=64)
+        # Extract sorted values (even positions) and indices (odd positions, UINT32 bits in f32)
+        vals: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(
+            merged, mask_pattern=pl.tile.MaskPattern.P0101
+        )
+        idx: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(
+            merged, mask_pattern=pl.tile.MaskPattern.P1010
+        )
+        out_val: pl.Tensor[[1, 128], pl.FP32] = pl.store(
+            vals, offsets=[0, 0], output_tensor=val_output
+        )
+        out_idx: pl.Tensor[[1, 128], pl.FP32] = pl.store(
+            idx, offsets=[0, 0], output_tensor=idx_output
+        )
+        return out_val, out_idx
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        src_tensor: pl.Tensor[[1, 128], pl.FP32],
+        idx_tensor: pl.Tensor[[1, 128], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.FP32]]:
+        val_output, idx_output = self.mrgsort1_kernel(
+            src_tensor, idx_tensor, val_output, idx_output
+        )
+        return val_output, idx_output
+
+
+@pl.program
 class GatherMaskFP32Program:
     """Gather elements using a fixed mask pattern (P1111 = all elements)."""
-
     @pl.function(type=pl.FunctionType.InCore)
     def gather_mask_kernel(
         self,
@@ -244,6 +301,69 @@ _VAL_GATHER_IDX = (
 _IDX_GATHER_IDX = (
     (torch.arange(0, 32, dtype=torch.int32) * 2 + 1).unsqueeze(0) + _ROW_OFFSETS
 ).contiguous()  # [8, 32]
+
+# Pre-compute tensors for single-row mrgsort format2 test.
+# sort32 idx: [0, 1, 2, ..., 31] for 1 row
+_IDX_1x32 = torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).contiguous()  # [1, 32]
+# Gather indices for extracting values from sort32 [1,64] interleaved output.
+# For rows=1, flat indices = column positions: even positions [0, 2, 4, ..., 62]
+_VAL_GIDX_1x32 = (
+    torch.arange(0, 32, dtype=torch.int32) * 2
+).unsqueeze(0).contiguous()  # [1, 32]
+
+# Pre-compute tensors for mrgsort format1 test (sort32 → mrgsort → gather pipeline).
+# 4 groups × 32 FP32 values: idx per group = [0, 2, 4, ..., 62] (FP32 sort32 stride-2 convention)
+_IDX_1x128 = torch.cat([
+    torch.arange(0, 32, dtype=torch.int32) * 2 for _ in range(4)
+]).unsqueeze(0).contiguous()  # [1, 128]
+
+
+class MrgSort1FP32TestCase(PTOTestCase):
+    """Test sort32 → mrgsort format1 → gather(P0101/P1010) pipeline.
+
+    4×32-element FP32 blocks are sorted by sort32, merged by mrgsort format1
+    (block_len=64, repeatTimes=1), then split into sorted values and permuted indices.
+    idx_output holds UINT32 bit patterns stored in f32 memory (sort32 convention).
+    """
+
+    def get_name(self) -> str:
+        return "mrgsort1_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        src = torch.randn(128).unsqueeze(0).contiguous()  # [1, 128] random FP32
+        return [
+            TensorSpec("src_tensor", [1, 128], DataType.FP32, init_value=src),
+            TensorSpec("idx_tensor", [1, 128], DataType.UINT32, init_value=_IDX_1x128),
+            TensorSpec("val_output", [1, 128], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [1, 128], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MrgSort1FP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """Compute expected val and idx outputs.
+
+        val_output: all 128 values sorted descending.
+        idx_output: within-group position × 2 (UINT32 bits in f32 memory), sorted by value.
+            For FP32 sort32: each idx = 2 × (original position within its 32-element group).
+        """
+        src = tensors["src_tensor"].flatten()  # [128]
+        _, global_order = torch.sort(src, descending=True)
+
+        # Expected sorted values
+        tensors["val_output"][:] = src[global_order].unsqueeze(0)
+
+        # Expected idx: within-group position × 2, reinterpreted as f32 bits
+        within_group_pos = global_order % 32
+        expected_idx_u32 = (within_group_pos * 2).to(torch.int32).view(torch.float32)
+        tensors["idx_output"][:] = expected_idx_u32.unsqueeze(0)
 
 
 class Sort32FP32TestCase(PTOTestCase):
@@ -403,7 +523,7 @@ class GatherMaskFP32TestCase(PTOTestCase):
 
 
 class TestSort:
-    """Test suite for sort32 operations."""
+    """Test suite for sort32 and mrgsort operations."""
 
     def test_sort32_fp32(self, test_runner):
         """Test sort32 with FP32 data: verify descending sort with index tracking.
@@ -440,6 +560,12 @@ class TestSort:
     def test_gather_mask_fp32(self, test_runner):
         """Test gather_mask with P1111 pattern: output should match input."""
         test_case = GatherMaskFP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_mrgsort1_fp32(self, test_runner):
+        """Test tmrgsort format1: merge 4 pre-sorted 64-element runs into single sorted list."""
+        test_case = MrgSort1FP32TestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -65,16 +65,10 @@ class Sort32FP32Program:
         idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
         output: pl.Out[pl.Tensor[[8, 64], pl.FP32]],
     ) -> pl.Tensor[[8, 64], pl.FP32]:
-        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
-        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
-            idx_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_tensor, offsets=[0, 0], shapes=[8, 32])
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(idx_tensor, offsets=[0, 0], shapes=[8, 32])
         sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
-        out: pl.Tensor[[8, 64], pl.FP32] = pl.store(
-            sorted_tile, offsets=[0, 0], output_tensor=output
-        )
+        out: pl.Tensor[[8, 64], pl.FP32] = pl.store(sorted_tile, offsets=[0, 0], output_tensor=output)
         return out
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -103,36 +97,20 @@ class Sort32GatherFP32Program:
         val_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
         idx_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
     ) -> tuple[pl.Tensor[[8, 32], pl.FP32], pl.Tensor[[8, 32], pl.FP32]]:
-        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
-        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
-            idx_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_tensor, offsets=[0, 0], shapes=[8, 32])
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(idx_tensor, offsets=[0, 0], shapes=[8, 32])
         sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
 
-        val_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(
-            val_gather_idx, offsets=[0, 0], shapes=[8, 32]
-        )
-        idx_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(
-            idx_gather_idx, offsets=[0, 0], shapes=[8, 32]
-        )
-        tmp_tile: pl.Tile[[8, 32], pl.INT32] = pl.load(
-            gather_tmp, offsets=[0, 0], shapes=[8, 32]
-        )
+        val_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(val_gather_idx, offsets=[0, 0], shapes=[8, 32])
+        idx_gidx: pl.Tile[[8, 32], pl.INT32] = pl.load(idx_gather_idx, offsets=[0, 0], shapes=[8, 32])
+        tmp_tile: pl.Tile[[8, 32], pl.INT32] = pl.load(gather_tmp, offsets=[0, 0], shapes=[8, 32])
 
-        val_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
-            sorted_tile, val_gidx, tmp_tile
-        )
+        val_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(sorted_tile, val_gidx, tmp_tile)
         # Index bits are stored as raw uint32 in f32 memory by sort32.
         # Keep as FP32 — host will .view(torch.int32) to reinterpret bits.
-        idx_tile_fp32: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
-            sorted_tile, idx_gidx, tmp_tile
-        )
+        idx_tile_fp32: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(sorted_tile, idx_gidx, tmp_tile)
 
-        val_out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
-            val_tile, offsets=[0, 0], output_tensor=val_output
-        )
+        val_out: pl.Tensor[[8, 32], pl.FP32] = pl.store(val_tile, offsets=[0, 0], output_tensor=val_output)
         idx_out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
             idx_tile_fp32, offsets=[0, 0], output_tensor=idx_output
         )
@@ -150,8 +128,7 @@ class Sort32GatherFP32Program:
         idx_output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
     ) -> tuple[pl.Tensor[[8, 32], pl.FP32], pl.Tensor[[8, 32], pl.FP32]]:
         val_output, idx_output = self.sort32_gather_kernel(
-            src_tensor, idx_tensor, val_gather_idx, idx_gather_idx,
-            gather_tmp, val_output, idx_output
+            src_tensor, idx_tensor, val_gather_idx, idx_gather_idx, gather_tmp, val_output, idx_output
         )
         return val_output, idx_output
 
@@ -167,12 +144,8 @@ class Sort32GatherMaskFP32Program:
         idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
         output: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
     ) -> pl.Tensor[[8, 32], pl.FP32]:
-        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
-        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
-            idx_tensor, offsets=[0, 0], shapes=[8, 32]
-        )
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_tensor, offsets=[0, 0], shapes=[8, 32])
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(idx_tensor, offsets=[0, 0], shapes=[8, 32])
         sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
         # P0101 selects every other element (stride=2): columns 0,2,4,...
         # sort32 layout is [val0, idx0, val1, idx1, ...], so P0101 extracts values.
@@ -180,9 +153,7 @@ class Sort32GatherMaskFP32Program:
         gathered: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(
             sorted_tile, mask_pattern=pl.tile.MaskPattern.P0101
         )
-        out: pl.Tensor[[8, 32], pl.FP32] = pl.store(
-            gathered, offsets=[0, 0], output_tensor=output
-        )
+        out: pl.Tensor[[8, 32], pl.FP32] = pl.store(gathered, offsets=[0, 0], output_tensor=output)
         return out
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -194,7 +165,6 @@ class Sort32GatherMaskFP32Program:
     ) -> pl.Tensor[[8, 32], pl.FP32]:
         output = self.sort32_gather_mask_kernel(src_tensor, idx_tensor, output)
         return output
-
 
 
 @pl.program
@@ -213,31 +183,21 @@ class MrgSort1FP32Program:
         val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
         idx_output: pl.Out[pl.Tensor[[1, 128], pl.UINT32]],
     ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.UINT32]]:
-        src_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[1, 128]
-        )
-        idx_tile: pl.Tile[[1, 128], pl.UINT32] = pl.load(
-            idx_tensor, offsets=[0, 0], shapes=[1, 128]
-        )
+        src_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(src_tensor, offsets=[0, 0], shapes=[1, 128])
+        idx_tile: pl.Tile[[1, 128], pl.UINT32] = pl.load(idx_tensor, offsets=[0, 0], shapes=[1, 128])
         # Sort each 32-element block descending → [1, 256] interleaved (val+idx pairs)
         sorted_tile: pl.Tile[[1, 256], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
         # Merge the 4 sorted 64-col runs into one sorted sequence (block_len=64, repeatTimes=1)
         merged: pl.Tile[[1, 256], pl.FP32] = pl.tile.mrgsort(sorted_tile, block_len=64)
         # Extract sorted values (even positions, FP32)
-        vals: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(
-            merged, mask_pattern=pl.tile.MaskPattern.P0101
-        )
+        vals: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(merged, mask_pattern=pl.tile.MaskPattern.P0101)
         # Extract indices (odd positions): bit-reinterpret FP32 → UINT32 in one step.
         # Hardware TGATHER mask form requires sizeof(dst) == sizeof(src), not same type.
         idx: pl.Tile[[1, 128], pl.UINT32] = pl.tile.gather(
             merged, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
         )
-        out_val: pl.Tensor[[1, 128], pl.FP32] = pl.store(
-            vals, offsets=[0, 0], output_tensor=val_output
-        )
-        out_idx: pl.Tensor[[1, 128], pl.UINT32] = pl.store(
-            idx, offsets=[0, 0], output_tensor=idx_output
-        )
+        out_val: pl.Tensor[[1, 128], pl.FP32] = pl.store(vals, offsets=[0, 0], output_tensor=val_output)
+        out_idx: pl.Tensor[[1, 128], pl.UINT32] = pl.store(idx, offsets=[0, 0], output_tensor=idx_output)
         return out_val, out_idx
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -248,9 +208,7 @@ class MrgSort1FP32Program:
         val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
         idx_output: pl.Out[pl.Tensor[[1, 128], pl.UINT32]],
     ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.UINT32]]:
-        val_output, idx_output = self.mrgsort1_kernel(
-            src_tensor, idx_tensor, val_output, idx_output
-        )
+        val_output, idx_output = self.mrgsort1_kernel(src_tensor, idx_tensor, val_output, idx_output)
         return val_output, idx_output
 
 
@@ -271,12 +229,8 @@ class MrgSort1DynFP32Program:
         val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
         idx_output: pl.Out[pl.Tensor[[1, 2048], pl.UINT32]],
     ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
-        src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(
-            src_tensor, offsets=[0, 0], shapes=[1, 2048]
-        )
-        idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(
-            idx_tensor, offsets=[0, 0], shapes=[1, 2048]
-        )
+        src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(src_tensor, offsets=[0, 0], shapes=[1, 2048])
+        idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(idx_tensor, offsets=[0, 0], shapes=[1, 2048])
         # Sort each 32-element block descending → [1, 4096] interleaved (val+idx pairs)
         sorted_tile: pl.Tile[[1, 4096], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
         # Iterative 4-way merge: block_len = 1<<(6+2*i) = 64, 256, 1024
@@ -286,19 +240,13 @@ class MrgSort1DynFP32Program:
             merged: pl.Tile[[1, 4096], pl.FP32] = pl.tile.mrgsort(tile_iter, block_len=block_len)
             result = pl.yield_(merged)
         # Extract sorted values (even positions, FP32)
-        vals: pl.Tile[[1, 2048], pl.FP32] = pl.tile.gather(
-            result, mask_pattern=pl.tile.MaskPattern.P0101
-        )
+        vals: pl.Tile[[1, 2048], pl.FP32] = pl.tile.gather(result, mask_pattern=pl.tile.MaskPattern.P0101)
         # Extract indices (odd positions): bit-reinterpret FP32 → UINT32
         idx: pl.Tile[[1, 2048], pl.UINT32] = pl.tile.gather(
             result, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
         )
-        out_val: pl.Tensor[[1, 2048], pl.FP32] = pl.store(
-            vals, offsets=[0, 0], output_tensor=val_output
-        )
-        out_idx: pl.Tensor[[1, 2048], pl.UINT32] = pl.store(
-            idx, offsets=[0, 0], output_tensor=idx_output
-        )
+        out_val: pl.Tensor[[1, 2048], pl.FP32] = pl.store(vals, offsets=[0, 0], output_tensor=val_output)
+        out_idx: pl.Tensor[[1, 2048], pl.UINT32] = pl.store(idx, offsets=[0, 0], output_tensor=idx_output)
         return out_val, out_idx
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -309,9 +257,7 @@ class MrgSort1DynFP32Program:
         val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
         idx_output: pl.Out[pl.Tensor[[1, 2048], pl.UINT32]],
     ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
-        val_output, idx_output = self.mrgsort1_dyn_kernel(
-            src_tensor, idx_tensor, val_output, idx_output
-        )
+        val_output, idx_output = self.mrgsort1_dyn_kernel(src_tensor, idx_tensor, val_output, idx_output)
         return val_output, idx_output
 
 

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -1,0 +1,153 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Test sort32 operation for fixed 32-element block sorting.
+
+TSORT32 sorts 32-element blocks descending. The result is written to dst as
+interleaved (value, index) pairs:
+  - float: dst cols = src cols × 2, layout [val_f32, idx_u32, val_f32, idx_u32, ...]
+  - idx is INPUT only — it is NOT modified by the sort.
+  - Sorted indices are stored inside dst at odd positions (u32 bits in f32 memory).
+
+To read back indices as integers on the host side, use:
+    values, indices = extract_sort32_results(output_f32)
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+
+def extract_sort32_results(output_f32: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Extract values and indices from interleaved sort32 output.
+
+    The hardware stores (value_f32, index_u32) pairs interleaved in f32 memory.
+    This function splits them and reinterprets index bits as int32.
+
+    Args:
+        output_f32: [rows, cols*2] f32 tensor with interleaved (value, index) pairs
+
+    Returns:
+        values:  [rows, cols] f32  — sorted values (descending)
+        indices: [rows, cols] int32 — original positions of sorted elements
+    """
+    values = output_f32[:, 0::2]
+    indices = output_f32.view(torch.int32)[:, 1::2]
+    return values, indices
+
+
+# --- Programs ---
+
+
+@pl.program
+class Sort32FP32Program:
+    """Sort 32-element blocks of FP32 data."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def sort32_kernel(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        output: pl.Out[pl.Tensor[[8, 64], pl.FP32]],
+    ) -> pl.Tensor[[8, 64], pl.FP32]:
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(
+            src_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(
+            idx_tensor, offsets=[0, 0], shapes=[8, 32]
+        )
+        sorted_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+        out: pl.Tensor[[8, 64], pl.FP32] = pl.store(
+            sorted_tile, offsets=[0, 0], output_tensor=output
+        )
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        src_tensor: pl.Tensor[[8, 32], pl.FP32],
+        idx_tensor: pl.Tensor[[8, 32], pl.UINT32],
+        output: pl.Out[pl.Tensor[[8, 64], pl.FP32]],
+    ) -> pl.Tensor[[8, 64], pl.FP32]:
+        output = self.sort32_kernel(src_tensor, idx_tensor, output)
+        return output
+
+
+# --- Test Cases ---
+
+
+# Pre-compute idx tensor: [0, 1, 2, ..., 31] per row (logical indices)
+_IDX_TENSOR_FP32 = torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).expand(8, -1).contiguous()
+
+
+class Sort32FP32TestCase(PTOTestCase):
+    """Test sort32 with FP32 data and PTO backend.
+
+    dst layout for float: [val_f32, idx_u32_as_f32, val_f32, idx_u32_as_f32, ...]
+    Sorted values at even positions, permuted indices (u32 bits) at odd positions.
+    """
+
+    def get_name(self) -> str:
+        return "sort32_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_IDX_TENSOR_FP32),
+            TensorSpec("output", [8, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return Sort32FP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: descending sort, interleaved [val, idx_as_f32, ...] layout."""
+        src = tensors["src_tensor"]  # [8, 32]
+        expected = torch.zeros(8, 64, dtype=torch.float32)
+        for row in range(8):
+            sorted_vals, sorted_indices = torch.sort(src[row], descending=True)
+            idx_as_f32 = sorted_indices.int().view(torch.float32)
+            expected[row, 0::2] = sorted_vals
+            expected[row, 1::2] = idx_as_f32
+        tensors["output"][:] = expected
+
+
+# --- Tests ---
+
+
+class TestSort:
+    """Test suite for sort32 operations."""
+
+    def test_sort32_fp32(self, test_runner):
+        """Test sort32 with FP32 data: verify descending sort with index tracking.
+
+        To manually inspect sorted indices from the interleaved output:
+            values, indices = extract_sort32_results(output_f32)
+            # values:  [8, 32] f32  — sorted descending
+            # indices: [8, 32] int32 — original positions
+        """
+        test_case = Sort32FP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -17,7 +17,7 @@ interleaved (value, index) pairs:
   - Sorted indices are stored inside dst at odd positions (u32 bits in f32 memory).
 
 TMRGSORT format2 merges 4 pre-sorted lists into a single sorted output:
-  - ins(src0, src1, src2, src3 {exhausted}) outs(dst, tmp, excuted)
+  - ins(src0, src1, src2, src3 {exhausted}) outs(dst, tmp, executed)
 
 To read back indices as integers on the host side, use:
     values, indices = extract_sort32_results(output_f32)

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -203,8 +203,8 @@ class Sort32GatherMaskFP32Program:
 class MrgSort1FP32Program:
     """Sort 4×32-element blocks with sort32, then merge with mrgsort format1.
 
-    Pipeline: sort32 → mrgsort(block_len=64) → gather(P0101) val + gather(P1010) idx
-    idx output is FP32 holding UINT32 bit patterns (sort32 convention).
+    Pipeline: sort32 → mrgsort(block_len=64) → gather(P0101) val + gather(P1010, UINT32) idx
+    idx output is UINT32 holding the actual sorted index values.
     """
 
     @pl.function(type=pl.FunctionType.InCore)
@@ -213,8 +213,8 @@ class MrgSort1FP32Program:
         src_tensor: pl.Tensor[[1, 128], pl.FP32],
         idx_tensor: pl.Tensor[[1, 128], pl.UINT32],
         val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
-        idx_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
-    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.FP32]]:
+        idx_output: pl.Out[pl.Tensor[[1, 128], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.UINT32]]:
         src_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(
             src_tensor, offsets=[0, 0], shapes=[1, 128]
         )
@@ -225,17 +225,19 @@ class MrgSort1FP32Program:
         sorted_tile: pl.Tile[[1, 256], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
         # Merge the 4 sorted 64-col runs into one sorted sequence (block_len=64, repeatTimes=1)
         merged: pl.Tile[[1, 256], pl.FP32] = pl.tile.mrgsort(sorted_tile, block_len=64)
-        # Extract sorted values (even positions) and indices (odd positions, UINT32 bits in f32)
+        # Extract sorted values (even positions, FP32)
         vals: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(
             merged, mask_pattern=pl.tile.MaskPattern.P0101
         )
-        idx: pl.Tile[[1, 128], pl.FP32] = pl.tile.gather(
-            merged, mask_pattern=pl.tile.MaskPattern.P1010
+        # Extract indices (odd positions): bit-reinterpret FP32 → UINT32 in one step.
+        # Hardware TGATHER mask form requires sizeof(dst) == sizeof(src), not same type.
+        idx: pl.Tile[[1, 128], pl.UINT32] = pl.tile.gather(
+            merged, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
         )
         out_val: pl.Tensor[[1, 128], pl.FP32] = pl.store(
             vals, offsets=[0, 0], output_tensor=val_output
         )
-        out_idx: pl.Tensor[[1, 128], pl.FP32] = pl.store(
+        out_idx: pl.Tensor[[1, 128], pl.UINT32] = pl.store(
             idx, offsets=[0, 0], output_tensor=idx_output
         )
         return out_val, out_idx
@@ -246,8 +248,8 @@ class MrgSort1FP32Program:
         src_tensor: pl.Tensor[[1, 128], pl.FP32],
         idx_tensor: pl.Tensor[[1, 128], pl.UINT32],
         val_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
-        idx_output: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
-    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.FP32]]:
+        idx_output: pl.Out[pl.Tensor[[1, 128], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 128], pl.FP32], pl.Tensor[[1, 128], pl.UINT32]]:
         val_output, idx_output = self.mrgsort1_kernel(
             src_tensor, idx_tensor, val_output, idx_output
         )
@@ -323,7 +325,7 @@ class MrgSort1FP32TestCase(PTOTestCase):
 
     4×32-element FP32 blocks are sorted by sort32, merged by mrgsort format1
     (block_len=64, repeatTimes=1), then split into sorted values and permuted indices.
-    idx_output holds UINT32 bit patterns stored in f32 memory (sort32 convention).
+    idx_output is UINT32 — index bits are extracted directly via cross-type gather_mask.
     """
 
     def get_name(self) -> str:
@@ -341,7 +343,7 @@ class MrgSort1FP32TestCase(PTOTestCase):
             TensorSpec("src_tensor", [1, 128], DataType.FP32, init_value=src),
             TensorSpec("idx_tensor", [1, 128], DataType.UINT32, init_value=_IDX_1x128),
             TensorSpec("val_output", [1, 128], DataType.FP32, is_output=True),
-            TensorSpec("idx_output", [1, 128], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [1, 128], DataType.UINT32, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -351,7 +353,7 @@ class MrgSort1FP32TestCase(PTOTestCase):
         """Compute expected val and idx outputs.
 
         val_output: all 128 values sorted descending.
-        idx_output: within-group position × 2 (UINT32 bits in f32 memory), sorted by value.
+        idx_output: within-group position × 2 as UINT32, sorted by value.
             For FP32 sort32: each idx = 2 × (original position within its 32-element group).
         """
         src = tensors["src_tensor"].flatten()  # [128]
@@ -360,9 +362,9 @@ class MrgSort1FP32TestCase(PTOTestCase):
         # Expected sorted values
         tensors["val_output"][:] = src[global_order].unsqueeze(0)
 
-        # Expected idx: within-group position × 2, reinterpreted as f32 bits
+        # Expected idx: within-group position × 2 as UINT32 (int32 in PyTorch, same bits)
         within_group_pos = global_order % 32
-        expected_idx_u32 = (within_group_pos * 2).to(torch.int32).view(torch.float32)
+        expected_idx_u32 = (within_group_pos * 2).to(torch.int32)
         tensors["idx_output"][:] = expected_idx_u32.unsqueeze(0)
 
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -779,5 +779,78 @@ class TestTileSliceCodegen:
             )
 
 
+class TestMrgSortCodegen:
+    """Tests for mrgsort format1 code generation with constant and variable block_len."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_mrgsort_format1_const_block_len(self):
+        """mrgsort with constant block_len=64 should generate pto.tmrgsort with i32 operand."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[1, 256], pl.FP32],
+                idx: pl.Tensor[[1, 256], pl.UINT32],
+            ) -> pl.Tensor[[1, 256], pl.FP32]:
+                src_tile: pl.Tile[[1, 256], pl.FP32] = pl.load(src, [0, 0], [1, 256])
+                idx_tile: pl.Tile[[1, 256], pl.UINT32] = pl.load(idx, [0, 0], [1, 256])
+                sorted_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+                merged: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(sorted_tile, block_len=64)
+                vals: pl.Tile[[1, 256], pl.FP32] = pl.tile.gather(
+                    merged, mask_pattern=pl.tile.MaskPattern.P0101
+                )
+                return pl.store(vals, [0, 0], src)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tmrgsort" in mlir, f"Expected pto.tmrgsort in codegen output:\n{mlir}"
+        # Constant block_len should appear as an i32 constant
+        tmrgsort_lines = [line for line in mlir.splitlines() if "pto.tmrgsort" in line]
+        assert tmrgsort_lines, "No pto.tmrgsort line found"
+        assert "i32" in tmrgsort_lines[0], f"block_len type annotation should be i32: {tmrgsort_lines[0]}"
+
+    def test_mrgsort_format1_variable_block_len(self):
+        """mrgsort with variable block_len (function parameter) should generate pto.tmrgsort."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[1, 256], pl.FP32],
+                idx: pl.Tensor[[1, 256], pl.UINT32],
+                block_len: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[1, 256], pl.FP32]:
+                src_tile: pl.Tile[[1, 256], pl.FP32] = pl.load(src, [0, 0], [1, 256])
+                idx_tile: pl.Tile[[1, 256], pl.UINT32] = pl.load(idx, [0, 0], [1, 256])
+                sorted_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+                merged: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
+                    sorted_tile, block_len=block_len
+                )
+                vals: pl.Tile[[1, 256], pl.FP32] = pl.tile.gather(
+                    merged, mask_pattern=pl.tile.MaskPattern.P0101
+                )
+                return pl.store(vals, [0, 0], src)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tmrgsort" in mlir, f"Expected pto.tmrgsort in codegen output:\n{mlir}"
+        tmrgsort_lines = [line for line in mlir.splitlines() if "pto.tmrgsort" in line]
+        assert tmrgsort_lines, "No pto.tmrgsort line found"
+        assert "i32" in tmrgsort_lines[0], f"block_len type annotation should be i32: {tmrgsort_lines[0]}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -837,9 +837,7 @@ class TestMrgSortCodegen:
                 src_tile: pl.Tile[[1, 256], pl.FP32] = pl.load(src, [0, 0], [1, 256])
                 idx_tile: pl.Tile[[1, 256], pl.UINT32] = pl.load(idx, [0, 0], [1, 256])
                 sorted_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
-                merged: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
-                    sorted_tile, block_len=block_len
-                )
+                merged: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(sorted_tile, block_len=block_len)
                 vals: pl.Tile[[1, 256], pl.FP32] = pl.tile.gather(
                     merged, mask_pattern=pl.tile.MaskPattern.P0101
                 )


### PR DESCRIPTION
## Summary
- Add `tile.sort32` operator for fixed 32-element block sorting with interleaved (value, index) output
- Add `tile.gather` and `tile.gather_mask` operators for index-based element selection, with `output_dtype` support for bit reinterpretation
- Add `tile.mrgsort` operator for 4-way merge sorting across sorted blocks
- Support runtime `block_len` in `tile.mrgsort` via bit-shift DSL ops for dynamic block size computation
- Full cross-layer implementation: C++ ops, Python IR, Python DSL, codegen, and runtime tests

## Changes
- **C++ ops**: `src/ir/op/tile_ops/sort.cpp`, `src/ir/op/tile_ops/gather.cpp` — op definitions with shape inference and validation
- **Codegen**: `src/backend/common/pto_ops_common.cpp`, `src/codegen/pto/pto_scalar_expr_codegen.cpp` — PTO code generation for all new ops including bit-shift scalar expressions
- **Python IR/DSL**: `python/pypto/ir/op/tile_ops.py`, `python/pypto/language/op/tile_ops.py` — IR builders and DSL wrappers
- **Tests**: `tests/st/runtime/test_sort.py` — end-to-end runtime tests for sort32, gather, gather_mask, mrgsort (static and dynamic block_len)
- **Tests**: `tests/ut/codegen/test_pto_codegen_ops.py` — codegen unit tests for all new ops

## Testing
- [ ] Unit tests for codegen output verification
- [ ] Runtime system tests covering sort32, sort32+gather, sort32+gather_mask, mrgsort (format1), mrgsort (dynamic block_len)