### PR TITLE
feat(ir,dsl): add optional name parameter to ScopeStmt

### DIFF
--- a/docs/en/dev/passes/07-outline_incore_scopes.md
+++ b/docs/en/dev/passes/07-outline_incore_scopes.md
@@ -50,8 +50,9 @@ program_outlined = outline_pass(program)
 
 **Naming**:
 
-- Outlined functions named: `{original_func}_incore_{counter}`
-- Example: `main_incore_0`, `main_incore_1`
+- Default: `{original_func}_incore_{counter}` (e.g., `main_incore_0`, `main_incore_1`)
+- User-provided: when `ScopeStmt.name` is non-empty, that name is used directly
+  - `with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):` → function named `fused_add`
 
 ## Example
 

--- a/docs/en/dev/passes/07-outline_incore_scopes.md
+++ b/docs/en/dev/passes/07-outline_incore_scopes.md
@@ -51,8 +51,8 @@ program_outlined = outline_pass(program)
 **Naming**:
 
 - Default: `{original_func}_incore_{counter}` (e.g., `main_incore_0`, `main_incore_1`)
-- User-provided: when `ScopeStmt.name` is non-empty, that name is used directly
-  - `with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):` → function named `fused_add`
+- User-provided: when `ScopeStmt.name_hint` is non-empty, that name is used directly
+  - `with pl.at(level=pl.Level.CORE_GROUP, name_hint="fused_add"):` → function named `fused_add`
 
 ## Example
 

--- a/docs/zh-cn/dev/passes/07-outline_incore_scopes.md
+++ b/docs/zh-cn/dev/passes/07-outline_incore_scopes.md
@@ -50,8 +50,9 @@ program_outlined = outline_pass(program)
 
 **命名规则**：
 
-- 提取函数命名格式：`{原函数名}_incore_{计数器}`
-- 示例：`main_incore_0`、`main_incore_1`
+- 默认：`{原函数名}_incore_{计数器}`（如 `main_incore_0`、`main_incore_1`）
+- 用户自定义：当 `ScopeStmt.name` 非空时，直接使用该名称
+  - `with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):` → 函数名为 `fused_add`
 
 ## 示例
 

--- a/docs/zh-cn/dev/passes/07-outline_incore_scopes.md
+++ b/docs/zh-cn/dev/passes/07-outline_incore_scopes.md
@@ -51,8 +51,8 @@ program_outlined = outline_pass(program)
 **命名规则**：
 
 - 默认：`{原函数名}_incore_{计数器}`（如 `main_incore_0`、`main_incore_1`）
-- 用户自定义：当 `ScopeStmt.name` 非空时，直接使用该名称
-  - `with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):` → 函数名为 `fused_add`
+- 用户自定义：当 `ScopeStmt.name_hint` 非空时，直接使用该名称
+  - `with pl.at(level=pl.Level.CORE_GROUP, name_hint="fused_add"):` → 函数名为 `fused_add`
 
 ## 示例
 

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -300,7 +300,8 @@ class IRBuilder {
    * @throws RuntimeError if not inside a function or loop
    */
   void BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level = std::nullopt,
-                  std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt);
+                  std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
+                  std::string name = "");
 
   /**
    * @brief End building a scope statement
@@ -669,12 +670,14 @@ class IfStmtContext : public BuildContext {
 class ScopeContext : public BuildContext {
  public:
   ScopeContext(ScopeKind scope_kind, Span span, std::optional<Level> level = std::nullopt,
-               std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt)
+               std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
+               std::string name = "")
       : BuildContext(Type::SCOPE, std::move(span)),
         scope_kind_(scope_kind),
         level_(level),
         role_(role),
-        split_(split) {}
+        split_(split),
+        name_(std::move(name)) {}
 
   void AddStmt(const StmtPtr& stmt) override { stmts_.push_back(stmt); }
 
@@ -682,6 +685,7 @@ class ScopeContext : public BuildContext {
   [[nodiscard]] std::optional<Level> GetLevel() const { return level_; }
   [[nodiscard]] std::optional<Role> GetRole() const { return role_; }
   [[nodiscard]] std::optional<SplitMode> GetSplit() const { return split_; }
+  [[nodiscard]] const std::string& GetName() const { return name_; }
   [[nodiscard]] const std::vector<StmtPtr>& GetStmts() const { return stmts_; }
 
  private:
@@ -689,6 +693,7 @@ class ScopeContext : public BuildContext {
   std::optional<Level> level_;
   std::optional<Role> role_;
   std::optional<SplitMode> split_;
+  std::string name_;
   std::vector<StmtPtr> stmts_;
 };
 

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -301,7 +301,7 @@ class IRBuilder {
    */
   void BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level = std::nullopt,
                   std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-                  std::string name = "");
+                  std::string name_hint = "");
 
   /**
    * @brief End building a scope statement
@@ -671,13 +671,13 @@ class ScopeContext : public BuildContext {
  public:
   ScopeContext(ScopeKind scope_kind, Span span, std::optional<Level> level = std::nullopt,
                std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-               std::string name = "")
+               std::string name_hint = "")
       : BuildContext(Type::SCOPE, std::move(span)),
         scope_kind_(scope_kind),
         level_(level),
         role_(role),
         split_(split),
-        name_(std::move(name)) {}
+        name_hint_(std::move(name_hint)) {}
 
   void AddStmt(const StmtPtr& stmt) override { stmts_.push_back(stmt); }
 
@@ -685,7 +685,7 @@ class ScopeContext : public BuildContext {
   [[nodiscard]] std::optional<Level> GetLevel() const { return level_; }
   [[nodiscard]] std::optional<Role> GetRole() const { return role_; }
   [[nodiscard]] std::optional<SplitMode> GetSplit() const { return split_; }
-  [[nodiscard]] const std::string& GetName() const { return name_; }
+  [[nodiscard]] const std::string& GetNameHint() const { return name_hint_; }
   [[nodiscard]] const std::vector<StmtPtr>& GetStmts() const { return stmts_; }
 
  private:
@@ -693,7 +693,7 @@ class ScopeContext : public BuildContext {
   std::optional<Level> level_;
   std::optional<Role> role_;
   std::optional<SplitMode> split_;
-  std::string name_;
+  std::string name_hint_;
   std::vector<StmtPtr> stmts_;
 };
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -718,14 +718,14 @@ class ScopeStmt : public Stmt {
    */
   ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span, std::optional<Level> level,
             std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-            std::string name = "")
+            std::string name_hint = "")
       : Stmt(std::move(span)),
         scope_kind_(scope_kind),
         body_(std::move(body)),
         level_(level),
         role_(role),
         split_(split),
-        name_(std::move(name)) {
+        name_hint_(std::move(name_hint)) {
     CHECK(scope_kind != ScopeKind::Hierarchy || level_.has_value()) << "Hierarchy scope requires a level";
   }
 
@@ -743,7 +743,7 @@ class ScopeStmt : public Stmt {
                                           reflection::UsualField(&ScopeStmt::level_, "level"),
                                           reflection::UsualField(&ScopeStmt::role_, "role"),
                                           reflection::UsualField(&ScopeStmt::split_, "split"),
-                                          reflection::UsualField(&ScopeStmt::name_, "name"),
+                                          reflection::UsualField(&ScopeStmt::name_hint_, "name_hint"),
                                           reflection::UsualField(&ScopeStmt::body_, "body")));
   }
 
@@ -752,7 +752,7 @@ class ScopeStmt : public Stmt {
   std::optional<Level> level_;      // Hierarchy level (nullopt for non-Hierarchy scopes)
   std::optional<Role> role_;        // Function role (nullopt for non-Hierarchy scopes)
   std::optional<SplitMode> split_;  // Split mode (nullopt or None for no split)
-  std::string name_;                // User-provided scope name (empty = auto-generate)
+  std::string name_hint_;           // User-provided scope name hint (empty = auto-generate)
   StmtPtr body_;                    // The nested statements
 };
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -717,13 +717,15 @@ class ScopeStmt : public Stmt {
    * @param split Split mode for cross-core transfer (for AutoInCore scopes)
    */
   ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span, std::optional<Level> level,
-            std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt)
+            std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
+            std::string name = "")
       : Stmt(std::move(span)),
         scope_kind_(scope_kind),
         body_(std::move(body)),
         level_(level),
         role_(role),
