### PR TITLE
fix(instrument): remove 5 of 6 roundtrip suppressions and fix root causes

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -199,6 +199,7 @@ std::string FormatShape(const std::vector<ExprPtr>& shape);
 inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const TileType>& src) {
   if (src->tile_view_.has_value()) {
     dst.blayout = src->tile_view_->blayout;
+    dst.slayout = src->tile_view_->slayout;
     dst.pad = src->tile_view_->pad;
   }
 }

--- a/python/pypto/ir/instruments.py
+++ b/python/pypto/ir/instruments.py
@@ -32,10 +32,14 @@ def make_roundtrip_instrument() -> _passes.CallbackInstrument:
       with SSA ``iter_args`` after ``ConvertToSSA``) have no valid Python DSL syntax.
       The instrument cannot roundtrip what it cannot print; it warns and skips.
 
-    - **UnknownType improvement**: Manually-constructed IR may use
-      ``ir.Call(ir.Op(...))`` without going through ``ir.create_op_call``, leaving
-      the call result typed as ``UnknownType``.  Parsing always infers a concrete
-      type instead — this is a type *improvement*, not a printer/parser bug.
+    - **Variable pointer mismatch**: Dynamic-shape ``Var`` nodes (e.g. ``M``
+      in ``pl.Tensor[[M, N], pl.FP32]``) appear in multiple places (params,
+      return type, body).  The original IR shares a single ``Var`` pointer
+      across all occurrences, but the parser may create separate ``Var``
+      objects for each occurrence.  ``structural_equal`` uses pointer-based
+      bijection and detects this as a mismatch.  This is a parser limitation
+      — it should reuse the same ``Var`` object for same-named dynamic-shape
+      parameters across all scopes.
 
     Returns:
         A ``CallbackInstrument`` named ``"RoundtripInstrument"``.
@@ -93,51 +97,13 @@ def make_roundtrip_instrument() -> _passes.CallbackInstrument:
             _ir.assert_structural_equal(program, reparsed)
         except Exception as exc:
             error_msg = str(exc)
-            # UnknownType in the original IR comes from manually-constructed IR that
-            # bypasses C++ type inference (ir.Call(ir.Op(...)) without create_op_call).
-            # Parsing always infers a concrete type in its place — this is a type
-            # improvement, not a printer/parser asymmetry.
-            if "UnknownType !=" in error_msg or "!= UnknownType" in error_msg:
-                return
-            # Variable pointer mismatch occurs when dynamic-shape Var nodes appear in
-            # return types or other positions outside the function body, where the
-            # first-encounter bijection in structural_equal cannot establish a mapping.
-            # This is a structural_equal limitation with dynamic shapes, not a
-            # printer/parser bug — the printed IR is faithfully parsed.
+            # Variable pointer mismatch: dynamic-shape Var nodes (e.g. M in
+            # Tensor[[M, N], FP32]) share a single pointer in the original IR,
+            # but the parser may create separate Var objects for each occurrence.
+            # The bijection in structural_equal detects this as a mismatch.
+            # TODO(#929): fix the parser to reuse same-named dynamic-shape Var
+            # objects across param types, return types, and body — then remove.
             if "Variable pointer mismatch" in error_msg:
