### PR TITLE
feat(ir,dsl): add tile.fillpad_inplace op with in-place buffer reuse

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -456,6 +456,25 @@ def fillpad(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span | None =
     return _ir_core.create_op_call("tile.fillpad", [tile], {"pad_value": pad_value}, actual_span)
 
 
+def fillpad_inplace(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span | None = None) -> Call:
+    """Fill padding elements of input tile in place with specified pad value.
+
+    Unlike fillpad which returns a new tile, this operation mutates the input
+    tile in place. The valid data region is unchanged; only out-of-bounds
+    (padding) elements are written.
+
+    Args:
+        tile: Input tile (TileType)
+        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression (result typically discarded since op is in-place)
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.fillpad_inplace", [tile], {"pad_value": pad_value}, actual_span)
+
+
 # ============================================================================
 # Element-wise Operations
 # ============================================================================

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -33,6 +33,7 @@ __all__ = [
     "move",
     "full",
     "fillpad",
+    "fillpad_inplace",
     "get_block_idx",
     "get_subblock_idx",
     "add",
@@ -416,6 +417,24 @@ def fillpad(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
         Tile wrapping the fillpad operation
     """
     call_expr = _ir_ops.fillpad(tile.unwrap(), pad_value=pad_value)
+    return Tile(expr=call_expr)
+
+
+def fillpad_inplace(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
+    """Fill padding elements of input tile in place.
+
+    Unlike fillpad which allocates a new output tile, this operation reuses
+    the input tile's UB buffer. The result shares the same memory address,
+    making it equivalent to TFILLPAD_INPLACE on the hardware.
+
+    Args:
+        tile: Input tile
+        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+
+    Returns:
+        Tile with padding filled (shares memory with the input tile).
+    """
+    call_expr = _ir_ops.fillpad_inplace(tile.unwrap(), pad_value=pad_value)
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1229,6 +1229,8 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.row_expand_sub",  "pto.trowexpandsub",    2},
     // Padding operations
     {"tile.fillpad",         "pto.tfillpad",         1},
+    // Inplace variant: set_output_reuses_input(0) makes src/dst share UB addr.
+    {"tile.fillpad_inplace", "pto.tfillpad",         1},
     // Matrix multiplication operations (PipeType::M → CUBE/AIC core)
     {"tile.matmul",          "pto.tmatmul",          2},
     {"tile.matmul_mx",       "pto.tmatmul.mx",       4},

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -459,7 +459,8 @@ void PTOCodegen::BuildVarToMemRefMapping(const FunctionPtr& func) {
           }
           // Track fillpad input variables so we know which tiles need
           // physical dims on alloc_tile + set_validshape after tload.
-          if (call->op_->name_ == "tile.fillpad" && !call->args_.empty()) {
+          if ((call->op_->name_ == "tile.fillpad" || call->op_->name_ == "tile.fillpad_inplace") &&
+              !call->args_.empty()) {
             if (auto input_var = As<ir::Var>(call->args_[0])) {
               fillpad_input_vars.insert(input_var.get());
             }

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -945,5 +945,39 @@ REGISTER_OP("tile.fillpad")
                                         tile_type->memory_space_);
     });
 
+REGISTER_OP("tile.fillpad_inplace")
+    .set_op_category("TileOp")
+    .set_description("Fill padding elements of input tile in place with specified pad value")
+    .add_argument("tile", "Input tile (TileType)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .set_output_reuses_input(0)
+    .set_attr<PadValue>("pad_value")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      CHECK(args.size() == 1) << "The operator tile.fillpad_inplace requires exactly 1 argument, but got "
+                              << args.size();
+
+      auto tile_type = As<TileType>(args[0]->GetType());
+      CHECK(tile_type)
+          << "The operator tile.fillpad_inplace requires first argument to be a TileType, but got "
+          << args[0]->GetType()->TypeName();
+
+      PadValue pad_value = PadValue::zero;
+      for (const auto& kv : kwargs) {
+        if (kv.first == "pad_value") {
+          pad_value = std::any_cast<PadValue>(kv.second);
+          CHECK(pad_value != PadValue::null)
+              << "tile.fillpad_inplace requires pad_value to be zero/max/min, not null";
+        }
+      }
+
+      TileView tile_view;
+      tile_view.valid_shape = tile_type->shape_;
+      tile_view.pad = pad_value;
+      return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, tile_type->memref_, tile_view,
+                                        tile_type->memory_space_);
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -940,6 +940,7 @@ REGISTER_OP("tile.fillpad")
       // After fillpad, the entire tile is valid (padding region is now filled with pad_value)
       TileView tile_view;
       tile_view.valid_shape = tile_type->shape_;  // Expand valid_shape to full shape
+      InheritTileViewLayout(tile_view, tile_type);
       tile_view.pad = pad_value;
       return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, tile_type->memref_, tile_view,
                                         tile_type->memory_space_);