-        split_(split) {
+        split_(split),
+        name_(std::move(name)) {
     CHECK(scope_kind != ScopeKind::Hierarchy || level_.has_value()) << "Hierarchy scope requires a level";
   }
 
@@ -741,6 +743,7 @@ class ScopeStmt : public Stmt {
                                           reflection::UsualField(&ScopeStmt::level_, "level"),
                                           reflection::UsualField(&ScopeStmt::role_, "role"),
                                           reflection::UsualField(&ScopeStmt::split_, "split"),
+                                          reflection::UsualField(&ScopeStmt::name_, "name"),
                                           reflection::UsualField(&ScopeStmt::body_, "body")));
   }
 
@@ -749,6 +752,7 @@ class ScopeStmt : public Stmt {
   std::optional<Level> level_;      // Hierarchy level (nullopt for non-Hierarchy scopes)
   std::optional<Role> role_;        // Function role (nullopt for non-Hierarchy scopes)
   std::optional<SplitMode> split_;  // Split mode (nullopt or None for no split)
+  std::string name_;                // User-provided scope name (empty = auto-generate)
   StmtPtr body_;                    // The nested statements
 };
 

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -317,13 +317,22 @@ class ScopeOutliner : public IRMutator {
    * @param used_after Variables (by pointer) used in subsequent statements (determines outputs)
    */
   StmtPtr OutlineScope(const ScopeStmtPtr& op, const std::unordered_set<const Var*>& used_after) {
-    // Generate unique function name (use level/role-aware suffix for Hierarchy scopes)
-    std::string suffix = (op->scope_kind_ == ScopeKind::Hierarchy && op->level_.has_value())
-                             ? GenerateHierarchySuffix(op->level_.value(), op->role_)
-                             : name_suffix_;
-    std::ostringstream name_stream;
-    name_stream << func_name_ << suffix << scope_counter_++;
-    std::string outlined_func_name = name_stream.str();
+    // Generate function name: use user-provided name when available, otherwise auto-generate
+    std::string outlined_func_name;
+    if (!op->name_.empty()) {
+      CHECK(!known_names_.count(op->name_))
+          << "Duplicate scope name '" << op->name_ << "': user-provided names must be unique";
+      outlined_func_name = op->name_;
+      scope_counter_++;  // Keep counter stable for unnamed scopes
+    } else {
+      std::string suffix = (op->scope_kind_ == ScopeKind::Hierarchy && op->level_.has_value())
+                               ? GenerateHierarchySuffix(op->level_.value(), op->role_)
+                               : name_suffix_;
+      std::ostringstream name_stream;
+      name_stream << func_name_ << suffix << scope_counter_++;
+      outlined_func_name = name_stream.str();
+    }
+    known_names_.insert(outlined_func_name);
 
     // Analyze the scope body for inputs and outputs (before recursing).
     // A single VarDefUseCollector replaces the old VarRefCollector + VarDefCollector pair.

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -317,12 +317,11 @@ class ScopeOutliner : public IRMutator {
    * @param used_after Variables (by pointer) used in subsequent statements (determines outputs)
    */
   StmtPtr OutlineScope(const ScopeStmtPtr& op, const std::unordered_set<const Var*>& used_after) {
-    // Generate function name: use user-provided name when available, otherwise auto-generate
+    // Generate function name: use user-provided hint when available, otherwise auto-generate.
+    // On collision, auto-deduplicate with a numeric suffix (name_hint semantics).
     std::string outlined_func_name;
-    if (!op->name_.empty()) {
-      CHECK(!known_names_.count(op->name_))
-          << "Duplicate scope name '" << op->name_ << "': user-provided names must be unique";
-      outlined_func_name = op->name_;
+    if (!op->name_hint_.empty()) {
+      outlined_func_name = op->name_hint_;
       scope_counter_++;  // Keep counter stable for unnamed scopes
     } else {
       std::string suffix = (op->scope_kind_ == ScopeKind::Hierarchy && op->level_.has_value())
@@ -331,6 +330,14 @@ class ScopeOutliner : public IRMutator {
       std::ostringstream name_stream;
       name_stream << func_name_ << suffix << scope_counter_++;
       outlined_func_name = name_stream.str();
+    }
+    // Deduplicate: append _0, _1, ... if name already taken
+    if (known_names_.count(outlined_func_name)) {
+      std::string base = outlined_func_name;
+      int dedup_counter = 0;
+      do {
+        outlined_func_name = base + "_" + std::to_string(dedup_counter++);
+      } while (known_names_.count(outlined_func_name));
     }
     known_names_.insert(outlined_func_name);
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -931,7 +931,7 @@ void BindIR(nb::module_& m) {
   scope_stmt_class.def(nb::init<ScopeKind, const StmtPtr&, const Span&, std::optional<Level>,
                                 std::optional<Role>, std::optional<SplitMode>, std::string>(),
                        nb::arg("scope_kind"), nb::arg("body"), nb::arg("span"), nb::arg("level") = nb::none(),
-                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(), nb::arg("name") = "",
+                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(), nb::arg("name_hint") = "",
                        "Create a scope statement");
   BindFields<ScopeStmt>(scope_stmt_class);
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -929,9 +929,9 @@ void BindIR(nb::module_& m) {
   auto scope_stmt_class = nb::class_<ScopeStmt, Stmt>(
       ir, "ScopeStmt", "Scope statement: marks a region with specific execution context");
   scope_stmt_class.def(nb::init<ScopeKind, const StmtPtr&, const Span&, std::optional<Level>,
-                                std::optional<Role>, std::optional<SplitMode>>(),
+                                std::optional<Role>, std::optional<SplitMode>, std::string>(),
                        nb::arg("scope_kind"), nb::arg("body"), nb::arg("span"), nb::arg("level") = nb::none(),
-                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
+                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(), nb::arg("name") = "",
                        "Create a scope statement");
   BindFields<ScopeStmt>(scope_stmt_class);
 

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -242,7 +242,7 @@ void BindIRBuilder(nb::module_& m) {
       // Scope building
       .def("begin_scope", &IRBuilder::BeginScope, nb::arg("scope_kind"), nb::arg("span"),
            nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
-           nb::arg("name") = "",
+           nb::arg("name_hint") = "",
            "Begin building a scope statement.\n\n"
            "Creates a new scope context. Must be closed with end_scope().\n\n"
            "Args:\n"
@@ -251,7 +251,7 @@ void BindIRBuilder(nb::module_& m) {
            "    level: Hierarchy level (default: None)\n"
            "    role: Hierarchy scope role (default: None)\n"
            "    split: Split mode for cross-core transfer (default: None)\n"
-           "    name: User-provided scope name (default: empty, auto-generated)\n\n"
+           "    name_hint: User-provided scope name hint (default: empty, auto-generated)\n\n"
            "Raises:\n"
            "    RuntimeError: If not inside a function or loop")
       .def("end_scope", &IRBuilder::EndScope, nb::arg("end_span"),

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -242,6 +242,7 @@ void BindIRBuilder(nb::module_& m) {
       // Scope building
       .def("begin_scope", &IRBuilder::BeginScope, nb::arg("scope_kind"), nb::arg("span"),
            nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
+           nb::arg("name") = "",
            "Begin building a scope statement.\n\n"
            "Creates a new scope context. Must be closed with end_scope().\n\n"
            "Args:\n"
@@ -249,7 +250,8 @@ void BindIRBuilder(nb::module_& m) {
            "    span: Source location for scope statement\n"
            "    level: Hierarchy level (default: None)\n"
            "    role: Hierarchy scope role (default: None)\n"
-           "    split: Split mode for cross-core transfer (default: None)\n\n"
+           "    split: Split mode for cross-core transfer (default: None)\n"
+           "    name: User-provided scope name (default: empty, auto-generated)\n\n"
            "Raises:\n"
            "    RuntimeError: If not inside a function or loop")
       .def("end_scope", &IRBuilder::EndScope, nb::arg("end_span"),

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -253,6 +253,7 @@ class IRBuilder:
         level: ir.Level | None = None,
         role: ir.Role | None = None,
         split: ir.SplitMode | None = None,
+        name: str = "",
     ) -> Iterator["ScopeBuilder"]:
         """Context manager for building scope statements.
 
@@ -262,6 +263,7 @@ class IRBuilder:
             level: Hierarchy level (for ScopeKind.Hierarchy)
             role: Function role (for ScopeKind.Hierarchy)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
+            name: User-provided scope name (empty = auto-generate)
 
         Yields:
             ScopeBuilder: Helper object for building the scope statement
@@ -276,7 +278,7 @@ class IRBuilder:
         self._ctx_counter += 1
         self._begin_spans[ctx_id] = begin_span
 
-        self._builder.begin_scope(scope_kind, begin_span, level, role, split)
+        self._builder.begin_scope(scope_kind, begin_span, level, role, split, name)
         builder_obj = ScopeBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -253,7 +253,7 @@ class IRBuilder:
         level: ir.Level | None = None,
         role: ir.Role | None = None,
         split: ir.SplitMode | None = None,
-        name: str = "",
+        name_hint: str = "",
     ) -> Iterator["ScopeBuilder"]:
         """Context manager for building scope statements.
 
@@ -263,7 +263,7 @@ class IRBuilder:
             level: Hierarchy level (for ScopeKind.Hierarchy)
             role: Function role (for ScopeKind.Hierarchy)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
-            name: User-provided scope name (empty = auto-generate)
+            name_hint: User-provided scope name hint (empty = auto-generate)
 
         Yields:
             ScopeBuilder: Helper object for building the scope statement
@@ -278,7 +278,7 @@ class IRBuilder:
         self._ctx_counter += 1
         self._begin_spans[ctx_id] = begin_span
 
-        self._builder.begin_scope(scope_kind, begin_span, level, role, split, name)
+        self._builder.begin_scope(scope_kind, begin_span, level, role, split, name_hint)
         builder_obj = ScopeBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -604,6 +604,9 @@ class IncoreContext:
     The parser recognizes this pattern and creates a ScopeStmt(InCore).
     """
 
+    def __init__(self, name: str = "") -> None:
+        self.name = name
+
     def __enter__(self) -> None:
         """Enter the InCore scope context."""
         pass
@@ -620,8 +623,9 @@ class AutoIncoreContext:
     The parser recognizes this pattern and creates a ScopeStmt(AutoInCore).
     """
 
-    def __init__(self, split: SplitMode = SplitMode.NONE) -> None:
+    def __init__(self, split: SplitMode = SplitMode.NONE, name: str = "") -> None:
         self.split = split
+        self.name = name
 
     def __enter__(self) -> None:
         """Enter the AutoInCore scope context."""
@@ -657,11 +661,14 @@ def auto_incore(split: SplitMode = SplitMode.UP_DOWN) -> AutoIncoreContext:
     return AutoIncoreContext(split=split)
 
 
-def incore() -> IncoreContext:
+def incore(*, name: str = "") -> IncoreContext:
     """Mark a region of code as belonging to the InCore execution context.
 
     This function returns a context manager that should be used with the 'with' statement.
     The parser recognizes this pattern and creates a ScopeStmt with ScopeKind.InCore.
+
+    Args:
+        name: Optional name for the outlined function (must be a valid identifier)
 
     Returns:
         Context manager for InCore scope
@@ -671,7 +678,7 @@ def incore() -> IncoreContext:
         ...     y = pl.ops.add(x, x)
         ...     z = pl.ops.mul(y, y)
     """
-    return IncoreContext()
+    return IncoreContext(name=name)
 
 
 class ClusterContext:
@@ -680,6 +687,9 @@ class ClusterContext:
     This is returned by pl.cluster() and used with the 'with' statement.
     The parser recognizes this pattern and creates a ScopeStmt(Cluster).
     """
+
+    def __init__(self, name: str = "") -> None:
+        self.name = name
 
     def __enter__(self) -> None:
         """Enter the Cluster scope context."""
@@ -690,7 +700,7 @@ class ClusterContext:
         pass
 
 
-def cluster() -> ClusterContext:
+def cluster(*, name: str = "") -> ClusterContext:
     """Mark a region of code as belonging to a Cluster execution context.
 
     A cluster groups co-scheduled AIC (Cube) and AIV (Vector) kernels that
@@ -705,7 +715,7 @@ def cluster() -> ClusterContext:
         ...     with pl.incore():
         ...         y = pl.add(x, x)
     """
-    return ClusterContext()
+    return ClusterContext(name=name)
 
 
 class AtContext:
@@ -724,10 +734,12 @@ class AtContext:
         role: ir.Role | None = None,
         *,
         optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
+        name: str = "",
     ) -> None:
         self.level = level
         self.role = role
         self.optimization = optimization
+        self.name = name
 
     def __enter__(self) -> None:
         pass
@@ -741,6 +753,7 @@ def at(
     role: ir.Role | None = None,
     *,
     optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
+    name: str = "",
 ) -> AtContext:
     """Mark a region of code for execution at a specific hierarchy level.
 
@@ -759,6 +772,7 @@ def at(
         optimization: Optional optimization hint. Use pl.chunked_loop_optimizer
             (or pl.chunked_loop_optimizer(split=...)) with level=CORE_GROUP
             to enable compiler-driven chunked loop outlining.
+        name: Optional name for the outlined function (must be a valid identifier)
 
     Returns:
         Context manager for the appropriate scope
@@ -766,6 +780,10 @@ def at(
     Examples:
         >>> # InCore scope (replaces pl.incore()):
         >>> with pl.at(level=pl.Level.CORE_GROUP):
+        ...     y = pl.ops.add(x, x)
+
+        >>> # Named InCore scope:
+        >>> with pl.at(level=pl.Level.CORE_GROUP, name="fused_matmul_add"):
         ...     y = pl.ops.add(x, x)
 
         >>> # AutoInCore scope (replaces pl.auto_incore()):
@@ -783,7 +801,7 @@ def at(
         >>> with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
         ...     y = pl.add(x, x)
     """
-    return AtContext(level, role, optimization=optimization)
+    return AtContext(level, role, optimization=optimization, name=name)
 
 
 __all__ = [

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -604,8 +604,8 @@ class IncoreContext:
     The parser recognizes this pattern and creates a ScopeStmt(InCore).
     """
 
-    def __init__(self, name: str = "") -> None:
-        self.name = name
+    def __init__(self, name_hint: str = "") -> None:
+        self.name_hint = name_hint
 
     def __enter__(self) -> None:
         """Enter the InCore scope context."""
@@ -623,9 +623,9 @@ class AutoIncoreContext:
     The parser recognizes this pattern and creates a ScopeStmt(AutoInCore).
     """
 
-    def __init__(self, split: SplitMode = SplitMode.NONE, name: str = "") -> None:
+    def __init__(self, split: SplitMode = SplitMode.NONE, name_hint: str = "") -> None:
         self.split = split
-        self.name = name
+        self.name_hint = name_hint
 
     def __enter__(self) -> None:
         """Enter the AutoInCore scope context."""
@@ -636,7 +636,7 @@ class AutoIncoreContext:
         pass
 
 
-def auto_incore(split: SplitMode = SplitMode.UP_DOWN) -> AutoIncoreContext:
+def auto_incore(split: SplitMode = SplitMode.UP_DOWN, *, name_hint: str = "") -> AutoIncoreContext:
     """Mark a region of code for automatic incore chunking.
 
     This function returns a context manager that should be used with the 'with' statement.
@@ -658,17 +658,17 @@ def auto_incore(split: SplitMode = SplitMode.UP_DOWN) -> AutoIncoreContext:
     """
     if split == SplitMode.NONE:
         raise ValueError("SplitMode.NONE is not supported by pto-isa now")
-    return AutoIncoreContext(split=split)
+    return AutoIncoreContext(split=split, name_hint=name_hint)
 
 
-def incore(*, name: str = "") -> IncoreContext:
+def incore(*, name_hint: str = "") -> IncoreContext:
     """Mark a region of code as belonging to the InCore execution context.
 
     This function returns a context manager that should be used with the 'with' statement.
     The parser recognizes this pattern and creates a ScopeStmt with ScopeKind.InCore.
 
     Args:
-        name: Optional name for the outlined function (must be a valid identifier)
+        name_hint: Optional name hint for the outlined function (must be a valid identifier)
 
     Returns:
         Context manager for InCore scope
@@ -678,7 +678,7 @@ def incore(*, name: str = "") -> IncoreContext:
         ...     y = pl.ops.add(x, x)
         ...     z = pl.ops.mul(y, y)
     """
-    return IncoreContext(name=name)
+    return IncoreContext(name_hint=name_hint)
 
 
 class ClusterContext:
@@ -688,8 +688,8 @@ class ClusterContext:
     The parser recognizes this pattern and creates a ScopeStmt(Cluster).
     """
 
-    def __init__(self, name: str = "") -> None:
-        self.name = name
+    def __init__(self, name_hint: str = "") -> None:
+        self.name_hint = name_hint
 
     def __enter__(self) -> None:
         """Enter the Cluster scope context."""
@@ -700,7 +700,7 @@ class ClusterContext:
         pass
 
 
-def cluster(*, name: str = "") -> ClusterContext:
+def cluster(*, name_hint: str = "") -> ClusterContext:
     """Mark a region of code as belonging to a Cluster execution context.
 
     A cluster groups co-scheduled AIC (Cube) and AIV (Vector) kernels that
@@ -715,7 +715,7 @@ def cluster(*, name: str = "") -> ClusterContext:
         ...     with pl.incore():
         ...         y = pl.add(x, x)
     """
-    return ClusterContext(name=name)
+    return ClusterContext(name_hint=name_hint)
 
 
 class AtContext:
@@ -734,12 +734,12 @@ class AtContext:
         role: ir.Role | None = None,
         *,
         optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
-        name: str = "",
+        name_hint: str = "",
     ) -> None:
         self.level = level
         self.role = role
         self.optimization = optimization
-        self.name = name
+        self.name_hint = name_hint
 
     def __enter__(self) -> None:
         pass
@@ -753,7 +753,7 @@ def at(
     role: ir.Role | None = None,
     *,
     optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
-    name: str = "",
+    name_hint: str = "",
 ) -> AtContext:
     """Mark a region of code for execution at a specific hierarchy level.
 
@@ -772,7 +772,7 @@ def at(
         optimization: Optional optimization hint. Use pl.chunked_loop_optimizer
             (or pl.chunked_loop_optimizer(split=...)) with level=CORE_GROUP
             to enable compiler-driven chunked loop outlining.
-        name: Optional name for the outlined function (must be a valid identifier)
+        name_hint: Optional name hint for the outlined function (must be a valid identifier)
 
     Returns:
         Context manager for the appropriate scope
@@ -783,7 +783,7 @@ def at(
         ...     y = pl.ops.add(x, x)
 
         >>> # Named InCore scope:
-        >>> with pl.at(level=pl.Level.CORE_GROUP, name="fused_matmul_add"):
+        >>> with pl.at(level=pl.Level.CORE_GROUP, name_hint="fused_matmul_add"):
         ...     y = pl.ops.add(x, x)
 
         >>> # AutoInCore scope (replaces pl.auto_incore()):
@@ -801,7 +801,7 @@ def at(
         >>> with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
         ...     y = pl.add(x, x)
     """
-    return AtContext(level, role, optimization=optimization, name=name)
+    return AtContext(level, role, optimization=optimization, name_hint=name_hint)
 
 
 __all__ = [

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -10,6 +10,7 @@
 """AST parsing for converting Python DSL to IR builder calls."""
 
 import ast
+import keyword as _keyword_mod
 import warnings
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -1600,7 +1601,7 @@ class ASTParser:
         level = None
         role = None
         opt_split: ir.SplitMode | None = None
-        name = ""
+        name_hint = ""
 
         # Parse positional arguments
         if len(call.args) >= 1:
@@ -1629,8 +1630,8 @@ class ASTParser:
                         span=self.span_tracker.get_span(kw),
                     )
                 opt_split = self._parse_chunked_loop_optimizer(kw.value)
-            elif kw.arg == "name":
-                name = self._parse_scope_name(kw.value, "pl.at()")
+            elif kw.arg == "name_hint":
+                name_hint = self._parse_scope_name_hint(kw.value, "pl.at()")
             elif kw.arg is None:
                 raise ParserSyntaxError(
                     "Unsupported **kwargs in pl.at()",
@@ -1639,14 +1640,14 @@ class ASTParser:
             else:
                 raise ParserSyntaxError(
                     f"Unknown keyword argument '{kw.arg}' in pl.at()",
-                    hint="Supported arguments: level, role, optimization, name",
+                    hint="Supported arguments: level, role, optimization, name_hint",
                 )
         if level is None:
             raise ParserSyntaxError(
                 "pl.at() requires a level argument",
                 hint="Use pl.at(pl.Level.HOST) or pl.at(level=pl.Level.HOST)",
             )
-        return level, role, opt_split, name
+        return level, role, opt_split, name_hint
 
     def _parse_chunked_loop_optimizer(self, value: ast.expr) -> "ir.SplitMode":
         """Parse pl.chunked_loop_optimizer or pl.chunked_loop_optimizer(split=...) AST node.
@@ -1707,30 +1708,30 @@ class ASTParser:
         """Extract SplitMode enum value from AST expression."""
         return extract_enum_value(value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
 
-    def _parse_scope_name(self, value: ast.expr, func_name: str) -> str:
-        """Extract and validate a scope name from an AST expression.
+    def _parse_scope_name_hint(self, value: ast.expr, func_name: str) -> str:
+        """Extract and validate a scope name hint from an AST expression.
 
         Args:
-            value: AST expression node for the name value
+            value: AST expression node for the name_hint value
             func_name: Function name for error messages (e.g. "pl.at()")
 
         Returns:
-            Validated name string.
+            Validated name hint string.
         """
         if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
             raise ParserSyntaxError(
-                f"{func_name} 'name' argument must be a string literal",
+                f"{func_name} 'name_hint' argument must be a string literal",
                 span=self.span_tracker.get_span(value),
-                hint='Use name="my_scope_name"',
+                hint='Use name_hint="my_scope_name"',
             )
-        name = value.value
-        if name and not name.isidentifier():
+        name_hint = value.value
+        if name_hint and (not name_hint.isidentifier() or _keyword_mod.iskeyword(name_hint)):
             raise ParserSyntaxError(
-                f"{func_name} 'name' must be a valid identifier, got {name!r}",
+                f"{func_name} 'name_hint' must be a valid non-keyword identifier, got {name_hint!r}",
                 span=self.span_tracker.get_span(value),
                 hint="Use a valid Python identifier like 'fused_matmul_add'",
             )
-        return name
+        return name_hint
 
     def _parse_legacy_scope(
         self,
@@ -1741,7 +1742,7 @@ class ASTParser:
     ) -> None:
         """Parse legacy scope context managers (pl.incore, pl.auto_incore, pl.cluster)."""
         split_mode = None
-        name = ""
+        name_hint = ""
         if func_attr in ("auto_incore", "incore"):
             if context_expr.args:
                 raise ParserSyntaxError(
@@ -1752,13 +1753,13 @@ class ASTParser:
             for kw in context_expr.keywords:
                 if kw.arg == "split":
                     split_mode = self._eval_split_mode(kw.value, stmt)
-                elif kw.arg == "name":
-                    name = self._parse_scope_name(kw.value, f"pl.{func_attr}()")
+                elif kw.arg == "name_hint":
+                    name_hint = self._parse_scope_name_hint(kw.value, f"pl.{func_attr}()")
                 else:
                     raise ParserSyntaxError(
                         f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
                         span=self.span_tracker.get_span(stmt),
-                        hint="Supported keywords: 'split', 'name'",
+                        hint="Supported keywords: 'split', 'name_hint'",
                     )
             if func_attr == "incore":
                 warnings.warn(
@@ -1782,13 +1783,13 @@ class ASTParser:
                     hint=f"Use 'with pl.{func_attr}():'",
                 )
             for kw in context_expr.keywords:
-                if kw.arg == "name":
-                    name = self._parse_scope_name(kw.value, f"pl.{func_attr}()")
+                if kw.arg == "name_hint":
+                    name_hint = self._parse_scope_name_hint(kw.value, f"pl.{func_attr}()")
                 else:
                     raise ParserSyntaxError(
                         f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
                         span=self.span_tracker.get_span(stmt),
-                        hint="Supported keywords: 'name'",
+                        hint="Supported keywords: 'name_hint'",
                     )
         elif context_expr.args or context_expr.keywords:
             raise ParserSyntaxError(
@@ -1798,7 +1799,7 @@ class ASTParser:
             )
         scope_kind = scope_kind_map[func_attr]
         span = self.span_tracker.get_span(stmt)
-        self._parse_scope_body(stmt, scope_kind, span, split=split_mode, name=name)
+        self._parse_scope_body(stmt, scope_kind, span, split=split_mode, name_hint=name_hint)
 
     def _parse_scope_body(
         self,
@@ -1809,10 +1810,10 @@ class ASTParser:
         level: "ir.Level | None" = None,
         role: "ir.Role | None" = None,
         split: "ir.SplitMode | None" = None,
-        name: str = "",
+        name_hint: str = "",
     ) -> None:
         """Build a scope statement from a with-statement body."""
-        with self.builder.scope(scope_kind, span, level=level, role=role, split=split, name=name):
+        with self.builder.scope(scope_kind, span, level=level, role=role, split=split, name_hint=name_hint):
             with self._scope_kind_context(scope_kind):
                 self.scope_manager.enter_scope("scope")
                 for body_stmt in stmt.body:
@@ -1821,7 +1822,7 @@ class ASTParser:
 
     def _parse_at_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:
         """Parse pl.at(...) context manager into a ScopeStmt."""
-        level, role, opt_split, name = self._parse_at_kwargs(context_expr)
+        level, role, opt_split, name_hint = self._parse_at_kwargs(context_expr)
         span = self.span_tracker.get_span(stmt)
 
         is_core_group = level == ir.Level.CORE_GROUP
@@ -1843,11 +1844,13 @@ class ASTParser:
             )
 
         if not is_core_group:
-            self._parse_scope_body(stmt, ir.ScopeKind.Hierarchy, span, level=level, role=role, name=name)
+            self._parse_scope_body(
+                stmt, ir.ScopeKind.Hierarchy, span, level=level, role=role, name_hint=name_hint
+            )
         elif opt_split is not None:
-            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=opt_split, name=name)
+            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=opt_split, name_hint=name_hint)
         else:
-            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span, name=name)
+            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span, name_hint=name_hint)
 
     def parse_with_statement(self, stmt: ast.With) -> None:
         """Parse with statement for scope contexts.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1575,23 +1575,21 @@ class ASTParser:
         self.in_if_stmt = False
         self.current_if_builder = None
 
-    def _parse_at_kwargs(self, call: ast.Call) -> tuple[ir.Level, ir.Role | None, ir.SplitMode | None]:
-        """Extract level, role, and optimization from pl.at(...) call.
+    def _parse_at_kwargs(self, call: ast.Call) -> tuple[ir.Level, ir.Role | None, ir.SplitMode | None, str]:
+        """Extract level, role, optimization, and name from pl.at(...) call.
 
         Supports both positional and keyword forms:
         - pl.at(pl.Level.HOST)
         - pl.at(pl.Level.HOST, pl.Role.Worker)
         - pl.at(level=pl.Level.HOST, role=pl.Role.Worker)
         - pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer)
-        - pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=...))
+        - pl.at(level=pl.Level.CORE_GROUP, name="my_kernel")
 
         Args:
             call: AST Call node for pl.at(...)
 
         Returns:
-            Tuple of (level, role, opt_split) where opt_split is None when no
-            optimization= kwarg is present, or a SplitMode when
-            chunked_loop_optimizer is used.
+            Tuple of (level, role, opt_split, name).
         """
         if len(call.args) > 2:
             raise ParserSyntaxError(
@@ -1602,6 +1600,7 @@ class ASTParser:
         level = None
         role = None
         opt_split: ir.SplitMode | None = None
+        name = ""
 
         # Parse positional arguments
         if len(call.args) >= 1:
@@ -1630,6 +1629,8 @@ class ASTParser:
                         span=self.span_tracker.get_span(kw),
                     )
                 opt_split = self._parse_chunked_loop_optimizer(kw.value)
+            elif kw.arg == "name":
+                name = self._parse_scope_name(kw.value, "pl.at()")
             elif kw.arg is None:
                 raise ParserSyntaxError(
                     "Unsupported **kwargs in pl.at()",
@@ -1638,14 +1639,14 @@ class ASTParser:
             else:
                 raise ParserSyntaxError(
                     f"Unknown keyword argument '{kw.arg}' in pl.at()",
-                    hint="Supported arguments: level, role, optimization",
+                    hint="Supported arguments: level, role, optimization, name",
                 )
         if level is None:
             raise ParserSyntaxError(
                 "pl.at() requires a level argument",
                 hint="Use pl.at(pl.Level.HOST) or pl.at(level=pl.Level.HOST)",
             )
-        return level, role, opt_split
+        return level, role, opt_split, name
 
     def _parse_chunked_loop_optimizer(self, value: ast.expr) -> "ir.SplitMode":
         """Parse pl.chunked_loop_optimizer or pl.chunked_loop_optimizer(split=...) AST node.
@@ -1706,6 +1707,99 @@ class ASTParser:
         """Extract SplitMode enum value from AST expression."""
         return extract_enum_value(value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
 
+    def _parse_scope_name(self, value: ast.expr, func_name: str) -> str:
+        """Extract and validate a scope name from an AST expression.
+
+        Args:
+            value: AST expression node for the name value
+            func_name: Function name for error messages (e.g. "pl.at()")
+
+        Returns:
+            Validated name string.
+        """
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            raise ParserSyntaxError(
+                f"{func_name} 'name' argument must be a string literal",
+                span=self.span_tracker.get_span(value),
+                hint='Use name="my_scope_name"',
+            )
+        name = value.value
+        if name and not name.isidentifier():
+            raise ParserSyntaxError(
+                f"{func_name} 'name' must be a valid identifier, got {name!r}",
+                span=self.span_tracker.get_span(value),
+                hint="Use a valid Python identifier like 'fused_matmul_add'",
+            )
+        return name
+
+    def _parse_legacy_scope(
+        self,
+        stmt: ast.With,
+        context_expr: ast.Call,
+        func_attr: str,
+        scope_kind_map: dict[str, "ir.ScopeKind"],
+    ) -> None:
+        """Parse legacy scope context managers (pl.incore, pl.auto_incore, pl.cluster)."""
+        split_mode = None
+        name = ""
+        if func_attr in ("auto_incore", "incore"):
+            if context_expr.args:
+                raise ParserSyntaxError(
+                    f"pl.{func_attr}() does not accept positional arguments",
+                    span=self.span_tracker.get_span(stmt),
+                    hint=f"Use 'with pl.{func_attr}(split=pl.SplitMode.UP_DOWN):'",
+                )
+            for kw in context_expr.keywords:
+                if kw.arg == "split":
+                    split_mode = self._eval_split_mode(kw.value, stmt)
+                elif kw.arg == "name":
+                    name = self._parse_scope_name(kw.value, f"pl.{func_attr}()")
+                else:
+                    raise ParserSyntaxError(
+                        f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
+                        span=self.span_tracker.get_span(stmt),
+                        hint="Supported keywords: 'split', 'name'",
+                    )
+            if func_attr == "incore":
+                warnings.warn(
+                    "pl.incore() is deprecated; use 'with pl.at(level=pl.Level.CORE_GROUP):' instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    "pl.auto_incore() is deprecated; use "
+                    "'with pl.at(level=pl.Level.CORE_GROUP, "
+                    "optimization=pl.chunked_loop_optimizer):' instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        elif func_attr == "cluster":
+            if context_expr.args:
+                raise ParserSyntaxError(
+                    f"pl.{func_attr}() does not accept positional arguments",
+                    span=self.span_tracker.get_span(stmt),
+                    hint=f"Use 'with pl.{func_attr}():'",
+                )
+            for kw in context_expr.keywords:
+                if kw.arg == "name":
+                    name = self._parse_scope_name(kw.value, f"pl.{func_attr}()")
+                else:
+                    raise ParserSyntaxError(
+                        f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
+                        span=self.span_tracker.get_span(stmt),
+                        hint="Supported keywords: 'name'",
+                    )
+        elif context_expr.args or context_expr.keywords:
+            raise ParserSyntaxError(
+                f"pl.{func_attr}() does not accept arguments",
+                span=self.span_tracker.get_span(stmt),
+                hint=f"Use 'with pl.{func_attr}():' without arguments",
+            )
+        scope_kind = scope_kind_map[func_attr]
+        span = self.span_tracker.get_span(stmt)
+        self._parse_scope_body(stmt, scope_kind, span, split=split_mode, name=name)
+
     def _parse_scope_body(
         self,
         stmt: ast.With,
@@ -1715,9 +1809,10 @@ class ASTParser:
         level: "ir.Level | None" = None,
         role: "ir.Role | None" = None,
         split: "ir.SplitMode | None" = None,
+        name: str = "",
     ) -> None:
         """Build a scope statement from a with-statement body."""
-        with self.builder.scope(scope_kind, span, level=level, role=role, split=split):
+        with self.builder.scope(scope_kind, span, level=level, role=role, split=split, name=name):
             with self._scope_kind_context(scope_kind):
                 self.scope_manager.enter_scope("scope")
                 for body_stmt in stmt.body:
@@ -1726,7 +1821,7 @@ class ASTParser:
 
     def _parse_at_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:
         """Parse pl.at(...) context manager into a ScopeStmt."""
-        level, role, opt_split = self._parse_at_kwargs(context_expr)
+        level, role, opt_split, name = self._parse_at_kwargs(context_expr)
         span = self.span_tracker.get_span(stmt)
 
         is_core_group = level == ir.Level.CORE_GROUP
@@ -1748,11 +1843,11 @@ class ASTParser:
             )
 
         if not is_core_group:
-            self._parse_scope_body(stmt, ir.ScopeKind.Hierarchy, span, level=level, role=role)
+            self._parse_scope_body(stmt, ir.ScopeKind.Hierarchy, span, level=level, role=role, name=name)
         elif opt_split is not None:
-            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=opt_split)
+            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=opt_split, name=name)
         else:
-            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span)
+            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span, name=name)
 
     def parse_with_statement(self, stmt: ast.With) -> None:
         """Parse with statement for scope contexts.
@@ -1795,49 +1890,7 @@ class ASTParser:
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "pl":
                 # Existing scope kinds: pl.incore(), pl.auto_incore(), pl.cluster()
                 if func.attr in _SCOPE_KIND_MAP:
-                    # Default split mode: None (validated later in ExpandMixedKernel for mixed kernels)
-                    split_mode = None
-                    if func.attr in ("auto_incore", "incore"):
-                        if context_expr.args:
-                            raise ParserSyntaxError(
-                                f"pl.{func.attr}() does not accept positional arguments",
-                                span=self.span_tracker.get_span(stmt),
-                                hint=f"Use 'with pl.{func.attr}(split=pl.SplitMode.UP_DOWN):'",
-                            )
-                        for kw in context_expr.keywords:
-                            if kw.arg == "split":
-                                split_mode = self._eval_split_mode(kw.value, stmt)
-                            else:
-                                raise ParserSyntaxError(
-                                    f"pl.{func.attr}() got unexpected keyword argument '{kw.arg}'",
-                                    span=self.span_tracker.get_span(stmt),
-                                    hint="Only 'split' keyword is supported",
-                                )
-                        # Emit deprecation warnings for incore/auto_incore
-                        if func.attr == "incore":
-                            warnings.warn(
-                                "pl.incore() is deprecated; use "
-                                "'with pl.at(level=pl.Level.CORE_GROUP):' instead",
-                                DeprecationWarning,
-                                stacklevel=2,
-                            )
-                        else:
-                            warnings.warn(
-                                "pl.auto_incore() is deprecated; use "
-                                "'with pl.at(level=pl.Level.CORE_GROUP, "
-                                "optimization=pl.chunked_loop_optimizer):' instead",
-                                DeprecationWarning,
-                                stacklevel=2,
-                            )
-                    elif context_expr.args or context_expr.keywords:
-                        raise ParserSyntaxError(
-                            f"pl.{func.attr}() does not accept arguments",
-                            span=self.span_tracker.get_span(stmt),
-                            hint=f"Use 'with pl.{func.attr}():' without arguments",
-                        )
-                    scope_kind = _SCOPE_KIND_MAP[func.attr]
-                    span = self.span_tracker.get_span(stmt)
-                    self._parse_scope_body(stmt, scope_kind, span, split=split_mode)
+                    self._parse_legacy_scope(stmt, context_expr, func.attr, _SCOPE_KIND_MAP)
                     return
 
                 # pl.at(level=..., role=..., optimization=...)

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1797,6 +1797,9 @@ class ScopeStmt(Stmt):
     split: Final[SplitMode | None]
     """Split mode for cross-core transfer (None for no split)."""
 
+    name: Final[str]
+    """User-provided scope name (empty string = auto-generate)."""
+
     body: Final[Stmt]
     """The nested statements."""
 
@@ -1808,6 +1811,7 @@ class ScopeStmt(Stmt):
         level: Level | None = None,
         role: Role | None = None,
         split: SplitMode | None = None,
+        name: str = "",
     ) -> None:
         """Create a scope statement.
 
@@ -1818,6 +1822,7 @@ class ScopeStmt(Stmt):
             level: Hierarchy level (for Hierarchy scopes)
             role: Function role (for Hierarchy scopes)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
+            name: User-provided scope name (empty = auto-generate)
         """
 
 class SeqStmts(Stmt):
@@ -2562,6 +2567,8 @@ class IRBuilder:
         span: Span,
         level: Level | None = None,
         role: Role | None = None,
+        split: SplitMode | None = None,
+        name: str = "",
     ) -> None:
         """Begin building a scope statement.
 
@@ -2570,6 +2577,8 @@ class IRBuilder:
             span: Source location for scope statement
             level: Hierarchy level (default: None)
             role: Hierarchy scope role (default: None)
+            split: Split mode for cross-core transfer (default: None)
+            name: User-provided scope name (default: empty, auto-generated)
         """
 
     def end_scope(self, end_span: Span) -> ScopeStmt:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1797,8 +1797,8 @@ class ScopeStmt(Stmt):
     split: Final[SplitMode | None]
     """Split mode for cross-core transfer (None for no split)."""
 
-    name: Final[str]
-    """User-provided scope name (empty string = auto-generate)."""
+    name_hint: Final[str]
+    """User-provided scope name hint (empty string = auto-generate)."""
 
     body: Final[Stmt]
     """The nested statements."""
@@ -1811,7 +1811,7 @@ class ScopeStmt(Stmt):
         level: Level | None = None,
         role: Role | None = None,
         split: SplitMode | None = None,
-        name: str = "",
+        name_hint: str = "",
     ) -> None:
         """Create a scope statement.
 
@@ -1822,7 +1822,7 @@ class ScopeStmt(Stmt):
             level: Hierarchy level (for Hierarchy scopes)
             role: Function role (for Hierarchy scopes)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
-            name: User-provided scope name (empty = auto-generate)
+            name_hint: User-provided scope name hint (empty = auto-generate)
         """
 
 class SeqStmts(Stmt):
@@ -2568,7 +2568,7 @@ class IRBuilder:
         level: Level | None = None,
         role: Role | None = None,
         split: SplitMode | None = None,
-        name: str = "",
+        name_hint: str = "",
     ) -> None:
         """Begin building a scope statement.
 
@@ -2578,7 +2578,7 @@ class IRBuilder:
             level: Hierarchy level (default: None)
             role: Hierarchy scope role (default: None)
             split: Split mode for cross-core transfer (default: None)
-            name: User-provided scope name (default: empty, auto-generated)
+            name_hint: User-provided scope name hint (default: empty, auto-generated)
         """
 
     def end_scope(self, end_span: Span) -> ScopeStmt:

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -288,12 +288,13 @@ StmtPtr IRBuilder::EndIf(const Span& end_span) {
 // ========== Scope Building ==========
 
 void IRBuilder::BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level,
-                           std::optional<Role> role, std::optional<SplitMode> split) {
+                           std::optional<Role> role, std::optional<SplitMode> split, std::string name) {
   CHECK(!context_stack_.empty()) << "Cannot begin scope: not inside a function or another valid context at "
                                  << span.to_string();
   CHECK(scope_kind != ScopeKind::Hierarchy || level.has_value())
       << "Hierarchy scope requires a level at " << span.to_string();
-  context_stack_.push_back(std::make_unique<ScopeContext>(scope_kind, span, level, role, split));
+  context_stack_.push_back(
+      std::make_unique<ScopeContext>(scope_kind, span, level, role, split, std::move(name)));
 }
 
 StmtPtr IRBuilder::EndScope(const Span& end_span) {
@@ -314,7 +315,7 @@ StmtPtr IRBuilder::EndScope(const Span& end_span) {
   // Create scope statement
   auto scope_stmt =
       std::make_shared<ScopeStmt>(scope_ctx->GetScopeKind(), body, combined_span, scope_ctx->GetLevel(),
-                                  scope_ctx->GetRole(), scope_ctx->GetSplit());
+                                  scope_ctx->GetRole(), scope_ctx->GetSplit(), scope_ctx->GetName());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -288,13 +288,13 @@ StmtPtr IRBuilder::EndIf(const Span& end_span) {
 // ========== Scope Building ==========
 
 void IRBuilder::BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level,
-                           std::optional<Role> role, std::optional<SplitMode> split, std::string name) {
+                           std::optional<Role> role, std::optional<SplitMode> split, std::string name_hint) {
   CHECK(!context_stack_.empty()) << "Cannot begin scope: not inside a function or another valid context at "
                                  << span.to_string();
   CHECK(scope_kind != ScopeKind::Hierarchy || level.has_value())
       << "Hierarchy scope requires a level at " << span.to_string();
   context_stack_.push_back(
-      std::make_unique<ScopeContext>(scope_kind, span, level, role, split, std::move(name)));
+      std::make_unique<ScopeContext>(scope_kind, span, level, role, split, std::move(name_hint)));
 }
 
 StmtPtr IRBuilder::EndScope(const Span& end_span) {
@@ -315,7 +315,7 @@ StmtPtr IRBuilder::EndScope(const Span& end_span) {
   // Create scope statement
   auto scope_stmt =
       std::make_shared<ScopeStmt>(scope_ctx->GetScopeKind(), body, combined_span, scope_ctx->GetLevel(),
-                                  scope_ctx->GetRole(), scope_ctx->GetSplit(), scope_ctx->GetName());
+                                  scope_ctx->GetRole(), scope_ctx->GetSplit(), scope_ctx->GetNameHint());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -561,10 +561,17 @@ static IRNodePtr DeserializeScopeStmt(const msgpack::object& fields_obj, msgpack
     split = static_cast<SplitMode>(split_obj->via.u64);
   }
 
+  // Deserialize optional name (backward compatible: missing field = empty)
+  std::string name;
+  auto name_obj = GetOptionalFieldObj(fields_obj, "name", ctx);
+  if (name_obj.has_value() && name_obj->type == msgpack::type::STR) {
+    name = name_obj->as<std::string>();
+  }
+
   // Deserialize body
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
-  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split);
+  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name));
 }
 
 // Deserialize SeqStmts

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -561,17 +561,17 @@ static IRNodePtr DeserializeScopeStmt(const msgpack::object& fields_obj, msgpack
     split = static_cast<SplitMode>(split_obj->via.u64);
   }
 
-  // Deserialize optional name (backward compatible: missing field = empty)
-  std::string name;
-  auto name_obj = GetOptionalFieldObj(fields_obj, "name", ctx);
-  if (name_obj.has_value() && name_obj->type == msgpack::type::STR) {
-    name = name_obj->as<std::string>();
+  // Deserialize optional name_hint (backward compatible: missing field = empty)
+  std::string name_hint;
+  auto name_hint_obj = GetOptionalFieldObj(fields_obj, "name_hint", ctx);
+  if (name_hint_obj.has_value() && name_hint_obj->type == msgpack::type::STR) {
+    name_hint = name_hint_obj->as<std::string>();
   }
 
   // Deserialize body
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
-  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name));
+  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name_hint));
 }
 
 // Deserialize SeqStmts

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -312,7 +312,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ScopeStmtPtr& op) {
 
   if (new_body.get() != op->body_.get()) {
     return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_, op->name_);
+                                             op->role_, op->split_, op->name_hint_);
   }
   return op;
 }

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -312,7 +312,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ScopeStmtPtr& op) {
 
   if (new_body.get() != op->body_.get()) {
     return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_);
+                                             op->role_, op->split_, op->name_);
   }
   return op;
 }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -570,7 +570,7 @@ StmtPtr IRMutator::VisitStmt_(const ScopeStmtPtr& op) {
   INTERNAL_CHECK(new_body) << "ScopeStmt body mutated to null";
   if (new_body.get() != op->body_.get()) {
     return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_);
+                                             op->role_, op->split_, op->name_);
   }
   return op;
 }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -570,7 +570,7 @@ StmtPtr IRMutator::VisitStmt_(const ScopeStmtPtr& op) {
   INTERNAL_CHECK(new_body) << "ScopeStmt body mutated to null";
   if (new_body.get() != op->body_.get()) {
     return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_, op->name_);
+                                             op->role_, op->split_, op->name_hint_);
   }
   return op;
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1023,6 +1023,13 @@ void IRPythonPrinter::VisitStmt_(const WhileStmtPtr& op) {
 }
 
 void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
