### PR TITLE
feat(arith): leverage INDEX dtype non-negativity in bound analysis

### DIFF
--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -202,14 +202,14 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   Bound VisitExpr_(const VarPtr& op) override {
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return Everything();
+    return DefaultBoundFromDtype(op);
   }
 
   Bound VisitExpr_(const IterArgPtr& op) override {
     // IterArg is a Var subclass — look up in var_map_
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return Everything();
+    return DefaultBoundFromDtype(op);
   }
 
   Bound VisitExpr_(const MemRefPtr& /*op*/) override { return Everything(); }
@@ -374,6 +374,16 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   }
 
  private:
+  /// INDEX-typed variables are implicitly non-negative; other types use full range.
+  Bound DefaultBoundFromDtype(const ExprPtr& expr) {
+    if (auto st = std::dynamic_pointer_cast<const ScalarType>(expr->GetType())) {
+      if (st->dtype_ == DataType::INDEX) {
+        return {0, Bound::kPosInf};
+      }
+    }
+    return Everything();
+  }
+
   Analyzer* parent_;
   std::unordered_map<const Expr*, Bound> var_map_;
 };

--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -202,14 +202,14 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   Bound VisitExpr_(const VarPtr& op) override {
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return DefaultBoundFromDtype(op);
+    return DefaultBoundFromDtype(op.get());
   }
 
   Bound VisitExpr_(const IterArgPtr& op) override {
     // IterArg is a Var subclass — look up in var_map_
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return DefaultBoundFromDtype(op);
+    return DefaultBoundFromDtype(op.get());
   }
 
   Bound VisitExpr_(const MemRefPtr& /*op*/) override { return Everything(); }
@@ -375,7 +375,7 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
 
  private:
   /// INDEX-typed variables are implicitly non-negative; other types use full range.
