### PR TITLE
feat(ir): add MutableCopy utility for IR node field updates in passes

### DIFF
--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -125,10 +125,15 @@ class IRNode {
   explicit IRNode(Span s) : span_(std::move(s)) {}
   virtual ~IRNode() = default;
 
-  // Disable copying and moving to enforce immutability
+  // Disable move to enforce shared_ptr-based ownership
   IRNode(IRNode&&) = delete;
   IRNode& operator=(IRNode&&) = delete;
 
+ protected:
+  // Allow derived classes to copy (for MutableCopy utility)
+  IRNode(const IRNode&) = default;
+
+ public:
   /**
    * @brief Get the Kind of this IR node
    *

--- a/include/pypto/ir/transforms/utils/mutable_copy.h
+++ b/include/pypto/ir/transforms/utils/mutable_copy.h
@@ -13,9 +13,12 @@
 #define PYPTO_IR_TRANSFORMS_UTILS_MUTABLE_COPY_H_
 
 #include <memory>
+#include <type_traits>
 
 namespace pypto {
 namespace ir {
+
+class Var;
 
 /// Create a mutable copy of an immutable IR node.
 ///
@@ -27,12 +30,12 @@ namespace ir {
 /// The mutable window is intentionally small — modify fields,
 /// then return as const. This preserves the IR's immutability contract
 /// while eliminating verbose constructor calls in passes.
-///
-/// WARNING: Do not use on identity-bearing nodes (Var, IterArg, MemRef)
-/// whose unique_id_ must remain unique per instance.
 template <typename T>
 std::shared_ptr<T> MutableCopy(const std::shared_ptr<const T>& node) {
-  return std::shared_ptr<T>(new T(*node));
+  static_assert(!std::is_base_of_v<Var, T>,
+                "MutableCopy must not be used on identity-bearing nodes "
+                "(Var, IterArg, MemRef) — their unique_id_ must stay unique");
+  return std::make_shared<T>(*node);
 }
 
 }  // namespace ir

--- a/include/pypto/ir/transforms/utils/mutable_copy.h
+++ b/include/pypto/ir/transforms/utils/mutable_copy.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_MUTABLE_COPY_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_MUTABLE_COPY_H_
+
+#include <memory>
+
+namespace pypto {
+namespace ir {
+
+/// Create a mutable copy of an immutable IR node.
+///
+/// Usage:
+///   auto new_op = MutableCopy(op);
+///   new_op->field_ = new_value;
+///   return new_op;  // implicitly converts to shared_ptr<const T>
+///
+/// The mutable window is intentionally small — modify fields,
+/// then return as const. This preserves the IR's immutability contract
+/// while eliminating verbose constructor calls in passes.
+///
+/// WARNING: Do not use on identity-bearing nodes (Var, IterArg, MemRef)
+/// whose unique_id_ must remain unique per instance.
+template <typename T>
+std::shared_ptr<T> MutableCopy(const std::shared_ptr<const T>& node) {
+  return std::shared_ptr<T>(new T(*node));
+}
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_MUTABLE_COPY_H_

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -44,6 +44,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -364,9 +365,10 @@ FunctionPtr TransformAllocateMemoryAddr(const FunctionPtr& func) {
 
   auto new_body = mutator.VisitStmt(func->body_);
 
-  return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->params_ = new_params;
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
@@ -667,10 +668,9 @@ class TypePropagatingMutator : public IRMutator {
     return UpdateLoopReturnVars(
         new_for->iter_args_, new_for->return_vars_, op->return_vars_,
         [&](auto new_rv) {
-          return std::make_shared<ForStmt>(new_for->loop_var_, new_for->start_, new_for->stop_,
-                                           new_for->step_, new_for->iter_args_, new_for->body_,
-                                           std::move(new_rv), new_for->span_, new_for->kind_,
-                                           new_for->chunk_config_, new_for->attrs_);
+          auto copy = MutableCopy(new_for);
+          copy->return_vars_ = std::move(new_rv);
+          return copy;
         },
         result);
   }
@@ -733,8 +733,12 @@ class TypePropagatingMutator : public IRMutator {
       return op;
     }
 
-    return std::make_shared<IfStmt>(new_condition, new_then_body, new_else_body, std::move(new_return_vars),
-                                    op->span_);
+    auto new_if = MutableCopy(op);
+    new_if->condition_ = new_condition;
+    new_if->then_body_ = new_then_body;
+    new_if->else_body_ = new_else_body;
+    new_if->return_vars_ = std::move(new_return_vars);
+    return new_if;
   }
 
   /// Handle a non-converted assignment: propagate type change if value type changed.
@@ -1516,12 +1520,10 @@ std::optional<ReturnedAssembleLoopRewrite> RewriteReturnedAssembleLoopToStore(
 
     auto new_return_var = std::make_shared<Var>(for_stmt->return_vars_[0]->name_hint_, out_tensor_type,
                                                 for_stmt->return_vars_[0]->span_);
-    auto new_for_stmt =
-        std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                  std::vector<IterArgPtr>{new_iter_arg},
-                                  SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_),
-                                  std::vector<VarPtr>{new_return_var}, for_stmt->span_, for_stmt->kind_,
-                                  for_stmt->chunk_config_, for_stmt->attrs_);
+    auto new_for_stmt = MutableCopy(for_stmt);
+    new_for_stmt->iter_args_ = std::vector<IterArgPtr>{new_iter_arg};
+    new_for_stmt->body_ = SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_);
+    new_for_stmt->return_vars_ = std::vector<VarPtr>{new_return_var};
 
     std::optional<size_t> dead_init_stmt_index;
     if (auto init_var = As<Var>(old_iter_arg->initValue_)) {
@@ -1782,8 +1784,10 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func, const Ite
 
         auto new_then_body = SeqStmts::Flatten(std::move(then_stmts), last_if_stmt->then_body_->span_);
         auto new_else_body = SeqStmts::Flatten(std::move(else_stmts), (*last_if_stmt->else_body_)->span_);
-        auto new_if_stmt =
-            std::make_shared<IfStmt>(last_if_stmt->condition_, new_then_body, new_else_body, new_rv, span);
+        auto new_if_stmt = MutableCopy(last_if_stmt);
+        new_if_stmt->then_body_ = new_then_body;
+        new_if_stmt->else_body_ = new_else_body;
+        new_if_stmt->return_vars_ = new_rv;
         new_stmts[last_if_index] = new_if_stmt;
 
         // Update mutator mappings so Phase 3b sees the new TensorType return vars.
@@ -2028,9 +2032,9 @@ FunctionPtr UpdateCallSites(const FunctionPtr& func,
   CallSiteUpdateMutator mutator(incore_added_outputs, transformed_incore_funcs, OpRegistry::GetInstance());
   auto new_body = mutator.VisitStmt(func->body_);
   if (new_body.get() == func->body_.get()) return func;
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 
@@ -231,8 +232,11 @@ class SSAConverter {
 
     StmtPtr new_body = func->body_ ? ConvertStmt(func->body_) : nullptr;
 
-    return std::make_shared<Function>(func->name_, new_params, new_dirs, func->return_types_, new_body,
-                                      func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
+    auto result = MutableCopy(func);
+    result->params_ = std::move(new_params);
+    result->param_directions_ = std::move(new_dirs);
+    result->body_ = std::move(new_body);
+    return result;
   }
 
  private:
@@ -561,8 +565,15 @@ class SSAConverter {
     StmtPtr body = new_body;
     if (!yields.empty()) body = ReplaceOrAppendYield(new_body, yields, op->span_);
 
-    return std::make_shared<ForStmt>(new_lv, new_start, new_stop, new_step, ias, body, all_rvs, op->span_,
-                                     op->kind_, op->chunk_config_, op->attrs_);
+    auto result = MutableCopy(op);
+    result->loop_var_ = std::move(new_lv);
+    result->start_ = std::move(new_start);
+    result->stop_ = std::move(new_stop);
+    result->step_ = std::move(new_step);
+    result->iter_args_ = std::move(ias);
+    result->body_ = std::move(body);
+    result->return_vars_ = std::move(all_rvs);
+    return result;
   }
 
   // ── WhileStmt ──────────────────────────────────────────────────────
@@ -688,7 +699,12 @@ class SSAConverter {
     StmtPtr body = new_body;
     if (!yields.empty()) body = ReplaceOrAppendYield(new_body, yields, op->span_);
 
-    return std::make_shared<WhileStmt>(new_cond, ias, body, all_rvs, op->span_);
+    auto result = MutableCopy(op);
+    result->condition_ = std::move(new_cond);
+    result->iter_args_ = std::move(ias);
+    result->body_ = std::move(body);
+    result->return_vars_ = std::move(all_rvs);
+    return result;
   }
 
   // ── IfStmt — phi node synthesis ────────────────────────────────────
@@ -737,7 +753,12 @@ class SSAConverter {
     // No divergence — return simple IfStmt
     if (phis.empty() && op->return_vars_.empty()) {
       cur_ = before;
-      return std::make_shared<IfStmt>(cond, new_then, new_else, std::vector<VarPtr>{}, op->span_);
+      auto result = MutableCopy(op);
+      result->condition_ = std::move(cond);
+      result->then_body_ = std::move(new_then);
+      result->else_body_ = std::move(new_else);
+      result->return_vars_ = {};
+      return result;
     }
 
     // No new phis but existing return_vars (explicit SSA) — version return_vars, keep branch yields
@@ -752,7 +773,12 @@ class SSAConverter {
         return_vars.push_back(nrv);
         cur_[rv_key] = nrv;
       }
-      return std::make_shared<IfStmt>(cond, new_then, new_else, return_vars, op->span_);
+      auto result = MutableCopy(op);
+      result->condition_ = std::move(cond);
+      result->then_body_ = std::move(new_then);
+      result->else_body_ = std::move(new_else);
+      result->return_vars_ = std::move(return_vars);
+      return result;
     }
 
     // Create phi outputs
@@ -801,8 +827,12 @@ class SSAConverter {
       else_with_yield = std::make_shared<YieldStmt>(else_yields, op->span_);
     }
 
-    return std::make_shared<IfStmt>(cond, then_with_yield, std::make_optional(else_with_yield), return_vars,
-                                    op->span_);
+    auto result = MutableCopy(op);
+    result->condition_ = std::move(cond);
+    result->then_body_ = std::move(then_with_yield);
+    result->else_body_ = std::make_optional(std::move(else_with_yield));
+    result->return_vars_ = std::move(return_vars);
+    return result;
   }
 
   // ── Simple statements ──────────────────────────────────────────────
@@ -826,9 +856,10 @@ class SSAConverter {
 
   StmtPtr ConvertScope(const ScopeStmtPtr& op) {
     auto body = ConvertStmt(op->body_);
-    return body != op->body_ ? std::make_shared<ScopeStmt>(op->scope_kind_, body, op->span_, op->level_,
-                                                           op->role_, op->split_)
-                             : op;
+    if (body == op->body_) return op;
+    auto result = MutableCopy(op);
+    result->body_ = std::move(body);
+    return result;
   }
 
   // ── Helpers ────────────────────────────────────────────────────────

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -638,8 +639,9 @@ class CtrlFlowTransformMutator : public IRMutator {
 
     if (!scan.has_break && !scan.has_continue) {
       if (new_body.get() != op->body_.get()) {
-        return std::make_shared<WhileStmt>(op->condition_, op->iter_args_, new_body, op->return_vars_,
-                                           op->span_);
+        auto result = MutableCopy(op);
+        result->body_ = new_body;
+        return result;
       }
       return op;
     }
@@ -662,9 +664,9 @@ class CtrlFlowTransformMutator : public IRMutator {
     if (new_body.get() == op->body_.get()) {
       return op;
     }
-    return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                     new_body, op->return_vars_, op->span_, op->kind_, op->chunk_config_,
-                                     op->attrs_);
+    auto result = MutableCopy(op);
+    result->body_ = new_body;
+    return result;
   }
 
   BodyResult ProcessBodyForBreakAndContinue(const DecomposedBody& decomposed,
@@ -689,9 +691,9 @@ class CtrlFlowTransformMutator : public IRMutator {
                                          name_counter_, op->span_);
     auto final_body = BuildFinalBody(std::move(result), decomposed.had_yield, op->span_);
 
-    return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, op->iter_args_,
-                                     final_body, op->return_vars_, op->span_, op->kind_, op->chunk_config_,
-                                     op->attrs_);
+    auto new_for = MutableCopy(op);
+    new_for->body_ = final_body;
+    return new_for;
   }
 
   // --------------------------------------------------------------------------
@@ -751,8 +753,9 @@ class CtrlFlowTransformMutator : public IRMutator {
                                          name_counter_, op->span_);
     auto final_body = BuildFinalBody(std::move(result), decomposed.had_yield, op->span_);
 
-    return std::make_shared<WhileStmt>(op->condition_, op->iter_args_, final_body, op->return_vars_,
-                                       op->span_);
+    auto new_while = MutableCopy(op);
+    new_while->body_ = final_body;
+    return new_while;
   }
 
   // --------------------------------------------------------------------------
@@ -797,9 +800,9 @@ FunctionPtr TransformCtrlFlow(const FunctionPtr& func) {
     return func;
   }
 
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto result = MutableCopy(func);
+  result->body_ = new_body;
+  return result;
 }
 
 }  // namespace

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -43,6 +43,7 @@
 #include "pypto/ir/transforms/utils/dead_code_elimination.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/tpop_chain_normalizer.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -461,10 +462,9 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
       if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
         auto new_body = BuildCoreBody(side, FlattenBody(for_stmt->body_), stmt_map, boundary_moves,
                                       tpop_var_remap, superseded_tpop_vars);
-        result.push_back(std::make_shared<ForStmt>(
-            for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
-            MakeBody(new_body, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
-            for_stmt->chunk_config_, for_stmt->attrs_));
+        auto new_for = MutableCopy(for_stmt);
+        new_for->body_ = MakeBody(new_body, for_stmt->span_);
+        result.push_back(new_for);
       } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
         auto new_then = BuildCoreBody(side, FlattenBody(if_stmt->then_body_), stmt_map, boundary_moves,
                                       tpop_var_remap, superseded_tpop_vars);
@@ -475,14 +475,16 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
                                               tpop_var_remap, superseded_tpop_vars);
           new_else = MakeBody(new_else_stmts, if_stmt->span_);
         }
-        result.push_back(std::make_shared<IfStmt>(if_stmt->condition_, MakeBody(new_then, if_stmt->span_),
-                                                  new_else, if_stmt->return_vars_, if_stmt->span_));
+        auto new_if = MutableCopy(if_stmt);
+        new_if->then_body_ = MakeBody(new_then, if_stmt->span_);
+        new_if->else_body_ = new_else;
+        result.push_back(new_if);
       } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
         auto new_body = BuildCoreBody(side, FlattenBody(while_stmt->body_), stmt_map, boundary_moves,
                                       tpop_var_remap, superseded_tpop_vars);
-        result.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_,
-                                                     MakeBody(new_body, while_stmt->span_),
-                                                     while_stmt->return_vars_, while_stmt->span_));
+        auto new_while = MutableCopy(while_stmt);
+        new_while->body_ = MakeBody(new_body, while_stmt->span_);
+        result.push_back(new_while);
       } else {
         result.push_back(stmt);  // Unknown compound, include as-is
       }
@@ -983,8 +985,10 @@ FunctionPtr AddGMSlotBufferParam(const FunctionPtr& func, int64_t gm_buffer_elem
   new_params.push_back(gm_var);
   auto new_directions = func->param_directions_;
   new_directions.push_back(ParamDirection::Out);
-  return std::make_shared<Function>(func->name_, new_params, new_directions, func->return_types_, func->body_,
-                                    func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
+  auto result = MutableCopy(func);
+  result->params_ = new_params;
+  result->param_directions_ = new_directions;
+  return result;
 }
 
 StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<std::string>& modified_funcs,
@@ -1018,10 +1022,9 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
       auto nb = RewriteCallsForGMBuffer(for_stmt->body_, modified_funcs, gm_param);
       if (nb != for_stmt->body_) {
-        new_stmts.push_back(
-            std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                      for_stmt->iter_args_, nb, for_stmt->return_vars_, for_stmt->span_,
-                                      for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
+        auto new_for = MutableCopy(for_stmt);
+        new_for->body_ = nb;
+        new_stmts.push_back(new_for);
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);
@@ -1038,8 +1041,10 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
         body_changed = (*ne != *else_body);
       }
       if (body_changed) {
-        new_stmts.push_back(
-            std::make_shared<IfStmt>(if_stmt->condition_, nt, ne, if_stmt->return_vars_, if_stmt->span_));
+        auto new_if = MutableCopy(if_stmt);
+        new_if->then_body_ = nt;
+        new_if->else_body_ = ne;
+        new_stmts.push_back(new_if);
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);
@@ -1047,8 +1052,9 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       auto nb = RewriteCallsForGMBuffer(while_stmt->body_, modified_funcs, gm_param);
       if (nb != while_stmt->body_) {
-        new_stmts.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_, nb,
-                                                        while_stmt->return_vars_, while_stmt->span_));
+        auto new_while = MutableCopy(while_stmt);
+        new_while->body_ = nb;
+        new_stmts.push_back(new_while);
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);
@@ -1300,9 +1306,9 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
 
     if (!mod_callees.empty()) {
       auto nb = RewriteCallsForGMBuffer(func->body_, mod_callees, gm_param);
-      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                        func->return_types_, nb, func->span_, func->func_type_, func->level_,
-                                        func->role_, func->attrs_);
+      auto updated = MutableCopy(func);
+      updated->body_ = nb;
+      func = updated;
     }
   }
 
@@ -1324,9 +1330,9 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
     int counter = 0;
     auto new_body = RewriteCallsWithPerCallGMBuffer(func->body_, mod_callees, gm_buffer_bytes,
                                                     gm_buffer_elems, func->span_, counter);
-    func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                      func->return_types_, new_body, func->span_, func->func_type_,
-                                      func->level_, func->role_, func->attrs_);
+    auto updated = MutableCopy(func);
+    updated->body_ = new_body;
+    func = updated;
   }
 }
 
@@ -1388,9 +1394,11 @@ Pass ExpandMixedKernel() {
         attrs.erase(
             std::remove_if(attrs.begin(), attrs.end(), [](const auto& kv) { return kv.first == "split"; }),
             attrs.end());
-        auto converted = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                                    func->return_types_, func->body_, func->span_, new_type,
-                                                    std::nullopt, std::nullopt, attrs);
+        auto converted = MutableCopy(func);
+        converted->func_type_ = new_type;
+        converted->level_ = std::nullopt;
+        converted->role_ = std::nullopt;
+        converted->attrs_ = attrs;
         new_functions.push_back(converted);
         continue;
       }

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -219,7 +220,11 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const IfStmtPtr& op) {
   // Restore condition pending for parent to handle
   pending_stmts_ = condition_pending;
 
-  return std::make_shared<IfStmt>(new_condition, new_then, new_else, op->return_vars_, op->span_);
+  auto result = MutableCopy(op);
+  result->condition_ = new_condition;
+  result->then_body_ = new_then;
+  result->else_body_ = new_else;
+  return result;
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const ForStmtPtr& op) {
@@ -250,8 +255,12 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ForStmtPtr& op) {
   // Restore range pending for parent to handle
   pending_stmts_ = range_pending;
 
-  return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                   op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
+  auto result = MutableCopy(op);
+  result->start_ = new_start;
+  result->stop_ = new_stop;
+  result->step_ = new_step;
+  result->body_ = new_body;
+  return result;
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {
@@ -274,7 +283,10 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {
   // Restore condition pending for parent to handle
   pending_stmts_ = condition_pending;
 
-  return std::make_shared<WhileStmt>(new_condition, op->iter_args_, new_body, op->return_vars_, op->span_);
+  auto result = MutableCopy(op);
+  result->condition_ = new_condition;
+  result->body_ = new_body;
+  return result;
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const ScopeStmtPtr& op) {
@@ -373,9 +385,9 @@ FunctionPtr TransformFlattenCallExpr(const FunctionPtr& func) {
 
   FlattenCallExprMutator mutator;
   auto new_body = mutator.VisitStmt(func->body_);
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto result = MutableCopy(func);
+  result->body_ = new_body;
+  return result;
 }
 
 }  // namespace

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
@@ -271,9 +272,9 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     if (auto scope = As<ScopeStmt>(stmt)) {
       auto body_stmts = FlattenToStmts(scope->body_);
       auto inner = TransformBody(body_stmts, ctx, op_registry, span);
-      result.push_back(std::make_shared<ScopeStmt>(scope->scope_kind_,
-                                                   SeqStmts::Flatten(std::move(inner), scope->body_->span_),
-                                                   scope->span_, scope->level_, scope->role_, scope->split_));
+      auto new_scope = MutableCopy(scope);
+      new_scope->body_ = SeqStmts::Flatten(std::move(inner), scope->body_->span_);
+      result.push_back(new_scope);
       continue;
     }
 
@@ -313,8 +314,12 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         }
       }
 
-      result.push_back(
-          std::make_shared<IfStmt>(new_cond, new_then_body, new_else_body, new_return_vars, if_stmt->span_));
+      auto new_if = MutableCopy(if_stmt);
+      new_if->condition_ = new_cond;
+      new_if->then_body_ = new_then_body;
+      new_if->else_body_ = new_else_body;
+      new_if->return_vars_ = new_return_vars;
+      result.push_back(new_if);
       continue;
     }
 
@@ -357,9 +362,14 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         }
       }
 
-      result.push_back(std::make_shared<ForStmt>(for_stmt->loop_var_, new_start, new_stop, new_step,
-                                                 new_iter_args, new_body, new_return_vars, for_stmt->span_,
-                                                 for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
+      auto new_for = MutableCopy(for_stmt);
+      new_for->start_ = new_start;
+      new_for->stop_ = new_stop;
+      new_for->step_ = new_step;
+      new_for->iter_args_ = new_iter_args;
+      new_for->body_ = new_body;
+      new_for->return_vars_ = new_return_vars;
+      result.push_back(new_for);
       continue;
     }
 
@@ -399,8 +409,12 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         }
       }
 
-      result.push_back(
-          std::make_shared<WhileStmt>(new_cond, new_iter_args, new_body, new_return_vars, while_stmt->span_));
+      auto new_while = MutableCopy(while_stmt);
+      new_while->condition_ = new_cond;
+      new_while->iter_args_ = new_iter_args;
+      new_while->body_ = new_body;
+      new_while->return_vars_ = new_return_vars;
+      result.push_back(new_while);
       continue;
     }
 
@@ -655,10 +669,9 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
 
   // return_types_ are unchanged: InCore functions return tensors (not tiles),
   // and this pass only flattens tile ops. Tensor types are never modified.
-  auto result =
-      std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                 new_body, span, func->func_type_, func->level_, func->role_, func->attrs_);
-  return result;
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 // ============================================================================

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/ir_property.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -355,9 +356,11 @@ class FuseCreateAssembleMutator : public IRMutator {
       new_body = transform_utils::Substitute(new_body, body_subst);
     }
 
-    return std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                     new_iter_args, new_body, new_return_vars, for_stmt->span_,
-                                     for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
+    auto new_for = MutableCopy(for_stmt);
+    new_for->iter_args_ = std::move(new_iter_args);
+    new_for->body_ = std::move(new_body);
+    new_for->return_vars_ = std::move(new_return_vars);
+    return new_for;
   }
 
   StmtPtr StripPassThroughWhileIterArgs(const StmtPtr& stmt) {
@@ -398,8 +401,11 @@ class FuseCreateAssembleMutator : public IRMutator {
       new_body = transform_utils::Substitute(new_body, body_subst);
     }
 
-    return std::make_shared<WhileStmt>(while_stmt->condition_, new_iter_args, new_body, new_return_vars,
-                                       while_stmt->span_);
+    auto new_while = MutableCopy(while_stmt);
+    new_while->iter_args_ = std::move(new_iter_args);
+    new_while->body_ = std::move(new_body);
+    new_while->return_vars_ = std::move(new_return_vars);
+    return new_while;
   }
 
   static YieldStmtPtr GetTrailingYield(const StmtPtr& body) {

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -417,10 +418,9 @@ FunctionPtr TransformInferTileMemorySpace(const FunctionPtr& func) {
   TileMemorySpaceMutator mutator(var_memory, collector.GetNeededMoves());
   auto new_body = mutator.VisitStmt(func->body_);
 
-  auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                           func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->attrs_);
-  return result;
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -38,6 +38,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/normalize_stmt_structure.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -375,9 +376,15 @@ class InitMemRefMutator : public IRMutator {
       new_chunk_config = ChunkConfig{VisitExpr(op->chunk_config_->size), op->chunk_config_->policy};
     }
 
-    auto new_for =
-        std::make_shared<ForStmt>(new_loop_var, new_start, new_stop, new_step, new_iter_args, new_body,
-                                  new_return_vars, op->span_, op->kind_, new_chunk_config, op->attrs_);
+    auto new_for = MutableCopy(op);
+    new_for->loop_var_ = new_loop_var;
+    new_for->start_ = new_start;
+    new_for->stop_ = new_stop;
+    new_for->step_ = new_step;
+    new_for->iter_args_ = new_iter_args;
+    new_for->body_ = new_body;
+    new_for->return_vars_ = new_return_vars;
+    new_for->chunk_config_ = new_chunk_config;
 
     // Patch return_vars so each shares its yield value's MemRef.
     auto yield_stmt = FindYieldStmt(new_body);
@@ -393,9 +400,8 @@ class InitMemRefMutator : public IRMutator {
 
     if (!changed) return new_for;
 
-    return std::make_shared<ForStmt>(new_for->loop_var_, new_for->start_, new_for->stop_, new_for->step_,
-                                     new_for->iter_args_, new_for->body_, std::move(patched), new_for->span_,
-                                     new_for->kind_, new_for->chunk_config_, new_for->attrs_);
+    new_for->return_vars_ = std::move(patched);
+    return new_for;
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {
@@ -417,8 +423,9 @@ class InitMemRefMutator : public IRMutator {
 
     if (!changed) return result;
 
-    return std::make_shared<IfStmt>(new_if->condition_, new_if->then_body_, new_if->else_body_,
-                                    std::move(patched), new_if->span_);
+    auto patched_if = MutableCopy(new_if);
+    patched_if->return_vars_ = std::move(patched);
+    return patched_if;
   }
 
  private:
@@ -501,10 +508,9 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
 
   auto new_body = mutator.VisitStmt(normalized_func->body_);
 
-  auto result_func = std::make_shared<Function>(
-      normalized_func->name_, new_params, normalized_func->param_directions_, normalized_func->return_types_,
-      new_body, normalized_func->span_, normalized_func->func_type_, normalized_func->level_,
-      normalized_func->role_, normalized_func->attrs_);
+  auto result_func = MutableCopy(normalized_func);
+  result_func->params_ = new_params;
+  result_func->body_ = new_body;
 
   // Step 3: Collect ALL MemRefs (DDR gets tensor.alloc, on-chip gets tile.alloc)
   memref_collectors::MemRefWithSpaceCollector collector(/*skip_ddr=*/false);
