### PR TITLE
chore(skills): integrate project board fields into issue skills

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -38,6 +38,8 @@ gh auth status
 
 If not authenticated, tell the user to run `gh auth login` and **stop**.
 
+Verify the token has `project` scope (needed for Step 7). If missing, tell the user to run `gh auth refresh -s project` and **stop**.
+
 ## Step 2: Check for Existing Issues
 
 **Launch a `general-purpose` agent** (via `Task` tool, **model: haiku**) to perform the dedup check. This keeps the main context clean and fast.
@@ -150,7 +152,7 @@ EOF
 )"
 ```
 
-**After creation**, display the issue URL to the user.
+**After creation**, capture the issue number from the output URL (e.g., `https://github.com/.../issues/123` → `ISSUE_NUMBER=123`) for use in Step 7. Display the issue URL to the user.
 
 ## Step 7: Set Project Board Fields
 
@@ -160,7 +162,7 @@ After creation, the "Auto-add to project" workflow adds the issue to **hw-native
 
 ```bash
 gh api graphql -f query='{ repository(owner:"hw-native-sys",name:"pypto") {
-  issue(number:ISSUE_NUM) { projectItems(first:5) { nodes { id project { number } } } } } }'
+  issue(number:ISSUE_NUMBER) { projectItems(first:5) { nodes { id project { number } } } } } }'
 ```
 
 Extract the item ID where `project.number == 3`. If not found, wait 5s and retry once (auto-add may be delayed).
@@ -224,7 +226,7 @@ For Sprint (iteration field), use `value:{ iterationId:"ITER_ID" }` instead. If 
 ## Checklist
 
 - [ ] Input source determined (KNOWN_ISSUES.md or direct)