-  Bound DefaultBoundFromDtype(const ExprPtr& expr) {
+  static Bound DefaultBoundFromDtype(const Expr* expr) {
     if (auto st = std::dynamic_pointer_cast<const ScalarType>(expr->GetType())) {
       if (st->dtype_ == DataType::INDEX) {
         return {0, Bound::kPosInf};
@@ -398,7 +398,7 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
   // Helper: try to tighten bound for a variable.
   auto TryTighten = [&](const Expr* var_ptr, const Bound& new_bound) {
     auto it = var_map_.find(var_ptr);
-    Bound old = (it != var_map_.end()) ? it->second : Everything();
+    Bound old = (it != var_map_.end()) ? it->second : DefaultBoundFromDtype(var_ptr);
     recovery.emplace_back(var_ptr, old);
     var_map_[var_ptr] = {std::max(old.min_value, new_bound.min_value),
                          std::min(old.max_value, new_bound.max_value)};

--- a/tests/ut/ir/arith/test_analyzer.py
+++ b/tests/ut/ir/arith/test_analyzer.py
@@ -616,6 +616,7 @@ class TestConstraintContext:
         # After constraint: back to [0, +inf)
         bound = analyzer.const_int_bound(n)
         assert bound.min_value == 0
+        analyzer.unbind(n)
 
 
 # ============================================================================

--- a/tests/ut/ir/arith/test_analyzer.py
+++ b/tests/ut/ir/arith/test_analyzer.py
@@ -599,6 +599,24 @@ class TestConstraintContext:
         analyzer.unbind(x)
         analyzer.unbind(y)
 
+    def test_index_non_negativity_preserved_under_constraint(self):
+        """INDEX var retains [0, +inf) lower bound when tightened by an upper-bound constraint."""
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), S)
+        # Without constraint: INDEX var is [0, +inf)
+        bound = analyzer.const_int_bound(n)
+        assert bound.min_value == 0
+
+        # Under n <= 10 constraint: should become [0, 10], not [-inf, 10]
+        constraint = ir.Le(n, ci(10), BOOL, S)
+        with analyzer.constraint_context(constraint):
+            bound = analyzer.const_int_bound(n)
+            assert bound.min_value == 0
+            assert bound.max_value == 10
+
+        # After constraint: back to [0, +inf)
+        bound = analyzer.const_int_bound(n)
+        assert bound.min_value == 0
+
 
 # ============================================================================
 # Cross-analyzer integration (TryCompare)

--- a/tests/ut/ir/arith/test_const_int_bound.py
+++ b/tests/ut/ir/arith/test_const_int_bound.py
@@ -64,6 +64,13 @@ class TestConstIntBoundBasics:
         assert b.max_value == ConstIntBound.kPosInf
         assert b.is_everything()
 
+    def test_index_var_non_negative(self):
+        """INDEX-typed vars are implicitly non-negative."""
+        idx_var = ir.Var("n", ir.ScalarType(DataType.INDEX), S)
+        b = analyzer(idx_var)
+        assert b.min_value == 0
+        assert b.max_value == ConstIntBound.kPosInf
+
     def test_bound_var(self):
         analyzer.bind(x, 0, 8)  # [0, 8) = [0, 7]
         b = analyzer(x)

--- a/tests/ut/ir/arith/test_rewrite_simplify.py
+++ b/tests/ut/ir/arith/test_rewrite_simplify.py
@@ -11,7 +11,7 @@
 
 import pytest
 from pypto import DataType, ir
-from pypto.arith import RewriteSimplifier
+from pypto.arith import Analyzer, RewriteSimplifier
 
 S = ir.Span.unknown()
 INT = DataType.INT64
@@ -452,6 +452,22 @@ class TestMinMaxRules:
         assert isinstance(result, ir.Mul)
         assert isinstance(result.left, ir.Max)
         assert_is_const_int(result.right, 3)
+
+    def test_max_index_non_negative(self):
+        """max(n, 0) => n when n has INDEX dtype (non-negative by definition)."""
+        ana = Analyzer()
+        n = ir.Var("n", ir.ScalarType(IDX), S)
+        expr = ir.Max(n, ir.ConstInt(0, IDX, S), IDX, S)
+        result = ana.simplify(expr)
+        assert result is n
+
+    def test_max_zero_index_commutative(self):
+        """max(0, n) => n when n has INDEX dtype."""
+        ana = Analyzer()
+        n = ir.Var("n", ir.ScalarType(IDX), S)
+        expr = ir.Max(ir.ConstInt(0, IDX, S), n, IDX, S)
+        result = ana.simplify(expr)
+        assert result is n
 
 
 # ============================================================================

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -616,12 +616,12 @@ class TestDynamicChunking:
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.auto_incore():
-                    for i_out, (x_outer,) in pl.range(0, pl.max(n_0, 0) // 4, 1, init_values=(x_0,)):
+                    for i_out, (x_outer,) in pl.range(0, n_0 // 4, 1, init_values=(x_0,)):
                         for i_in, (x_inner,) in pl.range(0, 4, 1, init_values=(x_outer,)):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
                             x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
-                    for i_rem, (x_rem,) in pl.range(0, pl.max(n_0, 0) % 4, 1, init_values=(x_outer_rv,)):
+                    for i_rem, (x_rem,) in pl.range(0, n_0 % 4, 1, init_values=(x_outer_rv,)):
                         x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
@@ -692,12 +692,12 @@ class TestDynamicChunking:
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.auto_incore():
-                    for i_out, (x_outer,) in pl.parallel(0, pl.max(n_0, 0) // 4, 1, init_values=(x_0,)):
+                    for i_out, (x_outer,) in pl.parallel(0, n_0 // 4, 1, init_values=(x_0,)):
                         for i_in, (x_inner,) in pl.parallel(0, 4, 1, init_values=(x_outer,)):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
                             x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
-                    for i_rem, (x_rem,) in pl.parallel(0, pl.max(n_0, 0) % 4, 1, init_values=(x_outer_rv,)):
+                    for i_rem, (x_rem,) in pl.parallel(0, n_0 % 4, 1, init_values=(x_outer_rv,)):
                         x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv


### PR DESCRIPTION
## Summary
- Teach `ConstIntBoundAnalyzer` that unbound variables with INDEX dtype have bounds `[0, +inf)` instead of `(-inf, +inf)`
- Existing bound-dependent rewrite rules in `RewriteSimplifier` automatically simplify `max(n, 0)` → `n` for INDEX-typed `n`
- Update downstream test expectations in `SplitChunkedLoops` to reflect the improved simplification

## Testing
- [x] New unit test for INDEX var non-negative bound (`test_const_int_bound.py`)
- [x] New integration tests for `max(n, 0)` elimination (`test_rewrite_simplify.py`)
- [x] Updated test expectations in `test_split_chunked_loops.py`
- [x] Full test suite passes (3376 passed, 0 failed)
- [x] Code review completed
- [x] Clang-tidy passed

## Related Issues
Fixes #907