### PR TITLE
perf(codegen): parallelize ptoas invocations across kernel units

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -14,10 +14,11 @@ Create tasks to track progress through this workflow:
 
 1. Fetch issue & create branch
 2. Plan the fix
-3. Implement the fix
-4. Run tests
-5. Commit changes
-6. Create PR (optional)
+3. Self-assign & set In Progress
+4. Implement the fix
+5. Run tests
+6. Commit changes
+7. Create PR (optional)
 
 ## Workflow
 
@@ -25,10 +26,11 @@ Create tasks to track progress through this workflow:
 2. Fetch issue content
 3. Create issue branch
 4. Enter plan mode to design fix
-5. Implement the fix
-6. Run tests (use `testing` skill)
-7. Commit changes (use `git-commit` skill)
-8. Create PR (optional, use `github-pr` skill)
+5. **Self-assign & set In Progress** (immediately after plan approval)
+6. Implement the fix
+7. Run tests (use `testing` skill)
+8. Commit changes (use `git-commit` skill)
+9. Create PR (optional, use `github-pr` skill)
 
 ## Step 1: Check gh CLI Authentication
 
@@ -98,9 +100,9 @@ Use `EnterPlanMode` to design the fix.
 - Documentation updates
 - Cross-layer changes (C++, Python, type stubs)
 
-## Step 4b: Mark Issue as In Progress
+## Step 5: Self-Assign & Set In Progress
 
-After plan approval, self-assign and set project status to "In Progress":
+**Do this IMMEDIATELY after plan approval, before writing any code.**
 
 ```bash
 # Self-assign
@@ -115,7 +117,7 @@ Update the project board status using the same GraphQL pattern as `create-issue`
 
 If the project item or Status field is not found, skip the board update and notify the user that manual update is needed. Do not block the fix workflow.
 
-## Step 5: Implement the Fix
+## Step 6: Implement the Fix
 
 After plan approval, follow PyPTO conventions:
 
@@ -125,7 +127,7 @@ After plan approval, follow PyPTO conventions:
 4. Add/update tests
 5. Maintain cross-layer sync (C++, Python, type stubs)
 
-## Step 6: Run Tests
+## Step 7: Run Tests
 
 ```text
 /testing
@@ -133,7 +135,7 @@ After plan approval, follow PyPTO conventions:
 
 Fix any failures before committing.
 
-## Step 7: Commit Changes
+## Step 8: Commit Changes
 
 ```text
 /git-commit
@@ -149,7 +151,7 @@ Fixes #ISSUE_NUMBER
 Detailed explanation of the fix.
 ```
 
