### PR TITLE
fix(runtime): stabilize mixed-kernel split AIV flow

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -336,6 +336,23 @@ def _get_fixed_subblock_id(func: _ir_core.Function) -> int | None:
     return 1 if func.name.endswith("__aiv1") else None
 
 
+def _uses_dynamic_subblock_id(func: _ir_core.Function) -> bool:
+    """Return whether the function reads subblock id from the runtime lane context."""
+    stmts = _ir_core.flatten_to_stmts(func.body)
+    for stmt in stmts:
+        call = None
+        if isinstance(stmt, _ir_core.EvalStmt):
+            call = stmt.expr
+        elif isinstance(stmt, _ir_core.AssignStmt):
+            call = stmt.value
+        if not isinstance(call, _ir_core.Call):
+            continue
+        op = getattr(call, "op", None)
+        if isinstance(op, _ir_core.Op) and op.name == "tile.get_subblock_idx":
+            return True
+    return False
+
+
 def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
     """Return whether A2A3 split AIV wrappers must source subblock id from runtime context."""
     split_mode = getattr(func, "split", None)
@@ -345,7 +362,7 @@ def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
         return False
     if _backend_core.get_backend_type() != _backend_core.BackendType.Ascend910B:
         return False
-    return not func.name.endswith("__aiv1")
+    return _uses_dynamic_subblock_id(func)
 
 
 def _generate_kernel_header(func: _ir_core.Function) -> str:
