### PR TITLE
fix(runtime): pass sim_context_path in cached RuntimeBinaries and bump pto-isa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,12 @@ jobs:
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=882c4db
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=38fcfb17
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device=$DEVICE_ID --platform=a2a3 --enable-profiling --forked --pto-isa-commit=882c4db
+            -v --device=$DEVICE_ID --platform=a2a3 --enable-profiling --forked --pto-isa-commit=38fcfb17
 
   system-tests-a5sim:
     runs-on: ubuntu-latest
@@ -177,7 +177,7 @@ jobs:
           pip install -v .
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=882c4db -m a5
+        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=38fcfb17 -m a5
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.18
-          PTOAS_SHA256=e61022d990e3142084529621d21ae10ca1aeea86c25fe6ba46222c61060f40af
+          PTOAS_VERSION=v0.24
+          PTOAS_SHA256=31a1f14767f23f0e530faeea0b0dea481ec22c09f9bee5045287b444df00b5bd
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -582,7 +582,9 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
             resolver = getattr(self, "_resolve_sim_context_path", None)
             sim_context_path = resolver() if resolver is not None else None
             return RuntimeBinaries(
-                host_path=host_file, aicpu_path=aicpu_file, aicore_path=aicore_file,
+                host_path=host_file,
+                aicpu_path=aicpu_file,
+                aicore_path=aicore_file,
                 sim_context_path=sim_context_path,
             )
         result = orig_get_binaries(self, name, build=build)

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -577,7 +577,14 @@ def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
         aicpu_file = cache_dir / f"{name}_{self.platform}_aicpu.bin"
         aicore_file = cache_dir / f"{name}_{self.platform}_aicore.bin"
         if host_file.exists() and aicpu_file.exists() and aicore_file.exists():
-            return RuntimeBinaries(host_path=host_file, aicpu_path=aicpu_file, aicore_path=aicore_file)
+            # sim_context_path is a shared per-platform SO (not per-runtime-name),
+            # so resolve it from the builder rather than caching as bytes.
+            resolver = getattr(self, "_resolve_sim_context_path", None)
+            sim_context_path = resolver() if resolver is not None else None
+            return RuntimeBinaries(
+                host_path=host_file, aicpu_path=aicpu_file, aicore_path=aicore_file,
+                sim_context_path=sim_context_path,
+            )
         result = orig_get_binaries(self, name, build=build)
         _save_binary(result.host_path.read_bytes(), host_file)
         _save_binary(result.aicpu_path.read_bytes(), aicpu_file)


### PR DESCRIPTION
## Summary
- Fix binary cache patch to include `sim_context_path` when returning cached `RuntimeBinaries`, preventing simulator failures from missing context SO
- Resolve `sim_context_path` only on cache hits (cache misses already carry it in the original result)
- Bump `pto-isa-commit` to `38fcfb17` across all CI workflows

## Testing
- [ ] A5 simulator tests pass with cached binaries
- [ ] Non-simulator (A2A3) tests unaffected
- [ ] CI workflows reference correct pto-isa commit