### PR TITLE
docs: add PTO project ecosystem overview

### DIFF
--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -133,7 +133,7 @@ Defines the tile-level instruction set for the target hardware. Provides C++ hea
 - **PTOAS** — the C++ code PTOAS generates calls pto-isa instructions
 - **simpler** — clones pto-isa headers at first build for runtime compilation
 
-**Interface:** C++ header-only library. Downstream consumers `#include` pto-isa headers and link against hardware-specific implementations.
+**Interface:** C++ header library defining the instruction API. Downstream consumers `#include` pto-isa headers; the hardware vendor provides the target-specific implementations that back these headers.
 
 ### simpler — Task Runtime
 
@@ -159,18 +159,18 @@ Each repo boundary has a well-defined interface:
 ```text
 pypto-lib ──[ Python API: pypto.language / pypto.ir ]──► pypto
      pypto ──[ .pto files: PTO-ISA MLIR dialect     ]──► PTOAS
-     PTOAS ──[ C++ #include: tile instruction hdrs  ]──► pto-isa
-     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
+   pto-isa ──[ C++ #include: tile instruction hdrs  ]──► PTOAS
    pto-isa ──[ C++ #include: ISA headers            ]──► simpler
+     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
 ```
 
-| Border | Format | Who produces | Who consumes |
+| Border | Format | Who provides | Who consumes |
 | ------ | ------ | ------------ | ------------ |
 | pypto-lib → pypto | Python imports | pypto-lib | pypto compiler |
 | pypto → PTOAS | `.pto` MLIR files | pypto PTO codegen | PTOAS parser |
-| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler runtime |
-| PTOAS → pto-isa | C++ `#include` | PTOAS codegen | pto-isa headers |
+| pto-isa → PTOAS | C++ `#include` | pto-isa headers | PTOAS codegen |
 | pto-isa → simpler | C++ `#include` | pto-isa headers | simpler build |
+| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler runtime |
 
 ## Cross-Repo Development
 

