### PR TITLE
refactor(ir): replace MemRef addr/id with base Ptr and byte_offset

### DIFF
--- a/docs/en/dev/passes/utils.md
+++ b/docs/en/dev/passes/utils.md
@@ -85,7 +85,7 @@ wrapper returning all `Var` pointers found. These operate on types
 | `CollectMemRefsWithSpace()` | All (MemRef, MemorySpace) pairs from a statement. |
 | `CollectNonDDRMemRefsWithSpace()` | Non-DDR (MemRef, MemorySpace) pairs from a statement. |
 | `CollectShapedTypeMemRefs()` | MemRefPtrs from any ShapedType (Tensor or Tile) in an expression. |
-| `CollectUsedMemRefPtrs()` | Raw MemRef pointers from TileType variables in a statement. |
+| `CollectUsedBasePtrs()` | Raw base Ptr pointers from MemRefs in TileType/TensorType variables. |
 
 ### Usage Examples
 
@@ -109,8 +109,8 @@ collector.VisitStmt(func->body_);
 // Collect from expressions (works with both TensorType and TileType)
 auto expr_memrefs = memref_collectors::CollectShapedTypeMemRefs(expr);
 
-// Raw pointer set for fast membership checks
-auto used = memref_collectors::CollectUsedMemRefPtrs(func->body_);
+// Raw base Ptr set for fast membership checks (unused alloc detection)
+auto used = memref_collectors::CollectUsedBasePtrs(func->body_);
 ```
 
 ## Other Shared Utilities

--- a/docs/zh-cn/dev/passes/utils.md
+++ b/docs/zh-cn/dev/passes/utils.md
@@ -84,7 +84,7 @@ for (const Var* def : collector.var_defs_ordered) {
 | `CollectMemRefsWithSpace()` | 语句中所有 (MemRef, MemorySpace) 对。 |
 | `CollectNonDDRMemRefsWithSpace()` | 语句中非 DDR 的 (MemRef, MemorySpace) 对。 |
 | `CollectShapedTypeMemRefs()` | 表达式中任意 ShapedType（Tensor 或 Tile）的 MemRefPtr。 |
-| `CollectUsedMemRefPtrs()` | 语句中 TileType 变量的原始 MemRef 指针。 |
+| `CollectUsedBasePtrs()` | 语句中 TileType/TensorType 变量的 MemRef base Ptr 原始指针。 |
 
 ### 使用示例
 
@@ -108,8 +108,8 @@ collector.VisitStmt(func->body_);
 // 从表达式收集（同时支持 TensorType 和 TileType）
 auto expr_memrefs = memref_collectors::CollectShapedTypeMemRefs(expr);
 
-// 原始指针集合用于快速成员检查
-auto used = memref_collectors::CollectUsedMemRefPtrs(func->body_);
+// base Ptr 原始指针集合用于快速成员检查（检测未使用的 alloc）
+auto used = memref_collectors::CollectUsedBasePtrs(func->body_);
 ```
 
 ## 其他共享工具

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -184,7 +184,7 @@ class PTOCodegen : public CodegenBase {
   /**
    * @brief Get tile_buf type string for a MemRef (e.g., "!pto.tile_buf<loc=vec, dtype=f32, ...>")
    */
-  std::string GetTileBufTypeString(const ir::MemRef* memref) const;
+  std::string GetTileBufTypeString(const ir::Var* base_ptr) const;
 
   /**
    * @brief Get type annotation for an expression (for ins/outs clauses)
@@ -355,7 +355,7 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] const ir::Var* GetVarKey(const ir::VarPtr& var) const;
   void BindVarToMlir(const ir::VarPtr& var, const std::string& mlir_name);
   void BindTensorView(const ir::VarPtr& var, const std::string& tensor_view_name);
-  void BindVarToMemRef(const ir::VarPtr& var, const ir::MemRef* memref);
+  void BindVarToMemRef(const ir::VarPtr& var, const ir::Var* base_ptr);
 
   /**
    * @brief Emit make_tensor_view for all tensor parameters
@@ -400,9 +400,10 @@ class PTOCodegen : public CodegenBase {
 
     std::map<const ir::Var*, std::string> var_to_mlir;
     std::map<const ir::Var*, std::string> tensor_to_view;
-    std::map<const ir::MemRef*, std::string> memref_to_mlir;
-    std::map<const ir::Var*, const ir::MemRef*> var_to_memref;
-    std::map<const ir::MemRef*, std::shared_ptr<const ir::TileType>> memref_to_tile_type;
+    std::map<const ir::Var*, std::string> memref_to_mlir;    ///< keyed by base_ Ptr
+    std::map<const ir::Var*, const ir::Var*> var_to_memref;  ///< maps tile var → base_ Ptr
+    std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
+        memref_to_tile_type;  ///< keyed by base_ Ptr
 
     std::map<int64_t, std::string> emitted_constants;
     std::map<int64_t, std::string> emitted_i64_constants;
@@ -423,7 +424,7 @@ class PTOCodegen : public CodegenBase {
     int temp_counter = 0;
     std::set<std::string> used_ssa_names;
 
-    std::map<const ir::MemRef*, std::string> memref_to_var_name;
+    std::map<const ir::Var*, std::string> memref_to_var_name;  ///< keyed by base_ Ptr
     std::vector<std::pair<ir::VarPtr, std::shared_ptr<const ir::TileType>>> tile_var_allocs;
     std::set<const ir::Var*> emitted_tile_alloc_vars;
     std::map<const ir::Var*, TpopResultInfo> tpop_result_vars;

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -98,6 +98,7 @@ enum class ObjectKind {
   // Type kinds
   UnknownType,
   MemRefType,
+  PtrType,
   ScalarType,
   ShapedType,
   TensorType,

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -102,6 +102,7 @@ DEFINE_KIND_TRAIT(TensorType, ObjectKind::TensorType)
 DEFINE_KIND_TRAIT(TileType, ObjectKind::TileType)
 DEFINE_KIND_TRAIT(TupleType, ObjectKind::TupleType)
 DEFINE_KIND_TRAIT(MemRefType, ObjectKind::MemRefType)
+DEFINE_KIND_TRAIT(PtrType, ObjectKind::PtrType)
 
 // Other IR node types
 DEFINE_KIND_TRAIT(Function, ObjectKind::Function)

--- a/include/pypto/ir/memory_allocator_policy.h
+++ b/include/pypto/ir/memory_allocator_policy.h
@@ -77,7 +77,7 @@ using MemoryAllocatorPolicyPtr = std::unique_ptr<MemoryAllocatorPolicy>;
  *
  * - Skips DDR (addresses managed externally)
  * - Uses 32-byte alignment for all on-chip memory spaces
- * - Sorts MemRefs by id_ for deterministic allocation order
+ * - Sorts MemRefs by name for deterministic allocation order
  */
 class DefaultMemoryAllocatorPolicy : public MemoryAllocatorPolicy {
  public:
@@ -89,7 +89,7 @@ class DefaultMemoryAllocatorPolicy : public MemoryAllocatorPolicy {
 
   void OrderMemRefs(std::vector<MemRefPtr>& refs) const override {
     std::sort(refs.begin(), refs.end(),
-              [](const MemRefPtr& a, const MemRefPtr& b) { return a->id_ < b->id_; });
+              [](const MemRefPtr& a, const MemRefPtr& b) { return a->name_hint_ < b->name_hint_; });
   }
 };
 

--- a/include/pypto/ir/memref.h
+++ b/include/pypto/ir/memref.h
@@ -19,7 +19,6 @@
 
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
-#include "pypto/ir/memory_space.h"
 #include "pypto/ir/reflection/field_traits.h"
 #include "pypto/ir/span.h"
 

--- a/include/pypto/ir/memref.h
+++ b/include/pypto/ir/memref.h
@@ -29,76 +29,55 @@ namespace ir {
 /**
  * @brief Memory reference variable for shaped types (tensor and tile)
  *
- * Represents a memory allocation with metadata (address, size, id).
- * Inherits from Var, making it a first-class IR expression that can be
- * declared and referenced like other variables.
+ * Represents a memory reference combining an allocation identity (base Ptr),
+ * a byte offset within that allocation, and a size.
  *
- * Memory references have auto-generated names based on their ID (e.g.,
- * "mem_123") and MemRefType as their type. Generated alloc buffers may use a
- * memory-space hint in the name (for example, "mem_vec_7"), but the memory
- * space itself is not stored on MemRef.
+ * - base_: VarPtr to the Ptr variable from tile.alloc/tensor.alloc (allocation identity)
+ * - byte_offset_: byte offset from base (0 for root alloc, computed for views)
+ * - size_: size in bytes of this memory region
+ *
+ * Aliasing is determined by comparing base_ pointers (SameAllocation) and
+ * checking for overlapping byte ranges (MayAlias).
  */
 class MemRef : public Var {
  public:
-  ExprPtr addr_;   ///< Starting address expression
-  uint64_t size_;  ///< Size in bytes (64-bit unsigned)
-  uint64_t id_;    ///< Unique identifier (used for name generation)
+  VarPtr base_;          ///< Ptr variable from alloc — allocation identity token
+  ExprPtr byte_offset_;  ///< Byte offset from base (0 for full alloc, view offset for views)
+  uint64_t size_;        ///< Size in bytes of this MemRef
 
   /**
-   * @brief Constructor with auto-generated generic name
-   *
-   * Generates a variable name from the ID (e.g., "mem_123") and creates
-   * a MemRefType for the type. Calls Var constructor with these values.
-   *
-   * @param addr Starting address expression
-   * @param size Size in bytes
-   * @param id Unique identifier (used to generate variable name)
-   * @param span Source location (defaults to Span::unknown())
+   * @brief Construct MemRef from base pointer, expression offset, and size.
+   * Name is derived from the base Ptr's name.
    */
-  MemRef(ExprPtr addr, uint64_t size, uint64_t id, Span span = Span::unknown());
+  MemRef(VarPtr base, ExprPtr byte_offset, uint64_t size, Span span = Span::unknown());
 
   /**
-   * @brief Constructor with space-specific generated name
-   *
-   * This is intended for generated alloc buffers whose name should retain the
-   * memory-space hint (e.g., "mem_vec_7"). The memory space is used only for
-   * naming; it is not stored on MemRef.
-   *
-   * @param naming_space Memory space used to build the generated variable name
-   * @param addr Starting address expression
-   * @param size Size in bytes
-   * @param id Unique identifier (used to generate variable name)
-   * @param span Source location (defaults to Span::unknown())
+   * @brief Convenience: construct with integer byte_offset (auto-wrapped in ConstInt).
    */
-  MemRef(MemorySpace naming_space, ExprPtr addr, uint64_t size, uint64_t id, Span span = Span::unknown());
+  MemRef(VarPtr base, int64_t byte_offset, uint64_t size, Span span = Span::unknown());
 
   /**
-   * @brief Constructor with explicit variable name
-   *
-   * Used by deserialization and transforms that need to preserve an existing
-   * MemRef variable name exactly.
-   *
-   * @param name Explicit variable name
-   * @param addr Starting address expression
-   * @param size Size in bytes
-   * @param id Unique identifier associated with the MemRef
-   * @param span Source location (defaults to Span::unknown())
+   * @brief Construct with explicit variable name. Used by deserialization and
+   * address allocation where the name must be preserved exactly.
    */
-  MemRef(std::string name, ExprPtr addr, uint64_t size, uint64_t id, Span span = Span::unknown());
+  MemRef(std::string name, VarPtr base, ExprPtr byte_offset, uint64_t size, Span span = Span::unknown());
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::MemRef; }
   [[nodiscard]] std::string TypeName() const override { return "MemRef"; }
 
-  /**
-   * @brief Get field descriptors for reflection-based visitation
-   *
-   * @return Tuple of field descriptors
-   */
+  /// Are two MemRefs from the same allocation? (compare base_ Ptr identity)
+  static bool SameAllocation(const MemRefPtr& a, const MemRefPtr& b) {
+    return a->base_.get() == b->base_.get();
+  }
+
+  /// Do two MemRefs potentially alias? (same base + overlapping byte ranges)
+  static bool MayAlias(const MemRefPtr& a, const MemRefPtr& b);
+
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(Var::GetFieldDescriptors(),
-                          std::make_tuple(reflection::UsualField(&MemRef::addr_, "addr"),
-                                          reflection::UsualField(&MemRef::size_, "size"),
-                                          reflection::UsualField(&MemRef::id_, "id")));
+                          std::make_tuple(reflection::UsualField(&MemRef::base_, "base"),
+                                          reflection::UsualField(&MemRef::byte_offset_, "byte_offset"),
+                                          reflection::UsualField(&MemRef::size_, "size")));
   }
 };
 

--- a/include/pypto/ir/transforms/utils/memref_collectors.h
+++ b/include/pypto/ir/transforms/utils/memref_collectors.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_TRANSFORMS_UTILS_MEMREF_COLLECTORS_H_
 
 #include <map>
+#include <memory>
 #include <set>
 #include <utility>
 #include <vector>

--- a/include/pypto/ir/transforms/utils/memref_collectors.h
+++ b/include/pypto/ir/transforms/utils/memref_collectors.h
@@ -109,24 +109,26 @@ inline std::set<MemRefPtr> CollectShapedTypeMemRefs(const ExprPtr& expr) {
   return std::move(collector.memrefs);
 }
 
-/// Collect raw MemRef pointers currently referenced by TileType variables
-/// in a statement subtree.
-///
-/// Returns raw pointers (not shared_ptrs) for fast membership checks,
-/// e.g. to identify unused tile.alloc statements.
-inline std::set<const MemRef*> CollectUsedMemRefPtrs(const StmtPtr& stmt) {
+/// Collect raw pointers of base_ Var objects referenced by MemRefs in
+/// TileType and TensorType variables.
+/// Used to identify unused tile.alloc/tensor.alloc Ptr variables.
+inline std::set<const Var*> CollectUsedBasePtrs(const StmtPtr& stmt) {
   class Collector : public IRVisitor {
    public:
-    std::set<const MemRef*> used_ptrs;
+    std::set<const Var*> used_bases;
     void VisitVarLike_(const VarPtr& op) override {
       if (auto tile_type = GetTileTypeWithMemRef(op->GetType())) {
-        used_ptrs.insert(GetDefinedMemRef(tile_type).get());
+        used_bases.insert(GetDefinedMemRef(tile_type)->base_.get());
+      } else if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(op->GetType())) {
+        if (tensor_type->memref_.has_value()) {
+          used_bases.insert(tensor_type->memref_.value()->base_.get());
+        }
       }
     }
   };
   Collector collector;
   collector.VisitStmt(stmt);
-  return std::move(collector.used_ptrs);
+  return std::move(collector.used_bases);
 }
 
 }  // namespace memref_collectors

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -14,20 +14,24 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -290,8 +290,8 @@ inline ExprPtr ComputeViewByteOffset(const CallPtr& call, const TypePtr& parent_
     INTERNAL_CHECK(shaped) << "Internal error: slice parent must be ShapedType";
 
     // tensor.slice(input, shape, offset) → offset is args[2]
-    // tile.slice(input, offset) → offset is args[1]
-    size_t offset_arg_idx = (op_name == "tensor.slice") ? 2 : 1;
+    // tile.slice(input, shape, offset[, valid_shape]) → offset is args[2]
+    size_t offset_arg_idx = 2;
     INTERNAL_CHECK(offset_arg_idx < call->args_.size())
         << "Internal error: " << op_name << " missing offset argument";
 

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -12,15 +12,22 @@
 #ifndef PYPTO_IR_TRANSFORMS_UTILS_MEMREF_UTILS_H_
 #define PYPTO_IR_TRANSFORMS_UTILS_MEMREF_UTILS_H_
 
+#include <algorithm>
+#include <cctype>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
+#include "pypto/ir/memref.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -154,11 +161,6 @@ inline MemRefPtr GetDefinedMemRef(const std::shared_ptr<const TileType>& tile_ty
   return *tile_type->memref_;
 }
 