-- [ ] gh CLI authenticated (with `project` scope for board fields)
+- [ ] gh CLI authenticated with `project` scope
 - [ ] Searched for existing issues (no duplicate)
 - [ ] Issue classified to correct template, all required fields filled
 - [ ] Issue created with correct prefix, labels, and markdown body

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -165,7 +165,7 @@ gh api graphql -f query='{ repository(owner:"hw-native-sys",name:"pypto") {
   issue(number:ISSUE_NUMBER) { projectItems(first:5) { nodes { id project { number } } } } } }'
 ```
 
-Extract the item ID where `project.number == 3`. If not found, wait 5s and retry once (auto-add may be delayed).
+Extract the item ID where `project.number == 3`. If not found, run `sleep 5` and retry once (auto-add may be delayed).
 
 ### 7b: Fetch Field Options
 
@@ -193,7 +193,7 @@ Based on the issue type and content, suggest values using this logic:
 | **Effort** | Cross-layer / new pass / major refactor → Large; Single-layer / moderate → Medium; One-file / docs → Small |
 | **Sprint** | Critical + Ready → current sprint; Normal planned → next sprint; Backlog → no sprint |
 
-To determine current sprint: find the sprint where `startDate <= today < startDate + duration_days`.
+To determine current sprint: get today's date (e.g., via `date +%Y-%m-%d`), then find the sprint where `startDate <= today < startDate + duration`.
 
 ### 7d: Present to User
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-issue
-description: Create a GitHub issue following the project's issue templates. Classifies the issue type, fills required fields per template, and creates it via gh CLI. Use when the user wants to file a bug, request a feature, report a pass bug, or create any GitHub issue.
+description: Create a GitHub issue following the project's issue templates. Classifies the issue type, fills required fields per template, creates it via gh CLI, and sets project board fields (Status, Priority, Effort, Sprint). Use when the user wants to file a bug, request a feature, report a pass bug, or create any GitHub issue.
 ---
 
 # Create GitHub Issue
@@ -152,44 +152,81 @@ EOF
 
 **After creation**, display the issue URL to the user.
 
+## Step 7: Set Project Board Fields
+
+After creation, the "Auto-add to project" workflow adds the issue to **hw-native-sys project #3**. Set Status, Priority, Effort, and Sprint.
+
+### 7a: Retrieve Project Item ID
+
+```bash
+gh api graphql -f query='{ repository(owner:"hw-native-sys",name:"pypto") {
+  issue(number:ISSUE_NUM) { projectItems(first:5) { nodes { id project { number } } } } } }'
+```
+
+Extract the item ID where `project.number == 3`. If not found, wait 5s and retry once (auto-add may be delayed).
+
+### 7b: Fetch Field Options
+
+Query current field option IDs dynamically (do NOT hardcode option IDs):
+
+```bash
+gh api graphql -f query='{ organization(login:"hw-native-sys") { projectV2(number:3) {
+  id
+  fields(first:20) { nodes {
+    ... on ProjectV2SingleSelectField { name id options { id name } }
+    ... on ProjectV2IterationField { name id configuration {
+      iterations { id title startDate duration } } } } } } } }'
+```
+
+Extract the project ID, and field/option IDs for Status, Priority, Effort, Sprint.
+
+### 7c: Analyze and Suggest Values
+
+Based on the issue type and content, suggest values using this logic:
+
+| Field | Logic |
+| ----- | ----- |
+| **Status** | Bugs with clear repro → Ready; Features with proposal/design included → Ready; Features needing design → Backlog; External dependency → Blocked |
+| **Priority** | Data corruption / security / blocking → Critical; Most issues → Normal; Cosmetic / code-health → Trivial |
+| **Effort** | Cross-layer / new pass / major refactor → Large; Single-layer / moderate → Medium; One-file / docs → Small |
+| **Sprint** | Critical + Ready → current sprint; Normal planned → next sprint; Backlog → no sprint |
+
+To determine current sprint: find the sprint where `startDate <= today < startDate + duration_days`.
+
+### 7d: Present to User
+
+Use `AskUserQuestion` to present 4 questions (one per field), each with the relevant options. Put the suggested value first with "(Recommended)" suffix. For Sprint, include a "None" option.
+
+### 7e: Apply Values via GraphQL
+
+For each field, run the mutation using the project/field/option IDs from step 7b:
+
+```bash
+gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: {
+  projectId:"PROJECT_ID" itemId:"ITEM_ID" fieldId:"FIELD_ID"
+  value:{ singleSelectOptionId:"OPTION_ID" }
+}) { projectV2Item { id } } }'
+```
+
+For Sprint (iteration field), use `value:{ iterationId:"ITER_ID" }` instead. If user chose "None" for Sprint, skip it.
+
 ## Template Field Reference
 
-### Bug Report (`[Bug]`)
-
-Required: Component (dropdown), Description, Steps to Reproduce, Expected Behavior, Actual Behavior, Git Commit ID, NPU Kind (dropdown), Host Platform (dropdown)
-
-### Pass Bug (`[Pass Bug]`)
-
-Required: Pass Name, Description, Git Commit ID, Before IR (`@pl.program`), Expected IR, Actual IR or Error
-Optional: NPU Kind (dropdown), Host Platform (dropdown)
-
-### Feature Request (`[Feature]`)
-
-Required: Summary, Motivation / Use Case
-
-### New Operation (`[New Op]`)
-
-Required: Operation Level (dropdown), Proposed Name & Signature, Semantics Description, Example Usage, Motivation / Use Case
-
-### Performance Issue (`[Performance]`)
-
-Required: Summary, Git Commit ID, NPU Kind (dropdown), Host Platform (dropdown), Reproduction Script, Expected Performance, Actual Performance
-
-### Documentation (`[Docs]`)
-
-Required: Documentation Location, What's Wrong or Missing?
+| Template | Required Fields |
+| -------- | --------------- |
+| Bug `[Bug]` | Component, Description, Steps to Reproduce, Expected/Actual Behavior, Git Commit ID, NPU Kind, Host Platform |
+| Pass Bug `[Pass Bug]` | Pass Name, Description, Git Commit ID, Before IR, Expected IR, Actual IR/Error. Optional: NPU Kind, Host Platform |
+| Feature `[Feature]` | Summary, Motivation / Use Case |
+| New Op `[New Op]` | Operation Level, Proposed Name & Signature, Semantics, Example Usage, Motivation |
+| Performance `[Performance]` | Summary, Git Commit ID, NPU Kind, Host Platform, Reproduction Script, Expected/Actual Performance |
+| Docs `[Docs]` | Documentation Location, What's Wrong or Missing? |
 
 ## Checklist
 
 - [ ] Input source determined (KNOWN_ISSUES.md or direct)
-- [ ] If from KNOWN_ISSUES.md: issue verified as still real and unresolved
-- [ ] gh CLI authenticated
-- [ ] Searched for existing issues (no exact duplicate found)
-- [ ] Related issues referenced in body (if any)
-- [ ] Issue classified to correct template
-- [ ] All required fields filled
-- [ ] Title uses correct prefix from template
-- [ ] Labels match template
-- [ ] Body formatted with markdown sections matching template fields
-- [ ] Issue created and URL displayed
+- [ ] gh CLI authenticated (with `project` scope for board fields)
+- [ ] Searched for existing issues (no duplicate)
+- [ ] Issue classified to correct template, all required fields filled
+- [ ] Issue created with correct prefix, labels, and markdown body
 - [ ] If from KNOWN_ISSUES.md: entry removed from file
+- [ ] Project board fields set (Status, Priority, Effort, Sprint)

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -72,7 +72,7 @@ Comments often contain clarifications, reproduction steps, or design decisions t
 
    If the project item is not found, skip the board status check (the issue may not be linked to the project yet) and continue.
 
-3. If **assigned to someone** or **Status is "In Progress"**: warn the user with `AskUserQuestion` — show who is assigned and/or the current status, and ask whether to proceed anyway or stop.
+3. If **assigned to someone** or **Status in project #3 is "In Progress"**: warn the user with `AskUserQuestion` — show who is assigned and/or the current status, and ask whether to proceed anyway or stop.
 
 ## Step 3: Create Issue Branch
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -64,11 +64,13 @@ Comments often contain clarifications, reproduction steps, or design decisions t
 
    ```bash
    gh api graphql -f query='{ repository(owner:"hw-native-sys",name:"pypto") {