--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -1,0 +1,185 @@
+# PTO Project Ecosystem
+
+## Overview
+
+The PTO (Parallel Tensor/Tile Operation) project is a multi-repo toolchain for programming AI accelerators. It spans the full stack from Python-level tensor programs down to hardware instruction execution.
+
+This document describes **what each repo does**, **how they connect**, and **where the boundaries lie**.
+
+## Repositories
+
+All repositories live under [github.com/hw-native-sys](https://github.com/hw-native-sys).
+
+| Repo | Role | URL |
+| ---- | ---- | --- |
+| **pypto** | Compiler framework | [hw-native-sys/pypto](https://github.com/hw-native-sys/pypto) |
+| **pypto-lib** | Model zoo & real-world cases | [hw-native-sys/pypto-lib](https://github.com/hw-native-sys/pypto-lib) |
+| **PTOAS** | PTO assembler & optimizer | [hw-native-sys/PTOAS](https://github.com/hw-native-sys/PTOAS) |
+| **pto-isa** | Instruction set architecture | [hw-native-sys/pto-isa](https://github.com/hw-native-sys/pto-isa) |
+| **simpler** | Task runtime | [hw-native-sys/simpler](https://github.com/hw-native-sys/simpler) |
+
+## Compilation Pipeline
+
+```text
+                    ┌─────────────────────────────────────────────┐
+                    │              pypto-lib                      │
+                    │  Real-world models & primitive tensor funcs │
+                    │  (uses pypto as its compiler framework)     │
+                    └──────────────────┬──────────────────────────┘
+                                       │ imports & compiles via
+                    ┌──────────────────▼──────────────────────────┐
+                    │                pypto                        │
+                    │  Python DSL → IR → Passes → CodeGen         │
+                    │                                             │
+                    │  Produces:                                  │
+                    │   • .pto files (InCore kernel → AICore)     │
+                    │   • Orchestration C++ (scheduling → AICPU)  │
+                    └───┬─────────────────────────────────────┬───┘
+          .pto files    │                                     │  orchestration C++
+        (InCore only)   │                                     │  (runs on AICPU)
+                    ┌───▼────────────────────┐                │
+                    │       PTOAS            │                │
+                    │  Assembler & Optimizer │                │
+                    │                        │                │
+                    │  .pto MLIR → C++       │                │
+                    │  (uses pto-isa hdrs)   │                │
+                    └───┬────────────────────┘                │
+                        │ kernel C++                          │
+                        │  (includes pto-isa)                 │
+                    ┌───▼────────────────────┐                │
+                    │       pto-isa          │                │
+                    │  ISA definition:       │                │
+                    │  tile instruction hdrs │                │
+                    └───┬────────────────────┘                │
+                        │ compiled AICore binaries            │
+                    ┌───▼─────────────────────────────────────▼───┐
+                    │              simpler                        │
+                    │  Runtime: task graph execution on device    │
+                    │  Host ↔ AICPU ↔ AICore coordination         │
+                    └─────────────────────────────────────────────┘
+```
+
+**Two codegen paths from pypto:**
+
+- **InCore functions** (tile-level compute) → `.pto` → PTOAS → pto-isa → AICore binaries
+- **Orchestration functions** (task scheduling) → C++ using PTO2 runtime API → compiled for AICPU
+
+## Component Details
+
+### pypto — Compiler Framework
+
+The core compiler. Takes Python tensor programs and compiles them into device-executable code.
+
+**Inputs:** Python programs written with `pypto.language` DSL (`@pl.program`, `@pl.function`)
+
+**Outputs:**
+
+- `.pto` files — PTO-ISA MLIR dialect, one per InCore kernel function (runs on AICore)
+- Orchestration C++ — task scheduling code using PTO2 runtime API (runs on AICPU)
+
+**Internal pipeline:**
+
+```text
+Python DSL → IR (immutable tree) → Pass Pipeline (20+ passes) → CodeGen
+```
+
+- **IR layer**: Multi-level representation — Tensor ops, Tile ops, and system ops coexist in the same IR
+- **Pass pipeline**: Progressively lowers tensor-level IR to tile-level IR (unrolling, SSA conversion, tiling, memory allocation, etc.)
+- **CodeGen**: Two backends — PTO codegen (InCore → `.pto` MLIR for AICore) and Orchestration codegen (→ C++ for AICPU)
+
+**Key directories:**
+
+| Path | Contents |
+| ---- | -------- |
+| `include/pypto/ir/` | C++ IR node definitions |
+| `src/ir/transforms/` | Compiler passes |
+| `src/codegen/` | PTO and Orchestration code generators |
+| `python/pypto/language/` | Python DSL frontend |
+| `python/pypto/ir/` | Pass manager, compile API |
+
+### pypto-lib — Model Zoo & Primitives
+
+A library of real-world models and primitive tensor functions built **on top of** pypto. Serves as:
+
+1. **Model zoo** — end-to-end model examples (e.g., DeepSeek, FFN, LLaMA) that exercise the full compilation pipeline
+2. **Primitive tensor functions** — reusable tensor-level building blocks (elementwise, reduction, matmul) that the compiler tiles and lowers to PTO-ISA
+
+**Depends on:** pypto (imports `pypto.language`, compiles via `pypto.ir.compile`)
+
+**Interface with pypto:** pypto-lib programs are standard pypto programs — they use the same `@pl.program`/`@pl.function` DSL and compile through the same pipeline. No special API exists between them; pypto-lib is a consumer of the pypto framework.
+
+### PTOAS — PTO Assembler & Optimizer
+
+An MLIR-based assembler that consumes `.pto` files produced by pypto's codegen and produces optimized C++ kernel code.
+
+**Inputs:** `.pto` files (PTO-ISA MLIR dialect)
+
+**Outputs:** C++ source files that `#include` pto-isa headers
+
+**Responsibilities:**
+
+- Parse PTO-ISA MLIR dialect
+- Apply PTO-level optimization passes (sync insertion, memory planning)
+- Lower PTO MLIR to C++ code that calls pto-isa tile instructions
+
+**Interface with pypto:** The `.pto` file is the contract. pypto's PTO codegen emits MLIR using the PTO dialect (ops like `pto.tload`, `pto.tmul`, `pto.alloc_tile`, etc.), and PTOAS parses that dialect. The two repos must agree on the PTO MLIR dialect definition.
+
+### pto-isa — Instruction Set Architecture
+
+Defines the tile-level instruction set for the target hardware. Provides C++ headers that declare the hardware tile instructions (load, store, compute, sync, etc.).
+
+**Consumed by:**
+
+- **PTOAS** — the C++ code PTOAS generates calls pto-isa instructions
+- **simpler** — clones pto-isa headers at first build for runtime compilation
+
+**Interface:** C++ header-only library. Downstream consumers `#include` pto-isa headers and link against hardware-specific implementations.
+
+### simpler — Task Runtime
+
+Executes compiled programs on Ascend hardware. Manages the three-program execution model: Host, AICPU kernel, and AICore kernel.
+
+**Inputs:**
+
+- Compiled AICore kernel binaries (InCore path: pypto → PTOAS → pto-isa → device compiler)
+- Compiled AICPU orchestration binary (Orchestration path: pypto → C++ with PTO2 runtime API → device compiler)
+
+**Responsibilities:**
+
+- Build and execute task dependency graphs
+- Coordinate Host ↔ AICPU ↔ AICore execution
+- Handle device memory, synchronization, and handshake protocols
+
+**Interface with pypto:** The orchestration C++ code that pypto generates uses the PTO2 runtime API (`pto2_rt_submit_task`, `make_tensor_external`, etc.), which simpler implements. The runtime API is the contract between pypto's orchestration codegen and simpler.
+
+## Interface Summary
+
+Each repo boundary has a well-defined interface:
+
+```text
+pypto-lib ──[ Python API: pypto.language / pypto.ir ]──► pypto
+     pypto ──[ .pto files: PTO-ISA MLIR dialect     ]──► PTOAS
+     PTOAS ──[ C++ #include: tile instruction hdrs  ]──► pto-isa
+     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
+   pto-isa ──[ C++ #include: ISA headers            ]──► simpler
+```
+
+| Border | Format | Who produces | Who consumes |
+| ------ | ------ | ------------ | ------------ |
+| pypto-lib → pypto | Python imports | pypto-lib | pypto compiler |
+| pypto → PTOAS | `.pto` MLIR files | pypto PTO codegen | PTOAS parser |
+| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler runtime |
+| PTOAS → pto-isa | C++ `#include` | PTOAS codegen | pto-isa headers |
+| pto-isa → simpler | C++ `#include` | pto-isa headers | simpler build |
+
+## Cross-Repo Development
+
+When a change spans multiple repos, identify which interfaces are affected:
+
+| Change | Repos involved | Interface affected |
+| ------ | -------------- | ------------------ |
+| New tile instruction | pto-isa + PTOAS + pypto | ISA headers, PTO MLIR dialect, pypto op/codegen |
+| New tensor primitive | pypto-lib + pypto | Python DSL (if new ops needed) |
+| New runtime feature | simpler + pypto | PTO2 runtime API, orchestration codegen |
+| New PTO MLIR op | PTOAS + pypto | PTO MLIR dialect, pypto PTO codegen |
+| New model example | pypto-lib only | None (consumer of existing APIs) |

--- a/docs/zh-cn/dev/00-ecosystem.md
+++ b/docs/zh-cn/dev/00-ecosystem.md
@@ -133,7 +133,7 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 - **PTOAS** — PTOAS 生成的 C++ 代码调用 pto-isa 指令
 - **simpler** — 首次构建时克隆 pto-isa 头文件用于运行时编译
 
-**接口：** C++ 头文件库。下游消费者 `#include` pto-isa 头文件并链接硬件特定实现。
+**接口：** 定义指令 API 的 C++ 头文件库。下游消费者 `#include` pto-isa 头文件；硬件厂商提供支撑这些头文件的目标特定实现。
 
 ### simpler — 任务运行时
 
@@ -159,18 +159,18 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 ```text
 pypto-lib ──[ Python API: pypto.language / pypto.ir ]──► pypto
      pypto ──[ .pto files: PTO-ISA MLIR dialect     ]──► PTOAS
-     PTOAS ──[ C++ #include: tile instruction hdrs  ]──► pto-isa
-     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
+   pto-isa ──[ C++ #include: tile instruction hdrs  ]──► PTOAS
    pto-isa ──[ C++ #include: ISA headers            ]──► simpler
+     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
 ```
 
-| 边界 | 格式 | 生产者 | 消费者 |
+| 边界 | 格式 | 提供者 | 消费者 |
 | ---- | ---- | ------ | ------ |
 | pypto-lib → pypto | Python imports | pypto-lib | pypto 编译器 |
 | pypto → PTOAS | `.pto` MLIR 文件 | pypto PTO codegen | PTOAS 解析器 |
-| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler 运行时 |
-| PTOAS → pto-isa | C++ `#include` | PTOAS codegen | pto-isa 头文件 |
+| pto-isa → PTOAS | C++ `#include` | pto-isa 头文件 | PTOAS codegen |
 | pto-isa → simpler | C++ `#include` | pto-isa 头文件 | simpler 构建 |
+| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler 运行时 |
 
 ## 跨仓库开发
 

--- a/docs/zh-cn/dev/00-ecosystem.md
+++ b/docs/zh-cn/dev/00-ecosystem.md
@@ -1,0 +1,185 @@
+# PTO 项目生态
+
+## 概述
+
+PTO（Parallel Tensor/Tile Operation）项目是一个多仓库工具链，用于 AI 加速器编程。它覆盖了从 Python 级别的张量程序到硬件指令执行的完整栈。
+
+本文档描述**每个仓库的职责**、**它们之间的连接方式**以及**各仓库的边界**。
+
+## 仓库列表
+
+所有仓库位于 [github.com/hw-native-sys](https://github.com/hw-native-sys) 组织下。
+
+| 仓库 | 角色 | URL |
+| ---- | ---- | --- |
+| **pypto** | 编译器框架 | [hw-native-sys/pypto](https://github.com/hw-native-sys/pypto) |
+| **pypto-lib** | 模型库与实际案例 | [hw-native-sys/pypto-lib](https://github.com/hw-native-sys/pypto-lib) |
+| **PTOAS** | PTO 汇编器与优化器 | [hw-native-sys/PTOAS](https://github.com/hw-native-sys/PTOAS) |
+| **pto-isa** | 指令集架构（ISA）定义 | [hw-native-sys/pto-isa](https://github.com/hw-native-sys/pto-isa) |
+| **simpler** | 任务运行时 | [hw-native-sys/simpler](https://github.com/hw-native-sys/simpler) |
+
+## 编译流水线
+
+```text
+                    ┌─────────────────────────────────────────────┐
+                    │              pypto-lib                      │
+                    │  实际模型与原语张量函数                         │
+                    │  （以 pypto 作为编译框架）                     │
+                    └──────────────────┬──────────────────────────┘
+                                       │ imports & compiles via
+                    ┌──────────────────▼──────────────────────────┐
+                    │                pypto                        │
+                    │  Python DSL → IR → Passes → CodeGen         │
+                    │                                             │
+                    │  产出:                                       │
+                    │   • .pto 文件（InCore 内核 → AICore）         │
+                    │   • Orchestration C++（任务调度 → AICPU）     │
+                    └───┬─────────────────────────────────────┬───┘
+          .pto files    │                                     │  orchestration C++
+        (仅 InCore)     │                                     │  (运行在 AICPU)
+                    ┌───▼────────────────────┐                │
+                    │       PTOAS            │                │
+                    │  汇编器与优化器          │                │
+                    │                        │                │
+                    │  .pto MLIR → C++       │                │
+                    │  （使用 pto-isa 头文件）  │                │
+                    └───┬────────────────────┘                │
+                        │ kernel C++                          │
+                        │  (includes pto-isa)                 │
+                    ┌───▼────────────────────┐                │
+                    │       pto-isa          │                │
+                    │  ISA 定义：             │                │
+                    │  tile 指令 C++ 头文件    │                │
+                    └───┬────────────────────┘                │
+                        │ compiled AICore binaries            │
+                    ┌───▼─────────────────────────────────────▼───┐
+                    │              simpler                        │
+                    │  运行时：设备上的任务图执行                     │
+                    │  Host ↔ AICPU ↔ AICore 协调                  │
+                    └─────────────────────────────────────────────┘
+```
+
+**pypto 的两条代码生成路径：**
+
+- **InCore 函数**（tile 级计算）→ `.pto` → PTOAS → pto-isa → AICore 二进制
+- **Orchestration 函数**（任务调度）→ 使用 PTO2 runtime API 的 C++ → 编译到 AICPU
+
+## 组件详情
+
+### pypto — 编译器框架
+
+核心编译器。将 Python 张量程序编译为设备可执行代码。
+
+**输入：** 使用 `pypto.language` DSL 编写的 Python 程序（`@pl.program`、`@pl.function`）
+
+**输出：**
+
+- `.pto` 文件 — PTO-ISA MLIR 方言，每个 InCore 内核函数一个文件（运行在 AICore 上）
+- Orchestration C++ — 使用 PTO2 runtime API 的任务调度代码（运行在 AICPU 上）
+
+**内部流水线：**
+
+```text
+Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
+```
+
+- **IR 层**：多级表示 — Tensor ops、Tile ops 和 system ops 共存于同一 IR 中
+- **Pass pipeline**：逐步将 tensor 级 IR 降低为 tile 级 IR（循环展开、SSA 转换、tiling、内存分配等）
+- **CodeGen**：两个后端 — PTO codegen（InCore → `.pto` MLIR，运行在 AICore）和 Orchestration codegen（→ C++，运行在 AICPU）
+
+**关键目录：**
+
+| 路径 | 内容 |
+| ---- | ---- |
+| `include/pypto/ir/` | C++ IR 节点定义 |
+| `src/ir/transforms/` | 编译 passes |
+| `src/codegen/` | PTO 和 Orchestration 代码生成器 |
+| `python/pypto/language/` | Python DSL 前端 |
+| `python/pypto/ir/` | Pass manager、compile API |
+
+### pypto-lib — 模型库与原语
+
+基于 pypto 构建的实际模型和原语张量函数库。作用包括：
+
+1. **模型库** — 端到端模型示例（如 DeepSeek、FFN、LLaMA），覆盖完整编译流水线
+2. **原语张量函数** — 可复用的张量级构建块（elementwise、reduction、matmul），由编译器 tiling 并降低到 PTO-ISA
+
+**依赖：** pypto（导入 `pypto.language`，通过 `pypto.ir.compile` 编译）
+
+**与 pypto 的接口：** pypto-lib 程序就是标准的 pypto 程序 — 使用相同的 `@pl.program`/`@pl.function` DSL，通过相同的流水线编译。两者之间没有特殊 API；pypto-lib 是 pypto 框架的使用者。
+
+### PTOAS — PTO 汇编器与优化器
+
+基于 MLIR 的汇编器，消费 pypto codegen 生成的 `.pto` 文件，产出优化后的 C++ 内核代码。
+
+**输入：** `.pto` 文件（PTO-ISA MLIR 方言）
+
+**输出：** `#include` pto-isa 头文件的 C++ 源文件
+
+**职责：**
+
+- 解析 PTO-ISA MLIR 方言
+- 应用 PTO 级优化 passes（同步插入、内存规划）
+- 将 PTO MLIR 降低为调用 pto-isa tile 指令的 C++ 代码
+
+**与 pypto 的接口：** `.pto` 文件是两者的契约。pypto 的 PTO codegen 使用 PTO 方言发射 MLIR（如 `pto.tload`、`pto.tmul`、`pto.alloc_tile` 等 ops），PTOAS 解析该方言。两个仓库必须在 PTO MLIR 方言定义上保持一致。
+
+### pto-isa — 指令集架构
+
+定义目标硬件的 tile 级指令集。提供声明硬件 tile 指令（load、store、compute、sync 等）的 C++ 头文件。
+
+**被以下仓库消费：**
+
+- **PTOAS** — PTOAS 生成的 C++ 代码调用 pto-isa 指令
+- **simpler** — 首次构建时克隆 pto-isa 头文件用于运行时编译
+
+**接口：** C++ 头文件库。下游消费者 `#include` pto-isa 头文件并链接硬件特定实现。
+
+### simpler — 任务运行时
+
+在 Ascend 硬件上执行编译后的程序。管理三程序执行模型：Host、AICPU kernel 和 AICore kernel。
+
+**输入：**
+
+- 编译后的 AICore 内核二进制文件（InCore 路径：pypto → PTOAS → pto-isa → 设备编译器）
+- 编译后的 AICPU orchestration 二进制文件（Orchestration 路径：pypto → 使用 PTO2 runtime API 的 C++ → 设备编译器）
+
+**职责：**
+
+- 构建和执行任务依赖图
+- 协调 Host ↔ AICPU ↔ AICore 执行
+- 管理设备内存、同步和握手协议
+
+**与 pypto 的接口：** pypto 生成的 orchestration C++ 代码使用 PTO2 runtime API（`pto2_rt_submit_task`、`make_tensor_external` 等），simpler 实现该 API。运行时 API 是 pypto orchestration codegen 和 simpler 之间的契约。
+
+## 接口总结
+
+每个仓库边界都有明确定义的接口：
+
+```text
+pypto-lib ──[ Python API: pypto.language / pypto.ir ]──► pypto
+     pypto ──[ .pto files: PTO-ISA MLIR dialect     ]──► PTOAS
+     PTOAS ──[ C++ #include: tile instruction hdrs  ]──► pto-isa
+     pypto ──[ C++ API: PTO2 runtime API calls      ]──► simpler
+   pto-isa ──[ C++ #include: ISA headers            ]──► simpler
+```
+
+| 边界 | 格式 | 生产者 | 消费者 |
+| ---- | ---- | ------ | ------ |
+| pypto-lib → pypto | Python imports | pypto-lib | pypto 编译器 |
+| pypto → PTOAS | `.pto` MLIR 文件 | pypto PTO codegen | PTOAS 解析器 |
+| pypto → simpler | Orchestration C++ | pypto orchestration codegen | simpler 运行时 |
+| PTOAS → pto-isa | C++ `#include` | PTOAS codegen | pto-isa 头文件 |
+| pto-isa → simpler | C++ `#include` | pto-isa 头文件 | simpler 构建 |
+
+## 跨仓库开发
+
+当变更涉及多个仓库时，识别受影响的接口：
+
+| 变更 | 涉及仓库 | 受影响接口 |
+| ---- | -------- | ---------- |
+| 新增 tile 指令 | pto-isa + PTOAS + pypto | ISA 头文件、PTO MLIR 方言、pypto op/codegen |
+| 新增张量原语 | pypto-lib + pypto | Python DSL（如需新 ops） |
+| 新增运行时特性 | simpler + pypto | PTO2 runtime API、orchestration codegen |
+| 新增 PTO MLIR op | PTOAS + pypto | PTO MLIR 方言、pypto PTO codegen |
+| 新增模型示例 | 仅 pypto-lib | 无（现有 API 的消费者） |


### PR DESCRIPTION
## Summary
- Add `docs/en/dev/00-ecosystem.md` and `docs/zh-cn/dev/00-ecosystem.md` documenting the PTO project ecosystem
- Covers all 5 repos (pypto, pypto-lib, PTOAS, pto-isa, simpler) with their roles, interfaces, and compilation pipeline
- Includes ASCII pipeline diagram showing the two codegen paths: InCore (→ PTOAS → pto-isa → AICore) and Orchestration (→ C++ → AICPU)
- Documents cross-repo development patterns and interface boundaries

## Testing
- [x] Both files pass markdownlint
- [x] Both files under 500-line doc limit (181 lines each)
- [x] English and Chinese versions are structurally consistent