### PR TITLE
fix(codegen): add internal checks for unregistered and misplaced tensor ops in orchestration

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -335,8 +335,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
           GenerateTupleReturnAliases(call);
         }
       } else {
-        INTERNAL_CHECK(false) << "Builtin op '" << op_name
-                              << "' found in Orchestration function (should be inside InCore block)";
+        INTERNAL_CHECK(false) << "Misplaced builtin op '" << op_name
+                              << "' in Orchestration function (should be inside InCore block)";
       }
     } else if (As<TupleGetItemExpr>(assign->value_)) {
       // No-op: tuple elements handled via tuple_var_to_elements_
@@ -377,8 +377,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       } else if (!IsBuiltinOp(op_name)) {
         GenerateFunctionCallCode(call, "");
       } else {
-        INTERNAL_CHECK(false) << "Builtin op '" << op_name
-                              << "' found in Orchestration function (should be inside InCore block)";
+        INTERNAL_CHECK(false) << "Misplaced builtin op '" << op_name
+                              << "' in Orchestration function (should be inside InCore block)";
       }
     }
   }
@@ -515,7 +515,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     auto& registry = OrchestrationOpRegistry::GetInstance();
     auto codegen_func = registry.Get(op_name);
-    INTERNAL_CHECK(codegen_func.has_value()) << "Unregistered tensor op '" << op_name
+    INTERNAL_CHECK(codegen_func.has_value()) << "Misplaced tensor op '" << op_name
                                              << "' in Orchestration function (should be inside InCore block)";
 
     if (op_name == "tensor.create" && assign_var &&

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -334,6 +334,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         } else {
           GenerateTupleReturnAliases(call);
         }
+      } else {
+        INTERNAL_CHECK(false) << "Builtin op '" << op_name
+                              << "' found in Orchestration function (should be inside InCore block)";
       }
     } else if (As<TupleGetItemExpr>(assign->value_)) {
       // No-op: tuple elements handled via tuple_var_to_elements_
@@ -373,6 +376,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         GenerateTensorOpCode(call, "", nullptr);
       } else if (!IsBuiltinOp(op_name)) {
         GenerateFunctionCallCode(call, "");
+      } else {
+        INTERNAL_CHECK(false) << "Builtin op '" << op_name
+                              << "' found in Orchestration function (should be inside InCore block)";
       }
     }
   }
@@ -509,9 +515,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     auto& registry = OrchestrationOpRegistry::GetInstance();
     auto codegen_func = registry.Get(op_name);
-    if (!codegen_func.has_value()) {
-      return;
-    }
+    INTERNAL_CHECK(codegen_func.has_value()) << "Unregistered tensor op '" << op_name
+                                             << "' in Orchestration function (should be inside InCore block)";
 
     if (op_name == "tensor.create" && assign_var &&
         (declared_var_ptrs_.count(assign_var.get()) || param_name_set_.count(GetVarName(assign_var)))) {

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1774,7 +1774,7 @@ class TestUnregisteredOpError:
 
         program = ir.Program([orch_func], "test_prog", ir.Span.unknown())
 
-        with pytest.raises(RuntimeError, match="Unregistered tensor op.*tensor.full"):
+        with pytest.raises(RuntimeError, match="Misplaced tensor op.*tensor.full"):
             codegen.generate_orchestration(program, orch_func)
 
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1753,5 +1753,30 @@ class TestTensorReadWriteOffsetCodegen:
         assert "pto2_rt_submit_task(mixed_0, params_t0);" in code
 
 
+class TestUnregisteredOpError:
+    """Test that unregistered/misplaced ops in Orchestration functions raise errors."""
+
+    def test_unregistered_tensor_op_raises_error(self):
+        """Unregistered tensor op (tensor.full) in Orchestration must raise RuntimeError."""
+        from pypto.ir.builder import IRBuilder
+        from pypto.ir.op import tensor as tensor_ops
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ib = IRBuilder()
+        with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+            x = orch_f.param("x", ir.TensorType([16, 16], pl.FP32))
+            orch_f.return_type(ir.TensorType([16, 16], pl.FP32))
+            filled = ib.let("filled", tensor_ops.full([16, 16], pl.FP32, 0.0))
+            ib.return_stmt(filled)
+        orch_func = orch_f.get_result()
+
+        program = ir.Program([orch_func], "test_prog", ir.Span.unknown())
+
+        with pytest.raises(RuntimeError, match="Unregistered tensor op.*tensor.full"):
+            codegen.generate_orchestration(program, orch_func)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Introduced `INTERNAL_CHECK` statements to ensure that built-in operations are not found in orchestration functions, enforcing that they should only appear within InCore blocks.
- Added a check for unregistered tensor operations, raising a runtime error if such an operation is detected during orchestration code generation.
- Enhanced unit tests to verify that unregistered tensor operations raise the expected errors.

## Testing
- [x] New tests added to validate error handling for unregistered tensor ops.
- [x] All existing tests pass.