+  // Helper: append name= kwarg when user-provided name is non-empty
+  auto append_name = [&]() {
+    if (!op->name_.empty()) {
+      stream_ << ", name=\"" << op->name_ << "\"";
+    }
+  };
+
   if (op->scope_kind_ == ScopeKind::Hierarchy) {
     // Print as: with pl.at(level=pl.Level.X, role=pl.Role.Y):
     stream_ << "with " << prefix_ << ".at(";
@@ -1035,19 +1042,28 @@ void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
       if (!first) stream_ << ", ";
       stream_ << "role=" << prefix_ << ".Role." << RoleToString(*op->role_);
     }
+    append_name();
     stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::InCore) {
-    stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP):\n";
+    stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP";
+    append_name();
+    stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::AutoInCore) {
     stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimization=";
     if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
       stream_ << prefix_ << ".chunked_loop_optimizer(split=" << prefix_ << ".SplitMode."
-              << SplitModeToPythonString(op->split_.value()) << ")):\n";
+              << SplitModeToPythonString(op->split_.value()) << ")";
     } else {
-      stream_ << prefix_ << ".chunked_loop_optimizer):\n";
+      stream_ << prefix_ << ".chunked_loop_optimizer";
     }
+    append_name();
+    stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::Cluster) {
-    stream_ << "with " << prefix_ << ".cluster():\n";
+    stream_ << "with " << prefix_ << ".cluster(";
+    if (!op->name_.empty()) {
+      stream_ << "name=\"" << op->name_ << "\"";
+    }
+    stream_ << "):\n";
   } else {
     INTERNAL_CHECK(false) << "Internal error: Unknown ScopeKind in python_printer: "
                           << ScopeKindToString(op->scope_kind_);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1024,9 +1024,9 @@ void IRPythonPrinter::VisitStmt_(const WhileStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
   // Helper: append name= kwarg when user-provided name is non-empty
-  auto append_name = [&]() {
-    if (!op->name_.empty()) {
-      stream_ << ", name=\"" << op->name_ << "\"";
+  auto append_name_hint = [&]() {
+    if (!op->name_hint_.empty()) {
+      stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
     }
   };
 
@@ -1042,11 +1042,11 @@ void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
       if (!first) stream_ << ", ";
       stream_ << "role=" << prefix_ << ".Role." << RoleToString(*op->role_);
     }
-    append_name();
+    append_name_hint();
     stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::InCore) {
     stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP";
-    append_name();
+    append_name_hint();
     stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::AutoInCore) {
     stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimization=";
@@ -1056,12 +1056,12 @@ void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
     } else {
       stream_ << prefix_ << ".chunked_loop_optimizer";
     }
-    append_name();
+    append_name_hint();
     stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::Cluster) {
     stream_ << "with " << prefix_ << ".cluster(";
-    if (!op->name_.empty()) {
-      stream_ << "name=\"" << op->name_ << "\"";
+    if (!op->name_hint_.empty()) {
+      stream_ << "name_hint=\"" << op->name_hint_ << "\"";
     }
     stream_ << "):\n";
   } else {

--- a/tests/ut/ir/statements/test_scope_stmt.py
+++ b/tests/ut/ir/statements/test_scope_stmt.py
@@ -62,6 +62,27 @@ class TestScopeStmt:
         printed = TestProgram.as_python()
         assert "with pl.at(level=pl.Level.CORE_GROUP):" in printed
 
+    def test_scope_stmt_with_name(self):
+        """Test ScopeStmt construction with a user-provided name."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        var_x = ir.Var("x", ir.TensorType([64], DataType.FP32), span)
+        var_y = ir.Var("y", ir.TensorType([64], DataType.FP32), span)
+        body = ir.AssignStmt(var_y, var_x, span)
+
+        scope = ir.ScopeStmt(ir.ScopeKind.InCore, body, span, name="my_kernel")
+        assert scope.name == "my_kernel"
+        assert scope.scope_kind == ir.ScopeKind.InCore
+
+    def test_scope_stmt_default_name_is_empty(self):
+        """Test that default name is empty string."""
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        var_x = ir.Var("x", ir.TensorType([64], DataType.FP32), span)
+        var_y = ir.Var("y", ir.TensorType([64], DataType.FP32), span)
+        body = ir.AssignStmt(var_y, var_x, span)
+
+        scope = ir.ScopeStmt(ir.ScopeKind.InCore, body, span)
+        assert scope.name == ""
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_scope_stmt.py
+++ b/tests/ut/ir/statements/test_scope_stmt.py
@@ -69,8 +69,8 @@ class TestScopeStmt:
         var_y = ir.Var("y", ir.TensorType([64], DataType.FP32), span)
         body = ir.AssignStmt(var_y, var_x, span)
 
-        scope = ir.ScopeStmt(ir.ScopeKind.InCore, body, span, name="my_kernel")
-        assert scope.name == "my_kernel"
+        scope = ir.ScopeStmt(ir.ScopeKind.InCore, body, span, name_hint="my_kernel")
+        assert scope.name_hint == "my_kernel"
         assert scope.scope_kind == ir.ScopeKind.InCore
 
     def test_scope_stmt_default_name_is_empty(self):
@@ -81,7 +81,7 @@ class TestScopeStmt:
         body = ir.AssignStmt(var_y, var_x, span)
 
         scope = ir.ScopeStmt(ir.ScopeKind.InCore, body, span)
-        assert scope.name == ""
+        assert scope.name_hint == ""
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -681,5 +681,85 @@ class TestSplitIncoreOrchVerifier:
                 assert "tensor.add" not in func_str
 
 
+class TestOutlineNamedIncoreScopes:
+    """Test OutlineIncoreScopes pass with user-provided scope names."""
+
+    def test_outline_named_incore_scope(self):
+        """Test that user-provided name is used for the outlined function."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fused_add(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.fused_add(x)
+                return y
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_mixed_named_and_unnamed_scopes(self):
+        """Test that unnamed scopes still get auto-generated names when mixed with named scopes."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name="first_kernel"):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(y, a)
+                return b
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def first_kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return a
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_1(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                b: pl.Tensor[[64], pl.FP32] = pl.add(y, a)
+                return b
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = self.first_kernel(x)
+                b: pl.Tensor[[64], pl.FP32] = self.main_incore_1(a, y)
+                return b
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -691,7 +691,7 @@ class TestOutlineNamedIncoreScopes:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, name="fused_add"):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="fused_add"):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
@@ -723,7 +723,7 @@ class TestOutlineNamedIncoreScopes:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, name="first_kernel"):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="first_kernel"):
                     a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 with pl.at(level=pl.Level.CORE_GROUP):
                     b: pl.Tensor[[64], pl.FP32] = pl.add(y, a)
@@ -753,6 +753,54 @@ class TestOutlineNamedIncoreScopes:
             ) -> pl.Tensor[[64], pl.FP32]:
                 a: pl.Tensor[[64], pl.FP32] = self.first_kernel(x)
                 b: pl.Tensor[[64], pl.FP32] = self.main_incore_1(a, y)
+                return b
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_duplicate_name_hint_auto_dedup(self):
+        """Test that duplicate name_hints are auto-deduplicated."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="my_kernel"):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="my_kernel"):
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(y, a)
+                return b
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def my_kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return a
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def my_kernel_0(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                b: pl.Tensor[[64], pl.FP32] = pl.add(y, a)
+                return b
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = self.my_kernel(x)
+                b: pl.Tensor[[64], pl.FP32] = self.my_kernel_0(a, y)
                 return b
 
         Before = passes.convert_to_ssa()(Before)

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -12,6 +12,7 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
 
 
 class TestScopeParsing:
@@ -118,7 +119,7 @@ class TestScopeNameParsing:
         class TestProgram:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, name="my_kernel"):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="my_kernel"):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
@@ -131,7 +132,7 @@ class TestScopeNameParsing:
         else:
             scope_stmt = body
         assert isinstance(scope_stmt, ir.ScopeStmt)
-        assert scope_stmt.name == "my_kernel"
+        assert scope_stmt.name_hint == "my_kernel"
         assert scope_stmt.scope_kind == ir.ScopeKind.InCore
 
     def test_parse_unnamed_scope_has_empty_name(self):
@@ -152,17 +153,17 @@ class TestScopeNameParsing:
         else:
             scope_stmt = body
         assert isinstance(scope_stmt, ir.ScopeStmt)
-        assert scope_stmt.name == ""
+        assert scope_stmt.name_hint == ""
 
     def test_parse_invalid_name_raises_error(self):
         """Test that invalid identifier names raise ParserSyntaxError."""
-        with pytest.raises(Exception, match="valid identifier"):
+        with pytest.raises(ParserSyntaxError, match="valid non-keyword identifier"):
 
             @pl.program
             class TestProgram:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    with pl.at(level=pl.Level.CORE_GROUP, name="has space"):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="has space"):
                         y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                     return y
 
@@ -173,12 +174,12 @@ class TestScopeNameParsing:
         class Original:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, name="my_kernel"):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="my_kernel"):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
         printed = Original.as_python()
