### PR TITLE
refactor(ir): merge ForStmt chunk_size and chunk_policy into ChunkConfig

### DIFF
--- a/docs/en/dev/passes/05-split_chunked_loops.md
+++ b/docs/en/dev/passes/05-split_chunked_loops.md
@@ -151,7 +151,7 @@ Each generated loop is tagged with a `LoopOrigin` annotation indicating how it w
 | `ChunkInner` | Inner loop iterating within a chunk |
 | `ChunkRemainder` | Remainder loop for leftover iterations |
 
-Access via `for_stmt.loop_origin` (Python) or `for_stmt->loop_origin_` (C++). Downstream passes can use this to distinguish generated loops from user-written ones.
+Access via `for_stmt.attrs.get("loop_origin")` (Python) or `for_stmt->GetAttr<LoopOrigin>("loop_origin")` (C++). Downstream passes can use this to distinguish generated loops from user-written ones.
 
 ## Pipeline Position
 

--- a/docs/en/dev/passes/utils.md
+++ b/docs/en/dev/passes/utils.md
@@ -32,7 +32,7 @@ Reusable utilities in `include/pypto/ir/transforms/utils/` for passes.
 | Statement | `var_defs` / `var_defs_ordered` | `var_assign_defs` | `var_uses` |
 | --------- | ------------------------------- | ----------------- | ---------- |
 | `AssignStmt` | `var_` | `var_` | RHS `value_` |
-| `ForStmt` | `loop_var_`, `return_vars_`, `iter_args_` | — | bounds, `chunk_size_`, initValues |
+| `ForStmt` | `loop_var_`, `return_vars_`, `iter_args_` | — | bounds, `chunk_config_->size`, initValues |
 | `WhileStmt` | `return_vars_`, `iter_args_` | — | `condition_`, initValues |
 | `IfStmt` | `return_vars_` | — | `condition_` |
 

--- a/docs/zh-cn/dev/passes/05-split_chunked_loops.md
+++ b/docs/zh-cn/dev/passes/05-split_chunked_loops.md
@@ -151,7 +151,7 @@ return x__cr_rv_v1
 | `ChunkInner` | 在分块内迭代的内层循环 |
 | `ChunkRemainder` | 处理剩余迭代的余数循环 |
 
-通过 `for_stmt.loop_origin`（Python）或 `for_stmt->loop_origin_`（C++）访问。下游 Pass 可使用此标记区分生成的循环与用户编写的循环。
+通过 `for_stmt.attrs.get("loop_origin")`（Python）或 `for_stmt->GetAttr<LoopOrigin>("loop_origin")`（C++）访问。下游 Pass 可使用此标记区分生成的循环与用户编写的循环。
 
 ## 流水线位置
 

--- a/docs/zh-cn/dev/passes/utils.md
+++ b/docs/zh-cn/dev/passes/utils.md
@@ -32,7 +32,7 @@
 | 语句 | `var_defs` / `var_defs_ordered` | `var_assign_defs` | `var_uses` |
 | ---- | ------------------------------- | ----------------- | ---------- |
 | `AssignStmt` | `var_` | `var_` | 右值 `value_` |
-| `ForStmt` | `loop_var_`、`return_vars_`、`iter_args_` | — | 边界、`chunk_size_`、initValues |
+| `ForStmt` | `loop_var_`、`return_vars_`、`iter_args_` | — | 边界、`chunk_config_->size`、initValues |
 | `WhileStmt` | `return_vars_`、`iter_args_` | — | `condition_`、initValues |
 | `IfStmt` | `return_vars_` | — | `condition_` |
 

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -145,9 +145,8 @@ class IRBuilder {
    */
   void BeginForLoop(const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop, const ExprPtr& step,
                     const Span& span, ForKind kind = ForKind::Sequential,
-                    std::optional<ExprPtr> chunk_size = std::nullopt,
-                    ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull,
-                    LoopOrigin loop_origin = LoopOrigin::Original);
+                    std::optional<ChunkConfig> chunk_config = std::nullopt,
+                    std::vector<std::pair<std::string, std::any>> attrs = {});
 
   /**
    * @brief Add an iteration argument to the current for loop
@@ -576,18 +575,16 @@ class FunctionContext : public BuildContext {
 class ForLoopContext : public BuildContext {
  public:
   ForLoopContext(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, Span span,
-                 ForKind kind = ForKind::Sequential, std::optional<ExprPtr> chunk_size = std::nullopt,
-                 ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull,
-                 LoopOrigin loop_origin = LoopOrigin::Original)
+                 ForKind kind = ForKind::Sequential, std::optional<ChunkConfig> chunk_config = std::nullopt,
+                 std::vector<std::pair<std::string, std::any>> attrs = {})
       : BuildContext(Type::FOR_LOOP, std::move(span)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
         stop_(std::move(stop)),
         step_(std::move(step)),
         kind_(kind),
-        chunk_size_(std::move(chunk_size)),
-        chunk_policy_(chunk_policy),
-        loop_origin_(loop_origin) {}
+        chunk_config_(std::move(chunk_config)),
+        attrs_(std::move(attrs)) {}
 
   void AddIterArg(const IterArgPtr& iter_arg) { iter_args_.push_back(iter_arg); }
   void AddReturnVar(const VarPtr& var) { return_vars_.push_back(var); }
@@ -600,9 +597,8 @@ class ForLoopContext : public BuildContext {
   [[nodiscard]] const std::vector<IterArgPtr>& GetIterArgs() const { return iter_args_; }
   [[nodiscard]] const std::vector<VarPtr>& GetReturnVars() const { return return_vars_; }
   [[nodiscard]] ForKind GetKind() const { return kind_; }
-  [[nodiscard]] const std::optional<ExprPtr>& GetChunkSize() const { return chunk_size_; }
-  [[nodiscard]] ChunkPolicy GetChunkPolicy() const { return chunk_policy_; }
-  [[nodiscard]] LoopOrigin GetLoopOrigin() const { return loop_origin_; }
+  [[nodiscard]] const std::optional<ChunkConfig>& GetChunkConfig() const { return chunk_config_; }
+  [[nodiscard]] const std::vector<std::pair<std::string, std::any>>& GetAttrs() const { return attrs_; }
 
  private:
   VarPtr loop_var_;
@@ -610,9 +606,8 @@ class ForLoopContext : public BuildContext {
   ExprPtr stop_;
   ExprPtr step_;
   ForKind kind_;
-  std::optional<ExprPtr> chunk_size_;
-  ChunkPolicy chunk_policy_;
-  LoopOrigin loop_origin_;
+  std::optional<ChunkConfig> chunk_config_;
+  std::vector<std::pair<std::string, std::any>> attrs_;
   std::vector<IterArgPtr> iter_args_;
   std::vector<VarPtr> return_vars_;
 };

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -12,6 +12,8 @@
 #ifndef PYPTO_IR_STMT_H_
 #define PYPTO_IR_STMT_H_
 
+#include <algorithm>
+#include <any>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -29,6 +31,7 @@ enum class Role : uint8_t;
 }  // namespace ir
 }  // namespace pypto
 
+#include "pypto/core/any_cast.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/core.h"
@@ -83,6 +86,17 @@ inline ChunkPolicy StringToChunkPolicy(const std::string& str) {
   }
   throw pypto::TypeError("Unknown ChunkPolicy: " + str);
 }
+
+/**
+ * @brief Chunk configuration for parallel loop splitting.
+ *
+ * Groups chunk_size and chunk_policy which always appear together.
+ * Only meaningful on parallel (chunked) loops.
+ */
+struct ChunkConfig {
+  ExprPtr size;                                   ///< Chunk size expression
+  ChunkPolicy policy = ChunkPolicy::LeadingFull;  ///< Distribution policy
+};
 
 /**
  * @brief Loop origin classification for tracking how a loop was generated
@@ -499,14 +513,13 @@ class ForStmt : public Stmt {
    * @param return_vars Return variables (capture final values, accessible after loop)
    * @param span Source location
    * @param kind Loop kind (Sequential, Parallel, or Unroll; default: Sequential)
-   * @param chunk_size Optional chunk size for loop chunking (nullopt = no chunking)
-   * @param chunk_policy Chunk distribution policy (default: LeadingFull)
-   * @param loop_origin Loop origin classification (default: Original)
+   * @param chunk_config Optional chunk configuration (nullopt = no chunking)
+   * @param attrs Loop-level attributes (key-value metadata, default: empty)
    */
   ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<IterArgPtr> iter_args,
           StmtPtr body, std::vector<VarPtr> return_vars, Span span, ForKind kind = ForKind::Sequential,
-          std::optional<ExprPtr> chunk_size = std::nullopt,
-          ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull, LoopOrigin loop_origin = LoopOrigin::Original)
+          std::optional<ChunkConfig> chunk_config = std::nullopt,
+          std::vector<std::pair<std::string, std::any>> attrs = {})
       : Stmt(std::move(span)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
@@ -516,9 +529,8 @@ class ForStmt : public Stmt {
         body_(std::move(body)),
         return_vars_(std::move(return_vars)),
         kind_(kind),
-        chunk_size_(std::move(chunk_size)),
-        chunk_policy_(chunk_policy),
-        loop_origin_(loop_origin) {}
+        chunk_config_(std::move(chunk_config)),
+        attrs_(std::move(attrs)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ForStmt; }
   [[nodiscard]] std::string TypeName() const override { return "ForStmt"; }
@@ -538,9 +550,8 @@ class ForStmt : public Stmt {
                                           reflection::UsualField(&ForStmt::body_, "body"),
                                           reflection::DefField(&ForStmt::return_vars_, "return_vars"),
                                           reflection::UsualField(&ForStmt::kind_, "kind"),
-                                          reflection::UsualField(&ForStmt::chunk_size_, "chunk_size"),
-                                          reflection::UsualField(&ForStmt::chunk_policy_, "chunk_policy"),
-                                          reflection::IgnoreField(&ForStmt::loop_origin_, "loop_origin")));
+                                          reflection::UsualField(&ForStmt::chunk_config_, "chunk_config"),
+                                          reflection::UsualField(&ForStmt::attrs_, "attrs")));
   }
 
  public:
@@ -552,9 +563,25 @@ class ForStmt : public Stmt {
   StmtPtr body_;                       // Loop body statement (must yield if iter_args non-empty)
   std::vector<VarPtr> return_vars_;    // Variables capturing final iteration values (accessible after loop)
   ForKind kind_;                       // Loop kind (Sequential, Parallel, or Unroll)
-  std::optional<ExprPtr> chunk_size_;  // Chunk size (nullopt = no chunking)
-  ChunkPolicy chunk_policy_ = ChunkPolicy::LeadingFull;  // Chunk distribution policy
-  LoopOrigin loop_origin_ = LoopOrigin::Original;        // Loop origin classification
+  std::optional<ChunkConfig> chunk_config_;              // Chunk configuration (nullopt = no chunking)
+  std::vector<std::pair<std::string, std::any>> attrs_;  // Loop-level attributes (key-value metadata)
+
+  /// Get a typed attribute value (returns default_value if key not found)
+  template <typename T>
+  [[nodiscard]] T GetAttr(const std::string& key, const T& default_value = T{}) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) return AnyCast<T>(v, "for_stmt attr key: " + key);
+    }
+    return default_value;
+  }
+
+  /// Check if an attribute exists
+  [[nodiscard]] bool HasAttr(const std::string& key) const {
+    return std::any_of(attrs_.begin(), attrs_.end(), [&key](const auto& pair) { return pair.first == key; });
+  }
+
+  /// Get all attributes
+  [[nodiscard]] const std::vector<std::pair<std::string, std::any>>& GetAttrs() const { return attrs_; }
 };
 
 using ForStmtPtr = std::shared_ptr<const ForStmt>;

