### PR TITLE
feat(ir): support cross-core transfer view on Ascend910B

### DIFF
--- a/docs/en/dev/passes/11-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/11-expand_mixed_kernel.md
@@ -26,7 +26,9 @@ Cross-core data transfer at CV boundaries is handled by splitting explicit `tile
 | Cube→Vector (e.g. Acc→Vec) | `tpush_to_aiv(source_tile)` | `dest_var = tpop_from_aic()` |
 | Vector→Cube (e.g. Vec→Mat/Left/Right) | `dest_var = tpop_from_aiv()` | `tile.move` to adapt fractal layout, then `tpush_to_aic(adapted_tile)` |
 
-**Fractal TileView layout (Ascend950)**: On Ascend950 backend, cross-core transfer tiles are assigned a fractal TileView based on the destination memory space:
+**Fractal TileView layout**: Cross-core transfer tile views are computed by `BuildCrossCoreTransferView` based on the destination memory space. The mapping differs between backends:
+
+Ascend950 (a5) — hardware cross-core pipe carries data in fractal layout:
 
 | Direction | Push/Pop TileView (blayout, slayout) | Name |
 | --------- | ------------------------------------ | ---- |
@@ -35,7 +37,16 @@ Cross-core data transfer at CV boundaries is handled by splitting explicit `tile
 | Vec→Mat | must be explicitly set in move | — |
 | Mat/Acc→Vec | must be explicitly set in move | — |
 
-This is implemented by `BuildCrossCoreTransferView`, which assigns the layout to both `tpop` result types and pre-tpush `tile.move` ops. On the AIV push side (V→C), a `tile.move` is inserted before `tpush_to_aic` to convert the source tile into the required fractal layout (NZ or ZN). The `tile.move` helper (`CreateMove`) propagates `blayout`/`slayout` kwargs when the result type carries a TileView.
+Ascend910B (a2a3) — cross-core transfer goes through GM → Mat, and Mat only supports the NZ layout. Both Left and Right destinations use NZ at the transfer boundary; the final Left/Right layout is resolved by the subsequent `Mat → Left/Right` `tile.move` (MTE1):
+
+| Direction | Push/Pop TileView (blayout, slayout) | Name |
+| --------- | ------------------------------------ | ---- |
+| Vec→Left | col_major, row_major | NZ |
+| Vec→Right | col_major, row_major | NZ |
+| Vec→Mat | preserve original | — |
+| Mat/Acc→Vec | preserve original | — |
+
+On both backends, the AIV push side (V→C) inserts a `tile.move` before `tpush_to_aic` to convert the source tile into the required fractal layout. The `tile.move` helper (`CreateMove`) propagates `blayout`/`slayout` kwargs when the result type carries a TileView.
 
 When split kernels contain cross-core `tpush`/`tpop`, the pass also prepends the required frontend pipe setup automatically:
 
@@ -68,7 +79,7 @@ For consumer-side cross-core tiles, the pass also normalizes statement order to 
 - Input IR must have InCore scopes outlined (run `OutlineIncoreScopes` first)
 - Tile ops must be flattened to 2D (run `FlattenTileNdTo2D` first)
 - Tile memory space must be inferred (run `InferTileMemorySpace` first)
-- Fractal TileView assignment requires Ascend950 backend (`backend::GetBackendType() == Ascend950`)
+- Cross-core fractal TileView assignment is supported on Ascend950 and Ascend910B backends
 
 **When to use**: Run after `InferTileMemorySpace` when InCore functions may contain both Cube and Vector tile operations.
 
@@ -107,7 +118,9 @@ Phase 2 — Expand each InCore function F:
      - For BOUNDARY (Cube→Vector): emit dest_var = tpop_from_aic() with fractal TileView
      - For BOUNDARY (Vector→Cube): emit tile.move to adapt fractal layout, then tpush_to_aic(adapted_tile)
   5a. Assign fractal TileView to all boundary tpop result types and pre-tpush tile.move ops
