### PR TITLE
refactor(pass): rename SimplifyExpr to Simplify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/resolve_backend_op_layouts_pass.cpp
     src/ir/transforms/resolve_transpose_layout_pass.cpp
     src/ir/transforms/python_printer.cpp
-    src/ir/transforms/simplify_expr_pass.cpp
+    src/ir/transforms/simplify_pass.cpp
     src/ir/transforms/split_chunked_loops_pass.cpp
     src/ir/transforms/interchange_chunk_loops_pass.cpp
     src/ir/transforms/unroll_loops_pass.cpp

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -58,9 +58,9 @@ inline const PassProperties kFlattenCallExprProperties{
 inline const PassProperties kNormalizeStmtStructureProperties{
     .produced = {IRProperty::NormalizedStmtStructure}};
 
-// -- Expression simplification pass -------------------------------------------
+// -- Simplification pass ------------------------------------------------------
 
-inline const PassProperties kSimplifyExprProperties{};
+inline const PassProperties kSimplifyProperties{};
 
 // -- Outlining pass -----------------------------------------------------------
 

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -355,13 +355,14 @@ Pass SplitVectorKernel();
 Pass RunVerifier(const IRPropertySet& properties);
 
 /**
- * @brief Simplify all scalar expressions in the program
+ * @brief Simplify scalar expressions and statements in the program
  *
- * Uses algebraic rewrite rules and bound analysis to reduce expression complexity.
+ * Uses algebraic rewrite rules and bound analysis to reduce complexity.
  * Automatically binds ForStmt loop variables to their iteration ranges for
  * range-aware simplification (e.g., i // 8 == 0 when i is in [0, 8)).
+ * Propagates if-branch constraints for tighter bounds in then/else bodies.
  */
-Pass SimplifyExpr();
+Pass Simplify();
 
 /**
  * @brief Create a pass that flattens nested call expressions

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -345,8 +345,9 @@ void BindPass(nb::module_& m) {
   passes.def("split_vector_kernel", &pass::SplitVectorKernel,
              "Create a pass that splits vector kernels based on SplitMode "
              "(adjusts tpush/tpop split, halves tpop shapes, adjusts store offsets)");
-  passes.def("simplify_expr", &pass::SimplifyExpr,
-             "Create a pass that simplifies scalar expressions using algebraic rules and bound analysis");
+  passes.def(
+      "simplify", &pass::Simplify,
+      "Create a pass that simplifies expressions and statements using algebraic rules and bound analysis");
   passes.def("flatten_call_expr", &pass::FlattenCallExpr,
              "Create a pass that flattens nested call expressions");
   passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure,

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -357,8 +357,8 @@ def expand_mixed_kernel() -> Pass:
 def split_vector_kernel() -> Pass:
     """Create a pass that splits vector kernels based on SplitMode."""
 
-def simplify_expr() -> Pass:
-    """Create a pass that simplifies scalar expressions using algebraic rules and bound analysis."""
+def simplify() -> Pass:
+    """Create a pass that simplifies expressions and statements using algebraic rules and bound analysis."""
 
 def flatten_call_expr() -> Pass:
     """Create a pass that flattens nested call expressions."""
@@ -455,7 +455,7 @@ __all__ = [
     "infer_tile_memory_space",
     "expand_mixed_kernel",
     "split_vector_kernel",
-    "simplify_expr",
+    "simplify",
     "flatten_call_expr",
     "normalize_stmt_structure",
     "NestedCallErrorType",

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -45,9 +45,9 @@ namespace {
 /// IRMutator's child visiting uses qualified calls (ExprFunctor::VisitExpr)
 /// that bypass VisitExpr overrides. Analyzer::Simplify handles deep
 /// recursive simplification of the entire expression tree.
-class SimplifyExprMutator : public arith::IRMutatorWithAnalyzer {
+class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
  public:
-  explicit SimplifyExprMutator(arith::Analyzer* analyzer) : IRMutatorWithAnalyzer(analyzer) {}
+  explicit SimplifyMutator(arith::Analyzer* analyzer) : IRMutatorWithAnalyzer(analyzer) {}
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     auto new_value = analyzer_->Simplify(op->value_);
@@ -164,9 +164,9 @@ class SimplifyExprMutator : public arith::IRMutatorWithAnalyzer {
   }
 };
 
-FunctionPtr TransformSimplifyExpr(const FunctionPtr& func) {
+FunctionPtr TransformSimplify(const FunctionPtr& func) {
   auto analyzer = std::make_shared<arith::Analyzer>();
-  SimplifyExprMutator mutator(analyzer.get());
+  SimplifyMutator mutator(analyzer.get());
   auto new_body = mutator.VisitStmt(func->body_);
   if (new_body.get() == func->body_.get()) return func;
   return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
@@ -178,9 +178,7 @@ FunctionPtr TransformSimplifyExpr(const FunctionPtr& func) {
 
 namespace pass {
 
-Pass SimplifyExpr() {
-  return CreateFunctionPass(TransformSimplifyExpr, "SimplifyExpr", kSimplifyExprProperties);
-}
+Pass Simplify() { return CreateFunctionPass(TransformSimplify, "Simplify", kSimplifyProperties); }
 
 }  // namespace pass
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -7,12 +7,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Tests for the SimplifyExpr pass.
+"""Tests for the Simplify pass.
 
-This pass simplifies all scalar expressions in the IR using algebraic rewrite
-rules and bound analysis. IRMutatorWithAnalyzer binds ForStmt loop variables
-to their ranges, and ConstraintContext propagates if-branch conditions,
-enabling range-aware simplification.
+This pass simplifies expressions and statements in the IR using algebraic
+rewrite rules and bound analysis. IRMutatorWithAnalyzer binds ForStmt loop
+variables to their ranges, and ConstraintContext propagates if-branch
+conditions, enabling range-aware simplification.
 
 Tests use the @pl.program DSL where possible. Constant folding tests use
 direct IR construction because Python eagerly evaluates constant expressions
@@ -54,15 +54,15 @@ def make_program(body_stmts):
 
 class TestPassMetadata:
     def test_pass_name(self):
-        p = passes.simplify_expr()
-        assert p.get_name() == "SimplifyExpr"
+        p = passes.simplify()
+        assert p.get_name() == "Simplify"
 
     def test_pass_no_required_properties(self):
-        p = passes.simplify_expr()
+        p = passes.simplify()
         assert p.get_required_properties().empty()
 
     def test_pass_no_produced_properties(self):
-        p = passes.simplify_expr()
+        p = passes.simplify()
         assert p.get_produced_properties().empty()
 
 
@@ -89,7 +89,7 @@ class TestIdentitySimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_zero_add(self):
@@ -109,7 +109,7 @@ class TestIdentitySimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_mul_one(self):
@@ -129,7 +129,7 @@ class TestIdentitySimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_sub_zero(self):
@@ -149,7 +149,7 @@ class TestIdentitySimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
 
@@ -168,7 +168,7 @@ class TestConstantFolding:
         assign_exp = ir.AssignStmt(y, ci(7), S)
         expected = make_program([assign_exp])
 
-        after = passes.simplify_expr()(before)
+        after = passes.simplify()(before)
         ir.assert_structural_equal(after, expected)
 
     def test_mul_constants(self):
@@ -180,7 +180,7 @@ class TestConstantFolding:
         assign_exp = ir.AssignStmt(y, ci(12), S)
         expected = make_program([assign_exp])
 
-        after = passes.simplify_expr()(before)
+        after = passes.simplify()(before)
         ir.assert_structural_equal(after, expected)
 
     def test_nested_constant_expr(self):
@@ -194,7 +194,7 @@ class TestConstantFolding:
         assign_exp = ir.AssignStmt(y, ci(20), S)
         expected = make_program([assign_exp])
 
-        after = passes.simplify_expr()(before)
+        after = passes.simplify()(before)
         ir.assert_structural_equal(after, expected)
 
 
@@ -221,7 +221,7 @@ class TestRangeAwareSimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_floormod_by_range_bound(self):
@@ -241,7 +241,7 @@ class TestRangeAwareSimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_floordiv_not_simplifiable(self):
@@ -254,7 +254,7 @@ class TestRangeAwareSimplification:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i // 4
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Before)
 
     def test_nested_loops(self):
@@ -276,7 +276,7 @@ class TestRangeAwareSimplification:
                     for j in pl.range(4):
                         _y: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
 
@@ -305,7 +305,7 @@ class TestIfBranchConstraint:
                     if i < 4:
                         _y: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_else_branch_uses_negated_condition(self):
@@ -332,7 +332,7 @@ class TestIfBranchConstraint:
                     else:
                         _y: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_nested_if_in_loop(self):
@@ -358,7 +358,7 @@ class TestIfBranchConstraint:
                     else:
                         _z: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
 
@@ -387,7 +387,7 @@ class TestControlFlow:
                     _y: pl.Scalar[pl.INDEX] = i
                     break
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_continue_stmt_passthrough(self):
@@ -409,7 +409,7 @@ class TestControlFlow:
                     _y: pl.Scalar[pl.INDEX] = i
                     continue
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_scope_stmt_traversal(self):
@@ -431,7 +431,7 @@ class TestControlFlow:
                     with pl.incore():
                         _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_while_condition_simplified(self):
@@ -453,7 +453,7 @@ class TestControlFlow:
                 while i < n:
                     i = i + 1
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_sequential_stmts(self):
@@ -475,7 +475,7 @@ class TestControlFlow:
                     _y: pl.Scalar[pl.INDEX] = i
                     _z: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_if_with_break_and_continue(self):
@@ -505,7 +505,7 @@ class TestControlFlow:
                         _y: pl.Scalar[pl.INDEX] = i
                         continue
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_for_loop_with_scope_and_if(self):
@@ -529,7 +529,7 @@ class TestControlFlow:
                         if i < 4:
                             _y: pl.Scalar[pl.INDEX] = 0
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
 
@@ -549,7 +549,7 @@ class TestNoChange:
                 for i in pl.range(8):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Before)
 
     def test_symbolic_loop_bounds(self):
@@ -569,7 +569,7 @@ class TestNoChange:
                 for i in pl.range(n):
                     _y: pl.Scalar[pl.INDEX] = i
 
-        after = passes.simplify_expr()(Before)
+        after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
     def test_empty_function(self):
@@ -578,7 +578,7 @@ class TestNoChange:
         func = ir.Function("main", [], [], body, S)
         before = ir.Program([func], "test", S)
 
-        after = passes.simplify_expr()(before)
+        after = passes.simplify()(before)
         ir.assert_structural_equal(after, before)
 
 

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -593,7 +593,7 @@ class TestDynamicChunking:
         """Run prerequisite passes, split chunked loops, and simplify expressions."""
         prepared = _prepare_for_split(program)
         split = passes.split_chunked_loops()(prepared)
-        return passes.simplify_expr()(split)
+        return passes.simplify()(split)
 
     def test_dynamic_stop(self):
         """Dynamic stop: outer+inner+remainder with FloorDiv/FloorMod bounds."""


### PR DESCRIPTION
## Summary
- Rename `SimplifyExpr` pass to `Simplify` across all layers (C++, Python binding, type stub, tests, CMake)
- The pass simplifies statements (loop bounds, if-branch constraints, while conditions) in addition to expressions, so the narrower `SimplifyExpr` name was misleading

## Files Changed
- `include/pypto/ir/transforms/passes.h` — `SimplifyExpr()` → `Simplify()`
- `include/pypto/ir/transforms/pass_properties.h` — `kSimplifyExprProperties` → `kSimplifyProperties`
- `src/ir/transforms/simplify_expr_pass.cpp` → `simplify_pass.cpp` — internal symbols renamed
- `python/bindings/modules/passes.cpp` — `simplify_expr` → `simplify`
- `python/pypto/pypto_core/passes.pyi` — stub + `__all__` updated
- `tests/ut/ir/transforms/test_simplify_expr_pass.py` → `test_simplify_pass.py`
- `tests/ut/ir/transforms/test_split_chunked_loops.py` — updated call site
- `CMakeLists.txt` — source file reference updated

## Testing
- [x] All 3373 tests pass
- [x] Code review completed (no stale references)
- [x] clang-tidy clean
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)