@@ -529,10 +535,8 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
   // Step 4: Insert alloc statements at the beginning of the function body
   auto final_body = InsertAllocsIntoBody(new_body, alloc_stmts);
 
-  return std::make_shared<Function>(result_func->name_, new_params, result_func->param_directions_,
-                                    result_func->return_types_, final_body, result_func->span_,
-                                    result_func->func_type_, result_func->level_, result_func->role_,
-                                    result_func->attrs_);
+  result_func->body_ = final_body;
+  return result_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/insert_sync_pass.cpp
+++ b/src/ir/transforms/insert_sync_pass.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -302,9 +303,9 @@ class SyncInserter {
     std::vector<PathElement> path;
     auto new_body = ApplyInsertions(func->body_, path);
 
-    return std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                      func->return_types_, new_body, func->span_, func->func_type_,
-                                      func->level_, func->role_, func->attrs_);
+    auto new_func = MutableCopy(func);
+    new_func->body_ = new_body;
+    return new_func;
   }
 
  private:

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -225,9 +226,9 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
     if (fs && ContainsInCoreScope(fs->body_)) {
       auto new_body = WrapNonIncoreStatementsInInCore(fs->body_, span, split);
       if (new_body.get() != fs->body_.get()) {
-        return std::make_shared<ForStmt>(fs->loop_var_, fs->start_, fs->stop_, fs->step_, fs->iter_args_,
-                                         new_body, fs->return_vars_, fs->span_, fs->kind_, fs->chunk_config_,
-                                         fs->attrs_);
+        auto new_for = MutableCopy(fs);
+        new_for->body_ = new_body;
+        return new_for;
       }
     }
     return s;