@@ -974,6 +975,7 @@ REGISTER_OP("tile.fillpad_inplace")
 
       TileView tile_view;
       tile_view.valid_shape = tile_type->shape_;
+      InheritTileViewLayout(tile_view, tile_type);
       tile_view.pad = pad_value;
       return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, tile_type->memref_, tile_view,
                                         tile_type->memory_space_);

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -60,7 +60,7 @@ using codegen::TileBufSignature;
 /// MemRef's root alloc type).
 static bool IsLegalViewOp(const std::string& op_name) {
   return op_name == "tile.reshape" || op_name == "tile.extract" || op_name == "tile.slice" ||
-         op_name == "tile.fillpad" || op_name == "tensor.slice";
+         op_name == "tile.fillpad" || op_name == "tile.fillpad_inplace" || op_name == "tensor.slice";
 }
 
 // -------------------------------------------------------------------------

--- a/tests/st/runtime/test_fillpad_inplace.py
+++ b/tests/st/runtime/test_fillpad_inplace.py
@@ -1,0 +1,226 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Test fillpad_inplace operation with different pad values (zero, max, min).
+
+Each test verifies that fillpad_inplace correctly fills the padding region in place:
+1. Load 48x64 data into 64x64 tile (rows 48-63 are padding region)
+2. fillpad_inplace with specified pad_value fills rows 48-63 in place (shared UB buffer)
+3. Store the full 64x64 tile to output
+4. Verify: rows 0-47 = input data, rows 48-63 = expected fill value
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# --- Programs ---
+
+
+@pl.program
+class FillpadInplaceZeroProgram:
+    """Load with partial valid_shape, fillpad_inplace with zero, store."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_inplace_zero_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.zero)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output = self.fillpad_inplace_zero_kernel(input_tensor, output)
+        return output
+
+
+@pl.program
+class FillpadInplaceMaxProgram:
+    """Load with partial valid_shape, fillpad_inplace with max, store."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_inplace_max_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.max)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output = self.fillpad_inplace_max_kernel(input_tensor, output)
+        return output
+
+
+@pl.program
+class FillpadInplaceMinProgram:
+    """Load with partial valid_shape, fillpad_inplace with min, store."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fillpad_inplace_min_kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+        )
+        padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.min)
+        out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        output = self.fillpad_inplace_min_kernel(input_tensor, output)
+        return output
+
+
+# --- Test Cases ---
+
+
+class FillpadInplaceZeroTestCase(PTOTestCase):
+    """Test fillpad_inplace - padding region should be filled with 0.0."""
+
+    def get_name(self) -> str:
+        return "fillpad_inplace_zero"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadInplaceZeroProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = 0.0"""
+        expected = torch.zeros(64, 64, dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+class FillpadInplaceMaxTestCase(PTOTestCase):
+    """Test fillpad_inplace - padding region should be filled with FP32 max."""
+
+    def get_name(self) -> str:
+        return "fillpad_inplace_max"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadInplaceMaxProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = FP32 max (+inf)"""
+        expected = torch.full((64, 64), float("inf"), dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+class FillpadInplaceMinTestCase(PTOTestCase):
+    """Test fillpad_inplace - padding region should be filled with FP32 min (-inf)."""
+
+    def get_name(self) -> str:
+        return "fillpad_inplace_min"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_tensor", [48, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [64, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FillpadInplaceMinProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Expected: rows 0-47 = input, rows 48-63 = -inf"""
+        expected = torch.full((64, 64), float("-inf"), dtype=torch.float32)
+        expected[:48, :] = tensors["input_tensor"]
+        tensors["output"][:] = expected
+
+
+# --- Tests ---
+
+
+class TestFillpadInplace:
+    """Test suite to verify fillpad_inplace fills padding region in place with different pad values."""
+
+    def test_fillpad_inplace_zero(self, test_runner):
+        """Verify fillpad_inplace fills the padding region with 0.0."""
+        test_case = FillpadInplaceZeroTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_fillpad_inplace_max(self, test_runner):
+        """Verify fillpad_inplace fills the padding region with FP32 max value."""
+        test_case = FillpadInplaceMaxTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_fillpad_inplace_min(self, test_runner):
+        """Verify fillpad_inplace fills the padding region with FP32 min value (-inf)."""
+        test_case = FillpadInplaceMinTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -339,6 +339,86 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     assert "v_col=128" in alloc_lines[1], f"Expected static v_col in padded tile: {alloc_lines[1]}"
 
 
+def test_pto_codegen_fillpad_inplace():
+    """Test that tile.fillpad_inplace emits pto.tfillpad and shares MemRef with input."""
+    span = ir.Span.unknown()
+    zero = ir.ConstInt(0, DataType.INDEX, span)
+    size = ir.ConstInt(128, DataType.INDEX, span)
+
+    input_tensor = ir.Var("a", ir.TensorType([128, 128], DataType.FP32), span)
+    output_tensor = ir.Var("output", ir.TensorType([128, 128], DataType.FP32), span)
+    m_var = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
+    n_var = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+    shared_memref = ir.MemRef(ir.MemorySpace.Vec, zero, 128 * 128 * 4, 0)
+
+    load_view = ir.TileView()
+    load_view.valid_shape = [m_var, n_var]
+    load_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, load_view, ir.MemorySpace.Vec)
+    load_tile = ir.Var("tile_a", load_tile_type, span)
+
+    padded_view = ir.TileView()
+    padded_view.valid_shape = [size, size]
+    padded_view.pad = ir.PadValue.zero
+    padded_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, padded_view, ir.MemorySpace.Vec)
+    padded_tile = ir.Var("padded", padded_tile_type, span)
+
+    result_var = ir.Var("result", ir.TensorType([128, 128], DataType.FP32), span)
+    offsets = ir.MakeTuple([zero, zero], span)
+    shapes = ir.MakeTuple([size, size], span)
+
+    load_call = ir.Call(ir.Op("tile.load"), [input_tensor, offsets, shapes], {}, load_tile_type, span)
+    fillpad_inplace_call = ir.Call(
+        ir.Op("tile.fillpad_inplace"),
+        [load_tile],
+        {"pad_value": ir.PadValue.zero},
+        padded_tile_type,
+        span,
+    )
+    store_call = ir.Call(ir.Op("tile.store"), [padded_tile, offsets, output_tensor], result_var.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.SeqStmts(
+                [
+                    ir.AssignStmt(load_tile, load_call, span),
+                    ir.AssignStmt(padded_tile, fillpad_inplace_call, span),
+                    ir.AssignStmt(result_var, store_call, span),
+                ],
+                span,
+            ),
+            ir.ReturnStmt([result_var], span),
+        ],
+        span,
+    )
+    func = ir.Function(
+        "fillpad_inplace_test",
+        [
+            (input_tensor, ir.ParamDirection.In),
+            (output_tensor, ir.ParamDirection.Out),
+            (m_var, ir.ParamDirection.In),
+            (n_var, ir.ParamDirection.In),
+        ],
+        [ir.TensorType([128, 128], DataType.FP32)],
+        body,
+        span,
+        ir.FunctionType.InCore,
+    )
+    program = ir.Program([func], "fillpad_inplace_test_program", span)
+
+    mlir_code = _generate_mlir(program)
+    alloc_lines = _get_alloc_tile_lines(mlir_code)
+
+    # Both allocs share the same addr (same MemRef)
+    assert len(alloc_lines) == 2, f"Expected two alloc_tiles for per-var alloc model, got: {alloc_lines}"
+    assert "addr = %c0i" in alloc_lines[0]
+    assert "addr = %c0i" in alloc_lines[1]
+    # Dynamic valid_shape tile: type has v_row=?, v_col=? (both dynamic per PTOAS requirement)
+    assert "v_row=?" in alloc_lines[0], f"Expected dynamic v_row=? in alloc: {alloc_lines[0]}"
+    assert "v_col=?" in alloc_lines[0], f"Expected dynamic v_col=? in alloc: {alloc_lines[0]}"
+    # fillpad_inplace emits pto.tfillpad; inplace semantics come from shared UB addr above.
+    assert "pto.tfillpad " in mlir_code, "Expected pto.tfillpad in MLIR output"
+
+
 def test_pto_codegen_dynamic_valid_shape_scalar_defined_in_body():
     """Dynamic valid_shape scalars defined in-body should still reach alloc_tile."""
 

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -442,9 +442,11 @@ def test_fillpad_kwarg_schema():
     """Test that fillpad ops declare pad_value in their kwarg schemas."""
     tensor_fillpad_op = ir.get_op("tensor.fillpad")
     tile_fillpad_op = ir.get_op("tile.fillpad")