--- a/include/pypto/ir/transforms/utils/var_collectors.h
+++ b/include/pypto/ir/transforms/utils/var_collectors.h
@@ -83,8 +83,8 @@ class VarDefUseCollector : public IRVisitor {
     VisitExpr(op->start_);
     VisitExpr(op->stop_);
     VisitExpr(op->step_);
-    if (op->chunk_size_.has_value() && *op->chunk_size_) {
-      VisitExpr(*op->chunk_size_);
+    if (op->chunk_config_.has_value() && op->chunk_config_->size) {
+      VisitExpr(op->chunk_config_->size);
     }
     VisitStmt(op->body_);
   }

--- a/python/bindings/module.h
+++ b/python/bindings/module.h
@@ -42,6 +42,17 @@ namespace python {
 std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nanobind::dict& kwargs_dict);
 
 /**
+ * @brief Convert a Python dict or list-of-tuples to a vector of (key, value) pairs
+ *
+ * Accepts either a dict or a list of (key, value) tuples. Returns empty vector for None.
+ * Used for attrs parameters on ForStmt, ScopeStmt, etc.
+ *
+ * @param attrs_or_none Python object (dict, list, or None)
+ * @return Vector of key-value pairs
+ */
+std::vector<std::pair<std::string, std::any>> ConvertAttrsFromPython(const nanobind::object& attrs_or_none);
+
+/**
  * @brief Register error exception types and exception translator
  *
  * This function registers all PyPTO error classes with Python and sets up

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -126,6 +126,8 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       kwargs.emplace_back(key, static_cast<int>(nb::cast<SplitMode>(item.second)));
     } else if (nb::isinstance<PadValue>(item.second)) {
       kwargs.emplace_back(key, nb::cast<PadValue>(item.second));
+    } else if (nb::isinstance<LoopOrigin>(item.second)) {
+      kwargs.emplace_back(key, nb::cast<LoopOrigin>(item.second));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<bool>(item.second));
     } else if (nb::isinstance<nb::int_>(item.second)) {
@@ -139,6 +141,25 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     }
   }
   return kwargs;
+}
+
+std::vector<std::pair<std::string, std::any>> ConvertAttrsFromPython(const nb::object& attrs_or_none) {
+  if (attrs_or_none.is_none()) return {};
+  if (nb::isinstance<nb::dict>(attrs_or_none)) {
+    return ConvertKwargsDict(nb::cast<nb::dict>(attrs_or_none));
+  }
+  if (nb::isinstance<nb::list>(attrs_or_none)) {
+    std::vector<std::pair<std::string, std::any>> attrs;
+    for (auto item : nb::cast<nb::list>(attrs_or_none)) {
+      auto tup = nb::cast<nb::tuple>(item);
+      nb::dict d;
+      d[tup[0]] = tup[1];
+      auto converted = ConvertKwargsDict(d);
+      attrs.push_back(converted[0]);
+    }
+    return attrs;
+  }
+  throw pypto::TypeError("attrs must be a dict, list of (key, value) tuples, or None");
 }
 
 /// Conditionally apply the registered format callback.
@@ -816,6 +837,13 @@ void BindIR(nb::module_& m) {
       .value("LeadingFull", ChunkPolicy::LeadingFull, "Full chunks first, smaller remainder at end")
       .export_values();
 
+  // ChunkConfig struct (must be before ForStmt which uses it)
+  nb::class_<ChunkConfig>(ir, "ChunkConfig", "Chunk configuration for parallel loop splitting")
+      .def(nb::init<ExprPtr, ChunkPolicy>(), nb::arg("size"), nb::arg("policy") = ChunkPolicy::LeadingFull,
+           "Create a chunk configuration")
+      .def_ro("size", &ChunkConfig::size, "Chunk size expression")
+      .def_ro("policy", &ChunkConfig::policy, "Chunk distribution policy");
+
   // LoopOrigin enum (must be before ForStmt which uses it)
   nb::enum_<LoopOrigin>(ir, "LoopOrigin", "Loop origin classification")
       .value("Original", LoopOrigin::Original, "Regular loop (default)")
@@ -827,15 +855,51 @@ void BindIR(nb::module_& m) {
   // ForStmt - const shared_ptr
   auto for_stmt_class = nb::class_<ForStmt, Stmt>(
       ir, "ForStmt", "For loop statement: for loop_var in range(start, stop, step): body");
-  for_stmt_class.def(nb::init<const VarPtr&, const ExprPtr&, const ExprPtr&, const ExprPtr&,
-                              const std::vector<IterArgPtr>&, const StmtPtr&, const std::vector<VarPtr>&,
-                              const Span&, ForKind, const std::optional<ExprPtr>&, ChunkPolicy, LoopOrigin>(),
-                     nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"),
-                     nb::arg("iter_args"), nb::arg("body"), nb::arg("return_vars"), nb::arg("span"),
-                     nb::arg("kind") = ForKind::Sequential, nb::arg("chunk_size") = nb::none(),
-                     nb::arg("chunk_policy") = ChunkPolicy::LeadingFull,
-                     nb::arg("loop_origin") = LoopOrigin::Original, "Create a for loop statement");
+  for_stmt_class.def(
+      "__init__",
+      [](ForStmt* self, const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop,
+         const ExprPtr& step, const std::vector<IterArgPtr>& iter_args, const StmtPtr& body,
+         const std::vector<VarPtr>& return_vars, const Span& span, ForKind kind,
+         const std::optional<ExprPtr>& chunk_size, ChunkPolicy chunk_policy,
+         const nb::object& attrs_or_none) {
+        auto attrs = ConvertAttrsFromPython(attrs_or_none);
+        std::optional<ChunkConfig> chunk_config =
+            chunk_size.has_value() ? std::optional{ChunkConfig{*chunk_size, chunk_policy}} : std::nullopt;
+        new (self) ForStmt(loop_var, start, stop, step, iter_args, body, return_vars, span, kind,
+                           std::move(chunk_config), std::move(attrs));
+      },
+      nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("iter_args"),
+      nb::arg("body"), nb::arg("return_vars"), nb::arg("span"), nb::arg("kind") = ForKind::Sequential,
+      nb::arg("chunk_size") = nb::none(), nb::arg("chunk_policy") = ChunkPolicy::LeadingFull,
+      nb::arg("attrs") = nb::none(), "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);
+  // Custom attrs property: convert vector<pair<string, any>> to Python dict
+  for_stmt_class.def_prop_ro(
+      "attrs",
+      [](const ForStmtPtr& self) {
+        nb::dict result;
+        for (const auto& [key, value] : self->attrs_) {
+          result[key.c_str()] = AnyToPyObject<int, bool, std::string, double, float, DataType, MemorySpace,
+                                              TensorLayout, TileLayout, PadValue, LoopOrigin>(value, key);
+        }
+        return result;
+      },
+      "Loop-level attributes as a dictionary");
+  // Convenience properties for chunk_size and chunk_policy (derived from chunk_config)
+  for_stmt_class.def_prop_ro(
+      "chunk_size",
+      [](const ForStmtPtr& self) -> std::optional<ExprPtr> {
+        if (self->chunk_config_.has_value()) return self->chunk_config_->size;
+        return std::nullopt;
+      },
+      "Chunk size expression (None if no chunking)");
+  for_stmt_class.def_prop_ro(
+      "chunk_policy",
+      [](const ForStmtPtr& self) -> ChunkPolicy {
+        if (self->chunk_config_.has_value()) return self->chunk_config_->policy;
+        return ChunkPolicy::LeadingFull;
+      },
+      "Chunk distribution policy");
 
   // WhileStmt - const shared_ptr
   auto while_stmt_class =
@@ -986,11 +1050,7 @@ void BindIR(nb::module_& m) {
             param_dirs.push_back(ParamDirection::In);
           }
         }
-        // Build attrs vector from attrs dict
-        std::vector<std::pair<std::string, std::any>> attrs;
-        if (!attrs_or_none.is_none()) {
-          attrs = ConvertKwargsDict(nb::cast<nb::dict>(attrs_or_none));
-        }
+        auto attrs = ConvertAttrsFromPython(attrs_or_none);
         new (self) Function(name, std::move(param_vars), std::move(param_dirs), return_types, body, span,
                             type, level, role, std::move(attrs));
       },

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -51,11 +51,7 @@ void BindIRBuilder(nb::module_& m) {
           "begin_function",
           [](IRBuilder& self, const std::string& name, const Span& span, FunctionType type,
              std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none) {
-            std::vector<std::pair<std::string, std::any>> attrs;
-            if (!attrs_or_none.is_none()) {
-              attrs = ConvertKwargsDict(nb::cast<nb::dict>(attrs_or_none));
-            }
-            self.BeginFunction(name, span, type, level, role, std::move(attrs));
+            self.BeginFunction(name, span, type, level, role, ConvertAttrsFromPython(attrs_or_none));
           },
           nb::arg("name"), nb::arg("span"), nb::arg("type") = FunctionType::Opaque,
           nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("attrs") = nb::none(),
@@ -104,24 +100,33 @@ void BindIRBuilder(nb::module_& m) {
            "    RuntimeError: If not inside a function context")
 
       // For loop building
-      .def("begin_for_loop", &IRBuilder::BeginForLoop, nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"),
-           nb::arg("step"), nb::arg("span"), nb::arg("kind") = ForKind::Sequential,
-           nb::arg("chunk_size") = nb::none(), nb::arg("chunk_policy") = ChunkPolicy::LeadingFull,
-           nb::arg("loop_origin") = LoopOrigin::Original,
-           "Begin building a for loop.\n\n"
-           "Creates a new for loop context. Must be closed with end_for_loop().\n\n"
-           "Args:\n"
-           "    loop_var: Loop variable\n"
-           "    start: Start value expression\n"
-           "    stop: Stop value expression\n"
-           "    step: Step value expression\n"
-           "    span: Source location for loop definition\n"
-           "    kind: Loop kind (Sequential or Parallel, default: Sequential)\n"
-           "    chunk_size: Optional chunk size for loop chunking\n"
-           "    chunk_policy: Chunk distribution policy (default: LeadingFull)\n"
-           "    loop_origin: Loop origin classification (default: Original)\n\n"
-           "Raises:\n"
-           "    RuntimeError: If not inside a valid context")
+      .def(
+          "begin_for_loop",
+          [](IRBuilder& self, const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop,
+             const ExprPtr& step, const Span& span, ForKind kind, std::optional<ExprPtr> chunk_size,
+             ChunkPolicy chunk_policy, const nb::object& attrs_or_none) {
+            std::optional<ChunkConfig> chunk_config =
+                chunk_size.has_value() ? std::optional{ChunkConfig{*chunk_size, chunk_policy}} : std::nullopt;
+            self.BeginForLoop(loop_var, start, stop, step, span, kind, std::move(chunk_config),
+                              ConvertAttrsFromPython(attrs_or_none));
+          },
+          nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("span"),
+          nb::arg("kind") = ForKind::Sequential, nb::arg("chunk_size") = nb::none(),
+          nb::arg("chunk_policy") = ChunkPolicy::LeadingFull, nb::arg("attrs") = nb::none(),
+          "Begin building a for loop.\n\n"
+          "Creates a new for loop context. Must be closed with end_for_loop().\n\n"
+          "Args:\n"
+          "    loop_var: Loop variable\n"
+          "    start: Start value expression\n"
+          "    stop: Stop value expression\n"
+          "    step: Step value expression\n"
+          "    span: Source location for loop definition\n"
+          "    kind: Loop kind (Sequential or Parallel, default: Sequential)\n"
+          "    chunk_size: Optional chunk size for loop chunking\n"
+          "    chunk_policy: Chunk distribution policy (default: LeadingFull)\n"
+          "    attrs: Loop-level attributes (default: empty)\n\n"
+          "Raises:\n"
+          "    RuntimeError: If not inside a valid context")
 
       .def("add_iter_arg", &IRBuilder::AddIterArg, nb::arg("iter_arg"),
            "Add an iteration argument to the current for loop.\n\n"

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -112,7 +112,7 @@ class IRBuilder:
         kind: ir.ForKind = ir.ForKind.Sequential,
         chunk_size: int | ir.Expr | None = None,
         chunk_policy: str = "leading_full",
-        loop_origin: ir.LoopOrigin = ir.LoopOrigin.Original,
+        attrs: dict[str, object] | None = None,
     ) -> Iterator["ForLoopBuilder"]:
         """Context manager for building for loops.
 
@@ -125,7 +125,7 @@ class IRBuilder:
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
             chunk_policy: Chunk distribution policy (default: "leading_full")
-            loop_origin: Loop origin classification (default: Original)
+            attrs: Loop-level attributes (key-value metadata, default: empty)
 
         Yields:
             ForLoopBuilder: Helper object for building the loop
@@ -151,6 +151,7 @@ class IRBuilder:
         if chunk_policy != "leading_full":
             raise ValueError(f"Unsupported chunk_policy: {chunk_policy!r}, expected 'leading_full'")
 
+        attrs_list = list((attrs or {}).items())
         self._builder.begin_for_loop(
             loop_var,
             start_expr,
@@ -160,7 +161,7 @@ class IRBuilder:
             kind,
             chunk_size_expr,
             ir.ChunkPolicy.LeadingFull,
-            loop_origin,
+            attrs_list,
         )
         builder_obj = ForLoopBuilder(self)
         try:

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -40,9 +40,12 @@ Typical usage:
 from pypto.ir import TensorView, TileView
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import (
+    ChunkConfig,
+    ChunkPolicy,
     ForKind,
     FunctionType,
     Level,
+    LoopOrigin,
     MemorySpace,
     PadValue,
     PipeType,
@@ -331,9 +334,12 @@ __all__ = [
     "dim",
     "full",
     "scatter_update",
+    "ChunkConfig",
+    "ChunkPolicy",
     "FunctionType",
     "ForKind",
     "Level",
+    "LoopOrigin",
     "MemRef",
     "Role",
     "SplitMode",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -29,7 +29,7 @@ from .diagnostics import (
     UnsupportedFeatureError,
     concise_error_message,
 )
-from .enum_utils import LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
+from .enum_utils import LEVEL_MAP, LOOP_ORIGIN_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
 from .expr_evaluator import ExprEvaluator
 from .scope_manager import ScopeManager
 from .span_tracker import SpanTracker
@@ -903,6 +903,7 @@ class ASTParser:
         prev_in_for_loop = self.in_for_loop
         prev_in_while_loop = self.in_while_loop
 
+        attrs_dict = range_args.get("attrs") or None
         with self.builder.for_loop(
             loop_var,
             range_args["start"],
@@ -912,6 +913,7 @@ class ASTParser:
             kind,
             chunk_size=chunk_expr,
             chunk_policy=chunk_policy_str,
+            attrs=attrs_dict,
         ) as loop:
             self.current_loop_builder = loop
             self.in_for_loop = True
@@ -980,6 +982,50 @@ class ASTParser:
                 hint="Use a positive integer for chunk: chunk=5",
             )
 
+    def _parse_range_keyword(self, keyword: ast.keyword, result: dict[str, Any]) -> None:
+        """Parse a single keyword argument from a pl.range() call."""
+        if keyword.arg == "init_values":
+            if isinstance(keyword.value, (ast.List, ast.Tuple)):
+                result["init_values"] = [self.parse_expression(elt) for elt in keyword.value.elts]
+            else:
+                raise ParserSyntaxError(
+                    "init_values must be a list or tuple",
+                    span=self.span_tracker.get_span(keyword.value),
+                    hint="Use a tuple for init_values: init_values=(var1, var2)",
+                )
+        elif keyword.arg == "chunk":
+            result["chunk"] = self.parse_expression(keyword.value)
+        elif keyword.arg == "chunk_policy":
+            if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                _VALID_CHUNK_POLICIES = {"leading_full"}
+                if keyword.value.value not in _VALID_CHUNK_POLICIES:
+                    raise ParserSyntaxError(
+                        f"Unsupported chunk_policy: {keyword.value.value!r}",
+                        span=self.span_tracker.get_span(keyword.value),
+                        hint=f"Supported values: {', '.join(sorted(_VALID_CHUNK_POLICIES))}",
+                    )
+                result["chunk_policy"] = keyword.value.value
+            else:
+                raise ParserSyntaxError(
+                    "chunk_policy must be a string literal",
+                    span=self.span_tracker.get_span(keyword.value),
+                    hint='Use a string like chunk_policy="leading_full"',
+                )
+        elif keyword.arg == "attrs":
+            if not isinstance(keyword.value, ast.Dict):
+                raise ParserSyntaxError(
+                    "attrs must be a dict literal",
+                    span=self.span_tracker.get_span(keyword.value),
+                    hint='Use a dict like attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}',
+                )
+            result["attrs"] = self._parse_attrs_dict(keyword.value)
+        else:
+            raise ParserSyntaxError(
+                f"Unknown keyword argument '{keyword.arg}' in range()",
+                span=self.span_tracker.get_span(keyword),
+                hint="Supported keywords: init_values, chunk, chunk_policy, attrs",
+            )
+
     def _parse_range_call(self, call: ast.Call) -> dict[str, Any]:
         """Parse pl.range() call arguments.
 
@@ -989,7 +1035,6 @@ class ASTParser:
         Returns:
             Dictionary with start, stop, step, init_values
         """
-        # Parse positional arguments
         if len(call.args) < 1:
             raise ParserSyntaxError(
                 "pl.range() requires at least 1 argument (stop)",
@@ -997,72 +1042,67 @@ class ASTParser:
                 hint="Provide at least the stop value: pl.range(10) or pl.range(0, 10)",
             )
 
-        # Default values
         start = 0
         step = 1
 
         if len(call.args) == 1:
-            # range(stop)
             stop = self.parse_expression(call.args[0])
         elif len(call.args) == 2:
-            # range(start, stop)
             start = self.parse_expression(call.args[0])
             stop = self.parse_expression(call.args[1])
         elif len(call.args) >= 3:
-            # range(start, stop, step)
             start = self.parse_expression(call.args[0])
             stop = self.parse_expression(call.args[1])
             step = self.parse_expression(call.args[2])
 
-        # Parse keyword arguments
-        init_values = []
-        chunk = None
-        chunk_policy = "leading_full"
+        result: dict[str, Any] = {
+            "init_values": [],
+            "chunk": None,
+            "chunk_policy": "leading_full",
+            "attrs": {},
+        }
         for keyword in call.keywords:
-            if keyword.arg == "init_values":
-                # Parse list of init values
-                if isinstance(keyword.value, (ast.List, ast.Tuple)):
-                    for elt in keyword.value.elts:
-                        init_values.append(self.parse_expression(elt))
-                else:
-                    raise ParserSyntaxError(
-                        "init_values must be a list or tuple",
-                        span=self.span_tracker.get_span(keyword.value),
-                        hint="Use a tuple for init_values: init_values=(var1, var2)",
-                    )
-            elif keyword.arg == "chunk":
-                chunk = self.parse_expression(keyword.value)
-            elif keyword.arg == "chunk_policy":
-                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                    _VALID_CHUNK_POLICIES = {"leading_full"}
-                    if keyword.value.value not in _VALID_CHUNK_POLICIES:
-                        raise ParserSyntaxError(
-                            f"Unsupported chunk_policy: {keyword.value.value!r}",
-                            span=self.span_tracker.get_span(keyword.value),
-                            hint=f"Supported values: {', '.join(sorted(_VALID_CHUNK_POLICIES))}",
-                        )
-                    chunk_policy = keyword.value.value
-                else:
-                    raise ParserSyntaxError(
-                        "chunk_policy must be a string literal",
-                        span=self.span_tracker.get_span(keyword.value),
-                        hint='Use a string like chunk_policy="leading_full"',
-                    )
+            self._parse_range_keyword(keyword, result)
+
+        result["start"] = start
+        result["stop"] = stop
+        result["step"] = step
+        return result
+
+    def _parse_attrs_dict(self, node: ast.Dict) -> dict[str, object]:
+        """Parse an attrs dict literal from AST.
+
+        Supports string keys with values that are:
+        - Integer/float/bool/string constants
+        - pl.LoopOrigin.<name> enum references
+        """
+        # Map of known enum attr keys to their (enum_map, enum_name, qualified) configs
+        _ENUM_ATTRS: dict[str, tuple[dict[str, object], str, str]] = {
+            "loop_origin": (LOOP_ORIGIN_MAP, "LoopOrigin", "pl.LoopOrigin"),
+        }
+
+        result: dict[str, object] = {}
+        for key_node, value_node in zip(node.keys, node.values):
+            if not isinstance(key_node, ast.Constant) or not isinstance(key_node.value, str):
+                raise ParserSyntaxError(
+                    "attrs keys must be string literals",
+                    span=self.span_tracker.get_span(key_node) if key_node else None,
+                )
+            key = key_node.value
+
+            if key in _ENUM_ATTRS:
+                enum_map, enum_name, qualified = _ENUM_ATTRS[key]
+                result[key] = extract_enum_value(value_node, enum_map, enum_name, qualified)
+            elif isinstance(value_node, ast.Constant):
+                result[key] = value_node.value
             else:
                 raise ParserSyntaxError(
-                    f"Unknown keyword argument '{keyword.arg}' in range()",
-                    span=self.span_tracker.get_span(keyword),
-                    hint="Supported keywords: init_values, chunk, chunk_policy",
+                    f"Unsupported value type for attrs key '{key}'",
+                    span=self.span_tracker.get_span(value_node),
+                    hint="Supported values: integer, float, bool, string,"
+                    " or enum (e.g., pl.LoopOrigin.ChunkOuter)",
                 )
-
-        return {
-            "start": start,
-            "stop": stop,
-            "step": step,
-            "init_values": init_values,
-            "chunk": chunk,
-            "chunk_policy": chunk_policy,
-        }
+        return result
 
     def _is_cond_call(self, stmt: ast.stmt) -> bool:
         """Check if statement is a pl.cond() call (without parsing).

--- a/python/pypto/language/parser/enum_utils.py
+++ b/python/pypto/language/parser/enum_utils.py
@@ -48,6 +48,13 @@ SPLIT_MODE_MAP: dict[str, ir.SplitMode] = {
     "LEFT_RIGHT": ir.SplitMode.LEFT_RIGHT,
 }
 
+LOOP_ORIGIN_MAP: dict[str, ir.LoopOrigin] = {
+    "Original": ir.LoopOrigin.Original,
+    "ChunkOuter": ir.LoopOrigin.ChunkOuter,
+    "ChunkInner": ir.LoopOrigin.ChunkInner,
+    "ChunkRemainder": ir.LoopOrigin.ChunkRemainder,
+}
+
 FUNCTION_TYPE_MAP: dict[str, ir.FunctionType] = {
     "Opaque": ir.FunctionType.Opaque,
     "Orchestration": ir.FunctionType.Orchestration,
@@ -101,6 +108,7 @@ def extract_enum_value(
 
 __all__ = [
     "LEVEL_MAP",
+    "LOOP_ORIGIN_MAP",
     "ROLE_MAP",
     "SPLIT_MODE_MAP",
     "FUNCTION_TYPE_MAP",

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -794,6 +794,23 @@ class ChunkPolicy(enum.Enum):
     LeadingFull = ...
     """Full chunks first, smaller remainder at end."""
 
+class ChunkConfig:
+    """Chunk configuration for parallel loop splitting."""
+
+    size: Final[Expr]
+    """Chunk size expression."""
+
+    policy: Final[ChunkPolicy]
+    """Chunk distribution policy."""
+
+    def __init__(self, size: Expr, policy: ChunkPolicy = ChunkPolicy.LeadingFull) -> None:
+        """Create a chunk configuration.
+
+        Args:
+            size: Chunk size expression
+            policy: Chunk distribution policy (default: LeadingFull)
+        """
+
 class LoopOrigin(enum.Enum):
     """Loop origin classification.
 
@@ -1661,14 +1678,17 @@ class ForStmt(Stmt):
     kind: Final[ForKind]
     """Loop kind (Sequential, Parallel, or Unroll)."""
 
+    chunk_config: Final[ChunkConfig | None]
+    """Chunk configuration (None = no chunking)."""
+
     chunk_size: Final[Expr | None]
-    """Chunk size for loop chunking (None = no chunking)."""
+    """Chunk size expression (None if no chunking). Convenience for chunk_config.size."""
 
     chunk_policy: Final[ChunkPolicy]
-    """Chunk distribution policy."""
+    """Chunk distribution policy. Convenience for chunk_config.policy."""
 
-    loop_origin: Final[LoopOrigin]
-    """Loop origin (Original, ChunkOuter, ChunkInner, or ChunkRemainder)."""
+    attrs: Final[dict[str, object]]
+    """Loop-level attributes (key-value metadata)."""
 
     def __init__(
         self,
@@ -1683,7 +1703,7 @@ class ForStmt(Stmt):
         kind: ForKind = ForKind.Sequential,
         chunk_size: Expr | None = None,
         chunk_policy: ChunkPolicy = ChunkPolicy.LeadingFull,
-        loop_origin: LoopOrigin = LoopOrigin.Original,
+        attrs: dict[str, object] | list[tuple[str, object]] | None = None,
     ) -> None:
         """Create a for loop statement.
 
@@ -1699,7 +1719,7 @@ class ForStmt(Stmt):
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
             chunk_policy: Chunk distribution policy (default: LeadingFull)
-            loop_origin: Loop origin classification (default: Original)
+            attrs: Loop-level attributes (default: empty)
         """
 
 class WhileStmt(Stmt):
@@ -2411,7 +2431,7 @@ class IRBuilder:
         kind: ForKind = ForKind.Sequential,
         chunk_size: Expr | None = None,
         chunk_policy: ChunkPolicy = ChunkPolicy.LeadingFull,
-        loop_origin: LoopOrigin = LoopOrigin.Original,
+        attrs: dict[str, object] | list[tuple[str, object]] | None = None,
     ) -> None:
         """Begin building a for loop.
 
@@ -2424,7 +2444,7 @@ class IRBuilder:
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
             chunk_policy: Chunk distribution policy (default: LeadingFull)
-            loop_origin: Loop origin classification (default: Original)
+            attrs: Loop-level attributes (default: empty)
         """
 
     def add_iter_arg(self, iter_arg: IterArg) -> None:

--- a/src/codegen/pto/tpop_chain_reorder.cpp
+++ b/src/codegen/pto/tpop_chain_reorder.cpp
@@ -110,7 +110,7 @@ std::vector<ir::StmtPtr> ReorderTpopChains(const std::vector<ir::StmtPtr>& stmts
       return std::make_shared<ir::ForStmt>(
           for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
           make_body(new_body, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
-          for_stmt->chunk_size_, for_stmt->chunk_policy_, for_stmt->loop_origin_);
+          for_stmt->chunk_config_, for_stmt->attrs_);
     }
     if (auto if_stmt = As<ir::IfStmt>(stmt)) {
       auto new_then = ReorderTpopChains(flatten_body(if_stmt->then_body_), tpop_result_vars);

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -94,15 +94,15 @@ FunctionPtr IRBuilder::EndFunction(const Span& end_span) {
 
 void IRBuilder::BeginForLoop(const VarPtr& loop_var, const ExprPtr& start, const ExprPtr& stop,
                              const ExprPtr& step, const Span& span, ForKind kind,
-                             std::optional<ExprPtr> chunk_size, ChunkPolicy chunk_policy,
-                             LoopOrigin loop_origin) {
+                             std::optional<ChunkConfig> chunk_config,
+                             std::vector<std::pair<std::string, std::any>> attrs) {
   if (context_stack_.empty()) {
     throw pypto::RuntimeError("Cannot begin for loop: not inside a function or another valid context at " +
                               span.to_string());
   }
 
-  context_stack_.push_back(std::make_unique<ForLoopContext>(
-      loop_var, start, stop, step, span, kind, std::move(chunk_size), chunk_policy, loop_origin));
+  context_stack_.push_back(std::make_unique<ForLoopContext>(loop_var, start, stop, step, span, kind,
+                                                            std::move(chunk_config), std::move(attrs)));
 }
 
 void IRBuilder::AddIterArg(const IterArgPtr& iter_arg) {
@@ -141,10 +141,10 @@ StmtPtr IRBuilder::EndForLoop(const Span& end_span) {
                      end_span.begin_line_, end_span.begin_column_);
 
   // Create for statement
-  auto for_stmt = std::make_shared<ForStmt>(
-      loop_ctx->GetLoopVar(), loop_ctx->GetStart(), loop_ctx->GetStop(), loop_ctx->GetStep(),
-      loop_ctx->GetIterArgs(), body, loop_ctx->GetReturnVars(), combined_span, loop_ctx->GetKind(),
-      loop_ctx->GetChunkSize(), loop_ctx->GetChunkPolicy(), loop_ctx->GetLoopOrigin());
+  auto for_stmt = std::make_shared<ForStmt>(loop_ctx->GetLoopVar(), loop_ctx->GetStart(), loop_ctx->GetStop(),
+                                            loop_ctx->GetStep(), loop_ctx->GetIterArgs(), body,
+                                            loop_ctx->GetReturnVars(), combined_span, loop_ctx->GetKind(),
+                                            loop_ctx->GetChunkConfig(), loop_ctx->GetAttrs());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -89,7 +89,8 @@ class FieldSerializerVisitor {
   result_type VisitLeafField(const FunctionType& field);
   result_type VisitLeafField(const ForKind& field);
   result_type VisitLeafField(const ChunkPolicy& field);
-  result_type VisitLeafField(const LoopOrigin& field);
+  result_type VisitLeafField(const std::optional<ChunkConfig>& field);
+
   result_type VisitLeafField(const ScopeKind& field);
   result_type VisitLeafField(const MemorySpace& field);
   result_type VisitLeafField(const Level& field);
@@ -539,8 +540,19 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(const ChunkPolicy& field)
   return msgpack::object(static_cast<uint8_t>(field), zone_);
 }
 
-msgpack::object FieldSerializerVisitor::VisitLeafField(const LoopOrigin& field) {
-  return msgpack::object(static_cast<uint8_t>(field), zone_);
+msgpack::object FieldSerializerVisitor::VisitLeafField(const std::optional<ChunkConfig>& field) {
+  if (!field.has_value()) return msgpack::object();
+  // Serialize as a map with "size" and "policy" keys
+  auto* kv = static_cast<msgpack::object_kv*>(zone_.allocate_align(sizeof(msgpack::object_kv) * 2));
+  kv[0].key = msgpack::object("size", zone_);
+  kv[0].val = ctx_.SerializeNode(field->size, zone_);
+  kv[1].key = msgpack::object("policy", zone_);
+  kv[1].val = msgpack::object(static_cast<uint8_t>(field->policy), zone_);
+  msgpack::object obj;
+  obj.type = msgpack::type::MAP;
+  obj.via.map.size = 2;
+  obj.via.map.ptr = kv;
+  return obj;
 }
 
 msgpack::object FieldSerializerVisitor::VisitLeafField(const ScopeKind& field) {
@@ -686,10 +698,16 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(
           break;
       }
       kwargs_msgs.push_back(make_pair(key, msgpack::object(pad_map, zone_)));
+    } else if (value.type() == typeid(LoopOrigin)) {
+      auto origin = AnyCast<LoopOrigin>(value, "serializing kwarg: " + key);
+      std::map<std::string, msgpack::object> origin_map;
+      origin_map["type"] = msgpack::object("LoopOrigin", zone_);
+      origin_map["value"] = msgpack::object(LoopOriginToString(origin), zone_);
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(origin_map, zone_)));
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
                       ", expected int, bool, std::string, double, float, DataType, MemorySpace, "
-                      "TensorLayout, TileLayout, or PadValue, but got " +
+                      "TensorLayout, TileLayout, PadValue, or LoopOrigin, but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -189,6 +189,11 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
         } else {
           throw TypeError("Unknown PadValue: " + value_str + " for kwarg: " + key);
         }
+      } else if (type_name == "LoopOrigin") {
+        if (value_str.empty()) {
+          throw TypeError("Missing 'value' field for LoopOrigin kwarg: " + key);
+        }
+        kwargs.emplace_back(key, StringToLoopOrigin(value_str));
       } else {
         // Try to deserialize as DataType
         try {
@@ -461,29 +466,38 @@ static IRNodePtr DeserializeForStmt(const msgpack::object& fields_obj, msgpack::
     kind = static_cast<ForKind>(kind_obj->via.u64);
   }
 
-  // Deserialize chunk_size (optional)
-  std::optional<ExprPtr> chunk_size = std::nullopt;
-  auto chunk_size_obj = GetOptionalFieldObj(fields_obj, "chunk_size", ctx);
-  if (chunk_size_obj.has_value() && chunk_size_obj->type != msgpack::type::NIL) {
-    chunk_size = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(*chunk_size_obj, zone));
+  // Deserialize chunk_config (optional map with "size" and "policy")
+  std::optional<ChunkConfig> chunk_config = std::nullopt;
+  auto chunk_config_obj = GetOptionalFieldObj(fields_obj, "chunk_config", ctx);
+  if (chunk_config_obj.has_value() && chunk_config_obj->type == msgpack::type::MAP) {
+    auto size_obj = ctx.GetFieldObj(*chunk_config_obj, "size");
+    auto chunk_size = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(size_obj, zone));
+    ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull;
+    auto policy_obj = GetOptionalFieldObj(*chunk_config_obj, "policy", ctx);
+    if (policy_obj.has_value()) {
+      chunk_policy = static_cast<ChunkPolicy>(policy_obj->via.u64);
+    }
+    chunk_config = ChunkConfig{chunk_size, chunk_policy};
   }
 
-  // Deserialize chunk_policy with backward compatibility (defaults to LeadingFull)
-  ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull;
-  auto chunk_policy_obj = GetOptionalFieldObj(fields_obj, "chunk_policy", ctx);
-  if (chunk_policy_obj.has_value()) {
-    chunk_policy = static_cast<ChunkPolicy>(chunk_policy_obj->via.u64);
-  }
-
-  // Deserialize loop_origin with backward compatibility (defaults to Original)
-  LoopOrigin loop_origin = LoopOrigin::Original;
-  auto loop_origin_obj = GetOptionalFieldObj(fields_obj, "loop_origin", ctx);
-  if (loop_origin_obj.has_value()) {
-    loop_origin = static_cast<LoopOrigin>(loop_origin_obj->via.u64);
+  // Deserialize attrs with backward compatibility for old loop_origin field
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_obj = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_obj.has_value() && attrs_obj->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_obj, "attrs");
+  } else {
+    // Legacy backward compat: convert old "loop_origin" field to attrs
+    auto loop_origin_obj = GetOptionalFieldObj(fields_obj, "loop_origin", ctx);
+    if (loop_origin_obj.has_value()) {
+      auto origin = static_cast<LoopOrigin>(loop_origin_obj->via.u64);
+      if (origin != LoopOrigin::Original) {
+        attrs.emplace_back("loop_origin", origin);
+      }
+    }
   }
 
   return std::make_shared<ForStmt>(loop_var, start, stop, step, iter_args, body, return_vars, span, kind,
-                                   chunk_size, chunk_policy, loop_origin);
+                                   chunk_config, std::move(attrs));
 }
 
 // Deserialize WhileStmt

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -667,10 +667,10 @@ class TypePropagatingMutator : public IRMutator {
     return UpdateLoopReturnVars(
         new_for->iter_args_, new_for->return_vars_, op->return_vars_,
         [&](auto new_rv) {
-          return std::make_shared<ForStmt>(
-              new_for->loop_var_, new_for->start_, new_for->stop_, new_for->step_, new_for->iter_args_,
-              new_for->body_, std::move(new_rv), new_for->span_, new_for->kind_, new_for->chunk_size_,
-              new_for->chunk_policy_, new_for->loop_origin_);
+          return std::make_shared<ForStmt>(new_for->loop_var_, new_for->start_, new_for->stop_,
+                                           new_for->step_, new_for->iter_args_, new_for->body_,
+                                           std::move(new_rv), new_for->span_, new_for->kind_,
+                                           new_for->chunk_config_, new_for->attrs_);
         },
         result);
   }
@@ -988,8 +988,8 @@ class VarUseVisitor : public IRVisitor {
     if (found_) return;
     VisitExpr(op->step_);
     if (found_) return;
-    if (op->chunk_size_.has_value()) {
-      VisitExpr(*op->chunk_size_);
+    if (op->chunk_config_.has_value()) {
+      VisitExpr(op->chunk_config_->size);
       if (found_) return;
     }
     for (const auto& iter_arg : op->iter_args_) {
@@ -1319,8 +1319,8 @@ YieldAliasInfo AnalyzeStmtAliases(const StmtPtr& stmt, AliasOriginMap& origin_ma
     if (auto step_call = As<Call>(for_stmt->step_)) {
       AnalyzeCallAccess(step_call, origin_map, has_read, has_write);
     }
-    if (for_stmt->chunk_size_.has_value()) {
-      if (auto chunk_call = As<Call>(*for_stmt->chunk_size_)) {
+    if (for_stmt->chunk_config_.has_value()) {
+      if (auto chunk_call = As<Call>(for_stmt->chunk_config_->size)) {
         AnalyzeCallAccess(chunk_call, origin_map, has_read, has_write);
       }
     }
@@ -1521,7 +1521,7 @@ std::optional<ReturnedAssembleLoopRewrite> RewriteReturnedAssembleLoopToStore(
                                   std::vector<IterArgPtr>{new_iter_arg},
                                   SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_),
                                   std::vector<VarPtr>{new_return_var}, for_stmt->span_, for_stmt->kind_,
-                                  for_stmt->chunk_size_, for_stmt->chunk_policy_, for_stmt->loop_origin_);
+                                  for_stmt->chunk_config_, for_stmt->attrs_);
 
     std::optional<size_t> dead_init_stmt_index;
     if (auto init_var = As<Var>(old_iter_arg->initValue_)) {

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -151,7 +151,7 @@ static std::unordered_set<const Var*> ComputeStmtLiveIn(const StmtPtr& stmt) {
     uc.CollectExpr(op->stop_);
     uc.CollectExpr(op->step_);
     for (const auto& ia : op->iter_args_) uc.CollectExpr(ia->initValue_);
-    if (op->chunk_size_.has_value()) uc.CollectExpr(*op->chunk_size_);
+    if (op->chunk_config_.has_value()) uc.CollectExpr(op->chunk_config_->size);
     auto body_li = ComputeStmtLiveIn(op->body_);
     body_li.erase(op->loop_var_.get());
     for (const auto& ia : op->iter_args_) body_li.erase(ia.get());
@@ -562,7 +562,7 @@ class SSAConverter {
     if (!yields.empty()) body = ReplaceOrAppendYield(new_body, yields, op->span_);
 
     return std::make_shared<ForStmt>(new_lv, new_start, new_stop, new_step, ias, body, all_rvs, op->span_,
-                                     op->kind_, op->chunk_size_, op->chunk_policy_, op->loop_origin_);
+                                     op->kind_, op->chunk_config_, op->attrs_);
   }
 
   // ── WhileStmt ──────────────────────────────────────────────────────

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -663,8 +663,8 @@ class CtrlFlowTransformMutator : public IRMutator {
       return op;
     }
     return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                     new_body, op->return_vars_, op->span_, op->kind_, op->chunk_size_,
-                                     op->chunk_policy_, op->loop_origin_);
+                                     new_body, op->return_vars_, op->span_, op->kind_, op->chunk_config_,
+                                     op->attrs_);
   }
 
   BodyResult ProcessBodyForBreakAndContinue(const DecomposedBody& decomposed,
@@ -690,8 +690,8 @@ class CtrlFlowTransformMutator : public IRMutator {
     auto final_body = BuildFinalBody(std::move(result), decomposed.had_yield, op->span_);
 
     return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                     final_body, op->return_vars_, op->span_, op->kind_, op->chunk_size_,
-                                     op->chunk_policy_, op->loop_origin_);
+                                     final_body, op->return_vars_, op->span_, op->kind_, op->chunk_config_,
+                                     op->attrs_);
   }
 
   // --------------------------------------------------------------------------

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -454,7 +454,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
         result.push_back(std::make_shared<ForStmt>(
             for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
             MakeBody(new_body, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
-            for_stmt->chunk_size_, for_stmt->chunk_policy_, for_stmt->loop_origin_));
+            for_stmt->chunk_config_, for_stmt->attrs_));
       } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
         auto new_then = BuildCoreBody(side, FlattenBody(if_stmt->then_body_), stmt_map, boundary_moves,
                                       tpop_var_remap, superseded_tpop_vars);
@@ -1001,10 +1001,10 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
       auto nb = RewriteCallsForGMBuffer(for_stmt->body_, modified_funcs, gm_param);
       if (nb != for_stmt->body_) {
-        new_stmts.push_back(std::make_shared<ForStmt>(
-            for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_, nb,
-            for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
-            for_stmt->chunk_policy_, for_stmt->loop_origin_));
+        new_stmts.push_back(
+            std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
+                                      for_stmt->iter_args_, nb, for_stmt->return_vars_, for_stmt->span_,
+                                      for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -251,8 +251,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ForStmtPtr& op) {
   pending_stmts_ = range_pending;
 
   return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                   op->return_vars_, op->span_, op->kind_, op->chunk_size_, op->chunk_policy_,
-                                   op->loop_origin_);
+                                   op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -359,8 +359,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
       result.push_back(std::make_shared<ForStmt>(for_stmt->loop_var_, new_start, new_stop, new_step,
                                                  new_iter_args, new_body, new_return_vars, for_stmt->span_,
-                                                 for_stmt->kind_, for_stmt->chunk_size_,
-                                                 for_stmt->chunk_policy_, for_stmt->loop_origin_));
+                                                 for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
       continue;
     }
 

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -357,8 +357,7 @@ class FuseCreateAssembleMutator : public IRMutator {
 
     return std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
                                      new_iter_args, new_body, new_return_vars, for_stmt->span_,
-                                     for_stmt->kind_, for_stmt->chunk_size_, for_stmt->chunk_policy_,
-                                     for_stmt->loop_origin_);
+                                     for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
   }
 
   StmtPtr StripPassThroughWhileIterArgs(const StmtPtr& stmt) {

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -370,14 +370,14 @@ class InitMemRefMutator : public IRMutator {
     }
 
     // Visit chunk_size if present
-    std::optional<ExprPtr> new_chunk_size = op->chunk_size_;
-    if (op->chunk_size_.has_value()) {
-      new_chunk_size = VisitExpr(*op->chunk_size_);
+    std::optional<ChunkConfig> new_chunk_config = op->chunk_config_;
+    if (op->chunk_config_.has_value()) {
+      new_chunk_config = ChunkConfig{VisitExpr(op->chunk_config_->size), op->chunk_config_->policy};
     }
 
-    auto new_for = std::make_shared<ForStmt>(new_loop_var, new_start, new_stop, new_step, new_iter_args,
-                                             new_body, new_return_vars, op->span_, op->kind_, new_chunk_size,
-                                             op->chunk_policy_, op->loop_origin_);
+    auto new_for =
+        std::make_shared<ForStmt>(new_loop_var, new_start, new_stop, new_step, new_iter_args, new_body,
+                                  new_return_vars, op->span_, op->kind_, new_chunk_config, op->attrs_);
 
     // Patch return_vars so each shares its yield value's MemRef.
     auto yield_stmt = FindYieldStmt(new_body);
@@ -395,8 +395,7 @@ class InitMemRefMutator : public IRMutator {
 
     return std::make_shared<ForStmt>(new_for->loop_var_, new_for->start_, new_for->stop_, new_for->step_,
                                      new_for->iter_args_, new_for->body_, std::move(patched), new_for->span_,
-                                     new_for->kind_, new_for->chunk_size_, new_for->chunk_policy_,
-                                     new_for->loop_origin_);
+                                     new_for->kind_, new_for->chunk_config_, new_for->attrs_);
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {

--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -827,10 +827,10 @@ class SyncInserter {
     auto normalized_body = EnsureSeqStmts(for_stmt->body_);
     auto new_body = ApplyInsertions(normalized_body, path);
     path.pop_back();
-    return std::make_shared<const ForStmt>(
-        for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
-        new_body, for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
-        for_stmt->chunk_policy_, for_stmt->loop_origin_);
+    return std::make_shared<const ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_,
+                                           for_stmt->step_, for_stmt->iter_args_, new_body,
+                                           for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
+                                           for_stmt->chunk_config_, for_stmt->attrs_);
   }
 };
 

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <any>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -35,6 +36,8 @@
 
 namespace pypto {
 namespace ir {
+
+using Attrs = std::vector<std::pair<std::string, std::any>>;
 
 namespace {
 
@@ -150,7 +153,8 @@ static bool ContainsChunkLoop(const StmtPtr& stmt) {
   switch (kind) {
     case ObjectKind::ForStmt: {
       auto for_stmt = std::static_pointer_cast<const ForStmt>(stmt);
-      return for_stmt->loop_origin_ != LoopOrigin::Original || ContainsChunkLoop(for_stmt->body_);
+      return for_stmt->GetAttr<LoopOrigin>("loop_origin") != LoopOrigin::Original ||
+             ContainsChunkLoop(for_stmt->body_);
     }
     case ObjectKind::SeqStmts: {
       auto seq = std::static_pointer_cast<const SeqStmts>(stmt);
@@ -212,8 +216,8 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
       auto new_body = WrapNonIncoreStatementsInInCore(fs->body_, span, split);
       if (new_body.get() != fs->body_.get()) {
         return std::make_shared<ForStmt>(fs->loop_var_, fs->start_, fs->stop_, fs->step_, fs->iter_args_,
-                                         new_body, fs->return_vars_, fs->span_, fs->kind_, fs->chunk_size_,
-                                         fs->chunk_policy_, fs->loop_origin_);
+                                         new_body, fs->return_vars_, fs->span_, fs->kind_, fs->chunk_config_,
+                                         fs->attrs_);
       }
     }
     return s;
@@ -316,11 +320,12 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       return IRMutator::VisitStmt_(op);
     }
 
-    if (op->loop_origin_ == LoopOrigin::ChunkOuter) {
+    auto loop_origin = op->GetAttr<LoopOrigin>("loop_origin");
+    if (loop_origin == LoopOrigin::ChunkOuter) {
       return HandleChunkOuter(op);
     }
 
-    if (op->loop_origin_ == LoopOrigin::ChunkRemainder) {
+    if (loop_origin == LoopOrigin::ChunkRemainder) {
       return HandleChunkRemainder(op);
     }
 
@@ -382,7 +387,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
    */
   static std::vector<ChainEntry> CollectChunkChain(const ForStmtPtr& start) {
     std::vector<ChainEntry> chain;
-    chain.push_back({start, start->loop_origin_});
+    chain.push_back({start, start->GetAttr<LoopOrigin>("loop_origin")});
 
     StmtPtr body = start->body_;
 
@@ -416,9 +421,10 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       }
 
       if (!next_for) break;
-      if (next_for->loop_origin_ == LoopOrigin::Original) break;
+      auto next_origin = next_for->GetAttr<LoopOrigin>("loop_origin");
+      if (next_origin == LoopOrigin::Original) break;
 
-      chain.push_back({next_for, next_for->loop_origin_});
+      chain.push_back({next_for, next_origin});
       body = next_for->body_;
     }
 