-        assert 'name="my_kernel"' in printed
+        assert 'name_hint="my_kernel"' in printed
 
     def test_parse_named_hierarchy_scope(self):
         """Test parsing with pl.at(level=HOST, name='host_func')."""
@@ -187,7 +188,7 @@ class TestScopeNameParsing:
         class TestProgram:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, name="host_func"):
+                with pl.at(level=pl.Level.HOST, name_hint="host_func"):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
@@ -198,7 +199,7 @@ class TestScopeNameParsing:
         else:
             scope_stmt = body
         assert isinstance(scope_stmt, ir.ScopeStmt)
-        assert scope_stmt.name == "host_func"
+        assert scope_stmt.name_hint == "host_func"
         assert scope_stmt.scope_kind == ir.ScopeKind.Hierarchy
 
 

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -108,5 +108,99 @@ class TestScopeParsing:
         assert "with pl.at(level=pl.Level.CORE_GROUP):" in printed
 
 
+class TestScopeNameParsing:
+    """Test parsing of scope name parameter."""
+
+    def test_parse_named_incore_scope(self):
+        """Test parsing with pl.at(level=..., name='my_kernel')."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name="my_kernel"):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        assert TestProgram is not None
+        main_func = list(TestProgram.functions.values())[0]
+        # Find the ScopeStmt and verify name field
+        body = main_func.body
+        if isinstance(body, ir.SeqStmts):
+            scope_stmt = body.stmts[0]
+        else:
+            scope_stmt = body
+        assert isinstance(scope_stmt, ir.ScopeStmt)
+        assert scope_stmt.name == "my_kernel"
+        assert scope_stmt.scope_kind == ir.ScopeKind.InCore
+
+    def test_parse_unnamed_scope_has_empty_name(self):
+        """Test that unnamed scopes have empty name."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        main_func = list(TestProgram.functions.values())[0]
+        body = main_func.body
+        if isinstance(body, ir.SeqStmts):
+            scope_stmt = body.stmts[0]
+        else:
+            scope_stmt = body
+        assert isinstance(scope_stmt, ir.ScopeStmt)
+        assert scope_stmt.name == ""
+
+    def test_parse_invalid_name_raises_error(self):
+        """Test that invalid identifier names raise ParserSyntaxError."""
+        with pytest.raises(Exception, match="valid identifier"):
+
+            @pl.program
+            class TestProgram:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.at(level=pl.Level.CORE_GROUP, name="has space"):
+                        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                    return y
+
+    def test_named_scope_printer_roundtrip(self):
+        """Test that named scopes roundtrip through the printer."""
+
+        @pl.program
+        class Original:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name="my_kernel"):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        printed = Original.as_python()
+        assert 'name="my_kernel"' in printed
+
+    def test_parse_named_hierarchy_scope(self):
+        """Test parsing with pl.at(level=HOST, name='host_func')."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.HOST, name="host_func"):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        main_func = list(TestProgram.functions.values())[0]
+        body = main_func.body
+        if isinstance(body, ir.SeqStmts):
+            scope_stmt = body.stmts[0]
+        else:
+            scope_stmt = body
+        assert isinstance(scope_stmt, ir.ScopeStmt)
+        assert scope_stmt.name == "host_func"
+        assert scope_stmt.scope_kind == ir.ScopeKind.Hierarchy
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add optional `name` field to `ScopeStmt` IR node so users can assign meaningful, stable names to outlined incore functions
- When `name` is provided (e.g., `with pl.at(level=pl.Level.CORE_GROUP, name="fused_add")`), the outline pass uses it directly instead of auto-generating opaque names like `main_incore_0`
- Cross-layer implementation: C++ IR, builder, outliner, printer, deserializer, Python bindings, DSL, parser, type stubs, docs

Fixes #953

## Test plan

- [x] Unit tests for `ScopeStmt` construction with/without name
- [x] Outline pass tests: named scope uses user name, mixed named/unnamed scopes
- [x] Parser tests: named scope parsing, invalid name detection, printer roundtrip, hierarchy scope with name
- [x] Full test suite passes (3426 passed, 0 failed)
- [x] Clang-tidy clean (no new warnings)
- [x] All pre-commit hooks pass