### PR TITLE
fix(pass): skip NZ tmov on Ascend910B, unify cross-core transfer view

### DIFF
--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -302,33 +302,15 @@ TileView BuildCrossCoreTransferView(MemorySpace dest_ms, const TileView& origina
   // constraint), so Left/Right/Mat destinations all use NZ at the transfer
   // boundary. The final Left/Right layout is resolved by a subsequent
   // Mat -> Left/Right move (MTE1).
-  if (backend_type == backend::BackendType::Ascend910B) {
-    switch (dest_ms) {
-      case MemorySpace::Left:
-      case MemorySpace::Right:
-      case MemorySpace::Mat:
-        result.blayout = TileLayout::col_major;
-        result.slayout = TileLayout::row_major;
-        return result;
-      case MemorySpace::Vec:
-        return original_view;
-      default:
-        INTERNAL_UNREACHABLE << "cross-core move destination must be Vec, Mat, Left, or Right, got "
-                             << static_cast<int>(dest_ms);
-    }
-  }
-
-  // Ascend950: encode the fractal layout directly at the transfer boundary.
+  // Ascend950: vec to Mat don't support ZN fractal, so use NZ for Right dest as 910B,
+  // this can also work.
   switch (dest_ms) {
     case MemorySpace::Left:
+    case MemorySpace::Right:
+    case MemorySpace::Mat:
       result.blayout = TileLayout::col_major;
       result.slayout = TileLayout::row_major;
       return result;
-    case MemorySpace::Right:
-      result.blayout = TileLayout::row_major;
-      result.slayout = TileLayout::col_major;
-      return result;
-    case MemorySpace::Mat:
     case MemorySpace::Vec:
       return original_view;
     default:
@@ -349,6 +331,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
                                    const std::map<const Stmt*, CVBoundaryMove>& boundary_moves,
                                    std::unordered_map<const Var*, VarPtr>& tpop_var_remap,
                                    std::unordered_set<const Var*>& superseded_tpop_vars) {
+  auto backend_type = backend::GetBackendType();
   // AIC keeps CUBE, skips VECTOR; AIV keeps VECTOR, skips CUBE
   CoreAffinity keep_affinity = (side == CoreSide::AIC) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
   CoreAffinity skip_affinity = (side == CoreSide::AIC) ? CoreAffinity::VECTOR : CoreAffinity::CUBE;
@@ -378,8 +361,9 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
           // AIV V->C push: insert tile.move (tmov) to adapt the source into
           // the required fractal layout before tpush.
           // On Ascend950: Left -> NZ, Right -> ZN.
-          // On Ascend910B: both Left and Right -> NZ (Mat only supports NZ).
-          if (side == CoreSide::AIV) {
+          // On Ascend910B: don't need to adapt layout! push/pop will be ub -> gm -> mat, ub -> gm can
+          // directly use nd
+          if (side == CoreSide::AIV && backend_type == backend::BackendType::Ascend950) {
             auto push_dest_type = std::dynamic_pointer_cast<const TileType>(bm.dest_var->GetType());
             INTERNAL_CHECK(push_dest_type && push_dest_type->memory_space_.has_value() &&
                            push_dest_type->tile_view_.has_value())

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -11,8 +11,12 @@
 Cross-Core Communication (TPUSH/TPOP) System Tests.
 
 Tests:
-  V2CTest : Vector→Cube, updown split. output = (a + b) @ (a - b)
-  C2VTest : Cube→Vector, left-right split. c += a @ b (parallel over N in blocks)
+  V2CUDTest      : Vector→Cube, updown split.      output = (a + b) @ (a - b)
+  V2CLRTest      : Vector→Cube, left-right split.  output = (a + b) @ (a - b)
+  C2VLRTest      : Cube→Vector, left-right split.  c += a @ b (parallel over N in blocks)
+  C2VUDTest      : Cube→Vector, updown split.      c += a @ b (parallel over N in blocks)
+  BiDirectUDTest : V↔C, updown split.              c += (a+1) @ b (parallel over N in blocks)
+  BiDirectLRTest : V↔C, left-right split.          c += (a+1) @ b (parallel over N in blocks)
 """
 
 from typing import Any
@@ -30,7 +34,7 @@ N_BLOCKS = N // N_BLOCK
 
 
 @pl.program
-class V2CProgram:
+class V2CUDProgram:
     """V2C updown-split cross-core program.
 
     Vector producer: loads tiles a and b, computes add and sub, pushes both to Cube.
@@ -54,13 +58,13 @@ class V2CProgram:
         return output
 
 
-class V2CTest(PTOTestCase):
-    """Cross-core V2C: output = (a + b) @ (a - b)."""
+class V2CUDTest(PTOTestCase):
+    """Cross-core V2C updown: output = (a + b) @ (a - b)."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return "cross_core_tpush_tpop_v2c_updown_32x32"
+        return "cross_core_v2c_updown"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -70,7 +74,7 @@ class V2CTest(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        return V2CProgram
+        return V2CUDProgram
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a = tensors["a"].float()
@@ -79,7 +83,56 @@ class V2CTest(PTOTestCase):
 
 
 @pl.program
-class C2VProgram:
+class V2CLRProgram:
+    """V2C left-right-split cross-core program.
+
+    Vector producer: loads tiles a and b, computes add and sub, pushes both to Cube.
+    Cube consumer: pops tiles, performs matmul, stores result.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[32, 32], pl.FP32],
+        b: pl.Tensor[[32, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
+            a_plus_b = pl.add(a, b)
+            sub = pl.sub(a, b)
+            out = pl.matmul(a_plus_b, sub)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+class V2CLRTest(PTOTestCase):
+    """Cross-core V2C left-right: output = (a + b) @ (a - b)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_v2c_leftright"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [32, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [32, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return V2CLRProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"].float()
+        b = tensors["b"].float()
+        tensors["output"][:] = torch.matmul(a + b, a - b)
+
+
+@pl.program
+class C2VLRProgram:
     """C2V left-right-split cross-core program.
 
     Cube producer: computes matmul in blocks over N, pushes results to Vector.
@@ -93,7 +146,9 @@ class C2VProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.auto_incore(split=pl.SplitMode.LEFT_RIGHT):
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -103,13 +158,13 @@ class C2VProgram:
         return c
 
 
-class C2VTest(PTOTestCase):
-    """Cross-core C2V: c += a @ b (parallel over N in blocks)."""
+class C2VLRTest(PTOTestCase):
+    """Cross-core C2V left-right: c += a @ b (parallel over N in blocks)."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return "cross_core_tpop_c2v_leftright"
+        return "cross_core_c2v_leftright"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -119,7 +174,7 @@ class C2VTest(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        return C2VProgram
+        return C2VLRProgram
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a = tensors["a"]
@@ -129,7 +184,59 @@ class C2VTest(PTOTestCase):
 
 
 @pl.program
-class BiDirectProgram:
+class C2VUDProgram:
+    """C2V updown-split cross-core program.
+
+    Cube producer: computes matmul in blocks over N, pushes results to Vector.
+    Vector consumer: accumulates result into output tensor.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+class C2VUDTest(PTOTestCase):
+    """Cross-core C2V updown: c += a @ b (parallel over N in blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_c2v_updown"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True, init_value=torch.randn),
+        ]
+
+    def get_program(self) -> Any:
+        return C2VUDProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        c_prev = tensors["c"].clone()
+        tensors["c"][:] = c_prev + torch.matmul(a, b)
+
+
+@pl.program
+class BiDirectUDProgram:
     """Bidirectional (V→C→V) updown-split cross-core program.
 
     Vector sends data to Cube for matmul, Cube sends results back to Vector.
@@ -142,7 +249,9 @@ class BiDirectProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -153,13 +262,13 @@ class BiDirectProgram:
         return c
 
 
-class BiDirectTest(PTOTestCase):
-    """Cross-core V->C->V: c += (a+1) @ b (parallel over N in blocks)."""
+class BiDirectUDTest(PTOTestCase):
+    """Cross-core V->C->V updown: c += (a+1) @ b (parallel over N in blocks)."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return "cross_core_tpop_bidirect_updown"
+        return "cross_core_bidirect_updown"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -169,7 +278,59 @@ class BiDirectTest(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        return BiDirectProgram
+        return BiDirectUDProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        c_prev = tensors["c"].clone()
+        tensors["c"][:] = c_prev + torch.matmul(a + 1, b)
+
+
+@pl.program
+class BiDirectLRProgram:
+    """Bidirectional (V→C→V) left-right-split cross-core program.
+
+    Vector sends data to Cube for matmul, Cube sends results back to Vector.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                a_add = pl.add(a, 1.0)
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a_add, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+class BiDirectLRTest(PTOTestCase):
+    """Cross-core V->C->V left-right: c += (a+1) @ b (parallel over N in blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_bidirect_leftright"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True, init_value=torch.randn),
+        ]
+
+    def get_program(self) -> Any:
+        return BiDirectLRProgram
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a = tensors["a"]
@@ -183,21 +344,39 @@ class TestCrossCore:
 
     def test_tpush_tpop_v2c_updown(self, test_runner):
         """V2C updown pipe: compile through full pipeline and verify kernel artifacts."""
-        test_case = V2CTest()
+        test_case = V2CUDTest()
         result = test_runner.run(test_case)
-        assert result.passed, f"Cross-core V2C compilation failed: {result.error}"
+        assert result.passed, f"Cross-core V2C updown compilation failed: {result.error}"
+
+    def test_tpush_tpop_v2c_leftright(self, test_runner):
+        """V2C left-right pipe: compile through full pipeline and verify kernel artifacts."""
+        test_case = V2CLRTest()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core V2C left-right compilation failed: {result.error}"
 
     def test_tpop_c2v_leftright(self, test_runner):
         """C2V left-right pipe: compile through full pipeline and verify correctness."""
-        test_case = C2VTest()
+        test_case = C2VLRTest()
         result = test_runner.run(test_case)
-        assert result.passed, f"Cross-core C2V compilation failed: {result.error}"
+        assert result.passed, f"Cross-core C2V left-right compilation failed: {result.error}"
+
+    def test_tpop_c2v_updown(self, test_runner):
+        """C2V updown pipe: compile through full pipeline and verify correctness."""
+        test_case = C2VUDTest()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core C2V updown compilation failed: {result.error}"
 
     def test_tpop_bidirect_updown(self, test_runner):
-        """bidirect updown pipe: compile through full pipeline and verify correctness."""
-        test_case = BiDirectTest()
+        """Bidirect updown pipe: compile through full pipeline and verify correctness."""
+        test_case = BiDirectUDTest()
         result = test_runner.run(test_case)
-        assert result.passed, f"Cross-core bidirect compilation failed: {result.error}"
+        assert result.passed, f"Cross-core bidirect updown compilation failed: {result.error}"
+
+    def test_tpop_bidirect_leftright(self, test_runner):
+        """Bidirect left-right pipe: compile through full pipeline and verify correctness."""
+        test_case = BiDirectLRTest()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core bidirect left-right compilation failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -8,15 +8,11 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """
-a2a3 Cross-Core Communication (TPUSH/TPOP) System Test.
+Cross-Core Communication (TPUSH/TPOP) System Tests.
 
-Program under test:
-  Vector (AIV): loads tiles a and b, computes (a+b) and (a-b), pushes both to Cube.
-  Cube  (AIC) : pops both tiles, performs matmul((a+b), (a-b)), stores result.
-  Golden      : output = (a + b) @ (a - b)
-
-Artifact-level split/layout validation is covered by dedicated unit tests and
-on-board execution checks.
+Tests:
+  V2CTest : Vector→Cube, updown split. output = (a + b) @ (a - b)
+  C2VTest : Cube→Vector, left-right split. c += a @ b (parallel over N in blocks)
 """
 
 from typing import Any
@@ -26,122 +22,182 @@ import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 
+M = 32
+K = 64
+N = 512
+N_BLOCK = 64
+N_BLOCKS = N // N_BLOCK
+
 
 @pl.program
-class CrossCoreTpushTpopProgram:
+class V2CProgram:
     """V2C updown-split cross-core program.
 
     Vector producer: loads tiles a and b, computes add and sub, pushes both to Cube.
     Cube consumer: pops tiles, performs matmul, stores result.
     """
 
-    @pl.function(type=pl.FunctionType.AIV)
-    def vector_producer(
-        self,
-        a: pl.Tensor[[16, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
-    ):
-        v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
-        pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer)
-
-        tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
-        tile_b: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
-        result_add: pl.Tile[[16, 16], pl.FP32] = pl.add(tile_a, tile_b)
-        result_sub: pl.Tile[[16, 16], pl.FP32] = pl.sub(tile_a, tile_b)
-
-        pl.tpush_to_aic(result_add, split=1)
-        pl.tpush_to_aic(result_sub, split=1)
-
-    @pl.function(type=pl.FunctionType.AIC)
-    def cube_consumer(
-        self,
-        a: pl.Tensor[[16, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
-    ) -> pl.Tensor[[16, 16], pl.FP32]:
-        pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
-        pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf)
-
-        # Chain 1: tpop -> move (use) -> tfree
-        received_add: pl.Tile[
-            [16, 16],
-            pl.FP32,
-            pl.MemorySpace.Mat,
-            pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
-        ] = pl.tpop_from_aiv(split=1)
-        received_add_left = pl.move(received_add, target_memory=pl.Mem.Left)
-        pl.tfree_to_aiv(received_add)
-
-        # Chain 2: tpop -> move (use) -> tfree
-        received_sub: pl.Tile[
-            [16, 16],
-            pl.FP32,
-            pl.MemorySpace.Mat,
-            pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
-        ] = pl.tpop_from_aiv(split=1)
-        received_sub_right = pl.move(received_sub, target_memory=pl.Mem.Right)
-        pl.tfree_to_aiv(received_sub)
-
-        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add_left, received_sub_right)
-
-        updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(mm_result, [0, 0], output)
-        return updated
-
-    @pl.function(type=pl.FunctionType.Group)
-    def group_func(
-        self,
-        a: pl.Tensor[[16, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
-    ):
-        updated = self.cube_consumer(a, b, output)
-        self.vector_producer(a, b, output)
-        return updated
-
-    @pl.function(type=pl.FunctionType.Orchestration)
+    @pl.function(type=pl.FunctionType.Opaque)
     def main(
         self,
-        a: pl.Tensor[[16, 16], pl.FP32],
-        b: pl.Tensor[[16, 16], pl.FP32],
-        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
-    ) -> pl.Tensor[[16, 16], pl.FP32]:
-        out = self.group_func(a, b, output)
-        return out
+        a: pl.Tensor[[32, 32], pl.FP32],
+        b: pl.Tensor[[32, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
+            a_plus_b = pl.add(a, b)
+            sub = pl.sub(a, b)
+            out = pl.matmul(a_plus_b, sub)
+            output = pl.assemble(output, out, [0, 0])
+        return output
 
 
-class CrossCoreTpushTpop(PTOTestCase):
-    """a2a3 cross-core V2C: output = (a + b) @ (a - b)."""
+class V2CTest(PTOTestCase):
+    """Cross-core V2C: output = (a + b) @ (a - b)."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return "cross_core_tpush_tpop_v2c_updown_16x16"
+        return "cross_core_tpush_tpop_v2c_updown_32x32"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("a", [16, 16], DataType.FP32, init_value=torch.randn),
-            TensorSpec("b", [16, 16], DataType.FP32, init_value=torch.randn),
-            TensorSpec("output", [16, 16], DataType.FP32, is_output=True),
+            TensorSpec("a", [32, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [32, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [32, 32], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return CrossCoreTpushTpopProgram
+        return V2CProgram
 
-    def compute_expected(self, tensors, params=None):
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a = tensors["a"].float()
         b = tensors["b"].float()
         tensors["output"][:] = torch.matmul(a + b, a - b)
 
 
+@pl.program
+class C2VProgram:
+    """C2V left-right-split cross-core program.
+
+    Cube producer: computes matmul in blocks over N, pushes results to Vector.
+    Vector consumer: accumulates result into output tensor.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.auto_incore(split=pl.SplitMode.LEFT_RIGHT):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+class C2VTest(PTOTestCase):
+    """Cross-core C2V: c += a @ b (parallel over N in blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_tpop_c2v_leftright"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True, init_value=torch.randn),
+        ]
+
+    def get_program(self) -> Any:
+        return C2VProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        c_prev = tensors["c"].clone()
+        tensors["c"][:] = c_prev + torch.matmul(a, b)
+
+
+@pl.program
+class BiDirectProgram:
+    """Bidirectional (V→C→V) updown-split cross-core program.
+
+    Vector sends data to Cube for matmul, Cube sends results back to Vector.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                a_add = pl.add(a, 1.0)
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a_add, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+class BiDirectTest(PTOTestCase):
+    """Cross-core V->C->V: c += (a+1) @ b (parallel over N in blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_tpop_bidirect_updown"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True, init_value=torch.randn),
+        ]
+
+    def get_program(self) -> Any:
+        return BiDirectProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        c_prev = tensors["c"].clone()
+        tensors["c"][:] = c_prev + torch.matmul(a + 1, b)
+
+
 class TestCrossCore:
-    """a2a3 cross-core communication system tests"""
+    """Cross-core communication system tests."""
 
     def test_tpush_tpop_v2c_updown(self, test_runner):
         """V2C updown pipe: compile through full pipeline and verify kernel artifacts."""
-        test_case = CrossCoreTpushTpop()
+        test_case = V2CTest()
         result = test_runner.run(test_case)
         assert result.passed, f"Cross-core V2C compilation failed: {result.error}"
+
+    def test_tpop_c2v_leftright(self, test_runner):
+        """C2V left-right pipe: compile through full pipeline and verify correctness."""
+        test_case = C2VTest()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core C2V compilation failed: {result.error}"
+
+    def test_tpop_bidirect_updown(self, test_runner):
+        """bidirect updown pipe: compile through full pipeline and verify correctness."""
+        test_case = BiDirectTest()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Cross-core bidirect compilation failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -410,8 +410,8 @@ def test_pto_codegen_fillpad_inplace():
 
     # Both allocs share the same addr (same MemRef)
     assert len(alloc_lines) == 2, f"Expected two alloc_tiles for per-var alloc model, got: {alloc_lines}"
-    assert "addr = %c0i" in alloc_lines[0]
-    assert "addr = %c0i" in alloc_lines[1]
+    assert "addr = %c0_i64" in alloc_lines[0]
+    assert "addr = %c0_i64" in alloc_lines[1]
     # Dynamic valid_shape tile: type has v_row=?, v_col=? (both dynamic per PTOAS requirement)
     assert "v_row=?" in alloc_lines[0], f"Expected dynamic v_row=? in alloc: {alloc_lines[0]}"
     assert "v_col=?" in alloc_lines[0], f"Expected dynamic v_col=? in alloc: {alloc_lines[0]}"

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -158,16 +158,15 @@ def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
 
 
 def test_v2c_boundary_uses_nz_layout_on_a2a3():
-    """On Ascend910B, cross-core transfer uses NZ layout for both Left and Right.
+    """On Ascend910B, cross-core push needs no layout adaptation on the AIV side.
 
-    Ascend910B routes data through GM → Mat, and Mat only supports NZ
-    (col_major blayout, row_major slayout). Unlike Ascend950 where Left uses
-    NZ and Right uses ZN, on 910B both destinations use NZ at the transfer
-    boundary.
+    Ascend910B routes push/pop through ub → gm → mat. The ub → gm transfer
+    uses ND layout directly, so no tile.move is needed before tpush_to_aic.
+    The AIC tpop still lands in Mat with NZ layout (col_major blayout), and a
+    subsequent Mat → Left tile.move resolves the final layout.
 
     The expected behavior on 910B:
-      - AIV side: a `tile.move` converts the source to NZ layout (producing
-        an `_nz` variable), then `tpush_to_aic(adapted_tile)`.
+      - AIV side: `tpush_to_aic(source_tile)` directly, no NZ/ZN tmov.
       - AIC side: `tpop_from_aiv()` lands in Mat with NZ layout (col_major
         blayout), followed by a `Mat → Left` `tile.move`.
     """
@@ -209,10 +208,9 @@ def test_v2c_boundary_uses_nz_layout_on_a2a3():
     aic_printed = python_print(aic_func)
     aiv_printed = python_print(aiv_func)
 
-    # AIV side: a tile.move converts the source to NZ layout before tpush.
-    # On 910B both Left and Right use NZ, so the intermediate var should be `_nz`.
+    # AIV side: push directly with no NZ/ZN layout adaptation (910B ub->gm uses ND).
     assert "pl.tile.tpush_to_aic(" in aiv_printed
-    assert "_nz" in aiv_printed
+    assert "_nz" not in aiv_printed
     assert "_zn" not in aiv_printed
 
     # AIC side: tpop lands in Mat with NZ layout (col_major blayout), and

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -2140,7 +2140,8 @@ class TestNestedStructures:
     def test_bidirectional_inside_for_loop(self):
         """V->C and C->V boundaries inside same loop body.
 
-        Pattern: load(Vec) -> add (V) -> move(Vec->Mat->Left) -> matmul (C) -> move(Acc->Vec) -> exp (V) -> store
+        Pattern: load(Vec) -> add (V) -> move(Vec->Mat->Left) -> matmul (C)
+                 -> move(Acc->Vec) -> exp (V) -> store
         V->C: add result flows to matmul via tpush_to_aic / tpop_from_aiv
         C->V: matmul result flows to exp via tpush_to_aiv / tpop_from_aic
         """


### PR DESCRIPTION
## Summary

- On Ascend910B, V->C push goes through ub→gm→mat. The ub→gm transfer uses ND layout directly, so no `tile.move` (NZ/ZN adaptation) is needed before `tpush_to_aic`. The guard `side == CoreSide::AIV` is now gated to Ascend950 only.
- Unify `BuildCrossCoreTransferView` for both backends: since Ascend950 vec-to-Mat doesn't support ZN fractal, Right destinations use NZ (same as 910B), collapsing the backend-specific branches into a single switch.
- Cache `GetBackendType()` at the top of `BuildCoreBody` to avoid repeated mutex-locked calls inside the statement loop.
- Fix ut error in test_pto_codegen.py::test_pto_codegen_fillpad_inplace introduced by cross merge.

## Testing

- Updated `test_expand_mixed_kernel_a2a3.py::test_v2c_boundary_uses_nz_layout_on_a2a3` to reflect new 910B behavior (no `_nz` tmov on AIV push side; AIC pop side unchanged).
- Added `C2VTest`, `V2CTest` and `BiDirectTest` with up/down and left/right split to `tests/st/runtime/test_cross_core.py`.