### PR TITLE
feat(pass): support dynamic loop bounds in SplitChunkedLoops

### DIFF
--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -43,9 +43,10 @@ using transform_utils::CollectDefVars;
 namespace {
 
 /**
- * @brief Extract a compile-time integer value from a ConstInt or Neg(ConstInt) expression.
+ * @brief Try to extract a compile-time integer from a ConstInt or Neg(ConstInt).
+ * @return The integer value, or std::nullopt if not a compile-time constant.
  */
-static int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
+static std::optional<int64_t> TryGetConstInt(const ExprPtr& expr) {
   auto ci = std::dynamic_pointer_cast<const ConstInt>(expr);
   if (ci) {
     return ci->value_;
@@ -57,6 +58,17 @@ static int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
       return -inner->value_;
     }
   }
+  return std::nullopt;
+}
+
+/**
+ * @brief Extract a compile-time integer value from a ConstInt or Neg(ConstInt) expression.
+ */
+static int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
+  auto val = TryGetConstInt(expr);
+  if (val.has_value()) {
+    return *val;
+  }
   throw pypto::ValueError("Chunked loop " + what + " must be a compile-time integer constant, got " +
                           expr->TypeName());
 }
@@ -66,6 +78,48 @@ static int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
  */
 static ExprPtr MakeConstIndex(int64_t value, const Span& span) {
   return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+}