@@ -532,8 +533,10 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       return op;
     }
 
-    return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_, new_iter_args, new_body,
-                                     op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
+    auto new_for = MutableCopy(op);
+    new_for->iter_args_ = new_iter_args;
+    new_for->body_ = new_body;
+    return new_for;
   }
 
   /**
@@ -813,10 +816,9 @@ FunctionPtr TransformInterchangeChunkLoops(const FunctionPtr& func) {
     return func;
   }
 
-  auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                           func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->attrs_);
-  return result;
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -744,10 +745,8 @@ class YieldFixupMutator : public IRMutator {
     auto new_body = InsertMovesAndReplaceYield(for_stmt->body_, new_yield, move_stmts);
 
     // Build intermediate ForStmt with new body, then patch iter_args/return_vars
-    auto intermediate_for =
-        std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                  for_stmt->iter_args_, new_body, for_stmt->return_vars_, for_stmt->span_,
-                                  for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
+    auto intermediate_for = MutableCopy(for_stmt);
+    intermediate_for->body_ = new_body;
 
     return PatchIterArgsAndReturnVars(intermediate_for, new_yield);
   }
@@ -825,8 +824,10 @@ class YieldFixupMutator : public IRMutator {
       new_else_body = InsertMovesAndReplaceYield(if_stmt->else_body_.value(), new_yield, else_move_stmts);
     }
 
-    return std::make_shared<IfStmt>(if_stmt->condition_, if_stmt->then_body_, new_else_body,
-                                    std::move(new_return_vars), if_stmt->span_);
+    auto new_if = MutableCopy(if_stmt);
+    new_if->else_body_ = new_else_body;
+    new_if->return_vars_ = std::move(new_return_vars);
+    return new_if;
   }
 
  private:
@@ -908,9 +909,11 @@ class YieldFixupMutator : public IRMutator {
       var_remap_.erase(old_iter_arg.get());
     }
 
-    return std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                     new_iter_args, patched_body, std::move(new_return_vars), for_stmt->span_,
-                                     for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_);
+    auto new_for = MutableCopy(for_stmt);
+    new_for->iter_args_ = new_iter_args;
+    new_for->body_ = patched_body;
+    new_for->return_vars_ = std::move(new_return_vars);
+    return new_for;
   }
 
   // Replace YieldStmt in body and insert move AssignStmts before it.

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -196,9 +197,10 @@ FunctionPtr ReorderReturns(const FunctionPtr& func, const std::vector<int>& perm
   new_stmts.push_back(new_return);
   auto new_body = std::make_shared<SeqStmts>(new_stmts, seq->span_);
 
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, new_return_types,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->return_types_ = new_return_types;
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 // Mutator that applies return-order permutations to TupleGetItemExpr indices

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -19,6 +19,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -72,9 +73,8 @@ Pass OutlineClusterScopes() {
                                             FunctionType::Group, "_cluster_");
       auto new_body = outliner.VisitStmt(func->body_);
 
-      auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                                 func->return_types_, new_body, func->span_, func->func_type_,
-                                                 func->level_, func->role_, func->attrs_);
+      auto new_func = MutableCopy(func);
+      new_func->body_ = new_body;
       new_functions.push_back(new_func);
 
       const auto& outlined = outliner.GetOutlinedFunctions();

--- a/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
+++ b/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
@@ -19,6 +19,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -77,9 +78,8 @@ Pass OutlineHierarchyScopes() {
       auto new_body = outliner.VisitStmt(func->body_);
 
       // Preserve parent function type (don't promote — hierarchy is orthogonal to FunctionType)
-      auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                                 func->return_types_, new_body, func->span_, func->func_type_,
-                                                 func->level_, func->role_, func->attrs_);
+      auto new_func = MutableCopy(func);
+      new_func->body_ = new_body;
       new_functions.push_back(new_func);
 
       const auto& outlined = outliner.GetOutlinedFunctions();

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -21,6 +21,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -82,9 +83,9 @@ Pass OutlineIncoreScopes() {
       // If any InCore scopes were outlined, promote Opaque -> Orchestration.
       const auto& outlined = outliner.GetOutlinedFunctions();
       FunctionType new_func_type = outlined.empty() ? func->func_type_ : FunctionType::Orchestration;
-      auto new_func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                                 func->return_types_, new_body, func->span_, new_func_type,
-                                                 func->level_, func->role_, func->attrs_);
+      auto new_func = MutableCopy(func);
+      new_func->body_ = new_body;
+      new_func->func_type_ = new_func_type;
       new_functions.push_back(new_func);
 
       // Collect outlined functions (prepend before parent so inner functions come first)

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -229,9 +230,9 @@ FunctionPtr RewriteFunction(const FunctionPtr& func) {
     return func;
   }
 
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/resolve_transpose_layout_pass.cpp
+++ b/src/ir/transforms/resolve_transpose_layout_pass.cpp
@@ -26,6 +26,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -135,9 +136,10 @@ FunctionPtr TransformIncoreParams(const FunctionPtr& func) {
 
   auto new_body = Substitute(func->body_, substitutions);
 
-  return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->params_ = new_params;
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 
 namespace pypto {
 namespace ir {
@@ -93,8 +94,13 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
                    chunk_config_changed;
     if (!changed) return op;
 
-    return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_, op->kind_, new_chunk_config, op->attrs_);
+    auto result = MutableCopy(op);
+    result->start_ = new_start;
+    result->stop_ = new_stop;
+    result->step_ = new_step;
+    result->body_ = new_body;
+    result->chunk_config_ = new_chunk_config;
+    return result;
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {
@@ -119,7 +125,11 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
                    (new_else.has_value() != op->else_body_.has_value()) ||
                    (new_else.has_value() && new_else->get() != op->else_body_->get());
     if (!changed) return op;
-    return std::make_shared<IfStmt>(new_condition, new_then, new_else, op->return_vars_, op->span_);
+    auto result = MutableCopy(op);
+    result->condition_ = new_condition;
+    result->then_body_ = new_then;
+    result->else_body_ = new_else;
+    return result;
   }
 
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
@@ -127,7 +137,10 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     auto new_body = VisitStmt(op->body_);
     bool changed = (new_condition.get() != op->condition_.get()) || (new_body.get() != op->body_.get());
     if (!changed) return op;
-    return std::make_shared<WhileStmt>(new_condition, op->iter_args_, new_body, op->return_vars_, op->span_);
+    auto result = MutableCopy(op);
+    result->condition_ = new_condition;
+    result->body_ = new_body;
+    return result;
   }
 
   StmtPtr VisitStmt_(const ReturnStmtPtr& op) override {
@@ -168,9 +181,9 @@ FunctionPtr TransformSimplify(const FunctionPtr& func) {
   SimplifyMutator mutator(analyzer.get());
   auto new_body = mutator.VisitStmt(func->body_);
   if (new_body.get() == func->body_.get()) return func;
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto result = MutableCopy(func);
+  result->body_ = new_body;
+  return result;
 }
 
 }  // namespace

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -242,8 +243,9 @@ class ChunkedLoopSplitter : public IRMutator {
       if (new_body.get() == op->body_.get()) {
         return op;
       }
-      return std::make_shared<ScopeStmt>(op->scope_kind_, new_body, op->span_, op->level_, op->role_,
-                                         op->split_);
+      auto new_scope = MutableCopy(op);
+      new_scope->body_ = std::move(new_body);
+      return new_scope;
     }
     return IRMutator::VisitStmt_(op);
   }
@@ -619,10 +621,9 @@ FunctionPtr TransformSplitChunkedLoops(const FunctionPtr& func) {
     return func;
   }
 
-  auto result = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
-                                           func->return_types_, new_body, func->span_, func->func_type_,
-                                           func->level_, func->role_, func->attrs_);
-  return result;
+  auto new_func = MutableCopy(func);
+  new_func->body_ = std::move(new_body);
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -503,8 +504,10 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       new_else = (new_else_stmts.size() == 1) ? new_else_stmts[0]
                                               : std::make_shared<SeqStmts>(new_else_stmts, if_stmt->span_);
     }
-    return std::make_shared<IfStmt>(if_stmt->condition_, new_then_body, new_else, if_stmt->return_vars_,
-                                    if_stmt->span_);
+    auto new_if = MutableCopy(if_stmt);
+    new_if->then_body_ = new_then_body;
+    new_if->else_body_ = new_else;
+    return new_if;
   }
 
   if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
@@ -594,10 +597,11 @@ FunctionPtr ProcessFunction(const FunctionPtr& func, SplitMode mode) {
   auto [cloned_body, clone_map_unused] = DeepClone(new_body);
   (void)clone_map_unused;
 
-  auto attrs = WithSplitAttr(func, mode);
-  return std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
-                                    cloned_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    attrs);
+  auto new_func = MutableCopy(func);
+  new_func->params_ = new_params;
+  new_func->body_ = cloned_body;
+  new_func->attrs_ = WithSplitAttr(func, mode);
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -26,6 +26,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 
 namespace pypto {
 namespace ir {
@@ -150,9 +151,9 @@ FunctionPtr TransformUnrollLoops(const FunctionPtr& func) {
     return func;  // No changes
   }
 
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
 }
 
 }  // namespace

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -20,6 +20,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 
@@ -138,10 +139,9 @@ std::vector<StmtPtr> FilterDeadCode(const std::vector<StmtPtr>& stmts,
       }
     } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
       auto filtered = FilterDeadCode(FlattenBody(for_stmt->body_), live);
-      result.push_back(std::make_shared<ForStmt>(
-          for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_, for_stmt->iter_args_,
-          MakeBody(filtered, for_stmt->span_), for_stmt->return_vars_, for_stmt->span_, for_stmt->kind_,
-          for_stmt->chunk_config_, for_stmt->attrs_));
+      auto new_for = MutableCopy(for_stmt);
+      new_for->body_ = MakeBody(filtered, for_stmt->span_);
+      result.push_back(new_for);
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       auto filtered_then = FilterDeadCode(FlattenBody(if_stmt->then_body_), live);
       std::optional<StmtPtr> filtered_else;
@@ -149,13 +149,15 @@ std::vector<StmtPtr> FilterDeadCode(const std::vector<StmtPtr>& stmts,
         auto fe = FilterDeadCode(FlattenBody(if_stmt->else_body_.value()), live);
         filtered_else = MakeBody(fe, if_stmt->span_);
       }
-      result.push_back(std::make_shared<IfStmt>(if_stmt->condition_, MakeBody(filtered_then, if_stmt->span_),
-                                                filtered_else, if_stmt->return_vars_, if_stmt->span_));
+      auto new_if = MutableCopy(if_stmt);
+      new_if->then_body_ = MakeBody(filtered_then, if_stmt->span_);
+      new_if->else_body_ = filtered_else;
+      result.push_back(new_if);
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       auto filtered = FilterDeadCode(FlattenBody(while_stmt->body_), live);
-      result.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_,
-                                                   MakeBody(filtered, while_stmt->span_),
-                                                   while_stmt->return_vars_, while_stmt->span_));
+      auto new_while = MutableCopy(while_stmt);
+      new_while->body_ = MakeBody(filtered, while_stmt->span_);
+      result.push_back(new_while);
     } else {
       result.push_back(stmt);
     }

--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/dead_code_elimination.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 
@@ -38,23 +39,33 @@ StmtPtr MakeBody(const std::vector<StmtPtr>& stmts, const Span& span) {
 }
 
 StmtPtr RebuildForStmt(const std::shared_ptr<const ForStmt>& f, const StmtPtr& new_body) {
-  return std::make_shared<ForStmt>(f->loop_var_, f->start_, f->stop_, f->step_, f->iter_args_, new_body,
-                                   f->return_vars_, f->span_, f->kind_, f->chunk_config_, f->attrs_);
+  auto new_for = MutableCopy(f);
+  new_for->body_ = new_body;
+  return new_for;
 }
 
 StmtPtr RebuildForStmt(const std::shared_ptr<const ForStmt>& f, const std::vector<IterArgPtr>& iter_args,
                        const StmtPtr& new_body, const std::vector<VarPtr>& return_vars) {
-  return std::make_shared<ForStmt>(f->loop_var_, f->start_, f->stop_, f->step_, iter_args, new_body,
-                                   return_vars, f->span_, f->kind_, f->chunk_config_, f->attrs_);
+  auto new_for = MutableCopy(f);
+  new_for->iter_args_ = iter_args;
+  new_for->body_ = new_body;
+  new_for->return_vars_ = return_vars;
+  return new_for;
 }
 
 StmtPtr RebuildWhileStmt(const std::shared_ptr<const WhileStmt>& w, const StmtPtr& new_body) {
-  return std::make_shared<WhileStmt>(w->condition_, w->iter_args_, new_body, w->return_vars_, w->span_);
+  auto new_while = MutableCopy(w);
+  new_while->body_ = new_body;
+  return new_while;
 }
 
 StmtPtr RebuildWhileStmt(const std::shared_ptr<const WhileStmt>& w, const std::vector<IterArgPtr>& iter_args,
                          const StmtPtr& new_body, const std::vector<VarPtr>& return_vars) {
-  return std::make_shared<WhileStmt>(w->condition_, iter_args, new_body, return_vars, w->span_);
+  auto new_while = MutableCopy(w);
+  new_while->iter_args_ = iter_args;
+  new_while->body_ = new_body;
+  new_while->return_vars_ = return_vars;
+  return new_while;
 }
 
 StmtPtr RebuildIfStmt(const std::shared_ptr<const IfStmt>& s, const std::vector<StmtPtr>& new_then,
@@ -63,8 +74,10 @@ StmtPtr RebuildIfStmt(const std::shared_ptr<const IfStmt>& s, const std::vector<
   if (new_else_stmts.has_value()) {
     new_else = MakeBody(new_else_stmts.value(), s->span_);
   }
-  return std::make_shared<IfStmt>(s->condition_, MakeBody(new_then, s->span_), new_else, s->return_vars_,
-                                  s->span_);
+  auto new_if = MutableCopy(s);
+  new_if->then_body_ = MakeBody(new_then, s->span_);
+  new_if->else_body_ = new_else;
+  return new_if;
 }
 
 StmtPtr RebuildLoop(const std::shared_ptr<const ForStmt>& for_stmt,

--- a/src/ir/transforms/utils/normalize_stmt_structure.cpp
+++ b/src/ir/transforms/utils/normalize_stmt_structure.cpp
@@ -21,6 +21,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 
 namespace pypto::ir {
 
@@ -114,7 +115,11 @@ StmtPtr NormalizeStmtStructureMutator::VisitStmt_(const IfStmtPtr& op) {
   if (changed) {
     // Visit condition (shouldn't change for normalization, but call for consistency)
     auto new_condition = VisitExpr(op->condition_);
-    return std::make_shared<IfStmt>(new_condition, new_then, new_else, op->return_vars_, op->span_);
+    auto new_if = MutableCopy(op);
+    new_if->condition_ = std::move(new_condition);
+    new_if->then_body_ = std::move(new_then);
+    new_if->else_body_ = std::move(new_else);
+    return new_if;
   }
   return op;
 }
@@ -130,8 +135,12 @@ StmtPtr NormalizeStmtStructureMutator::VisitStmt_(const ForStmtPtr& op) {
     auto new_stop = VisitExpr(op->stop_);
     auto new_step = VisitExpr(op->step_);
 
-    return std::make_shared<ForStmt>(op->loop_var_, new_start, new_stop, new_step, op->iter_args_, new_body,
-                                     op->return_vars_, op->span_, op->kind_, op->chunk_config_, op->attrs_);
+    auto new_for = MutableCopy(op);
+    new_for->start_ = std::move(new_start);
+    new_for->stop_ = std::move(new_stop);
+    new_for->step_ = std::move(new_step);
+    new_for->body_ = std::move(new_body);
+    return new_for;
   }
   return op;
 }
@@ -145,7 +154,10 @@ StmtPtr NormalizeStmtStructureMutator::VisitStmt_(const WhileStmtPtr& op) {
     // Visit condition (shouldn't change for normalization, but call for consistency)
     auto new_condition = VisitExpr(op->condition_);
 
-    return std::make_shared<WhileStmt>(new_condition, op->iter_args_, new_body, op->return_vars_, op->span_);
+    auto new_while = MutableCopy(op);
+    new_while->condition_ = std::move(new_condition);
+    new_while->body_ = std::move(new_body);
+    return new_while;
   }
   return op;
 }
@@ -157,9 +169,9 @@ FunctionPtr NormalizeStmtStructure(const FunctionPtr& func) {
   NormalizeStmtStructureMutator mutator;
   auto new_body = mutator.VisitStmt(func->body_);
 
-  return std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                    new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                    func->attrs_);
+  auto new_func = MutableCopy(func);
+  new_func->body_ = std::move(new_body);
+  return new_func;
 }
 
 }  // namespace pypto::ir


### PR DESCRIPTION
## Summary

- Add `MutableCopy<T>` template utility that creates a mutable copy of an immutable IR node, so passes can update specific fields and return the result as `shared_ptr<const T>`
- Make `IRNode` copy constructor `protected` to enable derived class copying while preventing external misuse
- Migrate ~75 `make_shared` call sites across 25 pass files to use `MutableCopy`, covering ForStmt (19), Function (22), IfStmt (21), WhileStmt (12), and ScopeStmt (3) node types

### Before
```cpp
// Must repeat all 11 fields, even when only changing body:
return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_,
    op->iter_args_, new_body, op->return_vars_, op->span_, op->kind_,
    op->chunk_config_, op->attrs_);
```

### After
```cpp
// Only changed fields are visible:
auto result = MutableCopy(op);
result->body_ = new_body;
return result;
```

## Motivation

- **Verbosity**: ForStmt has 11 constructor args, Function has 10 — most passes only change 1-2 fields
- **Fragility**: Adding a field to an IR node (e.g., ChunkConfig refactor in #937) required updating every `make_shared` call site across all passes
- **Readability**: `MutableCopy` makes diffs self-documenting — only the changed fields are visible

## Test plan

- [x] Build succeeds (`cmake --build build --parallel`)
- [x] All 3417 tests pass (`pytest tests/ut/ -n auto`)
- [x] clang-tidy passes (`python tests/lint/clang_tidy.py --diff-base HEAD`)
- [x] All pre-commit hooks pass (clang-format, cpplint, check-headers)

Fixes #938