-inline bool TryRegisterUniqueMemRef(const MemRefPtr& memref, std::set<const MemRef*>& seen_ptrs) {
-  CHECK(memref != nullptr) << "MemRef must not be null";
-  return seen_ptrs.insert(memref.get()).second;
-}
-
 inline bool TryRegisterUniqueMemRef(const MemRefPtr& memref, MemorySpace memory_space,
                                     std::map<const MemRef*, MemorySpace>& seen_ptrs) {
   CHECK(memref != nullptr) << "MemRef must not be null";
@@ -166,6 +168,148 @@ inline bool TryRegisterUniqueMemRef(const MemRefPtr& memref, MemorySpace memory_
   CHECK(inserted || it->second == memory_space)
       << "Conflicting TileType.memory_space values found for the same MemRef";
   return inserted;
+}
+
+// ============================================================================
+// Base Ptr name construction and parsing
+// ============================================================================
+
+/// Build a base Ptr variable name from memory space and counter: "mem_vec_7"
+inline std::string BuildBasePtrName(MemorySpace space, uint64_t id) {
+  std::string space_str = MemorySpaceToString(space);
+  std::transform(space_str.begin(), space_str.end(), space_str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return "mem_" + space_str + "_" + std::to_string(id);
+}
+
+/// Build a base Ptr variable name from counter only: "mem_7"
+inline std::string BuildBasePtrName(uint64_t id) { return "mem_" + std::to_string(id); }
+
+/// Extract the trailing numeric counter from a base Ptr name (e.g., "mem_vec_7" → 7).
+/// Returns std::nullopt if the name has no trailing numeric suffix.
+inline std::optional<uint64_t> ExtractNameCounter(const std::string& name) {
+  auto pos = name.find_last_of('_');
+  if (pos == std::string::npos || pos + 1 >= name.size()) return std::nullopt;
+  const std::string suffix = name.substr(pos + 1);
+  if (suffix.empty() ||
+      !std::all_of(suffix.begin(), suffix.end(), [](unsigned char c) { return std::isdigit(c); })) {
+    return std::nullopt;
+  }
+  return std::stoull(suffix);
+}
+
+// ============================================================================
+// Alloc statement creation
+// ============================================================================
+
+/// Create an alloc AssignStmt for a MemRef's base Ptr variable.
+/// DDR → tensor.alloc, on-chip → tile.alloc.
+/// Emits: base_ptr: Ptr = {tile,tensor}.alloc(memory_space, size)
+inline StmtPtr CreateAllocStatement(const MemRefPtr& memref, MemorySpace memory_space) {
+  std::string op_name = (memory_space == MemorySpace::DDR) ? "tensor.alloc" : "tile.alloc";
+  auto alloc_op = std::make_shared<Op>(op_name);
+
+  auto memspace_expr =
+      std::make_shared<ConstInt>(static_cast<int64_t>(memory_space), DataType::INDEX, Span::unknown());
+  auto size_expr =
+      std::make_shared<ConstInt>(static_cast<int64_t>(memref->size_), DataType::INDEX, Span::unknown());
+
+  std::vector<ExprPtr> alloc_args = {memspace_expr, size_expr};
+  auto alloc_call = std::make_shared<Call>(alloc_op, alloc_args, GetPtrType(), Span::unknown());
+
+  return std::make_shared<AssignStmt>(memref->base_, alloc_call, Span::unknown());
+}
+
+// ============================================================================
+// Byte offset computation helpers
+// ============================================================================
+
+/// Create a ConstInt(0) expression for byte offset initialization.
+inline ExprPtr MakeZeroByteOffset() {
+  return std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+}
+
+/// Create an addition expression: lhs + rhs.
+/// Folds ConstInt + ConstInt into a single ConstInt.
+inline ExprPtr AddByteOffsets(const ExprPtr& lhs, const ExprPtr& rhs) {
+  auto const_lhs = As<ConstInt>(lhs);
+  auto const_rhs = As<ConstInt>(rhs);
+  if (const_lhs && const_rhs) {
+    return std::make_shared<ConstInt>(const_lhs->value_ + const_rhs->value_, DataType::INDEX,
+                                      Span::unknown());
+  }
+  if (const_rhs && const_rhs->value_ == 0) return lhs;
+  if (const_lhs && const_lhs->value_ == 0) return rhs;
+  return std::make_shared<Add>(lhs, rhs, DataType::INDEX, Span::unknown());
+}
+
+/// Create a multiply expression: lhs * rhs.
+/// Folds ConstInt * ConstInt into a single ConstInt.
+inline ExprPtr MulByteOffsets(const ExprPtr& lhs, const ExprPtr& rhs) {
+  auto const_lhs = As<ConstInt>(lhs);
+  auto const_rhs = As<ConstInt>(rhs);
+  if (const_lhs && const_rhs) {
+    return std::make_shared<ConstInt>(const_lhs->value_ * const_rhs->value_, DataType::INDEX,
+                                      Span::unknown());
+  }
+  if (const_rhs && const_rhs->value_ == 1) return lhs;
+  if (const_lhs && const_lhs->value_ == 1) return rhs;
+  return std::make_shared<Mul>(lhs, rhs, DataType::INDEX, Span::unknown());
+}
+
+/// Compute byte offset for a slice operation.
+/// byte_offset = (o0 * s1 * ... * sN + o1 * s2 * ... * sN + ... + oN) * elem_bytes
+inline ExprPtr ComputeSliceByteOffset(const std::vector<ExprPtr>& offsets,
+                                      const std::vector<ExprPtr>& parent_shape, uint64_t elem_bytes) {
+  INTERNAL_CHECK(offsets.size() == parent_shape.size())
+      << "Internal error: slice offset rank (" << offsets.size() << ") must match parent shape rank ("
+      << parent_shape.size() << ")";
+
+  ExprPtr result = MakeZeroByteOffset();
+
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    ExprPtr stride = std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown());
+    for (size_t j = i + 1; j < parent_shape.size(); ++j) {
+      stride = MulByteOffsets(stride, parent_shape[j]);
+    }
+    result = AddByteOffsets(result, MulByteOffsets(offsets[i], stride));
+  }
+
+  auto elem_size_expr =
+      std::make_shared<ConstInt>(static_cast<int64_t>(elem_bytes), DataType::INDEX, Span::unknown());
+  return MulByteOffsets(result, elem_size_expr);
+}
+
+/// Compute additional byte offset for a view operation.
+/// Dispatches: slice ops → stride-based offset, others → zero offset.
+inline ExprPtr ComputeViewByteOffset(const CallPtr& call, const TypePtr& parent_type) {
+  const std::string& op_name = call->op_->name_;
+
+  if (op_name == "tensor.slice" || op_name == "tile.slice") {
+    auto shaped = std::dynamic_pointer_cast<const ShapedType>(parent_type);
+    INTERNAL_CHECK(shaped) << "Internal error: slice parent must be ShapedType";
+
+    // tensor.slice(input, shape, offset) → offset is args[2]
+    // tile.slice(input, offset) → offset is args[1]
+    size_t offset_arg_idx = (op_name == "tensor.slice") ? 2 : 1;
+    INTERNAL_CHECK(offset_arg_idx < call->args_.size())
+        << "Internal error: " << op_name << " missing offset argument";
+
+    // Extract individual offset elements from the MakeTuple expression
+    std::vector<ExprPtr> offsets;
+    if (auto make_tuple = As<MakeTuple>(call->args_[offset_arg_idx])) {
+      offsets = make_tuple->elements_;
+    } else {
+      offsets.push_back(call->args_[offset_arg_idx]);
+    }
+
+    uint64_t elem_bytes = (shaped->dtype_.GetBit() + 7) / 8;
+    return ComputeSliceByteOffset(offsets, shaped->shape_, elem_bytes);
+  }
+
+  // Non-slice view ops (reshape, transpose, extract):
+  // No additional byte offset — same memory region, different interpretation
+  return MakeZeroByteOffset();
 }
 
 }  // namespace pypto::ir

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -566,6 +566,35 @@ inline MemRefTypePtr GetMemRefType() {
   return memref_type;
 }
 
+/**
+ * @brief Pointer type for base allocation identity tokens
+ *
+ * Represents the type of variables returned by tile.alloc / tensor.alloc.
+ * A Ptr variable is the allocation identity token that MemRefs reference
+ * via their base_ field.
+ */
+class PtrType : public Type {
+ public:
+  PtrType() = default;
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::PtrType; }
+  [[nodiscard]] std::string TypeName() const override { return "Ptr"; }
+
+  static constexpr auto GetFieldDescriptors() { return Type::GetFieldDescriptors(); }
+};
+
+using PtrTypePtr = std::shared_ptr<const PtrType>;
+
+/**
+ * @brief Get a shared pointer to the singleton PtrType instance
+ *
+ * @return Shared pointer to PtrType
+ */
+inline PtrTypePtr GetPtrType() {
+  static const auto ptr_type = std::make_shared<PtrType>();
+  return ptr_type;
+}
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -17,7 +17,9 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 
+#include <algorithm>
 #include <any>
+#include <cctype>
 #include <memory>
 #include <optional>
 #include <string>
@@ -309,6 +311,13 @@ void BindIR(nb::module_& m) {
                        "Create a tuple type from a list of types");
   BindFields<TupleType>(tuple_type_class);
 
+  // PtrType - allocation identity token type
+  auto ptr_type_class =
+      nb::class_<PtrType, Type>(ir, "PtrType", "Pointer type for allocation identity tokens");
+  ptr_type_class.def(nb::init<>(), "Create a Ptr type");
+  ptr_type_class.def_static("get", &GetPtrType, "Get the singleton PtrType instance");
+  BindFields<PtrType>(ptr_type_class);
+
   // MemorySpace enum
   nb::enum_<MemorySpace>(ir, "MemorySpace", "Memory space enumeration")
       .value("DDR", MemorySpace::DDR, "DDR memory (off-chip)")