-                return
-            # tensor.add(x, scalar) → tensor.adds: the Python API dispatches scalar rhs
-            # to tensor.adds, so manually-constructed tensor.add(x, scalar_const) is
-            # normalized by roundtrip.  This is an IR-level discrepancy in the original,
-            # not a printer/parser bug.
-            if "Operator name mismatch" in error_msg and (
-                "'tensor.add' != 'tensor.adds'" in error_msg or "'tensor.adds' != 'tensor.add'" in error_msg
-            ):
-                return
-            # tile.load 3-arg → 4-arg: manually-constructed tile.load via ir.Call(ir.Op(...))
-            # may have only 3 positional args (tensor, offsets, shapes).  The Python API
-            # always produces 4 args (adding valid_shapes=shapes by default), and the C++
-            # type inference requires exactly 4 args.  The printer's special case pads the
-            # 3-arg form to 4-arg when printing, so the parsed version has 4 args.
-            # This 1-arg discrepancy is a manual-construction artifact, not a printer/parser bug.
-            if "Vector size mismatch (3 items != 4 items)" in error_msg:
-                return
-            # TileType tile_view presence mismatch: some passes (e.g. InferTileMemorySpace)
-            # update the Var type without rebuilding the Call's result type, creating a
-            # Var.type != Call.type inconsistency in the original IR.  On reparse, the
-            # annotation-driven override rebuilds the Call and introduces a presence
-            # mismatch between the original (implicit TileView = None) and parsed
-            # (non-implicit TileView from annotation).  This is a pass-level design issue,
-            # not a printer/parser asymmetry.
-            if "TileType tile_view presence mismatch" in error_msg:
-                return
-            # ScopeStmt InCore split presence mismatch: interchange_chunk_loops creates
-            # ScopeKind::InCore scopes with split_ set (propagated from the consumed
-            # AutoInCore). The printer emits these as pl.at(level=pl.Level.CORE_GROUP)
-            # (no split), because there is no DSL syntax for InCore-with-split.
-            # The split is consumed by outline_incore_scopes, so it is a transient
-            # internal attribute that roundtrip cannot preserve.
-            if "SplitMode optional presence mismatch" in error_msg:
                 return
             raise RuntimeError(
                 f"[RoundtripInstrument] Structural equality failed after pass '{pass_name}'.\n"

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -288,6 +288,39 @@ class TileMemorySpaceMutator : public IRMutator {
     return registry.Create(op->op_->name_, new_args, op->kwargs_, op->span_);
   }
 
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto new_var_expr = IRMutator::VisitExpr(op->var_);
+    auto new_value = IRMutator::VisitExpr(op->value_);
+    auto new_var = As<Var>(new_var_expr);
+    if (!new_var) {
+      if (new_var_expr.get() == op->var_.get() && new_value.get() == op->value_.get()) return op;
+      return std::make_shared<AssignStmt>(As<Var>(new_var_expr), new_value, op->span_);
+    }
+
+    // Sync LHS Var type with the rebuilt Call's result type.  When VisitExpr_(CallPtr)
+    // rebuilds the Call via OpRegistry after substituting moved arguments, the deduced
+    // result type may differ from the LHS Var's original type (e.g. tile_view changes
+    // because the inputs now have different layouts).  Without this sync, the Var
+    // annotation and the Call result type disagree, which breaks roundtrip equality.
+    auto new_call = As<Call>(new_value);
+    auto old_tile_type = As<TileType>(new_var->GetType());
+    if (new_call && old_tile_type) {
+      auto new_tile_type = As<TileType>(new_call->GetType());
+      if (new_tile_type && new_tile_type.get() != old_tile_type.get()) {
+        // Preserve the Var's memory_space (set by VisitExpr_(VarPtr) based on var_memory_).
+        auto synced_type =
+            std::make_shared<TileType>(new_tile_type->shape_, new_tile_type->dtype_, new_tile_type->memref_,
+                                       new_tile_type->tile_view_, old_tile_type->memory_space_);
+        auto synced_var = std::make_shared<Var>(new_var->name_hint_, std::move(synced_type), new_var->span_);
+        var_cache_[op->var_] = synced_var;
+        new_var = synced_var;
+      }
+    }
+
+    if (new_var.get() == op->var_.get() && new_value.get() == op->value_.get()) return op;
+    return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
+  }
+
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
     bool changed = false;
     auto new_stmts = VisitAndInsertMoves(op->stmts_, changed);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -553,22 +553,6 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     return;
   }
 
