### PR TITLE
feat(ir): implement tile.batch_matmul operation

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -110,6 +110,15 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+At the tile layer, `tile.batch_matmul` provides batched semantics for
+`TileType` operands. It accepts rank >= 2 tiles, broadcasts the leading batch
+dimensions, and keeps the same operand-only interface style as `tile.matmul`.
+If batch operands need transpose semantics, that can be expressed either with
+an explicit `tile.transpose(...)` on the inputs or by feeding a tile produced
+by `tile.load(..., transpose=True)`. During later lowering to 2D
+`tile.matmul`, both forms are normalized to the same operand-transpose
+semantics.
+
 ## Python Usage
 
 ```python

--- a/docs/en/dev/passes/11-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/11-flatten_tile_nd_to_2d.md
@@ -4,7 +4,12 @@ Flattens ND tile operations (3D+) to 2D in InCore functions by merging all dimen
 
 ## Overview
 
-PTO-ISA only accepts 2D tiles. After `ConvertTensorToTileOps`, tiles may be ND (matching tensor shapes). This pass flattens all >2D tile operations to 2D by merging higher axes into one dimension and keeping the last axis unchanged. For example, a tile `[2, 3, 4]` becomes `[6, 4]`.
+PTO-ISA only accepts 2D tiles. After `ConvertTensorToTileOps`, tiles may have rank > 2 (matching tensor shapes). This pass flattens all >2D tile operations to 2D by merging higher axes into one dimension and keeping the last axis unchanged. For example, a tile `[2, 3, 4]` becomes `[6, 4]`.
+
+For batched matrix multiplication, `ConvertTensorToTileOps` first preserves the
+high-level intent as `tile.batch_matmul`. `FlattenTileNdTo2D` then becomes the
+canonical legalization point that expands it into broadcast-aware per-batch
+2D `tile.matmul` operations.
 
 **Requirements**:
 
@@ -42,11 +47,12 @@ Per-statement handling:
 
 | Tile op | Transformation |
 | ------- | -------------- |
-| `tile.load` (>2D) | Change result type to 2D directly (load produces 2D tile from ND tensor) |
-| `tile.store` (ND tensor, >2D) | Inject original ND partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged |
+| `tile.load` (>2D) | Change result type to 2D directly (load produces a 2D tile from a rank>2 tensor window) |
+| `tile.store` (rank>2 tensor) | Inject the original tensor-rank partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged |
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
+| `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast and any explicit operand `tile.transpose` |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
 | 1D/2D tile ops | Unchanged |
 
@@ -81,8 +87,8 @@ class After:
 ```
 
 The 3D tile `[2, 3, 4]` is flattened to `[6, 4]`. `tile.load` directly produces a 2D tile —
-no `tile.reshape` is inserted. `tile.store` accepts the 2D tile and writes to the ND tensor. For ND
-tensors (>2D), the pass injects the original partition `shapes` as an extra 4th operand into the
+no `tile.reshape` is inserted. `tile.store` accepts the 2D tile and writes to the original rank>2 tensor. For
+rank>2 tensors, the pass injects the original partition `shapes` as an extra 4th operand into the
 transformed IR (e.g. `pl.store(y_tile, [0, 0, 0], out_0, (2, 3, 4))`); this operand is only
 present in the transformed IR and is not part of the source DSL.
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -110,6 +110,12 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+在 tile 层，`tile.batch_matmul` 为 `TileType` 操作数提供批量语义。它接受 rank >= 2 的
+tile，广播前导批量维度，并保持与 `tile.matmul` 相同的纯操作数接口风格。如果批量操作数
+需要转置语义，可以通过两种等价方式表达：在输入上显式使用 `tile.transpose(...)`，或让
+输入来自 `tile.load(..., transpose=True)`。在后续降级到 2D `tile.matmul` 时，这两种
+写法都会被统一识别为操作数转置语义。
+
 ## Python 用法
 
 ```python

--- a/docs/zh-cn/dev/passes/11-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/11-flatten_tile_nd_to_2d.md
@@ -4,7 +4,11 @@
 
 ## 概述
 
-PTO-ISA 仅支持 2D Tile。`ConvertTensorToTileOps` 之后，Tile 可能是 ND（匹配张量形状）。该 Pass 通过将高维轴合并为一个维度并保持最后一个轴不变，将所有 >2D 的 Tile 操作展平为 2D。例如，Tile `[2, 3, 4]` 变为 `[6, 4]`。
+PTO-ISA 仅支持 2D Tile。`ConvertTensorToTileOps` 之后，Tile 可能具有超过 2 个维度（匹配张量形状）。该 Pass 通过将高维轴合并为一个维度并保持最后一个轴不变，将所有 >2D 的 Tile 操作展平为 2D。例如，Tile `[2, 3, 4]` 变为 `[6, 4]`。
+
+对于 batch 矩阵乘法，`ConvertTensorToTileOps` 会先保留为
+`tile.batch_matmul`。随后由 `FlattenTileNdTo2D` 统一负责把它展开成带
+broadcast 语义的逐 batch 2D `tile.matmul`。
 
 **前置条件**：
 
@@ -42,11 +46,12 @@ program_2d = flatten_pass(program)
 
 | Tile 操作 | 变换方式 |
 | --------- | -------- |
-| `tile.load`（>2D） | 直接将结果类型改为 2D（load 从 ND 张量产生 2D tile） |
-| `tile.store`（ND 张量，>2D） | 在转换后 IR 中注入原始 ND 分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变 |
+| `tile.load`（>2D） | 直接将结果类型改为 2D（load 从 rank>2 张量窗口产生 2D tile） |
+| `tile.store`（rank>2 张量） | 在转换后 IR 中注入原始张量 rank 对应的分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变 |
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
+| `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，并处理 batch broadcast 与显式 operand `tile.transpose` |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
 | 1D/2D Tile 操作 | 不变 |
 
@@ -80,7 +85,7 @@ class After:
         return out_0
 ```
 