@@ -475,31 +484,60 @@ void BindIR(nb::module_& m) {
   memref_class
       .def(
           "__init__",
-          [](MemRef* self, int64_t addr, uint64_t size, uint64_t id, const Span& span) {
-            auto addr_expr = std::make_shared<ConstInt>(addr, DataType::INT64, span);
-            new (self) MemRef(addr_expr, size, id, span);
+          [](MemRef* self, const VarPtr& base, int64_t byte_offset, uint64_t size, const Span& span) {
+            new (self) MemRef(base, byte_offset, size, span);
           },
-          nb::arg("addr"), nb::arg("size"), nb::arg("id"), nb::arg("span") = Span::unknown(),
-          "Create a memory reference with integer addr, size, id, and span")
+          nb::arg("base"), nb::arg("byte_offset"), nb::arg("size"), nb::arg("span") = Span::unknown(),
+          "Create a memory reference with base Ptr, integer byte_offset, and size")
+      .def(nb::init<VarPtr, ExprPtr, uint64_t, Span>(), nb::arg("base"), nb::arg("byte_offset"),
+           nb::arg("size"), nb::arg("span") = Span::unknown(),
+           "Create a memory reference with base Ptr, byte_offset expression, and size")
+      // String base constructor: MemRef("base_name", byte_offset, size) — for forward references
+      // in printed IR where the base Ptr variable appears in annotations before its alloc statement
       .def(
           "__init__",
-          [](MemRef* self, MemorySpace memory_space, int64_t addr, uint64_t size, uint64_t id,
+          [](MemRef* self, const std::string& base_name, int64_t byte_offset, uint64_t size,
              const Span& span) {
-            auto addr_expr = std::make_shared<ConstInt>(addr, DataType::INT64, span);
-            new (self) MemRef(memory_space, addr_expr, size, id, span);
+            auto base = std::make_shared<Var>(base_name, GetPtrType(), Span::unknown());
+            new (self) MemRef(base, byte_offset, size, span);
+          },
+          nb::arg("base"), nb::arg("byte_offset"), nb::arg("size"), nb::arg("span") = Span::unknown(),
+          "Create a memory reference from base name string, integer byte_offset, and size")
+      // Legacy constructor: MemRef(MemorySpace, addr_expr, size, id) → auto-creates base Ptr
+      .def(
+          "__init__",
+          [](MemRef* self, MemorySpace memory_space, const ExprPtr& addr_expr, uint64_t size, uint64_t id,
+             const Span& span) {
+            // Build a name like "mem_vec_0" from memory_space and id
+            std::string space_str = MemorySpaceToString(memory_space);
+            std::transform(space_str.begin(), space_str.end(), space_str.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            std::string base_name = "mem_" + space_str + "_" + std::to_string(id);
+            auto base = std::make_shared<Var>(base_name, GetPtrType(), Span::unknown());
+            // Use addr_expr as byte_offset for backward compatibility
+            new (self) MemRef(base, addr_expr, size, span);
           },
           nb::arg("memory_space"), nb::arg("addr"), nb::arg("size"), nb::arg("id"),
           nb::arg("span") = Span::unknown(),
-          "Create a memory reference with legacy memory_space, integer addr, size, id, and span.")
-      .def(nb::init<MemorySpace, ExprPtr, uint64_t, uint64_t, Span>(), nb::arg("memory_space"),
-           nb::arg("addr"), nb::arg("size"), nb::arg("id"), nb::arg("span") = Span::unknown(),
-           "Create a memory reference with legacy memory_space, addr, size, id, and span."
-           " The memory space is kept only in the generated name for compatibility.")
-      .def(nb::init<ExprPtr, uint64_t, uint64_t, Span>(), nb::arg("addr"), nb::arg("size"), nb::arg("id"),
-           nb::arg("span") = Span::unknown(), "Create a memory reference with addr, size, id, and span")
-      .def_rw("addr_", &MemRef::addr_, "Starting address expression")
+          "Legacy constructor: create MemRef from memory_space, addr, size, id")
+      // Legacy constructor: MemRef(addr_int, size, id) → auto-creates base Ptr
+      .def(
+          "__init__",
+          [](MemRef* self, int64_t addr, uint64_t size, uint64_t id, const Span& span) {
+            std::string base_name = "mem_" + std::to_string(id);
+            auto base = std::make_shared<Var>(base_name, GetPtrType(), Span::unknown());
+            auto addr_expr = std::make_shared<ConstInt>(addr, DataType::INDEX, Span::unknown());
+            new (self) MemRef(base, addr_expr, size, span);
+          },
+          nb::arg("addr"), nb::arg("size"), nb::arg("id"), nb::arg("span") = Span::unknown(),
+          "Legacy constructor: create MemRef from integer addr, size, id")
+      .def_rw("base_", &MemRef::base_, "Base Ptr variable (allocation identity)")
+      .def_rw("byte_offset_", &MemRef::byte_offset_, "Byte offset from base")
       .def_rw("size_", &MemRef::size_, "Size in bytes (64-bit unsigned)")
-      .def_rw("id_", &MemRef::id_, "Unique identifier for this MemRef instance");
+      .def_static("same_allocation", &MemRef::SameAllocation, nb::arg("a"), nb::arg("b"),
+                  "Check if two MemRefs share the same allocation (same base_ Ptr)")
+      .def_static("may_alias", &MemRef::MayAlias, nb::arg("a"), nb::arg("b"),
+                  "Check if two MemRefs may alias (same base + overlapping byte ranges)");
 
   // ConstInt - const shared_ptr
   auto constint_class = nb::class_<ConstInt, Expr>(ir, "ConstInt", "Constant integer expression");

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -617,8 +617,9 @@ class IRBuilder:
             )
         if not isinstance(addr_or_size, int):
             raise TypeError("IRBuilder.memref(addr, size, id) requires an integer size")
-        addr_expr = _normalize_expr(memory_space_or_addr, actual_span)
-        return ir.MemRef(addr_expr, addr_or_size, size_or_id, actual_span)
+        if not isinstance(memory_space_or_addr, int):
+            raise TypeError("IRBuilder.memref(addr, size, id) requires an integer addr")
+        return ir.MemRef(memory_space_or_addr, addr_or_size, size_or_id, actual_span)
 
     def tile_view(
         self,

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -44,7 +44,6 @@ from pypto.pypto_core.ir import (
     FunctionType,
     Level,
     MemorySpace,
-    MemRef,
     PadValue,
     PipeType,
     PtrType,
@@ -167,7 +166,7 @@ from .op.unified_ops import (
 )
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
-from .typing import DynVar, InOut, IntLike, Out, Scalar, Tensor, Tile, Tuple, dynamic
+from .typing import DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
 Mem = MemorySpace

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -47,6 +47,7 @@ from pypto.pypto_core.ir import (
     MemRef,
     PadValue,
     PipeType,
+    PtrType,
     Role,
     SplitMode,
     TensorLayout,
@@ -170,6 +171,9 @@ from .typing import DynVar, InOut, IntLike, Out, Scalar, Tensor, Tile, Tuple, dy
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
 Mem = MemorySpace
+
+# Alias for PtrType — used in printed IR as type annotation for alloc LHS
+Ptr = PtrType
 
 # Re-export TensorLayout constants for convenience
 ND = TensorLayout.ND
@@ -335,6 +339,8 @@ __all__ = [
     "Mem",
     "MemRefType",
     "MemorySpace",
+    "Ptr",
+    "PtrType",
     "PipeType",
     "TensorLayout",
     "TensorView",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -59,13 +59,15 @@ __all__ = [
     "reshape",
     "transpose",
     "scatter_update",
+    "alloc",
 ]
 
 from pypto.ir.op import tensor_ops as _ir_ops
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Expr, PadValue, TensorLayout
+from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, TensorLayout
 
 from ..typing import IntLike, Scalar, Tensor
+from .tile_ops import MemRefType
 
 
 def _unwrap_rhs(rhs: int | float | Expr | Tensor | Scalar) -> int | float | Expr:
@@ -779,3 +781,16 @@ def scatter_update(
     """
     call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
     return Tensor(expr=call_expr)
+
+
+def alloc(
+    memory_space: MemorySpace,
+    size: int,
+) -> MemRefType:
+    """Stub for the internal ``tensor.alloc`` IR operation.
+
+    This function is never called in user-written DSL code. It is emitted
+    by the C++ python-printer after the InitMemRef pass and must be
+    importable so that the printed source is valid Python.
+    """
+    return MemRefType()

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -129,13 +129,11 @@ from .system_ops import (  # noqa: F401
 
 
 class MemRefType:
-    """Opaque sentinel type for tile.alloc results in printed IR.
+    """Opaque sentinel type for alloc results in printed IR.
 
-    tile.alloc is an internal IR operation created by the InitMemRef and
-    AllocateMemoryAddr passes.  It has no user-facing DSL constructor — this
-    class exists solely so that the Python code emitted by the C++ printer
-    (``mem_vec_0: pl.MemRefType = pl.tile.alloc(...)``) is valid Python that
-    pyright and the text-parser can process.
+    tile.alloc / tensor.alloc are internal IR operations created by the
+    InitMemRef and AllocateMemoryAddr passes.  This class exists solely so
+    that the Python code emitted by the C++ printer is valid Python.
     """
 
 
@@ -156,9 +154,7 @@ class MaskPattern:
 
 def alloc(
     memory_space: MemorySpace,
-    addr: int,
     size: int,
-    alloc_id: int,  # pyright: ignore[reportUnusedParameter]
 ) -> MemRefType:
     """Stub for the internal ``tile.alloc`` IR operation.
 
@@ -169,9 +165,7 @@ def alloc(
 
     Args:
         memory_space: Target memory space (e.g. ``pl.Mem.Vec``)
-        addr: Starting byte address
         size: Allocation size in bytes
-        alloc_id: MemRef identifier
 
     Returns:
         Opaque MemRefType sentinel (unused at runtime)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -458,22 +458,22 @@ class ASTParser:
                 span=self.span_tracker.get_span(stmt),
                 hint="Provide a value for the assignment",
             )
-        is_memref_type_annotation = (
+        is_ptr_type_annotation = (
             isinstance(stmt.annotation, ast.Attribute)
             and isinstance(stmt.annotation.value, ast.Name)
             and stmt.annotation.value.id == "pl"
-            and stmt.annotation.attr == "MemRefType"
-        ) or (isinstance(stmt.annotation, ast.Name) and stmt.annotation.id == "MemRefType")
+            and stmt.annotation.attr in ("Ptr", "MemRefType")
+        ) or (isinstance(stmt.annotation, ast.Name) and stmt.annotation.id in ("Ptr", "MemRefType"))
 
         if (
-            is_memref_type_annotation
+            is_ptr_type_annotation
             and isinstance(stmt.value, ast.Call)
-            and self._is_printed_tile_alloc_call(stmt.value)
+            and self._is_printed_alloc_call(stmt.value)
         ):
-            value_expr = self._parse_printed_tile_alloc_call(stmt.value)
-            memref_var = self._build_memref_from_alloc_call(var_name, value_expr, span)
-            self.builder.emit(ir.AssignStmt(memref_var, value_expr, span))
-            self.scope_manager.define_var(var_name, memref_var, span=span)
+            value_expr = self._parse_printed_alloc_call(stmt.value)
+            ptr_var = ir.Var(var_name, ir.PtrType(), span)
+            self.builder.emit(ir.AssignStmt(ptr_var, value_expr, span))
+            self.scope_manager.define_var(var_name, ptr_var, span=span)
             return
 
         value_expr = self.parse_expression(stmt.value)
@@ -489,7 +489,7 @@ class ASTParser:
                 isinstance(ann, ast.Attribute)
                 and isinstance(ann.value, ast.Name)
                 and ann.value.id == "pl"
-                and ann.attr in ("UnknownType", "MemRefType")
+                and ann.attr in ("UnknownType", "MemRefType", "Ptr")
             )
             if is_unresolvable:
                 resolved = None
@@ -579,35 +579,6 @@ class ASTParser:
         # Track buffer metadata for attribute access (e.g., pipe_buf.base)
         if isinstance(stmt.value, ast.Call):
             self._track_buffer_meta(var_name, stmt.value)
-
-    def _build_memref_from_alloc_call(self, var_name: str, alloc_call: ir.Call, span: ir.Span) -> ir.MemRef:
-        """Build a MemRef variable from a printer-emitted ``tile.alloc`` call."""
-        if len(alloc_call.args) != 4:
-            raise ParserTypeError(
-                f"tile.alloc for '{var_name}' must have 4 positional arguments",
-                span=span,
-                hint="Use tile.alloc(memory_space, addr, size, id)",
-            )
-
-        memory_space_expr, addr_expr, size_expr, id_expr = alloc_call.args
-        if not isinstance(size_expr, ir.ConstInt) or not isinstance(id_expr, ir.ConstInt):
-            raise ParserTypeError(
-                f"tile.alloc for '{var_name}' requires constant size/id in printed IR",
-                span=span,
-                hint="Use constant integer size/id for tile.alloc",
-            )
-
-        if isinstance(memory_space_expr, ir.ConstInt):
-            try:
-                memory_space = ir.MemorySpace(memory_space_expr.value)
-            except Exception as exc:  # pragma: no cover - defensive enum fallback
-                raise ParserTypeError(
-                    f"Invalid memory space value in tile.alloc for '{var_name}': {memory_space_expr.value}",
-                    span=span,
-                ) from exc
-            return ir.MemRef(memory_space, addr_expr, size_expr.value, id_expr.value, span)
-
-        return ir.MemRef(addr_expr, size_expr.value, id_expr.value, span)
 
     def _assign_or_let(
         self,
@@ -2628,41 +2599,49 @@ class ASTParser:
 
     def _parse_tensor_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tensor operation."""
+        if op_name == "alloc":
+            return self._parse_printed_alloc_call(call)
         return self._dispatch_op(ir_op.tensor, "tensor", op_name, call)
 
     def _parse_tile_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tile operation."""
         if op_name == "alloc":
-            return self._parse_printed_tile_alloc_call(call)
+            return self._parse_printed_alloc_call(call)
         return self._dispatch_op(ir_op.tile, "tile", op_name, call)
 
     @staticmethod
-    def _is_printed_tile_alloc_call(call: ast.Call) -> bool:
-        """Return whether the AST call matches printer-emitted ``pl.tile.alloc(...)``."""
+    def _is_printed_alloc_call(call: ast.Call) -> bool:
+        """Return whether the AST call matches printer-emitted ``pl.tile.alloc(...)``
+        or ``pl.tensor.alloc(...)``."""
         func = call.func
         return (
             isinstance(func, ast.Attribute)
             and func.attr == "alloc"
             and isinstance(func.value, ast.Attribute)
-            and func.value.attr == "tile"
+            and func.value.attr in ("tile", "tensor")
             and isinstance(func.value.value, ast.Name)
             and func.value.value.id == "pl"
         )
 
-    def _parse_printed_tile_alloc_call(self, call: ast.Call) -> ir.Call:
-        """Parse printer-emitted ``pl.tile.alloc(...)`` into a raw IR call."""
+    def _parse_printed_alloc_call(self, call: ast.Call) -> ir.Call:
+        """Parse printer-emitted ``pl.{tile,tensor}.alloc(...)`` into a raw IR call."""
+        func = call.func
+        assert isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute)
+        namespace = func.value.attr  # "tile" or "tensor"
+        op_name = f"{namespace}.alloc"
+
         if call.keywords:
             raise InvalidOperationError(
-                "tile.alloc in printed IR must use positional arguments only",
+                f"{op_name} in printed IR must use positional arguments only",
                 span=self.span_tracker.get_span(call),
             )
         args = [self.parse_expression(arg) for arg in call.args]
-        if len(args) != 4:
+        if len(args) != 2:
             raise InvalidOperationError(
-                f"tile.alloc in printed IR expects 4 positional arguments, got {len(args)}",
+                f"{op_name} in printed IR expects 2 positional args (memory_space, size), got {len(args)}",
                 span=self.span_tracker.get_span(call),
             )
-        return ir.create_op_call("tile.alloc", args, {}, self.span_tracker.get_span(call))
+        return ir.create_op_call(op_name, args, {}, self.span_tracker.get_span(call))
 
     def _parse_system_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse system operation."""

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -39,6 +39,10 @@ class _AutoDynVar(dict):
     """
 
     def __missing__(self, key: str) -> object:
+        # Skip dunder names — these are Python/framework internals (e.g. pytest's
+        # __tracebackhide__) and must not be auto-created as DynVars.
+        if key.startswith("__") and key.endswith("__"):
+            raise KeyError(key)
         pl_mod = self.get("pl")
         if pl_mod is not None and isinstance(key, str):
             dvar = pl_mod.dynamic(key)

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -452,7 +452,7 @@ class TypeResolver:
         if memref_node is not None and memory_space_node is None:
             raise ParserTypeError(
                 "Tile annotation with a memref argument must also specify explicit memory space",
-                hint="Use pl.Tile[[shape], dtype, pl.MemRef(addr, size, id), pl.Mem.Vec] or "
+                hint="Use pl.Tile[[shape], dtype, pl.MemRef(base, offset, size), pl.Mem.Vec] or "
                 "pl.Tile[[shape], dtype, memref_var, pl.Mem.Vec]",
             )
 
@@ -1316,7 +1316,11 @@ class TypeResolver:
         return True
 
     def resolve_memref(self, node: ast.expr) -> "ir.MemRef":
-        """Resolve a pl.MemRef(addr, size, id) AST call to ir.MemRef.
+        """Resolve a pl.MemRef(base, byte_offset, size) AST call to ir.MemRef.
+
+        Supports:
+        - New format: pl.MemRef(base_name, byte_offset, size) — bare name or string ref
+        - Legacy format: pl.MemRef(addr, size, id) — integer addr
 
         Args:
             node: AST Call node for pl.MemRef(...)
@@ -1330,38 +1334,88 @@ class TypeResolver:
         if not isinstance(node, ast.Call):
             raise ParserTypeError(
                 f"Expected pl.MemRef(...) call, got: {ast.unparse(node)}",
-                hint="Use pl.MemRef(addr, size, id)",
+                hint="Use pl.MemRef(base_name, byte_offset, size)",
             )
 
         span = self._get_span(node)
 
         if len(node.args) == 3:
-            addr_expr = self._resolve_memref_addr(node.args[0])
+            first_arg = node.args[0]
+
+            # New format: pl.MemRef(base_name, byte_offset, size)
+            # base_name is a bare Name or a string literal
+            base_name = self._try_resolve_memref_base(first_arg)
+            if base_name is not None:
+                byte_offset = self._resolve_memref_byte_offset(node.args[1])
+                size = self._resolve_int_literal(node.args[2], "size", non_negative=True)
+                base_var = ir.Var(base_name, ir.PtrType(), span)
+                return ir.MemRef(base_var, byte_offset, size, span)
+
+            # Legacy fallback: pl.MemRef(addr_int, size, id)
+            addr_val = self._resolve_int_literal(node.args[0], "addr")
             size = self._resolve_int_literal(node.args[1], "size", non_negative=True)
             memref_id = self._resolve_int_literal(node.args[2], "id", non_negative=True)
-            return ir.MemRef(addr_expr, size, memref_id, span)
+            return ir.MemRef(addr_val, size, memref_id, span)
 
-        if len(node.args) != 4:
-            raise ParserTypeError(
-                f"pl.MemRef requires 3 arguments (addr, size, id), got {len(node.args)}",
-                span=span,
-                hint="Use pl.MemRef(0, 1024, 0)",
-            )
+        if len(node.args) == 4:
+            # Legacy: pl.MemRef(memory_space, addr, size, id)
+            memory_space = self._resolve_memory_space(node.args[0])
+            addr_expr = self._resolve_memref_addr(node.args[1])
+            size = self._resolve_int_literal(node.args[2], "size", non_negative=True)
+            memref_id = self._resolve_int_literal(node.args[3], "id", non_negative=True)
+            return ir.MemRef(memory_space, addr_expr, size, memref_id, span)
 
-        # Backward-compatibility path: allow legacy DDR-only form
-        memory_space = self._resolve_memory_space(node.args[0])
-        if memory_space != ir.MemorySpace.DDR:
-            raise ParserTypeError(
-                "pl.MemRef(memory_space, ...) no longer stores memory space",
-                span=span,
-                hint="Use pl.MemRef(addr, size, id) and put non-DDR space on Tile annotations",
-            )
+        raise ParserTypeError(
+            f"pl.MemRef requires 3 arguments (base, byte_offset, size), got {len(node.args)}",
+            span=span,
+            hint="Use pl.MemRef(base_name, byte_offset, size)",
+        )
 
-        addr_expr = self._resolve_memref_addr(node.args[1])
-        size = self._resolve_int_literal(node.args[2], "size", non_negative=True)
-        memref_id = self._resolve_int_literal(node.args[3], "id", non_negative=True)
+    def _try_resolve_memref_base(self, node: ast.expr) -> str | None:
+        """Try to resolve the first arg of pl.MemRef as a base name.
 
-        return ir.MemRef(memory_space, addr_expr, size, memref_id, span)
+        Returns the name string if the node is a bare Name or string literal,
+        None if it's an integer (legacy addr format).
+        """
+        # String literal: pl.MemRef("mem_ddr_0", ...)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        # Bare name: pl.MemRef(mem_vec_0, ...)
+        if isinstance(node, ast.Name):
+            return node.id
+        # Integer → legacy format, not a base name
+        return None
+
+    def _resolve_memref_byte_offset(self, node: ast.expr) -> "ir.Expr":
+        """Resolve a MemRef byte_offset to an IR expression (int, variable, or arithmetic)."""
+        value = self._try_resolve_int(node)
+        if value is not None:
+            return ir.ConstInt(value, DataType.INDEX, self._get_span(node))
+
+        # Try resolving as a variable reference (for symbolic offsets)
+        if isinstance(node, ast.Name) and self.scope_lookup is not None:
+            var = self.scope_lookup(node.id)
+            if var is not None:
+                return var
+
+        # Handle arithmetic expressions (e.g., var * 4, var + 128)
+        if isinstance(node, ast.BinOp):
+            lhs = self._resolve_memref_byte_offset(node.left)
+            rhs = self._resolve_memref_byte_offset(node.right)
+            op_map: dict[type, str] = {
+                ast.Add: "__add__",
+                ast.Sub: "__sub__",
+                ast.Mult: "__mul__",
+            }
+            method = op_map.get(type(node.op))
+            if method is not None:
+                return getattr(lhs, method)(rhs)
+
+        raise ParserTypeError(
+            f"MemRef byte_offset must be an integer or variable, got: {ast.unparse(node)}",
+            span=self._get_span(node),
+            hint="Use an integer value for the byte offset, e.g., 0 or 1024",
+        )
 
     def _resolve_memory_space(self, node: ast.expr) -> "ir.MemorySpace":
         """Resolve a memory space AST node (e.g., pl.Mem.DDR or pl.MemorySpace.DDR)."""

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1348,7 +1348,7 @@ class TypeResolver:
             if base_name is not None:
                 byte_offset = self._resolve_memref_byte_offset(node.args[1])
                 size = self._resolve_int_literal(node.args[2], "size", non_negative=True)
-                base_var = ir.Var(base_name, ir.PtrType(), span)
+                base_var = self._intern_base_ptr(base_name, span)
                 return ir.MemRef(base_var, byte_offset, size, span)
 
             # Legacy fallback: pl.MemRef(addr_int, size, id)
@@ -1370,6 +1370,24 @@ class TypeResolver:
             span=span,
             hint="Use pl.MemRef(base_name, byte_offset, size)",
         )
+
+    def _intern_base_ptr(self, name: str, span: "ir.Span") -> "ir.Var":
+        """Get or create a shared Var for a base Ptr name.
+
+        Ensures that two MemRef annotations referencing the same base name
+        share the same Var instance, so MemRef.SameAllocation() works after
+        parse round-trips. Checks scope_lookup first (for alloc-defined vars),
+        then falls back to a per-resolver cache.
+        """
+        if self.scope_lookup is not None:
+            existing = self.scope_lookup(name)
+            if existing is not None:
+                return existing
+        if not hasattr(self, "_base_ptr_cache"):
+            self._base_ptr_cache: dict[str, ir.Var] = {}
+        if name not in self._base_ptr_cache:
+            self._base_ptr_cache[name] = ir.Var(name, ir.PtrType(), span)
+        return self._base_ptr_cache[name]
 
     def _try_resolve_memref_base(self, node: ast.expr) -> str | None:
         """Try to resolve the first arg of pl.MemRef as a base name.

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -20,6 +20,7 @@ from typing import TypeAlias
 
 from pypto.language.typing.direction import InOut, Out
 from pypto.language.typing.dynamic import DynVar, dynamic
+from pypto.language.typing.memref import MemRef
 from pypto.language.typing.scalar import Scalar
 from pypto.language.typing.tensor import Tensor
 from pypto.language.typing.tile import Tile
@@ -29,4 +30,4 @@ from pypto.pypto_core.ir import Expr
 IntLike: TypeAlias = int | Scalar | Expr
 """Type alias for shape/offset parameters that accept int literals, Scalar DSL values, or raw Expr."""
 
-__all__ = ["DynVar", "InOut", "IntLike", "Out", "Scalar", "Tensor", "Tile", "Tuple", "dynamic"]
+__all__ = ["DynVar", "InOut", "IntLike", "MemRef", "Out", "Scalar", "Tensor", "Tile", "Tuple", "dynamic"]

--- a/python/pypto/language/typing/memref.py
+++ b/python/pypto/language/typing/memref.py
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""MemRef wrapper type for PyPTO Language DSL.
+
+Thin subclass of ``ir.MemRef`` that adds ``PtrType`` to the accepted
+``base`` parameter so that pyright accepts ``pl.MemRef(ptr_var, 0, size)``
+when ``ptr_var`` is annotated as ``pl.Ptr`` inside ``@pl.program`` code.
+"""
+
+from typing import Any, overload
+
+from pypto.pypto_core.ir import (
+    Expr,
+    MemorySpace,
+    PtrType,
+    Span,
+    Var,
+)
+from pypto.pypto_core.ir import (
+    MemRef as _IrMemRef,
+)
+
+
+class MemRef(_IrMemRef):
+    """DSL-level memory reference accepting PtrType-annotated variables as base.
+
+    Identical to ``ir.MemRef`` at runtime. The only addition is that
+    the ``base`` parameter also accepts ``PtrType`` so that pyright
+    does not reject ``pl.MemRef(ptr_var, offset, size)`` when
+    ``ptr_var`` has the annotation ``pl.Ptr``.
+    """
+
+    @overload
+    def __init__(self, base: Var, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: Var, byte_offset: Expr, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: str, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: PtrType, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: PtrType, byte_offset: Expr, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, addr: int, size: int, id: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(
+        self, memory_space: MemorySpace, addr: Expr | int, size: int, id: int, span: Span = ...
+    ) -> None: ...
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+__all__ = ["MemRef"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -843,33 +843,55 @@ class MemorySpace(enum.Enum):
 Mem = MemorySpace
 """Short alias for MemorySpace (e.g., Mem.Vec instead of MemorySpace.Vec)."""
 
+class PtrType(Type):
+    """Pointer type for allocation identity tokens (returned by tile.alloc/tensor.alloc)."""
+
+    def __init__(self) -> None: ...
+    @staticmethod
+    def get() -> PtrType:
+        """Get the singleton PtrType instance."""
+        ...
+
 class MemRef(Var):
     """Memory reference variable for shaped types (inherits from Var)."""
 
-    addr_: Expr
-    """Starting address expression."""
+    base_: Var
+    """Base Ptr variable (allocation identity token)."""
+
+    byte_offset_: Expr
+    """Byte offset from base (0 for root alloc, computed for views)."""
 
     size_: int
     """Size in bytes (64-bit unsigned)."""
 
-    id_: int
-    """Unique identifier for this MemRef instance."""
-
     @overload
-    def __init__(self, addr: Expr | int, size: int, id: int, span: Span = ...) -> None: ...
+    def __init__(self, base: Var, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: Var, byte_offset: Expr, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, base: str, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    @overload
+    def __init__(self, addr: int, size: int, id: int, span: Span = ...) -> None: ...
     @overload
     def __init__(
         self, memory_space: MemorySpace, addr: Expr | int, size: int, id: int, span: Span = ...
     ) -> None: ...
     def __init__(self, *args, **kwargs) -> None:
-        """Create a memory reference with addr, size, id, and span.
+        """Create a memory reference.
 
-        Args:
-            addr: Starting address expression or integer address literal
-            size: Size in bytes
-            id: Unique identifier for this MemRef instance
-            span: Source location (defaults to Span.unknown())
+        New API: MemRef(base, byte_offset, size)
+        Legacy API: MemRef(memory_space, addr, size, id) or MemRef(addr, size, id)
         """
+
+    @staticmethod
+    def same_allocation(a: MemRef, b: MemRef) -> bool:
+        """Check if two MemRefs share the same allocation (same base_ Ptr)."""
+        ...
+
+    @staticmethod
+    def may_alias(a: MemRef, b: MemRef) -> bool:
+        """Check if two MemRefs may alias (same base + overlapping byte ranges)."""
+        ...
 
 DYNAMIC_DIM: Final[int]
 """Constant representing a dynamic dimension (value: -1).

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -86,8 +86,7 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   MemRefCollectorVisitor() = default;
 
   [[nodiscard]] const std::vector<MemRefPtr>& GetMemRefs() const { return memrefs_; }
-  [[nodiscard]] const std::map<const ir::MemRef*, std::shared_ptr<const TileType>>& GetMemRefTileTypes()
-      const {
+  [[nodiscard]] const std::map<const ir::Var*, std::shared_ptr<const TileType>>& GetMemRefTileTypes() const {
     return memref_tile_types_;
   }
 
@@ -105,21 +104,21 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
 
  private:
   std::vector<MemRefPtr> memrefs_;
-  std::set<const ir::MemRef*> seen_ptrs_;
-  std::map<const ir::MemRef*, std::shared_ptr<const TileType>> memref_tile_types_;
+  std::set<const ir::Var*> seen_bases_;
+  std::map<const ir::Var*, std::shared_ptr<const TileType>> memref_tile_types_;
   std::set<uint64_t> iter_arg_ids_;
 
   void AddMemRefIfUnique(const MemRefPtr& memref, const std::shared_ptr<const TileType>& tile_type) {
-    const ir::MemRef* raw_ptr = memref.get();
-    if (ir::TryRegisterUniqueMemRef(memref, seen_ptrs_)) {
+    const ir::Var* base_ptr = memref->base_.get();
+    if (seen_bases_.insert(base_ptr).second) {
       memrefs_.push_back(memref);
-      memref_tile_types_[raw_ptr] = tile_type;
+      memref_tile_types_[base_ptr] = tile_type;
     } else {
-      // Merge TileView properties when multiple tiles share the same MemRef:
+      // Merge TileView properties when multiple tiles share the same allocation:
       // - Keep valid_shape from the original tile (e.g., from load)
       // - Take pad from the new tile if it has a non-null pad (e.g., from fillpad)
       // This ensures fillpad's pad_value is used while preserving the original valid_shape
-      auto existing = memref_tile_types_[raw_ptr];
+      auto existing = memref_tile_types_[base_ptr];
       if (tile_type->tile_view_.has_value() && tile_type->tile_view_->pad != ir::PadValue::null) {
         // Merge: keep valid_shape from existing, take pad from new tile
         ir::TileView merged_view;
@@ -129,7 +128,7 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
         merged_view.pad = tile_type->tile_view_->pad;
         auto merged_tile_type = std::make_shared<TileType>(
             existing->shape_, existing->dtype_, existing->memref_, merged_view, existing->memory_space_);
-        memref_tile_types_[raw_ptr] = merged_tile_type;
+        memref_tile_types_[base_ptr] = merged_tile_type;
       }
     }
   }
@@ -236,9 +235,10 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
     auto memref = ir::GetDefinedMemRef(tile_type);
 
-    // Also maintain fs_.memref_to_mlir for compatibility (first var per MemRef)
-    if (fs_.memref_to_mlir.find(memref.get()) == fs_.memref_to_mlir.end()) {
-      fs_.memref_to_mlir[memref.get()] = ssa_name;
+    // Also maintain fs_.memref_to_mlir for compatibility (first var per allocation)
+    const ir::Var* base_ptr = memref->base_.get();
+    if (fs_.memref_to_mlir.find(base_ptr) == fs_.memref_to_mlir.end()) {
+      fs_.memref_to_mlir[base_ptr] = ssa_name;
     }
   }
 
@@ -337,8 +337,8 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   for (const auto& [tile_var, tile_type] : fs_.tile_var_allocs) {
     if (fs_.tpop_result_vars.count(tile_var.get()) > 0) continue;
     auto memref = ir::GetDefinedMemRef(tile_type);
-    if (memref && As<ir::ConstInt>(memref->addr_)) {
-      GetOrEmitI64Constant(As<ir::ConstInt>(memref->addr_)->value_);
+    if (memref && As<ir::ConstInt>(memref->byte_offset_)) {
+      GetOrEmitI64Constant(As<ir::ConstInt>(memref->byte_offset_)->value_);
     }
   }
 
@@ -412,14 +412,14 @@ std::vector<ir::StmtPtr> PTOCodegen::ReorderTpopChains(const std::vector<ir::Stm
 void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
   class VarMemRefMapper : public ir::IRVisitor {
    public:
-    std::map<const ir::Var*, const ir::MemRef*>& var_to_memref;
-    std::map<const ir::MemRef*, std::string>& memref_to_var_name;
+    std::map<const ir::Var*, const ir::Var*>& var_to_memref;    ///< tile var → base_ Ptr
+    std::map<const ir::Var*, std::string>& memref_to_var_name;  ///< base_ Ptr → var name
     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& tile_var_allocs;
     std::map<const ir::Var*, TpopResultInfo>& tpop_result_vars;
     std::set<const ir::Var*>& fillpad_input_vars;
 
-    VarMemRefMapper(std::map<const ir::Var*, const ir::MemRef*>& mapping,
-                    std::map<const ir::MemRef*, std::string>& reverse_mapping,
+    VarMemRefMapper(std::map<const ir::Var*, const ir::Var*>& mapping,
+                    std::map<const ir::Var*, std::string>& reverse_mapping,
                     std::vector<std::pair<VarPtr, std::shared_ptr<const TileType>>>& allocs,
                     std::map<const ir::Var*, TpopResultInfo>& tpop_vars,
                     std::set<const ir::Var*>& fillpad_vars)
@@ -432,10 +432,10 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
     void VisitStmt_(const AssignStmtPtr& op) override {
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
         const auto memref = ir::GetDefinedMemRef(tile_type);
-        const ir::MemRef* ptr = memref.get();
-        var_to_memref[op->var_.get()] = ptr;
-        if (memref_to_var_name.find(ptr) == memref_to_var_name.end()) {
-          memref_to_var_name[ptr] = op->var_->name_hint_;
+        const ir::Var* base_ptr = memref->base_.get();
+        var_to_memref[op->var_.get()] = base_ptr;
+        if (memref_to_var_name.find(base_ptr) == memref_to_var_name.end()) {
+          memref_to_var_name[base_ptr] = op->var_->name_hint_;
         }
         tile_var_allocs.emplace_back(op->var_, tile_type);
 
@@ -648,8 +648,8 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
   auto memref = ir::GetDefinedMemRef(tile_type);
   std::string addr_ssa;
   if (memref) {
-    if (auto const_addr = As<ir::ConstInt>(memref->addr_)) {
-      addr_ssa = GetOrEmitI64Constant(const_addr->value_);
+    if (auto const_offset = As<ir::ConstInt>(memref->byte_offset_)) {
+      addr_ssa = GetOrEmitI64Constant(const_offset->value_);
     }
   }
 
@@ -741,8 +741,9 @@ std::string PTOCodegen::GetOrEmitI32Constant(int32_t value) {
 }
 
 std::string PTOCodegen::GetTileBufForMemRef(const MemRefPtr& memref) const {
-  auto it = fs_.memref_to_mlir.find(memref.get());
-  INTERNAL_CHECK(it != fs_.memref_to_mlir.end()) << "MemRef not found in mapping";
+  auto it = fs_.memref_to_mlir.find(memref->base_.get());
+  INTERNAL_CHECK(it != fs_.memref_to_mlir.end())
+      << "Internal error: no MLIR mapping for MemRef base '" << memref->base_->name_hint_ << "'";
   return it->second;
 }
 
@@ -941,8 +942,8 @@ void PTOCodegen::BindTensorView(const VarPtr& var, const std::string& tensor_vie
   fs_.tensor_to_view[GetVarKey(var)] = tensor_view_name;
 }
 
-void PTOCodegen::BindVarToMemRef(const VarPtr& var, const ir::MemRef* memref) {
-  fs_.var_to_memref[GetVarKey(var)] = memref;
+void PTOCodegen::BindVarToMemRef(const VarPtr& var, const ir::Var* base_ptr) {
+  fs_.var_to_memref[GetVarKey(var)] = base_ptr;
 }
 
 std::string PTOCodegen::GetVarName(const VarPtr& var) const {
@@ -1071,10 +1072,10 @@ std::string PTOCodegen::GetTensorViewTypeString(const ir::TensorType* tensor_typ
   return oss.str();
 }
 
-std::string PTOCodegen::GetTileBufTypeString(const ir::MemRef* memref) const {
-  auto tile_it = fs_.memref_to_tile_type.find(memref);
+std::string PTOCodegen::GetTileBufTypeString(const ir::Var* base_ptr) const {
+  auto tile_it = fs_.memref_to_tile_type.find(base_ptr);
   INTERNAL_CHECK(tile_it != fs_.memref_to_tile_type.end())
-      << "Internal error: missing tile type for MemRef '" << memref->name_hint_ << "'";
+      << "Internal error: missing tile type for base Ptr '" << base_ptr->name_hint_ << "'";
   auto memory_space = tile_it->second->GetMemorySpace();
   INTERNAL_CHECK(memory_space.has_value()) << "Internal error: tile type must have memory_space";
 

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -168,8 +168,8 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string addr_ssa;
         std::string valid_row_ssa;
         std::string valid_col_ssa;
-        if (auto const_addr = As<ir::ConstInt>(tile_type->memref_.value()->addr_)) {
-          addr_ssa = GetOrEmitI64Constant(const_addr->value_);
+        if (auto const_offset = As<ir::ConstInt>(tile_type->memref_.value()->byte_offset_)) {
+          addr_ssa = GetOrEmitI64Constant(const_offset->value_);
         }
         auto [valid_row_var, valid_col_var] = GetTileValidShapeVars(tile_type);
         if (valid_row_var) valid_row_ssa = GetVarName(valid_row_var);
@@ -304,8 +304,8 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       BindTensorView(return_var, init_mlir_name);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
       const auto memref = ir::GetDefinedMemRef(tile_type);
-      BindVarToMemRef(iter_arg, memref.get());
-      BindVarToMemRef(return_var, memref.get());
+      BindVarToMemRef(iter_arg, memref->base_.get());
+      BindVarToMemRef(return_var, memref->base_.get());
     }
   }
 
@@ -443,8 +443,8 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
       BindTensorView(return_var, init_mlir_name);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
       const auto memref = ir::GetDefinedMemRef(tile_type);
-      BindVarToMemRef(iter_arg, memref.get());
-      BindVarToMemRef(return_var, memref.get());
+      BindVarToMemRef(iter_arg, memref->base_.get());
+      BindVarToMemRef(return_var, memref->base_.get());
     }
   }
 

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -11,14 +11,15 @@
 
 #include "pypto/ir/memref.h"
 
-#include <algorithm>
-#include <cctype>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
 
@@ -57,29 +58,35 @@ MemorySpace StringToMemorySpace(const std::string& str) {
   throw pypto::ValueError("Unknown MemorySpace: " + str);
 }
 
-// Helper function to convert string to lowercase
-static std::string ToLowerCase(const std::string& str) {
-  std::string result = str;
-  std::transform(result.begin(), result.end(), result.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return result;
-}
-
-static std::string BuildMemRefName(uint64_t id) { return "mem_" + std::to_string(id); }
-
-static std::string BuildMemRefName(MemorySpace naming_space, uint64_t id) {
-  return "mem_" + ToLowerCase(MemorySpaceToString(naming_space)) + "_" + std::to_string(id);
-}
-
 // MemRef implementation
-MemRef::MemRef(ExprPtr addr, uint64_t size, uint64_t id, Span span)
-    : MemRef(BuildMemRefName(id), std::move(addr), size, id, std::move(span)) {}
+MemRef::MemRef(VarPtr base, ExprPtr byte_offset, uint64_t size, Span span)
+    : Var(base->name_hint_, GetMemRefType(), std::move(span)),
+      base_(std::move(base)),
+      byte_offset_(std::move(byte_offset)),
+      size_(size) {}
 
-MemRef::MemRef(MemorySpace naming_space, ExprPtr addr, uint64_t size, uint64_t id, Span span)
-    : MemRef(BuildMemRefName(naming_space, id), std::move(addr), size, id, std::move(span)) {}
+MemRef::MemRef(VarPtr base, int64_t byte_offset, uint64_t size, Span span)
+    : MemRef(std::move(base), std::make_shared<ConstInt>(byte_offset, DataType::INDEX, Span::unknown()), size,
+             std::move(span)) {}
 
-MemRef::MemRef(std::string name, ExprPtr addr, uint64_t size, uint64_t id, Span span)
-    : Var(std::move(name), GetMemRefType(), std::move(span)), addr_(std::move(addr)), size_(size), id_(id) {}
+MemRef::MemRef(std::string name, VarPtr base, ExprPtr byte_offset, uint64_t size, Span span)
+    : Var(std::move(name), GetMemRefType(), std::move(span)),
+      base_(std::move(base)),
+      byte_offset_(std::move(byte_offset)),
+      size_(size) {}
+
+bool MemRef::MayAlias(const MemRefPtr& a, const MemRefPtr& b) {
+  if (a->base_.get() != b->base_.get()) return false;
+
+  auto off_a = As<ConstInt>(a->byte_offset_);
+  auto off_b = As<ConstInt>(b->byte_offset_);
+  if (off_a && off_b) {
+    int64_t end_a = off_a->value_ + static_cast<int64_t>(a->size_);
+    int64_t end_b = off_b->value_ + static_cast<int64_t>(b->size_);
+    return off_a->value_ < end_b && off_b->value_ < end_a;
+  }
+  return true;  // same base, symbolic offsets → conservatively alias
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -351,10 +351,11 @@ REGISTER_OP("tensor.create")
 
 REGISTER_OP("tensor.slice")
     .set_op_category("TensorOp")
-    .set_description("Create a slice of a tensor with new shape and offset")
+    .set_description("Create a slice (view) of a tensor with new shape and offset")
     .add_argument("input", "Input tensor (TensorType)")
     .add_argument("shape", "New shape dimensions (TupleType of ScalarType(INT64))")
     .add_argument("offset", "Offset dimensions (TupleType of ScalarType(INT64))")
+    .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorSliceType(args, kwargs);
@@ -478,6 +479,18 @@ REGISTER_OP("tensor.write")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorWriteType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.alloc")
+    .set_op_category("TensorOp")
+    .set_description("Declare DDR memory allocation, returning a Ptr")
+    .add_argument("memory_space", "Memory space (DDR)")
+    .add_argument("size", "Size in bytes (scalar)")
+    .no_memory_spec()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      CHECK(args.size() == 2) << "tensor.alloc expects 2 args (memory_space, size), got " << args.size();
+      return GetPtrType();
     });
 
 }  // namespace ir

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -262,13 +262,11 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
 TypePtr DeduceTileAllocType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs,
                             const std::string& op_name) {
-  // alloc signature: (memory_space, addr, size, id)
-  // Takes MemRef fields as arguments and returns MemRefType
-  CHECK(args.size() == 4) << "The operator " << op_name << " requires exactly 4 arguments, but got "
+  // alloc signature: (memory_space, size) — returns PtrType (allocation identity)
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
-  // Return MemRefType
-  return GetMemRefType();
+  return GetPtrType();
 }
 
 TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
@@ -552,11 +550,9 @@ REGISTER_OP("tile.move")
 
 REGISTER_OP("tile.alloc")
     .set_op_category("TileOp")
-    .set_description("Allocate memory for a MemRef object")
+    .set_description("Declare on-chip memory allocation, returning a Ptr")
     .add_argument("memory_space", "Memory space (int enum value)")
-    .add_argument("addr", "Starting address expression")
     .add_argument("size", "Size in bytes (scalar)")
-    .add_argument("id", "MemRef ID (scalar)")
     .no_memory_spec()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/reporter/memory_report_generator.cpp
+++ b/src/ir/reporter/memory_report_generator.cpp
@@ -71,9 +71,9 @@ class MemoryUsageCollector : public IRVisitor {
     auto& s = stats_[*memory_space];
     s.count++;
 
-    auto const_addr = std::dynamic_pointer_cast<const ConstInt>(memref->addr_);
-    if (const_addr && const_addr->value_ >= 0) {
-      uint64_t end = static_cast<uint64_t>(const_addr->value_) + memref->size_;
+    auto const_offset = std::dynamic_pointer_cast<const ConstInt>(memref->byte_offset_);
+    if (const_offset && const_offset->value_ >= 0) {
+      uint64_t end = static_cast<uint64_t>(const_offset->value_) + memref->size_;
       if (end > s.high_water) s.high_water = end;
     } else {
       // Address not yet allocated — use size as a lower bound

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -149,33 +149,36 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
 
     CHECK(obj.type == msgpack::type::MAP) << "Expected map for MemRef";
 
-    ExprPtr addr = nullptr;
+    std::string base_name;
+    ExprPtr byte_offset = nullptr;
     uint64_t size = 0;
-    uint64_t id = 0;
-    bool has_addr = false;
+    bool has_base = false;
+    bool has_byte_offset = false;
     bool has_size = false;
-    bool has_id = false;
 
     msgpack::object_kv* p = obj.via.map.ptr;
     msgpack::object_kv* const pend = obj.via.map.ptr + obj.via.map.size;
     for (; p < pend; ++p) {
       std::string key;
       p->key.convert(key);
-      if (key == "addr") {
-        addr = std::static_pointer_cast<const Expr>(DeserializeNode(p->val, zone));
-        has_addr = true;
+      if (key == "base") {
+        p->val.convert(base_name);
+        has_base = true;
+      } else if (key == "byte_offset") {
+        byte_offset = std::static_pointer_cast<const Expr>(DeserializeNode(p->val, zone));
+        has_byte_offset = true;
       } else if (key == "size") {
         p->val.convert(size);
         has_size = true;
-      } else if (key == "id") {
-        p->val.convert(id);
-        has_id = true;
       }
     }
 
-    CHECK(has_addr && has_size && has_id) << "MemRef missing required fields (addr, size, or id)";
+    CHECK(has_base && has_byte_offset && has_size)
+        << "MemRef missing required fields (base, byte_offset, or size)";
 
-    return std::make_shared<MemRef>(addr, size, id);
+    // Create a base Ptr variable from the name
+    auto base = std::make_shared<Var>(base_name, GetPtrType(), Span::unknown());
+    return std::make_shared<MemRef>(base, byte_offset, size);
   }
 
   std::optional<TileView> DeserializeTileView(const msgpack::object& obj, msgpack::zone& zone) {
@@ -380,6 +383,8 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
       return std::make_shared<TupleType>(types);
     } else if (type_kind == "MemRefType") {
       return GetMemRefType();
+    } else if (type_kind == "Ptr") {
+      return GetPtrType();
     } else if (type_kind == "UnknownType") {
       return GetUnknownType();
     } else {

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -246,9 +246,9 @@ class IRSerializer::Impl {
 
     const auto& memref = *memref_opt.value();
     std::map<std::string, msgpack::object> memref_map;
-    memref_map["addr"] = SerializeNode(memref.addr_, zone);
+    memref_map["base"] = msgpack::object(memref.base_->name_hint_, zone);
+    memref_map["byte_offset"] = SerializeNode(memref.byte_offset_, zone);
     memref_map["size"] = msgpack::object(memref.size_, zone);
-    memref_map["id"] = msgpack::object(memref.id_, zone);
     return msgpack::object(memref_map, zone);
   }
 
@@ -404,8 +404,8 @@ class IRSerializer::Impl {
         types_vec.push_back(SerializeType(t, zone));
       }
       type_map["types"] = msgpack::object(types_vec, zone);
-    } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type)) {
-      // MemRefType and UnknownType have no additional fields
+    } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type) || IsA<PtrType>(type)) {
+      // MemRefType, PtrType, and UnknownType have no additional fields
     } else {
       INTERNAL_UNREACHABLE << "Unknown Type subclass: " << type->TypeName();
     }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -230,10 +230,13 @@ static IRNodePtr DeserializeMemRef(const msgpack::object& fields_obj, msgpack::z
                                    DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
   std::string name_hint = GET_FIELD(std::string, "name_hint");
-  auto addr = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("addr"), zone));
+  auto byte_offset =
+      std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("byte_offset"), zone));
   uint64_t size = GET_FIELD(uint64_t, "size");
-  uint64_t id = GET_FIELD(uint64_t, "id");
-  return std::make_shared<MemRef>(name_hint, addr, size, id, span);
+  // base_ is a VarPtr, serialized as a full IRNode
+  auto base = std::static_pointer_cast<const Var>(ctx.DeserializeNode(GET_FIELD_OBJ("base"), zone));
+  INTERNAL_CHECK(base) << "MemRef base deserialized to null";
+  return std::make_shared<MemRef>(name_hint, base, byte_offset, size, span);
 }
 
 // Deserialize ConstInt

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -201,24 +201,8 @@ class MemRefUpdateMutator : public IRMutator {
   }
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
-    // Handle tile.alloc statements: update LHS MemRef and Call addr argument
-    auto memref_var = std::dynamic_pointer_cast<const MemRef>(op->var_);
-    if (memref_var) {
-      auto call = std::dynamic_pointer_cast<const Call>(op->value_);
-      if (call && call->op_->name_ == "tile.alloc") {
-        auto it = memref_map_.find(memref_var.get());
-        if (it != memref_map_.end()) {
-          const auto& new_memref = it->second;
-          // Rebuild Call with updated addr argument (index 1)
-          std::vector<ExprPtr> new_args = call->args_;
-          new_args[1] = new_memref->addr_;
-          auto new_call =
-              std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->GetType(), call->span_);
-          return std::make_shared<AssignStmt>(new_memref, new_call, op->span_);
-        }
-        return op;
-      }
-    }
+    // tile.alloc statements now have Ptr LHS (not MemRef), so no special handling needed.
+    // Just fall through to the default mutator which updates types via UpdateTypeMemRef.
     return IRMutator::VisitStmt_(op);
   }
 
@@ -314,11 +298,11 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       CHECK(old_memref->size_ > 0)
           << "AllocateMemoryAddr encountered zero-sized MemRef '" << old_memref->name_hint_
           << "'. InitMemRef should reject dynamic or invalid allocation shapes before address assignment.";
-      // Create new MemRef with allocated address
-      auto addr_expr =
+      // Create new MemRef with allocated byte_offset, reusing the same base_ Ptr
+      auto offset_expr =
           std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INDEX, Span::unknown());
-      auto new_memref =
-          std::make_shared<MemRef>(space, addr_expr, old_memref->size_, old_memref->id_, old_memref->span_);
+      auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_, offset_expr,
+                                                 old_memref->size_, old_memref->span_);
       memref_pairs.emplace_back(old_memref.get(), new_memref);
 
       // Next address = align(current + size)
@@ -326,17 +310,16 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
     }
   }
 
-  // Sort by address (ascending order) so alloc statements are in address order
+  // Sort by byte_offset (ascending order) so alloc statements are in address order
   std::sort(memref_pairs.begin(), memref_pairs.end(),
             [](const std::pair<const MemRef*, MemRefPtr>& a, const std::pair<const MemRef*, MemRefPtr>& b) {
-              // Extract address values for comparison
-              auto addr_a = std::dynamic_pointer_cast<const ConstInt>(a.second->addr_);
-              auto addr_b = std::dynamic_pointer_cast<const ConstInt>(b.second->addr_);
-              if (addr_a && addr_b) {
-                return addr_a->value_ < addr_b->value_;
+              auto off_a = std::dynamic_pointer_cast<const ConstInt>(a.second->byte_offset_);
+              auto off_b = std::dynamic_pointer_cast<const ConstInt>(b.second->byte_offset_);
+              if (off_a && off_b) {
+                return off_a->value_ < off_b->value_;
               }
-              // Fallback: sort by ID if addresses are not ConstInt
-              return a.second->id_ < b.second->id_;
+              // Fallback: sort by name
+              return a.second->name_hint_ < b.second->name_hint_;
             });
 
   return memref_pairs;
@@ -437,17 +420,16 @@ class AllocatedMemoryAddrVerifier : public IRVisitor {
     if (memory_space == MemorySpace::DDR) return;
     if (!seen_.insert(memref.get()).second) return;
 
-    auto const_addr = std::dynamic_pointer_cast<const ConstInt>(memref->addr_);
-    if (!const_addr || const_addr->value_ < 0) {
+    auto const_offset = std::dynamic_pointer_cast<const ConstInt>(memref->byte_offset_);
+    if (!const_offset || const_offset->value_ < 0) {
       diagnostics_.emplace_back(DiagnosticSeverity::Error, "AllocatedMemoryAddr", 0,
                                 "MemRef for variable '" + var_name + "' in " +
-                                    MemorySpaceToString(memory_space) +
-                                    " has no valid address allocated (addr=-1)",
+                                    MemorySpaceToString(memory_space) + " has no valid address allocated",
                                 span);
       return;
     }
 
-    uint64_t end = static_cast<uint64_t>(const_addr->value_) + memref->size_;
+    uint64_t end = static_cast<uint64_t>(const_offset->value_) + memref->size_;
     auto& hw = high_water_[memory_space];
     if (end > hw) hw = end;
   }

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -125,9 +126,9 @@ class InitMemRefMutator : public IRMutator {
     INTERNAL_CHECK(memory_space.has_value())
         << "Internal error: memory_space must be resolved before CreateMemRef";
 
-    auto addr = std::make_shared<ConstInt>(-1, DataType::INDEX, Span::unknown());
-    uint64_t id = next_id_++;
-    return std::make_shared<MemRef>(*memory_space, addr, size_bytes, id);
+    auto base =
+        std::make_shared<Var>(BuildBasePtrName(*memory_space, next_id_++), GetPtrType(), Span::unknown());
+    return std::make_shared<MemRef>(base, static_cast<int64_t>(0), size_bytes);
   }
 
   std::optional<MemorySpace> ExtractMemorySpaceFromType(const TypePtr& type) {
@@ -203,18 +204,63 @@ class InitMemRefMutator : public IRMutator {
   }
 
   /**
-   * @brief Share a MemRef from a source expression to the LHS variable of an assignment.
+   * @brief Create a view MemRef from a source expression for the LHS variable of an assignment.
    *
-   * Returns a new AssignStmt with the LHS type updated to share the source's MemRef,
-   * or nullptr if the source has no MemRef.
+   * Creates a NEW MemRef with the same base_ Ptr as the source's MemRef,
+   * accumulated byte offset, and computed size from the output shape.
+   * Returns nullptr if the source has no MemRef.
    */
   StmtPtr ShareMemRefFrom(const ExprPtr& source, const AssignStmtPtr& op, const ExprPtr& new_value) {
-    auto shared_memref = GetTypeMemRef(source->GetType());
-    if (!shared_memref.has_value()) return nullptr;
+    auto parent_memref_opt = GetTypeMemRef(source->GetType());
+    if (!parent_memref_opt.has_value()) return nullptr;
+    const auto& parent_memref = *parent_memref_opt;
+
+    // Compute additional byte offset from the view op (if applicable)
+    ExprPtr additional_offset = MakeZeroByteOffset();
+    if (auto call = As<Call>(new_value)) {
+      additional_offset = ComputeViewByteOffset(call, source->GetType());
+    }
+
+    // Accumulate: total_offset = parent.byte_offset + additional_offset
+    ExprPtr total_offset = AddByteOffsets(parent_memref->byte_offset_, additional_offset);
+
+    // Compute view size from the output type
+    uint64_t view_size = parent_memref->size_;  // default: same size as parent
+    if (auto out_shaped = std::dynamic_pointer_cast<const ShapedType>(op->var_->GetType())) {
+      uint64_t num_elements = 1;
+      bool is_static = true;
+      for (const auto& dim : out_shaped->shape_) {
+        if (auto const_dim = As<ConstInt>(dim)) {
+          num_elements *= static_cast<uint64_t>(const_dim->value_);
+        } else {
+          is_static = false;
+          break;
+        }
+      }
+      if (is_static) {
+        view_size = num_elements * ((out_shaped->dtype_.GetBit() + 7) / 8);
+      }
+    }
+
+    // For pure aliases (no offset change, same size), share the SAME MemRef shared_ptr
+    // to preserve base_ Ptr identity. MemoryReuse builds sharing groups by base_ Ptr —
+    // variables sharing the same base_ are merged into one lifetime group.
+    bool is_pure_alias = (view_size == parent_memref->size_);
+    if (is_pure_alias) {
+      if (auto const_offset = As<ConstInt>(additional_offset)) {
+        is_pure_alias = (const_offset->value_ == 0);
+      } else {
+        is_pure_alias = false;
+      }
+    }
+    MemRefPtr view_memref = is_pure_alias
+                                ? parent_memref
+                                : std::make_shared<MemRef>(parent_memref->base_, total_offset, view_size);
 
     auto source_ms = ExtractMemorySpaceFromType(source->GetType());
+    std::optional<MemRefPtr> view_opt = view_memref;
     TypePtr new_type = CloneTypeWithMemRefAndRemapExprs(
-        op->var_->GetType(), shared_memref, [this](const ExprPtr& e) { return VisitExpr(e); }, source_ms);
+        op->var_->GetType(), view_opt, [this](const ExprPtr& e) { return VisitExpr(e); }, source_ms);
     VarPtr new_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
     var_map_[op->var_] = new_var;
     return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
@@ -409,24 +455,6 @@ class InitMemRefMutator : public IRMutator {
   uint64_t next_id_ = 0;
 };
 
-// Create tile.alloc AssignStmt for a MemRef with addr=-1 (unallocated)
-StmtPtr CreateAllocStatement(const MemRefPtr& memref, MemorySpace memory_space) {
-  auto alloc_op = std::make_shared<Op>("tile.alloc");
-
-  auto memspace_expr =
-      std::make_shared<ConstInt>(static_cast<int64_t>(memory_space), DataType::INDEX, Span::unknown());
-  ExprPtr addr_expr = memref->addr_;
-  auto size_expr =
-      std::make_shared<ConstInt>(static_cast<int64_t>(memref->size_), DataType::INDEX, Span::unknown());
-  auto id_expr =
-      std::make_shared<ConstInt>(static_cast<int64_t>(memref->id_), DataType::INDEX, Span::unknown());
-
-  std::vector<ExprPtr> alloc_args = {memspace_expr, addr_expr, size_expr, id_expr};
-  auto alloc_call = std::make_shared<Call>(alloc_op, alloc_args, GetMemRefType(), Span::unknown());
-
-  return std::make_shared<AssignStmt>(memref, alloc_call, Span::unknown());
-}
-
 // Insert alloc statements at the beginning of a function body.
 StmtPtr InsertAllocsIntoBody(const StmtPtr& body, const std::vector<StmtPtr>& alloc_stmts) {
   if (alloc_stmts.empty()) return body;
@@ -479,8 +507,8 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
       new_body, normalized_func->span_, normalized_func->func_type_, normalized_func->level_,
       normalized_func->role_, normalized_func->attrs_);
 
-  // Step 3: Collect non-DDR MemRefs and create alloc statements
-  memref_collectors::MemRefWithSpaceCollector collector(/*skip_ddr=*/true);
+  // Step 3: Collect ALL MemRefs (DDR gets tensor.alloc, on-chip gets tile.alloc)
+  memref_collectors::MemRefWithSpaceCollector collector(/*skip_ddr=*/false);
   for (const auto& param : new_params) {
     collector.VisitExpr(param);
   }
@@ -489,10 +517,14 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
   const auto& memrefs = collector.memrefs;
   if (memrefs.empty()) return result_func;
 
+  // Deduplicate by base_ Ptr — one alloc per unique base
+  std::set<const Var*> seen_bases;
   std::vector<StmtPtr> alloc_stmts;
   alloc_stmts.reserve(memrefs.size());
   for (const auto& [memref, memory_space] : memrefs) {
-    alloc_stmts.push_back(CreateAllocStatement(memref, memory_space));
+    if (seen_bases.insert(memref->base_.get()).second) {
+      alloc_stmts.push_back(CreateAllocStatement(memref, memory_space));
+    }
   }
 
   // Step 4: Insert alloc statements at the beginning of the function body

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -33,7 +33,6 @@
 #include <vector>
 
 #include "pypto/codegen/pto/tile_buf_signature.h"
-#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -61,7 +61,7 @@ using codegen::TileBufSignature;
 /// MemRef's root alloc type).
 static bool IsLegalViewOp(const std::string& op_name) {
   return op_name == "tile.reshape" || op_name == "tile.extract" || op_name == "tile.slice" ||
-         op_name == "tile.fillpad";
+         op_name == "tile.fillpad" || op_name == "tensor.slice";
 }
 
 // -------------------------------------------------------------------------
@@ -69,7 +69,8 @@ static bool IsLegalViewOp(const std::string& op_name) {
 // -------------------------------------------------------------------------
 
 struct MemRefUsageInfo {
-  const MemRef* ptr = nullptr;
+  const Var* base_ptr = nullptr;  ///< base_ Ptr identity key
+  uint64_t alloc_size = 0;        ///< Size of the root allocation in bytes
   std::vector<std::pair<const Var*, TileBufSignature>> writers;
   std::vector<std::pair<const Var*, TileBufSignature>> view_users;
   std::vector<std::pair<const Var*, const Var*>> view_edges;
@@ -84,7 +85,8 @@ class MemRefUsageCollector : public IRVisitor {
       return;
     }
 
-    const MemRef* memref_ptr = GetDefinedMemRef(tile_type).get();
+    auto memref = GetDefinedMemRef(tile_type);
+    const Var* base_ptr = memref->base_.get();
     auto sig = TileBufSignature::FromTileType(*tile_type);
 
     CallPtr call;
@@ -96,13 +98,13 @@ class MemRefUsageCollector : public IRVisitor {
       }
     }
 
-    auto& info = GetOrCreate(memref_ptr);
+    auto& info = GetOrCreate(base_ptr, memref->size_);
     if (is_view) {
       info.view_users.emplace_back(op->var_.get(), sig);
       for (const auto& arg : call->args_) {
         if (auto source_var = As<Var>(arg)) {
           if (auto source_tile_type = GetTileTypeWithMemRef(source_var->GetType())) {
-            if (GetDefinedMemRef(source_tile_type).get() == memref_ptr) {
+            if (GetDefinedMemRef(source_tile_type)->base_.get() == base_ptr) {
               info.view_edges.emplace_back(source_var.get(), op->var_.get());
               break;
             }
@@ -116,17 +118,21 @@ class MemRefUsageCollector : public IRVisitor {
     IRVisitor::VisitStmt_(op);
   }
 
-  [[nodiscard]] const std::map<const MemRef*, MemRefUsageInfo>& GetUsages() const { return usages_; }
+  [[nodiscard]] const std::map<const Var*, MemRefUsageInfo>& GetUsages() const { return usages_; }
 
  private:
-  std::map<const MemRef*, MemRefUsageInfo> usages_;
+  std::map<const Var*, MemRefUsageInfo> usages_;
 
-  MemRefUsageInfo& GetOrCreate(const MemRef* ptr) {
-    auto it = usages_.find(ptr);
+  MemRefUsageInfo& GetOrCreate(const Var* base_ptr, uint64_t size) {
+    auto it = usages_.find(base_ptr);
     if (it == usages_.end()) {
       MemRefUsageInfo info;
-      info.ptr = ptr;
-      it = usages_.emplace(ptr, std::move(info)).first;
+      info.base_ptr = base_ptr;
+      info.alloc_size = size;
+      it = usages_.emplace(base_ptr, std::move(info)).first;
+    } else {
+      // Keep the max size across all uses
+      if (size > it->second.alloc_size) it->second.alloc_size = size;
     }
     return it->second;
   }
@@ -163,11 +169,11 @@ void PropagateSplitToViewUsers(const MemRefUsageInfo& info, const std::vector<co
   }
 }
 
-std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const MemRef*, MemRefUsageInfo>& usages,
+std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const Var*, MemRefUsageInfo>& usages,
                                                  uint64_t& next_id) {
   std::map<const Var*, MemRefPtr> splits;
 
-  for (const auto& [memref_ptr, info] : usages) {
+  for (const auto& [base_ptr, info] : usages) {
     if (info.writers.size() <= 1) continue;
 
     const auto& ref_sig = info.writers[0].second;
@@ -205,8 +211,9 @@ std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const MemRef*, M
       if (gid == 0) continue;
 
       auto memory_space = info.writers[indices[0]].second.memory_space;
-      auto addr = std::make_shared<ConstInt>(-1, DataType::INDEX, Span::unknown());
-      auto new_memref = std::make_shared<MemRef>(memory_space, addr, memref_ptr->size_, next_id++);
+      auto new_base =
+          std::make_shared<Var>(BuildBasePtrName(memory_space, next_id++), GetPtrType(), Span::unknown());
+      auto new_memref = std::make_shared<MemRef>(new_base, static_cast<int64_t>(0), info.alloc_size);
       std::vector<const Var*> split_roots;
 
       for (size_t idx : indices) {
@@ -277,14 +284,14 @@ class MemRefSplitMutator : public IRMutator {
 // -------------------------------------------------------------------------
 
 StmtPtr InsertNewAllocStatements(const StmtPtr& body, const std::map<const Var*, MemRefPtr>& splits) {
-  // Collect unique new MemRefs
-  std::map<const MemRef*, std::pair<MemRefPtr, MemorySpace>> new_memrefs;
+  // Collect unique new MemRefs (keyed by base_ Ptr identity)
+  std::map<const Var*, std::pair<MemRefPtr, MemorySpace>> new_memrefs;
   for (const auto& [var, memref] : splits) {
-    if (new_memrefs.count(memref.get()) > 0) continue;
+    if (new_memrefs.count(memref->base_.get()) > 0) continue;
     auto tile_type = As<TileType>(var->GetType());
     MemorySpace space =
         tile_type && tile_type->memory_space_.has_value() ? *tile_type->memory_space_ : MemorySpace::Vec;
-    new_memrefs[memref.get()] = {memref, space};
+    new_memrefs[memref->base_.get()] = {memref, space};
   }
   if (new_memrefs.empty()) return body;
 
@@ -292,18 +299,7 @@ StmtPtr InsertNewAllocStatements(const StmtPtr& body, const std::map<const Var*,
   std::vector<StmtPtr> alloc_stmts;
   for (const auto& [_, pair] : new_memrefs) {
     const auto& [memref, space] = pair;
-    auto alloc_op = std::make_shared<Op>("tile.alloc");
-    auto memspace_expr =
-        std::make_shared<ConstInt>(static_cast<int64_t>(space), DataType::INDEX, Span::unknown());
-    auto addr_expr = memref->addr_;
-    auto size_expr =
-        std::make_shared<ConstInt>(static_cast<int64_t>(memref->size_), DataType::INDEX, Span::unknown());
-    auto id_expr =
-        std::make_shared<ConstInt>(static_cast<int64_t>(memref->id_), DataType::INDEX, Span::unknown());
-
-    std::vector<ExprPtr> alloc_args = {memspace_expr, addr_expr, size_expr, id_expr};
-    auto alloc_call = std::make_shared<Call>(alloc_op, alloc_args, GetMemRefType(), Span::unknown());
-    alloc_stmts.push_back(std::make_shared<AssignStmt>(memref, alloc_call, Span::unknown()));
+    alloc_stmts.push_back(CreateAllocStatement(memref, space));
   }
 
   auto seq = As<SeqStmts>(body);
@@ -320,13 +316,14 @@ StmtPtr InsertNewAllocStatements(const StmtPtr& body, const std::map<const Var*,
 // Top-level transform
 // -------------------------------------------------------------------------
 
-/// Find the highest MemRef id in the function (for generating fresh ids)
+/// Find the highest MemRef base name counter in the function (for generating fresh ids).
 class MaxMemRefIdCollector : public IRVisitor {
  public:
   void VisitVarLike_(const VarPtr& op) override {
     if (auto tile_type = GetTileTypeWithMemRef(op->GetType())) {
       auto memref = GetDefinedMemRef(tile_type);
-      if (memref->id_ >= max_id_) max_id_ = memref->id_ + 1;
+      auto counter = ExtractNameCounter(memref->base_->name_hint_);
+      if (counter.has_value() && *counter >= max_id_) max_id_ = *counter + 1;
     }
   }
   [[nodiscard]] uint64_t GetNextId() const { return max_id_; }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -295,18 +295,18 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
     return {lifetimes, {}};
   }
 
-  // Step 2: Build MemRef sharing groups
-  std::map<const MemRef*, std::vector<VarPtr>> memref_groups;
+  // Step 2: Build MemRef sharing groups (keyed by base_ Ptr identity)
+  std::map<const Var*, std::vector<VarPtr>> memref_groups;
   for (const auto& var : result.ordered_defs) {
     auto tile_type = As<TileType>(var->GetType());
     if (tile_type && tile_type->memref_.has_value()) {
-      const MemRef* memref_ptr = tile_type->memref_.value().get();
-      memref_groups[memref_ptr].push_back(var);
+      const Var* base_ptr = tile_type->memref_.value()->base_.get();
+      memref_groups[base_ptr].push_back(var);
     }
   }
 
   std::map<VarPtr, std::vector<VarPtr>> var_sharing_groups;
-  for (const auto& [memref_ptr, vars] : memref_groups) {
+  for (const auto& [base_ptr, vars] : memref_groups) {
     if (vars.size() > 1) {
       for (const auto& var : vars) {
         var_sharing_groups[var] = vars;
@@ -716,7 +716,7 @@ class YieldFixupMutator : public IRMutator {
       if (!init_tile) continue;
       auto init_memref = GetDefinedMemRef(init_tile);
 
-      if (yield_memref.get() == init_memref.get()) continue;
+      if (MemRef::SameAllocation(yield_memref, init_memref)) continue;
 
       // MemRef mismatch — create tile.move to copy yield value into initValue's buffer
       auto target_memory = init_tile->GetMemorySpace();
@@ -789,7 +789,7 @@ class YieldFixupMutator : public IRMutator {
       // Check else branch: if MemRef differs from target, insert tile.move
       if (then_tile && else_tile) {
         auto else_memref = GetDefinedMemRef(else_tile);
-        if (else_memref.get() != target_memref.get()) {
+        if (!MemRef::SameAllocation(else_memref, target_memref)) {
           auto [moved_var, move_stmt] = CreateTileMove(else_var, target_memref, target_memory);
           else_move_stmts.emplace_back(std::move(move_stmt));
           else_moves.emplace_back(i, moved_var);
@@ -801,7 +801,7 @@ class YieldFixupMutator : public IRMutator {
       auto rv_tile = As<TileType>(new_return_vars[i]->GetType());
       if (rv_tile && rv_tile->memref_.has_value()) {
         auto rv_memref = GetDefinedMemRef(rv_tile);
-        if (rv_memref.get() != target_memref.get()) {
+        if (!MemRef::SameAllocation(rv_memref, target_memref)) {
           auto new_rv_type = CloneTypeWithMemRefAndRemapExprs(
               rv_tile, target_memref, [this](const ExprPtr& e) { return VisitExpr(e); }, target_memory);
           new_return_vars[i] =
@@ -866,7 +866,7 @@ class YieldFixupMutator : public IRMutator {
       auto ia_tile = As<TileType>(for_stmt->iter_args_[i]->GetType());
       if (ia_tile && ia_tile->memref_.has_value()) {
         auto ia_memref = GetDefinedMemRef(ia_tile);
-        if (ia_memref.get() != init_memref.get()) {
+        if (!MemRef::SameAllocation(ia_memref, init_memref)) {
           auto new_ia_type = CloneTypeWithMemRefAndRemapExprs(
               ia_tile, init_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
               init_tile->GetMemorySpace());
@@ -888,7 +888,7 @@ class YieldFixupMutator : public IRMutator {
       auto rv_tile = As<TileType>(new_return_vars[i]->GetType());
       if (!rv_tile || !rv_tile->memref_.has_value()) continue;
       auto rv_memref = GetDefinedMemRef(rv_tile);
-      if (rv_memref.get() != yield_memref.get()) {
+      if (!MemRef::SameAllocation(rv_memref, yield_memref)) {
         auto new_rv_type = CloneTypeWithMemRefAndRemapExprs(
             rv_tile, yield_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); },
             yield_tile->GetMemorySpace());
@@ -944,18 +944,18 @@ class YieldFixupMutator : public IRMutator {
 };
 
 // Check if a statement is a tile.alloc AssignStmt for an unused MemRef
-bool IsUnusedAllocStmt(const StmtPtr& stmt, const std::set<const MemRef*>& used_ptrs) {
+bool IsUnusedAllocStmt(const StmtPtr& stmt, const std::set<const Var*>& used_bases) {
   auto assign = As<AssignStmt>(stmt);
   if (!assign) return false;
-  auto memref = std::dynamic_pointer_cast<const MemRef>(assign->var_);
-  if (!memref) return false;
   auto call = As<Call>(assign->value_);
-  if (!call || call->op_->name_ != "tile.alloc") return false;
-  return used_ptrs.find(memref.get()) == used_ptrs.end();
+  if (!call) return false;
+  if (call->op_->name_ != "tile.alloc" && call->op_->name_ != "tensor.alloc") return false;
+  // Alloc LHS is a Ptr Var — check if any MemRef's base_ still references it
+  return used_bases.find(assign->var_.get()) == used_bases.end();
 }
 
 // Remove unused alloc statements from a SeqStmts body
-StmtPtr RemoveUnusedAllocStatements(const StmtPtr& body, const std::set<const MemRef*>& used_ptrs) {
+StmtPtr RemoveUnusedAllocStatements(const StmtPtr& body, const std::set<const Var*>& used_bases) {
   auto seq = As<SeqStmts>(body);
   if (!seq) return body;
 
@@ -963,7 +963,7 @@ StmtPtr RemoveUnusedAllocStatements(const StmtPtr& body, const std::set<const Me
   bool changed = false;
 
   for (const auto& child : seq->stmts_) {
-    if (IsUnusedAllocStmt(child, used_ptrs)) {
+    if (IsUnusedAllocStmt(child, used_bases)) {
       changed = true;
       continue;
     }
@@ -1007,8 +1007,8 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   new_body = yield_fixup.VisitStmt(new_body);
 
   // Step 5: Remove alloc statements for MemRefs no longer in use
-  auto used_ptrs = memref_collectors::CollectUsedMemRefPtrs(new_body);
-  new_body = RemoveUnusedAllocStatements(new_body, used_ptrs);
+  auto used_bases = memref_collectors::CollectUsedBasePtrs(new_body);
+  new_body = RemoveUnusedAllocStatements(new_body, used_bases);
 
   auto result = std::make_shared<const Function>(func->name_, func->params_, func->param_directions_,
                                                  func->return_types_, new_body, func->span_, func->func_type_,

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1542,10 +1542,14 @@ std::string IRPythonPrinter::PrintMemRef(const MemRef& memref) {
   oss << prefix_ << ".MemRef(";
 
   // Print base Ptr name as string literal to handle forward references
-  // (DDR bases appear in parameter annotations before their alloc statements)
-  oss << "\"" << memref.base_->name_hint_ << "\"";
+  // (DDR bases appear in parameter annotations before their alloc statements).
+  // Use GetVarName to respect SSA rename disambiguation.
+  oss << "\"" << GetVarName(memref.base_.get()) << "\"";
 
-  // Print byte offset
+  // Print byte offset using a temp printer to avoid corrupting the main stream.
+  // The temp printer has its own stream_ but shares no rename maps — that's fine
+  // because byte_offset expressions are ConstInt or arithmetic trees of loop vars
+  // which print by name_hint_ and don't need SSA renaming.
   oss << ", ";
   IRPythonPrinter temp_printer(prefix_);
   oss << temp_printer.Print(memref.byte_offset_);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -261,11 +261,6 @@ class IRPythonPrinter : public IRVisitor {
   // Built by BuildVarRenameMap() at the start of each function to handle SSA name shadowing.
   std::unordered_map<const Var*, std::string> var_rename_map_;
 
-  // Per-function MemRef name map: MemRef pointer → printed alloc name.
-  // Built from tile.alloc definition sites so tile/tensor annotations can refer
-  // to the same named buffers instead of re-printing inline pl.MemRef(...).
-  std::unordered_map<const MemRef*, std::string> memref_rename_map_;
-
   // Program-level dyn var rename map: Var pointer → disambiguated printed name.
   // Built once by VisitProgram for dynamic dimension variables used in type annotations.
   // When two distinct Var* share the same name_hint_, they get unique suffixed names.
@@ -279,17 +274,9 @@ class IRPythonPrinter : public IRVisitor {
   // Return the printed name for a Var, using rename map if SSA name shadowing occurred.
   std::string GetVarName(const Var* var) const;
 
-  // Return the printed name for a MemRef when it is defined in the current
-  // function (for example by tile.alloc). Falls back to the original hint.
-  std::string GetMemRefName(const MemRef* memref) const;
-
   // Build var_rename_map_ for a function by scanning all Var def-sites in DFS pre-order.
   // Assigns unique suffixed names (e.g., "i", "i_1") when two distinct Vars share a name.
   void BuildVarRenameMap(const FunctionPtr& func);
-
-  // Build memref_rename_map_ for a function from MemRef definition sites
-  // (currently tile.alloc assignments).
-  void BuildMemRefRenameMap(const FunctionPtr& func);
 
   // Print a statement block at current indent level.
   // SeqStmts is a transparent container - recursed into without extra indent.
@@ -443,6 +430,10 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
     return prefix_ + ".MemRefType";
   }
 
+  if (auto ptr_type = As<PtrType>(type)) {
+    return prefix_ + ".Ptr";
+  }
+
   return prefix_ + ".UnknownType";
 }
 
@@ -463,7 +454,7 @@ void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << GetVarName(op.ge
 
 void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << op->name_hint_; }
 
-void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << GetMemRefName(op.get()); }
+void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << op->name_hint_; }
 
 void IRPythonPrinter::VisitExpr_(const ConstIntPtr& op) {
   // DEFAULT_CONST_INT (= INT64) and INDEX both represent 64-bit integer constants
@@ -569,8 +560,8 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   for (size_t i = 0; i < op->args_.size(); ++i) {
     if (i > 0) stream_ << ", ";
 
-    // Special handling for tile.alloc's first argument (memory_space)
-    if (op->op_->name_ == "tile.alloc" && i == 0) {
+    // Special handling for tile.alloc/tensor.alloc first argument (memory_space)
+    if ((op->op_->name_ == "tile.alloc" || op->op_->name_ == "tensor.alloc") && i == 0) {
       // Try to extract the integer value and convert it to MemorySpace enum
       if (auto const_int = std::dynamic_pointer_cast<const ConstInt>(op->args_[i])) {
         int space_value = static_cast<int>(const_int->value_);
@@ -1134,37 +1125,12 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
   }
 }
 
-// Collect MemRef definition sites in DFS pre-order for alloc name reuse.
-static void CollectMemRefDefsInOrder(const StmtPtr& stmt, std::vector<const MemRef*>& out) {
-  if (!stmt) return;
-  if (auto assign = As<AssignStmt>(stmt)) {
-    if (auto memref = As<MemRef>(assign->var_)) out.push_back(memref.get());
-  } else if (auto for_stmt = As<ForStmt>(stmt)) {
-    CollectMemRefDefsInOrder(for_stmt->body_, out);
-  } else if (auto if_stmt = As<IfStmt>(stmt)) {
-    CollectMemRefDefsInOrder(if_stmt->then_body_, out);
-    if (if_stmt->else_body_.has_value()) CollectMemRefDefsInOrder(*if_stmt->else_body_, out);
-  } else if (auto while_stmt = As<WhileStmt>(stmt)) {
-    CollectMemRefDefsInOrder(while_stmt->body_, out);
-  } else if (auto seq = As<SeqStmts>(stmt)) {
-    for (auto& s : seq->stmts_) CollectMemRefDefsInOrder(s, out);
-  } else if (auto scope = As<ScopeStmt>(stmt)) {
-    CollectMemRefDefsInOrder(scope->body_, out);
-  }
-}
-
 std::string IRPythonPrinter::GetVarName(const Var* var) const {
   auto it = var_rename_map_.find(var);
   if (it != var_rename_map_.end()) return it->second;
   auto dyn_it = dyn_var_rename_map_.find(var);
   if (dyn_it != dyn_var_rename_map_.end()) return dyn_it->second;
   return var->name_hint_;
-}
-
-std::string IRPythonPrinter::GetMemRefName(const MemRef* memref) const {
-  auto it = memref_rename_map_.find(memref);
-  if (it != memref_rename_map_.end()) return it->second;
-  return memref->name_hint_;
 }
 
 void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
@@ -1179,14 +1145,7 @@ void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
   auto_name::BuildRenameMapForDefs(defs, var_rename_map_);
 }
 
-void IRPythonPrinter::BuildMemRefRenameMap(const FunctionPtr& func) {
-  std::vector<const MemRef*> defs;
-  if (func->body_) CollectMemRefDefsInOrder(func->body_, defs);
-  auto_name::BuildRenameMapForDefs(defs, memref_rename_map_, true);
-}
-
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
-  BuildMemRefRenameMap(func);
   // Build rename map for this function to handle SSA name shadowing.
   BuildVarRenameMap(func);
 
@@ -1495,7 +1454,7 @@ static std::unordered_map<const Var*, std::string> CollectDynVarMapping(const Pr
                      dyn_var_ptrs.end());
 
   // Phase 2: Assign unique printed names, disambiguating collisions.
-  // Reuses the same rename logic as BuildVarRenameMap / BuildMemRefRenameMap.
+  // Reuses the same rename logic as BuildVarRenameMap.
   // include_unique_names=true so VisitProgram can iterate the full map for
   // pl.dynamic() declarations.
   std::unordered_map<const Var*, std::string> result;
@@ -1579,18 +1538,20 @@ void IRPythonPrinter::PrintShapeDims(std::ostringstream& oss, const std::vector<
 
 // Helper methods for MemRef and TileView printing
 std::string IRPythonPrinter::PrintMemRef(const MemRef& memref) {
-  auto it = memref_rename_map_.find(&memref);
-  if (it != memref_rename_map_.end()) return it->second;
-
   std::ostringstream oss;
   oss << prefix_ << ".MemRef(";
 
-  // Print address expression
-  IRPythonPrinter temp_printer(prefix_);
-  oss << temp_printer.Print(memref.addr_);
+  // Print base Ptr name as string literal to handle forward references
+  // (DDR bases appear in parameter annotations before their alloc statements)
+  oss << "\"" << memref.base_->name_hint_ << "\"";
 
-  // Print size and id
-  oss << ", " << memref.size_ << ", " << memref.id_ << ")";
+  // Print byte offset
+  oss << ", ";
+  IRPythonPrinter temp_printer(prefix_);
+  oss << temp_printer.Print(memref.byte_offset_);
+
+  // Print size
+  oss << ", " << memref.size_ << ")";
   return oss.str();
 }
 

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -1072,8 +1072,8 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
       if (!EqualType(lhs_tuple->types_[i], rhs_tuple->types_[i])) return false;
     }
     return true;
-  } else if (IsA<MemRefType>(lhs) || IsA<UnknownType>(lhs)) {
-    return true;  // Singleton type, both being MemRefType or UnknownType is sufficient
+  } else if (IsA<MemRefType>(lhs) || IsA<UnknownType>(lhs) || IsA<PtrType>(lhs)) {
+    return true;  // Singleton type, both being same type kind is sufficient
   }
 
   INTERNAL_UNREACHABLE << "EqualType encountered unhandled Type: " << lhs->TypeName();
@@ -1159,10 +1159,18 @@ bool StructuralEqualImpl<AssertMode>::EqualMemRef(const MemRefPtr& lhs, const Me
     return false;
   }
 
-  // 2. Then, compare MemRef-specific fields (except id_ which is a naming counter)
-  if (!Equal(lhs->addr_, rhs->addr_)) {
+  // 2. Then, compare MemRef-specific fields: base_, byte_offset_, size_
+  if (!EqualVar(lhs->base_, rhs->base_)) {
     if constexpr (AssertMode) {
-      ThrowMismatch("MemRef addr mismatch", std::static_pointer_cast<const IRNode>(lhs),
+      ThrowMismatch("MemRef base mismatch", std::static_pointer_cast<const IRNode>(lhs),
+                    std::static_pointer_cast<const IRNode>(rhs));
+    }
+    return false;
+  }
+
+  if (!Equal(lhs->byte_offset_, rhs->byte_offset_)) {
+    if constexpr (AssertMode) {
+      ThrowMismatch("MemRef byte_offset mismatch", std::static_pointer_cast<const IRNode>(lhs),
                     std::static_pointer_cast<const IRNode>(rhs));
     }
     return false;

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -454,8 +454,8 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       INTERNAL_CHECK(t) << "structural_hash encountered null type in TupleType";
       h = hash_combine(h, HashType(t));
     }
-  } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type)) {
-    // MemRefType and UnknownType have no fields, only hash type name (already done above)
+  } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type) || IsA<PtrType>(type)) {
+    // MemRefType, PtrType, and UnknownType have no fields, only hash type name (already done above)
   } else {
     INTERNAL_CHECK(false) << "HashType encountered unhandled Type: " << type->TypeName();
   }

--- a/src/ir/transforms/utils/deep_clone_utils.cpp
+++ b/src/ir/transforms/utils/deep_clone_utils.cpp
@@ -104,9 +104,10 @@ class DeepCloneMutator : public IRMutator {
     if (it != expr_map_.end()) {
       return it->second;
     }
-    // Create fresh MemRef with cloned addr_
-    auto new_addr = op->addr_ ? IRMutator::VisitExpr(op->addr_) : op->addr_;
-    auto fresh = std::make_shared<MemRef>(op->name_hint_, std::move(new_addr), op->size_, op->id_, op->span_);
+    // Create fresh MemRef with cloned byte_offset_ and same base_
+    auto new_offset = op->byte_offset_ ? IRMutator::VisitExpr(op->byte_offset_) : op->byte_offset_;
+    auto fresh =
+        std::make_shared<MemRef>(op->name_hint_, op->base_, std::move(new_offset), op->size_, op->span_);
     expr_map_[op.get()] = fresh;
     return fresh;
   }

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -55,7 +55,7 @@ class TestMemRef:
         addr = ir.ConstInt(0, DataType.INT64, span)
         memref = ir.MemRef(ir.MemorySpace.DDR, addr, 1024, 0)
         assert memref is not None
-        assert memref.id_ == 0
+        assert memref.base_.name_hint == "mem_ddr_0"
 
     def test_memref_set_attributes(self):
         """Test setting MemRef attributes."""
@@ -66,7 +66,7 @@ class TestMemRef:
 
         assert not hasattr(memref, "memory_space_")
         assert memref.name_hint == "mem_ddr_0"
-        assert memref.addr_.same_as(addr)
+        assert memref.byte_offset_.same_as(addr)
         assert memref.size_ == 1024
 
     def test_memref_different_memory_spaces(self):
@@ -96,7 +96,7 @@ class TestMemRef:
 
         memref = ir.MemRef(ir.MemorySpace.Vec, addr_expr, 4096, 2)
 
-        assert isinstance(memref.addr_, ir.Add)
+        assert isinstance(memref.byte_offset_, ir.Add)
         assert memref.size_ == 4096
 
     def test_memref_large_size(self):
@@ -115,8 +115,8 @@ class TestMemRef:
 
         memref = ir.MemRef(ir.MemorySpace.Mat, addr, 512, 4)
 
-        assert isinstance(memref.addr_, ir.ConstInt)
-        assert memref.addr_.value == 0
+        assert isinstance(memref.byte_offset_, ir.ConstInt)
+        assert memref.byte_offset_.value == 0
 
 
 class TestTileView:
@@ -647,10 +647,10 @@ class TestMemRefStandaloneSerialization:
         assert isinstance(restored, ir.MemRef)
         assert not hasattr(restored, "memory_space_")
         assert restored.name_hint == "mem_vec_42"
-        assert isinstance(restored.addr_, ir.ConstInt)
-        assert restored.addr_.value == 0x1000
+        assert isinstance(restored.byte_offset_, ir.ConstInt)
+        assert restored.byte_offset_.value == 0x1000
         assert restored.size_ == 2048
-        assert restored.id_ == 42
+        assert restored.base_.name_hint == "mem_vec_42"
 
     def test_serialize_memref_all_memory_spaces(self):
         """Verify all MemorySpace values round-trip correctly."""
@@ -931,7 +931,7 @@ class TestMemRefConstructor:
 
         assert memref.name_hint == "mem_ddr_5"
         assert not hasattr(memref, "memory_space_")
-        assert memref.addr_.same_as(addr)
+        assert memref.byte_offset_.same_as(addr)
         assert memref.size_ == 1024
 
     def test_memref_constructor_different_spaces(self):
@@ -1193,7 +1193,7 @@ class TestPythonSyntaxPrinting:
         assert "pl.FP32" in printed
         # MemRef prints as positional arg (no keyword) with full constructor syntax
         assert "memref=" not in printed
-        assert "pl.MemRef(4096, 1024, 7)" in printed
+        assert 'pl.MemRef("mem_ddr_7", 4096, 1024)' in printed
 
     def test_tile_type_with_memref_and_tileview_print(self):
         """Test printing TileType with inline MemRef constructor syntax and TileView."""
@@ -1223,7 +1223,7 @@ class TestPythonSyntaxPrinting:
         assert "pl.Tile" in printed
         assert "pl.FP16" in printed
         assert "memref=" not in printed
-        assert "pl.MemRef(8192, 512, 8)" in printed
+        assert 'pl.MemRef("mem_left_8", 8192, 512)' in printed
         assert "pl.Mem.Left" in printed
         # TileView is now a positional arg in subscript (fixes #323), not keyword
         assert "pl.TileView" in printed
@@ -1343,13 +1343,13 @@ class TestPythonSyntaxPrinting:
         shape = [ir.ConstInt(32, DataType.INT64, span)]
         tensor_type_vec = ir.TensorType(shape, DataType.INT32, memref_vec)
         printed_vec = ir.python_print_type(tensor_type_vec)
-        assert "pl.MemRef(base_addr + 128, 2048, 9)" in printed_vec
+        assert 'pl.MemRef("mem_vec_9", base_addr + 128, 2048)' in printed_vec
 
         # DDR MemRef also prints in constructor form with symbolic address.
         memref_ddr = ir.MemRef(ir.MemorySpace.DDR, addr, 2048, 10)
         tensor_type_ddr = ir.TensorType(shape, DataType.INT32, memref_ddr)
         printed_ddr = ir.python_print_type(tensor_type_ddr)
-        assert "pl.MemRef(base_addr + 128, 2048, 10)" in printed_ddr
+        assert 'pl.MemRef("mem_ddr_10", base_addr + 128, 2048)' in printed_ddr
 
     def test_tensor_type_with_tensorview_print(self):
         """Test printing TensorType with TensorView."""
@@ -1390,7 +1390,7 @@ class TestPythonSyntaxPrinting:
         assert "pl.FP16" in printed
         # TensorType always prints MemRef inline because tensor memory space is DDR.
         assert "memref=" not in printed
-        assert "pl.MemRef(20480, 4096, 42)" in printed
+        assert 'pl.MemRef("mem_left_42", 20480, 4096)' in printed
         # tensor_view is now positional, not keyword in subscript
         assert "pl.TensorView" in printed
         assert "pl.TensorLayout.NZ" in printed
@@ -1503,7 +1503,7 @@ class TestIRBuilderHelpers:
         assert "pl.Tile[[32, 32], pl.FP32," in printed
         assert "pl.FP32" in printed
         assert "memref=" not in printed
-        assert "pl.MemRef(512, 1024, 36)" in printed
+        assert 'pl.MemRef("mem_right_36", 512, 1024)' in printed
         assert "pl.Mem.Right" in printed
         assert "pl.TileView" in printed  # positional arg (fixes #323)
 
@@ -1754,7 +1754,7 @@ class TestMemRefRoundTrip:
         # Verify valid Python syntax
         compile(printed, "<test_memref_valid_python>", "exec")
 
-        assert "pl.MemRef(0, 16384, 0)" in printed
+        assert 'pl.MemRef("mem_vec_0", 0, 16384)' in printed
         assert "pl.Mem.Vec" in printed
 
     def test_parse_tensor_with_memref(self):
@@ -1764,7 +1764,7 @@ class TestMemRefRoundTrip:
             class TestProg:
                 @pl.function
                 def test_fn(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    y: pl.Tensor[[64], pl.FP32, pl.MemRef(0, 256, 1)] = pl.add(x, 1.0)
+                    y: pl.Tensor[[64], pl.FP32, pl.MemRef(mem_ddr_1, 0, 256)] = pl.add(x, 1.0)
                     return y
         """)
         program = pl.parse(code)
@@ -1772,7 +1772,7 @@ class TestMemRefRoundTrip:
 
         # Verify the parsed IR contains memref by re-printing
         printed = program.as_python()
-        assert "pl.MemRef(0, 256, 1)" in printed
+        assert 'pl.MemRef("mem_ddr_1", 0, 256)' in printed
 
     def test_parse_tile_with_memref(self):
         """Parse tile memref annotations and reparse the printed IR."""
@@ -1783,14 +1783,14 @@ class TestMemRefRoundTrip:
                 def test_fn(self, x: pl.Tensor[[64, 64], pl.FP32]):
                     tile_a: pl.Tile[
                         [64, 64], pl.FP32,
-                        pl.MemRef(0, 16384, 0), pl.Mem.Vec
+                        pl.MemRef(mem_vec_0, 0, 16384), pl.Mem.Vec
                     ] = pl.tile.load(x, offsets=[0, 0], shapes=[64, 64])
         """)
         program = pl.parse(code)
         assert isinstance(program, ir.Program)
 
         printed = program.as_python()
-        assert "pl.MemRef(0, 16384, 0)" in printed
+        assert 'pl.MemRef("mem_vec_0", 0, 16384)' in printed
         assert "pl.Mem.Vec" in printed
         reparsed = pl.parse(printed)
         ir.assert_structural_equal(program, reparsed, enable_auto_mapping=True)
@@ -1804,7 +1804,7 @@ class TestMemRefRoundTrip:
                 def test_fn(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                     y: pl.Tensor[
                         [64], pl.FP32, pl.NZ,
-                        pl.MemRef(0, 256, 2)
+                        pl.MemRef(mem_ddr_2, 0, 256)
                     ] = pl.add(x, 1.0)
                     return y
         """)
@@ -1813,7 +1813,7 @@ class TestMemRefRoundTrip:
 
         # Verify both layout and memref are preserved
         printed = program.as_python()
-        assert "pl.MemRef(0, 256, 2)" in printed
+        assert 'pl.MemRef("mem_ddr_2", 0, 256)' in printed
         # Layout appears as positional TensorView arg (fixes #323)
         assert "pl.TensorView" in printed
 
@@ -1826,7 +1826,7 @@ class TestMemRefRoundTrip:
                 def test_fn(self, x: pl.Tensor[[64, 64], pl.FP32]):
                     tile_a: pl.Tile[
                         [64, 64], pl.FP32,
-                        pl.MemRef(0, 16384, 0), pl.Mem.DDR
+                        pl.MemRef(mem_ddr_0, 0, 16384), pl.Mem.DDR
                     ] = pl.tile.load(x, offsets=[0, 0], shapes=[64, 64])
         """)
         parsed1 = pl.parse(code)
@@ -1841,7 +1841,7 @@ class TestMemRefRoundTrip:
             class TestProg:
                 @pl.function
                 def test_fn(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    y: pl.Tensor[[64], pl.FP32, pl.MemRef(0, 256, 1)] = pl.add(x, 1.0)
+                    y: pl.Tensor[[64], pl.FP32, pl.MemRef(mem_ddr_1, 0, 256)] = pl.add(x, 1.0)
                     return y
         """)
         parsed1 = pl.parse(code)
@@ -1853,6 +1853,7 @@ class TestMemRefRoundTrip:
         """Test all supported tile memory spaces round-trip through as_python()."""
         spaces = ["DDR", "Vec", "Mat", "Left", "Right", "Acc"]
         for space_name in spaces:
+            base_name = f"mem_{space_name.lower()}_0"
             code = textwrap.dedent(f"""\
                 @pl.program
                 class TestProg:
@@ -1860,12 +1861,12 @@ class TestMemRefRoundTrip:
                     def test_fn(self, x: pl.Tensor[[64, 64], pl.FP32]):
                         tile_a: pl.Tile[
                             [64, 64], pl.FP32,
-                            pl.MemRef(0, 16384, 0), pl.Mem.{space_name}
+                            pl.MemRef({base_name}, 0, 16384), pl.Mem.{space_name}
                         ] = pl.tile.load(x, offsets=[0, 0], shapes=[64, 64])
             """)
             parsed1 = pl.parse(code)
             printed = parsed1.as_python()
-            assert "pl.MemRef(0, 16384, 0)" in printed, (
+            assert f'pl.MemRef("{base_name}", 0, 16384)' in printed, (
                 f"Expected explicit MemRef constructor in printed output, got: {printed}"
             )
             assert f"pl.Mem.{space_name}" in printed, (

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -507,7 +507,7 @@ def test_python_print_tile_type_prints_explicit_tile_memory_space():
 
     result = ir.python_print_type(tile_type)
 
-    assert "pl.MemRef(0, 512, 0)" in result
+    assert 'pl.MemRef("mem_vec_0", 0, 512)' in result
     assert ", pl.Mem.Vec" in result
 
 

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -66,8 +66,8 @@ def get_memref_addresses_from_tiles(func):
             var_type = stmt.var.type
             if isinstance(var_type, ir.TileType) and var_type.memref is not None:
                 memref = var_type.memref
-                if isinstance(memref.addr_, ir.ConstInt):
-                    memref_addrs[stmt.var.name_hint] = memref.addr_.value
+                if isinstance(memref.byte_offset_, ir.ConstInt):
+                    memref_addrs[stmt.var.name_hint] = memref.byte_offset_.value
     return memref_addrs
 
 
@@ -430,8 +430,8 @@ def test_memrefs_before_allocate_have_unallocated_addr():
     memref_addrs = get_memref_addresses_from_tiles(func)
     assert len(memref_addrs) > 0, "Should have MemRef addresses after init_mem_ref"
     for var_name, addr in memref_addrs.items():
-        assert addr == -1, (
-            f"MemRef address for '{var_name}' should be -1 before AllocateMemoryAddr, got {addr}"
+        assert addr == 0, (
+            f"MemRef byte_offset for '{var_name}' should be 0 before AllocateMemoryAddr, got {addr}"
         )
 
 

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -61,27 +61,27 @@ def _first_function(program):
     return next(iter(program.functions.values()))
 
 
-def _is_tile_alloc_assign(stmt):
-    """Return True if stmt is an AssignStmt wrapping a tile.alloc call."""
+def _is_alloc_assign(stmt):
+    """Return True if stmt is an AssignStmt wrapping a tile.alloc or tensor.alloc call."""
     return (
         isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "tile.alloc"
+        and stmt.value.op.name in ("tile.alloc", "tensor.alloc")
     )
 
 
 def _assert_leading_allocs(func, count):
-    """Assert that the first count statements in the body are tile.alloc assigns."""
+    """Assert that the first count statements in the body are alloc assigns."""
     assert isinstance(func.body, ir.SeqStmts)
     assert len(func.body.stmts) >= count
-    assert all(_is_tile_alloc_assign(stmt) for stmt in func.body.stmts[:count])
+    assert all(_is_alloc_assign(stmt) for stmt in func.body.stmts[:count])
 
 
 def _get_alloc_stmts(func):
-    """Get tile.alloc AssignStmts from function body."""
+    """Get alloc AssignStmts (tile.alloc or tensor.alloc) from function body."""
     allocs = []
     for stmt in _iter_assign_stmts(func):
-        if _is_tile_alloc_assign(stmt):
+        if _is_alloc_assign(stmt):
             allocs.append(stmt)
     return allocs
 
@@ -129,7 +129,7 @@ class TestBasic:
         for name in ("input_a", "input_b", "output"):
             assert name in param_types, f"param {name} should have MemRef"
             assert param_types[name].memory_space == MemorySpace.DDR
-            assert param_types[name].memref.addr_.value == -1
+            assert param_types[name].memref.byte_offset_.value == 0
             assert param_types[name].memref.size_ == 16384  # 64*64*4
 
         # Tiles: Vec, addr=-1, size=16384
@@ -137,14 +137,12 @@ class TestBasic:
         for name in ("tile_a", "tile_b", "tile_sum"):
             assert name in tile_types, f"tile {name} should have MemRef"
             assert tile_types[name].memory_space == MemorySpace.Vec
-            assert tile_types[name].memref.addr_.value == -1
+            assert tile_types[name].memref.byte_offset_.value == 0
             assert tile_types[name].memref.size_ == 16384
 
-        # Alloc count matches non-DDR tiles
+        # Alloc count matches non-DDR tiles (new format: tile.alloc(space, size))
         allocs = _get_alloc_stmts(func)
         assert len(allocs) == 3
-        for alloc in allocs:
-            assert alloc.value.args[1].value == -1
 
     def test_matmul_pipeline(self):
         """load→move→matmul→store: Vec/Mat/Left/Right/Acc memory spaces."""
@@ -198,7 +196,7 @@ class TestBasic:
             assert tile_types[name].memory_space == expected, (
                 f"{name}: expected {expected}, got {tile_types[name].memory_space}"
             )
-            assert tile_types[name].memref.addr_.value == -1
+            assert tile_types[name].memref.byte_offset_.value == 0
             if name == "tile_result":
                 assert tile_types[name].memref.size_ == 4096  # 32*32*4
             else:

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -73,23 +73,21 @@ def _assert_all_have_memrefs(func):
 
 
 def _count_alloc_stmts(func):
-    """Count tile.alloc AssignStmt in the function body."""
+    """Count alloc AssignStmts (tile.alloc or tensor.alloc) in the function body."""
     count = 0
     for stmt in _iter_all_assign_stmts(func.body):
-        if isinstance(stmt.value, ir.Call) and stmt.value.op.name == "tile.alloc":
+        if isinstance(stmt.value, ir.Call) and stmt.value.op.name in ("tile.alloc", "tensor.alloc"):
             count += 1
     return count
 
 
-def _get_alloc_memref_ids(func):
-    """Get the set of MemRef id_ values from tile.alloc statements."""
-    ids = set()
+def _get_alloc_base_names(func):
+    """Get the set of base Ptr names from alloc statements."""
+    names = set()
     for stmt in _iter_all_assign_stmts(func.body):
-        if isinstance(stmt.value, ir.Call) and stmt.value.op.name == "tile.alloc":
-            memref = stmt.var
-            assert isinstance(memref, ir.MemRef), "tile.alloc LHS must be MemRef"
-            ids.add(memref.id_)
-    return ids
+        if isinstance(stmt.value, ir.Call) and stmt.value.op.name in ("tile.alloc", "tensor.alloc"):
+            names.add(stmt.var.name_hint)
+    return names
 
 
 def _find_first_for_stmt(stmt):
@@ -262,10 +260,10 @@ class TestAllocCleanup:
             f"Expected 1 alloc stmt after chain reuse, got {_count_alloc_stmts(func)}"
         )
 
-        alloc_ids = _get_alloc_memref_ids(func)
+        alloc_names = _get_alloc_base_names(func)
         tile_a_type = _get_var_type(func, "tile_a")
         assert tile_a_type is not None and tile_a_type.memref is not None
-        assert tile_a_type.memref.id_ in alloc_ids
+        assert tile_a_type.memref.base_.name_hint in alloc_names
 
     def test_partial_reuse_with_overlapping_lifetimes(self):
         """When some lifetimes truly overlap, partial reuse happens."""

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -219,9 +219,8 @@ class TestPythonPrinterProgram:
         after = passes.allocate_memory_addr()(passes.init_mem_ref()(Before))
         code = after.as_python()
 
-        assert "pl.MemRefType = pl.tile.alloc(" in code
-        assert "pl.Tile[[64, 64], pl.FP32, mem_vec_" in code
-        assert "pl.Tile[[64, 64], pl.FP32, pl.MemRef(" not in code
+        assert "pl.Ptr = pl.tile.alloc(" in code
+        assert 'pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_' in code
 
 
 class TestPythonPrinterConstDtypeRoundtrip:

--- a/tests/ut/language/test_post_alloc_roundtrip.py
+++ b/tests/ut/language/test_post_alloc_roundtrip.py
@@ -139,12 +139,10 @@ class TestSoftmaxRescaleDSL:
                 mem_vec_0: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
                 mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
                 # mem_vec_* referenced in Tile annotations via MemRef
-                t: pl.Tile[
-                    [16, 128], pl.FP32, pl.MemRef(mem_vec_0, 0, 8192), pl.Mem.Vec  # pyright: ignore[reportArgumentType]
-                ] = pl.tile.load(x, [0, 0], [16, 128])
-                t2: pl.Tile[
-                    [16, 128], pl.FP32, pl.MemRef(mem_vec_1, 0, 8192), pl.Mem.Vec  # pyright: ignore[reportArgumentType]
-                ] = pl.tile.add(t, t)
+                t: pl.Tile[[16, 128], pl.FP32, pl.MemRef(mem_vec_0, 0, 8192), pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0], [16, 128]
+                )
+                t2: pl.Tile[[16, 128], pl.FP32, pl.MemRef(mem_vec_1, 0, 8192), pl.Mem.Vec] = pl.tile.add(t, t)
                 r: pl.Tensor[[16, 128], pl.FP32] = pl.tile.store(t2, [0, 0], out)
                 return r
 

--- a/tests/ut/language/test_post_alloc_roundtrip.py
+++ b/tests/ut/language/test_post_alloc_roundtrip.py
@@ -135,12 +135,16 @@ class TestSoftmaxRescaleDSL:
                 x: pl.Tensor[[16, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
-                # Fix #1: exactly what the printer emits after AllocateMemoryAddr
-                mem_vec_0: pl.MemRefType = pl.tile.alloc(pl.Mem.Vec, 0, 8192, 0)
-                mem_vec_1: pl.MemRefType = pl.tile.alloc(pl.Mem.Vec, 8192, 8192, 1)
-                # mem_vec_* referenced in Tile annotations just like the real dump
-                t: pl.Tile[[16, 128], pl.FP32, mem_vec_0, pl.Mem.Vec] = pl.tile.load(x, [0, 0], [16, 128])
-                t2: pl.Tile[[16, 128], pl.FP32, mem_vec_1, pl.Mem.Vec] = pl.tile.add(t, t)
+                # Exactly what the printer emits after AllocateMemoryAddr
+                mem_vec_0: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
+                mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
+                # mem_vec_* referenced in Tile annotations via MemRef
+                t: pl.Tile[
+                    [16, 128], pl.FP32, pl.MemRef(mem_vec_0, 0, 8192), pl.Mem.Vec  # pyright: ignore[reportArgumentType]
+                ] = pl.tile.load(x, [0, 0], [16, 128])
+                t2: pl.Tile[
+                    [16, 128], pl.FP32, pl.MemRef(mem_vec_1, 0, 8192), pl.Mem.Vec  # pyright: ignore[reportArgumentType]
+                ] = pl.tile.add(t, t)
                 r: pl.Tensor[[16, 128], pl.FP32] = pl.tile.store(t2, [0, 0], out)
                 return r
 


### PR DESCRIPTION
## Summary

Resolves #877

- Replace MemRef fields `(addr_, size_, id_)` with `(base_, byte_offset_, size_)` where `base_` is a `VarPtr` to a `PtrType` allocation identity token
- Add `PtrType` as new singleton type for alloc return values (`tile.alloc` / `tensor.alloc`)
- Add `tensor.alloc` op for DDR memory alongside existing `tile.alloc` for on-chip
- Add `MemRef::SameAllocation()` and `MayAlias()` for alias analysis via base pointer identity and byte range overlap
- Alloc statements now emit Ptr LHS: `base: Ptr = tile.alloc(space, size)`
- InitMemRef computes byte offsets for slice view chains
- Extract shared `BuildBasePtrName`, `ExtractNameCounter`, `CreateAllocStatement` utilities into `memref_utils.h`
- Add DSL-level `MemRef` wrapper accepting `PtrType` as base for pyright compatibility in `@pl.program` code

## Test plan

- [x] All 3339 tests pass
- [x] Code review completed (3 parallel review agents)
- [x] clang-tidy clean (no new warnings)
- [x] pyright passes (no type errors)
- [x] Pre-commit hooks all pass (clang-format, cpplint, ruff, markdownlint)
- [x] Round-trip tests verify parse → print → reparse for new MemRef format
- [x] Serialization/deserialization round-trips verified