-      via BuildCrossCoreTransferView (Ascend950 only: Left→NZ, Right→ZN, Mat/Vec→preserve)
+      via BuildCrossCoreTransferView:
+      - Ascend950: Left→NZ, Right→ZN, Mat/Vec→preserve
+      - Ascend910B: Left→NZ, Right→NZ (Mat only supports NZ), Mat/Vec→preserve
   6. Repair loop-carried state on both bodies
      - Strip dead iter_args whose carried values are unused on this side
      - Pull back missing init-value definitions for surviving iter_args

--- a/docs/zh-cn/dev/passes/11-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/11-expand_mixed_kernel.md
@@ -26,7 +26,9 @@ CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tp
 | Cube→Vector（如 Acc→Vec） | `tpush_to_aiv(source_tile)` | `dest_var = tpop_from_aic()` |
 | Vector→Cube（如 Vec→Mat/Left/Right） | `dest_var = tpop_from_aiv()` | `tile.move` 适配 fractal 布局，然后 `tpush_to_aic(adapted_tile)` |
 
-**Fractal TileView 布局（Ascend950）**：在 Ascend950 后端上，跨核传输 tile 会根据目标内存空间分配 fractal TileView：
+**Fractal TileView 布局**：跨核传输 tile 的 TileView 由 `BuildCrossCoreTransferView` 根据目标内存空间计算，不同后端的映射不同：
+
+Ascend950（a5）——硬件跨核 pipe 直接按 fractal 布局传输数据：
 
 | 方向 | Push/Pop TileView (blayout, slayout) | 名称 |
 | ---- | ------------------------------------ | ---- |
@@ -35,7 +37,16 @@ CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tp
 | Vec->Mat | 需要显式在move中设置，否则同src | — |
 | Mat/Acc->Vec | 需要显式在move中设置，否则同src | — |
 
-此功能由 `BuildCrossCoreTransferView` 实现，它为 `tpop` 结果类型和 tpush 前的 `tile.move` 操作分配布局。在 AIV 推送侧（V→C），会在 `tpush_to_aic` 前插入一个 `tile.move` 将源 tile 转换为所需的 fractal 布局（NZ 或 ZN）。`tile.move` 辅助函数（`CreateMove`）在结果类型携带 TileView 时会传播 `blayout`/`slayout` kwargs。
+Ascend910B（a2a3）——跨核传输经过 GM → Mat，Mat 仅支持 NZ 布局。因此 Left 和 Right 目标在传输边界统一使用 NZ，最终的 Left/Right 布局由后续 `Mat → Left/Right` `tile.move`（MTE1）处理：
+
+| 方向 | Push/Pop TileView (blayout, slayout) | 名称 |
+| ---- | ------------------------------------ | ---- |
+| Vec->Left | col_major, row_major | NZ |
+| Vec->Right | col_major, row_major | NZ |
+| Vec->Mat | 保持原始布局 | — |
+| Mat/Acc->Vec | 保持原始布局 | — |
+
+在两种后端上，AIV 推送侧（V→C）都会在 `tpush_to_aic` 前插入一个 `tile.move` 将源 tile 转换为所需的 fractal 布局。`tile.move` 辅助函数（`CreateMove`）在结果类型携带 TileView 时会传播 `blayout`/`slayout` kwargs。
 
 当拆分后的内核包含跨核 `tpush`/`tpop` 时，该 Pass 还会自动在函数前缀补齐前端 pipe setup：
 
@@ -68,7 +79,7 @@ CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tp
 - 输入 IR 必须已提取 InCore 作用域（需先运行 `OutlineIncoreScopes`）
 - Tile 操作必须已展平为 2D（需先运行 `FlattenTileNdTo2D`）
 - Tile 内存空间必须已推断（需先运行 `InferTileMemorySpace`）
-- Fractal TileView 分配需要 Ascend950 后端（`backend::GetBackendType() == Ascend950`）
+- 跨核 Fractal TileView 分配在 Ascend950 和 Ascend910B 后端均受支持
 
 **使用时机**：在 `InferTileMemorySpace` 之后运行，当 InCore 函数可能同时包含 Cube 和 Vector tile 操作时使用。
 