@@ -517,8 +523,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     }
 
     return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, new_iter_args, new_body,
-                                     op->return_vars_, op->span_, op->kind_, op->chunk_size_,
-                                     op->chunk_policy_, op->loop_origin_);
+                                     op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
   }
 
   /**
@@ -531,8 +536,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
                                                std::optional<SplitMode> split = std::nullopt) {
     auto should_wrap = [](const StmtPtr& s) -> bool {
       auto fs = std::dynamic_pointer_cast<const ForStmt>(s);
-      return fs && fs->loop_origin_ == LoopOrigin::ChunkRemainder && fs->kind_ == ForKind::Parallel &&
-             !ContainsInCoreScope(fs->body_);
+      return fs && fs->GetAttr<LoopOrigin>("loop_origin") == LoopOrigin::ChunkRemainder &&
+             fs->kind_ == ForKind::Parallel && !ContainsInCoreScope(fs->body_);
     };
 
     auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
@@ -597,8 +602,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       const auto& inner = inners[i];
       current = std::make_shared<ForStmt>(inner->loop_var_, inner->start_, inner->stop_, inner->step_,
                                           std::vector<IterArgPtr>{}, current, std::vector<VarPtr>{},
-                                          inner->span_, inner->kind_, std::nullopt, ChunkPolicy::LeadingFull,
-                                          LoopOrigin::ChunkInner);
+                                          inner->span_, inner->kind_, std::nullopt,
+                                          Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
     }
 
     // Wrap in InCore — skip if a parent chain already provides InCore context
@@ -612,8 +617,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       const auto& outer = outers[i];
       current = std::make_shared<ForStmt>(outer->loop_var_, outer->start_, outer->stop_, outer->step_,
                                           std::vector<IterArgPtr>{}, current, std::vector<VarPtr>{},
-                                          outer->span_, outer->kind_, std::nullopt, ChunkPolicy::LeadingFull,
-                                          LoopOrigin::ChunkOuter);
+                                          outer->span_, outer->kind_, std::nullopt,
+                                          Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
     }
 
     return current;
@@ -698,7 +703,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
 
     for (int i = static_cast<int>(total_loops) - 1; i >= 0; --i) {
       const auto& orig_loop = reordered[i];
-      bool is_inner = (orig_loop->loop_origin_ == LoopOrigin::ChunkInner);
+      bool is_inner = (orig_loop->GetAttr<LoopOrigin>("loop_origin") == LoopOrigin::ChunkInner);
 
       // Build yield for this loop from the inner loop's return_vars
       // (or body's yield values for the innermost)
@@ -723,12 +728,12 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       current = std::make_shared<ForStmt>(
           orig_loop->loop_var_, orig_loop->start_, orig_loop->stop_, orig_loop->step_, new_iter_args[i],
           current, new_return_vars[i], orig_loop->span_, orig_loop->kind_, std::nullopt,
-          ChunkPolicy::LeadingFull, is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter);
+          Attrs{{"loop_origin", is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter}});
 
       // Insert InCore scope right after building all inners (at the boundary).
       // Skip if a parent chain already provides InCore context.
       if (!prev_incore && !is_inner && i + 1 < static_cast<int>(total_loops) &&
-          reordered[i + 1]->loop_origin_ == LoopOrigin::ChunkInner) {
+          reordered[i + 1]->GetAttr<LoopOrigin>("loop_origin") == LoopOrigin::ChunkInner) {
         // The current ForStmt body already contains the inner loops.
         // We need to wrap the inner loop nest (current's body) in InCore.
         // But current IS the outermost outer that contains inners already.
@@ -763,7 +768,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
           current = std::make_shared<ForStmt>(outer_for->loop_var_, outer_for->start_, outer_for->stop_,
                                               outer_for->step_, outer_for->iter_args_, new_body,
                                               outer_for->return_vars_, outer_for->span_, outer_for->kind_,
-                                              std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+                                              std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
         } else {
           // No yield, wrap entire body
           auto incore_scope = std::make_shared<ScopeStmt>(ScopeKind::InCore, incore_body, span, std::nullopt,
@@ -771,7 +776,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
           current = std::make_shared<ForStmt>(outer_for->loop_var_, outer_for->start_, outer_for->stop_,
                                               outer_for->step_, outer_for->iter_args_, incore_scope,
                                               outer_for->return_vars_, outer_for->span_, outer_for->kind_,
-                                              std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+                                              std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
         }
       }
     }

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -41,6 +41,16 @@ using Attrs = std::vector<std::pair<std::string, std::any>>;
 
 namespace {
 
+/// Build attrs for a generated loop: copy original attrs (excluding loop_origin) and set the new origin.
+Attrs MakeLoopAttrs(const Attrs& original_attrs, LoopOrigin origin) {
+  Attrs result;
+  for (const auto& [key, value] : original_attrs) {
+    if (key != "loop_origin") result.emplace_back(key, value);
+  }
+  result.emplace_back("loop_origin", origin);
+  return result;
+}
+
 /**
  * @brief A single entry in a chunk-loop chain.
  */
