### PR TITLE
refactor(codegen): remove dead LoopEscapeInfoCollector from orchestration analysis

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -12,11 +12,9 @@
 #ifndef PYPTO_CODEGEN_ORCHESTRATION_ORCHESTRATION_ANALYSIS_H_
 #define PYPTO_CODEGEN_ORCHESTRATION_ORCHESTRATION_ANALYSIS_H_
 
-#include <cstddef>
 #include <map>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -102,23 +100,6 @@ class BufferRootCollector : public ir::IRVisitor {
 
   ir::ProgramPtr program_;
   std::unordered_map<const ir::Var*, std::vector<const ir::Var*>> tuple_output_roots_;
-};
-
-/**
- * @brief Detect ForStmt return variables that are referenced after the loop
- *
- * Identifies loop-carried variables whose values escape the loop scope and are
- * used in subsequent statements, enabling codegen to emit tracking state tensors.
- */
-class LoopEscapeInfoCollector : public ir::IRVisitor {
- public:
-  std::unordered_set<const ir::Var*> escaping_loop_returns;
-
- protected:
-  void VisitStmt_(const ir::SeqStmtsPtr& seq) override;
-
- private:
-  static bool IsVarReferencedLater(const ir::SeqStmtsPtr& seq, size_t start_index, const ir::Var* target);
 };
 
 /**

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -250,62 +250,6 @@ std::vector<const Var*> BufferRootCollector::CollectCallOutputRoots(const CallPt
 }
 
 // ---------------------------------------------------------------------------
-// LoopEscapeInfoCollector
-// ---------------------------------------------------------------------------
-
-namespace {
-
-class VarReferenceCollector : public IRVisitor {
- public:
-  explicit VarReferenceCollector(const Var* target) : target_(target) {}
-
-  bool found = false;
-
- protected:
-  void VisitExpr_(const VarPtr& op) override {
-    if (op.get() == target_) {
-      found = true;
-    }
-    IRVisitor::VisitExpr_(op);
-  }
-
-  void VisitExpr_(const IterArgPtr& op) override {
-    if (op.get() == target_) {
-      found = true;
-    }
-    IRVisitor::VisitExpr_(op);
-  }
-
- private:
-  const Var* target_;
-};
-
-}  // namespace
-
-void LoopEscapeInfoCollector::VisitStmt_(const SeqStmtsPtr& seq) {
-  for (size_t i = 0; i < seq->stmts_.size(); ++i) {
-    if (auto for_stmt = As<ForStmt>(seq->stmts_[i])) {
-      for (const auto& return_var : for_stmt->return_vars_) {
-        if (!return_var) continue;
-        if (IsVarReferencedLater(seq, i + 1, return_var.get())) {
-          escaping_loop_returns.insert(return_var.get());
-        }
-      }
-    }
-    VisitStmt(seq->stmts_[i]);
-  }
-}
-
-bool LoopEscapeInfoCollector::IsVarReferencedLater(const SeqStmtsPtr& seq, size_t start_index,
-                                                   const Var* target) {
-  VarReferenceCollector collector(target);
-  for (size_t i = start_index; i < seq->stmts_.size() && !collector.found; ++i) {
-    collector.VisitStmt(seq->stmts_[i]);
-  }
-  return collector.found;
-}
-
-// ---------------------------------------------------------------------------
 // VarLineageCollector
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #850

LoopEscapeInfoCollector and its helper VarReferenceCollector were added in PR #848 but never called by GenerateOrchestration or any other code path. The current codegen handles ForStmt loop-carried values through emit_name_map aliasing and VarLineageCollector, making this analysis class dead code. Remove it along with the unused <unordered_set> include.

Made-with: Cursor