+
+/**
+ * @brief Compute trip count from compile-time constant bounds.
+ */
+static int64_t ComputeStaticTripCount(int64_t start, int64_t stop, int64_t step) {
+  if (step > 0 && start < stop) {
+    return (stop - start + step - 1) / step;
+  }
+  if (step < 0 && start > stop) {
+    return (start - stop + (-step) - 1) / (-step);
+  }
+  return 0;
+}
+
+/**
+ * @brief Build trip count as an expression tree for dynamic bounds.
+ *
+ * Produces: max(ceildiv(stop - start, step), 0)  when step > 0
+ *           max(ceildiv(start - stop, -step), 0) when step < 0
+ */
+static ExprPtr BuildTripCountExpr(const ExprPtr& start, const ExprPtr& stop, int64_t step, const Span& sp) {
+  ExprPtr trip_count;
+  if (step > 0) {
+    ExprPtr range_size = MakeSub(stop, start, sp);
+    if (step == 1) {
+      trip_count = range_size;
+    } else {
+      trip_count =
+          MakeFloorDiv(MakeAdd(range_size, MakeConstIndex(step - 1, sp), sp), MakeConstIndex(step, sp), sp);
+    }
+  } else {
+    ExprPtr range_size = MakeSub(start, stop, sp);
+    int64_t abs_step = -step;
+    if (abs_step == 1) {
+      trip_count = range_size;
+    } else {
+      trip_count = MakeFloorDiv(MakeAdd(range_size, MakeConstIndex(abs_step - 1, sp), sp),
+                                MakeConstIndex(abs_step, sp), sp);
+    }
+  }
+  return MakeMax(trip_count, MakeConstIndex(0, sp), sp);
 }
 
 static void CollectDeclaredNames(const StmtPtr& stmt, std::unordered_set<std::string>& result) {
@@ -133,6 +187,7 @@ static StmtPtr MakeResultStmt(const std::vector<StmtPtr>& stmts, const Span& spa
  * @brief Mutator that splits ForStmt nodes with chunk_size_ into nested loops.
  *
  * Runs after SSA conversion. Propagates iter_args through generated loops.
+ * Handles both compile-time constant and dynamic (runtime) loop bounds.
  *
  * Transforms (SSA form):
  *   for i, (x_iter=x_0,) in range(start, stop, step, chunk=C) -> (x_rv,):
@@ -140,16 +195,19 @@ static StmtPtr MakeResultStmt(const std::vector<StmtPtr>& stmts, const Span& spa
  *     yield(x_1)
  *
  * Into:
- *   for i_out, (x_outer=x_0,) in range(0, num_full_chunks) -> (x_outer_rv,):
+ *   for i_out, (x_outer=x_0,) in range(0, n_full) -> (x_outer_rv,):
  *     for i_in, (x_inner=x_outer,) in range(0, C) -> (x_inner_rv,):
  *       x_1 = add(x_inner, 1.0)
  *       yield(x_1)
  *     yield(x_inner_rv)
  *   # optional remainder
- *   for i_rem, (x_rem=x_outer_rv,) in range(0, remainder) -> (x_rem_rv,):
+ *   for i_rem, (x_rem=x_outer_rv,) in range(0, n_rem) -> (x_rem_rv,):
  *     x_1_f = add(x_rem, 1.0)   (fresh DEF variable)
  *     yield(x_1_f)
  *   return uses x_rem_rv (or x_outer_rv if no remainder)
+ *
+ * Where n_full and n_rem are ExprPtr — either ConstInt (when bounds are
+ * compile-time constants) or FloorDiv/FloorMod expressions (when dynamic).
  */
 class ChunkedLoopSplitter : public IRMutator {
  public:
@@ -199,51 +257,61 @@ class ChunkedLoopSplitter : public IRMutator {
       return IRMutator::VisitStmt_(op);
     }
 
-    // Extract compile-time constants
-    int64_t start = GetConstIntValue(op->start_, "start");
-    int64_t stop = GetConstIntValue(op->stop_, "stop");
-    int64_t step = GetConstIntValue(op->step_, "step");
+    // chunk_size and step must always be compile-time constants
     int64_t chunk_size = GetConstIntValue(*op->chunk_size_, "chunk_size");
+    int64_t step = GetConstIntValue(op->step_, "step");
     CHECK(step != 0) << "Chunked loop step cannot be zero";
     CHECK(chunk_size > 0) << "Chunk size must be positive, got " << chunk_size;
 
-    // Compute trip count
-    int64_t trip_count = 0;
-    if (step > 0 && start < stop) {
-      trip_count = (stop - start + step - 1) / step;
-    } else if (step < 0 && start > stop) {
-      trip_count = (start - stop + (-step) - 1) / (-step);
+    Span sp = op->span_;
+    auto step_expr = MakeConstIndex(step, sp);
+    auto chunk_expr = MakeConstIndex(chunk_size, sp);
+
+    ExprPtr start_expr = VisitExpr(op->start_);
+    ExprPtr stop_expr = VisitExpr(op->stop_);
+
+    // Compute n_full and n_rem as ExprPtr.
+    // When start/stop are constants, produce ConstInt nodes directly for cleaner IR.
+    // When dynamic, produce FloorDiv/FloorMod expression trees.
+    ExprPtr n_full;
+    ExprPtr n_rem;
+    auto start_c = TryGetConstInt(start_expr);
+    auto stop_c = TryGetConstInt(stop_expr);
+    if (start_c && stop_c) {
+      int64_t tc = ComputeStaticTripCount(*start_c, *stop_c, step);
+      n_full = MakeConstIndex(tc / chunk_size, sp);
+      n_rem = MakeConstIndex(tc % chunk_size, sp);
+    } else {
+      ExprPtr trip_count = BuildTripCountExpr(start_expr, stop_expr, step, sp);
+      n_full = MakeFloorDiv(trip_count, chunk_expr, sp);
+      n_rem = MakeFloorMod(trip_count, chunk_expr, sp);
     }
 
-    int64_t num_full_chunks = trip_count / chunk_size;
-    int64_t remainder = trip_count % chunk_size;
+    // Determine which loops to emit. Dynamic bounds always emit both.
+    auto n_full_c = TryGetConstInt(n_full);
+    auto n_rem_c = TryGetConstInt(n_rem);
+    bool emit_full = !n_full_c || *n_full_c > 0;
+    bool emit_rem = !n_rem_c || *n_rem_c > 0;
 
     const Var* loop_var_key = op->loop_var_.get();
     auto loop_name = auto_name::Parse(op->loop_var_->name_hint_);
     std::string base_name = loop_name.base_name;
 
-    // Save previous substitutions for loop var and iter_args
     auto prev_loop_sub = SaveSubstitution(loop_var_key);
-
     std::vector<SavedSubstitution> prev_ia_subs;
     for (const auto& ia : op->iter_args_) {
       prev_ia_subs.push_back(SaveSubstitution(ia.get()));
     }
 
-    auto start_expr = MakeConstIndex(start, op->span_);
-    auto step_expr = MakeConstIndex(step, op->span_);
-    auto chunk_const = MakeConstIndex(chunk_size, op->span_);
-
     bool has_iter_args = !op->iter_args_.empty();
 
     if (!has_iter_args) {
-      // Simple path: no iter_args to propagate
-      return SplitSimple(op, start, step, chunk_size, num_full_chunks, remainder, loop_var_key, base_name,
-                         loop_name.version, start_expr, step_expr, chunk_const, prev_loop_sub);
+      return SplitSimple(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, chunk_expr,
+                         n_full, n_rem, chunk_size, emit_full, emit_rem, prev_loop_sub, sp);
     }
 
-    // Zero-trip loop: return vars resolve to iter_arg init values
-    if (trip_count == 0) {
+    // Zero-trip optimization: when statically known, skip loop emission entirely
+    if (n_full_c && n_rem_c && *n_full_c == 0 && *n_rem_c == 0) {
       INTERNAL_CHECK(op->return_vars_.size() == op->iter_args_.size())
           << "ForStmt return_vars/iter_args size mismatch in zero-trip chunk split";
       for (size_t i = 0; i < op->return_vars_.size(); ++i) {
@@ -251,169 +319,12 @@ class ChunkedLoopSplitter : public IRMutator {
       }
       RestoreSubstitution(prev_loop_sub);
       RestoreSubstitutions(prev_ia_subs);
-      return SeqStmts::Flatten(std::vector<StmtPtr>{}, op->span_);
+      return SeqStmts::Flatten(std::vector<StmtPtr>{}, sp);
     }
 
-    // SSA path: propagate iter_args through outer/inner/remainder loops
-    std::vector<StmtPtr> result_stmts;
-
-    // Track final return vars (from outer or remainder) to remap original return_vars
-    std::vector<VarPtr> final_return_vars;
-
-    // Main nested loops (if there are full chunks)
-    if (num_full_chunks > 0) {
-      auto out_var = std::make_shared<Var>(
-          auto_name::BuildName(base_name, auto_name::ChunkOuterQualifier(), "idx", loop_name.version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
-      auto in_var = std::make_shared<Var>(
-          auto_name::BuildName(base_name, auto_name::ChunkInnerQualifier(), "idx", loop_name.version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
-
-      // Create outer and inner iter_args/return_vars
-      std::vector<IterArgPtr> outer_iter_args;
-      std::vector<VarPtr> outer_return_vars;
-      std::vector<IterArgPtr> inner_iter_args;
-      std::vector<VarPtr> inner_return_vars;
-
-      for (const auto& ia : op->iter_args_) {
-        auto visited_init = VisitExpr(ia->initValue_);
-        auto ia_name = auto_name::Parse(ia->name_hint_);
-        auto outer_ia = std::make_shared<IterArg>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "iter",
-                                 ia_name.version),
-            ia->GetType(), visited_init, ia->span_);
-        auto outer_rv = std::make_shared<Var>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "rv", ia_name.version),
-            ia->GetType(), ia->span_);
-        outer_iter_args.push_back(outer_ia);
-        outer_return_vars.push_back(outer_rv);
-
-        ExprPtr inner_init = outer_ia;
-        auto inner_ia = std::make_shared<IterArg>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "iter",
-                                 ia_name.version),
-            ia->GetType(), inner_init, ia->span_);
-        auto inner_rv = std::make_shared<Var>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "rv", ia_name.version),
-            ia->GetType(), ia->span_);
-        inner_iter_args.push_back(inner_ia);
-        inner_return_vars.push_back(inner_rv);
-
-        // Remap original iter_arg references to inner iter_arg
-        substitution_map_[ia.get()] = inner_ia;
-      }
-
-      // Loop var substitution: i = start + (i_out * C + i_in) * step
-      ExprPtr substitution =
-          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_const), in_var), step_expr));
-      substitution_map_[loop_var_key] = substitution;
-
-      // Visit body -> inner_body
-      auto inner_body = VisitStmt(op->body_);
-
-      // Inner loop
-      auto inner_for = std::make_shared<ForStmt>(
-          in_var, MakeConstIndex(0, op->span_), MakeConstIndex(chunk_size, op->span_),
-          MakeConstIndex(1, op->span_), inner_iter_args, inner_body, inner_return_vars, op->span_, op->kind_,
-          std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
-
-      // Outer body = [inner_for, yield(inner_return_vars)]
-      auto outer_yield = std::make_shared<YieldStmt>(
-          std::vector<ExprPtr>(inner_return_vars.begin(), inner_return_vars.end()), op->span_);
-      auto outer_body = SeqStmts::Flatten(std::vector<StmtPtr>{inner_for, outer_yield}, op->span_);
-
-      // Outer loop
-      auto outer_for = std::make_shared<ForStmt>(
-          out_var, MakeConstIndex(0, op->span_), MakeConstIndex(num_full_chunks, op->span_),
-          MakeConstIndex(1, op->span_), outer_iter_args, outer_body, outer_return_vars, op->span_, op->kind_,
-          std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
-
-      result_stmts.push_back(outer_for);
-      final_return_vars = outer_return_vars;
-    }
-
-    // Remainder loop
-    if (remainder > 0) {
-      auto rem_var = std::make_shared<Var>(
-          auto_name::BuildName(base_name, auto_name::ChunkRemainderQualifier(), "idx", loop_name.version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
-
-      int64_t rem_start = start + num_full_chunks * chunk_size * step;
-      auto rem_start_expr = MakeConstIndex(rem_start, op->span_);
-
-      // Remainder iter_args
-      std::vector<IterArgPtr> rem_iter_args;
-      std::vector<VarPtr> rem_return_vars;
-
-      for (size_t i = 0; i < op->iter_args_.size(); ++i) {
-        const auto& ia = op->iter_args_[i];
-        ExprPtr rem_init = (num_full_chunks > 0) ? final_return_vars[i] : VisitExpr(ia->initValue_);
-        auto ia_name = auto_name::Parse(ia->name_hint_);
-        auto rem_ia = std::make_shared<IterArg>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkRemainderQualifier(), "iter",
-                                 ia_name.version),
-            ia->GetType(), rem_init, ia->span_);
-        auto rem_rv = std::make_shared<Var>(
-            auto_name::BuildName(ia_name.base_name, auto_name::ChunkRemainderQualifier(), "rv",
-                                 ia_name.version),
-            ia->GetType(), ia->span_);
-        rem_iter_args.push_back(rem_ia);
-        rem_return_vars.push_back(rem_rv);
-
-        substitution_map_[ia.get()] = rem_ia;
-      }
-
-      // Loop var substitution for remainder
-      ExprPtr rem_substitution = MakeAdd(rem_start_expr, MakeMul(rem_var, step_expr));
-      substitution_map_[loop_var_key] = rem_substitution;
-
-      // When both inner and remainder loops exist, the body is visited twice.
-      // DEF variables (AssignStmt targets) in the body would be shared, violating SSA.
-      // Create fresh copies of all DEF vars for the remainder body.
-      std::vector<SavedSubstitution> prev_def_subs;
-      if (num_full_chunks > 0) {
-        std::vector<VarPtr> body_def_vars;
-        CollectDefVars(op->body_, body_def_vars);
-        std::unordered_set<std::string> used_names = function_used_names_;
-        for (const auto& var : body_def_vars) {
-          used_names.insert(var->name_hint_);
-        }
-        for (const auto& var : body_def_vars) {
-          prev_def_subs.push_back(SaveSubstitution(var.get()));
-          auto fresh_name = auto_name::GenerateFreshNameLike(var->name_hint_, used_names);
-          used_names.insert(fresh_name);
-          function_used_names_.insert(fresh_name);
-          auto fresh = std::make_shared<Var>(fresh_name, var->GetType(), var->span_);
-          substitution_map_[var.get()] = fresh;
-        }
-      }
-
-      auto rem_body = VisitStmt(op->body_);
-
-      // Restore DEF var substitutions
-      RestoreSubstitutions(prev_def_subs);
-
-      auto rem_for = std::make_shared<ForStmt>(
-          rem_var, MakeConstIndex(0, op->span_), MakeConstIndex(remainder, op->span_),
-          MakeConstIndex(1, op->span_), rem_iter_args, rem_body, rem_return_vars, op->span_, op->kind_,
-          std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
-
-      result_stmts.push_back(rem_for);
-      final_return_vars = rem_return_vars;
-    }
-
-    // Remap original return_vars to final return vars
-    INTERNAL_CHECK(op->return_vars_.size() == final_return_vars.size())
-        << "SplitChunkedLoops produced mismatched return vars";
-    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
-      substitution_map_[op->return_vars_[i].get()] = final_return_vars[i];
-    }
-
-    // Restore substitutions
-    RestoreSubstitution(prev_loop_sub);
-    RestoreSubstitutions(prev_ia_subs);
-
-    return MakeResultStmt(result_stmts, op->span_);
+    return SplitWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
+                             chunk_expr, n_full, n_rem, chunk_size, emit_full, emit_rem, prev_loop_sub,
+                             prev_ia_subs, sp);
   }
 
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
@@ -449,17 +360,11 @@ class ChunkedLoopSplitter : public IRMutator {
 
   using SavedSubstitution = std::pair<const Var*, ExprPtr>;
 
-  /**
-   * @brief Save the current substitution for a key (returns nullptr if none).
-   */
   SavedSubstitution SaveSubstitution(const Var* key) {
     auto it = substitution_map_.find(key);
     return {key, (it != substitution_map_.end()) ? it->second : nullptr};
   }
 
-  /**
-   * @brief Restore a previously saved substitution.
-   */
   void RestoreSubstitution(const SavedSubstitution& saved) {
     if (saved.second) {
       substitution_map_[saved.first] = saved.second;
@@ -468,9 +373,6 @@ class ChunkedLoopSplitter : public IRMutator {
     }
   }
 
-  /**
-   * @brief Restore a batch of saved substitutions.
-   */
   void RestoreSubstitutions(const std::vector<SavedSubstitution>& saved) {
     for (const auto& entry : saved) {
       RestoreSubstitution(entry);
@@ -478,88 +380,217 @@ class ChunkedLoopSplitter : public IRMutator {
   }
 
   /**
-   * @brief Simple split path for loops without iter_args.
+   * @brief Freshen all DEF vars in the body to preserve SSA uniqueness.
+   *
+   * Used when the body is visited more than once (e.g. full-chunk + remainder).
+   * Returns saved substitutions that must be restored after visiting the body.
    */
-  StmtPtr SplitSimple(const ForStmtPtr& op, int64_t start, int64_t step, int64_t chunk_size,
-                      int64_t num_full_chunks, int64_t remainder, const Var* loop_var_key,
-                      const std::string& base_name, const std::optional<int>& loop_version,
-                      const ExprPtr& start_expr, const ExprPtr& step_expr, const ExprPtr& chunk_const,
-                      const SavedSubstitution& prev_loop_sub) {
+  std::vector<SavedSubstitution> FreshenBodyDefVars(const StmtPtr& body) {
+    std::vector<SavedSubstitution> prev_def_subs;
+    std::vector<VarPtr> body_def_vars;
+    CollectDefVars(body, body_def_vars);
+    for (const auto& var : body_def_vars) {
+      prev_def_subs.push_back(SaveSubstitution(var.get()));
+      auto fresh_name = auto_name::GenerateFreshNameLike(var->name_hint_, function_used_names_);
+      function_used_names_.insert(fresh_name);
+      auto fresh = std::make_shared<Var>(fresh_name, var->GetType(), var->span_);
+      substitution_map_[var.get()] = fresh;
+    }
+    return prev_def_subs;
+  }
+
+  /**
+   * @brief Split a chunked loop without iter_args.
+   *
+   * n_full and n_rem are ExprPtr — either ConstInt or dynamic expressions.
+   */
+  StmtPtr SplitSimple(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
+                      const std::optional<int>& loop_version, const ExprPtr& start_expr,
+                      const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
+                      const ExprPtr& n_rem, int64_t chunk_size, bool emit_full, bool emit_rem,
+                      const SavedSubstitution& prev_loop_sub, const Span& sp) {
+    auto zero = MakeConstIndex(0, sp);
+    auto one = MakeConstIndex(1, sp);
     std::vector<StmtPtr> result_stmts;
 
-    if (num_full_chunks > 0) {
+    if (emit_full) {
       auto out_var = std::make_shared<Var>(
           auto_name::BuildName(base_name, auto_name::ChunkOuterQualifier(), "idx", loop_version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
       auto in_var = std::make_shared<Var>(
           auto_name::BuildName(base_name, auto_name::ChunkInnerQualifier(), "idx", loop_version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
 
-      ExprPtr substitution =
-          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_const), in_var), step_expr));
-
-      substitution_map_[loop_var_key] = substitution;
+      // i = start + (i_out * C + i_in) * step
+      substitution_map_[loop_var_key] =
+          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
       auto inner_body = VisitStmt(op->body_);
 
       auto inner_for = std::make_shared<ForStmt>(
-          in_var, MakeConstIndex(0, op->span_), MakeConstIndex(chunk_size, op->span_),
-          MakeConstIndex(1, op->span_), std::vector<IterArgPtr>{}, inner_body, std::vector<VarPtr>{},
-          op->span_, op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
-
+          in_var, zero, chunk_expr, one, std::vector<IterArgPtr>{}, inner_body, std::vector<VarPtr>{}, sp,
+          op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
       auto outer_for = std::make_shared<ForStmt>(
-          out_var, MakeConstIndex(0, op->span_), MakeConstIndex(num_full_chunks, op->span_),
-          MakeConstIndex(1, op->span_), std::vector<IterArgPtr>{}, inner_for, std::vector<VarPtr>{},
-          op->span_, op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
-
+          out_var, zero, n_full, one, std::vector<IterArgPtr>{}, inner_for, std::vector<VarPtr>{}, sp,
+          op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
       result_stmts.push_back(outer_for);
     }
 
-    if (remainder > 0) {
+    if (emit_rem) {
       auto rem_var = std::make_shared<Var>(
           auto_name::BuildName(base_name, auto_name::ChunkRemainderQualifier(), "idx", loop_version),
-          std::make_shared<ScalarType>(DataType::INDEX), op->span_);
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
 
-      int64_t rem_start = start + num_full_chunks * chunk_size * step;
-      auto rem_start_expr = MakeConstIndex(rem_start, op->span_);
+      // i = start + (n_full * C + i_rem) * step
+      substitution_map_[loop_var_key] =
+          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(n_full, chunk_expr), rem_var), step_expr));
 
-      ExprPtr rem_substitution = MakeAdd(rem_start_expr, MakeMul(rem_var, step_expr));
-
-      substitution_map_[loop_var_key] = rem_substitution;
-
-      // When both full chunks and remainder exist, the body is visited twice.
-      // Freshen DEF vars for the remainder to preserve SSA uniqueness.
       std::vector<SavedSubstitution> prev_def_subs;
-      if (num_full_chunks > 0) {
-        std::vector<VarPtr> body_def_vars;
-        CollectDefVars(op->body_, body_def_vars);
-        std::unordered_set<std::string> used_names = function_used_names_;
-        for (const auto& var : body_def_vars) {
-          used_names.insert(var->name_hint_);
-        }
-        for (const auto& var : body_def_vars) {
-          prev_def_subs.push_back(SaveSubstitution(var.get()));
-          auto fresh_name = auto_name::GenerateFreshNameLike(var->name_hint_, used_names);
-          used_names.insert(fresh_name);
-          function_used_names_.insert(fresh_name);
-          auto fresh = std::make_shared<Var>(fresh_name, var->GetType(), var->span_);
-          substitution_map_[var.get()] = fresh;
-        }
+      if (emit_full) {
+        prev_def_subs = FreshenBodyDefVars(op->body_);
       }
       auto rem_body = VisitStmt(op->body_);
       RestoreSubstitutions(prev_def_subs);
 
-      auto rem_for = std::make_shared<ForStmt>(
-          rem_var, MakeConstIndex(0, op->span_), MakeConstIndex(remainder, op->span_),
-          MakeConstIndex(1, op->span_), std::vector<IterArgPtr>{}, rem_body, std::vector<VarPtr>{}, op->span_,
-          op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
-
+      auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, std::vector<IterArgPtr>{}, rem_body,
+                                               std::vector<VarPtr>{}, sp, op->kind_, std::nullopt,
+                                               ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
       result_stmts.push_back(rem_for);
     }
 
-    // Restore loop var substitution
     RestoreSubstitution(prev_loop_sub);
+    return MakeResultStmt(result_stmts, sp);
+  }
 
-    return MakeResultStmt(result_stmts, op->span_);
+  /**
+   * @brief Split a chunked loop with iter_args (SSA propagation).
+   *
+   * n_full and n_rem are ExprPtr — either ConstInt or dynamic expressions.
+   */
+  StmtPtr SplitWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
+                            const std::optional<int>& loop_version, const ExprPtr& start_expr,
+                            const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
+                            const ExprPtr& n_rem, int64_t chunk_size, bool emit_full, bool emit_rem,
+                            const SavedSubstitution& prev_loop_sub,
+                            const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
+    auto zero = MakeConstIndex(0, sp);
+    auto one = MakeConstIndex(1, sp);
+    std::vector<StmtPtr> result_stmts;
+    std::vector<VarPtr> final_return_vars;
+
+    if (emit_full) {
+      auto out_var = std::make_shared<Var>(
+          auto_name::BuildName(base_name, auto_name::ChunkOuterQualifier(), "idx", loop_version),
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
+      auto in_var = std::make_shared<Var>(
+          auto_name::BuildName(base_name, auto_name::ChunkInnerQualifier(), "idx", loop_version),
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
+
+      std::vector<IterArgPtr> outer_iter_args;
+      std::vector<VarPtr> outer_return_vars;
+      std::vector<IterArgPtr> inner_iter_args;
+      std::vector<VarPtr> inner_return_vars;
+
+      for (const auto& ia : op->iter_args_) {
+        auto visited_init = VisitExpr(ia->initValue_);
+        auto ia_name = auto_name::Parse(ia->name_hint_);
+        auto outer_ia = std::make_shared<IterArg>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "iter",
+                                 ia_name.version),
+            ia->GetType(), visited_init, ia->span_);
+        auto outer_rv = std::make_shared<Var>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "rv", ia_name.version),
+            ia->GetType(), ia->span_);
+        outer_iter_args.push_back(outer_ia);
+        outer_return_vars.push_back(outer_rv);
+
+        auto inner_ia = std::make_shared<IterArg>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "iter",
+                                 ia_name.version),
+            ia->GetType(), ExprPtr(outer_ia), ia->span_);
+        auto inner_rv = std::make_shared<Var>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "rv", ia_name.version),
+            ia->GetType(), ia->span_);
+        inner_iter_args.push_back(inner_ia);
+        inner_return_vars.push_back(inner_rv);
+
+        substitution_map_[ia.get()] = inner_ia;
+      }
+
+      // i = start + (i_out * C + i_in) * step
+      substitution_map_[loop_var_key] =
+          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
+      auto inner_body = VisitStmt(op->body_);
+
+      auto inner_for = std::make_shared<ForStmt>(in_var, zero, chunk_expr, one, inner_iter_args, inner_body,
+                                                 inner_return_vars, sp, op->kind_, std::nullopt,
+                                                 ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
+      auto outer_yield = std::make_shared<YieldStmt>(
+          std::vector<ExprPtr>(inner_return_vars.begin(), inner_return_vars.end()), sp);
+      auto outer_body = SeqStmts::Flatten(std::vector<StmtPtr>{inner_for, outer_yield}, sp);
+
+      auto outer_for = std::make_shared<ForStmt>(out_var, zero, n_full, one, outer_iter_args, outer_body,
+                                                 outer_return_vars, sp, op->kind_, std::nullopt,
+                                                 ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+
+      result_stmts.push_back(outer_for);
+      final_return_vars = outer_return_vars;
+    }
+
+    if (emit_rem) {
+      auto rem_var = std::make_shared<Var>(
+          auto_name::BuildName(base_name, auto_name::ChunkRemainderQualifier(), "idx", loop_version),
+          std::make_shared<ScalarType>(DataType::INDEX), sp);
+
+      std::vector<IterArgPtr> rem_iter_args;
+      std::vector<VarPtr> rem_return_vars;
+
+      for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+        const auto& ia = op->iter_args_[i];
+        ExprPtr rem_init = emit_full ? ExprPtr(final_return_vars[i]) : VisitExpr(ia->initValue_);
+        auto ia_name = auto_name::Parse(ia->name_hint_);
+        auto rem_ia = std::make_shared<IterArg>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkRemainderQualifier(), "iter",
+                                 ia_name.version),
+            ia->GetType(), rem_init, ia->span_);
+        auto rem_rv = std::make_shared<Var>(
+            auto_name::BuildName(ia_name.base_name, auto_name::ChunkRemainderQualifier(), "rv",
+                                 ia_name.version),
+            ia->GetType(), ia->span_);
+        rem_iter_args.push_back(rem_ia);
+        rem_return_vars.push_back(rem_rv);
+
+        substitution_map_[ia.get()] = rem_ia;
+      }
+
+      // i = start + (n_full * C + i_rem) * step
+      substitution_map_[loop_var_key] =
+          MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(n_full, chunk_expr), rem_var), step_expr));
+
+      std::vector<SavedSubstitution> prev_def_subs;
+      if (emit_full) {
+        prev_def_subs = FreshenBodyDefVars(op->body_);
+      }
+      auto rem_body = VisitStmt(op->body_);
+      RestoreSubstitutions(prev_def_subs);
+
+      auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, rem_iter_args, rem_body,
+                                               rem_return_vars, sp, op->kind_, std::nullopt,
+                                               ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
+
+      result_stmts.push_back(rem_for);
+      final_return_vars = rem_return_vars;
+    }
+
+    INTERNAL_CHECK(op->return_vars_.size() == final_return_vars.size())
+        << "SplitChunkedLoops produced mismatched return vars";
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      substitution_map_[op->return_vars_[i].get()] = final_return_vars[i];
+    }
+
+    RestoreSubstitution(prev_loop_sub);
+    RestoreSubstitutions(prev_ia_subs);
+
+    return MakeResultStmt(result_stmts, sp);
   }
 };
 

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -307,7 +307,7 @@ class ChunkedLoopSplitter : public IRMutator {
 
     if (!has_iter_args) {
       return SplitSimple(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, chunk_expr,
-                         n_full, n_rem, chunk_size, emit_full, emit_rem, prev_loop_sub, sp);
+                         n_full, n_rem, emit_full, emit_rem, prev_loop_sub, sp);
     }
 
     // Zero-trip optimization: when statically known, skip loop emission entirely