@@ -603,7 +613,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       current = std::make_shared<ForStmt>(inner->loop_var_, inner->start_, inner->stop_, inner->step_,
                                           std::vector<IterArgPtr>{}, current, std::vector<VarPtr>{},
                                           inner->span_, inner->kind_, std::nullopt,
-                                          Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
+                                          MakeLoopAttrs(inner->attrs_, LoopOrigin::ChunkInner));
     }
 
     // Wrap in InCore — skip if a parent chain already provides InCore context
@@ -618,7 +628,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       current = std::make_shared<ForStmt>(outer->loop_var_, outer->start_, outer->stop_, outer->step_,
                                           std::vector<IterArgPtr>{}, current, std::vector<VarPtr>{},
                                           outer->span_, outer->kind_, std::nullopt,
-                                          Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
+                                          MakeLoopAttrs(outer->attrs_, LoopOrigin::ChunkOuter));
     }
 
     return current;
@@ -728,7 +738,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       current = std::make_shared<ForStmt>(
           orig_loop->loop_var_, orig_loop->start_, orig_loop->stop_, orig_loop->step_, new_iter_args[i],
           current, new_return_vars[i], orig_loop->span_, orig_loop->kind_, std::nullopt,
-          Attrs{{"loop_origin", is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter}});
+          MakeLoopAttrs(orig_loop->attrs_, is_inner ? LoopOrigin::ChunkInner : LoopOrigin::ChunkOuter));
 
       // Insert InCore scope right after building all inners (at the boundary).
       // Skip if a parent chain already provides InCore context.
