### PR TITLE
fix(printer): print memref base as bare ref when defined in body

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -261,6 +261,9 @@ class IRPythonPrinter : public IRVisitor {
   // Built by BuildVarRenameMap() at the start of each function to handle SSA name shadowing.
   std::unordered_map<const Var*, std::string> var_rename_map_;
 
+  // Vars defined in the current function body (for PrintMemRef formatting).
+  std::unordered_set<const Var*> body_defined_vars_;
+
   // Program-level dyn var rename map: Var pointer → disambiguated printed name.
   // Built once by VisitProgram for dynamic dimension variables used in type annotations.
   // When two distinct Var* share the same name_hint_, they get unique suffixed names.
@@ -1188,10 +1191,12 @@ void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
   // Collect all Var def-sites in DFS pre-order: params first, then body.
   std::vector<const Var*> defs;
   for (auto& p : func->params_) defs.push_back(p.get());
+  body_defined_vars_.clear();
   if (func->body_) {
     var_collectors::VarDefUseCollector body_collector;
     body_collector.VisitStmt(func->body_);
     defs.insert(defs.end(), body_collector.var_defs_ordered.begin(), body_collector.var_defs_ordered.end());
+    body_defined_vars_ = std::move(body_collector.var_defs);
   }
   auto_name::BuildRenameMapForDefs(defs, var_rename_map_);
 }
@@ -1592,10 +1597,14 @@ std::string IRPythonPrinter::PrintMemRef(const MemRef& memref) {
   std::ostringstream oss;
   oss << prefix_ << ".MemRef(";
 
-  // Print base Ptr name as string literal to handle forward references
-  // (DDR bases appear in parameter annotations before their alloc statements).
-  // Use GetVarName to respect SSA rename disambiguation.
-  oss << "\"" << GetVarName(memref.base_.get()) << "\"";
+  // Base Ptrs defined in the function body (by alloc statements) are printed as
+  // bare variable references; everything else uses a string literal (forward
+  // references in parameter annotations, standalone type printing, etc.).
+  if (body_defined_vars_.count(memref.base_.get())) {
+    oss << GetVarName(memref.base_.get());
+  } else {
+    oss << "\"" << GetVarName(memref.base_.get()) << "\"";
+  }
 
   // Print byte offset using a temp printer to avoid corrupting the main stream.
   // The temp printer has its own stream_ but shares no rename maps — that's fine

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -1754,6 +1754,7 @@ class TestMemRefRoundTrip:
         # Verify valid Python syntax
         compile(printed, "<test_memref_valid_python>", "exec")
 
+        # No alloc statement defines the base Ptr → falls back to string literal
         assert 'pl.MemRef("mem_vec_0", 0, 16384)' in printed
         assert "pl.Mem.Vec" in printed
 
@@ -1772,6 +1773,7 @@ class TestMemRefRoundTrip:
 
         # Verify the parsed IR contains memref by re-printing
         printed = program.as_python()
+        # No alloc statement defines the base Ptr → falls back to string literal
         assert 'pl.MemRef("mem_ddr_1", 0, 256)' in printed
 
     def test_parse_tile_with_memref(self):
@@ -1790,6 +1792,7 @@ class TestMemRefRoundTrip:
         assert isinstance(program, ir.Program)
 
         printed = program.as_python()
+        # No alloc statement defines the base Ptr → falls back to string literal
         assert 'pl.MemRef("mem_vec_0", 0, 16384)' in printed
         assert "pl.Mem.Vec" in printed
         reparsed = pl.parse(printed)
@@ -1813,6 +1816,7 @@ class TestMemRefRoundTrip:
 
         # Verify both layout and memref are preserved
         printed = program.as_python()
+        # No alloc statement defines the base Ptr → falls back to string literal
         assert 'pl.MemRef("mem_ddr_2", 0, 256)' in printed
         # Layout appears as positional TensorView arg (fixes #323)
         assert "pl.TensorView" in printed
@@ -1866,8 +1870,9 @@ class TestMemRefRoundTrip:
             """)
             parsed1 = pl.parse(code)
             printed = parsed1.as_python()
+            # No alloc statement defines the base Ptr → falls back to string literal
             assert f'pl.MemRef("{base_name}", 0, 16384)' in printed, (
-                f"Expected explicit MemRef constructor in printed output, got: {printed}"
+                f"Expected MemRef string literal in printed output, got: {printed}"
             )
             assert f"pl.Mem.{space_name}" in printed, (
                 f"Expected pl.Mem.{space_name} in printed output, got: {printed}"

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -220,7 +220,8 @@ class TestPythonPrinterProgram:
         code = after.as_python()
 
         assert "pl.Ptr = pl.tile.alloc(" in code
-        assert 'pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_' in code
+        # Body MemRefs use bare variable references (not string literals)
+        assert "pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_" in code
 
 
 class TestPythonPrinterConstDtypeRoundtrip:


### PR DESCRIPTION
## Summary

- `PrintMemRef` now prints base Ptr as a bare variable reference (e.g., `pl.MemRef(mem_vec_0, ...)`) when the base is defined by an alloc statement in the function body
- Falls back to string literal format (e.g., `pl.MemRef("mem_ddr_0", ...)`) for parameter annotations, standalone type printing, or when no alloc defines the base
- Tracks body-defined vars via `body_defined_vars_` set populated from `VarDefUseCollector` during `BuildVarRenameMap` — zero extra traversal cost

## Testing

- [x] All 3427 tests pass (16 skipped)
- [x] Code review passed
- [x] Clang-tidy passed
- [x] Round-trip tests verified (parse → print → parse → structural equality)
- [x] Standalone type printing still uses string format (9 tests)
- [x] Body-defined vars use bare references (printer test)
- [x] Undefined-in-body vars fall back to string (5 memref round-trip tests)