-  // Special handling for tile.load: always print full form to ensure roundtrip stability.
-  // IR built directly via ir.Call may have only 3 positional args (tensor, offsets, shapes)
-  // but the Python API pl.tile.load() defaults valid_shapes=shapes, target_memory=Vec,
-  // transpose=False — after reparsing those defaults are filled in, causing mismatch.
-  if (op->op_->name_ == "tile.load" && op->args_.size() == 3 && op->kwargs_.empty()) {
-    VisitExpr(op->args_[0]);  // source tensor
-    stream_ << ", ";
-    VisitExpr(op->args_[1]);  // offsets
-    stream_ << ", ";
-    VisitExpr(op->args_[2]);  // shapes
-    stream_ << ", ";
-    VisitExpr(op->args_[2]);  // valid_shapes = shapes (default)
-    stream_ << ", target_memory=" << prefix_ << ".Mem.Vec, transpose=False)";
-    return;
-  }
-
   // Print positional arguments
   for (size_t i = 0; i < op->args_.size(); ++i) {
     if (i > 0) stream_ << ", ";

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1306,7 +1306,7 @@ class TestEscapingVariables:
         # Body: out = add(a, c)  — 'out' is first defined HERE, inside the loop
         out = ir.Var("out", tensor_type, span)
         add_op = ir.Op("tensor.add")
-        add_call = ir.Call(add_op, [a, c], span)
+        add_call = ir.Call(add_op, [a, c], tensor_type, span)
         body = ir.AssignStmt(out, add_call, span)
 
         # ForStmt with NO iter_args/return_vars (pre-SSA form)
@@ -1456,7 +1456,7 @@ class TestEscapingVariables:
         # else branch: out = add(x, c) — variable defined only here
         out = ir.Var("out", tensor_type, span)
         add_op = ir.Op("tensor.add")
-        add_call = ir.Call(add_op, [x, c], span)
+        add_call = ir.Call(add_op, [x, c], tensor_type, span)
         else_body = ir.AssignStmt(out, add_call, span)
 
         # then branch: pass (empty — from continue lowering)

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -81,6 +81,19 @@ def _tensor_t(shape: list[int], dtype: DataType) -> ir.TensorType:
     return ir.TensorType(shape, dtype)
 
 
+def _load_call(
+    source: ir.Var, offsets: ir.MakeTuple, shapes: ir.MakeTuple, tile_type: ir.TileType
+) -> ir.Call:
+    """Build a tile.load Call with default valid_shapes=shapes, target_memory=Vec, transpose=False."""
+    return ir.Call(
+        ir.Op("tile.load"),
+        [source, offsets, shapes, shapes],
+        {"target_memory": ir.MemorySpace.Vec, "transpose": False},
+        tile_type,
+        _SPAN,
+    )
+
+
 def _build_program(build_fn):
     alloc = _MemRefAlloc()
     ib = IRBuilder()
@@ -181,7 +194,7 @@ class TestLegalSharingPreserved:
         offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
         shapes = ir.MakeTuple([_ci(32), _ci(32)], _SPAN)
 
-        load_call = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes], {}, tile1_type, _SPAN)
+        load_call = _load_call(a_var, offsets, shapes, tile1_type)
         adds_call = ir.Call(ir.Op("tile.adds"), [t1, ir.ConstFloat(1.0, _FP32, _SPAN)], {}, tile2_type, _SPAN)
         result_var = ir.Var("result", output_t, _SPAN)
         store_call = ir.Call(ir.Op("tile.store"), [t2, offsets, b_var], result_var.type, _SPAN)
@@ -230,7 +243,7 @@ class TestLegalSharingPreserved:
         offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
         shapes = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
 