+    tile_fillpad_inplace_op = ir.get_op("tile.fillpad_inplace")
 
     assert tensor_fillpad_op.has_attr("pad_value")
     assert tile_fillpad_op.has_attr("pad_value")
+    assert tile_fillpad_inplace_op.has_attr("pad_value")
 
 
 class TestOpMemorySpecRegistry:
@@ -693,6 +695,7 @@ class TestRegistryInfrastructure:
             "tile.cmp",
             "tile.sel",
             "tile.fillpad",
+            "tile.fillpad_inplace",
             "tile.cast",
             "tile.abs",
             "tile.relu",


### PR DESCRIPTION
## Summary

Add `tile.fillpad_inplace` operation that performs in-place fill-padding by sharing the input tile's UB buffer for both src and dst. Unlike `tile.fillpad` which allocates a separate output buffer, this op reuses the input buffer via `set_output_reuses_input(0)`, making the hardware execute the equivalent of `TFILLPAD_INPLACE`.

- Register `tile.fillpad_inplace` op with `set_output_reuses_input(0)` in `InitMemRef` pass
- Map to `pto.tfillpad` in codegen (same PTO instruction, shared UB address)
- Add to `IsLegalViewOp` in `LegalizePTOBufferReuse` pass to preserve shared MemRef
- Add Python IR builder and DSL wrapper with docstrings
- Add UT (codegen, op registry) and ST (runtime zero/max/min) tests

