### PR TITLE
refactor(codegen): batch tensor.create into scope-level alloc_tensors

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -96,10 +96,11 @@ Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
 Tensor ext_dn = from_tensor_arg(orch_args.tensor(2));
 
 // Phase 5: Internal tensors (from pl.create_tensor — intermediates only)
-// TensorCreateInfo is emitted here. The Tensor variable is bound at the submit site:
-//   const Tensor& tmp = outs_t0.get_ref(0);
+// All tensor.create in the same scope are batched into a single alloc_tensors call.
 uint32_t tmp_ci_shapes[2] = {16, 16};
 TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
+TaskOutputTensors alloc_0 = alloc_tensors(tmp_ci);
+const Tensor& tmp = alloc_0.get_ref(0);
 ```
 
 ### Phase 6–8: Task Submission and Control Flow
@@ -111,9 +112,8 @@ PTO2_SCOPE() {
     Arg params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
-    params_t0.add_output(tmp_ci);            // add_output takes TensorCreateInfo for internal tensors
-    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-    const Tensor& tmp = outs_t0.get_ref(0); // non-DN: bind const ref at submit site
+    params_t0.add_output(tmp);               // pre-allocated tensor uses add_output(const Tensor&)
+    pto2_rt_submit_aiv_task(0, params_t0);
 
     // ForStmt example — plain for loop, no nested PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -129,9 +129,9 @@ PTO2_SCOPE() {
 | Type | Source | C++ Construction | Naming |
 | ---- | ------ | ---------------- | ------ |
 | External (ND/DN) | Function parameters | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
-| Internal | `pl.create_tensor(...)` in function body | `TensorCreateInfo var_ci(...)` + `const Tensor& var` bound at submit | `<name>` (no prefix) |
+| Internal | `pl.create_tensor(...)` in function body | `TensorCreateInfo var_ci(...)` + `alloc_tensors(...)` at scope entry | `<name>` (no prefix) |
 
-External tensors wrap device memory pointers passed from the host via `ChipStorageTaskArgs`. Internal tensors are allocated by the runtime from a ring buffer when passed to `add_output(var_ci)`.
+External tensors wrap device memory pointers passed from the host via `ChipStorageTaskArgs`. Internal tensors are pre-allocated at scope entry via `alloc_tensors()` — all `tensor.create` calls within the same scope (function body, for body, if body) are batched into a single `alloc_tensors` invocation. Pre-allocated tensors are then passed to kernels via `add_output(const Tensor&)` (OUTPUT_EXISTING overload).
 
 ### Parameter Direction
 
@@ -139,13 +139,13 @@ The `ParamDirection` of each function parameter determines how it appears in tas
 
 | Direction | Python Annotation | C++ Task Param | Semantics |
 | --------- | ----------------- | -------------- | --------- |
-| `In` | `pl.Tensor[...]` (default) | `params.add_input(ext_x)` | Read-only; if the tensor is from `pl.create_tensor`, uses `add_output` for first-time allocation |
+| `In` | `pl.Tensor[...]` (default) | `params.add_input(var)` | Read-only |
 | `Out` (external) | `pl.Out[pl.Tensor[...]]` (param) | `params.add_output(ext_x)` | Write-only pre-allocated buffer |
-| `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)` | Runtime ring-buffer alloc |
+| `Out` (internal) | `pl.Out[pl.Tensor[...]]` (tensor.create) | `params.add_output(x)` | Pre-allocated via `alloc_tensors`, uses OUTPUT_EXISTING overload |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | Read-write |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | Scalar constant (separate scalar slot) |
 
-When `add_output` is used, the submit call returns `TaskOutputTensors` and a `const Tensor& var = outs.get_ref(i)` binding is declared at the submit site.
+Internal tensors from `tensor.create` are pre-allocated at scope entry via `alloc_tensors()`. When passed to kernels, they use `add_output(const Tensor&)` which triggers the OUTPUT_EXISTING overload — the runtime reuses the pre-allocated buffer instead of allocating a new one.
 
 ### Scalar Parameter Encoding
 
@@ -223,7 +223,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR Operation | C++ Codegen | Description |
 | ------------ | ----------- | ----------- |
-| `tensor.create` | `TensorCreateInfo var_ci(...)` | Ring-buffer alloc info; `const Tensor& var` bound at submit |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` + `alloc_tensors(...)` | Scope-level batched alloc; `const Tensor& var = alloc_N.get_ref(i)` |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | Read scalar from host tensor |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
@@ -269,18 +269,19 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args) {
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // Internal tensor (intermediate) — only TensorCreateInfo declared here
-    uint32_t c_ci_shapes[2] = {16, 16};
-    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-
     PTO2_SCOPE() {
+        // Internal tensor — pre-allocated via alloc_tensors at scope entry
+        uint32_t c_ci_shapes[2] = {16, 16};
+        TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+        TaskOutputTensors alloc_0 = alloc_tensors(c_ci);
+        const Tensor& c = alloc_0.get_ref(0);
+
         // Task 0: kernel_add (a + b → c)
         Arg params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
-        params_t0.add_output(c_ci);
-        TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-        const Tensor& c = outs_t0.get_ref(0);  // non-DN: bind const ref at submit site
+        params_t0.add_output(c);
+        pto2_rt_submit_aiv_task(0, params_t0);
 
         // Task 1: kernel_add (c + b → d)
         Arg params_t1;
@@ -316,7 +317,7 @@ names in the output), but never for identity decisions.
 | Internal tensor | `<name>` (no prefix) | `c` |
 | Internal TensorCreateInfo | `<name>_ci` | `c_ci` |
 | Task params | `params_t<N>` | `params_t0` |
-| TaskOutputTensors | `outs_t<N>` | `outs_t0` |
+| Alloc result | `alloc_<N>` | `alloc_0` |
 | Tensor arg index | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
 | Scalar arg index | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -96,10 +96,11 @@ Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
 Tensor ext_dn = from_tensor_arg(orch_args.tensor(2));
 
 // 阶段 5：内部张量（来自 pl.create_tensor — 仅中间变量）
-// TensorCreateInfo 在此处生成，Tensor 变量在提交处绑定：
-//   const Tensor& tmp = outs_t0.get_ref(0);
+// 同一 scope 中的所有 tensor.create 批量合并为一条 alloc_tensors 调用
 uint32_t tmp_ci_shapes[2] = {16, 16};
 TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
+TaskOutputTensors alloc_0 = alloc_tensors(tmp_ci);
+const Tensor& tmp = alloc_0.get_ref(0);
 ```
 
 ### 阶段 6–8：任务提交与控制流
@@ -111,9 +112,8 @@ PTO2_SCOPE() {
     Arg params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
-    params_t0.add_output(tmp_ci);            // add_output 接受 TensorCreateInfo（内部张量）
-    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-    const Tensor& tmp = outs_t0.get_ref(0); // non-DN：在提交处绑定 const 引用
+    params_t0.add_output(tmp);               // 预分配张量使用 add_output(const Tensor&)
+    pto2_rt_submit_aiv_task(0, params_t0);
 
     // ForStmt 示例 — 普通 for 循环，不嵌套独立的 PTO2_SCOPE
     for (int64_t i = start; i < stop; i += step) {
@@ -129,9 +129,9 @@ PTO2_SCOPE() {
 | 类型 | 来源 | C++ 构造方式 | 命名 |
 | ---- | ---- | ------------ | ---- |
 | 外部（ND/DN） | 函数参数（`In`/`Out`/`InOut`） | `from_tensor_arg(orch_args.tensor(N))` | `ext_<name>` |
-| 内部 | 函数体中的 `pl.create_tensor(...)` | `TensorCreateInfo var_ci(...)` + 提交处 `const Tensor& var` 绑定 | `<name>`（无前缀） |
+| 内部 | 函数体中的 `pl.create_tensor(...)` | `TensorCreateInfo var_ci(...)` + scope 入口处 `alloc_tensors(...)` | `<name>`（无前缀） |
 
-外部张量封装从主机通过 `ChipStorageTaskArgs` 传入的设备内存指针。内部张量在传入 `add_output(var_ci)` 时由运行时从环形缓冲区分配。
+外部张量封装从主机通过 `ChipStorageTaskArgs` 传入的设备内存指针。内部张量在 scope 入口处通过 `alloc_tensors()` 预分配——同一 scope（函数体、for 循环体、if 分支体）中的所有 `tensor.create` 被批量合并为一条 `alloc_tensors` 调用。预分配的张量随后通过 `add_output(const Tensor&)` (OUTPUT_EXISTING 重载) 传递给核函数。
 
 ### 参数方向
 
@@ -139,13 +139,13 @@ PTO2_SCOPE() {
 
 | 方向 | Python 注解 | C++ 任务参数 | 语义 |
 | ---- | ----------- | ------------ | ---- |
-| `In` | `pl.Tensor[...]`（默认） | `params.add_input(ext_x)` | 只读；若为 `pl.create_tensor` 变量，首次使用改用 `add_output` 分配内存 |
+| `In` | `pl.Tensor[...]`（默认） | `params.add_input(var)` | 只读 |
 | `Out`（外部） | `pl.Out[pl.Tensor[...]]`（参数） | `params.add_output(ext_x)` | 只写预分配缓冲区 |
-| `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x_ci)` + `const Tensor& x = outs.get_ref(i)` | 运行时环形缓冲区分配 |
+| `Out`（内部） | `pl.Out[pl.Tensor[...]]`（tensor.create） | `params.add_output(x)` | 通过 `alloc_tensors` 预分配，使用 OUTPUT_EXISTING 重载 |
 | `InOut` | `pl.InOut[pl.Tensor[...]]` | `params.add_inout(ext_x)` | 读写 |
 | Scalar | `pl.Scalar[...]` | `params.add_scalar(value)` | 标量常量（独立 scalar 槽位） |
 
-使用 `add_output` 时，提交调用返回 `TaskOutputTensors`，并在提交处声明 `const Tensor& var = outs.get_ref(i)` 绑定。
+来自 `tensor.create` 的内部张量在 scope 入口通过 `alloc_tensors()` 预分配。传递给核函数时，使用 `add_output(const Tensor&)` 触发 OUTPUT_EXISTING 重载——运行时复用预分配的缓冲区，而非分配新的。
 
 ### 标量参数编码
 
@@ -223,7 +223,7 @@ pto2_rt_submit_task(mixed_0, params_t0);
 
 | IR 操作 | C++ 代码生成 | 描述 |
 | ------- | ------------ | ---- |
-| `tensor.create` | `TensorCreateInfo var_ci(...)` | 环形缓冲区分配信息；提交处 `const Tensor& var` 绑定 |
+| `tensor.create` | `TensorCreateInfo var_ci(...)` + `alloc_tensors(...)` | scope 级批量分配；`const Tensor& var = alloc_N.get_ref(i)` |
 | `tensor.read` | `*reinterpret_cast<T*>(arg_ptr + offset)` | 从主机张量读取标量 |
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
@@ -269,18 +269,19 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args) {
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_d = from_tensor_arg(orch_args.tensor(2));
 
-    // 内部张量（中间变量）— 此处仅声明 TensorCreateInfo
-    uint32_t c_ci_shapes[2] = {16, 16};
-    TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
-
     PTO2_SCOPE() {
+        // 内部张量 — 在 scope 入口通过 alloc_tensors 预分配
+        uint32_t c_ci_shapes[2] = {16, 16};
+        TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+        TaskOutputTensors alloc_0 = alloc_tensors(c_ci);
+        const Tensor& c = alloc_0.get_ref(0);
+
         // 任务 0: kernel_add (a + b → c)
         Arg params_t0;
         params_t0.add_input(ext_a);
         params_t0.add_input(ext_b);
-        params_t0.add_output(c_ci);
-        TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-        const Tensor& c = outs_t0.get_ref(0);  // non-DN：提交处绑定 const 引用
+        params_t0.add_output(c);
+        pto2_rt_submit_aiv_task(0, params_t0);
 
         // 任务 1: kernel_add (c + b → d)
         Arg params_t1;
@@ -315,7 +316,7 @@ void aicpu_orchestration_entry(const ChipStorageTaskArgs& orch_args) {
 | 内部张量 | `<name>`（无前缀） | `c` |
 | 内部 TensorCreateInfo | `<name>_ci` | `c_ci` |
 | 任务参数 | `params_t<N>` | `params_t0` |
-| TaskOutputTensors | `outs_t<N>` | `outs_t0` |
+| 分配结果 | `alloc_<N>` | `alloc_0` |
 | 张量参数索引 | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
 | 标量参数索引 | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 

--- a/examples/models/05_paged_attention_batch.py
+++ b/examples/models/05_paged_attention_batch.py
@@ -35,8 +35,6 @@ Pipeline per KV block iteration (all batches processed in a single kernel call):
   4. Online Update (AIV):    mi, li, oi, out = KernelOnlineUpdate(mij, lij, oi_new, mi, li, oi, out, ...)
 
 Kernel mapping to C++ implementations:
-  KernelAicHub         -> kernels/aic/aic_hub.cpp          (func_id=4)
-  KernelAivHub         -> kernels/aiv/aiv_hub.cpp          (func_id=5)
   KernelQkMatmul       -> kernels/aic/aic_qk_matmul.cpp   (func_id=0)
   KernelSoftmaxPrepare -> kernels/aiv/aiv_softmax_prepare.cpp (func_id=1)
   KernelPvMatmul       -> kernels/aic/aic_pv_matmul.cpp   (func_id=2)
@@ -82,26 +80,6 @@ def BuildBatchPagedAttentionProgram(
     @pl.program
     class BatchPagedAttentionProgram:
         """Batch paged attention with AIC (CUBE) and AIV (VECTOR) kernels."""
-
-        # ── AIC hub kernel (placeholder for AIC-side synchronisation) ────
-        @pl.function(type=pl.FunctionType.InCore)
-        def KernelAicHub(self) -> None:
-            """AIC hub: empty placeholder (func_id=4)."""
-
-        # ── AIV hub kernel: zero-initialise batch-sized accumulators ─────
-        @pl.function(type=pl.FunctionType.InCore)
-        def KernelAivHub(
-            self,
-            oi_batch: pl.Out[pl.Tensor[[batch_q_tile, head_dim], pl.FP32]],
-            li_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
-            mi_batch: pl.Out[pl.Tensor[[batch_q_tile, 1], pl.FP32]],
-        ) -> tuple[
-            pl.Tensor[[batch_q_tile, head_dim], pl.FP32],
-            pl.Tensor[[batch_q_tile, 1], pl.FP32],
-            pl.Tensor[[batch_q_tile, 1], pl.FP32],
-        ]:
-            """AIV hub: zero-initialise inplace accumulators (func_id=5)."""
-            return oi_batch, li_batch, mi_batch
 
         # ── CUBE kernel: QK matmul ──────────────────────────────────────
         # C++ params: query(in), key_cache(in), sij_batch(out),
@@ -434,9 +412,6 @@ def BuildBatchPagedAttentionProgram(
                 oi_batch = pl.create_tensor([batch_cfg * q_tile, head_dim_cfg], dtype=pl.FP32)
                 li_batch = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
                 mi_batch = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
-
-                # Zero-init accumulators via AIV hub (FUNC_AIV_HUB)
-                oi_batch, li_batch, mi_batch = self.KernelAivHub(oi_batch, li_batch, mi_batch)
 
                 for bn in pl.range(max_bn):
                     # Batch-sized intermediate tensors (mirrors C++ sij_b/pij_b/etc.)

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -31,7 +31,7 @@ Tile dimensions (matching multi-config Case2, q_tile=16):
   Online Update:   operates on (16, 128) data tiles, (16, 1) scalar tiles
 
 Module-level InCore kernels (reusable, importable):
-  kernel_aiv_hub, kernel_softmax_prepare, kernel_online_update
+  kernel_softmax_prepare, kernel_online_update
 
 Factory functions for batch-dynamic kernels:
   make_kernel_qk_matmul(key_cache_rows)
@@ -56,25 +56,6 @@ N_UNROLL_Q = N_UNROLL * Q_TILE  # 1024 — static sij/pij buffer height
 
 
 # ── Kernel factory functions ──────────────────────────────────────────────────
-
-
-def make_kernel_aiv_hub(q_tile: int, head_dim: int):
-    """Create aiv_hub InCore kernel with parameterised tile dimensions."""
-
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_aiv_hub(
-        oi: pl.Out[pl.Tensor[[q_tile, head_dim], pl.FP32]],
-        li: pl.Out[pl.Tensor[[q_tile, 1], pl.FP32]],
-        mi: pl.Out[pl.Tensor[[q_tile, 1], pl.FP32]],
-    ) -> tuple[
-        pl.Tensor[[q_tile, head_dim], pl.FP32],
-        pl.Tensor[[q_tile, 1], pl.FP32],
-        pl.Tensor[[q_tile, 1], pl.FP32],
-    ]:
-        """Initialize inplace accumulators to zero (VECTOR)."""
-        return oi, li, mi
-
-    return kernel_aiv_hub
 
 
 def make_kernel_softmax_prepare(q_tile: int, block_size: int, n_unroll_q: int):
@@ -272,7 +253,6 @@ def make_kernel_online_update(q_tile: int, head_dim: int):
 
 
 # ── Module-level kernel instances (backward-compatible imports) ───────────────
-kernel_aiv_hub = make_kernel_aiv_hub(Q_TILE, HEAD_DIM)
 kernel_softmax_prepare = make_kernel_softmax_prepare(Q_TILE, BLOCK_SIZE, N_UNROLL_Q)
 kernel_online_update = make_kernel_online_update(Q_TILE, HEAD_DIM)
 
@@ -466,7 +446,6 @@ def build_paged_attention_multi_config_program(
     out_rows = batch * num_heads
     block_table_flat_size = batch * max_num_blocks_per_req
 
-    _hub = make_kernel_aiv_hub(q_tile, head_dim)
     _sf = make_kernel_softmax_prepare(q_tile, block_size, n_unroll_q)
     _up = make_kernel_online_update(q_tile, head_dim)
     _qk = make_kernel_qk_matmul(key_cache_rows, q_tile, head_dim, block_size, n_unroll, n_unroll_q)
@@ -509,7 +488,6 @@ def build_paged_attention_multi_config_program(
                     oi = pl.create_tensor([q_tile, head_dim], dtype=pl.FP32)
                     li_update = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
                     mi_update = pl.create_tensor([q_tile, 1], dtype=pl.FP32)
-                    oi, li_update, mi_update = _hub(oi, li_update, mi_update)
 
                     qi = pl.slice(query, [q_tile, head_dim], [cur_offset, 0])
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -178,10 +178,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetCallToTupleKey(const std::map<const Call*, std::string>& mapping) { call_to_tuple_key_ = mapping; }
 
-  void SetEscapingLoopReturns(const std::unordered_set<const Var*>& returns) {
-    escaping_loop_returns_ = returns;
-  }
-
   void SetInitialIndent(int indent) { indent_ = indent; }
 
   std::string GetGeneratedCode() const { return code_.str(); }
@@ -198,10 +194,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return ci->value_;
   }
   std::string GetVarName(const VarPtr& var) const override {
-    auto escaped_it = escaped_loop_return_exprs_.find(var.get());
-    if (escaped_it != escaped_loop_return_exprs_.end()) {
-      return escaped_it->second;
-    }
     auto it = emit_name_map_.find(var.get());
     if (it != emit_name_map_.end()) {
       return it->second;
@@ -250,25 +242,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
           << "Internal error: ForStmt iter_arg initValue must be a variable, got non-variable expr";
       emit_name_map_[iter_arg.get()] = init_var_name;
       emit_name_map_[return_var.get()] = init_var_name;
-      auto tensor_type = As<TensorType>(return_var->GetType());
-      auto init_var = AsVarLike(iter_arg->initValue_);
-      // Transfer create-pending status from init_var to iter_arg.
-      // init_var is only referenced at the loop boundary; iter_arg is what
-      // BuildTaskParams will see when the var is passed inside the loop body.
-      bool is_create_pending = init_var && tensor_create_var_names_.count(init_var.get()) > 0;
-      if (is_create_pending) {
-        tensor_create_var_names_.erase(init_var.get());
-        tensor_create_var_names_.insert(iter_arg.get());
-      }
-      if (escaping_loop_returns_.count(return_var.get()) > 0 && is_create_pending) {
-        std::string state_name = ReserveSyntheticEmitName(init_var_name + "__loop_state");
-        INTERNAL_CHECK(tensor_type) << "Internal error: escaping loop-carried output must be a tensor";
-        code_ << Indent() << "Tensor " << state_name << " = make_tensor_external(nullptr, " << init_var_name
-              << "_ci_shapes, " << tensor_type->shape_.size() << ", "
-              << GetRuntimeDataTypeString(tensor_type->dtype_) << ");\n";
-        active_loop_output_states_[init_var_name] = state_name;
-        escaped_loop_return_exprs_[return_var.get()] = state_name;
-      }
     }
 
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
@@ -278,11 +251,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     indent_ += 4;
 
     auto saved = current_return_vars_;
-    auto saved_active_loop_output_states = active_loop_output_states_;
     current_return_vars_.clear();
     VisitStmt(for_stmt->body_);
     current_return_vars_ = saved;
-    active_loop_output_states_ = saved_active_loop_output_states;
 
     indent_ -= 4;
     code_ << Indent() << "}\n";
@@ -352,7 +323,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void VisitStmt_(const SeqStmtsPtr& seq) override {
+    EmitBatchedAllocTensors(seq->stmts_);
     for (const auto& stmt : seq->stmts_) {
+      if (batched_create_stmts_.count(stmt.get())) continue;
       VisitStmt(stmt);
     }
   }
@@ -431,14 +404,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   struct ParamEntry {
     ParamKind kind;
-    std::string value;    // expression passed to the method
-    std::string out_var;  // non-empty for internal Out tensors: the Tensor variable to bind via get_ref
-    const Var* out_var_ptr = nullptr;  // raw pointer into tensor_create_var_names_
-  };
-
-  struct InternalOutVar {
-    std::string name;
-    const Var* var_ptr = nullptr;
+    std::string value;
   };
 
   std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
@@ -451,40 +417,26 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (!var_name.empty()) {
         if (auto scalar_type = As<ScalarType>(arg->GetType())) {
           std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-          params.push_back({ParamKind::Scalar, EncodeScalarVar(var_name, cpp_type), ""});
+          params.push_back({ParamKind::Scalar, EncodeScalarVar(var_name, cpp_type)});
           continue;
         }
 
         std::string ext_name = GetExternalTensorName(var_name);
-        auto arg_var = AsVarLike(arg);
 
         INTERNAL_CHECK(arg_idx < callee_func->param_directions_.size())
             << "arg count (" << call->args_.size() << ") exceeds param count ("
             << callee_func->param_directions_.size() << ") for callee '" << callee_name << "'";
 
-        // Push an "add_output" entry for a tensor.create-allocated argument.
-        auto push_create_output = [&]() {
-          params.push_back({ParamKind::Output, var_name + "_ci", var_name, arg_var.get()});
-        };
-
         ParamDirection dir = callee_func->param_directions_[arg_idx];
         switch (dir) {
           case ParamDirection::Out:
-            if (arg_var && tensor_create_var_names_.count(arg_var.get())) {
-              push_create_output();
-            } else {
-              params.push_back({ParamKind::Output, ext_name, ""});
-            }
+            params.push_back({ParamKind::Output, ext_name});
             break;
           case ParamDirection::InOut:
-            params.push_back({ParamKind::InOut, ext_name, ""});
+            params.push_back({ParamKind::InOut, ext_name});
             break;
           case ParamDirection::In:
-            if (arg_var && tensor_create_var_names_.count(arg_var.get())) {
-              push_create_output();
-            } else {
-              params.push_back({ParamKind::Input, ext_name, ""});
-            }
+            params.push_back({ParamKind::Input, ext_name});
             break;
           default:
             INTERNAL_CHECK(false) << "Internal error: unexpected ParamDirection value "
@@ -493,13 +445,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
       } else if (auto const_int = As<ConstInt>(arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
-        params.push_back({ParamKind::Scalar, "(uint64_t)" + value, ""});
+        params.push_back({ParamKind::Scalar, "(uint64_t)" + value});
       } else if (auto const_float = As<ConstFloat>(arg)) {
         std::string cpp_type = const_float->dtype().ToCTypeString();
         std::string value = FormatConstFloatValue(const_float, cpp_type);
-        params.push_back({ParamKind::Scalar, EncodeScalarConst(value, cpp_type), ""});
+        params.push_back({ParamKind::Scalar, EncodeScalarConst(value, cpp_type)});
       } else if (auto const_bool = As<ConstBool>(arg)) {
-        params.push_back({ParamKind::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0", ""});
+        params.push_back({ParamKind::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
       }
     }
 
@@ -531,9 +483,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     current_result_var_ = emit_var;
 
-    if (op_name == "tensor.create" && assign_var) {
-      tensor_create_var_names_.insert(assign_var.get());
-    }
     std::string gen_code = (*codegen_func)(call, *this);
 
     std::istringstream iss(gen_code);
@@ -542,6 +491,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (!line.empty()) {
         code_ << Indent() << line << "\n";
       }
+    }
+
+    if (op_name == "tensor.create") {
+      EmitAllocBatch({emit_var});
     }
   }
 
@@ -576,32 +529,124 @@ class OrchestrationStmtCodegen : public CodegenBase {
     aiv_name = std::move(finder.aiv_name);
   }
 
-  void EmitTaskSubmitAndBind(const std::string& submit_expr, const std::vector<ParamEntry>& params) {
-    std::vector<InternalOutVar> internal_out_vars;
-    for (const auto& p : params) {
-      if (p.kind == ParamKind::Output && !p.out_var.empty()) {
-        internal_out_vars.push_back({p.out_var, p.out_var_ptr});
-      }
-    }
-
-    std::string ind = Indent();
-    if (internal_out_vars.empty()) {
-      code_ << ind << submit_expr << ";\n";
-    } else {
-      std::string outs_var = "outs_t" + std::to_string(task_counter_);
-      code_ << ind << "TaskOutputTensors " << outs_var << " = " << submit_expr << ";\n";
-      for (size_t i = 0; i < internal_out_vars.size(); ++i) {
-        const auto& ov = internal_out_vars[i];
-        code_ << ind << "const Tensor& " << ov.name << " = " << outs_var << ".get_ref(" << i << ");\n";
-        auto state_it = active_loop_output_states_.find(ov.name);
-        if (state_it != active_loop_output_states_.end()) {
-          code_ << ind << state_it->second << " = " << ov.name << ";\n";
-        }
-        if (ov.var_ptr) tensor_create_var_names_.erase(ov.var_ptr);
-      }
-    }
-
+  void EmitTaskSubmitAndBind(const std::string& submit_expr) {
+    code_ << Indent() << submit_expr << ";\n";
     task_counter_++;
+  }
+
+  static constexpr size_t kMaxAllocTensorsArgs = 16;
+
+  static bool ExprRefsAnyOf(const ExprPtr& expr, const std::unordered_set<const Var*>& vars) {
+    if (!expr) {
+      return false;
+    }
+    if (auto var = As<Var>(expr)) {
+      return vars.count(var.get()) > 0;
+    }
+    if (auto bin = As<BinaryExpr>(expr)) {
+      return ExprRefsAnyOf(bin->left_, vars) || ExprRefsAnyOf(bin->right_, vars);
+    }
+    if (auto un = As<UnaryExpr>(expr)) {
+      return ExprRefsAnyOf(un->operand_, vars);
+    }
+    if (auto cast_expr = As<Cast>(expr)) {
+      return ExprRefsAnyOf(cast_expr->operand_, vars);
+    }
+    return false;
+  }
+
+  bool ShapeDependsOnLocalVars(const CallPtr& call,
+                               const std::unordered_set<const Var*>& locally_defined) const {
+    auto result_type = As<TensorType>(call->GetType());
+    if (!result_type) {
+      return false;
+    }
+    for (const auto& dim : result_type->shape_) {
+      if (ExprRefsAnyOf(dim, locally_defined)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void EmitAllocBatch(const std::vector<std::string>& emit_names) {
+    std::string alloc_var = "alloc_" + std::to_string(alloc_counter_++);
+    code_ << Indent() << "TaskOutputTensors " << alloc_var << " = alloc_tensors(";
+    for (size_t i = 0; i < emit_names.size(); i++) {
+      if (i > 0) {
+        code_ << ", ";
+      }
+      code_ << emit_names[i] << "_ci";
+    }
+    code_ << ");\n";
+
+    for (size_t i = 0; i < emit_names.size(); i++) {
+      code_ << Indent() << "const Tensor& " << emit_names[i] << " = " << alloc_var << ".get_ref(" << i
+            << ");\n";
+    }
+  }
+
+  void EmitBatchedAllocTensors(const std::vector<StmtPtr>& stmts) {
+    struct PendingCreate {
+      std::string emit_name;
+      CallPtr call;
+    };
+    std::vector<PendingCreate> creates;
+
+    std::unordered_set<const Var*> locally_defined;
+
+    for (const auto& stmt : stmts) {
+      auto assign = As<AssignStmt>(stmt);
+      if (!assign) {
+        continue;
+      }
+      auto call = As<Call>(assign->value_);
+      if (!call || call->op_->name_ != "tensor.create") {
+        locally_defined.insert(assign->var_.get());
+        continue;
+      }
+      if (declared_var_ptrs_.count(assign->var_.get()) || param_name_set_.count(GetVarName(assign->var_))) {
+        continue;
+      }
+      if (ShapeDependsOnLocalVars(call, locally_defined)) {
+        locally_defined.insert(assign->var_.get());
+        continue;
+      }
+
+      declared_var_ptrs_.insert(assign->var_.get());
+      std::string emit_var = ReserveVarEmitName(assign->var_.get());
+      creates.push_back({emit_var, call});
+      batched_create_stmts_.insert(stmt.get());
+    }
+    if (creates.empty()) {
+      return;
+    }
+
+    auto& registry = OrchestrationOpRegistry::GetInstance();
+    auto handler = registry.Get("tensor.create");
+    INTERNAL_CHECK(handler.has_value()) << "Internal error: tensor.create handler not registered";
+
+    for (size_t batch_start = 0; batch_start < creates.size(); batch_start += kMaxAllocTensorsArgs) {
+      size_t batch_end = std::min(batch_start + kMaxAllocTensorsArgs, creates.size());
+
+      for (size_t i = batch_start; i < batch_end; i++) {
+        current_result_var_ = creates[i].emit_name;
+        std::string gen_code = (*handler)(creates[i].call, *this);
+        std::istringstream iss(gen_code);
+        std::string line;
+        while (std::getline(iss, line)) {
+          if (!line.empty()) {
+            code_ << Indent() << line << "\n";
+          }
+        }
+      }
+
+      std::vector<std::string> batch_names;
+      for (size_t i = batch_start; i < batch_end; i++) {
+        batch_names.push_back(creates[i].emit_name);
+      }
+      EmitAllocBatch(batch_names);
+    }
   }
 
   void GenerateFunctionCallCode(const CallPtr& call, const std::string& result_var) {
@@ -634,7 +679,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
-    EmitTaskSubmitAndBind(submit_expr, params);
+    EmitTaskSubmitAndBind(submit_expr);
   }
 
   void GenerateGroupCallCode(const CallPtr& call, const FunctionPtr& group_func) {
@@ -680,7 +725,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     std::string submit_expr =
         "pto2_rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";
-    EmitTaskSubmitAndBind(submit_expr, params);
+    EmitTaskSubmitAndBind(submit_expr);
   }
 
   // --- Alias generation helpers ---
@@ -791,18 +836,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::set<std::string> declared_var_names_;
   std::set<std::string> param_name_set_;
   std::map<std::string, int> param_name_to_orch_index_;
-  std::unordered_set<const Var*> tensor_create_var_names_;
   std::ostringstream code_;
   int indent_ = 4;
   std::string current_result_var_;
   std::vector<VarPtr> current_return_vars_;
   int task_counter_ = 0;
+  int alloc_counter_ = 0;
   std::map<std::string, std::vector<TupleElement>> tuple_var_to_elements_;
   std::map<const Call*, std::string> call_to_tuple_key_;
-  std::unordered_set<const Var*> escaping_loop_returns_;
-  std::unordered_map<const Var*, std::string> escaped_loop_return_exprs_;
-  std::unordered_map<std::string, std::string> active_loop_output_states_;
   std::unordered_set<const Var*> declared_var_ptrs_;
+  std::unordered_set<const Stmt*> batched_create_stmts_;
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {
@@ -821,9 +864,6 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   VarLineageCollector lineage;
   lineage.Initialize(func->params_);
   lineage.VisitStmt(func->body_);
-
-  LoopEscapeInfoCollector loop_escape_info;
-  loop_escape_info.VisitStmt(func->body_);
 
   std::unordered_map<const Var*, std::string> emit_name_map;
   std::set<std::string> param_name_set;
@@ -864,7 +904,6 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
                                         std::move(param_name_to_orch_index));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
-  stmt_codegen.SetEscapingLoopReturns(loop_escape_info.escaping_loop_returns);
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -59,9 +59,9 @@ static std::string CalculateTensorSizeExpr(const TensorTypePtr& tensor_type, Cod
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
-  // tensor.create emits TensorCreateInfo for runtime memory allocation via add_output().
-  // The Tensor binding is emitted at the task submission site:
-  //   const Tensor& var = outs_tN.get_ref(i);
+  // tensor.create emits TensorCreateInfo for runtime memory allocation via alloc_tensors().
+  // The batched alloc_tensors call and const Tensor& binding are emitted by
+  // EmitBatchedAllocTensors at scope entry (SeqStmts).
   auto result_type = As<TensorType>(op->GetType());
   CHECK(result_type) << "tensor.create must return TensorType";
 

--- a/tests/st/codegen/test_paged_attention_multi_config.py
+++ b/tests/st/codegen/test_paged_attention_multi_config.py
@@ -15,7 +15,6 @@ Orchestration pre-extracts block_indices via pl.slice() from block_table.
 Kernels receive block_indices tensor view instead of block_table + bt_offset.
 
 Module-level InCore kernels:
-  kernel_aiv_hub:         Zero-initialise oi, li, mi accumulators
   kernel_softmax_prepare: Two-pass softmax across n_blocks (global row_max, then exp+sum)
   kernel_online_update:   Online softmax update with inplace mi/li/oi
 
@@ -37,7 +36,6 @@ from examples.models.paged_attention_multi_config import (
     N_UNROLL_Q,
     Q_TILE,
     build_paged_attention_multi_config_program,
-    kernel_aiv_hub,
     kernel_online_update,
     kernel_softmax_prepare,
     make_kernel_pv_matmul,
@@ -46,47 +44,6 @@ from examples.models.paged_attention_multi_config import (
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-
-
-class AivHubTestCase(PTOTestCase):
-    """Test case for kernel_aiv_hub: zero-initialise oi, li, mi accumulators.
-
-    Verifies that all three output tensors are set to zero.
-    """
-
-    def get_name(self) -> str:
-        return "aiv_hub_zero_init"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("oi", [Q_TILE, HEAD_DIM], DataType.FP32, is_output=True),
-            TensorSpec("li", [Q_TILE, 1], DataType.FP32, is_output=True),
-            TensorSpec("mi", [Q_TILE, 1], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        @pl.program
-        class AivHubProgram:
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def orchestrator(
-                self,
-                oi: pl.Out[pl.Tensor[[Q_TILE, HEAD_DIM], pl.FP32]],
-                li: pl.Out[pl.Tensor[[Q_TILE, 1], pl.FP32]],
-                mi: pl.Out[pl.Tensor[[Q_TILE, 1], pl.FP32]],
-            ) -> tuple[
-                pl.Tensor[[Q_TILE, HEAD_DIM], pl.FP32],
-                pl.Tensor[[Q_TILE, 1], pl.FP32],
-                pl.Tensor[[Q_TILE, 1], pl.FP32],
-            ]:
-                oi, li, mi = kernel_aiv_hub(oi, li, mi)
-                return oi, li, mi
-
-        return AivHubProgram
-
-    def compute_expected(self, tensors, params=None):
-        tensors["oi"][:] = torch.zeros(16, 128, dtype=torch.float32)
-        tensors["li"][:] = torch.zeros(16, 1, dtype=torch.float32)
-        tensors["mi"][:] = torch.zeros(16, 1, dtype=torch.float32)
 
 
 class SoftmaxPrepareTestCase(PTOTestCase):
@@ -648,13 +605,6 @@ class PTOASTestCaseMixin:
         return BackendType.Ascend910B
 
 
-class AivHubPTOASTestCase(PTOASTestCaseMixin, AivHubTestCase):
-    """Test aiv_hub with PTO backend and Default optimization strategy."""
-
-    def get_name(self) -> str:
-        return "aiv_hub_ptoas_zero_init"
-
-
 class SoftmaxPreparePTOASTestCase(PTOASTestCaseMixin, SoftmaxPrepareTestCase):
     """Test softmax prepare with PTO backend and Default optimization strategy."""
 
@@ -702,12 +652,6 @@ class TestPagedAttentionMultiConfigKernels:
     Each test instantiates the corresponding PTOTestCase and runs it through
     the test_runner fixture.
     """
-
-    def test_aiv_hub_ptoas(self, test_runner):
-        """Test aiv_hub with PTO backend and Default optimization."""
-        test_case = AivHubPTOASTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Aiv hub PTOAS test failed: {result.error}"
 
     @pytest.mark.parametrize("n_blocks", [1, 2, 4])
     def test_softmax_prepare_ptoas(self, test_runner, n_blocks):

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -119,14 +119,15 @@ class TestOrchestration:
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+                    TaskOutputTensors alloc_0 = alloc_tensors(c_ci);
+                    const Tensor& c = alloc_0.get_ref(0);
 
                     // Task 0: kernel_add
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c_ci);
-                    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-                    const Tensor& c = outs_t0.get_ref(0);
+                    params_t0.add_output(c);
+                    pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add
                     Arg params_t1;
@@ -361,44 +362,45 @@ class TestOrchestration:
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
+                    uint32_t d_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo d_ci(d_ci_shapes, 2, DataType::FLOAT32);
+                    uint32_t e_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo e_ci(e_ci_shapes, 2, DataType::FLOAT32);
+                    uint32_t g_ci_shapes[2] = {16, 16};
+                    TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
+                    TaskOutputTensors alloc_0 = alloc_tensors(c_ci, d_ci, e_ci, g_ci);
+                    const Tensor& c = alloc_0.get_ref(0);
+                    const Tensor& d = alloc_0.get_ref(1);
+                    const Tensor& e = alloc_0.get_ref(2);
+                    const Tensor& g = alloc_0.get_ref(3);
 
                     // Task 0: kernel_add
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c_ci);
-                    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);
-                    const Tensor& c = outs_t0.get_ref(0);
-                    uint32_t d_ci_shapes[2] = {16, 16};
-                    TensorCreateInfo d_ci(d_ci_shapes, 2, DataType::FLOAT32);
+                    params_t0.add_output(c);
+                    pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add_scalar
                     Arg params_t1;
                     params_t1.add_input(c);
-                    params_t1.add_output(d_ci);
+                    params_t1.add_output(d);
                     params_t1.add_scalar(to_u64(1.000000f));
-                    TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);
-                    const Tensor& d = outs_t1.get_ref(0);
-                    uint32_t e_ci_shapes[2] = {16, 16};
-                    TensorCreateInfo e_ci(e_ci_shapes, 2, DataType::FLOAT32);
+                    pto2_rt_submit_aiv_task(1, params_t1);
 
                     // Task 2: kernel_add_scalar
                     Arg params_t2;
                     params_t2.add_input(c);
-                    params_t2.add_output(e_ci);
+                    params_t2.add_output(e);
                     params_t2.add_scalar(to_u64(2.000000f));
-                    TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);
-                    const Tensor& e = outs_t2.get_ref(0);
-                    uint32_t g_ci_shapes[2] = {16, 16};
-                    TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
+                    pto2_rt_submit_aiv_task(1, params_t2);
 
                     // Task 3: kernel_mul
                     Arg params_t3;
                     params_t3.add_input(d);
                     params_t3.add_input(e);
-                    params_t3.add_output(g_ci);
-                    TaskOutputTensors outs_t3 = pto2_rt_submit_aiv_task(2, params_t3);
-                    const Tensor& g = outs_t3.get_ref(0);
+                    params_t3.add_output(g);
+                    pto2_rt_submit_aiv_task(2, params_t3);
 
                     // Task 4: kernel_add
                     Arg params_t4;
@@ -1141,14 +1143,11 @@ class TestOrchestration:
         transformed = pm.run_passes(LoopCarriedStateProgram)
         code = _generate_orch_code(transformed)
 
-        assert (
-            "Tensor acc__loop_state = make_tensor_external(nullptr, acc_ci_shapes, 2, DataType::FLOAT32);"
-            in code
-        )
-        assert "const Tensor& acc = outs_t0.get_ref(0);" in code
-        assert "acc__loop_state = acc;" in code
-        assert "params_t1.add_input(acc__loop_state);" in code
-        assert "params_t1.add_input(acc);" not in code
+        assert "alloc_tensors(acc_ci)" in code
+        assert "const Tensor& acc = alloc_0.get_ref(0);" in code
+        assert "make_tensor_external(nullptr" not in code
+        assert "acc__loop_state" not in code
+        assert "params_t1.add_input(acc);" in code
 
     def test_for_loop_with_inplace_return_after_passes(self):
         """Test inplace detection when return var has compound auto-name suffixes from pass pipeline.
@@ -1399,11 +1398,229 @@ class TestOrchestration:
 
         assert code.count("TensorCreateInfo ret0__out_ci(") == 1
         assert code.count("TensorCreateInfo ret0__out_1_ci(") == 1
-        assert "params_t0.add_output(ret0__out_ci)" in code
-        assert "params_t1.add_output(ret0__out_1_ci)" in code
+        assert "alloc_tensors(ret0__out_ci, ret0__out_1_ci)" in code
+        assert "params_t0.add_output(ret0__out)" in code
+        assert "params_t1.add_output(ret0__out_1)" in code
         assert "const Tensor& first = ret0__out;" in code
         assert "const Tensor& second = ret0__out_1;" in code
-        assert "add_output(ret0)" not in code
+
+    def test_multi_scope_alloc_tensors_batching(self):
+        """Each scope (function body, for body) batches its own alloc_tensors independently."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class MultiScopeAllocProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_op(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                y: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                # Outer scope: 2 create_tensor -> batched into alloc_0
+                t1: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                t2: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                t1 = self.kernel_op(x, y, t1)
+                t2 = self.kernel_op(t1, x, t2)
+                for i in pl.range(4):
+                    # Inner scope (for body): 1 create_tensor -> batched into alloc_1
+                    tmp: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                    tmp = self.kernel_op(t2, y, tmp)
+                    t2 = self.kernel_op(tmp, t1, t2)
+                out = self.kernel_op(t2, t1, out)
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(MultiScopeAllocProgram)
+        code = _generate_orch_code(transformed)
+
+        # Outer scope batches t1 and t2 together
+        assert "alloc_tensors(t1_ci, t2_ci)" in code
+        # Inner scope (for body) has its own alloc_tensors for tmp
+        assert "alloc_tensors(tmp_ci)" in code
+        # Two separate alloc_tensors calls (alloc_0 and alloc_1)
+        assert "alloc_0 = alloc_tensors(" in code
+        assert "alloc_1 = alloc_tensors(" in code
+        # Verify bindings from each alloc
+        assert "const Tensor& t1 = alloc_0.get_ref(0);" in code
+        assert "const Tensor& t2 = alloc_0.get_ref(1);" in code
+        assert "const Tensor& tmp = alloc_1.get_ref(0);" in code
+
+    def test_alloc_tensors_splits_at_16(self):
+        """More than 16 create_tensor in one scope are split into multiple alloc_tensors calls."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ManyCreateProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_copy(
+                self,
+                x: pl.Tensor[[8], pl.FP32],
+                out: pl.Out[pl.Tensor[[8], pl.FP32]],
+            ) -> pl.Tensor[[8], pl.FP32]:
+                t: pl.Tile[[8], pl.FP32] = pl.load(x, [0], [8])
+                r: pl.Tensor[[8], pl.FP32] = pl.store(t, [0], out)
+                return r
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                src: pl.Tensor[[8], pl.FP32],
+                dst: pl.Out[pl.Tensor[[8], pl.FP32]],
+            ) -> pl.Tensor[[8], pl.FP32]:
+                t0: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t1: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t2: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t3: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t4: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t5: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t6: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t7: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t8: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t9: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t10: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t11: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t12: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t13: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t14: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t15: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t16: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t17: pl.Tensor[[8], pl.FP32] = pl.create_tensor([8], dtype=pl.FP32)
+                t0 = self.kernel_copy(src, t0)
+                t1 = self.kernel_copy(t0, t1)
+                t2 = self.kernel_copy(t1, t2)
+                t3 = self.kernel_copy(t2, t3)
+                t4 = self.kernel_copy(t3, t4)
+                t5 = self.kernel_copy(t4, t5)
+                t6 = self.kernel_copy(t5, t6)
+                t7 = self.kernel_copy(t6, t7)
+                t8 = self.kernel_copy(t7, t8)
+                t9 = self.kernel_copy(t8, t9)
+                t10 = self.kernel_copy(t9, t10)
+                t11 = self.kernel_copy(t10, t11)
+                t12 = self.kernel_copy(t11, t12)
+                t13 = self.kernel_copy(t12, t13)
+                t14 = self.kernel_copy(t13, t14)
+                t15 = self.kernel_copy(t14, t15)
+                t16 = self.kernel_copy(t15, t16)
+                t17 = self.kernel_copy(t16, t17)
+                dst = self.kernel_copy(t17, dst)
+                return dst
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(ManyCreateProgram)
+        code = _generate_orch_code(transformed)
+
+        # First batch: 16 tensors
+        assert "alloc_0 = alloc_tensors(" in code
+        first_alloc_line = [line for line in code.splitlines() if "alloc_0 = alloc_tensors(" in line][0]
+        assert first_alloc_line.count("_ci") == 16
+
+        # Second batch: remaining 2 tensors
+        assert "alloc_1 = alloc_tensors(" in code
+        second_alloc_line = [line for line in code.splitlines() if "alloc_1 = alloc_tensors(" in line][0]
+        assert second_alloc_line.count("_ci") == 2
+
+        # Second batch get_ref indices reset to 0
+        assert "alloc_1.get_ref(0)" in code
+        assert "alloc_1.get_ref(1)" in code
+
+    def test_create_tensor_with_local_shape_dep_not_hoisted(self):
+        """create_tensor whose shape depends on a locally-defined variable is not hoisted.
+
+        Constructs IR directly where a tensor.create has a shape referencing a
+        Var defined by an earlier statement. Verifies the create is emitted
+        in-place (its own alloc_tensors) rather than batched at scope entry.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        from pypto.pypto_core import DataType
+
+        span = ir.Span.unknown()
+        INDEX = DataType.INDEX
+        FP32 = DataType.FP32
+        dyn_n = ir.Var("n", ir.ScalarType(INDEX), span)
+        dim_expr = ir.Mul(dyn_n, ir.ConstInt(16, INDEX, span), INDEX, span)
+
+        tensor_create_op = ir.Op("tensor.create")
+        static_create_call = ir.Call(
+            tensor_create_op,
+            [],
+            ir.TensorType([16, 8], FP32),
+            span,
+        )
+        dyn_create_call = ir.Call(
+            tensor_create_op,
+            [],
+            ir.TensorType([dim_expr, ir.ConstInt(8, INDEX, span)], FP32),
+            span,
+        )
+
+        t1_var = ir.Var("t1", ir.TensorType([16, 8], FP32), span)
+        t2_var = ir.Var(
+            "t2",
+            ir.TensorType([dim_expr, ir.ConstInt(8, INDEX, span)], FP32),
+            span,
+        )
+
+        stmts = [
+            ir.AssignStmt(t1_var, static_create_call, span),
+            ir.AssignStmt(dyn_n, ir.ConstInt(4, INDEX, span), span),
+            ir.AssignStmt(t2_var, dyn_create_call, span),
+            ir.ReturnStmt(span),
+        ]
+        body = ir.SeqStmts(stmts, span)
+
+        func = ir.Function(
+            "orch",
+            [],
+            [],
+            body,
+            span,
+            type=ir.FunctionType.Orchestration,
+        )
+        program = ir.Program([func], "test_prog", span)
+
+        code = codegen.generate_orchestration(program, func).code
+        lines = code.splitlines()
+
+        def line_index_containing(text):
+            for i, line in enumerate(lines):
+                if text in line:
+                    return i
+            return -1
+
+        # t1 (constant shape) is batched at scope entry
+        assert line_index_containing("alloc_tensors(t1_ci)") >= 0
+
+        # n must be defined BEFORE t2_ci
+        n_line = line_index_containing("int64_t n =")
+        t2_ci_line = line_index_containing("TensorCreateInfo t2_ci(")
+        assert n_line >= 0 and t2_ci_line >= 0
+        assert n_line < t2_ci_line, f"n definition (line {n_line}) must precede t2_ci (line {t2_ci_line})"
+
+        # t2 gets its own alloc_tensors, separate from t1
+        t2_alloc_line = line_index_containing("alloc_tensors(t2_ci)")
+        assert t2_alloc_line >= 0, "t2 should get its own alloc_tensors(t2_ci)"
+        assert t2_alloc_line > n_line, "t2 alloc must come after n definition"
 
     def test_scalar_taskarg(self):
         """Scalar params get ChipStorageTaskArgs scalar slots (0-indexed) via from_u64<T>()."""
@@ -1666,8 +1883,8 @@ class TestTensorReadWriteOffsetCodegen:
         # dst comes from ForStmt yield tracing back to a dst Out param.
         # Before the fix, dst would incorrectly alias to the acc Out param.
 
-        # Ensure the two tuple aliases reference DIFFERENT get_ref indices.
-        get_ref_matches = re.findall(r"outs_t0\.get_ref\((\d+)\)", code)
+        # Ensure the two alloc_tensors aliases reference DIFFERENT get_ref indices.
+        get_ref_matches = re.findall(r"alloc_\d+\.get_ref\((\d+)\)", code)
         assert len(set(get_ref_matches)) >= 2, (
             f"Expected at least 2 distinct get_ref indices, got {get_ref_matches}"
         )

--- a/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
+++ b/tests/ut/codegen/test_pto_codegen_paged_attn_multi_config.py
@@ -31,25 +31,6 @@ N_UNROLL_Q = N_UNROLL * Q_TILE
 # ── Kernel factory functions ─────────────────────────────────────────────────
 
 
-def make_kernel_aiv_hub(q_tile: int, head_dim: int):
-    """Create aiv_hub InCore kernel with parameterised tile dimensions."""
-
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel_aiv_hub(
-        oi: pl.Out[pl.Tensor[[q_tile, head_dim], pl.FP32]],
-        li: pl.Out[pl.Tensor[[q_tile, 1], pl.FP32]],
-        mi: pl.Out[pl.Tensor[[q_tile, 1], pl.FP32]],
-    ) -> tuple[
-        pl.Tensor[[q_tile, head_dim], pl.FP32],
-        pl.Tensor[[q_tile, 1], pl.FP32],
-        pl.Tensor[[q_tile, 1], pl.FP32],
-    ]:
-        """Initialize inplace accumulators to zero (VECTOR)."""
-        return oi, li, mi
-
-    return kernel_aiv_hub
-
-
 def make_kernel_softmax_prepare(q_tile: int, block_size: int, n_unroll_q: int):
     """Create softmax_prepare InCore kernel with parameterised tile dimensions."""
 
@@ -321,7 +302,6 @@ def build_paged_attention_multi_config_program(
     q_loop_static = (num_heads + q_tile - 1) // q_tile
     max_bn = (context_len + block_size - 1) // block_size
 
-    _hub = make_kernel_aiv_hub(q_tile, head_dim)
     _sf = make_kernel_softmax_prepare(q_tile, block_size, n_unroll_q)
     _up = make_kernel_online_update(q_tile, head_dim)
     _qk = make_kernel_qk_matmul(key_cache_rows, q_tile, head_dim, block_size, n_unroll, n_unroll_q)
@@ -361,8 +341,6 @@ def build_paged_attention_multi_config_program(
                         [q_tile, 1],
                         dtype=pl.FP32,
                     )
-                    oi, li_update, mi_update = _hub(oi, li_update, mi_update)
-
                     qi: pl.Tensor[[q_tile, head_dim], pl.BF16] = pl.slice(
                         query,
                         [q_tile, head_dim],
@@ -477,7 +455,6 @@ def test_paged_attention_multi_config_codegen():
         func.name: func for func in optimized_program.functions.values() if ir.is_incore_type(func.func_type)
     }
     expected_incore = {
-        "kernel_aiv_hub",
         "kernel_softmax_prepare",
         "kernel_online_update",
         "kernel_qk_matmul",


### PR DESCRIPTION
Replace deferred tensor allocation (add_output with TensorCreateInfo at task submit) with scope-level batched alloc_tensors() pre-allocation. All tensor.create calls within the same scope (function body, for body, if body) are collected and emitted as a single alloc_tensors invocation.
- Add EmitBatchedAllocTensors to orchestration_codegen.cpp
- Remove tensor_create_var_names_ and deferred allocation logic
- Simplify BuildTaskParams/EmitTaskSubmitAndBind (no more internal out tracking)
- Remove loop-carried state workarounds (escaped_loop_return_exprs_, etc.)
- Remove hub kernel definitions and calls from paged attention examples
- Update unit/system tests and EN/ZH-CN documentation