-        load_call = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes], {}, load_type, _SPAN)
+        load_call = _load_call(a_var, offsets, shapes, load_type)
         fillpad_call = ir.Call(
             ir.Op("tile.fillpad"),
             [t1],
@@ -287,13 +300,7 @@ class TestAscend910BSplitLoadTpopHazard:
         offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
         tile_shape = ir.MakeTuple([_ci(8), _ci(128)], _SPAN)
 
-        load_call = ir.Call(
-            ir.Op("tile.load"),
-            [down, offsets, tile_shape, tile_shape],
-            {"target_memory": ir.MemorySpace.Vec, "transpose": False},
-            load_t,
-            _SPAN,
-        )
+        load_call = _load_call(down, offsets, tile_shape, load_t)
         tpop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 1}, pipe_t, _SPAN)
         add_call = ir.Call(ir.Op("tile.add"), [down_prev, pipe_chunk], {}, add_t, _SPAN)
         store_call = ir.Call(ir.Op("tile.store"), [down_next, offsets, down], down_tensor_t, _SPAN)
@@ -365,8 +372,8 @@ class TestIllegalSharingSplit:
         shapes_128 = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
         shapes_64 = ir.MakeTuple([_ci(64), _ci(64)], _SPAN)
 
-        load1 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_128], {}, tile1_type, _SPAN)
-        load2 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_64], {}, tile2_type, _SPAN)
+        load1 = _load_call(a_var, offsets, shapes_128, tile1_type)
+        load2 = _load_call(a_var, offsets, shapes_64, tile2_type)
         result_var = ir.Var("result", output_t, _SPAN)
         store_call = ir.Call(ir.Op("tile.store"), [t2, offsets, b_var], result_var.type, _SPAN)
 
@@ -423,8 +430,8 @@ class TestIllegalSharingSplit:
         shapes_128 = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
         shapes_64 = ir.MakeTuple([_ci(64), _ci(64)], _SPAN)
 