-3D Tile `[2, 3, 4]` 被展平为 `[6, 4]`。`tile.load` 直接产生 2D tile，无需插入 `tile.reshape`。`tile.store` 接受 2D tile 并写入 ND 张量。对于 ND 张量（>2D），Pass 会在转换后 IR 中将原始分区 `shapes` 注入为额外的第 4 个操作数（例如 `pl.store(y_tile, [0, 0, 0], out_0, (2, 3, 4))`）；该操作数仅存在于转换后的 IR 中，不属于 DSL 源码。
+3D Tile `[2, 3, 4]` 被展平为 `[6, 4]`。`tile.load` 直接产生 2D tile，无需插入 `tile.reshape`。`tile.store` 接受 2D tile 并写入原始的 rank>2 张量。对于 rank>2 张量，Pass 会在转换后 IR 中将原始分区 `shapes` 注入为额外的第 4 个操作数（例如 `pl.store(y_tile, [0, 0, 0], out_0, (2, 3, 4))`）；该操作数仅存在于转换后的 IR 中，不属于 DSL 源码。
 
 ## 实现
 

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -325,6 +325,7 @@ def _register_ops() -> None:
 
     # tile matmul variants — .float() to match hardware FP32 accumulation output
     m["tile.matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
+    m["tile.batch_matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
     m["tile.matmul_acc"] = lambda a, _kw: f"({a[0]} + torch.matmul({a[1]}, {a[2]}).float())"
     m["tile.matmul_bias"] = lambda a, _kw: f"(torch.matmul({a[0]}, {a[1]}).float() + {a[2]})"
     m["tile.gemv"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1307,6 +1307,28 @@ def matmul_bias(lhs: Expr, rhs: Expr, bias: Expr, span: Span | None = None) -> C
     return _ir_core.create_op_call("tile.matmul_bias", [lhs, rhs, bias], {}, actual_span)
 
 
+def batch_matmul(
+    lhs: Expr,
+    rhs: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Batch matrix multiplication of two tiles with broadcasting.
+
+    For inputs with shape [...batch_dims, M, K] and [...batch_dims, K, N],
+    the output has shape [...broadcast_batch_dims, M, N].
+
+    Args:
+        lhs: Left-hand side tile (TileType, at least 2D)
+        rhs: Right-hand side tile (TileType, at least 2D)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for batch matrix multiplication
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.batch_matmul", [lhs, rhs], {}, actual_span)
+
+
 def gemv(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     """General Matrix-Vector multiplication: C[1,N] = A[1,K] @ B[K,N].
 
@@ -1865,21 +1887,32 @@ def reshape(
     return _ir_core.create_op_call("tile.reshape", args, {}, actual_span)
 
 
-def transpose(tile: Expr, axis1: int, axis2: int, span: Span | None = None) -> Call:
+def transpose(tile: Expr, axis1: int | ConstInt, axis2: int | ConstInt, span: Span | None = None) -> Call:
     """Transpose tile by swapping two axes.
 
     Args:
         tile: Input tile expression
-        axis1: First axis to swap (supports negative indexing)
-        axis2: Second axis to swap (supports negative indexing)
+        axis1: First axis to swap as an int or ConstInt (supports negative indexing)
+        axis2: Second axis to swap as an int or ConstInt (supports negative indexing)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for tile transpose
     """
     actual_span = _get_span_or_capture(span)
-    axis1_expr = ConstInt(axis1, DataType.INDEX, actual_span)
-    axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
+    if isinstance(axis1, ConstInt):
+        axis1_expr = axis1
+    elif isinstance(axis1, int):
+        axis1_expr = ConstInt(axis1, DataType.INDEX, actual_span)
+    else:
+        raise TypeError(f"axis1 must be int or ConstInt, got {type(axis1)}")
+
+    if isinstance(axis2, ConstInt):
+        axis2_expr = axis2
+    elif isinstance(axis2, int):
+        axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
+    else:
+        raise TypeError(f"axis2 must be int or ConstInt, got {type(axis2)}")
 
     args = [tile, axis1_expr, axis2_expr]
 

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -136,6 +136,7 @@ from .op.tile_ops import (
 )
 from .op.unified_ops import (
     add,
+    batch_matmul,
     cast,
     col_expand,
     col_expand_div,
@@ -260,6 +261,7 @@ __all__ = [
     "transpose",
     "slice",
     "matmul",
+    "batch_matmul",
     "row_max",
     "row_sum",
     "row_min",

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -55,6 +55,7 @@ __all__ = [
     "relu",
     "cast",
     "matmul",
+    "batch_matmul",
     "matmul_acc",
     "matmul_bias",
     "gemv",
@@ -736,6 +737,20 @@ def matmul(lhs: Tile, rhs: Tile) -> Tile:
         Tile wrapping the matmul operation
     """
     call_expr = _ir_ops.matmul(lhs.unwrap(), rhs.unwrap())
+    return Tile(expr=call_expr)
+
+
+def batch_matmul(lhs: Tile, rhs: Tile) -> Tile:
+    """Batch matrix multiplication of two tiles.
+
+    Args:
+        lhs: Left-hand side tile
+        rhs: Right-hand side tile
+
+    Returns:
+        Tile wrapping the batch_matmul operation
+    """
+    call_expr = _ir_ops.batch_matmul(lhs.unwrap(), rhs.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -45,6 +45,7 @@ __all__ = [
     "slice",
     "fillpad",
     "matmul",
+    "batch_matmul",
     "matmul_acc",
     "row_max",
     "row_sum",
@@ -380,6 +381,16 @@ def matmul(
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.matmul(lhs, rhs)
     _raise_type_dispatch_error("matmul", lhs, rhs)
+
+
+def batch_matmul(lhs: Tile, rhs: Tile) -> Tile:
+    """Tile-only batched matrix multiplication.
+
+    Tensor batched matmul continues to use ``pl.matmul`` / ``pl.tensor.matmul``.
+    """
+    if isinstance(lhs, Tile) and isinstance(rhs, Tile):
+        return _tile.batch_matmul(lhs, rhs)
+    _raise_type_dispatch_error("batch_matmul", lhs, rhs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -111,6 +111,110 @@ static const std::vector<std::string> round_modes = {"NONE", "RINT",  "ROUND", "
 static const std::vector<std::string> mask_patterns = {"",      "P0101", "P1010", "P0001",
                                                        "P0010", "P0100", "P1000", "P1111"};
 
+// Build a partition_tensor_view type string from dimension strings and element dtype.
+static std::string MakePartitionTensorViewType(const std::vector<std::string>& dims,
+                                               const std::string& dtype_str) {
+  std::ostringstream oss;
+  oss << "!pto.partition_tensor_view<";
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (i > 0) oss << "x";
+    oss << dims[i];
+  }
+  oss << "x" << dtype_str << ">";
+  return oss.str();
+}
+
+// Convert expressions to MLIR operand strings.
+static std::vector<std::string> GetExprCodes(const std::vector<ir::ExprPtr>& exprs,
+                                             codegen::PTOCodegen& codegen) {
+  std::vector<std::string> codes;
+  codes.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    codes.push_back(codegen.GetExprAsCode(expr));
+  }
+  return codes;
+}
+
+// Convert statically-known dimensions to plain integer strings for MLIR types.
+static std::vector<std::string> GetStaticDimStrings(const std::vector<ir::ExprPtr>& exprs,
+                                                    codegen::PTOCodegen& codegen) {
+  std::vector<std::string> dims;
+  dims.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    dims.push_back(std::to_string(codegen.GetConstIntValue(expr)));
+  }
+  return dims;
+}
+
+// Convert statically-known dimensions to index-typed MLIR constants.
+static std::vector<std::string> GetStaticIndexCodes(const std::vector<ir::ExprPtr>& exprs,
+                                                    codegen::PTOCodegen& codegen) {
+  std::vector<std::string> codes;
+  codes.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    codes.push_back(codegen.GetOrEmitConstant(codegen.GetConstIntValue(expr), DataType::INDEX));
+  }
+  return codes;
+}
+
+// Get dimension strings handling both static (ConstInt) and dynamic dimensions.
+// Static dims become numeric strings; dynamic dims become "?".
+static std::vector<std::string> GetDimStrings(const std::vector<ir::ExprPtr>& exprs) {
+  std::vector<std::string> dims;
+  dims.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    if (auto c = As<ir::ConstInt>(expr)) {
+      dims.push_back(std::to_string(c->value_));
+    } else {
+      dims.emplace_back("?");
+    }
+  }
+  return dims;
+}
+
+// Convert expressions to MLIR size codes, using constants when available and
+// GetExprAsCode for dynamic values.
+static std::vector<std::string> GetSizeCodes(const std::vector<ir::ExprPtr>& exprs,
+                                             codegen::PTOCodegen& codegen) {
+  std::vector<std::string> codes;
+  codes.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    if (auto c = As<ir::ConstInt>(expr)) {
+      codes.push_back(codegen.GetOrEmitConstant(c->value_, DataType::INDEX));
+    } else {
+      codes.push_back(codegen.GetExprAsCode(expr));
+    }
+  }
+  return codes;
+}
+
+// Emit a pto.partition_view op and return the generated SSA name.
+static std::string EmitPartitionViewPTO(const std::string& name_hint, const std::string& tensor_view,
+                                        const std::string& tensor_view_type,
+                                        const std::string& partition_type,
+                                        const std::vector<std::string>& offset_codes,
+                                        const std::vector<std::string>& size_codes,
+                                        codegen::PTOCodegen& codegen) {
+  std::string partition_view = codegen.NewNamedTemp(name_hint + "_pview");
+  std::ostringstream oss;
+  oss << partition_view << " = pto.partition_view " << tensor_view;
+  oss << ", offsets = [";
+  for (size_t i = 0; i < offset_codes.size(); ++i) {
+    if (i > 0) oss << ", ";
+    oss << offset_codes[i];
+  }
+  oss << "]";
+  oss << ", sizes = [";
+  for (size_t i = 0; i < size_codes.size(); ++i) {
+    if (i > 0) oss << ", ";
+    oss << size_codes[i];
+  }
+  oss << "]";
+  oss << " : " << tensor_view_type << " -> " << partition_type;
+  codegen.Emit(oss.str());
+  return partition_view;
+}
+
 // Helper function for input & output generation (with type annotations)
 static std::string GenerateInsOutsClause(const CallPtr& op, codegen::PTOCodegen& codegen,
                                          const std::string& config_attr = "") {
@@ -549,49 +653,27 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
 
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
-  // Build partition type with all ND dimensions to match the sizes attribute.
-  // For DN layout, swap the last two shape elements (same as offsets) so that
-  // sizes are in the transposed coordinate system used by make_tensor_view.
+
   bool is_dn =
       tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
+
+  // Build partition type with all ND dimensions to match the sizes attribute.
+  // For DN layout, swap the last two shape/offset elements so that the partition
+  // coordinates are in the transposed coordinate system used by make_tensor_view.
   auto shape_elems = shapes_tuple->elements_;
   if (is_dn && shape_elems.size() >= 2) {
     std::iter_swap(shape_elems.rbegin(), shape_elems.rbegin() + 1);
   }
-  std::string partition_type = "!pto.partition_tensor_view<";
-  for (size_t i = 0; i < ndim; ++i) {
-    if (i > 0) partition_type += "x";
-    partition_type += std::to_string(codegen.GetConstIntValue(shape_elems[i]));
-  }
-  partition_type += "x" + dtype_str + ">";
-
-  std::string partition_view = codegen.NewNamedTemp(tensor->name_hint_ + "_pview");
-  std::ostringstream partition_line;
-  partition_line << partition_view << " = pto.partition_view " << tensor_view;
-
-  // For DN layout, swap the last two offset elements so that the partition
-  // base address is in the transposed coordinate system used by make_tensor_view.
-  // With the "original coordinates" DSL convention, offsets are always written in
-  // the tensor's declared coordinate system, so a swap is always needed for DN.
   auto offset_elems = offsets_tuple->elements_;
   if (is_dn && offset_elems.size() >= 2) {
     std::iter_swap(offset_elems.rbegin(), offset_elems.rbegin() + 1);
   }
 
-  partition_line << ", offsets = [";
-  for (size_t i = 0; i < offset_elems.size(); ++i) {
-    if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetExprAsCode(offset_elems[i]);
-  }
-  partition_line << "]";
-  partition_line << ", sizes = [";
-  for (size_t i = 0; i < shape_elems.size(); ++i) {
-    if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetOrEmitConstant(codegen.GetConstIntValue(shape_elems[i]), DataType::INDEX);
-  }
-  partition_line << "]";
-  partition_line << " : " << tensor_view_type << " -> " << partition_type;
-  codegen.Emit(partition_line.str());
+  std::string partition_type =
+      MakePartitionTensorViewType(GetStaticDimStrings(shape_elems, codegen), dtype_str);
+  std::string partition_view = EmitPartitionViewPTO(tensor->name_hint_, tensor_view, tensor_view_type,
+                                                    partition_type, GetExprCodes(offset_elems, codegen),
+                                                    GetStaticIndexCodes(shape_elems, codegen), codegen);
 
   std::ostringstream tload_line;
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";
@@ -672,53 +754,43 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
-  std::string partition_view = codegen.NewNamedTemp(output_tensor->name_hint_ + "_pview");
-  std::ostringstream partition_line;
-  partition_line << partition_view << " = pto.partition_view " << tensor_view;
-  // Use all offsets elements to match tensor_view rank (handles ND tensors)
-  partition_line << ", offsets = [";
-  for (size_t i = 0; i < offsets_tuple->elements_.size(); ++i) {
-    if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetExprAsCode(offsets_tuple->elements_[i]);
-  }
-  partition_line << "]";
-  partition_line << ", sizes = [";
-
-  // Build partition_type and sizes to match the tensor rank so they are consistent.
+  std::string partition_view;
   std::string partition_type;
   const size_t tensor_rank = tensor_type->shape_.size();
-  if (tensor_rank > 2) {
-    // Use the explicit shapes tuple (args[3]) injected by FlattenTileNdTo2D.
-    // Signature: (tile, offsets, output_tensor[, shapes]) — shapes at args[3]
-    // when 4 args total.
-    INTERNAL_CHECK_SPAN(op->args_.size() > 3, op->span_)
-        << "tile.store on ND tensor requires shapes tuple (args[3])";
-    auto shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
-    INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "tile.store args[3] must be a shapes MakeTuple";
-    partition_type = "!pto.partition_tensor_view<";
-    for (size_t i = 0; i < shapes_tuple->elements_.size(); ++i) {
-      if (i > 0) partition_line << ", ";
-      if (auto c = As<ir::ConstInt>(shapes_tuple->elements_[i])) {
-        partition_line << codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
-        if (i > 0) partition_type += "x";
-        partition_type += std::to_string(c->value_);
-      } else {
-        partition_line << codegen.GetExprAsCode(shapes_tuple->elements_[i]);
-        if (i > 0) partition_type += "x";
-        partition_type += "?";
-      }
+
+  bool is_dn =
+      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
+
+  // Check if FlattenTileNdTo2D injected an explicit shapes tuple as args[3].
+  ir::MakeTuplePtr shapes_tuple;
+  if (tensor_rank > 2 && op->args_.size() > 3) {
+    shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
+  }
+
+  if (shapes_tuple) {
+    // N-rank partition path: use the explicit shapes tuple from FlattenTileNdTo2D.
+    auto shape_elems = shapes_tuple->elements_;
+    auto offset_elems = offsets_tuple->elements_;
+    if (is_dn && shape_elems.size() >= 2) {
+      std::iter_swap(shape_elems.rbegin(), shape_elems.rbegin() + 1);
     }
-    partition_type += "x" + dtype_str + ">";
+    if (is_dn && offset_elems.size() >= 2) {
+      std::iter_swap(offset_elems.rbegin(), offset_elems.rbegin() + 1);
+    }
+    partition_type = MakePartitionTensorViewType(GetDimStrings(shape_elems), dtype_str);
+    partition_view = EmitPartitionViewPTO(output_tensor->name_hint_, tensor_view, tensor_view_type,
+                                          partition_type, GetExprCodes(offset_elems, codegen),
+                                          GetSizeCodes(shape_elems, codegen), codegen);
   } else {
+    // Standard 1D/2D path
     std::string height_dim = "?", width_dim = "?";
     if (auto h = As<ir::ConstInt>(valid_shape[0])) height_dim = std::to_string(h->value_);
     if (auto w = As<ir::ConstInt>(valid_shape[1])) width_dim = std::to_string(w->value_);
-    partition_type = "!pto.partition_tensor_view<" + height_dim + "x" + width_dim + "x" + dtype_str + ">";
-    partition_line << height_code << ", " << width_code;
+    partition_type = MakePartitionTensorViewType({height_dim, width_dim}, dtype_str);
+    partition_view = EmitPartitionViewPTO(output_tensor->name_hint_, tensor_view, tensor_view_type,
+                                          partition_type, GetExprCodes(offsets_tuple->elements_, codegen),
+                                          {height_code, width_code}, codegen);
   }
-  partition_line << "]";
-  partition_line << " : " << tensor_view_type << " -> " << partition_type;
-  codegen.Emit(partition_line.str());
 
   std::ostringstream tstore_line;
   tstore_line << "pto.tstore ins(" << tile_buf;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -510,27 +510,61 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       // whose physical memory layout differs from the view shape).
       bool has_explicit_stride =
           tensor_type->tensor_view_.has_value() && !tensor_type->tensor_view_->stride.empty();
+      const size_t rank = tensor_type->shape_.size();
 
-      // For N-D (N > 2): pre-compute row-major strides as SSA values using arith.muli
-      // so that dynamic dimensions (ir::Var) are handled correctly. Emit any needed
-      // multiply instructions BEFORE the make_tensor_view line.
+      // Materialize one shape dimension as an MLIR SSA value.
+      auto get_shape_dim_mlir = [&](size_t dim_idx) -> std::string {
+        if (auto var = As<ir::Var>(tensor_type->shape_[dim_idx])) {
+          return GetVarName(var);
+        }
+        return GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[dim_idx]), DataType::INDEX);
+      };
+
+      // DN tensor views keep the original logical shape in IR typing, but the
+      // emitted make_tensor_view must expose the trailing two visible dimensions
+      // in DN order so PTOAS interprets shape/stride/layout consistently.
+      // Column vectors are handled separately.
+      auto get_shape_source_idx = [&](size_t dim_idx) -> size_t {
+        if (!(layout_DN && rank >= 2 && !is_column_vector)) return dim_idx;
+        if (dim_idx == rank - 2) return rank - 1;
+        if (dim_idx == rank - 1) return rank - 2;
+        return dim_idx;
+      };
+
+      // Emit one stride multiply and return the resulting SSA.
+      auto emit_stride_mul = [&](const std::string& lhs, size_t dim_idx, size_t stride_slot) -> std::string {
+        std::string mul_name = NewNamedTemp(param->name_hint_ + "_s" + std::to_string(stride_slot));
+        stream_ << GetIndent() << mul_name << " = arith.muli " << lhs << ", " << get_shape_dim_mlir(dim_idx)
+                << " : index\n";
+        return mul_name;
+      };
+
+      // For N-D (N > 2): pre-compute strides as SSA values using arith.muli.
+      // ND uses standard row-major strides. DN keeps the same outer batch/page
+      // walk as ND, but the trailing two strides must match the visible DN shape:
+      // for logical [B, N, K], emit visible shape [B, K, N] with strides [N*K, 1, K].
       // Skip when explicit strides are available.
       std::vector<std::string> nd_stride_names;
-      if (!has_explicit_stride && tensor_type->shape_.size() > 2) {
-        const size_t rank = tensor_type->shape_.size();
+      if (!has_explicit_stride && rank > 2) {
         nd_stride_names.resize(rank);
-        nd_stride_names[rank - 1] = GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
-        for (int j = static_cast<int>(rank) - 2; j >= 0; j--) {
-          std::string dim_mlir;
-          if (auto var = As<ir::Var>(tensor_type->shape_[j + 1])) {
-            dim_mlir = GetVarName(var);
-          } else {
-            dim_mlir = GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j + 1]), DataType::INDEX);
+        if (layout_DN) {
+          // For shape [B, N, K], DN strides are [N*K, 1, K].
+          nd_stride_names[rank - 2] = GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+          nd_stride_names[rank - 1] = get_shape_dim_mlir(rank - 1);
+          if (rank > 2) {
+            nd_stride_names[rank - 3] = emit_stride_mul(nd_stride_names[rank - 1], rank - 2, rank - 3);
+            for (int j = static_cast<int>(rank) - 4; j >= 0; j--) {
+              size_t dim = static_cast<size_t>(j);
+              nd_stride_names[dim] = emit_stride_mul(nd_stride_names[dim + 1], dim + 1, dim);
+            }
           }
-          std::string mul_name = NewNamedTemp(param->name_hint_ + "_s" + std::to_string(j));
-          stream_ << GetIndent() << mul_name << " = arith.muli " << nd_stride_names[j + 1] << ", " << dim_mlir
-                  << " : index\n";
-          nd_stride_names[j] = mul_name;
+        } else {
+          // Standard row-major strides
+          nd_stride_names[rank - 1] = GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+          for (int j = static_cast<int>(rank) - 2; j >= 0; j--) {
+            size_t dim = static_cast<size_t>(j);
+            nd_stride_names[dim] = emit_stride_mul(nd_stride_names[dim + 1], dim + 1, dim);
+          }
         }
       }
 
@@ -538,26 +572,10 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       stream_ << GetVarName(param);
 
       stream_ << ", shape = [";
-      if (layout_DN && tensor_type->shape_.size() == 2 && !is_column_vector) {
-        // General DN 2D: emit transposed shape [shape[1], shape[0]] so that PTOAS
-        // sees the column-major convention while the IR keeps original shape.
-        for (int j = 1; j >= 0; j--) {
-          if (j < 1) stream_ << ", ";
-          if (auto var = As<ir::Var>(tensor_type->shape_[j])) {
-            stream_ << GetVarName(var);
-          } else {
-            stream_ << GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j]), DataType::INDEX);
-          }
-        }
-      } else {
-        for (size_t j = 0; j < tensor_type->shape_.size(); j++) {
-          if (j > 0) stream_ << ", ";
-          if (auto var = As<ir::Var>(tensor_type->shape_[j])) {
-            stream_ << GetVarName(var);
-          } else {
-            stream_ << GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j]), DataType::INDEX);
-          }
-        }
+      // DN swaps the last two visible shape dimensions; ND keeps the original order.
+      for (size_t j = 0; j < rank; j++) {
+        if (j > 0) stream_ << ", ";
+        stream_ << get_shape_dim_mlir(get_shape_source_idx(j));
       }
       stream_ << "],";
 