@@ -772,10 +789,11 @@ def generate(
     groups, ungrouped = _build_group_mapping(transformed_program)
 
     # ── Phase 1: IR → MLIR (sequential, fast) ────────────────────────
-    # PTOCodegen converts IR to MLIR strings.  This is cheap (pure string
+    # PTOCodegen converts IR to MLIR strings. This is cheap (pure string
     # generation) and runs sequentially so that we don't contend on the GIL.
     units: list[_CodegenUnit] = []
 
+    # Grouped functions: one MLIR module per group
     for group_name, members in groups.items():
         try:
             grouped_program = _ir_core.Program(members, group_name, transformed_program.span)

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -100,8 +100,9 @@ std::unordered_set<const Var*> CollectTpopVars(const std::vector<StmtPtr>& stmts
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       auto inner = CollectTpopVars(FlattenBody(if_stmt->then_body_));
       result.insert(inner.begin(), inner.end());
-      if (if_stmt->else_body_.has_value()) {
-        auto inner2 = CollectTpopVars(FlattenBody(if_stmt->else_body_.value()));
+      const auto& else_body = if_stmt->else_body_;
+      if (else_body.has_value()) {
+        auto inner2 = CollectTpopVars(FlattenBody(*else_body));
         result.insert(inner2.begin(), inner2.end());
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
@@ -162,9 +163,10 @@ CoreAffinity AnalyzeStmtAffinity(const StmtPtr& stmt, std::unordered_map<const S
     result = AnalyzeStmtsAffinity(FlattenBody(for_stmt->body_), stmt_map, var_affinity, tpop_vars);
   } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
     result = AnalyzeStmtsAffinity(FlattenBody(if_stmt->then_body_), stmt_map, var_affinity, tpop_vars);
-    if (if_stmt->else_body_.has_value()) {
-      result = CombineAffinity(result, AnalyzeStmtsAffinity(FlattenBody(if_stmt->else_body_.value()),
-                                                            stmt_map, var_affinity, tpop_vars));
+    const auto& else_body = if_stmt->else_body_;
+    if (else_body.has_value()) {
+      result = CombineAffinity(
+          result, AnalyzeStmtsAffinity(FlattenBody(*else_body), stmt_map, var_affinity, tpop_vars));
     }
   } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
     result = AnalyzeStmtsAffinity(FlattenBody(while_stmt->body_), stmt_map, var_affinity, tpop_vars);
@@ -212,8 +214,9 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
       CollectCVBoundaryMoves(FlattenBody(for_stmt->body_), boundary_moves, var_to_tpop);
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       CollectCVBoundaryMoves(FlattenBody(if_stmt->then_body_), boundary_moves, var_to_tpop);
-      if (if_stmt->else_body_.has_value()) {
-        CollectCVBoundaryMoves(FlattenBody(if_stmt->else_body_.value()), boundary_moves, var_to_tpop);
+      const auto& else_body = if_stmt->else_body_;
+      if (else_body.has_value()) {
+        CollectCVBoundaryMoves(FlattenBody(*else_body), boundary_moves, var_to_tpop);
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       CollectCVBoundaryMoves(FlattenBody(while_stmt->body_), boundary_moves, var_to_tpop);
@@ -243,9 +246,13 @@ CallPtr CreateMove(const ExprPtr& tile, MemorySpace target_memory, const TypePtr
   auto op = OpRegistry::GetInstance().GetOp("tile.move");
 
   std::vector<std::pair<std::string, std::any>> kwargs{{"target_memory", std::any(target_memory)}};
-  if (auto tt = std::dynamic_pointer_cast<const TileType>(result_type); tt && tt->tile_view_.has_value()) {
-    kwargs.emplace_back("blayout", std::any(tt->tile_view_->blayout));
-    kwargs.emplace_back("slayout", std::any(tt->tile_view_->slayout));
+  if (auto tt = std::dynamic_pointer_cast<const TileType>(result_type); tt) {
+    const auto& tile_view = tt->tile_view_;
+    if (tile_view.has_value()) {
+      const auto& view = *tile_view;
+      kwargs.emplace_back("blayout", std::any(view.blayout));
+      kwargs.emplace_back("slayout", std::any(view.slayout));
+    }
   }
   return std::make_shared<Call>(op, std::vector<ExprPtr>{tile}, std::move(kwargs), result_type, span);
 }
@@ -283,13 +290,16 @@ std::string BuildBoundaryTpopName(CoreSide side, const std::string& dest_name) {
 ///   Right -> ZN (row_major blayout, col_major slayout)
 ///   Mat/Vec -> preserve original (already-final layout)
 ///
-/// Ascend910B (a2a3): cross-core transfer goes through GM -> Mat, and Mat only
-/// supports NZ (col_major blayout, row_major slayout). All GM -> L1 transfers
-/// (Left, Right, Mat) use NZ; Vec preserves the original view.
+/// Ascend910B (a2a3): cross-core transfer goes through GM. Left/Right/Mat use
+/// NZ bridge tiles because GM -> Mat transfer requires fractal layout.
+/// Vec destinations must preserve the original Vec view: the GM-backed C2V pop
+/// materializes through an ND GlobalTensor on the consumer side, and PTO-ISA
+/// only supports Vec loads for matching ND/DN/NZ layouts. Emitting an NZ Vec
+/// bridge tile would make the generated kernel invalid.
 ///   Left -> NZ (col_major blayout, row_major slayout)
 ///   Right -> NZ (col_major blayout, row_major slayout)
 ///   Mat -> NZ (col_major blayout, row_major slayout)
-///   Vec -> preserve original
+///   Vec -> preserve original view
 TileView BuildCrossCoreTransferView(MemorySpace dest_ms, const TileView& original_view) {
   auto backend_type = backend::GetBackendType();
   INTERNAL_CHECK(backend_type == backend::BackendType::Ascend950 ||
@@ -396,14 +406,14 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
                          dest_tile_type->tile_view_.has_value())
               << "Boundary move destination must have TileType, MemSpace and TileView";
           auto tpop_type = BuildBoundaryTpopType(side, bm.dest_var->GetType());
-          bool needs_post_move = NeedsPostTpopMove(side, *dest_tile_type);
-          std::string tpop_name = needs_post_move ? BuildBoundaryTpopName(side, bm.dest_var->name_hint_)
-                                                  : bm.dest_var->name_hint_;
           // Build tpop result type: with fractal TileView for boundary
           // NOLINT: optional checked by INTERNAL_CHECK above
           auto fractal_view = BuildCrossCoreTransferView(
               dest_tile_type->memory_space_.value(),  // NOLINT(bugprone-unchecked-optional-access)
               dest_tile_type->tile_view_.value());    // NOLINT(bugprone-unchecked-optional-access)
+          bool needs_post_move = NeedsPostTpopMove(side, *dest_tile_type);
+          std::string tpop_name = needs_post_move ? BuildBoundaryTpopName(side, bm.dest_var->name_hint_)
+                                                  : bm.dest_var->name_hint_;
           auto tt = std::dynamic_pointer_cast<const TileType>(tpop_type);
           auto tpop_result_type = std::make_shared<TileType>(tt->shape_, tt->dtype_, std::nullopt,
                                                              fractal_view, tt->memory_space_);
@@ -459,9 +469,10 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
         auto new_then = BuildCoreBody(side, FlattenBody(if_stmt->then_body_), stmt_map, boundary_moves,
                                       tpop_var_remap, superseded_tpop_vars);
         std::optional<StmtPtr> new_else;
-        if (if_stmt->else_body_.has_value()) {
-          auto new_else_stmts = BuildCoreBody(side, FlattenBody(if_stmt->else_body_.value()), stmt_map,
-                                              boundary_moves, tpop_var_remap, superseded_tpop_vars);
+        const auto& else_body = if_stmt->else_body_;
+        if (else_body.has_value()) {
+          auto new_else_stmts = BuildCoreBody(side, FlattenBody(*else_body), stmt_map, boundary_moves,
+                                              tpop_var_remap, superseded_tpop_vars);
           new_else = MakeBody(new_else_stmts, if_stmt->span_);
         }
         result.push_back(std::make_shared<IfStmt>(if_stmt->condition_, MakeBody(new_then, if_stmt->span_),
@@ -783,8 +794,12 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
     aiv_return_type = std::make_shared<TupleType>(func->return_types_);
   }
 
-  auto aiv_call = aiv_return_type ? std::make_shared<Call>(aiv_gvar, call_args, aiv_return_type, func->span_)
-                                  : std::make_shared<Call>(aiv_gvar, call_args, func->span_);
+  CallPtr aiv_call;
+  if (aiv_return_type) {
+    aiv_call = std::make_shared<Call>(aiv_gvar, call_args, aiv_return_type, func->span_);
+  } else {
+    aiv_call = std::make_shared<Call>(aiv_gvar, call_args, func->span_);
+  }
 
   // Build group body
   std::vector<StmtPtr> group_stmts;
@@ -906,8 +921,9 @@ bool HasInitializePipeOps(const std::vector<StmtPtr>& stmts) {
       if (HasInitializePipeOps(FlattenBody(for_stmt->body_))) return true;
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       if (HasInitializePipeOps(FlattenBody(if_stmt->then_body_))) return true;
-      if (if_stmt->else_body_.has_value()) {
-        if (HasInitializePipeOps(FlattenBody(if_stmt->else_body_.value()))) return true;
+      const auto& else_body = if_stmt->else_body_;
+      if (else_body.has_value()) {
+        if (HasInitializePipeOps(FlattenBody(*else_body))) return true;
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       if (HasInitializePipeOps(FlattenBody(while_stmt->body_))) return true;
@@ -948,7 +964,8 @@ void BuildCallGraphFromFunctions(const std::vector<FunctionPtr>& functions,
           walk(FlattenBody(for_stmt->body_));
         } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
           walk(FlattenBody(if_stmt->then_body_));
-          if (if_stmt->else_body_.has_value()) walk(FlattenBody(if_stmt->else_body_.value()));
+          const auto& else_body = if_stmt->else_body_;
+          if (else_body.has_value()) walk(FlattenBody(*else_body));
         } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
           walk(FlattenBody(while_stmt->body_));
         }
@@ -965,7 +982,7 @@ FunctionPtr AddGMSlotBufferParam(const FunctionPtr& func, int64_t gm_buffer_elem
   auto new_params = func->params_;
   new_params.push_back(gm_var);
   auto new_directions = func->param_directions_;
-  new_directions.push_back(ParamDirection::In);
+  new_directions.push_back(ParamDirection::Out);
   return std::make_shared<Function>(func->name_, new_params, new_directions, func->return_types_, func->body_,
                                     func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
 }
@@ -1012,12 +1029,13 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       auto nt = RewriteCallsForGMBuffer(if_stmt->then_body_, modified_funcs, gm_param);
       std::optional<StmtPtr> ne;
-      if (if_stmt->else_body_.has_value()) {
-        ne = RewriteCallsForGMBuffer(if_stmt->else_body_.value(), modified_funcs, gm_param);
+      const auto& else_body = if_stmt->else_body_;
+      if (else_body.has_value()) {
+        ne = RewriteCallsForGMBuffer(*else_body, modified_funcs, gm_param);
       }
       bool body_changed = (nt != if_stmt->then_body_);
-      if (!body_changed && ne.has_value() && if_stmt->else_body_.has_value()) {
-        body_changed = (ne.value() != if_stmt->else_body_.value());
+      if (!body_changed && ne.has_value() && else_body.has_value()) {
+        body_changed = (*ne != *else_body);
       }
       if (body_changed) {
         new_stmts.push_back(
@@ -1028,6 +1046,121 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       auto nb = RewriteCallsForGMBuffer(while_stmt->body_, modified_funcs, gm_param);
+      if (nb != while_stmt->body_) {
+        new_stmts.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_, nb,
+                                                        while_stmt->return_vars_, while_stmt->span_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else {
+      new_stmts.push_back(stmt);
+    }
+  }
+  if (!any_changed) return body;
+  return SeqStmts::Flatten(std::move(new_stmts), body->span_);
+}
+
+/// Create a tensor.create Call for the GM pipe buffer workspace.
+CallPtr CreateGMPipeBufferTensorCreate(int64_t buffer_size_bytes, const Span& span) {
+  int64_t shape_dim = (buffer_size_bytes + 3) / 4;  // FP32 elements (ceil)
+  auto shape_elem = std::make_shared<ConstInt>(shape_dim, DataType::INT64, span);
+  auto shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{shape_elem}, span);
+  return OpRegistry::GetInstance().Create("tensor.create", {shape_tuple},
+                                          {{"dtype", std::any(DataType::FP32)},
+                                           {"layout", std::any(TensorLayout::ND)},
+                                           {"manual_dep", std::any(true)}},
+                                          span);
+}
+
+/// Rewrite calls in orchestration functions to inject a per-call tensor.create for gm_pipe_buffer.
+/// Each call to a modified function gets its own unique gm_pipe_buffer_N variable.
+StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
+                                        const std::unordered_set<std::string>& modified_funcs,
+                                        int64_t gm_buffer_bytes, int64_t gm_buffer_elems, const Span& span,
+                                        int& counter) {
+  auto gm_type = std::make_shared<TensorType>(std::vector<int64_t>{gm_buffer_elems}, DataType::FP32,
+                                              std::nullopt, std::nullopt);
+  auto stmts = FlattenBody(body);
+  std::vector<StmtPtr> new_stmts;
+  bool any_changed = false;
+
+  auto try_rewrite = [&](const CallPtr& call) -> std::pair<StmtPtr, CallPtr> {
+    if (!call) return std::make_pair(StmtPtr{}, CallPtr{});
+    auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    if (!gv || !modified_funcs.count(gv->name_)) return std::make_pair(StmtPtr{}, CallPtr{});
+
+    // Create a unique gm_pipe_buffer variable and tensor.create for this call site
+    std::string var_name = std::string("gm_pipe_buffer_") + std::to_string(counter++);
+    auto gm_var = std::make_shared<Var>(var_name, gm_type, span);
+    auto create_call = CreateGMPipeBufferTensorCreate(gm_buffer_bytes, span);
+    auto create_stmt = std::make_shared<AssignStmt>(gm_var, create_call, span);
+
+    std::vector<ExprPtr> new_args = call->args_;
+    new_args.push_back(gm_var);
+    CallPtr new_call;
+    if (auto call_type = call->GetType()) {
+      new_call = std::make_shared<Call>(call->op_, new_args, call_type, call->span_);
+    } else {
+      new_call = std::make_shared<Call>(call->op_, new_args, call->span_);
+    }
+    StmtPtr create_stmt_ptr = create_stmt;
+    return std::make_pair(create_stmt_ptr, new_call);
+  };
+
+  for (const auto& stmt : stmts) {
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_));
+      if (rw) {
+        new_stmts.push_back(create);
+        new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, rw, assign->span_));
+        any_changed = true;
+        continue;
+      }
+    } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_));
+      if (rw) {
+        new_stmts.push_back(create);
+        new_stmts.push_back(std::make_shared<EvalStmt>(rw, eval->span_));
+        any_changed = true;
+        continue;
+      }
+    }
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      auto nb = RewriteCallsWithPerCallGMBuffer(for_stmt->body_, modified_funcs, gm_buffer_bytes,
+                                                gm_buffer_elems, span, counter);
+      if (nb != for_stmt->body_) {
+        new_stmts.push_back(
+            std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
+                                      for_stmt->iter_args_, nb, for_stmt->return_vars_, for_stmt->span_,
+                                      for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      auto nt = RewriteCallsWithPerCallGMBuffer(if_stmt->then_body_, modified_funcs, gm_buffer_bytes,
+                                                gm_buffer_elems, span, counter);
+      std::optional<StmtPtr> ne;
+      const auto& else_body = if_stmt->else_body_;
+      if (else_body.has_value()) {
+        ne = RewriteCallsWithPerCallGMBuffer(*else_body, modified_funcs, gm_buffer_bytes, gm_buffer_elems,
+                                             span, counter);
+      }
+      bool body_changed = (nt != if_stmt->then_body_);
+      if (!body_changed && ne.has_value() && else_body.has_value()) {
+        body_changed = (*ne != *else_body);
+      }
+      if (body_changed) {
+        new_stmts.push_back(
+            std::make_shared<IfStmt>(if_stmt->condition_, nt, ne, if_stmt->return_vars_, if_stmt->span_));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto nb = RewriteCallsWithPerCallGMBuffer(while_stmt->body_, modified_funcs, gm_buffer_bytes,
+                                                gm_buffer_elems, span, counter);
       if (nb != while_stmt->body_) {
         new_stmts.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_, nb,
                                                         while_stmt->return_vars_, while_stmt->span_));
@@ -1086,18 +1219,6 @@ int64_t ComputeGMBufferSizeFromPipeOps(const std::vector<FunctionPtr>& functions
     scan_stmts(FlattenBody(func->body_));
   }
   return max_bytes;
-}
-
-/// Create a tensor.create Call for the GM pipe buffer workspace.
-CallPtr CreateGMPipeBufferTensorCreate(int64_t buffer_size_bytes, const Span& span) {
-  int64_t shape_dim = (buffer_size_bytes + 3) / 4;  // FP32 elements (ceil)
-  auto shape_elem = std::make_shared<ConstInt>(shape_dim, DataType::INT64, span);
-  auto shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{shape_elem}, span);
-  return OpRegistry::GetInstance().Create("tensor.create", {shape_tuple},
-                                          {{"dtype", std::any(DataType::FP32)},
-                                           {"layout", std::any(TensorLayout::ND)},
-                                           {"manual_dep", std::any(true)}},
-                                          span);
 }
 
 /// Inject __gm_pipe_buffer into pipe-using functions and propagate through callers.
@@ -1185,23 +1306,12 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
     }
   }
 
-  // For Orchestration functions: insert tensor.create + rewrite calls to pass the buffer
+  // For Orchestration functions: inject per-call tensor.create for each call site
   if (orch_needs_tensor_create.empty()) return;
 
   for (auto& func : functions) {
     if (!orch_needs_tensor_create.count(func->name_)) continue;
 
-    Span span = func->span_;
-    // Create: gm_pipe_buffer = tensor.create(shape, dtype=FP32)
-    // Use "gm_pipe_buffer" (no leading "__") to avoid auto_name::Parse splitting on "__".
-    static constexpr const char* kOrchGMBufferName = "gm_pipe_buffer";
-    auto gm_type = std::make_shared<TensorType>(std::vector<int64_t>{gm_buffer_elems}, DataType::FP32,
-                                                std::nullopt, std::nullopt);
-    auto gm_var = std::make_shared<Var>(kOrchGMBufferName, gm_type, span);
-    auto create_call = CreateGMPipeBufferTensorCreate(gm_buffer_bytes, span);
-    auto create_stmt = std::make_shared<AssignStmt>(gm_var, create_call, span);
-
-    // Rewrite calls to Group/InCore functions that need __gm_pipe_buffer
     std::unordered_set<std::string> mod_callees;
     auto ci = callees.find(func->name_);
     if (ci != callees.end()) {
@@ -1209,22 +1319,14 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
         if (needs_gm_param.count(c)) mod_callees.insert(c);
       }
     }
+    if (mod_callees.empty()) continue;
 
-    auto body = func->body_;
-    if (!mod_callees.empty()) {
-      body = RewriteCallsForGMBuffer(body, mod_callees, gm_var);
-    }
-
-    // Prepend tensor.create to body
-    auto body_stmts = FlattenBody(body);
-    std::vector<StmtPtr> new_stmts;
-    new_stmts.push_back(create_stmt);
-    new_stmts.insert(new_stmts.end(), body_stmts.begin(), body_stmts.end());
-    auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
-
-    func =
-        std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                   new_body, span, func->func_type_, func->level_, func->role_, func->attrs_);
+    int counter = 0;
+    auto new_body = RewriteCallsWithPerCallGMBuffer(func->body_, mod_callees, gm_buffer_bytes,
+                                                    gm_buffer_elems, func->span_, counter);
+    func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                      func->return_types_, new_body, func->span_, func->func_type_,
+                                      func->level_, func->role_, func->attrs_);
   }
 }
 

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -29,9 +29,12 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/codegen/pto/tile_buf_signature.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
@@ -70,7 +73,14 @@ static bool IsLegalViewOp(const std::string& op_name) {
 struct MemRefUsageInfo {
   const Var* base_ptr = nullptr;  ///< base_ Ptr identity key
   uint64_t alloc_size = 0;        ///< Size of the root allocation in bytes
-  std::vector<std::pair<const Var*, TileBufSignature>> writers;
+  struct WriterInfo {
+    const Var* var = nullptr;
+    TileBufSignature signature;
+    std::string op_name;
+    std::vector<const Var*> input_vars;
+  };
+
+  std::vector<WriterInfo> writers;
   std::vector<std::pair<const Var*, TileBufSignature>> view_users;
   std::vector<std::pair<const Var*, const Var*>> view_edges;
 };
@@ -111,16 +121,34 @@ class MemRefUsageCollector : public IRVisitor {
         }
       }
     } else {
-      info.writers.emplace_back(op->var_.get(), sig);
+      std::vector<const Var*> input_vars;
+      std::string op_name;
+      if (call && call->op_) {
+        op_name = call->op_->name_;
+        for (const auto& arg : call->args_) {
+          if (auto input_var = As<Var>(arg)) {
+            input_vars.push_back(input_var.get());
+          }
+        }
+        if (op_name == "tile.tpop_from_aic") {
+          tpop_from_aic_vars_.insert(op->var_.get());
+        }
+      }
+      info.writers.push_back(
+          MemRefUsageInfo::WriterInfo{op->var_.get(), sig, std::move(op_name), std::move(input_vars)});
     }
 
     IRVisitor::VisitStmt_(op);
   }
 
   [[nodiscard]] const std::map<const Var*, MemRefUsageInfo>& GetUsages() const { return usages_; }