-        load1 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_128], {}, tile1_type, _SPAN)
-        load2 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_64], {}, tile2_type, _SPAN)
+        load1 = _load_call(a_var, offsets, shapes_128, tile1_type)
+        load2 = _load_call(a_var, offsets, shapes_64, tile2_type)
         fillpad = ir.Call(
             ir.Op("tile.fillpad"),
             [t2],
@@ -492,7 +499,7 @@ class TestLegalizeWithCodegen:
         offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
         shapes = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
 
-        load_call = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes], {}, load_type, _SPAN)
+        load_call = _load_call(a_var, offsets, shapes, load_type)
         fillpad_call = ir.Call(
             ir.Op("tile.fillpad"),
             [t1],
@@ -557,7 +564,7 @@ class TestLegalizeWithCodegen:
         offsets = ir.MakeTuple([_ci(0), _ci(0)], _SPAN)
         shapes = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
 
-        load_call = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes], {}, load_type, _SPAN)
+        load_call = _load_call(a_var, offsets, shapes, load_type)
         fillpad_call = ir.Call(
             ir.Op("tile.fillpad"),
             [t1],
@@ -637,8 +644,8 @@ class TestLegalizeWithCodegen:
         shapes_128 = ir.MakeTuple([_ci(128), _ci(128)], _SPAN)
         shapes_64 = ir.MakeTuple([_ci(64), _ci(64)], _SPAN)
 
-        load1 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_128], {}, tile1_type, _SPAN)
-        load2 = ir.Call(ir.Op("tile.load"), [a_var, offsets, shapes_64], {}, tile2_type, _SPAN)
+        load1 = _load_call(a_var, offsets, shapes_128, tile1_type)
+        load2 = _load_call(a_var, offsets, shapes_64, tile2_type)
         store_call = ir.Call(ir.Op("tile.store"), [t2, offsets, b_var], result_var.type, _SPAN)
 
         body = ir.SeqStmts(

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -31,7 +31,7 @@ def test_normalize_simple_function():
     assign_before = ir.AssignStmt(
         ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -58,7 +58,7 @@ def test_normalize_simple_function():
     assign_expected = ir.AssignStmt(
         ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -95,7 +95,7 @@ def test_normalize_seqstmts_with_bare_assigns():
     assign1_before = ir.AssignStmt(
         a_before,
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -105,7 +105,7 @@ def test_normalize_seqstmts_with_bare_assigns():
     assign2_before = ir.AssignStmt(
         b_before,
         ir.Call(
-            ir.get_op("tensor.mul"),
+            ir.get_op("tensor.muls"),
             [a_before, ir.ConstFloat(2.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -134,7 +134,7 @@ def test_normalize_seqstmts_with_bare_assigns():
     assign1_expected = ir.AssignStmt(
         a_expected,
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -144,7 +144,7 @@ def test_normalize_seqstmts_with_bare_assigns():
     assign2_expected = ir.AssignStmt(
         b_expected,
         ir.Call(
-            ir.get_op("tensor.mul"),
+            ir.get_op("tensor.muls"),
             [a_expected, ir.ConstFloat(2.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -179,7 +179,7 @@ def test_idempotence():
     assign_before = ir.AssignStmt(
         ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,
@@ -206,7 +206,7 @@ def test_idempotence():
     assign_expected = ir.AssignStmt(
         ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
         ir.Call(
-            ir.get_op("tensor.add"),
+            ir.get_op("tensor.adds"),
             [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
             ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
             span,

--- a/tests/ut/ir/transforms/test_verify_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_verify_ssa_pass.py
@@ -71,7 +71,7 @@ def test_verify_ssa_name_shadowing():
 
         outer_i = ib.let("i", a)
 
-        loop_var = ib.var("i", ir.ScalarType(DataType.INT64))  # Shadows outer 'i'
+        loop_var = ib.var("i", ir.ScalarType(DataType.INDEX))  # Shadows outer 'i'
         with ib.for_loop(loop_var, 0, 5, 1):
             _tmp = ib.let("tmp", loop_var)
 
@@ -93,16 +93,16 @@ def test_verify_ssa_missing_yield():
     params: list[ir.Var] = [a]
     return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-    loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+    loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
     iter_arg = ir.IterArg("sum", ir.ScalarType(DataType.INT64), a, span)
     body = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), loop_var, span)  # No yield!
     result_var = ir.Var("result", ir.ScalarType(DataType.INT64), span)
 
     for_stmt = ir.ForStmt(
         loop_var,
-        ir.ConstInt(0, DataType.INT64, span),
-        ir.ConstInt(10, DataType.INT64, span),
-        ir.ConstInt(1, DataType.INT64, span),
+        ir.ConstInt(0, DataType.INDEX, span),
+        ir.ConstInt(10, DataType.INDEX, span),
+        ir.ConstInt(1, DataType.INDEX, span),
         [iter_arg],
         body,
         [result_var],
@@ -150,7 +150,7 @@ def test_verify_ssa_valid_control_flow():
     return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
     # Valid ForStmt
-    loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+    loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
     iter_arg = ir.IterArg("sum", ir.ScalarType(DataType.INT64), a, span)
     yield_value = ir.Add(iter_arg, loop_var, DataType.INT64, span)
     body = ir.YieldStmt([yield_value], span)
@@ -158,9 +158,9 @@ def test_verify_ssa_valid_control_flow():
 
     for_stmt = ir.ForStmt(
         loop_var,
-        ir.ConstInt(0, DataType.INT64, span),
-        ir.ConstInt(10, DataType.INT64, span),
-        ir.ConstInt(1, DataType.INT64, span),
+        ir.ConstInt(0, DataType.INDEX, span),
+        ir.ConstInt(10, DataType.INDEX, span),
+        ir.ConstInt(1, DataType.INDEX, span),
         [iter_arg],
         body,
         [result_var],
@@ -260,15 +260,15 @@ class TestScopeViolation:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         inner_var = ir.Var("inner", ir.ScalarType(DataType.INT64), span)
         body = ir.AssignStmt(inner_var, loop_var, span)
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [],
             body,
             [],
@@ -315,7 +315,7 @@ class TestScopeViolation:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
         yield_value = ir.Add(iter_arg, loop_var, DataType.INT64, span)
         body = ir.YieldStmt([yield_value], span)
@@ -323,9 +323,9 @@ class TestScopeViolation:
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [iter_arg],
             body,
             [result_var],
@@ -349,14 +349,14 @@ class TestScopeViolation:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         body = ir.YieldStmt([], span)
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [],
             body,
             [],
@@ -408,7 +408,7 @@ class TestCardinalityChecks:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
         body = ir.YieldStmt([iter_arg], span)
         # Two return_vars for one iter_arg — mismatch
@@ -417,9 +417,9 @@ class TestCardinalityChecks:
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [iter_arg],
             body,
             [rv1, rv2],
@@ -442,7 +442,7 @@ class TestCardinalityChecks:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         iter_arg1 = ir.IterArg("acc1", ir.ScalarType(DataType.INT64), a, span)
         iter_arg2 = ir.IterArg("acc2", ir.ScalarType(DataType.INT64), a, span)
         # Only one yield value for two iter_args — mismatch
@@ -452,9 +452,9 @@ class TestCardinalityChecks:
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [iter_arg1, iter_arg2],
             body,
             [rv1, rv2],
@@ -505,7 +505,7 @@ class TestValidScopePatterns:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
         yield_value = ir.Add(iter_arg, loop_var, DataType.INT64, span)
         body = ir.YieldStmt([yield_value], span)
@@ -513,9 +513,9 @@ class TestValidScopePatterns:
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [iter_arg],
             body,
             [result_var],
@@ -561,7 +561,7 @@ class TestValidScopePatterns:
         params: list[ir.Var] = [a]
         return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
 
-        loop_var = ir.Var("i", ir.ScalarType(DataType.INT64), span)
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
         iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
         # Use 'a' (parameter) inside the loop body — should be valid
         yield_value = ir.Add(iter_arg, a, DataType.INT64, span)
@@ -570,9 +570,9 @@ class TestValidScopePatterns:
 
         for_stmt = ir.ForStmt(
             loop_var,
-            ir.ConstInt(0, DataType.INT64, span),
-            ir.ConstInt(5, DataType.INT64, span),
-            ir.ConstInt(1, DataType.INT64, span),
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(5, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
             [iter_arg],
             body,
             [result_var],


### PR DESCRIPTION
## Summary

Closes #929

Remove 5 of 6 error message suppressions from `RoundtripInstrument` structural equality check, fixing underlying issues at their source instead of papering over them.

### Suppressions removed (5)

- **UnknownType**: fixed tests to pass correct result type to `ir.Call` instead of relying on `UnknownType` default
- **tensor.add/adds dispatch**: fixed tests to use `tensor.adds` for scalar operands (matching DSL dispatch)
- **tile.load 3→4 args**: fixed tests to construct 4-arg `tile.load` with `valid_shapes` and kwargs; removed printer special case that padded 3-arg to 4-arg
- **TileType tile_view presence**: already fixed upstream (#777)
- **SplitMode optional presence**: already fixed upstream (#964)

### Additional fixes

- Fixed for-loop vars/bounds in `test_verify_ssa_pass.py` to use `INDEX` dtype (matching DSL `pl.range()` behavior) instead of `INT64`
- Extracted `_load_call()` helper in `test_legalize_pto_buffer_reuse.py` to reduce duplication

### Suppression kept (1)

- **Variable pointer mismatch**: the parser creates separate `Var` objects for same-named dynamic-shape parameters across param types, return types, and body. Root cause tracked in #970.

## Test plan

- [x] All 3416 unit tests pass (0 failures)
- [x] Verified `Variable pointer mismatch` suppression is still needed (test_dynamic_shape fails without it)
- [x] Verified removed suppressions are no longer triggered by any test