@@ -577,12 +595,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         // For column vector [M, 1]: stride dim is shape[0] (= M) → strides [1, M].
         // For other 2D: stride dim is shape[1] (= C) → DN [1, C] or ND [C, 1].
         int stride_idx = is_column_vector ? 0 : 1;
-        std::string row_stride;
-        if (auto var = As<ir::Var>(tensor_type->shape_[stride_idx])) {
-          row_stride = GetVarName(var);
-        } else {
-          row_stride = GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[stride_idx]), DataType::INDEX);
-        }
+        std::string row_stride = get_shape_dim_mlir(stride_idx);
         if (layout_DN) {
           stream_ << GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX) << ", " << row_stride;
         } else {
@@ -617,7 +630,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       stream_ << " {layout = #pto.layout<" << layout_str << ">}";
 
       stream_ << ": !pto.tensor_view<";
-      for (size_t j = 0; j < tensor_type->shape_.size(); j++) {
+      for (size_t j = 0; j < rank; j++) {
         if (j > 0) stream_ << "x";
         stream_ << "?";
       }

--- a/src/ir/op/tile_ops/batch_matmul.cpp
+++ b/src/ir/op/tile_ops/batch_matmul.cpp
@@ -52,6 +52,7 @@ namespace ir {
 TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
                                   const std::string& op_name) {
+  (void)kwargs;
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -79,7 +80,7 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
   size_t lhs_ndim = lhs_shape.size();
   size_t rhs_ndim = rhs_shape.size();
 
-  // Extract matrix dimensions (last 2 dimensions)
+  // Extract matrix dimensions from the trailing matrix axes.
   ExprPtr m_dim = lhs_shape[lhs_ndim - 2];
   ExprPtr k_dim_lhs = lhs_shape[lhs_ndim - 1];
   ExprPtr k_dim_rhs = rhs_shape[rhs_ndim - 2];
@@ -119,14 +120,22 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
     output_shape.push_back(n_dim);
   }
 
-  // Promote data types
-  auto result_dtype = PromoteDataTypes(lhs_type->dtype_, rhs_type->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+  CHECK(lhs_type->dtype_ == rhs_type->dtype_)
+      << "The operator " << op_name << " requires identical lhs and rhs data types, but got "
+      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+  // Hardware matmul accumulates to FP32 for float inputs, INT32 for integer inputs.
+  auto result_dtype =
+      (lhs_type->dtype_.IsFloat() && rhs_type->dtype_.IsFloat()) ? DataType::FP32 : DataType::INT32;
 
+  // The matmul output tile uses the hardware's native accumulator layout:
+  // - blayout=col_major, slayout=row_major: hardware's column-major block / row-major sub-block
+  // - fractal=1024: 32x32 sub-tile fractal size (standard for this hardware's matrix unit)
   TileView tile_view;
+  tile_view.blayout = TileLayout::col_major;
+  tile_view.slayout = TileLayout::row_major;
+  tile_view.fractal = 1024;
   tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
 }
 
 // ============================================================================

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -17,6 +17,7 @@
  * These operations handle data movement between tensors and unified buffers (tiles).
  */
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <memory>
@@ -134,8 +135,8 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
       << " only supports transpose=true when target_memory is Mat (L1), but got "
       << static_cast<int>(target_memory);
 
-  CHECK(!transpose || shapes_tuple->elements_.size() == 2)
-      << "The operator " << op_name << " only supports transpose=true for 2D loads, but got "
+  CHECK(!transpose || shapes_tuple->elements_.size() >= 2)
+      << "The operator " << op_name << " requires at least 2D shapes for transpose=true, but got "
       << shapes_tuple->elements_.size() << "D";
 
   // Nz/Zn for transpose false/true
@@ -153,16 +154,16 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
 
   // Build tile shape from shapes tuple.
   // When transpose=true, shapes are in original (source tensor) coordinates;
-  // swap to transposed coordinates for the output TileType.
+  // swap the last two dimensions to transposed coordinates for the output TileType.
   auto shape_elements = shapes_tuple->elements_;
-  if (transpose && shape_elements.size() == 2) {
-    std::swap(shape_elements[0], shape_elements[1]);
+  if (transpose && shape_elements.size() >= 2) {
+    std::iter_swap(shape_elements.end() - 2, shape_elements.end() - 1);
   }
   std::vector<ExprPtr> tile_shape(shape_elements.begin(), shape_elements.end());
 
   auto valid_elements = valid_shapes_tuple->elements_;
-  if (transpose && valid_elements.size() == 2) {
-    std::swap(valid_elements[0], valid_elements[1]);
+  if (transpose && valid_elements.size() >= 2) {
+    std::iter_swap(valid_elements.end() - 2, valid_elements.end() - 1);
   }
   tile_view.valid_shape = valid_elements;
 
@@ -175,7 +176,8 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
                             const std::string& op_name) {
   // store signature: (tile, offsets_tuple, output_tensor[, shapes_tuple])
   // shapes_tuple is an optional 4th argument injected by FlattenTileNdTo2D
-  // for ND tensors to carry the original partition shape for codegen.
+  // for ND tensors to carry the ND partition shape for codegen.
+  // When present, shapes_tuple has the same rank as offsets_tuple (both ND).
   CHECK(args.size() == 3 || args.size() == 4)
       << "The operator " << op_name
       << " requires 3 or 4 arguments (tile, offsets, output_tensor[, shapes]), but got " << args.size();

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -9,13 +9,16 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -37,6 +40,7 @@
 #include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 #include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
@@ -107,6 +111,111 @@ ExprPtr MakeShapeTupleFromInts(const std::vector<int64_t>& dims, const Span& spa
 std::vector<ExprPtr> Make2DShapeExprs(int64_t merged, int64_t last, const Span& span) {
   return {std::make_shared<ConstInt>(merged, DataType::INDEX, span),
           std::make_shared<ConstInt>(last, DataType::INDEX, span)};
+}
+
+/// Build a canonical index add, folding simple ConstInt cases to avoid
+/// unstable roundtrip forms such as `0 + 1`.
+ExprPtr MakeCanonicalIndexAdd(const ExprPtr& lhs, const ExprPtr& rhs, const Span& span) {
+  auto lhs_const = As<ConstInt>(lhs);
+  auto rhs_const = As<ConstInt>(rhs);
+  if (lhs_const && rhs_const) {
+    CHECK((rhs_const->value_ >= 0 && lhs_const->value_ <= INT64_MAX - rhs_const->value_) ||
+          (rhs_const->value_ < 0 && lhs_const->value_ >= INT64_MIN - rhs_const->value_))
+        << "FlattenTileNdTo2D: integer overflow while canonicalizing index add";
+    return std::make_shared<ConstInt>(lhs_const->value_ + rhs_const->value_, DataType::INDEX, span);
+  }
+  if (lhs_const && lhs_const->value_ == 0) {
+    return rhs;
+  }
+  if (rhs_const && rhs_const->value_ == 0) {
+    return lhs;
+  }
+  return MakeAdd(lhs, rhs, span);
+}
+
+/// Convert a vector of ExprPtr shape dimensions into static int64 values.
+std::vector<int64_t> ToStaticDims(const std::vector<ExprPtr>& shape, const std::string& context) {
+  std::vector<int64_t> dims;
+  dims.reserve(shape.size());
+  for (size_t i = 0; i < shape.size(); ++i) {
+    dims.push_back(GetStaticDim(shape[i], context + " dim " + std::to_string(i)));
+  }
+  return dims;
+}
+
+/// Multiply all static dimensions together, with overflow checking.
+int64_t MultiplyStaticDims(const std::vector<int64_t>& dims, const std::string& context) {
+  int64_t product = 1;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    CHECK(dims[i] > 0) << "FlattenTileNdTo2D: dimension " << i << " must be positive in " << context
+                       << ", got " << dims[i];
+    CHECK(product <= INT64_MAX / dims[i]) << "FlattenTileNdTo2D: integer overflow when computing " << context;
+    product *= dims[i];
+  }
+  return product;
+}
+
+/// Decompose a flat batch index into per-dimension indices for the given batch shape.
+/// e.g. flat_index=5 with batch_shape=[2,3] → indices=[1,2].
+std::vector<int64_t> BuildBatchIndices(int64_t flat_index, const std::vector<int64_t>& batch_shape) {
+  std::vector<int64_t> indices;
+  if (batch_shape.empty()) return indices;
+
+  indices.reserve(batch_shape.size());
+  for (size_t dim = 0; dim < batch_shape.size(); ++dim) {
+    int64_t stride = 1;
+    for (size_t suffix = dim + 1; suffix < batch_shape.size(); ++suffix) {
+      CHECK(stride <= INT64_MAX / batch_shape[suffix])
+          << "FlattenTileNdTo2D: integer overflow while computing batch stride";
+      stride *= batch_shape[suffix];
+    }
+    int64_t linear_index = (dim + 1 < batch_shape.size()) ? flat_index / stride : flat_index;
+    indices.push_back(linear_index % batch_shape[dim]);
+  }
+  return indices;
+}
+
+/// Compute the flat batch index for an operand whose batch shape may be smaller
+/// than the output batch shape (NumPy-style broadcast: size-1 dims map to index 0).
+int64_t BuildOperandFlatBatchIndex(const std::vector<int64_t>& operand_batch_shape,
+                                   const std::vector<int64_t>& output_batch_shape,
+                                   const std::vector<int64_t>& output_batch_indices) {
+  if (operand_batch_shape.empty()) return 0;
+
+  CHECK(output_batch_shape.size() >= operand_batch_shape.size())
+      << "FlattenTileNdTo2D: output batch rank must cover operand batch rank";
+  CHECK(output_batch_indices.size() == output_batch_shape.size())
+      << "FlattenTileNdTo2D: output batch indices must match output batch rank";
+
+  int64_t flat_index = 0;
+  const size_t lead_dims = output_batch_shape.size() - operand_batch_shape.size();
+  for (size_t i = 0; i < operand_batch_shape.size(); ++i) {
+    int64_t operand_dim = operand_batch_shape[i];
+    int64_t batch_index = operand_dim == 1 ? 0 : output_batch_indices[lead_dims + i];
+    CHECK(flat_index <= INT64_MAX / operand_dim)
+        << "FlattenTileNdTo2D: integer overflow while flattening broadcasted batch index";
+    flat_index = flat_index * operand_dim + batch_index;
+  }
+  return flat_index;
+}
+
+/// Normalize a potentially negative axis index (Python-style) to a valid range.
+int64_t NormalizeAxisIndex(int64_t axis, size_t ndim, const std::string& context) {
+  int64_t normalized = axis;
+  if (normalized < 0) {
+    normalized += static_cast<int64_t>(ndim);
+  }
+  CHECK(normalized >= 0 && normalized < static_cast<int64_t>(ndim))
+      << "FlattenTileNdTo2D: axis " << axis << " is out of range for rank " << ndim << " in " << context;
+  return normalized;
+}
+
+/// Check whether (axis1, axis2) is a swap of the last two dimensions.
+bool IsTrailingMatrixAxisSwap(int64_t axis1, int64_t axis2, size_t ndim) {
+  int64_t trailing_axis0 = static_cast<int64_t>(ndim) - 2;
+  int64_t trailing_axis1 = static_cast<int64_t>(ndim) - 1;
+  return (axis1 == trailing_axis0 && axis2 == trailing_axis1) ||
+         (axis1 == trailing_axis1 && axis2 == trailing_axis0);
 }
 
 // ============================================================================
@@ -231,6 +340,557 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
   return {};
 }
 
+// ============================================================================
+// Batch matmul lowering
+// ============================================================================
+//
+// tile.batch_matmul performs batched matrix multiplication on rank>2 tiles:
+//   lhs [..., M, K] x rhs [..., K, N] -> result [..., M, N]
+// where "..." are broadcast-compatible batch dimensions.
+//
+// The 2D backend only supports tile.matmul on rank-2 tiles. This lowering
+// eliminates tile.batch_matmul by unrolling the batch dimensions at compile
+// time (all shapes are static) into a flat sequence of 2D tile.matmul calls.
+//
+// Overall flow:
+//
+//   1. Normalize operand transpose semantics — peel off inline tile.transpose
+//      wrappers and recognize tile.load(transpose=True) as the same logical
+//      operand-transpose contract (batch_matmul uses structural transpose, not kwargs).
+//
+//   2. Broadcast batch dimensions — compute the output batch shape via
+//      NumPy-style broadcasting (e.g. [2,1] x [1,3] -> [2,3]).
+//
+//   3. Detect direct-store fusion — if the very next statement is a tile.store
+//      consuming this result, fuse per-batch stores directly instead of
+//      assembling into a temporary tile. This avoids an intermediate buffer.
+//
+//   4. Unroll — for each flat batch index 0..batch_count-1:
+//      a. Decompose the flat index into per-dim indices for lhs and rhs,
+//         respecting broadcast (size-1 dims always map to index 0).
+//      b. Extract the 2D [M,K] / [K,N] page via one of three strategies:
+//         - Re-emit tile.load with batch-adjusted offsets (when the original
+//           operand was a Mat-memory tile.load — avoids a slice+reshape).
+//         - tile.slice on already-flattened 2D tile (row-offset slicing).
+//         - rank>2 tile.slice + tile.reshape to 2D (general fallback).
+//      c. Optionally append tile.transpose(0,1) for transposed operands.
+//      d. Emit tile.matmul(lhs_2d, rhs_2d).
+//      e. Cast dtype if matmul output (FP32) differs from expected result dtype.
+//      f. Either tile.store (fused path) or tile.assemble into output tile.
+//
+// The result is a flat 2D tile [batch_count*M, N] (non-fused) or a chain
+// of per-batch tile.store calls (fused), with no tile.batch_matmul remaining.
+//
+
+/// Map from Var raw pointer to its defining AssignStmt, for O(1) def lookup.
+using AssignDefMap = std::unordered_map<const Var*, AssignStmtPtr>;
+
+AssignDefMap BuildAssignDefMap(const std::vector<StmtPtr>& stmts) {
+  AssignDefMap map;
+  for (const auto& stmt : stmts) {
+    if (auto assign = As<AssignStmt>(stmt)) {
+      map[assign->var_.get()] = assign;
+    }
+  }
+  return map;
+}
+
+/// Parsed information about a batch_matmul operand.
+struct BatchOperandInfo {
+  ExprPtr operand;            ///< After var_map substitution
+  ExprPtr original_operand;   ///< Before substitution (for def lookup)
+  TileTypePtr operand_type;   ///< Type after substitution
+  TileTypePtr original_type;  ///< Type before substitution
+  bool transpose = false;     ///< True if wrapped in trailing-axis tile.transpose
+};
+
+/// Resolve an inline or single-definition tile.transpose wrapper around a batch_matmul operand.
+CallPtr ResolveBatchOperandTranspose(const ExprPtr& operand_expr, const AssignDefMap& def_map) {
+  if (auto transpose_call = As<Call>(operand_expr)) {
+    if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
+      return transpose_call;
+    }
+  }
+
+  if (auto operand_var = As<Var>(operand_expr)) {
+    auto def_it = def_map.find(operand_var.get());
+    if (def_it != def_map.end()) {
+      if (auto transpose_call = As<Call>(def_it->second->value_)) {
+        if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
+          return transpose_call;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+/// Normalize one batch_matmul operand by:
+///  - peeling off a direct tile.transpose wrapper
+///  - recognizing tile.load(transpose=True) as the same operand-transpose semantic
+///  - returning a base operand plus unified transpose/type information
+BatchOperandInfo NormalizeBatchMatmulOperand(const ExprPtr& operand_expr, const std::string& operand_name,
+                                             const AssignDefMap& def_map, const FlattenContext& ctx) {
+  BatchOperandInfo info;
+  ExprPtr base_operand = operand_expr;
+
+  if (auto transpose_call = ResolveBatchOperandTranspose(operand_expr, def_map)) {
+    if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
+      CHECK(transpose_call->args_.size() == 3)
+          << "FlattenTileNdTo2D: tile.transpose inside tile.batch_matmul must have 3 arguments";
+
+      auto input_type = As<TileType>(transpose_call->args_[0]->GetType());
+      CHECK(input_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
+                        << " transpose operand must wrap a TileType, but got "
+                        << transpose_call->args_[0]->GetType()->TypeName();
+
+      auto axis1_const = As<ConstInt>(transpose_call->args_[1]);
+      auto axis2_const = As<ConstInt>(transpose_call->args_[2]);
+      CHECK(axis1_const && axis2_const)
+          << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name << " transpose axes must be ConstInt";
+
+      int64_t axis1 = NormalizeAxisIndex(axis1_const->value_, input_type->shape_.size(),
+                                         "tile.batch_matmul " + operand_name + " transpose axis1");
+      int64_t axis2 = NormalizeAxisIndex(axis2_const->value_, input_type->shape_.size(),
+                                         "tile.batch_matmul " + operand_name + " transpose axis2");
+      CHECK(IsTrailingMatrixAxisSwap(axis1, axis2, input_type->shape_.size()))
+          << "FlattenTileNdTo2D: tile.batch_matmul only supports operand transpose on the trailing "
+             "matrix axes, but got axes "
+          << axis1 << " and " << axis2;
+
+      base_operand = transpose_call->args_[0];
+      info.transpose = true;
+    }
+  }
+
+  // If no tile.transpose wrapper found, check if the operand is a tile.load(transpose=True).
+  // In this case the load result already has swapped trailing dims (done by DeduceTileLoadType),
+  // so we record transpose=true but must also un-swap original_type so that LowerBatchMatmul
+  // sees the pre-transpose "source" shape (matching the tile.transpose-wrapper convention).
+  bool transpose_from_load = false;
+  if (!info.transpose) {
+    ExprPtr check_expr = base_operand;
+    // Resolve through Var to its definition if needed.
+    if (auto operand_var = As<Var>(check_expr)) {
+      auto def_it = def_map.find(operand_var.get());
+      if (def_it != def_map.end()) {
+        check_expr = def_it->second->value_;
+      }
+    }
+    if (auto load_call = As<Call>(check_expr)) {
+      if (load_call->op_ && load_call->op_->name_ == "tile.load" &&
+          load_call->GetKwarg<bool>("transpose", false)) {
+        info.transpose = true;
+        transpose_from_load = true;
+      }
+    }
+  }
+
+  info.original_operand = base_operand;
+  info.original_type = As<TileType>(base_operand->GetType());
+  CHECK(info.original_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
+                            << " expects TileType operand, but got " << base_operand->GetType()->TypeName();
+
+  // When transpose came from tile.load(transpose=True), the result shape is already
+  // post-transpose. Un-swap the trailing two dims so original_type matches the convention
+  // expected by LowerBatchMatmul (pre-transpose "source" shape).
+  if (transpose_from_load && info.original_type->shape_.size() >= 2) {
+    auto unswapped_shape = info.original_type->shape_;
+    std::iter_swap(unswapped_shape.end() - 2, unswapped_shape.end() - 1);
+    info.original_type =
+        std::make_shared<TileType>(unswapped_shape, info.original_type->dtype_, info.original_type->memref_,
+                                   info.original_type->tile_view_, info.original_type->memory_space_);
+  }
+
+  info.operand = Substitute(base_operand, ctx.var_map);
+  info.operand_type = As<TileType>(info.operand->GetType());
+  CHECK(info.operand_type) << "FlattenTileNdTo2D: tile.batch_matmul substituted " << operand_name
+                           << " expects TileType operand, but got " << info.operand->GetType()->TypeName();
+  return info;
+}
+
+/// Build batch-adjusted offset elements: add batch indices to the batch dimensions
+/// of base offsets, then append the trailing matrix-dimension offsets unchanged.
+std::vector<ExprPtr> BuildBatchAdjustedOffsets(const std::vector<ExprPtr>& base_offset_elems,
+                                               const std::vector<int64_t>& batch_indices, size_t batch_rank,
+                                               const Span& span) {
+  std::vector<ExprPtr> adjusted;
+  adjusted.reserve(base_offset_elems.size());
+  for (size_t dim = 0; dim < batch_rank; ++dim) {
+    if (batch_indices[dim] == 0) {
+      adjusted.push_back(base_offset_elems[dim]);
+    } else {
+      auto offset = std::make_shared<ConstInt>(batch_indices[dim], DataType::INDEX, span);
+      adjusted.push_back(MakeCanonicalIndexAdd(base_offset_elems[dim], offset, span));
+    }
+  }
+  for (size_t dim = batch_rank; dim < base_offset_elems.size(); ++dim) {
+    adjusted.push_back(base_offset_elems[dim]);
+  }
+  return adjusted;
+}
+
+/// Result of extracting a 2D batch page from a rank>2 operand.
+struct BatchPageResult {
+  VarPtr var;                  ///< The 2D variable (possibly transposed)
+  std::vector<StmtPtr> stmts;  ///< Statements emitted to produce it
+};
+
+/// Extract the 2D matrix page for a given batch index from an operand.
+///
+/// Three strategies:
+///  (1) Mat-load: re-emit tile.load with batch-adjusted offsets (avoids intermediate tile)
+///  (2) 2D-flat: tile.slice at the right row offset (operand already flattened)
+///  (3) Rank>2 fallback: tile.slice + tile.reshape to 2D
+///
+/// Appends tile.transpose if the operand should be transposed.
+BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector<int64_t>& operand_dims,
+                                 const std::vector<int64_t>& operand_batch_shape, int64_t batch_index,
+                                 const std::string& base_name, const AssignDefMap& def_map,
+                                 const FlattenContext& ctx, const OpRegistry& op_registry, const Span& span) {
+  BatchPageResult page;
+  const auto& operand = info.operand;
+  const auto& operand_type = info.operand_type;
+
+  int64_t source_rows = operand_dims[operand_dims.size() - 2];
+  int64_t source_cols = operand_dims.back();
+  std::string suffix = std::to_string(batch_index);
+
+  // Check if original operand was produced by a tile.load with Mat target_memory.
+  auto original_var = As<Var>(info.original_operand);
+  auto def_it = original_var ? def_map.find(original_var.get()) : def_map.end();
+  auto original_assign = (def_it != def_map.end()) ? def_it->second : nullptr;
+  auto original_load_call = original_assign ? As<Call>(original_assign->value_) : nullptr;
+  bool is_mat_load = original_load_call && original_load_call->op_->name_ == "tile.load" &&
+                     original_load_call->args_.size() >= 4;
+  auto original_load_offsets = is_mat_load ? As<MakeTuple>(original_load_call->args_[1]) : nullptr;
+  auto original_load_input = is_mat_load ? Substitute(original_load_call->args_[0], ctx.var_map) : nullptr;
+  auto original_load_input_type =
+      original_load_input ? As<TensorType>(original_load_input->GetType()) : nullptr;
+  auto original_target_memory =
+      is_mat_load ? original_load_call->GetKwarg<MemorySpace>("target_memory") : MemorySpace::DDR;
+  bool original_load_transpose = is_mat_load ? original_load_call->GetKwarg<bool>("transpose", false) : false;
+
+  VarPtr current;
+
+  // Track whether Strategy 1 is used so we can skip redundant tile.transpose.
+  bool used_strategy1 = false;
+
+  if (is_mat_load && original_load_offsets && original_load_input_type &&
+      original_target_memory == MemorySpace::Mat) {
+    // Strategy 1: Re-emit tile.load with batch-adjusted offsets.
+    // transpose=True is preserved in the kwargs, so per-batch loads inherit it.
+    auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
+    auto load_offset_elems = BuildBatchAdjustedOffsets(original_load_offsets->elements_, batch_indices,
+                                                       operand_batch_shape.size(), span);
+
+    std::vector<int64_t> load_shape_values(operand_batch_shape.size(), 1);
+    load_shape_values.push_back(source_rows);
+    load_shape_values.push_back(source_cols);
+
+    // Keep the original tensor-rank offsets and shapes on the load call so
+    // codegen still sees the original source window. Type inference will still
+    // produce a rank>2 TileType from these shapes; this pass immediately
+    // overrides the call result type to 2D below because hardware tiles are
+    // always 2D.
+    // For transposed loads (transpose=True), the original tensor-rank offsets
+    // are required so that codegen routes the load through the standard DN
+    // path. A flat 2D view cannot represent within-batch column-major
+    // addressing.
+
+    auto batch_load_offsets = std::make_shared<MakeTuple>(load_offset_elems, span);
+    auto batch_load_shape = MakeShapeTupleFromInts(load_shape_values, span);
+    std::vector<ExprPtr> batch_load_args = {original_load_input, batch_load_offsets, batch_load_shape,
+                                            batch_load_shape};
+    auto batch_load = op_registry.Create("tile.load", batch_load_args, original_load_call->kwargs_, span);
+
+    // DeduceTileLoadType produces a rank>2 TileType from these shapes, but
+    // hardware tiles are always 2D. Manually override the result type to 2D.
+    int64_t flat_rows = original_load_transpose ? source_cols : source_rows;
+    int64_t flat_cols = original_load_transpose ? source_rows : source_cols;
+    auto flat_shape_exprs = Make2DShapeExprs(flat_rows, flat_cols, span);
+    auto batch_load_type = As<TileType>(batch_load->GetType());
+    std::optional<TileView> flat_tile_view;
+    if (batch_load_type && batch_load_type->tile_view_.has_value()) {
+      const auto& orig_tv = *batch_load_type->tile_view_;
+      flat_tile_view = TileView(flat_shape_exprs, /*stride=*/{}, /*start_offset=*/nullptr, orig_tv.blayout,
+                                orig_tv.slayout, orig_tv.fractal, orig_tv.pad);
+    }
+    auto flat_type = std::make_shared<TileType>(
+        flat_shape_exprs, batch_load_type ? batch_load_type->dtype_ : operand_type->dtype_, std::nullopt,
+        flat_tile_view, batch_load_type ? batch_load_type->memory_space_ : operand_type->memory_space_);
+    auto flat_load = std::make_shared<Call>(batch_load->op_, batch_load_args, batch_load->kwargs_, flat_type,
+                                            batch_load->span_);
+    current = std::make_shared<Var>(base_name + "_load_" + suffix, flat_type, span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, flat_load, span));
+    used_strategy1 = true;
+
+  } else if (operand_type->shape_.size() == 2) {
+    // Strategy 2: Slice from already-flattened 2D tile.
+    auto offset = MakeShapeTupleFromInts({batch_index * source_rows, 0}, span);
+    auto shape = MakeShapeTupleFromInts({source_rows, source_cols}, span);
+    auto slice = op_registry.Create("tile.slice", {operand, shape, offset}, span);
+    current = std::make_shared<Var>(base_name + "_slice_" + suffix, slice->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, slice, span));
+
+  } else {
+    // Strategy 3: rank>2 tile.slice + tile.reshape to 2D.
+    auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
+    std::vector<int64_t> offset_values = batch_indices;
+    offset_values.push_back(0);
+    offset_values.push_back(0);
+
+    std::vector<int64_t> slice_shape_values(operand_batch_shape.size(), 1);
+    slice_shape_values.push_back(source_rows);
+    slice_shape_values.push_back(source_cols);
+
+    auto offset = MakeShapeTupleFromInts(offset_values, span);
+    auto slice_shape = MakeShapeTupleFromInts(slice_shape_values, span);
+    auto slice = op_registry.Create("tile.slice", {operand, slice_shape, offset}, span);
+    auto slice_var = std::make_shared<Var>(base_name + "_nd_slice_" + suffix, slice->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice, span));
+
+    auto reshape_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(source_rows, source_cols, span), span);
+    auto reshape = op_registry.Create("tile.reshape", {slice_var, reshape_shape}, span);
+    current = std::make_shared<Var>(base_name + "_2d_" + suffix, reshape->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, reshape, span));
+  }
+
+  // Optionally transpose the 2D page.
+  // Skip if Strategy 1 was used AND the original load has transpose=True: the re-emitted
+  // tile.load already carries transpose=True in its kwargs, so an extra tile.transpose
+  // would double-transpose. When Strategy 1 is used but the load doesn't have transpose,
+  // we still need the explicit tile.transpose (old tile.transpose-wrapper pattern).
+  if (info.transpose && !(used_strategy1 && original_load_transpose)) {
+    auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+    auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+    auto transpose_call = op_registry.Create("tile.transpose", {current, axis0, axis1}, span);
+    auto transpose_var = std::make_shared<Var>(base_name + "_t_" + suffix, transpose_call->GetType(), span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose_call, span));
+    current = transpose_var;
+  }
+
+  page.var = current;
+  return page;
+}
+
+/// Detect whether the next statement is a tile.store consuming the batch_matmul result.
+struct DirectStoreInfo {
+  bool detected = false;
+  AssignStmtPtr store_assign;
+  CallPtr store_call;
+};
+
+DirectStoreInfo DetectDirectStore(const std::vector<StmtPtr>& stmts, size_t stmt_index,
+                                  const VarPtr& result_var) {
+  DirectStoreInfo info;
+  if (stmt_index + 1 >= stmts.size()) return info;
+
+  auto store_assign = As<AssignStmt>(stmts[stmt_index + 1]);
+  auto store_call = store_assign ? As<Call>(store_assign->value_) : nullptr;
+  if (!store_call || store_call->op_->name_ != "tile.store") return info;
+
+  auto store_input = !store_call->args_.empty() ? As<Var>(store_call->args_[0]) : nullptr;
+  if (!store_input || store_input.get() != result_var.get()) return info;
+
+  info.detected = true;
+  info.store_assign = store_assign;
+  info.store_call = store_call;
+  return info;
+}
+
+/// Result of lowering a tile.batch_matmul operation.
+struct BatchMatmulResult {
+  std::vector<StmtPtr> stmts;  ///< Emitted statements
+  VarPtr output_var;           ///< Result variable (non-fused path)
+  bool fused_store = false;    ///< True if direct-store fusion was applied
+  VarPtr store_result_var;     ///< Final store var (fused path)
+  VarPtr store_orig_var;       ///< Original store var being replaced (fused path)
+};
+
+/// Lower tile.batch_matmul into unrolled 2D tile.matmul calls.
+///
+/// Enumerates every batch index combination, extracts the 2D matrix page from each
+/// operand, emits a tile.matmul per batch element, and either assembles results into
+/// a flat 2D output tile or fuses directly into per-batch tile.store when possible.
+BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& call,
+                                   const std::vector<StmtPtr>& stmts, size_t stmt_index,
+                                   const FlattenContext& ctx, const OpRegistry& op_registry,
+                                   const Span& span) {
+  BatchMatmulResult out;
+  auto def_map = BuildAssignDefMap(stmts);
+
+  // Normalize operands.
+  auto lhs_info = NormalizeBatchMatmulOperand(call->args_[0], "lhs", def_map, ctx);
+  auto rhs_info = NormalizeBatchMatmulOperand(call->args_[1], "rhs", def_map, ctx);
+  auto orig_result_type = As<TileType>(call->GetType());
+  CHECK(orig_result_type) << "FlattenTileNdTo2D: tile.batch_matmul expects TileType result";
+
+  // Extract static dimensions.
+  auto lhs_dims = ToStaticDims(lhs_info.original_type->shape_, "tile.batch_matmul lhs");
+  auto rhs_dims = ToStaticDims(rhs_info.original_type->shape_, "tile.batch_matmul rhs");
+  CHECK(lhs_dims.size() >= 2) << "FlattenTileNdTo2D: tile.batch_matmul lhs must be at least 2D";
+  CHECK(rhs_dims.size() >= 2) << "FlattenTileNdTo2D: tile.batch_matmul rhs must be at least 2D";
+
+  // Compute broadcast batch dimensions.
+  std::vector<ExprPtr> lhs_batch_exprs(lhs_info.original_type->shape_.begin(),
+                                       lhs_info.original_type->shape_.end() - 2);
+  std::vector<ExprPtr> rhs_batch_exprs(rhs_info.original_type->shape_.begin(),
+                                       rhs_info.original_type->shape_.end() - 2);
+  auto broadcast_result = BroadcastShapes(lhs_batch_exprs, rhs_batch_exprs);
+  CHECK(broadcast_result.success) << "FlattenTileNdTo2D: tile.batch_matmul batch dimensions must broadcast";
+
+  auto output_batch_dims = ToStaticDims(broadcast_result.shape, "tile.batch_matmul output batch");
+  int64_t batch_count = MultiplyStaticDims(output_batch_dims, "tile.batch_matmul output batch size");
+
+  std::vector<int64_t> lhs_batch_dims(lhs_dims.begin(), lhs_dims.end() - 2);
+  std::vector<int64_t> rhs_batch_dims(rhs_dims.begin(), rhs_dims.end() - 2);
+
+  // Compute effective matrix dimensions (after transpose).
+  int64_t lhs_source_rows = lhs_dims[lhs_dims.size() - 2];
+  int64_t lhs_source_cols = lhs_dims.back();
+  int64_t rhs_source_rows = rhs_dims[rhs_dims.size() - 2];
+  int64_t rhs_source_cols = rhs_dims.back();
+
+  int64_t lhs_rows = lhs_info.transpose ? lhs_source_cols : lhs_source_rows;
+  int64_t lhs_cols = lhs_info.transpose ? lhs_source_rows : lhs_source_cols;
+  int64_t rhs_rows = rhs_info.transpose ? rhs_source_cols : rhs_source_rows;
+  int64_t rhs_cols = rhs_info.transpose ? rhs_source_rows : rhs_source_cols;
+
+  CHECK(lhs_cols == rhs_rows)
+      << "FlattenTileNdTo2D: tile.batch_matmul requires matching inner dimensions after "
+         "transpose, but got "
+      << lhs_cols << " and " << rhs_rows;
+
+  // Detect direct-store fusion opportunity.
+  auto direct_store = DetectDirectStore(stmts, stmt_index, assign->var_);
+
+  // Allocate output tile (non-fused path only).
+  VarPtr out_var;
+  if (!direct_store.detected) {
+    auto out_shape =
+        std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * lhs_rows, rhs_cols, span), span);
+    std::vector<std::pair<std::string, std::any>> create_kw = {{"dtype", orig_result_type->dtype_}};
+    auto create_out = op_registry.Create("tile.create", {out_shape}, create_kw, span);
+    out_var = std::make_shared<Var>(assign->var_->name_hint_, create_out->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
+  }
+
+  // Prepare direct-store state.
+  ExprPtr current_store_tensor;
+  MakeTuplePtr direct_store_offsets;
+  std::vector<ExprPtr> direct_store_shape;
+  if (direct_store.detected) {
+    current_store_tensor = Substitute(direct_store.store_call->args_[2], ctx.var_map);
+    direct_store_offsets = As<MakeTuple>(Substitute(direct_store.store_call->args_[1], ctx.var_map));
+    auto store_tensor_type = As<TensorType>(current_store_tensor->GetType());
+    CHECK(store_tensor_type) << "FlattenTileNdTo2D: tile.batch_matmul direct store target must be TensorType";
+    CHECK(direct_store_offsets) << "FlattenTileNdTo2D: tile.store offsets must be a MakeTuple";
+    CHECK(direct_store_offsets->elements_.size() == output_batch_dims.size() + 2)
+        << "FlattenTileNdTo2D: tile.store offsets rank must match batch_matmul result rank";
+    if (store_tensor_type->shape_.size() > 2) {
+      // Build the original tensor-rank partition shape:
+      // [1, ..., 1, M, N] (left-padded with 1s for batch dims)
+      const size_t tensor_rank = store_tensor_type->shape_.size();
+      const size_t tile_rank = 2;  // matmul result is always 2D
+      direct_store_shape.reserve(tensor_rank);
+      for (size_t i = tile_rank; i < tensor_rank; ++i) {
+        direct_store_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
+      }
+      direct_store_shape.push_back(std::make_shared<ConstInt>(lhs_rows, DataType::INDEX, span));
+      direct_store_shape.push_back(std::make_shared<ConstInt>(rhs_cols, DataType::INDEX, span));
+    }
+  }
+
+  // Unroll batch dimensions.
+  for (int64_t i = 0; i < batch_count; ++i) {
+    auto output_batch_indices = BuildBatchIndices(i, output_batch_dims);
+    int64_t lhs_batch_idx =
+        BuildOperandFlatBatchIndex(lhs_batch_dims, output_batch_dims, output_batch_indices);
+    int64_t rhs_batch_idx =
+        BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
+
+    // Extract 2D pages.
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
+                                     op_registry, span);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
+                                     op_registry, span);
+    out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
+    out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
+
+    // Emit tile.matmul.
+    auto matmul = op_registry.Create("tile.matmul", {lhs_page.var, rhs_page.var}, span);
+    auto matmul_var = std::make_shared<Var>("matmul_" + std::to_string(i), matmul->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, span));
+
+    // Move matmul result from Acc to Vec, then cast dtype if needed.
+    // The explicit tile.move is always required for the non-fused (assemble) path so
+    // that ExpandMixedKernel sees a clear AIC→AIV boundary. For the fused (direct
+    // store) path, the tile.store codegen handles the Acc→DDR transfer directly.
+    ExprPtr batch_result = matmul_var;
+    auto batch_result_type = As<TileType>(matmul_var->GetType());
+    bool needs_cast = batch_result_type && batch_result_type->dtype_ != orig_result_type->dtype_;
+    if (!direct_store.detected || needs_cast) {
+      std::vector<std::pair<std::string, std::any>> move_kw = {
+          {"target_memory", MemorySpace::Vec},
+      };
+      auto move = op_registry.Create("tile.move", {matmul_var}, move_kw, span);
+      auto move_var = std::make_shared<Var>("matmul_vec_" + std::to_string(i), move->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(move_var, move, span));
+      batch_result = move_var;
+    }
+    if (needs_cast) {
+      std::vector<std::pair<std::string, std::any>> cast_kw = {
+          {"target_type", orig_result_type->dtype_},
+          {"mode", 2},
+      };
+      auto cast = op_registry.Create("tile.cast", {batch_result}, cast_kw, span);
+      auto cast_var = std::make_shared<Var>("matmul_cast_" + std::to_string(i), cast->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(cast_var, cast, span));
+      batch_result = cast_var;
+    }
+
+    if (direct_store.detected) {
+      // Fused path: emit per-batch tile.store.
+      // Keep the original tensor-rank offsets — codegen reconstructs the
+      // corresponding partition_view from that window description.
+      auto store_offset_elems = BuildBatchAdjustedOffsets(
+          direct_store_offsets->elements_, output_batch_indices, output_batch_dims.size(), span);
+      auto store_offset = std::make_shared<MakeTuple>(store_offset_elems, span);
+
+      std::vector<ExprPtr> store_args = {batch_result, store_offset, current_store_tensor};
+      if (!direct_store_shape.empty()) {
+        store_args.push_back(std::make_shared<MakeTuple>(direct_store_shape, span));
+      }
+      auto batch_store = op_registry.Create("tile.store", store_args, span);
+      auto batch_store_var =
+          std::make_shared<Var>(direct_store.store_assign->var_->name_hint_ + "_" + std::to_string(i),
+                                batch_store->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(batch_store_var, batch_store, span));
+      current_store_tensor = batch_store_var;
+    } else {
+      // Non-fused path: assemble into output tile.
+      auto out_offset = MakeShapeTupleFromInts({i * lhs_rows, 0}, span);
+      auto assemble = op_registry.Create("tile.assemble", {out_var, batch_result, out_offset}, span);
+      out_var = std::make_shared<Var>(out_var->name_hint_, assemble->GetType(), span);
+      out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, span));
+    }
+  }
+
+  if (direct_store.detected) {
+    auto final_store_var = As<Var>(current_store_tensor);
+    CHECK(final_store_var) << "FlattenTileNdTo2D: expected final direct store result to be a Var";
+    out.fused_store = true;
+    out.store_result_var = final_store_var;
+    out.store_orig_var = direct_store.store_assign->var_;
+  } else {
+    out.output_var = out_var;
+  }
+
+  return out;
+}
+
 /**
  * @brief Recursively transform statements, flattening >2D tile ops to 2D.
  */