-     issue(number:ISSUE_NUM) { projectItems(first:5) { nodes { id project { number }
+     issue(number:ISSUE_NUMBER) { projectItems(first:5) { nodes { id project { number }
        fieldValues(first:10) { nodes {
          ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2SingleSelectField { name } } name }
        } } } } } } }'
    ```
+
+   If the project item is not found, skip the board status check (the issue may not be linked to the project yet) and continue.
 
 3. If **assigned to someone** or **Status is "In Progress"**: warn the user with `AskUserQuestion` — show who is assigned and/or the current status, and ask whether to proceed anyway or stop.
 
@@ -110,6 +112,8 @@ Update the project board status using the same GraphQL pattern as `create-issue`
 1. Get project item ID from the query in Step 2 (already fetched)
 2. Fetch field options dynamically (query `organization.projectV2.fields`)
 3. Set Status to "In Progress" via `updateProjectV2ItemFieldValue` mutation
+
+If the project item or Status field is not found, skip the board update and notify the user that manual update is needed. Do not block the fix workflow.
 
 ## Step 5: Implement the Fix
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -44,18 +44,33 @@ gh CLI is not authenticated. Please run: gh auth login
 
 ⚠️ **Stop here if not authenticated** - user must login first.
 
-## Step 2: Fetch Issue Content and Comments
+## Step 2: Fetch Issue Content and Check Ownership
 
 ```bash
-gh issue view ISSUE_NUMBER --json number,title,body,state,labels
+gh issue view ISSUE_NUMBER --json number,title,body,state,labels,assignees
 gh issue view ISSUE_NUMBER --comments
 ```
 
-**Parse**: Issue number, title, description, state (open/closed), labels, and all comments.
+**Parse**: Issue number, title, description, state (open/closed), labels, assignees, and all comments.
 
 Comments often contain clarifications, reproduction steps, or design decisions that are critical for understanding the full context of the issue.
 
 **If issue is closed**: Ask user if they still want to work on it.
+
+**Check for existing ownership** before proceeding:
+
+1. Check if anyone is already assigned (`assignees` field)
+2. Query the project board status:
+
+   ```bash
+   gh api graphql -f query='{ repository(owner:"hw-native-sys",name:"pypto") {
+     issue(number:ISSUE_NUM) { projectItems(first:5) { nodes { id project { number }
+       fieldValues(first:10) { nodes {
+         ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2SingleSelectField { name } } name }
+       } } } } } } }'
+   ```
+
+3. If **assigned to someone** or **Status is "In Progress"**: warn the user with `AskUserQuestion` — show who is assigned and/or the current status, and ask whether to proceed anyway or stop.
 
 ## Step 3: Create Issue Branch
 
@@ -80,6 +95,21 @@ Use `EnterPlanMode` to design the fix.
 - Testing approach
 - Documentation updates
 - Cross-layer changes (C++, Python, type stubs)
+
+## Step 4b: Mark Issue as In Progress
+
+After plan approval, self-assign and set project status to "In Progress":
+
+```bash
+# Self-assign
+gh issue edit ISSUE_NUMBER --add-assignee @me
+```
+
+Update the project board status using the same GraphQL pattern as `create-issue` Step 7:
+
+1. Get project item ID from the query in Step 2 (already fetched)
+2. Fetch field options dynamically (query `organization.projectV2.fields`)
+3. Set Status to "In Progress" via `updateProjectV2ItemFieldValue` mutation
 
 ## Step 5: Implement the Fix
 
@@ -136,8 +166,10 @@ Detailed explanation of the fix.
 
 - [ ] gh CLI authenticated
 - [ ] Issue content fetched and understood
+- [ ] Checked for existing assignees / In Progress status
 - [ ] Issue branch created from latest main
 - [ ] Plan created and approved
+- [ ] Issue self-assigned and set to In Progress on project board
 - [ ] Fix implemented following PyPTO rules
 - [ ] Tests added/updated and passing
 - [ ] Changes committed with issue reference


### PR DESCRIPTION
## Summary
- **create-issue skill**: Add Step 7 to set project board fields (Status, Priority, Effort, Sprint) after issue creation via GraphQL mutations. Analyzes issue type to suggest values, presents to user for confirmation via AskUserQuestion, then applies via `updateProjectV2ItemFieldValue`.
- **fix-issue skill**: Check for existing assignees / "In Progress" status before planning — warns user of conflicts. After plan approval, self-assigns and sets project status to "In Progress".

## Testing
- [x] Verified GraphQL read queries work (project item ID, field values)
- [x] Verified GraphQL mutations work for Status, Priority, Sprint fields
- [x] Token requires `project` scope (added via `gh auth refresh -s project`)
- [x] Markdown lint passes