@@ -765,18 +775,18 @@ class InterchangeChunkLoopsMutator : public IRMutator {
                                                           std::nullopt, std::nullopt, current_split_);
           auto new_body = SeqStmts::Flatten(std::vector<StmtPtr>{incore_scope, last_stmt}, span);
 
-          current = std::make_shared<ForStmt>(outer_for->loop_var_, outer_for->start_, outer_for->stop_,
-                                              outer_for->step_, outer_for->iter_args_, new_body,
-                                              outer_for->return_vars_, outer_for->span_, outer_for->kind_,
-                                              std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
+          current = std::make_shared<ForStmt>(
+              outer_for->loop_var_, outer_for->start_, outer_for->stop_, outer_for->step_,
+              outer_for->iter_args_, new_body, outer_for->return_vars_, outer_for->span_, outer_for->kind_,
+              std::nullopt, MakeLoopAttrs(outer_for->attrs_, LoopOrigin::ChunkOuter));
         } else {
           // No yield, wrap entire body
           auto incore_scope = std::make_shared<ScopeStmt>(ScopeKind::InCore, incore_body, span, std::nullopt,
                                                           std::nullopt, current_split_);
-          current = std::make_shared<ForStmt>(outer_for->loop_var_, outer_for->start_, outer_for->stop_,
-                                              outer_for->step_, outer_for->iter_args_, incore_scope,
-                                              outer_for->return_vars_, outer_for->span_, outer_for->kind_,
-                                              std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
+          current = std::make_shared<ForStmt>(
+              outer_for->loop_var_, outer_for->start_, outer_for->stop_, outer_for->step_,
+              outer_for->iter_args_, incore_scope, outer_for->return_vars_, outer_for->span_,
+              outer_for->kind_, std::nullopt, MakeLoopAttrs(outer_for->attrs_, LoopOrigin::ChunkOuter));
         }
       }
     }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -744,10 +744,10 @@ class YieldFixupMutator : public IRMutator {
     auto new_body = InsertMovesAndReplaceYield(for_stmt->body_, new_yield, move_stmts);
 
     // Build intermediate ForStmt with new body, then patch iter_args/return_vars
-    auto intermediate_for = std::make_shared<ForStmt>(
-        for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
-        new_body, for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_, for_stmt->chunk_size_,
-        for_stmt->chunk_policy_, for_stmt->loop_origin_);
+    auto intermediate_for =
+        std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
+                                  for_stmt->iter_args_, new_body, for_stmt->return_vars_, for_stmt->span_,
+                                  for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
 
     return PatchIterArgsAndReturnVars(intermediate_for, new_yield);
   }