+  [[nodiscard]] const std::unordered_set<const Var*>& GetTpopFromAicVars() const {
+    return tpop_from_aic_vars_;
+  }
 
  private:
   std::map<const Var*, MemRefUsageInfo> usages_;
+  std::unordered_set<const Var*> tpop_from_aic_vars_;
 
   MemRefUsageInfo& GetOrCreate(const Var* base_ptr, uint64_t size) {
     auto it = usages_.find(base_ptr);
@@ -141,12 +169,68 @@ class MemRefUsageCollector : public IRVisitor {
 // Phase 2 — Decide which MemRefs must be split
 // -------------------------------------------------------------------------
 
+bool NeedsAscend910BSplitLoadTpopHazardWorkaround(const FunctionPtr& func) {
+  if (backend::GetBackendType() != backend::BackendType::Ascend910B ||
+      func->func_type_ != FunctionType::AIV) {
+    return false;
+  }
+
+  const auto split_mode = func->GetSplitMode();
+  return split_mode.has_value() && *split_mode != SplitMode::None;
+}
+
+std::unordered_set<const Var*> CollectLoadFamilyVars(const MemRefUsageInfo& info) {
+  std::unordered_set<const Var*> load_family;
+  std::vector<const Var*> worklist;
+  for (const auto& writer : info.writers) {
+    if (writer.op_name != "tile.load") continue;
+    load_family.insert(writer.var);
+    worklist.push_back(writer.var);
+  }
+  for (size_t i = 0; i < worklist.size(); ++i) {
+    const Var* source = worklist[i];
+    for (const auto& [view_source, view_user] : info.view_edges) {
+      if (view_source != source || load_family.count(view_user) != 0) continue;
+      load_family.insert(view_user);
+      worklist.push_back(view_user);
+    }
+  }
+  return load_family;
+}
+
+std::unordered_set<size_t> CollectForcedSplitWriterIndices(
+    const MemRefUsageInfo& info, const std::unordered_set<const Var*>& tpop_from_aic_vars,
+    bool enable_ascend910b_split_workaround) {
+  std::unordered_set<size_t> forced_indices;
+  if (!enable_ascend910b_split_workaround) return forced_indices;
+
+  const auto load_family = CollectLoadFamilyVars(info);
+  if (load_family.empty()) return forced_indices;
+
+  for (size_t i = 0; i < info.writers.size(); ++i) {
+    const auto& writer = info.writers[i];
+    if (writer.op_name.empty() || writer.op_name == "tile.load") continue;
+
+    bool uses_shared_load = false;
+    bool uses_tpop = false;
+    for (const Var* input_var : writer.input_vars) {
+      uses_shared_load = uses_shared_load || load_family.count(input_var) != 0;
+      uses_tpop = uses_tpop || tpop_from_aic_vars.count(input_var) != 0;
+    }
+    if (uses_shared_load && uses_tpop) {
+      forced_indices.insert(i);
+    }
+  }
+  return forced_indices;
+}
+
 /// For each MemRef that has multiple writers with incompatible signatures,
 /// collect the set of Var* that need a fresh MemRef.
 ///
-/// Strategy: the first writer keeps the original MemRef.  Every subsequent
-/// writer that is not PTO-materializable from the first writer's signature
-/// gets a new MemRef.
+/// Strategy: the first writer keeps the original MemRef. Every subsequent
+/// writer that is not PTO-materializable from the first writer's signature,
+/// or that matches an Ascend910B split-AIV load+tpop hazard pattern, gets a
+/// new MemRef.
 void PropagateSplitToViewUsers(const MemRefUsageInfo& info, const std::vector<const Var*>& split_roots,
                                const MemRefPtr& new_memref, std::map<const Var*, MemRefPtr>& splits) {
   std::vector<const Var*> worklist = split_roots;
@@ -169,16 +253,20 @@ void PropagateSplitToViewUsers(const MemRefUsageInfo& info, const std::vector<co
 }
 
 std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const Var*, MemRefUsageInfo>& usages,
-                                                 uint64_t& next_id) {
+                                                 const std::unordered_set<const Var*>& tpop_from_aic_vars,
+                                                 bool enable_ascend910b_split_workaround, uint64_t& next_id) {
   std::map<const Var*, MemRefPtr> splits;
 
   for (const auto& [base_ptr, info] : usages) {
     if (info.writers.size() <= 1) continue;
 
-    const auto& ref_sig = info.writers[0].second;
+    const auto& ref_sig = info.writers[0].signature;
+    const auto forced_split_indices =
+        CollectForcedSplitWriterIndices(info, tpop_from_aic_vars, enable_ascend910b_split_workaround);
+
     bool needs_split = false;
     for (size_t i = 1; i < info.writers.size(); ++i) {
-      if (!ref_sig.IsPTOMaterializable(info.writers[i].second)) {
+      if (forced_split_indices.count(i) != 0 || !ref_sig.IsPTOMaterializable(info.writers[i].signature)) {
         needs_split = true;
         break;
       }
@@ -186,11 +274,14 @@ std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const Var*, MemR
     if (!needs_split) continue;
 
     // Group writers by materializable-compatibility; first group keeps original MemRef
-    std::map<int, std::vector<size_t>> sig_groups;
-    std::vector<TileBufSignature> group_reps;
+    std::vector<int> group_ids(info.writers.size(), -1);
+    std::vector<TileBufSignature> group_reps{info.writers[0].signature};
+    group_ids[0] = 0;
 
-    for (size_t i = 0; i < info.writers.size(); ++i) {
-      const auto& sig = info.writers[i].second;
+    for (size_t i = 1; i < info.writers.size(); ++i) {
+      if (forced_split_indices.count(i) != 0) continue;
+
+      const auto& sig = info.writers[i].signature;
       int group_id = -1;
       for (size_t g = 0; g < group_reps.size(); ++g) {
         if (group_reps[g].IsPTOMaterializable(sig)) {
@@ -202,22 +293,33 @@ std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const Var*, MemR
         group_id = static_cast<int>(group_reps.size());
         group_reps.push_back(sig);
       }
-      sig_groups[group_id].push_back(i);
+      group_ids[i] = group_id;
+    }
+
+    for (size_t i = 1; i < info.writers.size(); ++i) {
+      if (forced_split_indices.count(i) == 0) continue;
+      group_ids[i] = static_cast<int>(group_reps.size());
+      group_reps.push_back(info.writers[i].signature);
+    }
+
+    std::map<int, std::vector<size_t>> sig_groups;
+    for (size_t i = 0; i < group_ids.size(); ++i) {
+      sig_groups[group_ids[i]].push_back(i);
     }
 
     // Group 0 keeps original MemRef; groups 1..N get fresh MemRefs
     for (auto& [gid, indices] : sig_groups) {
       if (gid == 0) continue;
 
-      auto memory_space = info.writers[indices[0]].second.memory_space;
+      auto memory_space = info.writers[indices[0]].signature.memory_space;
       auto new_base =
           std::make_shared<Var>(BuildBasePtrName(memory_space, next_id++), GetPtrType(), Span::unknown());
       auto new_memref = std::make_shared<MemRef>(new_base, static_cast<int64_t>(0), info.alloc_size);
       std::vector<const Var*> split_roots;
 
       for (size_t idx : indices) {
-        splits[info.writers[idx].first] = new_memref;
-        split_roots.push_back(info.writers[idx].first);
+        splits[info.writers[idx].var] = new_memref;
+        split_roots.push_back(info.writers[idx].var);
       }
       PropagateSplitToViewUsers(info, split_roots, new_memref, splits);
     }
@@ -288,8 +390,13 @@ StmtPtr InsertNewAllocStatements(const StmtPtr& body, const std::map<const Var*,
   for (const auto& [var, memref] : splits) {
     if (new_memrefs.count(memref->base_.get()) > 0) continue;
     auto tile_type = As<TileType>(var->GetType());
-    MemorySpace space =
-        tile_type && tile_type->memory_space_.has_value() ? *tile_type->memory_space_ : MemorySpace::Vec;
+    MemorySpace space = MemorySpace::Vec;
+    if (tile_type) {
+      const auto& memory_space = tile_type->memory_space_;
+      if (memory_space.has_value()) {
+        space = *memory_space;
+      }
+    }
     new_memrefs[memref->base_.get()] = {memref, space};
   }
   if (new_memrefs.empty()) return body;
@@ -345,8 +452,10 @@ FunctionPtr TransformLegalizePTOBufferReuse(const FunctionPtr& func) {
   MaxMemRefIdCollector id_collector;
   if (func->body_) id_collector.VisitStmt(func->body_);
   uint64_t next_id = id_collector.GetNextId();
+  const bool enable_ascend910b_split_workaround = NeedsAscend910BSplitLoadTpopHazardWorkaround(func);
 
-  auto splits = PlanMemRefSplits(usages, next_id);
+  auto splits =
+      PlanMemRefSplits(usages, collector.GetTpopFromAicVars(), enable_ascend910b_split_workaround, next_id);
   if (splits.empty()) return func;
 
   LOG_DEBUG << "LegalizePTOBufferReuse: splitting " << splits.size() << " variable(s) into new MemRefs";

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -237,6 +237,25 @@ ExprPtr AdjustOffsets(const ExprPtr& offsets_expr, int split_dim, const ExprPtr&
   return std::make_shared<MakeTuple>(std::move(new_elements), offsets->span_);
 }
 
+TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_dim_size) {
+  auto tt = std::dynamic_pointer_cast<const TileType>(type);
+  if (!tt || dim < 0 || dim >= static_cast<int>(tt->shape_.size())) return type;
+
+  std::vector<ExprPtr> new_shape = tt->shape_;
+  new_shape[dim] = half_dim_size;
+
+  std::optional<TileView> new_tile_view = tt->tile_view_;
+  if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
+    TileView tv = tile_view.value();
+    if (dim < static_cast<int>(tv.valid_shape.size())) {
+      tv.valid_shape[dim] = half_dim_size;
+    }
+    new_tile_view = std::move(tv);
+  }
+
+  return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
+}
+
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
                                   int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
                                   bool is_aiv, const ExprPtr& subblock_idx,
@@ -375,29 +394,50 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
   }
 
   if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-    // Phase 1: Update iter_args — halve tile types and eagerly substitute initValues.
-    // Eager initValue substitution ensures new_ia is the final form. If we deferred to the
-    // final Substitute, it would create new_ia2 (with updated initValue) while body references
-    // would get new_ia — causing a pointer mismatch in structural equality.
+    // Eagerly substitute initValues while rebuilding iter_args. If this is
+    // deferred to the final Substitute pass, it can create a second IterArg
+    // instance whose pointer diverges from the one referenced by the rebuilt
+    // loop body, breaking structural equality.
     std::vector<IterArgPtr> new_iter_args;
     new_iter_args.reserve(for_stmt->iter_args_.size());
+    std::vector<VarPtr> new_return_vars = for_stmt->return_vars_;
+
+    // Propagate tile_vars from init values to iter_args BEFORE processing body.
+    // Iter_args carry the init_value into the loop; if the init is a tracked
+    // halved tile, the iter_arg must also be tracked so that operations on it
+    // inside the loop body are correctly recognized.
     for (const auto& ia : for_stmt->iter_args_) {
-      auto tt = std::dynamic_pointer_cast<const TileType>(ia->GetType());
-      if (is_aiv && tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        auto new_type = HalveTileShape(ia->GetType(), split_dim);
-        auto new_init = transform_utils::Substitute(ia->initValue_, var_replacements);
-        auto new_ia = std::make_shared<IterArg>(ia->name_hint_, new_type, new_init, ia->span_);
-        var_replacements[ia.get()] = new_ia;
-        TileInfo info{ComputeHalfDimSize(tt->shape_[split_dim])};
-        tile_vars[ia.get()] = info;
-        tile_vars[new_ia.get()] = info;
-        new_iter_args.push_back(new_ia);
+      auto new_init_value = ia->initValue_;
+      if (new_init_value && !var_replacements.empty()) {
+        new_init_value = transform_utils::Substitute(new_init_value, var_replacements);
+      }
+      TypePtr new_type = ia->GetType();
+      bool has_tracked_tile = false;
+      TileInfo tracked_info;
+      if (ia->initValue_) {
+        if (auto init_var = AsVarLike(ia->initValue_)) {
+          auto it = tile_vars.find(init_var.get());
+          if (it != tile_vars.end()) {
+            has_tracked_tile = true;
+            tracked_info = it->second;
+            tile_vars[ia.get()] = it->second;
+            new_type = ApplyTrackedTileShape(ia->GetType(), split_dim, it->second.half_dim_size);
+          }
+        }
+      }
+
+      if (new_type != ia->GetType() || new_init_value != ia->initValue_) {
+        auto new_iter_arg = std::make_shared<IterArg>(ia->name_hint_, new_type, new_init_value, ia->span_);
+        new_iter_args.push_back(new_iter_arg);
+        var_replacements[ia.get()] = new_iter_arg;
+        if (has_tracked_tile) {
+          tile_vars[new_iter_arg.get()] = tracked_info;
+        }
       } else {
         new_iter_args.push_back(ia);
       }
     }
 
-    // Phase 2: Process loop body with updated var_replacements.
     auto flat = std::vector<StmtPtr>();
     if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(for_stmt->body_)) {
       flat = seq->stmts_;
@@ -410,29 +450,27 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
                            ? new_body_stmts[0]
                            : std::make_shared<SeqStmts>(new_body_stmts, for_stmt->span_);
 
-    // Phase 3: Update return_vars — halve type if corresponding iter_arg was halved,
-    // and register in tile_vars so downstream tile.store picks up the subblock offset.
-    // Invariant: |iter_args| == |return_vars|, so indexing is safe.
+    // Propagate tile_vars tracking from iter_args to return_vars.
+    // ForStmt return_vars are the loop-exit versions of the corresponding
+    // iter_args.  If an iter_arg carries a halved tile, the return_var must
+    // inherit the tile info so that downstream tile.store gets the correct
+    // subblock offset adjustment.
     INTERNAL_CHECK(for_stmt->iter_args_.size() == for_stmt->return_vars_.size())
         << "Internal error: ForStmt iter_args and return_vars sizes must match, got "
         << for_stmt->iter_args_.size() << " vs " << for_stmt->return_vars_.size();
-    std::vector<VarPtr> new_return_vars;
-    new_return_vars.reserve(for_stmt->return_vars_.size());
-    for (size_t i = 0; i < for_stmt->return_vars_.size(); ++i) {
-      const auto& rv = for_stmt->return_vars_[i];
-      const bool ia_halved = (new_iter_args[i].get() != for_stmt->iter_args_[i].get());
-      if (ia_halved) {
-        auto new_rv_type = HalveTileShape(rv->GetType(), split_dim);
-        auto new_rv = std::make_shared<Var>(rv->name_hint_, new_rv_type, rv->span_);
-        var_replacements[rv.get()] = new_rv;
-        // Register in tile_vars so tile.store after this loop adjusts its offset.
-        auto old_tt = std::dynamic_pointer_cast<const TileType>(for_stmt->iter_args_[i]->GetType());
-        TileInfo info{ComputeHalfDimSize(old_tt->shape_[split_dim])};
-        tile_vars[rv.get()] = info;
-        tile_vars[new_rv.get()] = info;
-        new_return_vars.push_back(new_rv);
-      } else {
-        new_return_vars.push_back(rv);
+    for (size_t i = 0; i < new_iter_args.size() && i < new_return_vars.size(); ++i) {
+      auto it = tile_vars.find(new_iter_args[i].get());
+      if (it != tile_vars.end()) {
+        tile_vars[new_return_vars[i].get()] = it->second;
+        auto new_type =
+            ApplyTrackedTileShape(new_return_vars[i]->GetType(), split_dim, it->second.half_dim_size);
+        if (new_type != new_return_vars[i]->GetType()) {
+          auto new_return_var =
+              std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
+          new_return_vars[i] = new_return_var;
+          tile_vars[new_return_var.get()] = it->second;
+          var_replacements[for_stmt->return_vars_[i].get()] = new_return_var;
+        }
       }
     }
 

--- a/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
+++ b/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
@@ -1,0 +1,376 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3 decode scope-3 mixed-kernel runtime system test.
+
+This scope covers:
+  1. Output projection: attn_out x wo, accumulated in Q_OUT_CHUNK tiles
+  2. Residual addition with hidden_states
+  3. Post-attention RMSNorm
+  4. MLP: gate/up projections, SiLU activation, down projection
+  5. Final residual addition
+
+The original file was a standalone script executed via:
+    python tests/st/runtime/test_qwen3_decode_scope3_mixed.py -d <device>
+
+It is now structured as a standard pytest ST case so it can be collected and
+run together with the rest of tests/st/, while preserving the same program and
+reference compute logic. The __main__ block keeps a thin compatibility layer
+for translating the old -d/-p flags into pytest's --device/--platform options.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Mirror tests/st/conftest.py so direct `python <file>.py` execution can
+# resolve the local harness package before pytest takes over.
+_ST_DIR = Path(__file__).resolve().parents[1]
+if str(_ST_DIR) not in sys.path:
+    sys.path.insert(0, str(_ST_DIR))
+
+_PROJECT_ROOT = _ST_DIR.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# These imports intentionally follow sys.path bootstrapping so direct
+# `python tests/st/runtime/test_qwen3_decode_scope3_mixed.py` execution can
+# resolve the local harness package and worktree sources.
+import pypto.language as pl  # noqa: E402
+import pytest  # noqa: E402
+import torch  # noqa: E402
+from harness.core.harness import DataType, PTOTestCase, TensorSpec  # noqa: E402
+from pypto.backend import BackendType  # noqa: E402
+from pypto.runtime.runner import RunConfig  # noqa: E402
+
+BATCH = 16
+HIDDEN = 5120
+INTERMEDIATE = 25600
+
+EPS = 1e-6
+
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+MLP_OUT_CHUNK = 64
+DOWN_OUT_CHUNK = 64
+BATCH_TILE = 16
+
+
+def build_qwen3_scope3_program(
+    batch: int = BATCH,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+):
+    BATCH_CFG = batch
+    HIDDEN_CFG = hidden_size
+    INTER_CFG = intermediate_size
+
+    HIDDEN_BLOCKS = HIDDEN_CFG // K_CHUNK
+    Q_OUT_BLOCKS = HIDDEN_CFG // Q_OUT_CHUNK
+    MLP_OUT_BLOCKS = INTER_CFG // MLP_OUT_CHUNK
+    hidden_inv = 1.0 / HIDDEN_CFG
+
+    @pl.program
+    class Qwen3Scope3:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def scope3(
+            self,
+            attn_out: pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16],
+            hidden_states: pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16],
+            wo: pl.Tensor[[HIDDEN_CFG, HIDDEN_CFG], pl.BF16],
+            post_rms_weight: pl.Tensor[[1, HIDDEN_CFG], pl.FP32],
+            w_gate: pl.Tensor[[HIDDEN_CFG, INTER_CFG], pl.BF16],
+            w_up: pl.Tensor[[HIDDEN_CFG, INTER_CFG], pl.BF16],
+            w_down: pl.Tensor[[INTER_CFG, HIDDEN_CFG], pl.BF16],
+            out: pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16],
+        ) -> pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16]:
+            with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
+                for b0 in pl.range(0, BATCH_CFG, BATCH_TILE):
+                    resid1_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
+                    for ob in pl.parallel(0, Q_OUT_BLOCKS):
+                        o0 = ob * Q_OUT_CHUNK
+                        zero_resid1 = pl.full([BATCH_TILE, Q_OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        resid1_tile = pl.assemble(resid1_tile, zero_resid1, [0, o0])
+
+                    # Output projection: attn_out × wo, tiled by Q_OUT_CHUNK.
+                    for ob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8):
+                        o0 = ob * Q_OUT_CHUNK
+                        o_acc = pl.full([BATCH_TILE, Q_OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            a_chunk = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, k0])
+                            w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
+                            o_acc = pl.add(o_acc, pl.matmul(a_chunk, w_chunk))
+                        resid = pl.cast(
+                            pl.slice(hidden_states, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0]),
+                            target_type=pl.FP32,
+                        )
+                        resid1_tile = pl.assemble(resid1_tile, pl.add(o_acc, resid), [0, o0])
+
+                    # Post-attention RMSNorm: compute inv_rms over resid1_tile.
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(HIDDEN_BLOCKS):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        sq_sum = pl.add(
+                            sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_TILE])
+                        )
+                    inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS))
+
+                    # Normalize and zero-init down_proj accumulator.
+                    post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.BF16)
+                    down_proj_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
+                    for zi in pl.range(HIDDEN_BLOCKS):
+                        z0 = zi * K_CHUNK
+                        down_zero_chunk = pl.full([BATCH_TILE, K_CHUNK], dtype=pl.FP32, value=0.0)
+                        down_proj_tile = pl.assemble(down_proj_tile, down_zero_chunk, [0, z0])
+
+                    for kb in pl.range(HIDDEN_BLOCKS):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, pl.reshape(inv_rms, [BATCH_TILE, 1])), gamma
+                        )
+                        post_norm_tile = pl.assemble(
+                            post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0]
+                        )
+
+                    # MLP: gate/up projections + SiLU + down projection.
+                    for ob in pl.range(MLP_OUT_BLOCKS):
+                        o0 = ob * MLP_OUT_CHUNK
+                        gate_acc = pl.full([BATCH_TILE, MLP_OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        up_acc = pl.full([BATCH_TILE, MLP_OUT_CHUNK], dtype=pl.FP32, value=0.0)
+
+                        for kb in pl.range(HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            wg = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                            wu = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                            gate_acc = pl.add(gate_acc, pl.matmul(post_chunk, wg))
+                            up_acc = pl.add(up_acc, pl.matmul(post_chunk, wu))
+
+                        sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                        mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                        mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+
+                        for dob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4):
+                            d0 = dob * K_CHUNK
+                            for doff in pl.range(0, K_CHUNK, DOWN_OUT_CHUNK):
+                                d1 = d0 + doff
+                                down_prev = pl.slice(down_proj_tile, [BATCH_TILE, DOWN_OUT_CHUNK], [0, d1])
+                                w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, DOWN_OUT_CHUNK], [o0, d1])
+                                down_next = pl.add(down_prev, pl.matmul(mlp_chunk_bf16, w_down_chunk))
+                                down_proj_tile = pl.assemble(down_proj_tile, down_next, [0, d1])
+
+                    # Final residual: down_proj + resid1, write to output.
+                    for ob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4):
+                        o0 = ob * K_CHUNK
+                        down_acc = pl.add(
+                            pl.slice(down_proj_tile, [BATCH_TILE, K_CHUNK], [0, o0]),
+                            pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, o0]),
+                        )
+                        out = pl.assemble(out, pl.cast(down_acc, target_type=pl.BF16), [b0, o0])
+
+            return out
+
+    return Qwen3Scope3
+
+
+def golden(tensors: dict, params: dict | None = None) -> None:
+    """Reference computation for Scope 3.
+
+    Steps:
+      1. Output projection: attn_out (cast BF16) × wo, FP32 accumulation + residual
+      2. Post-attention RMSNorm
+      3. SwiGLU MLP: gate/up projections → silu(gate) * up → down projection
+      4. Final residual addition → BF16 output
+    """
+    attn_out = tensors["attn_out"]  # [B, H], BF16
+    hidden_states = tensors["hidden_states"]  # [B, H], BF16
+    wo = tensors["wo"]  # [H, H], BF16
+    post_rms_weight = tensors["post_rms_weight"]  # [1, H], FP32
+    w_gate = tensors["w_gate"]  # [H, I], BF16
+    w_up = tensors["w_up"]  # [H, I], BF16
+    w_down = tensors["w_down"]  # [I, H], BF16
+
+    eps = 1e-6
+
+    # 1. Output projection (BF16 inputs, FP32 accumulation) + residual.
+    o_proj = torch.matmul(attn_out.float(), wo.float())
+    resid1 = o_proj + hidden_states.float()
+
+    # 2. Post-attention RMSNorm.
+    variance = resid1.pow(2).mean(dim=-1, keepdim=True)
+    inv_rms = torch.rsqrt(variance + eps)
+    normed_bf16 = (resid1 * inv_rms * post_rms_weight).bfloat16()
+
+    # 3. SwiGLU MLP: gate/up projections, silu activation, down projection.
+    gate = torch.matmul(normed_bf16.float(), w_gate.float())
+    up = torch.matmul(normed_bf16.float(), w_up.float())
+    mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+    down = torch.matmul(mlp_bf16.float(), w_down.float())
+
+    # 4. Final residual + cast to BF16.
+    tensors["out"][:] = (down + resid1).bfloat16()
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+) -> list[TensorSpec]:
+    def init_attn_out():
+        fan_in = hidden_size
+        return (torch.randn([batch, hidden_size], dtype=torch.float32) / (fan_in**0.5)).to(torch.bfloat16)
+
+    def init_hidden_states():
+        fan_in = hidden_size
+        return (torch.randn([batch, hidden_size], dtype=torch.float32) / (fan_in**0.5)).to(torch.bfloat16)
+
+    def init_wo():
+        fan_in = hidden_size
+        return (torch.randn([hidden_size, hidden_size], dtype=torch.float32) / (fan_in**0.5)).to(
+            torch.bfloat16
+        )
+
+    def init_post_rms_weight():
+        fan_in = hidden_size
+        return torch.randn([1, hidden_size], dtype=torch.float32) / (fan_in**0.5)
+
+    def init_w_gate():
+        fan_in = intermediate_size
+        return (torch.randn([hidden_size, intermediate_size], dtype=torch.float32) / (fan_in**0.5)).to(
+            torch.bfloat16
+        )
+
+    def init_w_up():
+        fan_in = intermediate_size
+        return (torch.randn([hidden_size, intermediate_size], dtype=torch.float32) / (fan_in**0.5)).to(
+            torch.bfloat16
+        )
+
+    def init_w_down():
+        fan_in = hidden_size
+        return (torch.randn([intermediate_size, hidden_size], dtype=torch.float32) / (fan_in**0.5)).to(
+            torch.bfloat16
+        )
+
+    return [
+        TensorSpec("attn_out", [batch, hidden_size], DataType.BF16, init_value=init_attn_out),
+        TensorSpec("hidden_states", [batch, hidden_size], DataType.BF16, init_value=init_hidden_states),
+        TensorSpec("wo", [hidden_size, hidden_size], DataType.BF16, init_value=init_wo),
+        TensorSpec("post_rms_weight", [1, hidden_size], DataType.FP32, init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [hidden_size, intermediate_size], DataType.BF16, init_value=init_w_gate),
+        TensorSpec("w_up", [hidden_size, intermediate_size], DataType.BF16, init_value=init_w_up),
+        TensorSpec("w_down", [intermediate_size, hidden_size], DataType.BF16, init_value=init_w_down),
+        TensorSpec("out", [batch, hidden_size], DataType.BF16, is_output=True),
+    ]
+
+
+class _Qwen3DecodeScope3MixedBase(PTOTestCase):
+    """Shared ST test case for Qwen3 decode scope-3 mixed kernel."""
+
+    __test__ = False
+    compute_expected = staticmethod(golden)
+
+    def __init__(
+        self,
+        batch: int = BATCH,
+        hidden_size: int = HIDDEN,
+        intermediate_size: int = INTERMEDIATE,
+        config: RunConfig | None = None,
+    ):
+        # Preserve the original standalone script tolerances.
+        super().__init__(config or RunConfig(rtol=1e-3, atol=1e-3))
+        self._batch = batch
+        self._hidden_size = hidden_size
+        self._intermediate_size = intermediate_size
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return build_tensor_specs(
+            batch=self._batch,
+            hidden_size=self._hidden_size,
+            intermediate_size=self._intermediate_size,
+        )
+
+    def get_program(self) -> Any:
+        return build_qwen3_scope3_program(
+            batch=self._batch,
+            hidden_size=self._hidden_size,
+            intermediate_size=self._intermediate_size,
+        )
+
+
+class Qwen3DecodeScope3MixedTestCase(_Qwen3DecodeScope3MixedBase):
+    """Ascend 910B runtime test for Qwen3 decode scope-3 mixed kernel."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"qwen3_decode_scope3_mixed_b{self._batch}_h{self._hidden_size}_i{self._intermediate_size}"
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+
+class Qwen3DecodeScope3MixedA5TestCase(_Qwen3DecodeScope3MixedBase):
+    """Ascend 950 runtime test for Qwen3 decode scope-3 mixed kernel."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"qwen3_decode_scope3_mixed_a5_b{self._batch}_h{self._hidden_size}_i{self._intermediate_size}"
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+
+class TestQwen3DecodeScope3Mixed:
+    """Pytest entry points for the Qwen3 decode scope-3 ST coverage."""
+
+    @pytest.mark.hardware
+    def test_qwen3_decode_scope3_mixed(self, test_runner):
+        """Run the original a2a3 hardware case under the shared ST harness."""
+        result = test_runner.run(Qwen3DecodeScope3MixedTestCase())
+        assert result.passed, f"Qwen3 decode scope-3 mixed test failed: {result.error}"
+
+    @pytest.mark.a5
+    def test_qwen3_decode_scope3_mixed_a5(self, test_runner):
+        """Run the same scope-3 test on the Ascend 950 backend."""
+        if test_runner.config.platform.endswith("sim"):
+            pytest.skip("a5sim CPU stub does not support BF16 TMATMUL for this mixed-kernel case yet")
+        result = test_runner.run(Qwen3DecodeScope3MixedA5TestCase())
+        assert result.passed, f"Qwen3 decode scope-3 mixed A5 test failed: {result.error}"
+
+
+def _build_pytest_args(argv: list[str]) -> list[str]:
+    """Translate legacy standalone flags into pytest-compatible arguments."""
+    pytest_args = [__file__, "-v"]
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in {"-d", "--device"}:
+            if i + 1 >= len(argv):
+                raise SystemExit("Missing value for -d/--device")
+            pytest_args.extend(["--device", argv[i + 1]])
+            i += 2
+            continue
+        if arg in {"-p", "--platform"}:
+            if i + 1 >= len(argv):
+                raise SystemExit("Missing value for -p/--platform")
+            pytest_args.extend(["--platform", argv[i + 1]])
+            i += 2
+            continue
+        pytest_args.append(arg)
+        i += 1
+    return pytest_args
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main(_build_pytest_args(sys.argv[1:])))

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -224,5 +224,258 @@ def test_v2c_boundary_uses_nz_layout_on_a2a3():
     assert "blayout=pl.TileLayout.col_major" in aic_printed
 
 