@@ -323,8 +323,7 @@ class ChunkedLoopSplitter : public IRMutator {
     }
 
     return SplitWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
-                             chunk_expr, n_full, n_rem, chunk_size, emit_full, emit_rem, prev_loop_sub,
-                             prev_ia_subs, sp);
+                             chunk_expr, n_full, n_rem, emit_full, emit_rem, prev_loop_sub, prev_ia_subs, sp);
   }
 
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
@@ -407,7 +406,7 @@ class ChunkedLoopSplitter : public IRMutator {
   StmtPtr SplitSimple(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
                       const std::optional<int>& loop_version, const ExprPtr& start_expr,
                       const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
-                      const ExprPtr& n_rem, int64_t chunk_size, bool emit_full, bool emit_rem,
+                      const ExprPtr& n_rem, bool emit_full, bool emit_rem,
                       const SavedSubstitution& prev_loop_sub, const Span& sp) {
     auto zero = MakeConstIndex(0, sp);
     auto one = MakeConstIndex(1, sp);
@@ -469,7 +468,7 @@ class ChunkedLoopSplitter : public IRMutator {
   StmtPtr SplitWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
                             const std::optional<int>& loop_version, const ExprPtr& start_expr,
                             const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
-                            const ExprPtr& n_rem, int64_t chunk_size, bool emit_full, bool emit_rem,
+                            const ExprPtr& n_rem, bool emit_full, bool emit_rem,
                             const SavedSubstitution& prev_loop_sub,
                             const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
     auto zero = MakeConstIndex(0, sp);

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -585,5 +585,154 @@ class TestNestedChunking:
             )
 
 
+class TestDynamicChunking:
+    """Tests for chunked loops where start/stop are dynamic (runtime) scalars."""
+
+    @staticmethod
+    def _split_and_simplify(program):
+        """Run prerequisite passes, split chunked loops, and simplify expressions."""
+        prepared = _prepare_for_split(program)
+        split = passes.split_chunked_loops()(prepared)
+        return passes.simplify_expr()(split)
+
+    def test_dynamic_stop(self):
+        """Dynamic stop: outer+inner+remainder with FloorDiv/FloorMod bounds."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.range(0, n, 1, chunk=4):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i_out, (x_outer,) in pl.range(0, pl.max(n_0, 0) // 4, 1, init_values=(x_0,)):
+                        for i_in, (x_inner,) in pl.range(0, 4, 1, init_values=(x_outer,)):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                    for i_rem, (x_rem,) in pl.range(0, pl.max(n_0, 0) % 4, 1, init_values=(x_outer_rv,)):
+                        x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
+                        x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
+                return x_rem_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_dynamic_start_and_stop(self):
+        """Both start and stop are dynamic."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                lo: pl.Scalar[pl.INDEX],
+                hi: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.range(lo, hi, 1, chunk=4):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x_0: pl.Tensor[[64], pl.FP32],
+                lo_0: pl.Scalar[pl.INDEX],
+                hi_0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i_out, (x_outer,) in pl.range(0, pl.max(hi_0 - lo_0, 0) // 4, 1, init_values=(x_0,)):
+                        for i_in, (x_inner,) in pl.range(0, 4, 1, init_values=(x_outer,)):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                    for i_rem, (x_rem,) in pl.range(
+                        0, pl.max(hi_0 - lo_0, 0) % 4, 1, init_values=(x_outer_rv,)
+                    ):
+                        x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
+                        x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
+                return x_rem_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_dynamic_stop_parallel(self):
+        """Dynamic stop with pl.parallel should also work."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.parallel(0, n, 1, chunk=4):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i_out, (x_outer,) in pl.parallel(0, pl.max(n_0, 0) // 4, 1, init_values=(x_0,)):
+                        for i_in, (x_inner,) in pl.parallel(0, 4, 1, init_values=(x_outer,)):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                    for i_rem, (x_rem,) in pl.parallel(0, pl.max(n_0, 0) % 4, 1, init_values=(x_outer_rv,)):
+                        x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
+                        x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
+                return x_rem_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_static_still_works(self):
+        """Regression: static bounds should continue to produce same IR as before."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i in pl.range(0, 10, 1, chunk=5):
+                        x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_split(Input)
+        After = passes.split_chunked_loops()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_incore():
+                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 2, 1, init_values=(x_0,)):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
+                            x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
+                return x_iter_1_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Support dynamic (runtime) `start`/`stop` bounds in `SplitChunkedLoops`, enabling `pl.parallel(0, ctx_blocks, chunk=C)` under `pl.auto_incore()`
- Use a unified expression-based approach: `n_full` and `n_rem` are `ExprPtr` (either `ConstInt` for static bounds or `FloorDiv`/`FloorMod` trees for dynamic bounds)
- Single code path replaces the dual-method (`SplitAllStatic`/`SplitDynamic`) approach from #903
- All existing tests pass unchanged; static-bound IR output is identical to before

Fixes #891

## Test plan

- [x] All 19 existing `test_split_chunked_loops` tests pass (static bounds produce identical IR)
- [x] 4 new `TestDynamicChunking` tests with `assert_structural_equal`:
  - `test_dynamic_stop` — dynamic stop, step=1, chunk=4
  - `test_dynamic_start_and_stop` — both bounds dynamic
  - `test_dynamic_stop_parallel` — `pl.parallel` with dynamic stop
  - `test_static_still_works` — regression guard for static bounds