@@ -238,7 +898,98 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
                                    const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
 
-  for (const auto& stmt : stmts) {
+  // Pre-scan: identify tile.load/tile.transpose results consumed exclusively by
+  // tile.batch_matmul. When ExtractBatchPage Strategy 1 re-emits per-batch loads
+  // from the original tensor, the full-batch load becomes dead code. Skip emitting
+  // it to avoid wasted memory and potential hardware pipeline interference.
+  //
+  // Safety: we count ALL Var references across every statement type (Return, Yield,
+  // If conditions, For/While bounds, etc.), not just Call arguments. A Var used
+  // anywhere outside a tile.batch_matmul Call prevents it from being skipped.
+  std::unordered_set<const Var*> batch_matmul_only_vars;
+  {
+    std::unordered_map<const Var*, int> use_count;
+    std::vector<const Var*> batch_matmul_operands;  // ordered to avoid nondeterministic iteration
+
+    // Helper: recursively count all Var references within an expression.
+    std::function<void(const ExprPtr&)> CountVarRefs = [&](const ExprPtr& expr) {
+      if (!expr) return;
+      if (auto v = As<Var>(expr)) {
+        use_count[v.get()]++;
+        return;
+      }
+      if (auto tup = As<MakeTuple>(expr)) {
+        for (const auto& e : tup->elements_) CountVarRefs(e);
+        return;
+      }
+      if (auto call = As<Call>(expr)) {
+        for (const auto& a : call->args_) CountVarRefs(a);
+        return;
+      }
+    };
+
+    for (const auto& s : stmts) {
+      // AssignStmt: count call args; mark batch_matmul operands separately.
+      if (auto a = As<AssignStmt>(s)) {
+        if (auto c = As<Call>(a->value_)) {
+          bool is_batch_mm = (c->op_->name_ == "tile.batch_matmul");
+          for (const auto& arg : c->args_) {
+            if (auto v = As<Var>(arg)) {
+              use_count[v.get()]++;
+              if (is_batch_mm) batch_matmul_operands.push_back(v.get());
+            }
+          }
+        } else {
+          // Non-call assignment (e.g. plain Var alias): count all Var refs.
+          CountVarRefs(a->value_);
+        }
+        continue;
+      }
+      // ReturnStmt / YieldStmt: count all returned/yielded Var refs.
+      if (auto ret = As<ReturnStmt>(s)) {
+        for (const auto& v : ret->value_) CountVarRefs(v);
+        continue;
+      }
+      if (auto yield = As<YieldStmt>(s)) {
+        for (const auto& v : yield->value_) CountVarRefs(v);
+        continue;
+      }
+      // EvalStmt: count Var refs in the expression.
+      if (auto eval = As<EvalStmt>(s)) {
+        CountVarRefs(eval->expr_);
+        continue;
+      }
+      // IfStmt: count condition Var refs.
+      if (auto if_stmt = As<IfStmt>(s)) {
+        CountVarRefs(if_stmt->condition_);
+        continue;
+      }
+      // ForStmt: count start/stop/step and iter_arg init Var refs.
+      if (auto for_stmt = As<ForStmt>(s)) {
+        CountVarRefs(for_stmt->start_);
+        CountVarRefs(for_stmt->stop_);
+        CountVarRefs(for_stmt->step_);
+        for (const auto& ia : for_stmt->iter_args_) CountVarRefs(ia->initValue_);
+        continue;
+      }
+      // WhileStmt: count condition and iter_arg init Var refs.
+      if (auto while_stmt = As<WhileStmt>(s)) {
+        CountVarRefs(while_stmt->condition_);
+        for (const auto& ia : while_stmt->iter_args_) CountVarRefs(ia->initValue_);
+        continue;
+      }
+    }
+    // De-duplicate batch_matmul_operands before checking counts.
+    std::unordered_set<const Var*> seen;
+    for (const auto* v : batch_matmul_operands) {
+      if (seen.insert(v).second && use_count[v] == 1) {
+        batch_matmul_only_vars.insert(v);
+      }
+    }
+  }
+
+  for (size_t stmt_index = 0; stmt_index < stmts.size(); ++stmt_index) {
+    const auto& stmt = stmts[stmt_index];
     // ReturnStmt: substitute return values
     if (auto ret = As<ReturnStmt>(stmt)) {
       std::vector<ExprPtr> new_values;
@@ -480,9 +1231,25 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     const auto& op_name = call->op_->name_;
 
-    // ---- tile.load on >2D tile: produce 2D tile directly ----
-    // tile.load semantics: ND tensor → 2D tile. No reshape needed.
+    // ---- tile.load on >2D tile: preserve the original tensor-rank source window,
+    //      but flatten the result tile ----
+    // Keep the original tensor-rank offsets/shapes on the call for codegen, then
+    // manually replace the inferred rank>2 TileType with a 2D TileType because
+    // hardware tiles are always 2D.
     if (op_name == "tile.load") {
+      // Skip tile.load whose result is consumed exclusively by tile.batch_matmul,
+      // but ONLY when ExtractBatchPage Strategy 1 can reconstruct per-batch loads
+      // (i.e. target_memory == Mat). Strategy 1 now supports transpose=True loads
+      // by propagating the kwarg to per-batch loads. Other strategies (2/3) need
+      // the original load result as their input operand.
+      if (batch_matmul_only_vars.count(assign->var_.get())) {
+        auto target_mem = call->GetKwarg<MemorySpace>("target_memory", MemorySpace::DDR);
+        if (target_mem == MemorySpace::Mat) {
+          ctx.Insert(assign->var_, assign->var_);  // identity mapping so lookups still work
+          continue;
+        }
+      }
+
       // Substitute args via ctx.var_map so all operand Vars reference the latest SSA values.
       std::vector<ExprPtr> sub_args;
       sub_args.reserve(call->args_.size());
@@ -492,16 +1259,14 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
       auto result_tile = As<TileType>(call->GetType());
       if (result_tile && result_tile->shape_.size() > 2) {
+        // Rank>2 tile.load: keep the original tensor-rank offsets/shapes, but
+        // construct a 2D TileType for the result. DeduceTileLoadType produces a
+        // rank>2 TileType from those shapes, but hardware tiles are always 2D.
+        // The pass manually overrides the result type to 2D.
         auto [merged, last] = ComputeMergedShape(result_tile->shape_, "tile.load result");
 
-        // Construct call with explicit 2D TileType (bypasses ND type inference).
-        // Create a 2D tile_view and preserve memory_space for type consistency
-        // with downstream ops (op_registry always adds tile_view + memory_space).
         auto flat_shape_exprs = Make2DShapeExprs(merged, last, span);
         // Assign the implicit TileView for the flattened 2D shape+memory_space.
-        // This ensures print→parse roundtrip stability: the printer omits TileView
-        // fields that match the implicit defaults, and C++ type inference on reparse
-        // produces the same implicit TileView, so structural_equal sees identical types.
         auto flat_tile_view = std::make_optional(
             tile_view_semantics::GetImplicitTileView(flat_shape_exprs, result_tile->memory_space_));
         auto flat_tile_type = std::make_shared<TileType>(flat_shape_exprs, result_tile->dtype_, std::nullopt,
@@ -522,17 +1287,10 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       continue;
     }
 
-    // ---- tile.store: pass through, injecting shapes for ND tensors ----
-    // tile.store semantics: (flattened-)2D tile → ND tensor. No reshape needed.
-    // When the output tensor is ND (rank > 2), inject an explicit shapes tuple as
-    // args[3] so that the codegen can reconstruct the correct pto.partition_view.
-    // The shapes tuple is the tile's original shape left-padded with 1s to reach
-    // the tensor rank.  Examples:
-    //   tile [A,B,C] (ND, rank 3) → tensor rank 3: shapes = (A,B,C)       [no pad]
-    //   tile [A,B,C] (ND, rank 3) → tensor rank 4: shapes = (1,A,B,C)     [1 pad]
-    //   tile [H,W]   (2D, rank 2) → tensor rank 3: shapes = (1,H,W)       [1 pad]
-    // The original tile type is read BEFORE substitution so it still carries the
-    // pre-flatten ND shape.
+    // ---- tile.store: inject original tensor-rank partition shape for rank>2 tensors ----
+    // tile.store semantics: (2D) tile -> rank>2 tensor. Original tensor-rank
+    // offsets are preserved; codegen uses the tensor view plus a partition_view
+    // over the original tensor-rank window to produce the 2D result.
     // Signature: (tile, offsets, output_tensor[, shapes])
     if (op_name == "tile.store") {
       auto orig_tile_type = As<TileType>(call->args_[0]->GetType());
@@ -543,22 +1301,23 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       for (const auto& arg : call->args_) {
         new_args.push_back(Substitute(arg, ctx.var_map));
       }
-      // Inject shapes tuple whenever the output tensor is ND (rank > 2).
-      // Codegen always requires args[3] in that case regardless of tile rank.
+
       auto out_tensor_type = As<TensorType>(new_args[2]->GetType());
       if (orig_tile_type && out_tensor_type && out_tensor_type->shape_.size() > 2) {
+        // Inject the original tensor-rank partition shape tuple as the 4th argument.
+        // The partition shape has the same rank as the tensor, with 1s for
+        // batch dims that are not covered by the tile, followed by the tile dims.
         const size_t tensor_rank = out_tensor_type->shape_.size();
         const size_t tile_rank = orig_tile_type->shape_.size();
-        std::vector<ExprPtr> shapes;
-        shapes.reserve(tensor_rank);
-        // Left-pad with 1s when tile rank < tensor rank.
+        std::vector<ExprPtr> partition_shape;
+        partition_shape.reserve(tensor_rank);
         for (size_t i = tile_rank; i < tensor_rank; ++i) {
-          shapes.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
+          partition_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
         }
         for (const auto& dim : orig_tile_type->shape_) {
-          shapes.push_back(dim);
+          partition_shape.push_back(dim);
         }
-        new_args.push_back(std::make_shared<MakeTuple>(shapes, span));
+        new_args.push_back(std::make_shared<MakeTuple>(partition_shape, span));
       }
 
       // Construct call directly: store result type = output tensor type (args[2])
@@ -631,6 +1390,25 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       }
     }
 
+    // ---- tile.batch_matmul: delegate to LowerBatchMatmul ----
+    if (op_name == "tile.batch_matmul") {
+      auto lowering = LowerBatchMatmul(assign, call, stmts, stmt_index, ctx, op_registry, span);
+      result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
+      if (lowering.fused_store) {
+        ctx.Insert(lowering.store_orig_var, lowering.store_result_var);
+        ++stmt_index;  // Skip the next tile.store; it has been fused above.
+      } else {
+        ctx.Insert(assign->var_, lowering.output_var);
+      }
+      continue;
+    }
+
+    // ---- tile.transpose feeding only tile.batch_matmul: skip and let LowerBatchMatmul peel it ----
+    if (op_name == "tile.transpose" && batch_matmul_only_vars.count(assign->var_.get()) != 0) {
+      ctx.Insert(assign->var_, assign->var_);  // identity mapping for safety
+      continue;
+    }
+
     // ---- All other tile ops (including tile.reshape) and non-tile ops: substitute args ----
     {
       std::vector<ExprPtr> new_args;
@@ -665,6 +1443,11 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
 /**
  * @brief Transform a single InCore function: flatten >2D tiles to 2D.
+ *
+ * This includes:
+ * 1. Flattening >2D tile ops in the function body to 2D
+ * 2. Preserving original tensor-rank offsets/shapes in tile.load/store for
+ *    codegen to use with tensor_view + partition_view
  */
 FunctionPtr TransformFunction(const FunctionPtr& func) {
   if (!IsInCoreType(func->func_type_)) {
@@ -678,8 +1461,9 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
   PreconditionChecker checker;
   checker.VisitStmt(func->body_);
 
-  // Transform body
   FlattenContext ctx;
+
+  // Transform body
   auto body_stmts = FlattenToStmts(func->body_);
   auto new_stmts = TransformBody(body_stmts, ctx, op_registry, span);
   auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
@@ -729,7 +1513,8 @@ class TileOps2DVerifier : public IRVisitor {
     if (name.substr(0, 5) != "tile.") return;
 
     // tile.load/tile.store are permitted to have any tile rank:
-    // load produces 2D tiles from ND tensors; store accepts 2D tiles and writes to ND tensors.
+    // load produces 2D tiles from rank>2 tensors; store accepts 2D tiles and
+    // writes them back to rank>2 tensors.
     if (name == "tile.load" || name == "tile.store" || name == "tile.reshape") return;
 
     // Check result type

--- a/src/ir/transforms/resolve_transpose_layout_pass.cpp
+++ b/src/ir/transforms/resolve_transpose_layout_pass.cpp
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -113,13 +112,9 @@ FunctionPtr TransformIncoreParams(const FunctionPtr& func) {
       continue;
     }
 
-    if (transpose_results.end() !=
-        std::find_if(transpose_results.begin(), transpose_results.end(),
-                     [idx](const auto& info) { return info.param_index == idx; })) {
-      CHECK(old_tensor_type->shape_.size() == 2)
-          << "transpose layout resolution only supports 2D tensors, got " << old_tensor_type->shape_.size()
-          << "D";
-    }
+    CHECK(old_tensor_type->shape_.size() >= 2)
+        << "transpose layout resolution requires at least 2D tensors, got " << old_tensor_type->shape_.size()
+        << "D";
 
     auto new_tensor_type = std::make_shared<TensorType>(
         old_tensor_type->shape_, old_tensor_type->dtype_, old_tensor_type->memref_,

--- a/tests/st/runtime/test_batch_matmul.py
+++ b/tests/st/runtime/test_batch_matmul.py
@@ -1,0 +1,265 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+System tests for tile.batch_matmul operation.
+
+This test validates the tile.batch_matmul operation through the complete
+compilation and execution pipeline, comparing results against PyTorch reference.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+
+class TestBatchMatmulTile(PTOTestCase):
+    """Tile-level batch matmul: explicit load → batch_matmul → store.
+
+    Uses tile.batch_matmul directly, mirroring how TestMatmul uses tile.matmul.
+    """
+
+    __test__ = False
+
+    def __init__(self, batch: int = 2, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.batch = batch
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"batch_matmul_tile_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.batch, self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.batch, self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.batch, self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.batch, self.M, self.K, self.N
+
+        @pl.program
+        class BatchMatmulTileProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul_tile(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                tile_a = pl.load(a, offsets=[0, 0, 0], shapes=[B, M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, offsets=[0, 0, 0], shapes=[B, K, N], target_memory=pl.MemorySpace.Mat)
+                tile_c = pl.batch_matmul(tile_a, tile_b)
+                out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul_tile(a, b, c)
+                return out_c
+
+        return BatchMatmulTileProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.bmm(tensors["a"], tensors["b"])
+
+
+class TestBatchMatmulBTranspose(PTOTestCase):
+    """Tile-level batch matmul with B transposed: C = A @ B^T.
+
+    B is stored as [batch, N, K] and transposed inline before batch_matmul.
+    """
+
+    __test__ = False
+
+    def __init__(self, batch: int = 2, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.batch = batch
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"batch_matmul_b_trans_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.batch, self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.batch, self.N, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.batch, self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.batch, self.M, self.K, self.N
+
+        @pl.program
+        class BatchMatmulBTransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul_bt(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                tile_a = pl.load(a, offsets=[0, 0, 0], shapes=[B, M, K], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(
+                    b, offsets=[0, 0, 0], shapes=[B, N, K], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_c = pl.batch_matmul(tile_a, tile_b)
+                out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul_bt(a, b, c)
+                return out_c
+
+        return BatchMatmulBTransProgram
+
+    def compute_expected(self, tensors, params=None):
+        # B is [batch, N, K], transpose last two dims → [batch, K, N]
+        tensors["c"][:] = torch.bmm(tensors["a"], tensors["b"].transpose(-2, -1))
+
+
+class TestBatchMatmulATranspose(PTOTestCase):
+    """Tile-level batch matmul with A transposed: C = A^T @ B.
+
+    A is stored as [batch, K, M] and transposed inline before batch_matmul.
+    """
+
+    __test__ = False
+
+    def __init__(self, batch: int = 2, m: int = 64, k: int = 64, n: int = 64, config=None):
+        super().__init__(config)
+        self.batch = batch
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"batch_matmul_a_trans_{self.batch}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.batch, self.K, self.M], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.batch, self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.batch, self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.batch, self.M, self.K, self.N
+
+        @pl.program
+        class BatchMatmulATransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul_at(
+                self,
+                a: pl.Tensor[[B, K, M], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                tile_a = pl.load(
+                    a, offsets=[0, 0, 0], shapes=[B, K, M], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_b = pl.load(b, offsets=[0, 0, 0], shapes=[B, K, N], target_memory=pl.MemorySpace.Mat)
+                tile_c = pl.batch_matmul(tile_a, tile_b)
+                out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, K, M], pl.FP32],
+                b: pl.Tensor[[B, K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul_at(a, b, c)
+                return out_c
+
+        return BatchMatmulATransProgram
+
+    def compute_expected(self, tensors, params=None):
+        # A is [batch, K, M], transpose last two dims → [batch, M, K]
+        tensors["c"][:] = torch.bmm(tensors["a"].transpose(-2, -1), tensors["b"])
+
+
+class TestBatchMatmulOperations:
+    """Test suite for tile-level batch matrix multiplication.
+
+    Covers both rank>2 tensor inputs and transpose-driven DN-layout codegen.
+    """
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            (1, 128, 64, 128),
+            # Non-square rank>2 coverage on the non-DN path (no transpose).
+            (2, 64, 32, 64),
+            (2, 32, 64, 128),
+        ],
+    )
+    def test_batch_matmul_tile(self, test_runner, batch, m, k, n):
+        """Test tile.batch_matmul with explicit load/store on the rank>2 non-DN path."""
+        test_case = TestBatchMatmulTile(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            # Non-square DN-layout coverage: B is [batch, N, K] and transpose=True.
+            (2, 64, 32, 128),
+            (2, 32, 64, 48),
+        ],
+    )
+    def test_batch_matmul_b_transpose(self, test_runner, batch, m, k, n):
+        """Test tile.batch_matmul with B transposed on the DN-layout codegen path."""
+        test_case = TestBatchMatmulBTranspose(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (B-trans): {result.error}"
+
+    @pytest.mark.parametrize(
+        "batch,m,k,n",
+        [
+            (2, 64, 64, 64),
+            (4, 32, 32, 32),
+            # Non-square DN-layout coverage: A is [batch, K, M] and transpose=True.
+            (2, 128, 32, 64),
+            (2, 48, 64, 32),
+        ],
+    )
+    def test_batch_matmul_a_transpose(self, test_runner, batch, m, k, n):
+        """Test tile.batch_matmul with A transposed on the DN-layout codegen path."""
+        test_case = TestBatchMatmulATranspose(batch=batch, m=m, k=k, n=n)
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (A-trans): {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--forked"])

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1628,6 +1628,40 @@ class TestColumnVectorCodegen:
         assert "layout = #pto.layout<nd>" in row_view
 
 
+def test_pto_codegen_3d_dn_tensor_view_uses_last_dim_stride():
+    """3D DN tensor emits swapped shape and DN strides based on the original last dim.
+
+    Regression test for non-square batch transpose cases such as B:[B, N, K] with N != K.
+    The DN stride for the last dimension must be K (the original last dim), not N.
+    """
+
+    @pl.program
+    class DN3DProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            b: pl.Tensor[[2, 48, 64], pl.FP32, pl.DN],
+            out: pl.Out[pl.Tensor[[2, 48, 64], pl.FP32]],
+        ) -> pl.Tensor[[2, 48, 64], pl.FP32]:
+            tile_b = pl.load(b, [0, 0, 0], [2, 48, 64])
+            return pl.store(tile_b, [0, 0, 0], out)
+
+    mlir_code = _generate_default_mlir(DN3DProgram)
+    lines = _get_mlir_lines(mlir_code)
+    b_view = _single_line(lines, "pto.make_tensor_view %arg0")
+    stride_mul_lines = _find_lines(lines, "arith.muli")
+
+    assert "shape = [%c2_index, %c64_index, %c48_index]" in b_view
+    assert "strides = [" in b_view and ", %c1_index, %c64_index]" in b_view, (
+        f"3D DN stride must end with [1, 64] for shape [2, 48, 64]: {b_view}"
+    )
+    assert any("%c64_index" in line and "%c48_index" in line for line in stride_mul_lines), (
+        "Expected batch stride to be computed from the original last two dims (64 * 48). "
+        f"Got muli lines: {stride_mul_lines}"
+    )
+    assert "layout = #pto.layout<dn>" in b_view
+
+
 def test_pto_codegen_constant_indent_consistency():
     """All arith.constant lines must have consistent 2-space indent.
 

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -323,6 +323,34 @@ def test_matmul_with_transpose_kwargs():
     assert isinstance(call.type, ir.TensorType)
 
 
+def test_tile_batch_matmul_type_deduction():
+    """Test tile.batch_matmul type deduction without transpose kwargs."""
+    span = ir.Span.unknown()
+
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+
+    type_a = ir.TileType([dim2, dim128, dim64], DataType.FP16)
+    type_b = ir.TileType([dim2, dim64, dim32], DataType.FP16)
+    var_a = ir.Var("a_tile", type_a, span)
+    var_b = ir.Var("b_tile", type_b, span)
+
+    call = ir.create_op_call("tile.batch_matmul", [var_a, var_b], span)
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TileType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+    assert isinstance(result_type.shape[0], ir.ConstInt)
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert isinstance(result_type.shape[2], ir.ConstInt)
+    assert result_type.shape[0].value == 2
+    assert result_type.shape[1].value == 128
+    assert result_type.shape[2].value == 32
+
+
 def test_matmul_with_unknown_kwarg():
     """Test tensor.matmul with unknown kwarg should raise error."""
     span = ir.Span.unknown()
@@ -415,6 +443,14 @@ def test_matmul_kwarg_schema():
     assert "out_dtype" in keys
     assert "a_trans" in keys
     assert "b_trans" in keys
+
+
+def test_tile_batch_matmul_kwarg_schema():
+    """Test that tile.batch_matmul does not add custom kwargs."""
+    batch_matmul_op = ir.get_op("tile.batch_matmul")
+
+    keys = batch_matmul_op.get_attr_keys()
+    assert not keys
 
 
 def test_cast_kwarg_schema():

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1114,14 +1114,14 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 2
-        assert result_type.dtype == DataType.FP16
+        assert result_type.dtype == DataType.FP32
 
     def test_batch_matmul_3d(self):
         """Test tile.batch_matmul with 3D tiles (batch dimension)."""
@@ -1140,7 +1140,7 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
@@ -1167,14 +1167,14 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         assert call.op.name == "tile.batch_matmul"
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 4
-        assert result_type.dtype == DataType.FP16
+        assert result_type.dtype == DataType.FP32
 
     def test_batch_matmul_broadcast(self):
         """Test tile.batch_matmul with broadcasting batch dimensions."""
@@ -1194,15 +1194,74 @@ class TestTileBatchMatMulOps:
         rhs = ir.Var("rhs", rhs_type, span)
 
         # Create batch_matmul call
-        call = ir.create_op_call("tile.batch_matmul", [lhs, rhs], {}, span)
+        call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 3
 
+    def test_batch_matmul_dtype_mismatch(self):
+        """Test tile.batch_matmul rejects mismatched dtypes."""
+        span = ir.Span.unknown()
 
-class TestMultiDimensionalTileOps:
+        dim4 = ir.ConstInt(4, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim4, dim16, dim32], DataType.FP16)
+        rhs_type = ir.TileType([dim4, dim32, dim16], DataType.FP32)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        with pytest.raises(ValueError, match="identical"):
+            tile.batch_matmul(lhs, rhs, span)
+
+    def test_batch_matmul_int_accumulation(self):
+        """Test tile.batch_matmul with integer inputs produces INT32 accumulator dtype."""
+        span = ir.Span.unknown()
+
+        dim2 = ir.ConstInt(2, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim2, dim16, dim32], DataType.INT8)
+        rhs_type = ir.TileType([dim2, dim32, dim16], DataType.INT8)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        call = tile.batch_matmul(lhs, rhs, span)
+
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.INT32
+
+    def test_batch_matmul_output_tile_view(self):
+        """Test tile.batch_matmul output has correct TileView (col_major, row_major, fractal=1024)."""
+        span = ir.Span.unknown()
+
+        dim2 = ir.ConstInt(2, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+
+        lhs_type = ir.TileType([dim2, dim16, dim32], DataType.FP16)
+        rhs_type = ir.TileType([dim2, dim32, dim64], DataType.FP16)
+
+        lhs = ir.Var("lhs", lhs_type, span)
+        rhs = ir.Var("rhs", rhs_type, span)
+
+        call = tile.batch_matmul(lhs, rhs, span)
+
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        assert result_type.tile_view.blayout == ir.TileLayout.col_major
+        assert result_type.tile_view.slayout == ir.TileLayout.row_major
+        assert result_type.tile_view.fractal == 1024
+
     """Tests for multi-dimensional TileType operations."""
 
     def test_transpose_3d(self):

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -26,11 +26,11 @@ def _load2d(
     flat_shape: list,
     dtype: DataType,
 ) -> ir.Call:
-    """Create tile.load Call with explicit 2D TileType (bypasses op registry type inference).
+    """Create tile.load Call with original tensor-rank offsets/shapes and a 2D TileType.
 
-    tile.load hardware semantics: ND tensor -> 2D tile. The pass changes the result type
-    directly to 2D without inserting a tile.reshape, preserving tile_view and memory_space
-    from the original ND type.
+    After the refactor, FlattenTileNdTo2D keeps the original tensor-rank
+    offsets/shapes in tile.load but overrides the result TileType to 2D.
+    This helper constructs that expected IR shape.
     """
     nd_call = tile_ops.load(tensor, offsets, shapes, span=ir.Span.unknown())
     # Create a reference 2D tile.load to get the correct type (with proper tile_view + memory_space)
@@ -1552,7 +1552,9 @@ class TestFlattenTileNdTo2DReduceAndCompute:
                 a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.create([6, 4], dtype=pl.FP32)
                 b_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.full([6, 4], dtype=pl.FP32, value=1.0)
                 c_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(a_tile, b_tile)
-                out_store: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(c_tile, [0, 0, 0], out_0, [2, 3, 4])
+                out_store: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(
+                    c_tile, [0, 0, 0], out_0, shapes=[2, 3, 4]
+                )
                 return out_store
 
             @pl.function
@@ -1794,6 +1796,493 @@ class TestFlattenTileNdTo2DControlFlow:
         props = passes.IRPropertySet()
         props.insert(passes.IRProperty.TileOps2D)
         passes.verify_properties(props, After, "test_while_stmt_tile_iter_arg")
+
+
+class TestFlattenTileNdTo2DBatchMatmul:
+    """Tests for tile.batch_matmul lowering inside FlattenTileNdTo2D."""
+
+    @staticmethod
+    def _flattened_incore(before: ir.Program) -> ir.Function:
+        """Run FlattenTileNdTo2D and return `main_incore_0`."""
+        after = passes.flatten_tile_nd_to_2d()(before)
+        after_func = after.get_function("main_incore_0")
+        assert after_func is not None
+        return after_func
+
+    @staticmethod
+    def _top_level_calls(func: ir.Function) -> list[ir.Call]:
+        """Return top-level AssignStmt call values from a function body."""
+        body = cast(ir.SeqStmts, func.body)
+        calls: list[ir.Call] = []
+        for stmt in body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                calls.append(stmt.value)
+        return calls
+
+    @staticmethod
+    def _tuple_const_values(expr: ir.Expr) -> list[int]:
+        """Extract integer values from a MakeTuple of ConstInt expressions."""
+        tup = cast(ir.MakeTuple, expr)
+        return [cast(ir.ConstInt, elem).value for elem in tup.elements]
+
+    def test_batch_matmul_broadcasts_and_unrolls(self):
+        """Broadcasted tile.batch_matmul [2,1,M,K]x[1,3,K,N] expands to 6 per-batch 2D tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 3, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 1, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0, 0], [2, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[1, 3, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0, 0], [1, 3, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 3, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 3, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 3, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                lhs_load_0: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_0: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_0: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                out_0_0: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_0, [0, 0, 0, 0], out_0, shapes=[1, 1, 16, 64]
+                )
+
+                lhs_load_1: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_1: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_1: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                out_0_1: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_1, [0, 1, 0, 0], out_0_0, shapes=[1, 1, 16, 64]
+                )
+
+                lhs_load_2: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_2: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_2: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_2, rhs_load_2)
+                out_0_2: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_2, [0, 2, 0, 0], out_0_1, shapes=[1, 1, 16, 64]
+                )
+
+                lhs_load_3: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_3: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_3: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_3, rhs_load_3)
+                out_0_3: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_3, [1, 0, 0, 0], out_0_2, shapes=[1, 1, 16, 64]
+                )
+
+                lhs_load_4: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_4: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_4: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_4, rhs_load_4)
+                out_0_4: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_4, [1, 1, 0, 0], out_0_3, shapes=[1, 1, 16, 64]
+                )
+
+                lhs_load_5: pl.Tile[[16, 128], pl.FP16] = pl.load(
+                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_load_5: pl.Tile[[128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                matmul_5: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_5, rhs_load_5)
+                out_0_5: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
+                    matmul_5, [1, 2, 0, 0], out_0_4, shapes=[1, 1, 16, 64]
+                )
+                return out_0_5
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 3, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        after_func = self._flattened_incore(Before)
+        expected_func = Expected.get_function("main_incore_0")
+        assert expected_func is not None
+        ir.assert_structural_equal(after_func, expected_func)
+
+    def test_batch_matmul_with_both_operands_load_transpose_unrolls_per_batch(self):
+        """Both operands use load(transpose=True): per-batch load with transpose kwarg, no tile.transpose."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_load_0: pl.Tile[
+                    [16, 128],
+                    pl.FP16,
+                    pl.MemorySpace.Mat,
+                    pl.TileView(
+                        valid_shape=[16, 128],
+                        blayout=pl.TileLayout.row_major,
+                        slayout=pl.TileLayout.col_major,
+                    ),
+                ] = pl.load(lhs, [0, 0, 0], [1, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True)
+                rhs_load_0: pl.Tile[
+                    [128, 64],
+                    pl.FP16,
+                    pl.MemorySpace.Mat,
+                    pl.TileView(
+                        valid_shape=[128, 64],
+                        blayout=pl.TileLayout.row_major,
+                        slayout=pl.TileLayout.col_major,
+                    ),
+                ] = pl.load(rhs, [0, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+                matmul_0: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                out_0_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(
+                    matmul_0, [0, 0, 0], out_0, shapes=[1, 16, 64]
+                )
+
+                lhs_load_1: pl.Tile[
+                    [16, 128],
+                    pl.FP16,
+                    pl.MemorySpace.Mat,
+                    pl.TileView(
+                        valid_shape=[16, 128],
+                        blayout=pl.TileLayout.row_major,
+                        slayout=pl.TileLayout.col_major,
+                    ),
+                ] = pl.load(lhs, [1, 0, 0], [1, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True)
+                rhs_load_1: pl.Tile[
+                    [128, 64],
+                    pl.FP16,
+                    pl.MemorySpace.Mat,
+                    pl.TileView(
+                        valid_shape=[128, 64],
+                        blayout=pl.TileLayout.row_major,
+                        slayout=pl.TileLayout.col_major,
+                    ),
+                ] = pl.load(rhs, [1, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+                matmul_1: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                out_0_1: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(
+                    matmul_1, [1, 0, 0], out_0_0, shapes=[1, 16, 64]
+                )
+                return out_0_1
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        after_func = self._flattened_incore(Before)
+        expected_func = Expected.get_function("main_incore_0")
+        assert expected_func is not None
+        ir.assert_structural_equal(after_func, expected_func)
+
+    def test_batch_matmul_with_named_load_transpose_unrolls_per_batch(self):
+        """Named load(transpose=True) operands: same output as inline load transpose."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_t: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                rhs_t: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_t, rhs_t)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 64, 128], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        func = self._flattened_incore(Before)
+        calls = self._top_level_calls(func)
+        assert [call.op.name for call in calls] == [
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+        ]
+        load_calls = [call for call in calls if call.op.name == "tile.load"]
+        assert len(load_calls) == 4
+        assert all(call.kwargs["transpose"] is True for call in load_calls)
+        assert [self._tuple_const_values(call.args[1]) for call in load_calls] == [
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+        ]
+        assert [self._tuple_const_values(call.args[2]) for call in load_calls] == [
+            [1, 128, 16],
+            [1, 64, 128],
+            [1, 128, 16],
+            [1, 64, 128],
+        ]
+        store_calls = [call for call in calls if call.op.name == "tile.store"]
+        assert [self._tuple_const_values(call.args[1]) for call in store_calls] == [[0, 0, 0], [1, 0, 0]]
+        assert [self._tuple_const_values(call.args[3]) for call in store_calls] == [[1, 16, 64], [1, 16, 64]]
+
+    def test_batch_matmul_3d_no_transpose_unrolls(self):
+        """tile.batch_matmul [2,M,K]x[2,K,N] expands to 2 per-batch 2D tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        func = self._flattened_incore(Before)
+        calls = self._top_level_calls(func)
+        assert [call.op.name for call in calls] == [
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+        ]
+        load_calls = [call for call in calls if call.op.name == "tile.load"]
+        assert [call.kwargs["transpose"] for call in load_calls] == [False, False, False, False]
+        assert [self._tuple_const_values(call.args[1]) for call in load_calls] == [
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+        ]
+        assert [self._tuple_const_values(call.args[2]) for call in load_calls] == [
+            [1, 16, 128],
+            [1, 128, 64],
+            [1, 16, 128],
+            [1, 128, 64],
+        ]
+        store_calls = [call for call in calls if call.op.name == "tile.store"]
+        assert [self._tuple_const_values(call.args[1]) for call in store_calls] == [[0, 0, 0], [1, 0, 0]]
+        assert [self._tuple_const_values(call.args[3]) for call in store_calls] == [[1, 16, 64], [1, 16, 64]]
+
+    def test_batch_matmul_single_batch_unrolls(self):
+        """tile.batch_matmul [1,M,K]x[1,K,N] expands to 1 per-batch 2D tile.matmul."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[1, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[1, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [1, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[1, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [1, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[1, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[1, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[1, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([1, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        func = self._flattened_incore(Before)
+        calls = self._top_level_calls(func)
+        assert [call.op.name for call in calls] == ["tile.load", "tile.load", "tile.matmul", "tile.store"]
+        load_calls = [call for call in calls if call.op.name == "tile.load"]
+        assert [self._tuple_const_values(call.args[1]) for call in load_calls] == [[0, 0, 0], [0, 0, 0]]
+        assert [self._tuple_const_values(call.args[2]) for call in load_calls] == [[1, 16, 128], [1, 128, 64]]
+        store_call = next(call for call in calls if call.op.name == "tile.store")
+        assert self._tuple_const_values(store_call.args[1]) == [0, 0, 0]
+        assert self._tuple_const_values(store_call.args[3]) == [1, 16, 64]
+
+    def test_batch_matmul_with_load_transpose_unrolls_per_batch(self):
+        """One operand uses load(transpose=True): per-batch load with transpose kwarg."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        func = self._flattened_incore(Before)
+        calls = self._top_level_calls(func)
+        assert [call.op.name for call in calls] == [
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+            "tile.load",
+            "tile.load",
+            "tile.matmul",
+            "tile.store",
+        ]
+        load_calls = [call for call in calls if call.op.name == "tile.load"]
+        assert [call.kwargs["transpose"] for call in load_calls] == [True, False, True, False]
+        assert [self._tuple_const_values(call.args[1]) for call in load_calls] == [
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+        ]
+        assert [self._tuple_const_values(call.args[2]) for call in load_calls] == [
+            [1, 128, 16],
+            [1, 128, 64],
+            [1, 128, 16],
+            [1, 128, 64],
+        ]
+        store_calls = [call for call in calls if call.op.name == "tile.store"]
+        assert [self._tuple_const_values(call.args[1]) for call in store_calls] == [[0, 0, 0], [1, 0, 0]]
+        assert [self._tuple_const_values(call.args[3]) for call in store_calls] == [[1, 16, 64], [1, 16, 64]]
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -524,6 +524,33 @@ class TestUnifiedBlockDispatch:
 
         ir.assert_structural_equal(unified, explicit)
 
+    def test_batch_matmul(self):
+        @pl.function
+        def unified(
+            t1: pl.Tensor[[2, 64, 64], pl.FP16],
+            t2: pl.Tensor[[2, 64, 64], pl.FP16],
+            out: pl.Tensor[[2, 64, 64], pl.FP16],
+        ) -> pl.Tensor[[2, 64, 64], pl.FP16]:
+            a: pl.Tile[[2, 64, 64], pl.FP16] = pl.tile.load(t1, offsets=[0, 0, 0], shapes=[2, 64, 64])
+            b: pl.Tile[[2, 64, 64], pl.FP16] = pl.tile.load(t2, offsets=[0, 0, 0], shapes=[2, 64, 64])
+            c: pl.Tile[[2, 64, 64], pl.FP32] = pl.batch_matmul(a, b)
+            result: pl.Tensor[[2, 64, 64], pl.FP16] = pl.tile.store(c, offsets=[0, 0, 0], output_tensor=out)
+            return result
+
+        @pl.function
+        def explicit(
+            t1: pl.Tensor[[2, 64, 64], pl.FP16],
+            t2: pl.Tensor[[2, 64, 64], pl.FP16],
+            out: pl.Tensor[[2, 64, 64], pl.FP16],
+        ) -> pl.Tensor[[2, 64, 64], pl.FP16]:
+            a: pl.Tile[[2, 64, 64], pl.FP16] = pl.tile.load(t1, offsets=[0, 0, 0], shapes=[2, 64, 64])
+            b: pl.Tile[[2, 64, 64], pl.FP16] = pl.tile.load(t2, offsets=[0, 0, 0], shapes=[2, 64, 64])
+            c: pl.Tile[[2, 64, 64], pl.FP32] = pl.tile.batch_matmul(a, b)
+            result: pl.Tensor[[2, 64, 64], pl.FP16] = pl.tile.store(c, offsets=[0, 0, 0], output_tensor=out)
+            return result
+
+        ir.assert_structural_equal(unified, explicit)
+
     def test_row_sum(self):
         @pl.function
         def unified(
@@ -1010,6 +1037,19 @@ class TestUnifiedOpsTypeErrors:
             unified_ops.add(t, ti)  # type: ignore[arg-type]
         with pytest.raises(TypeError, match="cannot mix Tensor and Tile"):
             unified_ops.add(ti, t)  # type: ignore[arg-type]
+
+    def test_batch_matmul_tensor_inputs(self):
+        """batch_matmul is tile-only; passing Tensors raises TypeError."""
+        span = ir.Span.unknown()
+        t1 = Tensor(expr=ir.Var("a", ir.TensorType([2, 64, 64], DataType.FP16), span))
+        t2 = Tensor(expr=ir.Var("b", ir.TensorType([2, 64, 64], DataType.FP16), span))
+        with pytest.raises(TypeError, match="expected Tensor or Tile operands"):
+            unified_ops.batch_matmul(t1, t2)  # type: ignore[arg-type]
+
+    def test_batch_matmul_invalid_lhs(self):
+        """batch_matmul with non-Tensor/Tile input raises TypeError."""
+        with pytest.raises(TypeError, match="expected Tensor or Tile operands"):
+            unified_ops.batch_matmul(1, 2)  # type: ignore
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implement `tile.batch_matmul` for batched matrix multiplication on rank >= 2 tile operands with NumPy-style broadcasting on the leading batch dimensions:

```text
lhs [..., M, K] × rhs [..., K, N] -> result [..., M, N]
```

The hardware backend only supports rank-2 `tile.matmul`, so this PR lowers `tile.batch_matmul` to a sequence of 2D matmuls in `FlattenTileNdTo2D`.

This PR also fixes the shared load/store/codegen path required by that lowering: the original tensor-rank batch windows must stay in their original coordinates, while the compute tile itself must still become 2D; tensors with `DN` layout must emit shape/stride information that actually matches `layout=dn`.

Closes #536

## Changes

### IR and Python surface
- Register `tile.batch_matmul` with hardware accumulator dtype/layout behavior.
- Validate K-dimension compatibility and require identical lhs/rhs dtypes.
- Export `pl.batch_matmul` through unified ops and add the debug torch-codegen mapping.
- Update English and Chinese operator/pass docs.

### `FlattenTileNdTo2D` lowering
- Lower `tile.batch_matmul` by computing the broadcasted batch shape, unrolling each batch page, and emitting 2D `tile.matmul` calls.
- Normalize transpose semantics from both `tile.transpose(...)` and `tile.load(..., transpose=True)` so batch-matmul lowering sees a single operand-transpose model.
- Extract per-batch 2D pages with three strategies:
  - re-emit `tile.load` from the original tensor when the source is a Mat-memory load
  - `tile.slice` on an already-2D operand
  - rank>2 `tile.slice` + `tile.reshape` fallback
- Preserve the original tensor-rank offsets/shapes on reconstructed `tile.load` / `tile.store` calls, but override the actual compute tile result type to 2D.
- Skip original `tile.load` / `tile.transpose` statements only when they are consumed exclusively by `tile.batch_matmul` and can be reconstructed safely.
- Keep direct-store fusion when the lowered matmul result is written out immediately.

### Shared load / transpose / codegen fixes
- `src/ir/op/tile_ops/memory.cpp`
  - Extend `tile.load(transpose=True)` from rank-2-only handling to rank >= 2 by swapping the trailing two dimensions.
- `src/codegen/pto/pto_codegen.cpp`
  - Fix `pto.make_tensor_view` emission for rank>2 tensors with `DN` layout.
  - For `DN` tensors, the outer batch walk stays the same, but the trailing visible shape/stride now correctly follow DN order.
- `src/backend/common/pto_ops_common.cpp`
  - **Unify ND and DN codegen paths** for `tile.load` and `tile.store`: both now follow a single flow with an in-place swap of the trailing two shape/offset elements for DN layout, eliminating the previous `if (!is_dn) { ... } else { ... }` branching.
  - For `tile.store`, use a defensive check on the shapes tuple injected by `FlattenTileNdTo2D`: if `args[3]` is a `MakeTuple`, use the N-rank partition path; otherwise fall back to the standard 2D path.
  - Add helper functions `GetDimStrings` and `GetSizeCodes` for clean dimension/code extraction from expression lists.
- `src/ir/transforms/resolve_transpose_layout_pass.cpp`
  - Relax transpose-layout resolution from exactly 2D to rank >= 2.

## Test coverage
- Add UT coverage for op registration/type deduction, tile op validation, FlattenTileNdTo2D lowering, and PTO codegen (including 3D DN tensor view test).
- Add simulator ST coverage for tile/PTO batch matmul, including transpose and non-square cases.

## Local validation
- `pre-commit run --all-files` — all passed
- `python tests/lint/clang_tidy.py --diff-base origin/main` — no errors in changed files (only pre-existing `convert_to_ssa_pass.cpp` unused include)
- `pytest tests/ut/ -n auto --maxprocesses 8` — 3671 passed
- `pytest tests/ut/codegen/test_pto_codegen.py -q` — 57 passed
- `pytest tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py -q` — 43 passed
- `local-ci --job pre-commit` — passed