### PR TITLE
fix(pass): keep extracted temporaries inside ScopeStmt during FlattenCallExpr

### DIFF
--- a/docs/en/dev/passes/04-flatten_call_expr.md
+++ b/docs/en/dev/passes/04-flatten_call_expr.md
@@ -48,6 +48,7 @@ program_flat = flatten_pass(program)
 
 - Before AssignStmt/EvalStmt: Insert directly before
 - Before IfStmt/ForStmt: Insert as sibling statements in the enclosing `SeqStmts`
+- Inside ScopeStmt (`pl.at()`): Temporaries are always inserted **inside** the scope body, preserving execution-context boundaries
 
 ## Example
 
@@ -116,6 +117,25 @@ t__tmp_v1 = compute(b)
 x = t__tmp_v0 + t__tmp_v1
 ```
 
+### Nested Call inside Scope Block
+
+**Before**:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    result = assemble(target, cast(x, BF16), offsets)
+```
+
+**After**:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    t__tmp_v0 = cast(x, BF16)
+    result = assemble(target, t__tmp_v0, offsets)
+```
+
+The temporary stays inside the `pl.at()` block. Without this scope-awareness, `t__tmp_v0 = cast(...)` would be hoisted outside the scope, causing a "Misplaced tensor op" error during codegen.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`
@@ -144,6 +164,7 @@ passes.def("flatten_call_expr", &pass::FlattenCallExpr, "Flatten nested calls");
 - Tests for range extraction
 - Tests binary/unary expression extraction
 - Tests multiple nested calls
+- Tests scope-aware extraction (`pl.at()` blocks)
 
 ## Error Types
 

--- a/docs/zh-cn/dev/passes/04-flatten_call_expr.md
+++ b/docs/zh-cn/dev/passes/04-flatten_call_expr.md
@@ -48,6 +48,7 @@ program_flat = flatten_pass(program)
 
 - AssignStmt/EvalStmt 之前：直接插入在前面
 - 在 IfStmt/ForStmt 之前：作为外层 `SeqStmts` 中的同级语句插入
+- ScopeStmt 内部（`pl.at()`）：临时变量始终插入在 scope body **内部**，保持执行上下文边界
 
 ## 示例
 
@@ -116,6 +117,25 @@ t__tmp_v1 = compute(b)
 x = t__tmp_v0 + t__tmp_v1
 ```
 
+### Scope 块内的嵌套调用
+
+**变换前**：
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    result = assemble(target, cast(x, BF16), offsets)
+```
+
+**变换后**：
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    t__tmp_v0 = cast(x, BF16)
+    result = assemble(target, t__tmp_v0, offsets)
+```
+
+临时变量保留在 `pl.at()` 块内。如果没有这种 scope 感知机制，`t__tmp_v0 = cast(...)` 会被提升到 scope 外部，导致代码生成时出现 "Misplaced tensor op" 错误。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`
@@ -144,6 +164,7 @@ passes.def("flatten_call_expr", &pass::FlattenCallExpr, "Flatten nested calls");
 - 测试 for 范围提取
 - 测试二元/一元表达式提取
 - 测试多个嵌套调用
+- 测试 scope 感知提取（`pl.at()` 块）
 
 ## 错误类型
 

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -56,6 +56,7 @@ class FlattenCallExprMutator : public IRMutator {
   StmtPtr VisitStmt_(const IfStmtPtr& op) override;
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override;
+  StmtPtr VisitStmt_(const ScopeStmtPtr& op) override;
 
   // Expression visitors
   ExprPtr VisitExpr_(const CallPtr& op) override;
@@ -275,6 +276,34 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {
   pending_stmts_ = condition_pending;
 
   return std::make_shared<WhileStmt>(new_condition, op->iter_args_, new_body, op->return_vars_, op->span_);
+}
+
+StmtPtr FlattenCallExprMutator::VisitStmt_(const ScopeStmtPtr& op) {
+  auto outer_pending = std::move(pending_stmts_);
+  pending_stmts_.clear();
+
+  auto new_body = VisitStmt(op->body_);
+
+  // When body is a SeqStmts, VisitStmt_(SeqStmts) already flushed pending
+  // stmts as siblings inside the sequence.  Only single-statement bodies
+  // need explicit flushing here.
+  if (!As<SeqStmts>(op->body_) && !pending_stmts_.empty()) {
+    std::vector<StmtPtr> body_stmts;
+    body_stmts.reserve(pending_stmts_.size() + 1);
+    for (const auto& pending : pending_stmts_) {
+      body_stmts.push_back(pending);
+    }
+    body_stmts.push_back(new_body);
+    new_body = SeqStmts::Flatten(std::move(body_stmts), op->body_->span_);
+  }
+
+  pending_stmts_ = std::move(outer_pending);
+
+  if (new_body.get() != op->body_.get()) {
+    return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
+                                             op->role_, op->split_);
+  }
+  return op;
 }
 
 // Expression visitors implementation

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -548,5 +548,148 @@ class TestFlattenPreservesFuncType:
         assert after_func.func_type == pl.FunctionType.InCore
 
 
+class TestFlattenCallInScopeStmt:
+    """Tests for flattening nested calls inside ScopeStmt (pl.incore / pl.at) blocks.
+
+    Verifies that extracted temporaries stay inside the enclosing scope,
+    preventing tensor ops from being hoisted outside incore/at blocks.
+    Regression tests for issue #941.
+    """
+
+    def test_nested_call_inside_at_core_group(self):
+        """Test that nested call inside pl.at(level=CORE_GROUP) keeps temp inside the scope."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(x, 1.0), 2.0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v0, 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_multiple_nested_calls_inside_scope(self):
+        """Test multiple nested calls inside a scope block preserve ordering."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(pl.mul(x, 2.0), 1.0)
+                    b: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(a, 3.0), 4.0)
+                return b
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v0, 1.0)
+                    t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.add(a, 3.0)
+                    b: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v1, 4.0)
+                return b
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_nested_scope_blocks(self):
+        """Test nested scope blocks keep temporaries in the correct inner scope."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(x, 1.0), 2.0)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(pl.exp(y), 3.0)
+                return pl.add(a, b)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                a: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v0, 2.0)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.exp(y)
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v1, 3.0)
+                return pl.add(a, b)
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_scope_inside_for_loop_with_nested_calls(self):
+        """Test scope block inside a for loop with nested calls."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = x
+                for _i in pl.range(10):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        result = pl.mul(pl.add(result, 1.0), 2.0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = x
+                for _i in pl.range(10):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(result, 1.0)
+                        result = pl.mul(t__tmp_v0, 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(passes.convert_to_ssa()(Before))
+        ir.assert_structural_equal(After, NormalizeIR(passes.convert_to_ssa()(Expected)))
+
+    def test_deeply_nested_call_inside_scope(self):
+        """Test deeply nested calls inside scope: mul(add(exp(x), 1.0), 2.0)"""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(pl.exp(x), 1.0), 2.0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.exp(x)
+                    t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v0, 1.0)
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v1, 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #941

FlattenCallExpr lacked a VisitStmt_ override for ScopeStmt, so nested calls extracted from inside pl.incore()/pl.at() blocks had their temp assignments hoisted outside the scope boundary. This caused downstream codegen to report "Misplaced tensor op" errors.

Add scope-aware handling that flushes pending statements inside the scope body instead of leaking them to the parent SeqStmts.

Made-with: Cursor