### PR TITLE
fix(codegen): emit correct dtype for ConstFloat and ConstInt expressions

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -61,8 +61,8 @@ class PTOCodegen : public CodegenBase {
   // PTO-specific helpers for operator codegen
   std::string NewTemp();
   std::string GetOrCreateTensorView(const ir::VarPtr& tensor);
-  std::string GetIndexConstant(int64_t val);
-  std::string GetOrEmitFloatConstant(double value, const std::string& mlir_type = "f32");
+  std::string GetOrEmitConstant(int64_t value, DataType dt);   // int/index overload
+  std::string GetOrEmitConstant(double value, DataType dt);    // float overload
   std::string GetTensorViewTypeString(const ir::TensorType* tensor_type) const;
   std::string GetTileBufTypeString(const ir::MemRef* memref) const;
   std::string GetExprTypeAnnotation(const ir::ExprPtr& expr);
@@ -178,8 +178,8 @@ For each `TensorType` parameter, the codegen generates:
 
 ```mlir
 %0 = pto.make_tensor_view %arg0,
-     shape = [%c32, %c32]
-     strides = [%c32, %c1]
+     shape = [%c32_index, %c32_index]
+     strides = [%c32_index, %c1_index]
      {layout = #pto.layout<nd>}
      : !pto.tensor_view<?x?xf32>
 ```
@@ -188,7 +188,7 @@ For each `TensorType` parameter, the codegen generates:
 
 - Shape from `TensorType.shape_`
 - Strides computed as row-major: `[dim1, 1]` for 2D tensors
-- Constants (`%c32`, `%c1`) auto-generated
+- Constants (`%c32_index`, `%c1_index`) auto-generated
 - Tensor view type uses `?` for each dimension (e.g., `?x?xf32` for 2D)
 
 #### Layout Handling for 2D Tensors
@@ -214,7 +214,7 @@ Example for a `[16, 1]` column vector (no DN annotation in DSL):
 
 ```mlir
 %col_view = pto.make_tensor_view %arg1,
-    shape = [%c16, %c1], strides = [%c1, %c16]
+    shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
     : !pto.tensor_view<?x?xf32>
 ```
@@ -224,10 +224,10 @@ Example for a `[16, 1]` column vector (no DN annotation in DSL):
 Based on TileType variables collected from the function body. Each tile variable gets its own `pto.alloc_tile` instruction with an explicit `addr` attribute derived from the variable's MemRef. Variables sharing the same MemRef share the same address:
 
 ```mlir
-%mi_tile = pto.alloc_tile addr = %c8320 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1,
+%mi_tile = pto.alloc_tile addr = %c8320_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1,
                       v_row=16, v_col=1, blayout=col_major,
                       slayout=none_box, fractal=512, pad=0>
-%mi_tile_nd = pto.alloc_tile addr = %c8320 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16,
+%mi_tile_nd = pto.alloc_tile addr = %c8320_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16,
                       v_row=1, v_col=16, blayout=row_major,
                       slayout=none_box, fractal=512, pad=0>
 ```
@@ -252,8 +252,8 @@ tile_a = pl.load(tensor_a, [0, 0], [32, 32])
 
 ```mlir
 # 1. Create partition view
-%3 = pto.partition_view %tensor_view, offsets = [%c0, %c0],
-                 sizes = [%c32, %c32]
+%3 = pto.partition_view %tensor_view, offsets = [%c0_index, %c0_index],
+                 sizes = [%c32_index, %c32_index]
                  : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Load into tile buffer
@@ -279,8 +279,8 @@ pl.store(tile_c, [0, 0], tensor_out)
 
 ```mlir
 # 1. Create partition view for output
-%5 = pto.partition_view %output_view, offsets = [%c0, %c0],
-                 sizes = [%c32, %c32]
+%5 = pto.partition_view %output_view, offsets = [%c0_index, %c0_index],
+                 sizes = [%c32_index, %c32_index]
                  : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Store from tile buffer
@@ -345,17 +345,17 @@ module {
                           %arg1: !pto.ptr<f32>,
                           %arg2: !pto.ptr<f32>) {
     // Constants
-    %c32 = arith.constant 32 : index
-    %c1 = arith.constant 1 : index
-    %c0 = arith.constant 0 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
 
     // Tensor views
-    %3 = pto.make_tensor_view %arg0, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %4 = pto.make_tensor_view %arg1, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %5 = pto.make_tensor_view %arg2, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %3 = pto.make_tensor_view %arg0, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+    %4 = pto.make_tensor_view %arg1, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+    %5 = pto.make_tensor_view %arg2, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
 
     // Allocations
     %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
@@ -363,13 +363,13 @@ module {
     %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
 
     // Load tile_a
-    %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %6 = pto.partition_view %3, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%6 : !pto.partition_tensor_view<32x32xf32>)
               outs(%0 : !pto.tile_buf<...>)
 
     // Load tile_b
-    %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %7 = pto.partition_view %4, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%7 : !pto.partition_tensor_view<32x32xf32>)
               outs(%1 : !pto.tile_buf<...>)
@@ -379,7 +379,7 @@ module {
              outs(%2 : !pto.tile_buf<...>)
 
     // Store tile_c
-    %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %8 = pto.partition_view %5, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tstore ins(%2 : !pto.tile_buf<...>)
                outs(%8 : !pto.partition_tensor_view<32x32xf32>)
@@ -405,7 +405,7 @@ The codegen maintains several mappings to track MLIR variable names:
 **SSA value naming**:
 
 - Parameters: `%arg0`, `%arg1`, `%arg2`, ...
-- Constants: `%c0`, `%c1`, `%c32`, `%cst`, ...
+- Constants: `%c0_index`, `%c1_index`, `%c32_index`, `%c0_i64`, `%cst`, ...
 - Results: `%0`, `%1`, `%2`, ...
 
 ### MemRef-based Resolution

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -61,8 +61,8 @@ class PTOCodegen : public CodegenBase {
   // PTO-specific helpers for operator codegen
   std::string NewTemp();
   std::string GetOrCreateTensorView(const ir::VarPtr& tensor);
-  std::string GetIndexConstant(int64_t val);
-  std::string GetOrEmitFloatConstant(double value, const std::string& mlir_type = "f32");
+  std::string GetOrEmitConstant(int64_t value, DataType dt);   // int/index 重载
+  std::string GetOrEmitConstant(double value, DataType dt);    // float 重载
   std::string GetTensorViewTypeString(const ir::TensorType* tensor_type) const;
   std::string GetTileBufTypeString(const ir::MemRef* memref) const;
   std::string GetExprTypeAnnotation(const ir::ExprPtr& expr);
@@ -178,8 +178,8 @@ print(pto_code)
 
 ```mlir
 %0 = pto.make_tensor_view %arg0,
-     shape = [%c32, %c32]
-     strides = [%c32, %c1]
+     shape = [%c32_index, %c32_index]
+     strides = [%c32_index, %c1_index]
      {layout = #pto.layout<nd>}
      : !pto.tensor_view<?x?xf32>
 ```
@@ -188,7 +188,7 @@ print(pto_code)
 
 - 形状来自 `TensorType.shape_`
 - 步幅按行主序计算: 二维张量为 `[dim1, 1]`
-- 常量 (`%c32`, `%c1`) 自动生成
+- 常量 (`%c32_index`, `%c1_index`) 自动生成
 - 张量视图类型每个维度使用 `?` (如二维为 `?x?xf32`)
 
 #### 二维张量的 Layout 处理
@@ -211,7 +211,7 @@ print(pto_code)
 
 ```mlir
 %col_view = pto.make_tensor_view %arg1,
-    shape = [%c16, %c1], strides = [%c1, %c16]
+    shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
     : !pto.tensor_view<?x?xf32>
 ```
@@ -221,10 +221,10 @@ print(pto_code)
 基于附加到 TileType 变量的 MemRef 对象。代码生成器从关联的 TileType 推导 Tile 维度和数据类型:
 
 ```mlir
-%mi_tile = pto.alloc_tile addr = %c8320 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1,
+%mi_tile = pto.alloc_tile addr = %c8320_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1,
                        v_row=16, v_col=1, blayout=col_major,
                        slayout=none_box, fractal=512, pad=0>
-%mi_tile_nd = pto.alloc_tile addr = %c8320 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16,
+%mi_tile_nd = pto.alloc_tile addr = %c8320_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16,
                        v_row=1, v_col=16, blayout=row_major,
                        slayout=none_box, fractal=512, pad=0>
 ```
@@ -249,8 +249,8 @@ tile_a = pl.load(tensor_a, [0, 0], [32, 32])
 
 ```mlir
 # 1. Create partition view
-%3 = pto.partition_view %tensor_view, offsets = [%c0, %c0],
-                 sizes = [%c32, %c32]
+%3 = pto.partition_view %tensor_view, offsets = [%c0_index, %c0_index],
+                 sizes = [%c32_index, %c32_index]
                  : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Load into tile buffer
@@ -276,8 +276,8 @@ pl.store(tile_c, [0, 0], tensor_out)
 
 ```mlir
 # 1. Create partition view for output
-%5 = pto.partition_view %output_view, offsets = [%c0, %c0],
-                 sizes = [%c32, %c32]
+%5 = pto.partition_view %output_view, offsets = [%c0_index, %c0_index],
+                 sizes = [%c32_index, %c32_index]
                  : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Store from tile buffer
@@ -342,17 +342,17 @@ module {
                           %arg1: !pto.ptr<f32>,
                           %arg2: !pto.ptr<f32>) {
     // Constants
-    %c32 = arith.constant 32 : index
-    %c1 = arith.constant 1 : index
-    %c0 = arith.constant 0 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
 
     // Tensor views
-    %3 = pto.make_tensor_view %arg0, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %4 = pto.make_tensor_view %arg1, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %5 = pto.make_tensor_view %arg2, shape = [%c32, %c32]
-         strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %3 = pto.make_tensor_view %arg0, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+    %4 = pto.make_tensor_view %arg1, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+    %5 = pto.make_tensor_view %arg2, shape = [%c32_index, %c32_index]
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
 
     // Allocations
     %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
@@ -360,13 +360,13 @@ module {
     %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
 
     // Load tile_a
-    %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %6 = pto.partition_view %3, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%6 : !pto.partition_tensor_view<32x32xf32>)
               outs(%0 : !pto.tile_buf<...>)
 
     // Load tile_b
-    %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %7 = pto.partition_view %4, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%7 : !pto.partition_tensor_view<32x32xf32>)
               outs(%1 : !pto.tile_buf<...>)
@@ -376,7 +376,7 @@ module {
              outs(%2 : !pto.tile_buf<...>)
 
     // Store tile_c
-    %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c32, %c32]
+    %8 = pto.partition_view %5, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tstore ins(%2 : !pto.tile_buf<...>)
                outs(%8 : !pto.partition_tensor_view<32x32xf32>)
@@ -402,7 +402,7 @@ module {
 **SSA 值命名**:
 
 - 参数: `%arg0`, `%arg1`, `%arg2`, ...
-- 常量: `%c0`, `%c1`, `%c32`, `%cst`, ...
+- 常量: `%c0_index`, `%c1_index`, `%c32_index`, `%c0_i64`, `%cst`, ...
 - 结果: `%0`, `%1`, `%2`, ...
 
 ### 基于 MemRef 的解析

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -101,20 +101,26 @@ class PTOCodegen : public CodegenBase {
   std::string GetOrCreateTensorView(const ir::VarPtr& tensor);
 
   /**
-   * @brief Get or emit index constant
+   * @brief Get or emit a numeric constant of any dtype (int, index, or float).
    *
-   * @param val Constant value
-   * @return Index constant string
+   * Both overloads write the constant to the constants section on first use and
+   * return the SSA name. Subsequent calls for the same (value, dtype) pair
+   * return the cached name without emitting again.
+   *
+   * @param value Integer or index value
+   * @param dt    Data type (e.g., DataType::INDEX, DataType::INT32, DataType::INT64)
+   * @return SSA variable name for the constant
    */
-  std::string GetIndexConstant(int64_t val);
+  std::string GetOrEmitConstant(int64_t value, DataType dt);
 
   /**
-   * @brief Get or emit i32 constant (for cross-core consumer buffer addresses)
+   * @brief Get or emit a floating-point constant of any float dtype.
    *
-   * @param value Constant value
-   * @return SSA variable name for the constant (e.g., "%c0_i32")
+   * @param value Floating-point value
+   * @param dt    Data type (e.g., DataType::FP32, DataType::BF16, DataType::FP16)
+   * @return SSA variable name for the constant
    */
-  std::string GetOrEmitI32Constant(int32_t value);
+  std::string GetOrEmitConstant(double value, DataType dt);
 
   /**
    * @brief Emit arith.index_cast if var is not already index type
@@ -166,15 +172,6 @@ class PTOCodegen : public CodegenBase {
    * @brief Get the IR variable currently being assigned
    */
   [[nodiscard]] ir::VarPtr GetCurrentResultVar() const;
-
-  /**
-   * @brief Get or emit float constant (emits to constants section, returns SSA name)
-   *
-   * @param value Constant value
-   * @param mlir_type MLIR type string (e.g., "f32", "i32")
-   * @return SSA variable name for the constant
-   */
-  std::string GetOrEmitFloatConstant(double value, const std::string& mlir_type = "f32");
 
   /**
    * @brief Get tensor_view type string for a TensorType (e.g., "!pto.tensor_view<?x?xf32>")
@@ -378,16 +375,6 @@ class PTOCodegen : public CodegenBase {
   std::string GetIndent() const;
 
   /**
-   * @brief Get or emit index constant (internal; writes to constants section)
-   */
-  std::string GetOrEmitIndexConstant(int64_t value);
-
-  /**
-   * @brief Get or emit i64 constant (for tile buffer addresses)
-   */
-  std::string GetOrEmitI64Constant(int64_t value);
-
-  /**
    * @brief Get tile_buf name for a MemRef
    */
   std::string GetTileBufForMemRef(const ir::MemRefPtr& memref) const;
@@ -405,11 +392,7 @@ class PTOCodegen : public CodegenBase {
     std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
         memref_to_tile_type;  ///< keyed by base_ Ptr
 
-    std::map<int64_t, std::string> emitted_constants;
-    std::map<int64_t, std::string> emitted_i64_constants;
-    std::map<int32_t, std::string> emitted_i32_constants;
-    std::set<double> emitted_float_constants;
-    std::map<double, std::string> float_const_names;
+    std::map<std::pair<int64_t, uint8_t>, std::string> emitted_numeric_constants;
 
     struct ExtraAllocTile {
       std::string name;
@@ -453,11 +436,7 @@ class PTOCodegen : public CodegenBase {
       var_to_memref.clear();
       memref_to_tile_type.clear();
 
-      emitted_constants.clear();
-      emitted_i64_constants.clear();
-      emitted_i32_constants.clear();
-      emitted_float_constants.clear();
-      float_const_names.clear();
+      emitted_numeric_constants.clear();
 
       extra_alloc_tiles.clear();
       ssa_to_tile_buf_type.clear();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -464,7 +464,8 @@ static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const 
   // runtime variables (e.g., loop-carried block_len) go through GetExprAsCode + cast.
   std::string block_len;
   if (auto const_int = ir::As<ir::ConstInt>(op->args_[1])) {
-    block_len = codegen.GetOrEmitI32Constant(static_cast<int32_t>(const_int->value_));
+    block_len = codegen.GetOrEmitConstant(static_cast<int64_t>(static_cast<int32_t>(const_int->value_)),
+                                          DataType::INT32);
   } else {
     block_len = codegen.GetExprAsCode(op->args_[1]);
     block_len = codegen.EmitCastToI32(op->args_[1], block_len);
@@ -562,7 +563,7 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   partition_line << ", sizes = [";
   for (size_t i = 0; i < shape_elems.size(); ++i) {
     if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetIndexConstant(codegen.GetConstIntValue(shape_elems[i]));
+    partition_line << codegen.GetOrEmitConstant(codegen.GetConstIntValue(shape_elems[i]), DataType::INDEX);
   }
   partition_line << "]";
   partition_line << " : " << tensor_view_type << " -> " << partition_type;
@@ -591,7 +592,7 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
           vr = codegen.EmitCastToIndex(var, mlir_name);
           has_dynamic = true;
         } else if (auto c = ir::As<ir::ConstInt>(tv.valid_shape[0])) {
-          vr = codegen.GetIndexConstant(c->value_);
+          vr = codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
         }
       }
 
@@ -602,7 +603,7 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
           vc = codegen.EmitCastToIndex(var, mlir_name);
           has_dynamic = true;
         } else if (auto c = ir::As<ir::ConstInt>(tv.valid_shape[1])) {
-          vc = codegen.GetIndexConstant(c->value_);
+          vc = codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
         }
       }
 
@@ -672,7 +673,7 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
     for (size_t i = 0; i < shapes_tuple->elements_.size(); ++i) {
       if (i > 0) partition_line << ", ";
       if (auto c = As<ir::ConstInt>(shapes_tuple->elements_[i])) {
-        partition_line << codegen.GetIndexConstant(c->value_);
+        partition_line << codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
         if (i > 0) partition_type += "x";
         partition_type += std::to_string(c->value_);
       } else {
@@ -763,7 +764,7 @@ static std::string GetFlatOffsetSSA(const ir::MakeTuplePtr& indices_tuple,
   }
 
   if (all_constant) {
-    return codegen.GetIndexConstant(flat_offset);
+    return codegen.GetOrEmitConstant(flat_offset, DataType::INDEX);
   }
 
   return ComputeFlatOffsetPTO(indices_tuple, shape, codegen);
@@ -920,7 +921,7 @@ static std::string MakeTensorDimCodegenPTO(const CallPtr& op, codegen::CodegenBa
   if (auto dyn_shape = ir::As<ir::Var>(shape)) {
     shape_name = codegen.GetVarName(dyn_shape);
   } else if (auto static_shape = ir::As<ir::ConstInt>(shape)) {
-    shape_name = codegen.GetIndexConstant(static_shape->value_);
+    shape_name = codegen.GetOrEmitConstant(static_shape->value_, DataType::INDEX);
   } else {
     INTERNAL_CHECK(false) << "Internal error: tensor.dim shape is neither Var nor ConstInt";
   }
@@ -1081,7 +1082,7 @@ static bool ExprIsI32Scalar(const ir::ExprPtr& expr) {
 // Pipe buffer operands are i32 SSA. GetExprAsCode(ConstInt) uses index constants; use i32 here.
 static std::string GetPipeBufOperandI32SSA(codegen::PTOCodegen& codegen, const ir::ExprPtr& expr) {
   if (auto c = As<ir::ConstInt>(expr)) {
-    return codegen.GetOrEmitI32Constant(static_cast<int32_t>(c->value_));
+    return codegen.GetOrEmitConstant(static_cast<int64_t>(static_cast<int32_t>(c->value_)), DataType::INT32);
   }
   INTERNAL_CHECK(ExprIsI32Scalar(expr))
       << "Initialize-pipe buffer operand must be INT32 scalar SSA or integral ConstInt placeholder";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iomanip>
 #include <ios>
 #include <map>
@@ -338,7 +339,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     if (fs_.tpop_result_vars.count(tile_var.get()) > 0) continue;
     auto memref = ir::GetDefinedMemRef(tile_type);
     if (memref && As<ir::ConstInt>(memref->byte_offset_)) {
-      GetOrEmitI64Constant(As<ir::ConstInt>(memref->byte_offset_)->value_);
+      GetOrEmitConstant(As<ir::ConstInt>(memref->byte_offset_)->value_, DataType::INT64);
     }
   }
 
@@ -356,7 +357,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
       for (const auto& j : tensor_type->shape_) {
         if (As<ir::ConstInt>(j)) {
-          GetOrEmitIndexConstant(GetConstIntValue(j));
+          GetOrEmitConstant(GetConstIntValue(j), DataType::INDEX);
         }
       }
       // Pre-emit stride constants: use explicit tensor_view_.stride if available,
@@ -366,19 +367,19 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
       if (has_explicit_stride) {
         for (const auto& s : tensor_type->tensor_view_->stride) {
           if (As<ir::ConstInt>(s)) {
-            GetOrEmitIndexConstant(GetConstIntValue(s));
+            GetOrEmitConstant(GetConstIntValue(s), DataType::INDEX);
           }
         }
       } else if (tensor_type->shape_.size() == 2) {
         if (As<ir::ConstInt>(tensor_type->shape_[1])) {
-          GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[1]));
+          GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[1]), DataType::INDEX);
         }
-        GetOrEmitIndexConstant(1);
+        GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
       } else {
         // 1-D and N-D (N>2): pre-emit constant 1 (innermost stride). For N>2,
         // other strides are computed dynamically via arith.muli in
         // EmitMakeTensorViews to support dynamic dims.
-        GetOrEmitIndexConstant(1);
+        GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
       }
     }
   }
@@ -516,13 +517,13 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       if (!has_explicit_stride && tensor_type->shape_.size() > 2) {
         const size_t rank = tensor_type->shape_.size();
         nd_stride_names.resize(rank);
-        nd_stride_names[rank - 1] = GetOrEmitIndexConstant(1);
+        nd_stride_names[rank - 1] = GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
         for (int j = static_cast<int>(rank) - 2; j >= 0; j--) {
           std::string dim_mlir;
           if (auto var = As<ir::Var>(tensor_type->shape_[j + 1])) {
             dim_mlir = GetVarName(var);
           } else {
-            dim_mlir = GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[j + 1]));
+            dim_mlir = GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j + 1]), DataType::INDEX);
           }
           std::string mul_name = NewNamedTemp(param->name_hint_ + "_s" + std::to_string(j));
           stream_ << GetIndent() << mul_name << " = arith.muli " << nd_stride_names[j + 1] << ", " << dim_mlir
