### PR TITLE
fix(codegen): emit add_output for pl.Out external params instead of add_inout

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -140,7 +140,7 @@ The `ParamDirection` of each function parameter determines how it appears in tas
 | Direction | Python Annotation | C++ Task Param | Semantics |
 | --------- | ----------------- | -------------- | --------- |
 | `In` | `pl.Tensor[...]` (default) | `params.add_input(ext_x)` | Read-only; if the tensor is from `pl.create_tensor`, uses `add_output` for first-time allocation |
-| `Out` (external) | `pl.Out[pl.Tensor[...]]` (param) | `params.add_inout(ext_x)` | Pre-allocated buffer |
+| `Out` (external) | `pl.Out[pl.Tensor[...]]` (param) | `params.add_output(ext_x)` | Write-only pre-allocated buffer |
 | `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)` | Runtime ring-buffer alloc |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | Read-write |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | Scalar constant (separate scalar slot) |
@@ -171,7 +171,7 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 ```cpp
 // Generated C++
 Arg params_t0;
-params_t0.add_inout(ext_output);
+params_t0.add_output(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
 const Tensor& result = ext_output;  // alias — result refers to ext_output
 ```
@@ -286,7 +286,7 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args) {
         Arg params_t1;
         params_t1.add_input(c);
         params_t1.add_input(ext_b);
-        params_t1.add_inout(ext_d);
+        params_t1.add_output(ext_d);
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -140,7 +140,7 @@ PTO2_SCOPE() {
 | 方向 | Python 注解 | C++ 任务参数 | 语义 |
 | ---- | ----------- | ------------ | ---- |
 | `In` | `pl.Tensor[...]`（默认） | `params.add_input(ext_x)` | 只读；若为 `pl.create_tensor` 变量，首次使用改用 `add_output` 分配内存 |
-| `Out`（外部） | `pl.Out[pl.Tensor[...]]`（参数） | `params.add_inout(ext_x)` | 预分配缓冲区 |
+| `Out`（外部） | `pl.Out[pl.Tensor[...]]`（参数） | `params.add_output(ext_x)` | 只写预分配缓冲区 |
 | `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)` | 运行时环形缓冲区分配 |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | 读写 |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | 标量常量（独立 scalar 槽位） |
@@ -171,7 +171,7 @@ result = self.kernel_add(a, b, output)  # result ≠ output
 ```cpp
 // 生成的 C++
 Arg params_t0;
-params_t0.add_inout(ext_output);
+params_t0.add_output(ext_output);
 pto2_rt_submit_aiv_task(0, params_t0);
 const Tensor& result = ext_output;  // 别名 — result 引用 ext_output
 ```
@@ -286,7 +286,7 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args) {
         Arg params_t1;
         params_t1.add_input(c);
         params_t1.add_input(ext_b);
-        params_t1.add_inout(ext_d);
+        params_t1.add_output(ext_d);
         pto2_rt_submit_aiv_task(1, params_t1);
     }
 }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -467,7 +467,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
             if (arg_var && tensor_create_var_names_.count(arg_var.get())) {
               push_create_output();
             } else {
-              params.push_back({ParamKind::InOut, ext_name, ""});
+              params.push_back({ParamKind::Output, ext_name, ""});
             }
             break;
           case ParamDirection::InOut:

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -132,7 +132,7 @@ class TestOrchestration:
                     Arg params_t1;
                     params_t1.add_input(c);
                     params_t1.add_input(ext_b);
-                    params_t1.add_inout(ext_d);
+                    params_t1.add_output(ext_d);
                     pto2_rt_submit_aiv_task(0, params_t1);
                 }
             }
@@ -404,7 +404,7 @@ class TestOrchestration:
                     Arg params_t4;
                     params_t4.add_input(g);
                     params_t4.add_input(c);
-                    params_t4.add_inout(ext_f);
+                    params_t4.add_output(ext_f);
                     pto2_rt_submit_aiv_task(0, params_t4);
                 }
             }
@@ -607,11 +607,11 @@ class TestOrchestration:
         # online_update: 3 In + 3 InOut + 1 Out = 7 params
         assert "params_t0.add_input(ext_mij)" in code
         assert "params_t0.add_inout(ext_mi_in)" in code
-        assert "params_t0.add_inout(ext_dst_in)" in code
+        assert "params_t0.add_output(ext_dst_in)" in code
 
         # kernel_add: 2 In + 1 Out = 3 params
         assert "params_t1.add_input(ext_oi_in)" in code
-        assert "params_t1.add_inout(ext_final)" in code
+        assert "params_t1.add_output(ext_final)" in code
 
         # PTO2_SCOPE wraps all task submissions
         assert "PTO2_SCOPE" in code
@@ -749,7 +749,7 @@ class TestOrchestration:
                     params_t0.add_inout(ext_mi);
                     params_t0.add_inout(ext_li);
                     params_t0.add_inout(ext_oi);
-                    params_t0.add_inout(ext_dst);
+                    params_t0.add_output(ext_dst);
                     pto2_rt_submit_aiv_task(0, params_t0);
                 }
             }
@@ -1233,7 +1233,7 @@ class TestOrchestration:
         code = _generate_orch_code(transformed)
 
         assert "Tensor row = ext_out.view(row_shapes, row_offsets);" in code
-        assert "params_t0.add_inout(row)" in code
+        assert "params_t0.add_output(row)" in code
         assert "Tensor row = make_tensor(" not in code
         assert "memcpy(" not in code
         assert "ext_out = out;" not in code
@@ -1576,7 +1576,7 @@ class TestTensorReadWriteOffsetCodegen:
         code = _generate_orch_code(transformed)
 
         assert "params_t0.add_input(ext_x)" in code
-        assert "params_t0.add_inout(ext_out)" in code
+        assert "params_t0.add_output(ext_out)" in code
 
     def test_infer_inout_param_from_loop_carried_read_modify_write(self):
         """Loop-carried read-modify-write should emit inout params."""


### PR DESCRIPTION
Fixes #882

Commit 2d78a2a6 (#786) incorrectly changed external pl.Out parameters from add_output(Tensor) to add_inout(Tensor), confusing the two add_output overloads. The add_output(Tensor) overload marks a pre-allocated buffer as write-only, while add_inout implies read-write semantics. Restore the correct add_output(Tensor) call for ParamDirection::Out with external tensors, matching the original behavior from commit 043a6ed5 (#728).