+def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
+    """On Ascend910B, C2V Vec pops must stay in the final Vec layout.
+
+    The A2A3 GM-backed pipe consumer materializes the popped tile through an ND
+    GlobalTensor. PTO-ISA does not support loading that ND buffer into an NZ
+    Vec tile, so ExpandMixedKernel must not introduce an NZ Vec bridge tile
+    here.
+    """
+
+    @pl.program
+    class MixedMatmul:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(MixedMatmul))
+        )
+
+    aiv_func = transformed.get_function("main_incore_0_aiv")
+    assert aiv_func is not None
+
+    aiv_printed = python_print(aiv_func)
+    assert "pl.tile.tpop_from_aic(" in aiv_printed
+    assert "pl.tile.move(" not in aiv_printed
+    assert "blayout=pl.TileLayout.col_major" not in aiv_printed
+    assert "slayout=pl.TileLayout.row_major" not in aiv_printed
+
+
+def test_gm_pipe_buffer_per_call_allocation():
+    """Each cross-core Group call gets its own gm_pipe_buffer tensor.create.
+
+    When an orchestration function calls multiple Group functions that use
+    cross-core pipes, each call must independently allocate its own
+    gm_pipe_buffer via a separate tensor.create.  Sharing a single buffer
+    causes scope escape and synchronization conflicts.
+    """
+
+    @pl.program
+    class MultiCallProgram:
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_producer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ):
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer)
+            tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+            pl.tpush_to_aic(tile_a, split=0)
+
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_consumer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+            pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf)
+            received: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+            pl.tfree_to_aiv(received)
+            updated: pl.Tensor[[16, 16], pl.FP16] = pl.store(received, [0, 0], out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.cube_consumer(a, out)
+            self.vector_producer(a, out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            out = self.group_func(a, out)
+            out = self.group_func(a, out)
+            return out
+
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(MultiCallProgram))
+        )
+
+    orch_func = transformed.get_function("main")
+    assert orch_func is not None
+    orch_printed = python_print(orch_func)
+
+    # Each call should have its own tensor.create with a unique name
+    creates = [
+        line for line in orch_printed.split("\n") if "gm_pipe_buffer" in line and "tensor.create" in line
+    ]
+    assert len(creates) == 2, f"Expected 2 tensor.creates, got {len(creates)}: {creates}"
+    assert "gm_pipe_buffer_0" in orch_printed
+    assert "gm_pipe_buffer_1" in orch_printed
+
+
+def test_gm_pipe_buffer_per_call_inside_for_loop():
+    """Per-call gm_pipe_buffer must also work inside for-loops."""
+
+    @pl.program
+    class LoopedCrossCore:
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_producer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ):
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer)
+            tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+            pl.tpush_to_aic(tile_a, split=0)
+
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_consumer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+            pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf)
+            received: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+            pl.tfree_to_aiv(received)
+            updated: pl.Tensor[[16, 16], pl.FP16] = pl.store(received, [0, 0], out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.cube_consumer(a, out)
+            self.vector_producer(a, out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            for b in pl.range(4):
+                out = self.group_func(a, out)
+            return out
+
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(LoopedCrossCore))
+        )
+
+    orch_func = transformed.get_function("main")
+    assert orch_func is not None
+    orch_printed = python_print(orch_func)
+    lines = orch_printed.strip().split("\n")
+
+    # tensor.create must appear inside the for-loop (after the for header)
+    for_line_idx = None
+    create_line_idx = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if for_line_idx is None and stripped.startswith("for ") and "pl.range" in stripped:
+            for_line_idx = idx
+        if create_line_idx is None and "gm_pipe_buffer" in stripped and "tensor.create" in stripped:
+            create_line_idx = idx
+
+    assert for_line_idx is not None, "for-loop not found in orchestration body"
+    assert create_line_idx is not None, "gm_pipe_buffer tensor.create not found"
+    assert for_line_idx < create_line_idx, "gm_pipe_buffer tensor.create must appear inside the for-loop body"
+
+
+def test_gm_pipe_buffer_param_direction_is_out():
+    """The __gm_pipe_buffer parameter must have Out direction."""
+
+    @pl.program
+    class CrossCoreProgram:
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_producer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ):
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer)
+            tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+            pl.tpush_to_aic(tile_a, split=0)
+
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_consumer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+            pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf)
+            received: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+            pl.tfree_to_aiv(received)
+            updated: pl.Tensor[[16, 16], pl.FP16] = pl.store(received, [0, 0], out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.cube_consumer(a, out)
+            self.vector_producer(a, out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.group_func(a, out)
+            return updated
+
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(CrossCoreProgram))
+        )
+
+    group_func = transformed.get_function("group_func")
+    assert group_func is not None
+    gm_idx = next(i for i, p in enumerate(group_func.params) if p.name_hint == "__gm_pipe_buffer")
+    assert group_func.param_directions[gm_idx] == ir.ParamDirection.Out
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -265,6 +265,73 @@ class TestLegalSharingPreserved:
         _assert_shares_memref(result_func, "loaded", "padded")
 
 