@@ -543,7 +544,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
           if (auto var = As<ir::Var>(tensor_type->shape_[j])) {
             stream_ << GetVarName(var);
           } else {
-            stream_ << GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[j]));
+            stream_ << GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j]), DataType::INDEX);
           }
         }
       } else {
@@ -552,7 +553,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
           if (auto var = As<ir::Var>(tensor_type->shape_[j])) {
             stream_ << GetVarName(var);
           } else {
-            stream_ << GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[j]));
+            stream_ << GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[j]), DataType::INDEX);
           }
         }
       }
@@ -567,7 +568,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
           if (auto var = As<ir::Var>(strides[j])) {
             stream_ << GetVarName(var);
           } else {
-            stream_ << GetOrEmitIndexConstant(GetConstIntValue(strides[j]));
+            stream_ << GetOrEmitConstant(GetConstIntValue(strides[j]), DataType::INDEX);
           }
         }
       } else if (tensor_type->shape_.size() == 2) {
@@ -578,15 +579,15 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         if (auto var = As<ir::Var>(tensor_type->shape_[stride_idx])) {
           row_stride = GetVarName(var);
         } else {
-          row_stride = GetOrEmitIndexConstant(GetConstIntValue(tensor_type->shape_[stride_idx]));
+          row_stride = GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[stride_idx]), DataType::INDEX);
         }
         if (layout_DN) {
-          stream_ << GetOrEmitIndexConstant(1) << ", " << row_stride;
+          stream_ << GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX) << ", " << row_stride;
         } else {
-          stream_ << row_stride << ", " << GetOrEmitIndexConstant(1);
+          stream_ << row_stride << ", " << GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
         }
       } else if (tensor_type->shape_.size() == 1) {
-        stream_ << GetOrEmitIndexConstant(1);
+        stream_ << GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
       } else {
         // Use pre-computed SSA stride names (built above via arith.muli)
         for (size_t j = 0; j < nd_stride_names.size(); j++) {
@@ -654,12 +655,12 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
       if (has_fillpad) {
         if (tile_type->shape_.size() >= 1) {
           if (auto c = As<ir::ConstInt>(tile_type->shape_[0])) {
-            valid_row_mlir = GetOrEmitIndexConstant(c->value_);
+            valid_row_mlir = GetOrEmitConstant(c->value_, DataType::INDEX);
           }
         }
         if (tile_type->shape_.size() >= 2) {
           if (auto c = As<ir::ConstInt>(tile_type->shape_[1])) {
-            valid_col_mlir = GetOrEmitIndexConstant(c->value_);
+            valid_col_mlir = GetOrEmitConstant(c->value_, DataType::INDEX);
           }
         }
       } else {
@@ -676,7 +677,7 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
   std::string addr_ssa;
   if (memref) {
     if (auto const_offset = As<ir::ConstInt>(memref->byte_offset_)) {
-      addr_ssa = GetOrEmitI64Constant(const_offset->value_);
+      addr_ssa = GetOrEmitConstant(const_offset->value_, DataType::INT64);
     }
   }
 
@@ -697,73 +698,61 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
 
 std::string PTOCodegen::GetIndent() const { return std::string(static_cast<size_t>(indent_level_) * 2, ' '); }
 
-std::string PTOCodegen::GetOrEmitIndexConstant(int64_t value) {
-  auto it = fs_.emitted_constants.find(value);
-  if (it != fs_.emitted_constants.end()) {
-    return it->second;
+std::string PTOCodegen::GetOrEmitConstant(int64_t value, DataType dt) {
+  auto key = std::make_pair(value, dt.Code());
+  auto it = fs_.emitted_numeric_constants.find(key);
+  if (it != fs_.emitted_numeric_constants.end()) return it->second;
+
+  std::string mlir_type = GetTypeString(dt);
+  std::string ssa_suffix = "_" + mlir_type;
+
+  std::string ssa_id;
+  if (value == 0) {
+    ssa_id = "c0" + ssa_suffix;
+  } else if (value < 0) {
+    uint64_t mag = static_cast<uint64_t>(-(value + 1)) + 1;
+    ssa_id = "cn" + std::to_string(mag) + ssa_suffix;
+  } else {
+    ssa_id = "c" + std::to_string(value) + ssa_suffix;
   }
-  std::string ssa_id = "c" + std::to_string(value);
+
   std::string name;
-  if (fs_.used_ssa_names.find(ssa_id) == fs_.used_ssa_names.end()) {
+  if (!fs_.used_ssa_names.count(ssa_id)) {
     fs_.used_ssa_names.insert(ssa_id);
     name = "%" + ssa_id;
   } else {
     name = NewTemp();
   }
-  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : index\n";
-  fs_.emitted_constants[value] = name;
+  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : " << mlir_type
+                        << "\n";
+  fs_.emitted_numeric_constants[key] = name;
   return name;
 }
 
-std::string PTOCodegen::GetOrEmitI64Constant(int64_t value) {
-  auto it = fs_.emitted_i64_constants.find(value);
-  if (it != fs_.emitted_i64_constants.end()) {
-    return it->second;
-  }
-  std::string ssa_id;
-  if (value == 0) {
-    ssa_id = "c0i";
-  } else if (value < 0) {
-    uint64_t magnitude = static_cast<uint64_t>(-(value + 1)) + 1;
-    ssa_id = "cn" + std::to_string(magnitude);
-  } else {
-    ssa_id = "c" + std::to_string(value);
-  }
-  std::string name;
-  if (fs_.used_ssa_names.find(ssa_id) == fs_.used_ssa_names.end()) {
-    fs_.used_ssa_names.insert(ssa_id);
-    name = "%" + ssa_id;
-  } else {
-    name = NewTemp();
-  }
-  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : i64\n";
-  fs_.emitted_i64_constants[value] = name;
-  return name;
-}
+std::string PTOCodegen::GetOrEmitConstant(double value, DataType dt) {
+  int64_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  auto key = std::make_pair(bits, dt.Code());
+  auto it = fs_.emitted_numeric_constants.find(key);
+  if (it != fs_.emitted_numeric_constants.end()) return it->second;
 
-std::string PTOCodegen::GetOrEmitI32Constant(int32_t value) {
-  auto it = fs_.emitted_i32_constants.find(value);
-  if (it != fs_.emitted_i32_constants.end()) {
-    return it->second;
-  }
-  std::string ssa_id;
-  if (value == 0) {
-    ssa_id = "c0_i32";
-  } else if (value < 0) {
-    uint32_t magnitude = static_cast<uint32_t>(-(value + 1)) + 1;
-    ssa_id = "cn" + std::to_string(magnitude) + "_i32";
-  } else {
-    ssa_id = "c" + std::to_string(value) + "_i32";
+  std::string mlir_type = GetTypeString(dt);
+  std::string ssa_id = "cst";
+  if (!fs_.emitted_numeric_constants.empty()) {
+    ssa_id += "_" + std::to_string(fs_.emitted_numeric_constants.size());
   }
   std::string name;
-  if (fs_.used_ssa_names.find(ssa_id) == fs_.used_ssa_names.end()) {
+  if (!fs_.used_ssa_names.count(ssa_id)) {
     fs_.used_ssa_names.insert(ssa_id);
     name = "%" + ssa_id;
   } else {
     name = NewTemp();
   }
-  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << value << " : i32\n";
-  fs_.emitted_i32_constants[value] = name;
+  std::ostringstream val_str;
+  val_str << std::scientific << std::setprecision(6) << value;
+  fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << val_str.str() << " : "
+                        << mlir_type << "\n";
+  fs_.emitted_numeric_constants[key] = name;
   return name;
 }
 
@@ -935,10 +924,10 @@ std::string PTOCodegen::GetExprAsCode(const ExprPtr& expr) {
     return GetVarName(var);
   }
   if (auto const_int = As<ir::ConstInt>(expr)) {
-    return GetIndexConstant(const_int->value_);
+    return GetOrEmitConstant(const_int->value_, const_int->dtype());
   }
   if (auto const_float = As<ir::ConstFloat>(expr)) {
-    return GetOrEmitFloatConstant(const_float->value_, "f32");
+    return GetOrEmitConstant(const_float->value_, const_float->dtype());
   }
 
   // Fall back to visitor pattern for complex expressions (arithmetic, comparisons)
@@ -1060,34 +1049,6 @@ std::string PTOCodegen::GetOrCreateTensorView(const VarPtr& tensor_var) {
   return "";
 }
 
-std::string PTOCodegen::GetIndexConstant(int64_t val) { return GetOrEmitIndexConstant(val); }
-
-std::string PTOCodegen::GetOrEmitFloatConstant(double value, const std::string& mlir_type) {
-  if (fs_.emitted_float_constants.find(value) == fs_.emitted_float_constants.end()) {
-    std::string ssa_id = "cst";
-    if (!fs_.emitted_float_constants.empty()) {
-      ssa_id += "_" + std::to_string(fs_.emitted_float_constants.size());
-    }
-    std::string name;
-    if (fs_.used_ssa_names.find(ssa_id) == fs_.used_ssa_names.end()) {
-      fs_.used_ssa_names.insert(ssa_id);
-      name = "%" + ssa_id;
-    } else {
-      name = NewTemp();
-    }
-
-    std::ostringstream val_str;
-    val_str << std::scientific << std::setprecision(6) << value;
-
-    fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << val_str.str() << " : "
-                          << mlir_type << "\n";
-    fs_.emitted_float_constants.insert(value);
-    fs_.float_const_names[value] = name;
-    return name;
-  }
-  return fs_.float_const_names[value];
-}
-
 std::string PTOCodegen::GetTensorViewTypeString(const ir::TensorType* tensor_type) const {
   std::ostringstream oss;
   oss << "!pto.tensor_view<";
@@ -1173,10 +1134,10 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
     }
   }
   if (auto const_float = As<ir::ConstFloat>(expr)) {
-    return "f32";
+    return GetTypeString(const_float->dtype());
   }
   if (auto const_int = As<ir::ConstInt>(expr)) {
-    return "index";
+    return GetTypeString(const_int->dtype());
   }
   return "";
 }

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <iomanip>
 #include <ios>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -749,7 +750,7 @@ std::string PTOCodegen::GetOrEmitConstant(double value, DataType dt) {
     name = NewTemp();
   }
   std::ostringstream val_str;
-  val_str << std::scientific << std::setprecision(6) << value;
+  val_str << std::scientific << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
   fs_.constants_section << fs_.constants_indent << name << " = arith.constant " << val_str.str() << " : "
                         << mlir_type << "\n";
   fs_.emitted_numeric_constants[key] = name;

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -169,7 +169,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string valid_row_ssa;
         std::string valid_col_ssa;
         if (auto const_offset = As<ir::ConstInt>(tile_type->memref_.value()->byte_offset_)) {
-          addr_ssa = GetOrEmitI64Constant(const_offset->value_);
+          addr_ssa = GetOrEmitConstant(const_offset->value_, DataType::INT64);
         }
         auto [valid_row_var, valid_col_var] = GetTileValidShapeVars(tile_type);
         if (valid_row_var) valid_row_ssa = GetVarName(valid_row_var);

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -52,15 +52,15 @@ std::string PTOCodegen::EmitArithOperand(const ir::ExprPtr& expr, const std::str
 
   if (wanted_mlir_type == "index") {
     if (auto ci = As<ir::ConstInt>(expr)) {
-      return GetOrEmitIndexConstant(ci->value_);
+      return GetOrEmitConstant(ci->value_, DataType::INDEX);
     }
   } else if (wanted_mlir_type == "i64") {
     if (auto ci = As<ir::ConstInt>(expr)) {
-      return GetOrEmitI64Constant(ci->value_);
+      return GetOrEmitConstant(ci->value_, DataType::INT64);
     }
   } else if (wanted_mlir_type == "i32") {
     if (auto ci = As<ir::ConstInt>(expr)) {
-      return GetOrEmitI32Constant(static_cast<int32_t>(ci->value_));
+      return GetOrEmitConstant(static_cast<int64_t>(static_cast<int32_t>(ci->value_)), DataType::INT32);
     }
   }
 
@@ -171,15 +171,11 @@ void PTOCodegen::VisitExpr_(const ir::IterArgPtr& op) {
 }
 
 void PTOCodegen::VisitExpr_(const ir::ConstIntPtr& op) {
-  fs_.current_expr_value = GetOrEmitIndexConstant(op->value_);
+  fs_.current_expr_value = GetOrEmitConstant(op->value_, op->dtype());
 }
 
 void PTOCodegen::VisitExpr_(const ir::ConstFloatPtr& op) {
-  std::string mlir_type = "f32";
-  if (auto scalar_type = As<ScalarType>(op->GetType())) {
-    mlir_type = GetTypeString(scalar_type->dtype_);
-  }
-  fs_.current_expr_value = GetOrEmitFloatConstant(op->value_, mlir_type);
+  fs_.current_expr_value = GetOrEmitConstant(op->value_, op->dtype());
 }
 
 void PTOCodegen::VisitExpr_(const ir::ConstBoolPtr& op) {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -535,7 +535,17 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       }
     }
     stream_ << ", value=";
-    VisitExpr(op->args_[1]);  // value (as keyword)
+    // Print value as a bare numeric literal (dtype is already captured in dtype=...).
+    // Using VisitExpr would emit pl.const(v, pl.BF16) which the Python API cannot accept
+    // as the `value: int | float` parameter.
+    const auto& val_expr = op->args_[1];
+    if (auto cf = As<ConstFloat>(val_expr)) {
+      stream_ << FormatFloatLiteral(cf->value_);
+    } else if (auto ci = As<ConstInt>(val_expr)) {
+      stream_ << ci->value_;
+    } else {
+      VisitExpr(val_expr);
+    }
     stream_ << ")";
     return;
   }

--- a/tests/ut/codegen/test_dynamic_shape.py
+++ b/tests/ut/codegen/test_dynamic_shape.py
@@ -103,11 +103,11 @@ def test_add_kernel_dynamic_shape_pto_codegen():
     assert "%arg4: index" in mlir_code
     # Dynamic dim variables used in make_tensor_view shape and strides
     assert "shape = [%arg3, %arg4]" in mlir_code
-    assert "strides = [%arg4, %c1]" in mlir_code
+    assert "strides = [%arg4, %c1_index]" in mlir_code
     # Dynamic type annotation uses wildcard
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
     # Dynamic dims must not appear as zero constants in make_tensor_view shape
-    assert "shape = [%c0" not in mlir_code
+    assert "shape = [%c0_index" not in mlir_code
 
 
 def test_add_kernel_valid_shape_pto_codegen():
@@ -127,8 +127,8 @@ def test_add_kernel_valid_shape_pto_codegen():
     assert "%arg3: index" in mlir_code
     assert "%arg4: index" in mlir_code
     # Static tensor views use constant dims from the 128x128 tensor type
-    assert "shape = [%c128, %c128]" in mlir_code
-    assert "strides = [%c128, %c1]" in mlir_code
+    assert "shape = [%c128_index, %c128_index]" in mlir_code
+    assert "strides = [%c128_index, %c1_index]" in mlir_code
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
     # Tile allocation uses shapes (128x128), not dynamic valid_shapes
     assert "partition_tensor_view<128x128xf32>" in mlir_code

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -231,7 +231,7 @@ def test_pto_codegen_tensor_parameters():
 
     # Verify make_tensor_view generation
     assert "pto.make_tensor_view" in mlir_code
-    assert "shape = [%c64, %c64]" in mlir_code or "shape = [%c32, %c32]" in mlir_code
+    assert "shape = [%c64_index, %c64_index]" in mlir_code or "shape = [%c32_index, %c32_index]" in mlir_code
     assert "strides = " in mlir_code
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
 
@@ -328,8 +328,8 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
 
     assert len(alloc_lines) == 2, f"Expected two alloc_tiles for per-var alloc model, got: {alloc_lines}"
     # Both share the same addr (same MemRef)
-    assert "addr = %c0i" in alloc_lines[0]
-    assert "addr = %c0i" in alloc_lines[1]
+    assert "addr = %c0_i64" in alloc_lines[0]
+    assert "addr = %c0_i64" in alloc_lines[1]
     # Dynamic valid_shape tile: type has v_row=?, v_col=? (both dynamic per PTOAS requirement)
     assert "v_row=?" in alloc_lines[0], f"Expected dynamic v_row=? in alloc: {alloc_lines[0]}"
     assert "v_col=?" in alloc_lines[0], f"Expected dynamic v_col=? in alloc: {alloc_lines[0]}"
@@ -428,8 +428,8 @@ def test_pto_codegen_tile_load_lowering():
 
     # Verify partition_view generation
     assert "pto.partition_view" in mlir_code
-    assert "offsets = [%c0, %c0]" in mlir_code
-    assert "sizes = [%c32, %c32]" in mlir_code
+    assert "offsets = [%c0_index, %c0_index]" in mlir_code
+    assert "sizes = [%c32_index, %c32_index]" in mlir_code
     assert "!pto.partition_tensor_view<32x32xf32>" in mlir_code
 
     # Verify tload generation
@@ -518,7 +518,7 @@ def test_pto_codegen_constants():
     # Verify index constants
     assert "arith.constant" in mlir_code
     assert ": index" in mlir_code
-    assert "%c0" in mlir_code or "%c32" in mlir_code
+    assert "%c0_index" in mlir_code or "%c32_index" in mlir_code
 
 
 def test_pto_codegen_ssa_naming():
@@ -1480,8 +1480,8 @@ class TestColumnVectorCodegen:
         mlir_code = _generate_default_mlir(ColVecProgram)
         lines = _get_mlir_lines(mlir_code)
         col_vec_view = _single_line(lines, "pto.make_tensor_view %arg0")
-        assert "shape = [%c16, %c1]" in col_vec_view
-        assert "strides = [%c1, %c16]" in col_vec_view
+        assert "shape = [%c16_index, %c1_index]" in col_vec_view
+        assert "strides = [%c1_index, %c16_index]" in col_vec_view
         assert "layout = #pto.layout<dn>" in col_vec_view
 
     def test_column_vector_with_explicit_dn(self):
@@ -1501,8 +1501,8 @@ class TestColumnVectorCodegen:
         mlir_code = _generate_default_mlir(ColVecDNProgram)
         lines = _get_mlir_lines(mlir_code)
         col_vec_view = _single_line(lines, "pto.make_tensor_view %arg0")
-        assert "shape = [%c16, %c1]" in col_vec_view
-        assert "strides = [%c1, %c16]" in col_vec_view
+        assert "shape = [%c16_index, %c1_index]" in col_vec_view
+        assert "strides = [%c1_index, %c16_index]" in col_vec_view
         assert "layout = #pto.layout<dn>" in col_vec_view
 
     def test_regular_2d_nd_unchanged(self):
@@ -1522,8 +1522,8 @@ class TestColumnVectorCodegen:
         mlir_code = _generate_default_mlir(RegularProgram)
         lines = _get_mlir_lines(mlir_code)
         a_view = _single_line(lines, "pto.make_tensor_view %arg0")
-        assert "shape = [%c16, %c128]" in a_view
-        assert "strides = [%c128, %c1]" in a_view
+        assert "shape = [%c16_index, %c128_index]" in a_view
+        assert "strides = [%c128_index, %c1_index]" in a_view
         assert "layout = #pto.layout<nd>" in a_view
 
     def test_row_vector_stays_nd(self):
@@ -1543,8 +1543,8 @@ class TestColumnVectorCodegen:
         mlir_code = _generate_default_mlir(RowVecProgram)
         lines = _get_mlir_lines(mlir_code)
         row_view = _single_line(lines, "pto.make_tensor_view %arg0")
-        assert "shape = [%c1, %c128]" in row_view
-        assert "strides = [%c128, %c1]" in row_view
+        assert "shape = [%c1_index, %c128_index]" in row_view
+        assert "strides = [%c128_index, %c1_index]" in row_view
         assert "layout = #pto.layout<nd>" in row_view
 
 
@@ -1635,14 +1635,14 @@ def test_pto_codegen_view_output_uses_physical_stride():
     out_view_lines = _find_lines(lines, "pto.make_tensor_view %arg1")
     assert len(out_view_lines) == 1, f"Expected one make_tensor_view for out param, got: {out_view_lines}"
     out_view = out_view_lines[0]
-    assert "strides = [%c128, %c1]" in out_view, (
+    assert "strides = [%c128_index, %c1_index]" in out_view, (
         f"Out param stride should be [128, 1] (physical stride), not [32, 1] (view shape). Got: {out_view}"
     )
 
     # The a param (arg0) should still use shape-based stride [128, 1]
     a_view_lines = _find_lines(lines, "pto.make_tensor_view %arg0")
     assert len(a_view_lines) == 1
-    assert "strides = [%c128, %c1]" in a_view_lines[0]
+    assert "strides = [%c128_index, %c1_index]" in a_view_lines[0]
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -850,5 +850,61 @@ class TestMrgSortCodegen:
         assert "i32" in tmrgsort_lines[0], f"block_len type annotation should be i32: {tmrgsort_lines[0]}"
 
 
+class TestConstDtypeCodegen:
+    """Regression tests for const dtype emission (Issue #934).
+
+    Previously, codegen hardcoded 'f32' for all float consts and 'index' for
+    all int consts. These tests verify the actual dtype is emitted.
+    """
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_full_bf16_const_emits_bf16(self):
+        """tile.full with a bf16 fill value must emit bf16, not f32 (Issue #934)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.BF16],
+            ) -> pl.Tensor[[16, 16], pl.BF16]:
+                t = pl.tile.full([16, 16], dtype=pl.BF16, value=1.0)
+                return pl.store(t, [0, 0], a)
+
+        mlir = self._generate_mlir(Prog)
+        assert "bf16" in mlir, f"Expected bf16 in MLIR output:\n{mlir}"
+        assert "1.000000e+00 : bf16" in mlir, f"Expected bf16 float constant in MLIR:\n{mlir}"
+        # Ensure no f32 constant was emitted for the fill value
+        assert "1.000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
+
+    def test_full_f16_const_emits_f16(self):
+        """tile.full with an f16 fill value must emit f16, not f32 (Issue #934)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP16],
+            ) -> pl.Tensor[[16, 16], pl.FP16]:
+                t = pl.tile.full([16, 16], dtype=pl.FP16, value=0.0)
+                return pl.store(t, [0, 0], a)
+
+        mlir = self._generate_mlir(Prog)
+        assert "f16" in mlir, f"Expected f16 in MLIR output:\n{mlir}"
+        assert "0.000000e+00 : f16" in mlir, f"Expected f16 float constant in MLIR:\n{mlir}"
+        assert "0.000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -883,9 +883,9 @@ class TestConstDtypeCodegen:
 
         mlir = self._generate_mlir(Prog)
         assert "bf16" in mlir, f"Expected bf16 in MLIR output:\n{mlir}"
-        assert "1.000000e+00 : bf16" in mlir, f"Expected bf16 float constant in MLIR:\n{mlir}"
+        assert "1.00000000000000000e+00 : bf16" in mlir, f"Expected bf16 float constant in MLIR:\n{mlir}"
         # Ensure no f32 constant was emitted for the fill value
-        assert "1.000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
+        assert "1.00000000000000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
 
     def test_full_f16_const_emits_f16(self):
         """tile.full with an f16 fill value must emit f16, not f32 (Issue #934)."""
@@ -902,8 +902,8 @@ class TestConstDtypeCodegen:
 
         mlir = self._generate_mlir(Prog)
         assert "f16" in mlir, f"Expected f16 in MLIR output:\n{mlir}"
-        assert "0.000000e+00 : f16" in mlir, f"Expected f16 float constant in MLIR:\n{mlir}"
-        assert "0.000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
+        assert "0.00000000000000000e+00 : f16" in mlir, f"Expected f16 float constant in MLIR:\n{mlir}"
+        assert "0.00000000000000000e+00 : f32" not in mlir, f"f32 constant leaked into MLIR:\n{mlir}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Unify `GetOrEmitIndexConstant`/`I64Constant`/`I32Constant`/`FloatConstant` into two overloads: `GetOrEmitConstant(int64_t, DataType)` and `GetOrEmitConstant(double, DataType)`
- Fix `VisitExpr_(ConstFloatPtr)` and `VisitExpr_(ConstIntPtr)` to use the actual `dtype()` from the IR node instead of hardcoded `f32`/`index`
- Fix `GetExprAsCode` and `GetExprTypeAnnotation` to use actual dtype from IR node
- Fix python_printer `tile.full` to emit bare float literal for the value arg (avoids roundtrip breakage since `tile.full()` only accepts `int|float`)
- Use `dt.Code()` (uint8_t) as the map key since `DataType` lacks `operator<`
- Use `_<mlir_type>` suffix for all constant SSA names including index (e.g. `%c1_index`)
- Update test assertions for renamed SSA constants (`%c1` → `%c1_index`, etc.)
- Add `TestConstDtypeCodegen` regression tests

## Testing

- [x] All unit tests pass
- [x] Regression tests added for the fixed behavior

## Related Issues

Fixes #934