@@ -106,8 +117,9 @@ program_expanded = expand_pass(program)
   5. 构建 AIV 函数体：对称（保留 VECTOR + SHARED，删除 CUBE）
      - 对于 BOUNDARY（Cube→Vector）：生成 dest_var = tpop_from_aic()，携带 fractal TileView
      - 对于 BOUNDARY（Vector→Cube）：生成 tile.move 适配 fractal 布局，然后 tpush_to_aic(adapted_tile)
-  5a. 通过 BuildCrossCoreTransferView 为所有边界 tpop 结果类型和 tpush 前的 tile.move 操作
-      分配 fractal TileView（仅 Ascend950：Left→NZ，Right→ZN，Mat/Vec→保持原始）
+  5a. 通过 BuildCrossCoreTransferView 为所有边界 tpop 结果类型和 tpush 前的 tile.move 操作分配 fractal TileView：
+      - Ascend950：Left→NZ，Right→ZN，Mat/Vec→保持原始
+      - Ascend910B：Left→NZ，Right→NZ（Mat 仅支持 NZ），Mat/Vec→保持原始
   6. 修复两侧函数体中的循环携带状态
      - 删除在当前核心侧无用的 dead iter_args
      - 为保留下来的 iter_args 补回缺失的 init value 定义

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -277,12 +277,48 @@ std::string BuildBoundaryTpopName(CoreSide side, const std::string& dest_name) {
 
 /// Determine the fractal TileView for cross-core data transfer based on the
 /// boundary move destination memory space.
-/// Non-transpose 950: Left -> NZ, Right -> ZN, Mat/Vec -> preserve original.
+///
+/// Ascend950 (a5): hardware cross-core pipe carries data in fractal layout.
+///   Left -> NZ (col_major blayout, row_major slayout)
+///   Right -> ZN (row_major blayout, col_major slayout)
+///   Mat/Vec -> preserve original (already-final layout)
+///
+/// Ascend910B (a2a3): cross-core transfer goes through GM -> Mat, and Mat only
+/// supports NZ (col_major blayout, row_major slayout). All GM -> L1 transfers
+/// (Left, Right, Mat) use NZ; Vec preserves the original view.
+///   Left -> NZ (col_major blayout, row_major slayout)
+///   Right -> NZ (col_major blayout, row_major slayout)
+///   Mat -> NZ (col_major blayout, row_major slayout)
+///   Vec -> preserve original
 TileView BuildCrossCoreTransferView(MemorySpace dest_ms, const TileView& original_view) {
-  INTERNAL_CHECK(backend::GetBackendType() == backend::BackendType::Ascend950)
-      << "BuildCrossCoreTransferView is only supported on Ascend950 backend";
+  auto backend_type = backend::GetBackendType();
+  INTERNAL_CHECK(backend_type == backend::BackendType::Ascend950 ||
+                 backend_type == backend::BackendType::Ascend910B)
+      << "BuildCrossCoreTransferView only supports Ascend950 and Ascend910B backends";
 
   TileView result = original_view;
+
+  // Ascend910B: all GM -> Mat transfers must be in NZ layout (hardware
+  // constraint), so Left/Right/Mat destinations all use NZ at the transfer
+  // boundary. The final Left/Right layout is resolved by a subsequent
+  // Mat -> Left/Right move (MTE1).
+  if (backend_type == backend::BackendType::Ascend910B) {
+    switch (dest_ms) {
+      case MemorySpace::Left:
+      case MemorySpace::Right:
+      case MemorySpace::Mat:
+        result.blayout = TileLayout::col_major;
+        result.slayout = TileLayout::row_major;
+        return result;
+      case MemorySpace::Vec:
+        return original_view;
+      default:
+        INTERNAL_UNREACHABLE << "cross-core move destination must be Vec, Mat, Left, or Right, got "
+                             << static_cast<int>(dest_ms);
+    }
+  }
+
+  // Ascend950: encode the fractal layout directly at the transfer boundary.
   switch (dest_ms) {
     case MemorySpace::Left:
       result.blayout = TileLayout::col_major;
@@ -339,7 +375,10 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
         const auto& bm = bm_it->second;
         if (bm.direction == push_direction) {
           ExprPtr push_source = bm.source_tile;
-          // AIV V->C push: insert tile.move (tmov) to adapt fractal layout before tpush
+          // AIV V->C push: insert tile.move (tmov) to adapt the source into
+          // the required fractal layout before tpush.
+          // On Ascend950: Left -> NZ, Right -> ZN.
+          // On Ascend910B: both Left and Right -> NZ (Mat only supports NZ).
           if (side == CoreSide::AIV) {
             auto push_dest_type = std::dynamic_pointer_cast<const TileType>(bm.dest_var->GetType());
             INTERNAL_CHECK(push_dest_type && push_dest_type->memory_space_.has_value() &&

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -12,15 +12,22 @@
 from typing import cast
 
 import pypto.language as pl
+import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
 from pypto.ir.printer import python_print
 
 
-def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    """Configure Ascend910B backend before each test and reset afterward."""
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
 
+
+def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
     @pl.program
     class CrossCoreProgram:
         @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
@@ -84,9 +91,6 @@ def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
 
 
 def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
-    backend.reset_for_testing()
-    backend.set_backend_type(BackendType.Ascend910B)
-
     @pl.program
     class NestedPipeProgram:
         @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
@@ -151,3 +155,76 @@ def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
     cube_buffer_dim = cast(ir.ConstInt, cube_buffer_type.shape[0])
     assert vector_buffer_dim.value == 1024
     assert cube_buffer_dim.value == 1024
+
+
+def test_v2c_boundary_uses_nz_layout_on_a2a3():
+    """On Ascend910B, cross-core transfer uses NZ layout for both Left and Right.
+
+    Ascend910B routes data through GM → Mat, and Mat only supports NZ
+    (col_major blayout, row_major slayout). Unlike Ascend950 where Left uses
+    NZ and Right uses ZN, on 910B both destinations use NZ at the transfer
+    boundary.
+
+    The expected behavior on 910B:
+      - AIV side: a `tile.move` converts the source to NZ layout (producing
+        an `_nz` variable), then `tpush_to_aic(adapted_tile)`.
+      - AIC side: `tpop_from_aiv()` lands in Mat with NZ layout (col_major
+        blayout), followed by a `Mat → Left` `tile.move`.
+    """
+
+    @pl.program
+    class MixedMatmul:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            x_tile = pl.load(x, [0, 0], [16, 128])
+            # Direct Vec -> Left boundary (exercises BuildCrossCoreTransferView with Left)
+            x_left = pl.move(x_tile, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(MixedMatmul))
+        )
+
+    aic_func = transformed.get_function("main_incore_0_aic")
+    aiv_func = transformed.get_function("main_incore_0_aiv")
+    assert aic_func is not None
+    assert aiv_func is not None
+
+    aic_printed = python_print(aic_func)
+    aiv_printed = python_print(aiv_func)
+
+    # AIV side: a tile.move converts the source to NZ layout before tpush.
+    # On 910B both Left and Right use NZ, so the intermediate var should be `_nz`.
+    assert "pl.tile.tpush_to_aic(" in aiv_printed
+    assert "_nz" in aiv_printed
+    assert "_zn" not in aiv_printed
+
+    # AIC side: tpop lands in Mat with NZ layout (col_major blayout), and
+    # the subsequent Mat -> Left move is present.
+    assert "pl.tile.tpop_from_aiv(" in aic_printed
+    assert "pl.Mem.Mat" in aic_printed
+    assert "pl.Mem.Left" in aic_printed
+    assert "target_memory=pl.Mem.Left" in aic_printed
+    # The tpop result type carries NZ layout (col_major blayout) because
+    # 910B transfers go through Mat which only supports NZ.
+    assert "blayout=pl.TileLayout.col_major" in aic_printed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
On Ascend910B, cross-core transfers go through GM -> Mat, and Mat only
supports NZ (col_major blayout, row_major slayout). Both Left and Right
destinations use NZ at the transfer boundary; the final Left/Right layout
is resolved by the subsequent Mat->Left/Right move (MTE1). This differs
from Ascend950 where Left uses NZ and Right uses ZN directly.

The AIV V->C push path inserts a pre-tpush tile.move to adapt the source
into NZ layout on both backends.