+class TestAscend910BSplitLoadTpopHazard:
+    """Ascend910B split AIV kernels should split load+tpop writer reuse."""
+
+    def _build_split_aiv_program(self) -> ir.Program:
+        alloc = _MemRefAlloc()
+        shared = alloc.vec([8, 128], _FP32)
+        pipe = alloc.vec([8, 128], _FP32)
+
+        down_tensor_t = _tensor_t([16, 128], _FP32)
+        load_t = _tile_t([8, 128], _FP32, shared)
+        add_t = _tile_t([8, 128], _FP32, shared)
+        pipe_t = _tile_t([8, 128], _FP32, pipe)
+
+        down = ir.Var("down", down_tensor_t, _SPAN)
+        down_prev = ir.Var("down_prev", load_t, _SPAN)
+        pipe_chunk = ir.Var("pipe_chunk", pipe_t, _SPAN)
+        down_next = ir.Var("down_next", add_t, _SPAN)
+        result = ir.Var("result", down_tensor_t, _SPAN)
+
+        offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
+        tile_shape = ir.MakeTuple([_ci(8), _ci(128)], _SPAN)
+
+        load_call = ir.Call(
+            ir.Op("tile.load"),
+            [down, offsets, tile_shape, tile_shape],
+            {"target_memory": ir.MemorySpace.Vec, "transpose": False},
+            load_t,
+            _SPAN,
+        )
+        tpop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 1}, pipe_t, _SPAN)
+        add_call = ir.Call(ir.Op("tile.add"), [down_prev, pipe_chunk], {}, add_t, _SPAN)
+        store_call = ir.Call(ir.Op("tile.store"), [down_next, offsets, down], down_tensor_t, _SPAN)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(down_prev, load_call, _SPAN),
+                ir.AssignStmt(pipe_chunk, tpop_call, _SPAN),
+                ir.AssignStmt(down_next, add_call, _SPAN),
+                ir.AssignStmt(result, store_call, _SPAN),
+                ir.ReturnStmt([result], _SPAN),
+            ],
+            _SPAN,
+        )
+
+        func = ir.Function(
+            "main",
+            [(down, ir.ParamDirection.InOut)],
+            [down_tensor_t],
+            body,
+            _SPAN,
+            type=ir.FunctionType.AIV,
+            attrs={"split": ir.SplitMode.UP_DOWN},
+        )
+        return ir.Program([func], "Test", _SPAN)
+
+    def test_ascend910b_split_aiv_splits_load_plus_tpop_reuse(self):
+        result_func = _run_legalize(self._build_split_aiv_program())
+        _assert_different_memref(result_func, "down_prev", "down_next")
+
+    def test_ascend950_keeps_compatible_share(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        result_func = _run_legalize(self._build_split_aiv_program())
+        _assert_shares_memref(result_func, "down_prev", "down_next")
+
+
 # ---------------------------------------------------------------------------
 # Tests: incompatible signatures cause split
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -13,6 +13,7 @@ import pypto.language as pl
 import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
+from pypto.ir.printer import python_print
 
 
 @pytest.fixture(autouse=True)
@@ -181,6 +182,78 @@ class TestSplitVectorKernelUpDown:
                 return out_0_store
 
         _assert_split_matches_expected(Before, Expected)
+
+    def test_loop_iter_arg_keeps_split_tracking(self):
+        """Loop iter_args seeded by halved tiles must keep split-aware store offsets."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(
+                self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                accum: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
+                )
+                for i in pl.range(2):
+                    out_0 = pl.store(accum, [0, 0], out_0)
+                    pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
+                        pl.tpop_from_aic(split=0)
+                    )
+                    accum = pl.add(accum, pop_tile)
+                return out_0
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        main_aiv = actual.get_function("main_aiv")
+        assert main_aiv is not None
+        loop_stmt = next(stmt for stmt in ir.flatten_to_stmts(main_aiv.body) if isinstance(stmt, ir.ForStmt))
+        iter_arg_type = loop_stmt.iter_args[0].type
+        assert isinstance(iter_arg_type, ir.TileType)
+        assert isinstance(iter_arg_type.shape[0], ir.ConstInt)
+        assert iter_arg_type.shape[0].value == 8
+        assert "def main_aiv(" in printed
+        assert "def main_aiv__aiv1(" not in printed
+        assert "pl.tile.get_subblock_idx()" in printed
+        assert "pl.tile.load(data__ssa_v0, [0 + subblock_idx * 8, 0], [8, 128], [8, 128]" in printed
+        assert "pl.tile.tpop_from_aic(split=1)" in printed
+        assert "pl.tile.store(accum__iter_v1, [0 + subblock_idx * 8, 0], out_0__iter_v1)" in printed
+
+    def test_loop_return_var_keeps_split_tracking(self):
+        """Loop return_vars fed by split tiles must keep split-aware store offsets after the loop."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(
+                self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                accum: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
+                )
+                for i in pl.range(2):
+                    pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
+                        pl.tpop_from_aic(split=0)
+                    )
+                    accum = pl.add(accum, pop_tile)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(accum, [0, 0], out_0)
+                return out_0_store
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        main_aiv = actual.get_function("main_aiv")
+        assert main_aiv is not None
+        loop_stmt = next(stmt for stmt in ir.flatten_to_stmts(main_aiv.body) if isinstance(stmt, ir.ForStmt))
+        return_var_type = loop_stmt.return_vars[0].type
+        assert isinstance(return_var_type, ir.TileType)
+        assert isinstance(return_var_type.shape[0], ir.ConstInt)
+        assert return_var_type.shape[0].value == 8
+        assert "def main_aiv(" in printed
+        assert "def main_aiv__aiv1(" not in printed
+        assert "pl.tile.get_subblock_idx()" in printed
+        assert "pl.tile.load(data__ssa_v0, [0 + subblock_idx * 8, 0], [8, 128], [8, 128]" in printed
+        assert "pl.tile.tpop_from_aic(split=1)" in printed
+        assert "pl.tile.store(accum__rv_v2, [0 + subblock_idx * 8, 0], out_0__ssa_v0)" in printed
 
     def test_injected_subblock_idx_avoids_name_collision(self):
         """Injected lane temp should pick a fresh name when subblock_idx already exists."""


### PR DESCRIPTION
Preserve shared split AIV dispatch through runtime subblock bridging on A2A3 while keeping split tile tracking correct across loops.

Fix mixed-kernel GM pipe buffer handling and Vec boundary layout legalization for qwen3 scope-3 style flows.

Convert the qwen3 scope-3 mixed runtime script into a pytest ST case and keep direct script execution compatibility.