@@ -910,8 +910,7 @@ class YieldFixupMutator : public IRMutator {
 
     return std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
                                      new_iter_args, patched_body, std::move(new_return_vars), for_stmt->span_,
-                                     for_stmt->kind_, for_stmt->chunk_size_, for_stmt->chunk_policy_,
-                                     for_stmt->loop_origin_);
+                                     for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
   }
 
   // Replace YieldStmt in body and insert move AssignStmts before it.

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -478,24 +478,24 @@ StmtPtr IRMutator::VisitStmt_(const ForStmtPtr& op) {
     }
   }
 
-  std::optional<ExprPtr> new_chunk_size = op->chunk_size_;
-  bool chunk_size_changed = false;
-  if (op->chunk_size_.has_value()) {
-    auto new_cs = ExprFunctor<ExprPtr>::VisitExpr(*op->chunk_size_);
+  std::optional<ChunkConfig> new_chunk_config = op->chunk_config_;
+  bool chunk_config_changed = false;
+  if (op->chunk_config_.has_value()) {
+    auto new_cs = ExprFunctor<ExprPtr>::VisitExpr(op->chunk_config_->size);
     INTERNAL_CHECK(new_cs) << "ForStmt chunk_size mutated to null";
-    if (new_cs.get() != (*op->chunk_size_).get()) {
-      new_chunk_size = new_cs;
-      chunk_size_changed = true;
+    if (new_cs.get() != op->chunk_config_->size.get()) {
+      new_chunk_config = ChunkConfig{new_cs, op->chunk_config_->policy};
+      chunk_config_changed = true;
     }
   }
 
   if (new_loop_var.get() != op->loop_var_.get() || new_start.get() != op->start_.get() ||
       new_stop.get() != op->stop_.get() || new_step.get() != op->step_.get() || iter_args_changed ||
-      body_changed || return_vars_changed || chunk_size_changed) {
+      body_changed || return_vars_changed || chunk_config_changed) {
     return std::make_shared<const ForStmt>(std::move(new_loop_var), std::move(new_start), std::move(new_stop),
                                            std::move(new_step), std::move(new_iter_args), std::move(new_body),
                                            std::move(new_return_vars), op->span_, op->kind_,
-                                           std::move(new_chunk_size), op->chunk_policy_, op->loop_origin_);
+                                           std::move(new_chunk_config), op->attrs_);
   }
   return op;
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -934,12 +934,35 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
   }
 
   // Add chunk kwargs