-## Step 8: Create PR (Optional)
+## Step 9: Create PR (Optional)
 
 ```text
 /github-pr

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -24,11 +24,14 @@ import re
 import shutil
 import subprocess
 import textwrap
+import time
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
 from typing import Any
 
-from pypto.compile_profiling import CompileProfiler
+from pypto.compile_profiling import CompileProfiler, StageRecord
 from pypto.pypto_core import backend as _backend_core
 from pypto.pypto_core import codegen as _codegen_core
 from pypto.pypto_core import ir as _ir_core
@@ -612,6 +615,127 @@ def _profiling_stage(prof: CompileProfiler | None, name: str) -> AbstractContext
     return nullcontext()
 
 
+# ---------------------------------------------------------------------------
+# Parallel ptoas helpers
+# ---------------------------------------------------------------------------
+
+_CODEGEN_MAX_WORKERS_ENV = "PYPTO_CODEGEN_MAX_WORKERS"
+
+
+def _get_max_workers() -> int | None:
+    """Determine max worker threads for parallel ptoas invocations.
+
+    Returns:
+        ``None`` to use the ``ThreadPoolExecutor`` default, or an explicit
+        thread count.  ``1`` means sequential execution (no thread pool).
+    """
+    env_val = os.environ.get(_CODEGEN_MAX_WORKERS_ENV, "").strip()
+    if not env_val:
+        return None  # ThreadPoolExecutor default
+    try:
+        n = int(env_val)
+    except ValueError:
+        logger.warning("Invalid %s='%s', using default", _CODEGEN_MAX_WORKERS_ENV, env_val)
+        return None
+    return max(1, n)
+
+
+@dataclass
+class _CodegenUnit:
+    """One kernel codegen unit prepared for ptoas emission."""
+
+    name: str
+    pto_code: str  # MLIR from PTOCodegen (Phase 1 output)
+    funcs: list[_ir_core.Function]
+    is_group: bool
+    stage_record: StageRecord  # profiling record (started in Phase 1)
+
+
+@dataclass
+class _EmitResult:
+    """Result of emitting one codegen unit (ptoas + wrapper generation)."""
+
+    name: str
+    files: dict[str, str]
+    ptoas_record: StageRecord
+    error: Exception | None = None
+
+
+def _emit_unit(
+    unit: _CodegenUnit,
+    output_dir: str,
+    skip_ptoas: bool,
+) -> _EmitResult:
+    """Run ptoas + wrapper generation for one codegen unit.
+
+    This is the Phase 2 worker — called from a thread pool or sequentially.
+    PTOCodegen has already run; ``unit.pto_code`` contains the MLIR.
+    """
+    local_files: dict[str, str] = {}
+    ptoas_record = StageRecord(name="ptoas", start=time.perf_counter())
+    try:
+        if unit.is_group:
+            _emit_group_output(local_files, unit.name, unit.funcs, unit.pto_code, output_dir, skip_ptoas)
+        else:
+            _emit_single_function_output(local_files, unit.funcs[0], unit.pto_code, output_dir, skip_ptoas)
+        ptoas_record.end = time.perf_counter()
+        return _EmitResult(name=unit.name, files=local_files, ptoas_record=ptoas_record)
+    except Exception as e:
+        ptoas_record.end = time.perf_counter()
+        if unit.is_group:
+            func_names = ", ".join(m.name for m in unit.funcs)
+            logger.error("Failed to compile group '%s' [%s]: %s", unit.name, func_names, e)
+        else:
+            logger.error("Failed to compile function '%s': %s", unit.name, e)
+        return _EmitResult(name=unit.name, files={}, ptoas_record=ptoas_record, error=e)
+
+
+def _merge_stage_record(prof: CompileProfiler | None, record: StageRecord) -> None:
+    """Append a completed stage record into the profiler's current nesting level."""
+    if prof is not None:
+        prof.add_stage_record(record)
+
+
+def _collect_emit_result(
+    result: _EmitResult,
+    unit: _CodegenUnit,
+    prof: CompileProfiler | None,
+    result_files: dict[str, str],
+    errors: list[tuple[str, Exception]],
+) -> None:
+    """Finalize one emit result: merge profiling, collect files and errors."""
+    unit.stage_record.children.append(result.ptoas_record)
+    unit.stage_record.end = time.perf_counter()
+    _merge_stage_record(prof, unit.stage_record)
+    result_files.update(result.files)
+    if result.error is not None:
+        errors.append((result.name, result.error))
+
+
+def _run_ptoas_phase(
+    units: list[_CodegenUnit],
+    output_dir: str,
+    skip_ptoas: bool,
+    prof: CompileProfiler | None,
+    result_files: dict[str, str],
+    errors: list[tuple[str, Exception]],
+) -> None:
+    """Phase 2: run ptoas for all codegen units, sequentially or in parallel."""
+    max_workers = _get_max_workers()
+
+    if max_workers == 1 or len(units) <= 1:
+        for unit in units:
+            result = _emit_unit(unit, output_dir, skip_ptoas)
+            _collect_emit_result(result, unit, prof, result_files, errors)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_emit_unit, unit, output_dir, skip_ptoas): unit for unit in units}
+            for future in as_completed(futures):
+                unit = futures[future]
+                result = future.result()  # exceptions caught inside _emit_unit
+                _collect_emit_result(result, unit, prof, result_files, errors)
+
+
 def generate(
     transformed_program: _ir_core.Program,
     output_dir: str,
@@ -648,20 +772,25 @@ def generate(
 
     groups, ungrouped = _build_group_mapping(transformed_program)
 
-    # Grouped functions: one MLIR module per group
+    # ── Phase 1: IR → MLIR (sequential, fast) ────────────────────────
+    # PTOCodegen converts IR to MLIR strings.  This is cheap (pure string
+    # generation) and runs sequentially so that we don't contend on the GIL.
+    units: list[_CodegenUnit] = []
+
     for group_name, members in groups.items():
         try:
             grouped_program = _ir_core.Program(members, group_name, transformed_program.span)
-            codegen_instance = _codegen_core.PTOCodegen()
-            with _profiling_stage(prof, f"kernel_codegen:{group_name}"):
-                pto_code = codegen_instance.generate(grouped_program)
-                _emit_group_output(result_files, group_name, members, pto_code, output_dir, skip_ptoas)
+            stage = StageRecord(name=f"kernel_codegen:{group_name}", start=time.perf_counter())
+            ir_record = StageRecord(name="ir_to_mlir", start=time.perf_counter())
+            pto_code = _codegen_core.PTOCodegen().generate(grouped_program)
+            ir_record.end = time.perf_counter()
+            stage.children.append(ir_record)
+            units.append(_CodegenUnit(group_name, pto_code, members, is_group=True, stage_record=stage))
         except Exception as e:
             func_names = ", ".join(m.name for m in members)
             logger.error("Failed to compile group '%s' [%s]: %s", group_name, func_names, e)
             errors.append((group_name, e))
 
-    # Ungrouped functions: one MLIR module per function (existing behavior)
     for func in ungrouped:
         try:
             peer_names = _extract_peer_function_names(func)
@@ -671,13 +800,21 @@ def generate(
                 if peer_func is not None:
                     peer_funcs.append(peer_func)
             single_program = _ir_core.Program([*peer_funcs, func], func.name, transformed_program.span)
-            codegen_instance = _codegen_core.PTOCodegen()
-            with _profiling_stage(prof, f"kernel_codegen:{func.name}"):
-                pto_code = codegen_instance.generate(single_program)
-                _emit_single_function_output(result_files, func, pto_code, output_dir, skip_ptoas)
+            stage = StageRecord(name=f"kernel_codegen:{func.name}", start=time.perf_counter())
+            ir_record = StageRecord(name="ir_to_mlir", start=time.perf_counter())
+            pto_code = _codegen_core.PTOCodegen().generate(single_program)
+            ir_record.end = time.perf_counter()
+            stage.children.append(ir_record)
+            units.append(_CodegenUnit(func.name, pto_code, [func], is_group=False, stage_record=stage))
         except Exception as e:
             logger.error("Failed to compile function '%s': %s", func.name, e)
             errors.append((func.name, e))
+
+    # ── Phase 2: ptoas (parallel, slow) ──────────────────────────────
+    # Each _emit_unit call runs the ptoas subprocess and generates the
+    # kernel wrapper.  These are data-independent and subprocess-heavy, so
+    # a thread pool gives real parallelism (subprocess.run releases the GIL).
+    _run_ptoas_phase(units, output_dir, skip_ptoas, prof, result_files, errors)
 
     # Orchestration + config
     if orch_func is not None:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -26,7 +26,7 @@ import subprocess
 import textwrap
 import time
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import Any
@@ -729,9 +729,8 @@ def _run_ptoas_phase(
             _collect_emit_result(result, unit, prof, result_files, errors)
     else:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {executor.submit(_emit_unit, unit, output_dir, skip_ptoas): unit for unit in units}
-            for future in as_completed(futures):
-                unit = futures[future]
+            futures = [executor.submit(_emit_unit, unit, output_dir, skip_ptoas) for unit in units]
+            for unit, future in zip(units, futures):
                 result = future.result()  # exceptions caught inside _emit_unit
                 _collect_emit_result(result, unit, prof, result_files, errors)
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -705,7 +705,7 @@ def _collect_emit_result(
 ) -> None:
     """Finalize one emit result: merge profiling, collect files and errors."""
     unit.stage_record.children.append(result.ptoas_record)
-    unit.stage_record.end = time.perf_counter()
+    unit.stage_record.end = result.ptoas_record.end
     _merge_stage_record(prof, unit.stage_record)
     result_files.update(result.files)
     if result.error is not None:

--- a/python/pypto/compile_profiling.py
+++ b/python/pypto/compile_profiling.py
@@ -124,6 +124,17 @@ class CompileProfiler:
             self._stack[-1].end = time.perf_counter()
             self._stack.pop()
 
+    def add_stage_record(self, record: StageRecord) -> None:
+        """Insert a pre-built stage record into the current nesting level.
+
+        Use this to merge timing data collected outside the profiler's
+        context-manager API (e.g. from parallel worker threads).
+        """
+        if self._stack:
+            self._stack[-1].children.append(record)
+        else:
+            self._root_stages.append(record)
+
     # ------------------------------------------------------------------
     # Output
     # ------------------------------------------------------------------

--- a/tests/ut/core/test_compile_profiling.py
+++ b/tests/ut/core/test_compile_profiling.py
@@ -123,6 +123,30 @@ class TestCompileProfiler:
         for s in stages:
             assert s["seconds"] > 0
 
+    def test_add_stage_record_at_root(self):
+        record = StageRecord(name="external", start=0.0, end=1.0)
+        with CompileProfiler() as prof:
+            prof.add_stage_record(record)
+
+        stages = prof.to_dict()["stages"]
+        assert len(stages) == 1
+        assert stages[0]["name"] == "external"
+        assert stages[0]["seconds"] == 1.0
+
+    def test_add_stage_record_nested(self):
+        child = StageRecord(name="worker_kernel", start=0.0, end=0.5)
+        with CompileProfiler() as prof:
+            with prof.stage("codegen"):
+                prof.add_stage_record(child)
+
+        stages = prof.to_dict()["stages"]
+        assert len(stages) == 1
+        assert stages[0]["name"] == "codegen"
+        children = stages[0]["children"]
+        assert len(children) == 1
+        assert children[0]["name"] == "worker_kernel"
+        assert children[0]["seconds"] == 0.5
+
 
 class TestSummary:
     """Human-readable summary output."""


### PR DESCRIPTION
## Summary

- Split kernel codegen into two phases: sequential IR→MLIR (`PTOCodegen`) and parallel MLIR→C++ (ptoas subprocess) via `ThreadPoolExecutor`
- Add `ir_to_mlir` / `ptoas` sub-profiling stages under each `kernel_codegen:{name}` for timing verification
- Add `CompileProfiler.add_stage_record()` public API for merging externally-built stage records
- Control parallelism via `PYPTO_CODEGEN_MAX_WORKERS` env var (default: auto, `1` for sequential fallback)

### Performance (LLaMA Mini, 11 kernels)

| Metric | Sequential | Parallel | Speedup |
|--------|-----------|----------|---------|
| Total compile | 5.761s | 574.5ms | **10.0x** |
| Codegen phase | 5.751s | 564.2ms | **10.2x** |

Sub-profiling confirms the hypothesis: ptoas is **99.97%** of each kernel's codegen time (e.g., 506ms ptoas vs 0.2ms `ir_to_mlir`).

### Skill fix
- Promote "Self-assign & set In Progress" from a sub-step (4b) to a standalone Step 5 in the `fix-issue` skill to prevent it being skipped

## Testing
- [x] All 3417 unit tests pass
- [x] All 154 codegen tests pass
- [x] Sequential fallback (`PYPTO_CODEGEN_MAX_WORKERS=1`) verified
- [x] Compile profiling tests pass
- [x] Pre-commit hooks pass (ruff, pyright)

Fixes #933