## Key Design

The in-place semantics are achieved entirely through MemRef sharing in `InitMemRef`, not by emitting a different PTO instruction. Both `tile.fillpad` and `tile.fillpad_inplace` emit `pto.tfillpad`; the difference is that the inplace variant's output `alloc_tile` shares the same `addr` as the input, so `TFILLPAD(dst, src)` with `dst==src` becomes a hardware no-op copy equivalent to `TFILLPAD_INPLACE`.

## Why InitMemRef MemRef Sharing Instead of Memory Reuse Pass?

PyPTO has two distinct buffer-sharing mechanisms:

1. **`set_output_reuses_input(N)` in `InitMemRef` pass** — declarative, unconditional sharing driven by op-registry metadata. When an op declares this flag, `InitMemRef` calls `ShareMemRefFrom()` to make the output variable's `MemRef` the same object as the Nth input's `MemRef`. No compatibility checks — the op itself guarantees correctness.

2. **Memory Reuse Pass** (`src/ir/transforms/memory_reuse_pass.cpp`) — automatic lifetime-based reuse. Analyzes def/use points and greedily matches non-overlapping variables, but requires `AreTileTypesCompatible` to pass: **same dtype, same shape, AND same `TileView` (valid_shape, pad, stride, layout)**.

**Memory Reuse Pass cannot handle `tile.fillpad_inplace`** because input and output `TileView` values are different by design:

| Side | `valid_shape` | `pad` |
| ---- | ------------- | ----- |
| Input tile | `[48, 64]` (partial) | `null` |
| Output tile | `[64, 64]` (full) | `zero`/`max`/`min` |

`AreTileTypesCompatible` checks `TileView` equality and would reject this pairing, so the pass would allocate a fresh buffer for the output — defeating the whole point of an in-place op.

`set_output_reuses_input(0)` runs earlier in `InitMemRef` and bypasses compatibility checks entirely. It encodes the invariant "this op writes back into its input buffer" as op metadata, which is semantically correct here: the hardware `TFILLPAD` with `dst == src` only rewrites the padding region, leaving valid data untouched. This is exactly the pattern already used by `tile.matmul_acc`, `tile.gemv_acc`, and `tile.store`.

## Testing

- [x] All 3341 unit tests pass (0 failures)
- [x] ST tests: `test_fillpad_inplace_zero`, `test_fillpad_inplace_max`, `test_fillpad_inplace_min`
- [x] Code review passed
- [x] clang-tidy clean (no new warnings)

## Related Issues

Closes #880