-  if (op->chunk_size_.has_value()) {
+  if (op->chunk_config_.has_value()) {
     stream_ << ", chunk=";
-    VisitExpr(*op->chunk_size_);
-    if (op->chunk_policy_ != ChunkPolicy::LeadingFull) {
-      stream_ << ", chunk_policy=\"" << ChunkPolicyToString(op->chunk_policy_) << "\"";
+    VisitExpr(op->chunk_config_->size);
+    if (op->chunk_config_->policy != ChunkPolicy::LeadingFull) {
+      stream_ << ", chunk_policy=\"" << ChunkPolicyToString(op->chunk_config_->policy) << "\"";
     }
+  }
+
+  // Add attrs kwargs
+  if (!op->attrs_.empty()) {
+    stream_ << ", attrs={";
+    bool first_attr = true;
+    for (const auto& [key, value] : op->attrs_) {
+      if (!first_attr) stream_ << ", ";
+      first_attr = false;
+      stream_ << "\"" << key << "\": ";
+      if (value.type() == typeid(LoopOrigin)) {
+        stream_ << prefix_ << ".LoopOrigin." << LoopOriginToString(AnyCast<LoopOrigin>(value, key));
+      } else if (value.type() == typeid(int)) {
+        stream_ << AnyCast<int>(value, key);
+      } else if (value.type() == typeid(bool)) {
+        stream_ << (AnyCast<bool>(value, key) ? "True" : "False");
+      } else if (value.type() == typeid(std::string)) {
+        stream_ << "\"" << AnyCast<std::string>(value, key) << "\"";
+      } else {
+        stream_ << "...";  // Unknown type placeholder
+      }
+    }
+    stream_ << "}";
   }
 
   stream_ << "):\n";

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -954,12 +954,17 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
         stream_ << prefix_ << ".LoopOrigin." << LoopOriginToString(AnyCast<LoopOrigin>(value, key));
       } else if (value.type() == typeid(int)) {
         stream_ << AnyCast<int>(value, key);
+      } else if (value.type() == typeid(double)) {
+        stream_ << AnyCast<double>(value, key);
+      } else if (value.type() == typeid(float)) {
+        stream_ << AnyCast<float>(value, key);
       } else if (value.type() == typeid(bool)) {
         stream_ << (AnyCast<bool>(value, key) ? "True" : "False");
       } else if (value.type() == typeid(std::string)) {
         stream_ << "\"" << AnyCast<std::string>(value, key) << "\"";
       } else {
-        stream_ << "...";  // Unknown type placeholder
+        INTERNAL_CHECK(false) << "Unsupported attrs value type for key '" << key
+                              << "': " << DemangleTypeName(value.type().name());
       }
     }
     stream_ << "}";

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -949,19 +949,19 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
     for (const auto& [key, value] : op->attrs_) {
       if (!first_attr) stream_ << ", ";
       first_attr = false;
-      stream_ << "\"" << key << "\": ";
+      stream_ << std::quoted(key) << ": ";
       if (value.type() == typeid(LoopOrigin)) {
         stream_ << prefix_ << ".LoopOrigin." << LoopOriginToString(AnyCast<LoopOrigin>(value, key));
       } else if (value.type() == typeid(int)) {
         stream_ << AnyCast<int>(value, key);
       } else if (value.type() == typeid(double)) {
-        stream_ << AnyCast<double>(value, key);
+        stream_ << FormatFloatLiteral(AnyCast<double>(value, key));
       } else if (value.type() == typeid(float)) {
-        stream_ << AnyCast<float>(value, key);
+        stream_ << FormatFloatLiteral(static_cast<double>(AnyCast<float>(value, key)));
       } else if (value.type() == typeid(bool)) {
         stream_ << (AnyCast<bool>(value, key) ? "True" : "False");
       } else if (value.type() == typeid(std::string)) {
-        stream_ << "\"" << AnyCast<std::string>(value, key) << "\"";
+        stream_ << std::quoted(AnyCast<std::string>(value, key));
       } else {
         INTERNAL_CHECK(false) << "Unsupported attrs value type for key '" << key
                               << "': " << DemangleTypeName(value.type().name());

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -62,13 +62,13 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     auto new_step = analyzer_->Simplify(op->step_);
 
     // Simplify chunk_size (pre-loop, before binding).
-    std::optional<ExprPtr> new_chunk_size = op->chunk_size_;
-    bool chunk_size_changed = false;
-    if (op->chunk_size_.has_value()) {
-      auto new_cs = analyzer_->Simplify(*op->chunk_size_);
-      if (new_cs.get() != (*op->chunk_size_).get()) {
-        new_chunk_size = new_cs;
-        chunk_size_changed = true;
+    std::optional<ChunkConfig> new_chunk_config = op->chunk_config_;
+    bool chunk_config_changed = false;
+    if (op->chunk_config_.has_value()) {
+      auto new_cs = analyzer_->Simplify(op->chunk_config_->size);
+      if (new_cs.get() != op->chunk_config_->size.get()) {
+        new_chunk_config = ChunkConfig{new_cs, op->chunk_config_->policy};
+        chunk_config_changed = true;
       }
     }
 
@@ -90,12 +90,11 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
 
     bool changed = (new_start.get() != op->start_.get()) || (new_stop.get() != op->stop_.get()) ||
                    (new_step.get() != op->step_.get()) || (new_body.get() != op->body_.get()) ||
-                   chunk_size_changed;
+                   chunk_config_changed;
     if (!changed) return op;
 
     return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_, op->kind_, new_chunk_size,
-                                     op->chunk_policy_, op->loop_origin_);
+                                     op->return_vars_, op->span_, op->kind_, new_chunk_config, op->attrs_);
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -44,6 +44,16 @@ using transform_utils::CollectDefVars;
 
 namespace {
 
+/// Build attrs for a generated loop: copy original attrs (excluding loop_origin) and set the new origin.
+Attrs MakeLoopAttrs(const Attrs& original_attrs, LoopOrigin origin) {
+  Attrs result;
+  for (const auto& [key, value] : original_attrs) {
+    if (key != "loop_origin") result.emplace_back(key, value);
+  }
+  result.emplace_back("loop_origin", origin);
+  return result;
+}
+
 /**
  * @brief Try to extract a compile-time integer from a ConstInt or Neg(ConstInt).
  * @return The integer value, or std::nullopt if not a compile-time constant.
@@ -429,10 +439,10 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto inner_for = std::make_shared<ForStmt>(
           in_var, zero, chunk_expr, one, std::vector<IterArgPtr>{}, inner_body, std::vector<VarPtr>{}, sp,
-          op->kind_, std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
+          op->kind_, std::nullopt, MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkInner));
       auto outer_for = std::make_shared<ForStmt>(
           out_var, zero, n_full, one, std::vector<IterArgPtr>{}, inner_for, std::vector<VarPtr>{}, sp,
-          op->kind_, std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
+          op->kind_, std::nullopt, MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkOuter));
       result_stmts.push_back(outer_for);
     }
 
@@ -454,7 +464,7 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, std::vector<IterArgPtr>{}, rem_body,
                                                std::vector<VarPtr>{}, sp, op->kind_, std::nullopt,
-                                               Attrs{{"loop_origin", LoopOrigin::ChunkRemainder}});
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkRemainder));
       result_stmts.push_back(rem_for);
     }
 
@@ -524,14 +534,14 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto inner_for = std::make_shared<ForStmt>(in_var, zero, chunk_expr, one, inner_iter_args, inner_body,
                                                  inner_return_vars, sp, op->kind_, std::nullopt,
-                                                 Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
+                                                 MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkInner));
       auto outer_yield = std::make_shared<YieldStmt>(
           std::vector<ExprPtr>(inner_return_vars.begin(), inner_return_vars.end()), sp);
       auto outer_body = SeqStmts::Flatten(std::vector<StmtPtr>{inner_for, outer_yield}, sp);
 
       auto outer_for = std::make_shared<ForStmt>(out_var, zero, n_full, one, outer_iter_args, outer_body,
                                                  outer_return_vars, sp, op->kind_, std::nullopt,
-                                                 Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
+                                                 MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkOuter));
 
       result_stmts.push_back(outer_for);
       final_return_vars = outer_return_vars;
@@ -576,7 +586,7 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, rem_iter_args, rem_body,
                                                rem_return_vars, sp, op->kind_, std::nullopt,
-                                               Attrs{{"loop_origin", LoopOrigin::ChunkRemainder}});
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkRemainder));
 
       result_stmts.push_back(rem_for);
       final_return_vars = rem_return_vars;

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <any>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -38,6 +39,7 @@
 namespace pypto {
 namespace ir {
 
+using Attrs = std::vector<std::pair<std::string, std::any>>;
 using transform_utils::CollectDefVars;
 
 namespace {
@@ -184,7 +186,7 @@ static StmtPtr MakeResultStmt(const std::vector<StmtPtr>& stmts, const Span& spa
 }
 
 /**
- * @brief Mutator that splits ForStmt nodes with chunk_size_ into nested loops.
+ * @brief Mutator that splits ForStmt nodes with chunk_config_ into nested loops.
  *
  * Runs after SSA conversion. Propagates iter_args through generated loops.
  * Handles both compile-time constant and dynamic (runtime) loop bounds.
@@ -253,12 +255,12 @@ class ChunkedLoopSplitter : public IRMutator {
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    if (!op->chunk_size_.has_value() || !inside_auto_incore_) {
+    if (!op->chunk_config_.has_value() || !inside_auto_incore_) {
       return IRMutator::VisitStmt_(op);
     }
 
     // chunk_size and step must always be compile-time constants
-    int64_t chunk_size = GetConstIntValue(*op->chunk_size_, "chunk_size");
+    int64_t chunk_size = GetConstIntValue(op->chunk_config_->size, "chunk_size");
     int64_t step = GetConstIntValue(op->step_, "step");
     CHECK(step != 0) << "Chunked loop step cannot be zero";
     CHECK(chunk_size > 0) << "Chunk size must be positive, got " << chunk_size;
@@ -427,10 +429,10 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto inner_for = std::make_shared<ForStmt>(
           in_var, zero, chunk_expr, one, std::vector<IterArgPtr>{}, inner_body, std::vector<VarPtr>{}, sp,
-          op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
+          op->kind_, std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
       auto outer_for = std::make_shared<ForStmt>(
           out_var, zero, n_full, one, std::vector<IterArgPtr>{}, inner_for, std::vector<VarPtr>{}, sp,
-          op->kind_, std::nullopt, ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+          op->kind_, std::nullopt, Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
       result_stmts.push_back(outer_for);
     }
 
@@ -452,7 +454,7 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, std::vector<IterArgPtr>{}, rem_body,
                                                std::vector<VarPtr>{}, sp, op->kind_, std::nullopt,
-                                               ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
+                                               Attrs{{"loop_origin", LoopOrigin::ChunkRemainder}});
       result_stmts.push_back(rem_for);
     }
 
@@ -522,14 +524,14 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto inner_for = std::make_shared<ForStmt>(in_var, zero, chunk_expr, one, inner_iter_args, inner_body,
                                                  inner_return_vars, sp, op->kind_, std::nullopt,
-                                                 ChunkPolicy::LeadingFull, LoopOrigin::ChunkInner);
+                                                 Attrs{{"loop_origin", LoopOrigin::ChunkInner}});
       auto outer_yield = std::make_shared<YieldStmt>(
           std::vector<ExprPtr>(inner_return_vars.begin(), inner_return_vars.end()), sp);
       auto outer_body = SeqStmts::Flatten(std::vector<StmtPtr>{inner_for, outer_yield}, sp);
 
       auto outer_for = std::make_shared<ForStmt>(out_var, zero, n_full, one, outer_iter_args, outer_body,
                                                  outer_return_vars, sp, op->kind_, std::nullopt,
-                                                 ChunkPolicy::LeadingFull, LoopOrigin::ChunkOuter);
+                                                 Attrs{{"loop_origin", LoopOrigin::ChunkOuter}});
 
       result_stmts.push_back(outer_for);
       final_return_vars = outer_return_vars;
@@ -574,7 +576,7 @@ class ChunkedLoopSplitter : public IRMutator {
 
       auto rem_for = std::make_shared<ForStmt>(rem_var, zero, n_rem, one, rem_iter_args, rem_body,
                                                rem_return_vars, sp, op->kind_, std::nullopt,
-                                               ChunkPolicy::LeadingFull, LoopOrigin::ChunkRemainder);
+                                               Attrs{{"loop_origin", LoopOrigin::ChunkRemainder}});
 
       result_stmts.push_back(rem_for);
       final_return_vars = rem_return_vars;

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -532,6 +532,21 @@ class StructuralEqualImpl {
       } else if (lhs_val.type() == typeid(LoopOrigin)) {
         values_equal = (AnyCast<LoopOrigin>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
                         AnyCast<LoopOrigin>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(TensorLayout)) {
+        values_equal = (AnyCast<TensorLayout>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
+                        AnyCast<TensorLayout>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(TileLayout)) {
+        values_equal = (AnyCast<TileLayout>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
+                        AnyCast<TileLayout>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(PadValue)) {
+        values_equal = (AnyCast<PadValue>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
+                        AnyCast<PadValue>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(float)) {
+        values_equal = (AnyCast<float>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
+                        AnyCast<float>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else {
+        INTERNAL_CHECK(false) << "Unsupported kwargs value type for key '" << lhs[i].first
+                              << "': " << DemangleTypeName(lhs_val.type().name());
       }
       if (!values_equal) {
         if constexpr (AssertMode) {

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -349,16 +349,16 @@ class StructuralEqualImpl {
     return true;
   }
 
-  [[nodiscard]] result_type VisitLeafField(const LoopOrigin& lhs, const LoopOrigin& rhs) {
-    if (lhs != rhs) {
+  result_type VisitLeafField(const std::optional<ChunkConfig>& lhs, const std::optional<ChunkConfig>& rhs) {
+    if (lhs.has_value() != rhs.has_value()) {
       if constexpr (AssertMode) {
-        std::ostringstream msg;
-        msg << "LoopOrigin mismatch (" << LoopOriginToString(lhs) << " != " << LoopOriginToString(rhs) << ")";
-        ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+        ThrowMismatch("ChunkConfig presence mismatch", IRNodePtr(), IRNodePtr(), "", "");
       }
       return false;
     }
-    return true;
+    if (!lhs.has_value()) return true;
+    if (!VisitIRNodeField(lhs->size, rhs->size)) return false;
+    return VisitLeafField(lhs->policy, rhs->policy);
   }
 
   [[nodiscard]] result_type VisitLeafField(const ScopeKind& lhs, const ScopeKind& rhs) {
@@ -529,6 +529,9 @@ class StructuralEqualImpl {
       } else if (lhs_val.type() == typeid(MemorySpace)) {
         values_equal = (AnyCast<MemorySpace>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
                         AnyCast<MemorySpace>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(LoopOrigin)) {
+        values_equal = (AnyCast<LoopOrigin>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
+                        AnyCast<LoopOrigin>(rhs_val, "comparing kwarg: " + lhs[i].first));
       }
       if (!values_equal) {
         if constexpr (AssertMode) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -196,8 +196,10 @@ class StructuralHasher {
     return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
   }
 
-  result_type VisitLeafField(const LoopOrigin& field) {
-    return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
+  result_type VisitLeafField(const std::optional<ChunkConfig>& field) {
+    if (!field.has_value()) return 0;
+    result_type h = VisitIRNodeField(field->size);
+    return hash_combine(h, VisitLeafField(field->policy));
   }
 
   result_type VisitLeafField(const ScopeKind& field) {
@@ -287,6 +289,9 @@ class StructuralHasher {
         h = hash_combine(h, std::hash<float>{}(AnyCast<float>(value, "hashing kwarg: " + key)));
       } else if (value.type() == typeid(DataType)) {
         h = hash_combine(h, std::hash<uint8_t>{}(AnyCast<DataType>(value, "hashing kwarg: " + key).Code()));
+      } else if (value.type() == typeid(LoopOrigin)) {
+        h = hash_combine(h, std::hash<uint8_t>{}(
+                                static_cast<uint8_t>(AnyCast<LoopOrigin>(value, "hashing kwarg: " + key))));
       } else {
         throw TypeError("Invalid kwarg type for key: " + key +
                         ", expected int, bool, std::string, double, float, or DataType, but got " +

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -292,9 +292,20 @@ class StructuralHasher {
       } else if (value.type() == typeid(LoopOrigin)) {
         h = hash_combine(h, std::hash<uint8_t>{}(
                                 static_cast<uint8_t>(AnyCast<LoopOrigin>(value, "hashing kwarg: " + key))));
+      } else if (value.type() == typeid(MemorySpace)) {
+        h = hash_combine(h, std::hash<uint8_t>{}(
+                                static_cast<uint8_t>(AnyCast<MemorySpace>(value, "hashing kwarg: " + key))));
+      } else if (value.type() == typeid(TensorLayout)) {
+        h = hash_combine(h, std::hash<uint8_t>{}(
+                                static_cast<uint8_t>(AnyCast<TensorLayout>(value, "hashing kwarg: " + key))));
+      } else if (value.type() == typeid(TileLayout)) {
+        h = hash_combine(h, std::hash<uint8_t>{}(
+                                static_cast<uint8_t>(AnyCast<TileLayout>(value, "hashing kwarg: " + key))));
+      } else if (value.type() == typeid(PadValue)) {
+        h = hash_combine(
+            h, std::hash<uint8_t>{}(static_cast<uint8_t>(AnyCast<PadValue>(value, "hashing kwarg: " + key))));
       } else {
-        throw TypeError("Invalid kwarg type for key: " + key +
-                        ", expected int, bool, std::string, double, float, or DataType, but got " +
+        throw TypeError("Unsupported kwarg type for key: " + key + ": " +
                         DemangleTypeName(value.type().name()));
       }
     }

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -130,7 +130,7 @@ class LoopUnrollMutator : public IRMutator {
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    if (op->kind_ != ForKind::Unroll || op->chunk_size_.has_value()) {
+    if (op->kind_ != ForKind::Unroll || op->chunk_config_.has_value()) {
       return IRMutator::VisitStmt_(op);
     }
     return UnrollForStmt(op);

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -141,7 +141,7 @@ std::vector<StmtPtr> FilterDeadCode(const std::vector<StmtPtr>& stmts,
       result.push_back(std::make_shared<ForStmt>(
           for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
           MakeBody(filtered, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
-          for_stmt->chunk_size_, for_stmt->chunk_policy_, for_stmt->loop_origin_));
+          for_stmt->chunk_config_, for_stmt->attrs_));
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       auto filtered_then = FilterDeadCode(FlattenBody(if_stmt->then_body_), live);
       std::optional<StmtPtr> filtered_else;

--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -39,15 +39,13 @@ StmtPtr MakeBody(const std::vector<StmtPtr>& stmts, const Span& span) {
 
 StmtPtr RebuildForStmt(const std::shared_ptr<const ForStmt>& f, const StmtPtr& new_body) {
   return std::make_shared<ForStmt>(f->loop_var_, f->start_, f->stop_, f->step_, f->iter_args_, new_body,
-                                   f->return_vars_, f->span_, f->kind_, f->chunk_size_, f->chunk_policy_,
-                                   f->loop_origin_);
+                                   f->return_vars_, f->span_, f->kind_, f->chunk_config_, f->attrs_);
 }
 
 StmtPtr RebuildForStmt(const std::shared_ptr<const ForStmt>& f, const std::vector<IterArgPtr>& iter_args,
                        const StmtPtr& new_body, const std::vector<VarPtr>& return_vars) {
   return std::make_shared<ForStmt>(f->loop_var_, f->start_, f->stop_, f->step_, iter_args, new_body,
-                                   return_vars, f->span_, f->kind_, f->chunk_size_, f->chunk_policy_,
-                                   f->loop_origin_);
+                                   return_vars, f->span_, f->kind_, f->chunk_config_, f->attrs_);
 }
 
 StmtPtr RebuildWhileStmt(const std::shared_ptr<const WhileStmt>& w, const StmtPtr& new_body) {

--- a/src/ir/transforms/utils/normalize_stmt_structure.cpp
+++ b/src/ir/transforms/utils/normalize_stmt_structure.cpp
@@ -131,8 +131,7 @@ StmtPtr NormalizeStmtStructureMutator::VisitStmt_(const ForStmtPtr& op) {
     auto new_step = VisitExpr(op->step_);
 
     return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_, op->kind_, op->chunk_size_,
-                                     op->chunk_policy_, op->loop_origin_);
+                                     op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
   }
   return op;
 }

--- a/src/ir/verifier/verify_use_after_def.cpp
+++ b/src/ir/verifier/verify_use_after_def.cpp
@@ -101,8 +101,8 @@ class UseAfterDefChecker : public IRVisitor {
     if (op->start_) VisitExpr(op->start_);
     if (op->stop_) VisitExpr(op->stop_);
     if (op->step_) VisitExpr(op->step_);
-    if (op->chunk_size_.has_value() && *op->chunk_size_) {
-      VisitExpr(*op->chunk_size_);
+    if (op->chunk_config_.has_value() && op->chunk_config_->size) {
+      VisitExpr(op->chunk_config_->size);
     }
 
     // IterArg initial values are evaluated in the outer scope.

--- a/src/ir/verifier/warning_unused_var.cpp
+++ b/src/ir/verifier/warning_unused_var.cpp
@@ -64,8 +64,8 @@ class UseCollector : public IRVisitor {
     if (op->start_) VisitExpr(op->start_);
     if (op->stop_) VisitExpr(op->stop_);
     if (op->step_) VisitExpr(op->step_);
-    if (op->chunk_size_.has_value() && *op->chunk_size_) {
-      VisitExpr(*op->chunk_size_);
+    if (op->chunk_config_.has_value() && op->chunk_config_->size) {
+      VisitExpr(op->chunk_config_->size);
     }
     for (const auto& iter_arg : op->iter_args_) {
       if (iter_arg && iter_arg->initValue_) {

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -105,7 +105,7 @@ def _strip_auto_tfree_from_stmt(stmt):
             stmt.kind,
             stmt.chunk_size,
             stmt.chunk_policy,
-            stmt.loop_origin,
+            stmt.attrs,
         )
     if isinstance(stmt, ir.IfStmt):
         new_then = _strip_auto_tfree_from_body(stmt.then_body)

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -60,7 +60,7 @@ class TestSingleParallelChunk:
         stmts = _top_level_stmts(After)
 
         outer_for = cast(ir.ForStmt, stmts[0])
-        assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         assert outer_for.kind == ir.ForKind.Parallel
 
         # Outer body = SeqStmts [InCore, yield]
@@ -70,7 +70,7 @@ class TestSingleParallelChunk:
 
         # InCore body = inner ForStmt
         inner_for = cast(ir.ForStmt, scope_stmt.body)
-        assert inner_for.loop_origin == ir.LoopOrigin.ChunkInner
+        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
         assert inner_for.kind == ir.ForKind.Parallel
 
 
@@ -98,13 +98,13 @@ class TestNestedParallelChunks:
 
         # i_out
         i_out = cast(ir.ForStmt, stmts[0])
-        assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert i_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         assert i_out.kind == ir.ForKind.Parallel
 
         # j_out inside i_out body
         i_out_body = _body_stmts(i_out.body)
         j_out = cast(ir.ForStmt, i_out_body[0])
-        assert j_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert j_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         assert j_out.kind == ir.ForKind.Parallel
 
         # InCore inside j_out body
@@ -114,13 +114,13 @@ class TestNestedParallelChunks:
 
         # i_in inside InCore
         i_in = cast(ir.ForStmt, scope.body)
-        assert i_in.loop_origin == ir.LoopOrigin.ChunkInner
+        assert i_in.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
         assert i_in.kind == ir.ForKind.Parallel
 
         # j_in inside i_in body
         i_in_body = _body_stmts(i_in.body)
         j_in = cast(ir.ForStmt, i_in_body[0])
-        assert j_in.loop_origin == ir.LoopOrigin.ChunkInner
+        assert j_in.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
         assert j_in.kind == ir.ForKind.Parallel
 
     def test_two_nested_parallel_with_iter_args(self):
@@ -319,7 +319,7 @@ class TestChunkWithRemainderInChain:
 
         # i_out (ChunkOuter, Parallel — preserves original kind from pl.parallel)
         i_out = cast(ir.ForStmt, stmts[0])
-        assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert i_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         assert i_out.kind == ir.ForKind.Parallel
         assert len(i_out.iter_args) == 1
 
@@ -329,7 +329,7 @@ class TestChunkWithRemainderInChain:
         assert scope.scope_kind == ir.ScopeKind.InCore
 
         i_in = cast(ir.ForStmt, scope.body)
-        assert i_in.loop_origin == ir.LoopOrigin.ChunkInner
+        assert i_in.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
         assert len(i_in.iter_args) == 1
 
         # i_in's iter_arg should chain from i_out's iter_arg (not from original init)
@@ -380,18 +380,18 @@ class TestRemainderLoops:
 
         # Main chunk pair: i_out → j_out → InCore { i_in → j_in → body }
         i_out = cast(ir.ForStmt, stmts[0])
-        assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert i_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         # Remainder: i_rem contains j_out→InCore{j_in} + InCore{j_rem}
         i_rem = cast(ir.ForStmt, stmts[1])
-        assert i_rem.loop_origin == ir.LoopOrigin.ChunkRemainder
+        assert i_rem.attrs.get("loop_origin") == ir.LoopOrigin.ChunkRemainder
 
         # Inside i_rem body, look for InCore scopes
         i_rem_body = _body_stmts(i_rem.body)
 
         # j_out should have InCore wrapping j_in inside its body
         j_out_in_rem = cast(ir.ForStmt, i_rem_body[0])
-        assert j_out_in_rem.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert j_out_in_rem.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         j_out_body = _body_stmts(j_out_in_rem.body)
         assert cast(ir.ScopeStmt, j_out_body[0]).scope_kind == ir.ScopeKind.InCore
 
@@ -637,7 +637,7 @@ class TestNonChunkStatementsWrapping:
 
         # Second stmt should be ChunkOuter (interchanged)
         outer_for = cast(ir.ForStmt, stmts[1])
-        assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
     def test_standalone_op_after_parallel_chunk(self):
         """Standalone op after parallel chunk: chunk interchanged, op wrapped separately."""
@@ -659,7 +659,7 @@ class TestNonChunkStatementsWrapping:
 
         # First stmt should be ChunkOuter (interchanged)
         outer_for = cast(ir.ForStmt, stmts[0])
-        assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         # There should be an InCore wrapping the standalone mul op
         after_str = python_print(After)
@@ -713,9 +713,9 @@ class TestNonChunkStatementsWrapping:
 
         # Both should be ChunkOuter loops (interchanged)
         i_out = cast(ir.ForStmt, stmts[0])
-        assert i_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert i_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
         j_out = cast(ir.ForStmt, stmts[1])
-        assert j_out.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert j_out.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         # No extra InCore wrapping around the outers themselves
         assert "auto_incore" not in python_print(After)
@@ -759,7 +759,7 @@ class TestNonChunkStatementsWrapping:
         stmts = _top_level_stmts(After)
 
         # First stmt: ChunkOuter from parallel chunk (interchanged)
-        assert cast(ir.ForStmt, stmts[0]).loop_origin == ir.LoopOrigin.ChunkOuter
+        assert cast(ir.ForStmt, stmts[0]).attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         # Sequential chunk should be wrapped in InCore
         after_str = python_print(After)

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -70,8 +70,16 @@ class TestBasicChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
@@ -99,12 +107,26 @@ class TestBasicChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 1, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):  # noqa: E501
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):  # noqa: E501
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
-                    for i_0_rem, (x_iter_1_rem,) in pl.range(0, 2, 1, init_values=(x_iter_1_outer_rv,)):
+                    for i_0_rem, (x_iter_1_rem,) in pl.range(
+                        0,
+                        2,
+                        1,
+                        init_values=(x_iter_1_outer_rv,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
+                    ):  # noqa: E501
                         x_3_f: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_rem, 1.0)
                         x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3_f)
                 return x_iter_1_rem_rv
@@ -131,8 +153,16 @@ class TestBasicChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 1, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
@@ -164,8 +194,16 @@ class TestChunkingWithStep:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
@@ -193,7 +231,9 @@ class TestChunkingWithStep:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_rem, (x_iter_1_rem,) in pl.range(0, 3, 1, init_values=(x_0,)):
+                    for i_0_rem, (x_iter_1_rem,) in pl.range(
+                        0, 3, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder}
+                    ):
                         x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_rem, 1.0)
                         x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                 return x_iter_1_rem_rv
@@ -224,8 +264,16 @@ class TestChunkingWithKind:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.parallel(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.parallel(0, 4, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.parallel(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.parallel(
+                            0,
+                            4,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
@@ -401,12 +449,12 @@ class TestLoopOrigin:
         inner_stmts = self._get_auto_incore_body_stmts(After)
         outer_for = cast(ir.ForStmt, inner_stmts[0])
 
-        assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         # Inner loop is inside outer body
         outer_body_stmts = _body_stmts(outer_for.body)
         inner_for = cast(ir.ForStmt, outer_body_stmts[0])
-        assert inner_for.loop_origin == ir.LoopOrigin.ChunkInner
+        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
 
     def test_non_divisible_chunk_origin(self):
         """Verify outer=ChunkOuter, inner=ChunkInner, remainder=ChunkRemainder."""
@@ -428,13 +476,13 @@ class TestLoopOrigin:
         outer_for = cast(ir.ForStmt, inner_stmts[0])
         remainder_for = cast(ir.ForStmt, inner_stmts[1])
 
-        assert outer_for.loop_origin == ir.LoopOrigin.ChunkOuter
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
 
         outer_body_stmts = _body_stmts(outer_for.body)
         inner_for = cast(ir.ForStmt, outer_body_stmts[0])
-        assert inner_for.loop_origin == ir.LoopOrigin.ChunkInner
+        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
 
-        assert remainder_for.loop_origin == ir.LoopOrigin.ChunkRemainder
+        assert remainder_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkRemainder
 
     def test_all_remainder_origin(self):
         """Verify remainder=ChunkRemainder when trip_count < chunk_size."""
@@ -453,7 +501,7 @@ class TestLoopOrigin:
 
         inner_stmts = self._get_auto_incore_body_stmts(After)
         remainder_for = cast(ir.ForStmt, inner_stmts[0])
-        assert remainder_for.loop_origin == ir.LoopOrigin.ChunkRemainder
+        assert remainder_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkRemainder
 
     def test_non_chunked_loop_origin(self):
         """Verify regular (non-chunked) loops have Original origin."""
@@ -471,7 +519,7 @@ class TestLoopOrigin:
 
         stmts = self._get_func_body_stmts(After)
         for_stmt = cast(ir.ForStmt, stmts[0])
-        assert for_stmt.loop_origin == ir.LoopOrigin.Original
+        assert "loop_origin" not in for_stmt.attrs
 
 
 class TestNestedChunking:
@@ -503,10 +551,22 @@ class TestNestedChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.parallel(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.parallel(0, 4, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.parallel(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.parallel(
+                            0,
+                            4,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             for j_0_rem, (x_iter_3_rem,) in pl.parallel(
-                                0, 1, 1, init_values=(x_iter_1_inner,)
+                                0,
+                                1,
+                                1,
+                                init_values=(x_iter_1_inner,),
+                                attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
                             ):
                                 x_5: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x_iter_3_rem, 1.0)
                                 x_iter_3_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_5)
@@ -537,13 +597,29 @@ class TestNestedChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.parallel(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.parallel(0, 4, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.parallel(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.parallel(
+                            0,
+                            4,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             for j_0_out, (x_iter_3_outer,) in pl.parallel(
-                                0, 3, 1, init_values=(x_iter_1_inner,)
+                                0,
+                                3,
+                                1,
+                                init_values=(x_iter_1_inner,),
+                                attrs={"loop_origin": pl.LoopOrigin.ChunkOuter},
                             ):
                                 for j_0_in, (x_iter_3_inner,) in pl.parallel(
-                                    0, 4, 1, init_values=(x_iter_3_outer,)
+                                    0,
+                                    4,
+                                    1,
+                                    init_values=(x_iter_3_outer,),
+                                    attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
                                 ):
                                     x_5: pl.Tensor[[64], pl.FP32] = pl.tensor.add(x_iter_3_inner, 1.0)
                                     x_iter_3_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_5)
@@ -616,12 +692,22 @@ class TestDynamicChunking:
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_out, (x_outer,) in pl.range(0, n_0 // 4, 1, init_values=(x_0,)):
-                        for i_in, (x_inner,) in pl.range(0, 4, 1, init_values=(x_outer,)):
+                    for i_out, (x_outer,) in pl.range(
+                        0, n_0 // 4, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            0, 4, 1, init_values=(x_outer,), attrs={"loop_origin": pl.LoopOrigin.ChunkInner}
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
                             x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
-                    for i_rem, (x_rem,) in pl.range(0, n_0 % 4, 1, init_values=(x_outer_rv,)):
+                    for i_rem, (x_rem,) in pl.range(
+                        0,
+                        n_0 % 4,
+                        1,
+                        init_values=(x_outer_rv,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
+                    ):
                         x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
@@ -657,13 +743,25 @@ class TestDynamicChunking:
                 hi_0: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_out, (x_outer,) in pl.range(0, pl.max(hi_0 - lo_0, 0) // 4, 1, init_values=(x_0,)):
-                        for i_in, (x_inner,) in pl.range(0, 4, 1, init_values=(x_outer,)):
+                    for i_out, (x_outer,) in pl.range(
+                        0,
+                        pl.max(hi_0 - lo_0, 0) // 4,
+                        1,
+                        init_values=(x_0,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkOuter},
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            0, 4, 1, init_values=(x_outer,), attrs={"loop_origin": pl.LoopOrigin.ChunkInner}
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
                             x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                     for i_rem, (x_rem,) in pl.range(
-                        0, pl.max(hi_0 - lo_0, 0) % 4, 1, init_values=(x_outer_rv,)
+                        0,
+                        pl.max(hi_0 - lo_0, 0) % 4,
+                        1,
+                        init_values=(x_outer_rv,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
                     ):
                         x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
@@ -692,12 +790,22 @@ class TestDynamicChunking:
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_out, (x_outer,) in pl.parallel(0, n_0 // 4, 1, init_values=(x_0,)):
-                        for i_in, (x_inner,) in pl.parallel(0, 4, 1, init_values=(x_outer,)):
+                    for i_out, (x_outer,) in pl.parallel(
+                        0, n_0 // 4, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.parallel(
+                            0, 4, 1, init_values=(x_outer,), attrs={"loop_origin": pl.LoopOrigin.ChunkInner}
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
                             x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
-                    for i_rem, (x_rem,) in pl.parallel(0, n_0 % 4, 1, init_values=(x_outer_rv,)):
+                    for i_rem, (x_rem,) in pl.parallel(
+                        0,
+                        n_0 % 4,
+                        1,
+                        init_values=(x_outer_rv,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
+                    ):
                         x_4: pl.Tensor[[64], pl.FP32] = pl.add(x_rem, 1.0)
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
@@ -724,8 +832,16 @@ class TestDynamicChunking:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i_0_out, (x_iter_1_outer,) in pl.range(0, 2, 1, init_values=(x_0,)):
-                        for i_0_in, (x_iter_1_inner,) in pl.range(0, 5, 1, init_values=(x_iter_1_outer,)):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
                             x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
                             x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)


### PR DESCRIPTION
## Summary
- Replace separate `chunk_size_` (`optional<ExprPtr>`) and `chunk_policy_` (`ChunkPolicy`) fields on `ForStmt` with a single `optional<ChunkConfig>` struct that groups them structurally
- Add `ChunkConfig` struct with `size` and `policy` fields, exposed as a Python class with nanobind binding
- Retain `chunk_size`/`chunk_policy` as convenience properties on the Python `ForStmt` for backward compatibility
- Fix missing `LoopOrigin` handling in structural hash/equal kwargs comparison (would crash or silently compare equal)
- Update documentation references for `loop_origin` and `chunk_size` field access patterns

## Motivation
`chunk_size` and `chunk_policy` always appear together and are only meaningful on parallel chunked loops. Merging them into a single `ChunkConfig` struct makes this invariant explicit in the type system and simplifies the `ForStmt` constructor from 12 parameters to 11.

## Test plan
- [x] All 3385 tests pass (including 12 updated `test_split_chunked_loops` expected programs and `test_interchange_chunk_loops` assertions)
- [x] Code review completed
- [x] clang-tidy clean
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)
- [x] Documentation updated (en + zh-cn)