### PR TITLE
feat(ir): add guarded chunk policy for dynamic-bound pl.parallel/pl.range

### DIFF
--- a/docs/en/dev/passes/05-split_chunked_loops.md
+++ b/docs/en/dev/passes/05-split_chunked_loops.md
@@ -1,14 +1,19 @@
 # SplitChunkedLoops Pass
 
-Splits loops with `chunk` into nested outer/inner loops for chunked iteration.
+Splits loops with `chunk` into nested outer/inner loops under one of two policies.
 
 ## Overview
 
-This pass transforms for loops created with `chunk=C` into nested loops: an outer loop over chunk indices and an inner loop within each chunk. When the trip count is not divisible by the chunk size, a remainder loop is appended. Runs after SSA conversion and propagates `iter_args` through the generated nested loops.
+This pass transforms a for loop created with `chunk=C` into a pair of nested loops: an outer loop over chunk indices and an inner loop iterating within each chunk. Two codegen policies are supported:
 
-**Requires**: TypeChecked, SSAForm properties.
+- **`guarded`** (default) — emit a single outer loop of `ceil(T/C)` chunks plus an inner loop of `C`, and wrap the body in `if (idx < stop)` (or `idx > stop` for negative step). Out-of-range iterations become no-ops. A single kernel is emitted.
+- **`leading_full`** — emit a full-chunk loop of `T/C` chunks plus a separate remainder loop of `T % C` iterations. Two sibling loops are emitted.
 
-**When to use**: Runs automatically in the default pipeline after `FlattenCallExpr` and before `InterchangeChunkLoops`. Use `chunk=` on `pl.range()`, `pl.parallel()`, or `pl.unroll()` inside a `with pl.auto_incore():` scope to split a loop into chunks. Chunked loops outside `auto_incore` are not split.
+Both policies run after SSA conversion and propagate `iter_args` through the generated loops.
+
+**Requires**: `TypeChecked`, `SSAForm`.
+
+**When to use**: Runs automatically in the default pipeline after `FlattenCallExpr` and before `InterchangeChunkLoops`. Use `chunk=` on `pl.range()`, `pl.parallel()`, or `pl.unroll()` inside a `with pl.auto_incore():` scope. Chunked loops outside `auto_incore` are not split.
 
 ## API
 
@@ -16,119 +21,135 @@ This pass transforms for loops created with `chunk=C` into nested loops: an oute
 | --- | ------ | ----- |
 | `pass::SplitChunkedLoops()` | `passes.split_chunked_loops()` | Function-level |
 
-**Python usage**:
-
 ```python
 from pypto import passes
-
 result = passes.split_chunked_loops()(program)
 ```
 
 ## DSL Syntax
 
-Chunked loops must be wrapped in `with pl.auto_incore():` to be split:
+Chunked loops must be wrapped in `with pl.auto_incore():`:
 
 ```python
 with pl.auto_incore():
-    # Chunked sequential loop: 10 iterations in chunks of 5
+    # Default (guarded): single kernel with if-guard
     for i in pl.range(10, chunk=5):
         x = pl.add(x, 1.0)
 
-    # Chunked parallel loop: inner loop is parallel, outer is sequential
-    for i in pl.parallel(8, chunk=4):
+    # Explicit guarded (same as default)
+    for i in pl.parallel(n, chunk=4, chunk_policy="guarded"):
         x = pl.add(x, 1.0)
 
-    # Chunked unroll loop: inner loop is unrolled, outer is sequential
-    for i in pl.unroll(12, chunk=4):
+    # Explicit leading_full: peels remainder into separate loop
+    for i in pl.range(7, chunk=5, chunk_policy="leading_full"):
         x = pl.add(x, 1.0)
+
+    # iter_args are supported under both policies
+    for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
+        s = pl.add(s, 1.0)
+        s = pl.yield_(s)
 ```
 
-Chunked loops outside `auto_incore` are rejected earlier by the DSL parser, so this pass only sees valid chunked loops that are already inside `auto_incore`.
+## Choosing a Policy
+
+| Criterion | Prefer `guarded` | Prefer `leading_full` |
+| --------- | ---------------- | --------------------- |
+| Dynamic bound (`stop` not a compile-time constant) | ✅ — single kernel preserves loop-carried state across the boundary | ❌ — remainder kernel receives iter_args as input-only copies, breaking cross-iteration accumulation |
+| Static bound, trip_count known divisible | Slightly redundant guard | ✅ — no guard, no remainder |
+| Want minimum kernel count under `pl.auto_incore()` | ✅ | Produces 2 kernels per chunked loop |
+| Want to eliminate masked iterations inside the hot loop | ❌ | ✅ — full chunks run unconditionally |
+
+`guarded` is the default because (1) it preserves `add_inout()` accumulation under dynamic bounds and (2) it avoids doubling the kernel count under `pl.auto_incore()`.
 
 ## Constraints
 
 | Constraint | Reason |
 | ---------- | ------ |
-| `start`, `stop`, `step`, `chunk` must be integer constants | Values needed at compile time |
-| `chunk` must be a positive integer | Non-positive chunk sizes are invalid |
-| `chunk` cannot be used with `init_values` in DSL | User-specified iter_args not supported on chunked loops |
-| Chunked loops must be inside `pl.auto_incore()` | Only loops within `auto_incore` scope are split |
+| `step`, `chunk` must be integer constants | Needed at compile time |
+| `chunk` must be a positive integer | Non-positive sizes are invalid |
+| `step` may be negative (descending loop) | `guarded` adapts the predicate to the step sign |
+| `start`, `stop` may be dynamic expressions under `guarded` | Trip count becomes `max(abs(stop - start), 0) / abs(step)` |
+| Chunked loop must be inside `pl.auto_incore()` | Only `auto_incore`-scoped loops are split |
+| `chunk` may be combined with `init_values` | Both policies thread iter_args through the generated loops |
 
 ## Algorithm
 
-Given a chunked loop in SSA form:
+Let `T = ceil(max(|stop - start|, 0) / |step|)` and `C = chunk`.
 
-```text
-for i, (x__iter_v1=x__ssa_v0,) in range(start, stop, step, chunk=C) -> (x__rv_v2,):
-    x__ssa_v3 = add(x__iter_v1, 1.0)
-    yield(x__ssa_v3)
-```
+### `guarded` (default)
 
-1. Compute `trip_count = ceil((stop - start) / step)`
-2. `num_full_chunks = trip_count // C`, `remainder = trip_count % C`
-3. Generate outer loop with iter_args initialized from original init values
-4. Generate inner loop with iter_args fed from outer iter_args, body substitution: `i = start + (i_out * C + i_in) * step`
-5. Inner loop yields to inner return_vars; outer loop yields inner return_vars to outer return_vars
-6. If `remainder > 0`, generate remainder loop with iter_args chained from outer return_vars
-7. Remap original return_vars to the final loop's return_vars
+1. `n_total = ceil(T / C)` — static when bounds are const, otherwise `(T + C - 1) // C`.
+2. Emit outer loop `for out_var in [0, n_total)` and inner loop `for in_var in [0, C)`.
+3. Compute `idx = start + (out_var * C + in_var) * step` (substituted into body).
+4. Wrap the visited body in an `IfStmt` whose condition is:
+   - `idx < stop` when `step > 0`
+   - `idx > stop` when `step < 0`
+5. **Without iter_args** — IfStmt has no else branch; skipped iterations are no-ops.
+6. **With iter_args** — IfStmt gets `return_vars` acting as phi nodes: the then-branch keeps the user body's trailing `YieldStmt` (updated values), the else-branch yields the inner iter_args unchanged. The inner loop's trailing `YieldStmt` references the IfStmt's phi vars, so loop-carried state threads through both guarded and skipped iterations.
 
-The inner loop preserves the original `ForKind` (Sequential, Parallel, or Unroll). The outer loop is always Sequential.
+### `leading_full`
+
+1. `n_full = T // C`, `n_rem = T % C`.
+2. Emit outer loop `for out_var in [0, n_full)` and inner loop `for in_var in [0, C)` with `idx = start + (out_var * C + in_var) * step`. Skip if `n_full == 0`.
+3. If `n_rem > 0`, emit a remainder loop `for rem_var in [0, n_rem)` with `idx = start + (n_full * C + rem_var) * step`. Its `init_values` chain from the outer loop's `return_vars` (or from the original init if no full-chunk loop was emitted).
+4. Remap the original `return_vars` to the final loop's `return_vars`.
+
+Both paths preserve the original `ForKind` (Sequential, Parallel, or Unroll) on inner and outer/remainder loops.
 
 ## Auto-Name Abbreviations
 
-The printed IR examples use the compact auto-name format `base__qualifier_role_vN`.
-To keep generated names readable, some qualifiers are abbreviated:
+Printed IR uses the compact auto-name format `base__qualifier_role_vN`. Abbreviated qualifiers:
 
-| Abbreviation | Meaning |
-| ------------ | ------- |
-| `co` | `chunk_outer` |
-| `ci` | `chunk_inner` |
-| `cr` | `chunk_rem` / chunk remainder |
+| Abbreviation | Meaning | Emitted by |
+| ------------ | ------- | ---------- |
+| `co` | chunk_outer | both policies |
+| `ci` | chunk_inner | both policies |
+| `cr` | chunk_rem (remainder) | `leading_full` only |
+| `cg` | chunk_guard (IfStmt phi) | `guarded` with iter_args only |
 
-Examples:
+Examples: `i__co_idx_v0` (outer index), `x__ci_iter_v1` (inner iter_arg), `x__cr_rv_v1` (remainder return var), `x__cg_rv_v1` (IfStmt phi var).
 
-- `i__co_idx_v0` = outer chunk loop index
-- `x__ci_iter_v1` = inner chunk iter_arg
-- `x__cr_rv_v1` = remainder-loop return var
+## Examples
 
-Roles such as `idx`, `iter`, `rv`, and `ssa` keep their full spelling because they are already short and commonly used across passes.
+### `guarded`, divisible (`chunk=5`, trip_count=10)
 
-## Example
-
-**Before** (printed SSA IR form; not valid DSL source since `chunk` + `init_values` is forbidden in the DSL):
+**After**:
 
 ```python
-@pl.program
-class Before:
-    @pl.function
-    def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        for i__idx_v0, (x__iter_v1,) in pl.range(10, init_values=(x__ssa_v0,), chunk=5):
-            x__ssa_v3 = pl.tensor.add(x__iter_v1, 1.0)
-            x__rv_v2 = pl.yield_(x__ssa_v3)
-        return x__rv_v2
+for i__co_idx_v0, (x__co_iter_v1,) in pl.range(2, init_values=(x__ssa_v0,)):
+    for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(5, init_values=(x__co_iter_v1,)):
+        if i__co_idx_v0 * 5 + i__ci_idx_v0 < 10:
+            x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
+            x__cg_rv_v1 = pl.yield_(x__ssa_v3)
+        else:
+            x__cg_rv_v1 = pl.yield_(x__ci_iter_v1)
+        x__ci_rv_v1 = pl.yield_(x__cg_rv_v1)
+    x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
+return x__co_rv_v1
 ```
 
-**After** (nested loops, divisible):
+### `guarded`, dynamic bound (`chunk=4`, `stop=n`)
+
+**After** (single kernel, `n_total = (n + 3) // 4`):
 
 ```python
-@pl.program
-class After:
-    @pl.function
-    def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        for i__co_idx_v0, (x__co_iter_v1,) in pl.range(2, init_values=(x__ssa_v0,)):
-            for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(
-                5, init_values=(x__co_iter_v1,)
-            ):
-                x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
-                x__ci_rv_v1 = pl.yield_(x__ssa_v3)
-            x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
-        return x__co_rv_v1
+for i__co_idx_v0, (x__co_iter_v1,) in pl.range((n + 3) // 4, init_values=(x__ssa_v0,)):
+    for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(4, init_values=(x__co_iter_v1,)):
+        if i__co_idx_v0 * 4 + i__ci_idx_v0 < n:
+            x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
+            x__cg_rv_v1 = pl.yield_(x__ssa_v3)
+        else:
+            x__cg_rv_v1 = pl.yield_(x__ci_iter_v1)
+        x__ci_rv_v1 = pl.yield_(x__cg_rv_v1)
+    x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
+return x__co_rv_v1
 ```
 
-**With remainder** (`chunk=5`, trip_count=7):
+### `leading_full`, non-divisible (`chunk=5`, trip_count=7)
+
+**After** (two sibling loops):
 
 ```python
-# Generates: outer(0,1) * inner(0,5) + remainder(0,2)
 for i__co_idx_v0, (x__co_iter_v1,) in pl.range(1, init_values=(x__ssa_v0,)):
     for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(5, init_values=(x__co_iter_v1,)):
         x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
@@ -142,16 +163,14 @@ return x__cr_rv_v1
 
 ## LoopOrigin Tagging
 
-Each generated loop is tagged with a `LoopOrigin` annotation indicating how it was produced:
+| LoopOrigin | Description | Emitted by |
+| ---------- | ----------- | ---------- |
+| `Original` | Regular user loop (default) | — |
+| `ChunkOuter` | Outer loop over chunk indices | both policies |
+| `ChunkInner` | Inner loop within a chunk | both policies |
+| `ChunkRemainder` | Remainder loop for leftover iterations | `leading_full` only |
 
-| LoopOrigin | Description |
-| ---------- | ----------- |
-| `Original` | Regular loop (default, not generated by splitting) |
-| `ChunkOuter` | Outer loop iterating over chunk indices |
-| `ChunkInner` | Inner loop iterating within a chunk |
-| `ChunkRemainder` | Remainder loop for leftover iterations |
-
-Access via `for_stmt.attrs.get("loop_origin")` (Python) or `for_stmt->GetAttr<LoopOrigin>("loop_origin")` (C++). Downstream passes can use this to distinguish generated loops from user-written ones.
+Access via `for_stmt.attrs.get("loop_origin")` (Python) or `for_stmt->GetAttr<LoopOrigin>("loop_origin")` (C++).
 
 ## Pipeline Position
 

--- a/docs/zh-cn/dev/passes/05-split_chunked_loops.md
+++ b/docs/zh-cn/dev/passes/05-split_chunked_loops.md
@@ -1,14 +1,19 @@
 # SplitChunkedLoops Pass
 
-将带有 `chunk` 的循环拆分为嵌套的外层/内层循环，实现分块迭代。
+将带有 `chunk` 的循环按两种策略之一拆分为嵌套的外层/内层循环。
 
 ## 概述
 
-此 Pass 将使用 `chunk=C` 创建的 for 循环转换为嵌套循环：外层循环遍历分块索引，内层循环在每个分块内迭代。当迭代总次数不能被分块大小整除时，会附加一个余数循环 (remainder loop)。在 SSA 转换之后运行，将 `iter_args` 传播到生成的嵌套循环中。
+此 Pass 将使用 `chunk=C` 创建的 for 循环转换为嵌套循环：外层循环遍历分块索引，内层循环在每个分块内迭代。支持两种生成策略：
 
-**前置条件**: TypeChecked、SSAForm 属性。
+- **`guarded`**（默认）— 发射一个长度为 `ceil(T/C)` 的外层循环和一个长度为 `C` 的内层循环，并用 `if (idx < stop)`（负步长时为 `idx > stop`）包裹循环体。越界迭代变为空操作。只发射一个 kernel。
+- **`leading_full`** — 发射一个长度为 `T/C` 的满块循环加一个长度为 `T % C` 的独立余数循环。发射两个并列循环。
 
-**使用时机**: 在默认流水线中自动运行，位于 `FlattenCallExpr` 之后、`InterchangeChunkLoops` 之前。在 `with pl.auto_incore():` 作用域内的 `pl.range()`、`pl.parallel()` 或 `pl.unroll()` 上使用 `chunk=` 来将循环拆分为分块。`auto_incore` 之外的分块循环不会被拆分。
+两种策略都在 SSA 转换之后运行，并将 `iter_args` 传播到生成的循环中。
+
+**前置条件**: `TypeChecked`、`SSAForm`。
+
+**使用时机**: 在默认流水线中自动运行，位于 `FlattenCallExpr` 之后、`InterchangeChunkLoops` 之前。在 `with pl.auto_incore():` 作用域内的 `pl.range()`、`pl.parallel()`、`pl.unroll()` 上使用 `chunk=`。`auto_incore` 之外的分块循环不会被拆分。
 
 ## API
 
@@ -16,119 +21,135 @@
 | --- | ------ | ---- |
 | `pass::SplitChunkedLoops()` | `passes.split_chunked_loops()` | 函数级 |
 
-**Python 用法**:
-
 ```python
 from pypto import passes
-
 result = passes.split_chunked_loops()(program)
 ```
 
 ## DSL 语法
 
-分块循环必须包裹在 `with pl.auto_incore():` 中才会被拆分：
+分块循环必须包裹在 `with pl.auto_incore():` 中：
 
 ```python
 with pl.auto_incore():
-    # 分块顺序循环：10 次迭代，每块 5 次
+    # 默认 (guarded)：单 kernel + if-guard
     for i in pl.range(10, chunk=5):
         x = pl.add(x, 1.0)
 
-    # 分块并行循环：内层循环并行，外层顺序
-    for i in pl.parallel(8, chunk=4):
+    # 显式 guarded（与默认等价）
+    for i in pl.parallel(n, chunk=4, chunk_policy="guarded"):
         x = pl.add(x, 1.0)
 
-    # 分块展开循环：内层循环展开，外层顺序
-    for i in pl.unroll(12, chunk=4):
+    # 显式 leading_full：余数剥离为独立循环
+    for i in pl.range(7, chunk=5, chunk_policy="leading_full"):
         x = pl.add(x, 1.0)
+
+    # 两种策略都支持 iter_args
+    for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
+        s = pl.add(s, 1.0)
+        s = pl.yield_(s)
 ```
 
-`auto_incore` 之外的分块循环会在 DSL parser 阶段被提前拒绝，因此该 Pass 只会看到已经位于 `auto_incore` 内的合法分块循环。
+## 策略选择
+
+| 场景 | 偏好 `guarded` | 偏好 `leading_full` |
+| ---- | -------------- | ------------------- |
+| 动态 bound（`stop` 非编译期常量） | ✅ —— 单 kernel 保留跨边界的 loop-carried 状态 | ❌ —— 余数 kernel 的 iter_args 只能以 input-only 拷贝方式传入，破坏跨迭代累积 |
+| 静态 bound 且可整除 | guard 稍显冗余 | ✅ —— 无 guard、无余数 |
+| 希望 `pl.auto_incore()` 下 kernel 数量最少 | ✅ | 每个分块循环会生成 2 个 kernel |
+| 希望热点循环内部不存在掩码迭代 | ❌ | ✅ —— 满块无条件执行 |
+
+`guarded` 被设为默认，原因在于：(1) 动态 bound 下能保留 `add_inout()` 累积；(2) 避免 `pl.auto_incore()` 下 kernel 数量翻倍。
 
 ## 约束
 
 | 约束 | 原因 |
 | ---- | ---- |
-| `start`、`stop`、`step`、`chunk` 必须为整数常量 | 编译时需要确定值 |
+| `step`、`chunk` 必须为整数常量 | 编译期需要确定值 |
 | `chunk` 必须为正整数 | 非正数的分块大小无效 |
-| DSL 中 `chunk` 不能与 `init_values` 一起使用 | 分块循环不支持用户指定的 iter_args |
+| `step` 可以为负（下降循环） | `guarded` 会根据步长符号选择判据 |
+| `start`、`stop` 在 `guarded` 下可以是动态表达式 | 迭代次数取 `max(abs(stop - start), 0) / abs(step)` |
 | 分块循环必须在 `pl.auto_incore()` 内 | 仅 `auto_incore` 作用域内的循环会被拆分 |
+| `chunk` 可以与 `init_values` 同时使用 | 两种策略都会将 iter_args 串联到生成的循环 |
 
 ## 算法
 
-给定 SSA 形式的分块循环：
+记 `T = ceil(max(|stop - start|, 0) / |step|)`，`C = chunk`。
 
-```text
-for i, (x__iter_v1=x__ssa_v0,) in range(start, stop, step, chunk=C) -> (x__rv_v2,):
-    x__ssa_v3 = add(x__iter_v1, 1.0)
-    yield(x__ssa_v3)
-```
+### `guarded`（默认）
 
-1. 计算 `trip_count = ceil((stop - start) / step)`
-2. `num_full_chunks = trip_count // C`，`remainder = trip_count % C`
-3. 生成外层循环，iter_args 从原始初始值初始化
-4. 生成内层循环，iter_args 从外层 iter_args 提供，循环体替换：`i = start + (i_out * C + i_in) * step`
-5. 内层循环 yield 到内层 return_vars；外层循环 yield 内层 return_vars 到外层 return_vars
-6. 若 `remainder > 0`，生成余数循环，iter_args 从外层 return_vars 链接
-7. 将原始 return_vars 重映射到最终循环的 return_vars
+1. `n_total = ceil(T / C)`。静态 bound 直接计算，动态 bound 用 `(T + C - 1) // C`。
+2. 发射外层循环 `for out_var in [0, n_total)` 与内层循环 `for in_var in [0, C)`。
+3. 计算 `idx = start + (out_var * C + in_var) * step`，并替换到循环体里。
+4. 将访问后的循环体包裹进 `IfStmt`，条件为：
+   - `idx < stop`（当 `step > 0`）
+   - `idx > stop`（当 `step < 0`）
+5. **无 iter_args** —— IfStmt 无 else 分支；被跳过的迭代为空操作。
+6. **有 iter_args** —— IfStmt 的 `return_vars` 作为 phi：then 分支保留用户循环体的末尾 `YieldStmt`（更新后的值），else 分支 yield 未变的 inner iter_args。内层循环的末尾 `YieldStmt` 引用 IfStmt 的 phi 变量，从而在生效与被跳过的迭代之间都能串联循环携带状态。
 
-内层循环保留原始的 `ForKind`（Sequential、Parallel 或 Unroll），外层循环始终为 Sequential。
+### `leading_full`
+
+1. `n_full = T // C`，`n_rem = T % C`。
+2. 发射外层 `for out_var in [0, n_full)` 与内层 `for in_var in [0, C)`，`idx = start + (out_var * C + in_var) * step`；若 `n_full == 0` 则跳过。
+3. 若 `n_rem > 0`，发射余数循环 `for rem_var in [0, n_rem)`，`idx = start + (n_full * C + rem_var) * step`。其 `init_values` 链接自外层循环的 `return_vars`（如果没有满块循环，则链接自原始 init 值）。
+4. 将原始 `return_vars` 重映射到最终循环的 `return_vars`。
+
+两种路径都在内层与外层/余数循环上保留原始的 `ForKind`（Sequential、Parallel、Unroll）。
 
 ## 自动命名缩写
 
-打印出来的 IR 示例使用紧凑的自动命名格式 `base__qualifier_role_vN`。
-为了让生成名更短、更易读，一些 qualifier 采用了缩写：
+打印出来的 IR 使用紧凑的自动命名格式 `base__qualifier_role_vN`。缩写 qualifier：
 
-| 缩写 | 含义 |
-| ---- | ---- |
-| `co` | `chunk_outer` |
-| `ci` | `chunk_inner` |
-| `cr` | `chunk_rem` / 余数分块 |
+| 缩写 | 含义 | 发射时机 |
+| ---- | ---- | -------- |
+| `co` | chunk_outer | 两种策略 |
+| `ci` | chunk_inner | 两种策略 |
+| `cr` | chunk_rem（余数） | 仅 `leading_full` |
+| `cg` | chunk_guard（IfStmt phi） | 仅带 iter_args 的 `guarded` |
 
-示例：
-
-- `i__co_idx_v0`：外层分块循环索引
-- `x__ci_iter_v1`：内层分块 iter_arg
-- `x__cr_rv_v1`：余数循环 return var
-
-像 `idx`、`iter`、`rv`、`ssa` 这样的 role 保持全拼，因为它们已经足够短，而且在多个 pass 中通用。
+示例：`i__co_idx_v0`（外层索引）、`x__ci_iter_v1`（内层 iter_arg）、`x__cr_rv_v1`（余数 return var）、`x__cg_rv_v1`（IfStmt phi 变量）。
 
 ## 示例
 
-**之前**（打印的 SSA IR 形式；非合法 DSL 源码，因为 DSL 中 `chunk` + `init_values` 不能同时使用）：
+### `guarded`，可整除（`chunk=5`，trip_count=10）
+
+**之后**：
 
 ```python
-@pl.program
-class Before:
-    @pl.function
-    def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        for i__idx_v0, (x__iter_v1,) in pl.range(10, init_values=(x__ssa_v0,), chunk=5):
-            x__ssa_v3 = pl.tensor.add(x__iter_v1, 1.0)
-            x__rv_v2 = pl.yield_(x__ssa_v3)
-        return x__rv_v2
+for i__co_idx_v0, (x__co_iter_v1,) in pl.range(2, init_values=(x__ssa_v0,)):
+    for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(5, init_values=(x__co_iter_v1,)):
+        if i__co_idx_v0 * 5 + i__ci_idx_v0 < 10:
+            x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
+            x__cg_rv_v1 = pl.yield_(x__ssa_v3)
+        else:
+            x__cg_rv_v1 = pl.yield_(x__ci_iter_v1)
+        x__ci_rv_v1 = pl.yield_(x__cg_rv_v1)
+    x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
+return x__co_rv_v1
 ```
 
-**之后**（嵌套循环，整除情况）：
+### `guarded`，动态 bound（`chunk=4`，`stop=n`）
+
+**之后**（单 kernel，`n_total = (n + 3) // 4`）：
 
 ```python
-@pl.program
-class After:
-    @pl.function
-    def main(self, x__ssa_v0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        for i__co_idx_v0, (x__co_iter_v1,) in pl.range(2, init_values=(x__ssa_v0,)):
-            for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(
-                5, init_values=(x__co_iter_v1,)
-            ):
-                x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
-                x__ci_rv_v1 = pl.yield_(x__ssa_v3)
-            x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
-        return x__co_rv_v1
+for i__co_idx_v0, (x__co_iter_v1,) in pl.range((n + 3) // 4, init_values=(x__ssa_v0,)):
+    for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(4, init_values=(x__co_iter_v1,)):
+        if i__co_idx_v0 * 4 + i__ci_idx_v0 < n:
+            x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
+            x__cg_rv_v1 = pl.yield_(x__ssa_v3)
+        else:
+            x__cg_rv_v1 = pl.yield_(x__ci_iter_v1)
+        x__ci_rv_v1 = pl.yield_(x__cg_rv_v1)
+    x__co_rv_v1 = pl.yield_(x__ci_rv_v1)
+return x__co_rv_v1
 ```
 
-**带余数**（`chunk=5`，trip_count=7）：
+### `leading_full`，不可整除（`chunk=5`，trip_count=7）
+
+**之后**（两个并列循环）：
 
 ```python
-# 生成：outer(0,1) * inner(0,5) + remainder(0,2)
 for i__co_idx_v0, (x__co_iter_v1,) in pl.range(1, init_values=(x__ssa_v0,)):
     for i__ci_idx_v0, (x__ci_iter_v1,) in pl.range(5, init_values=(x__co_iter_v1,)):
         x__ssa_v3 = pl.tensor.add(x__ci_iter_v1, 1.0)
@@ -142,16 +163,14 @@ return x__cr_rv_v1
 
 ## LoopOrigin 标记
 
-每个生成的循环都带有 `LoopOrigin` 注解，标识其产生方式：
+| LoopOrigin | 说明 | 发射时机 |
+| ---------- | ---- | -------- |
+| `Original` | 普通用户循环（默认） | — |
+| `ChunkOuter` | 遍历分块索引的外层循环 | 两种策略 |
+| `ChunkInner` | 在分块内迭代的内层循环 | 两种策略 |
+| `ChunkRemainder` | 处理剩余迭代的余数循环 | 仅 `leading_full` |
 
-| LoopOrigin | 说明 |
-| ---------- | ---- |
-| `Original` | 普通循环（默认，非拆分生成） |
-| `ChunkOuter` | 遍历分块索引的外层循环 |
-| `ChunkInner` | 在分块内迭代的内层循环 |
-| `ChunkRemainder` | 处理剩余迭代的余数循环 |
-
-通过 `for_stmt.attrs.get("loop_origin")`（Python）或 `for_stmt->GetAttr<LoopOrigin>("loop_origin")`（C++）访问。下游 Pass 可使用此标记区分生成的循环与用户编写的循环。
+通过 `for_stmt.attrs.get("loop_origin")`（Python）或 `for_stmt->GetAttr<LoopOrigin>("loop_origin")`（C++）访问。
 
 ## 流水线位置
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -61,7 +61,8 @@ enum class ForKind : uint8_t {
  * Controls how iterations are distributed across chunks.
  */
 enum class ChunkPolicy : uint8_t {
-  LeadingFull = 0  ///< Full chunks first, smaller remainder at end
+  LeadingFull = 0,  ///< Full chunks first, smaller remainder at end (splits into two kernels)
+  Guarded = 1       ///< Single loop over ceil(N/C) chunks with per-iteration if-guard (default)
 };
 
 /**
@@ -71,6 +72,8 @@ inline std::string ChunkPolicyToString(ChunkPolicy policy) {
   switch (policy) {
     case ChunkPolicy::LeadingFull:
       return "LeadingFull";
+    case ChunkPolicy::Guarded:
+      return "Guarded";
     default:
       INTERNAL_CHECK(false) << "Unknown ChunkPolicy: " << static_cast<int>(policy);
       return "";  // Unreachable
@@ -84,6 +87,9 @@ inline ChunkPolicy StringToChunkPolicy(const std::string& str) {
   if (str == "LeadingFull" || str == "leading_full") {
     return ChunkPolicy::LeadingFull;
   }
+  if (str == "Guarded" || str == "guarded") {
+    return ChunkPolicy::Guarded;
+  }
   throw pypto::TypeError("Unknown ChunkPolicy: " + str);
 }
 
@@ -94,8 +100,8 @@ inline ChunkPolicy StringToChunkPolicy(const std::string& str) {
  * Only meaningful on parallel (chunked) loops.
  */
 struct ChunkConfig {
-  ExprPtr size;                                   ///< Chunk size expression
-  ChunkPolicy policy = ChunkPolicy::LeadingFull;  ///< Distribution policy
+  ExprPtr size;                               ///< Chunk size expression
+  ChunkPolicy policy = ChunkPolicy::Guarded;  ///< Distribution policy (default: Guarded)
 };
 
 /**

--- a/include/pypto/ir/transforms/utils/auto_name_utils.h
+++ b/include/pypto/ir/transforms/utils/auto_name_utils.h
@@ -76,6 +76,8 @@ inline std::string ChunkInnerQualifier() { return "ci"; }
 
 inline std::string ChunkRemainderQualifier() { return "cr"; }
 
+inline std::string ChunkGuardQualifier() { return "cg"; }
+
 inline std::string LoopLevelQualifier(int level) { return "l" + std::to_string(level); }
 
 inline std::string RowMajorQualifier() { return "rm"; }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -835,11 +835,13 @@ void BindIR(nb::module_& m) {
   // ChunkPolicy enum (must be before ForStmt which uses it)
   nb::enum_<ChunkPolicy>(ir, "ChunkPolicy", "Chunk policy for loop chunking")
       .value("LeadingFull", ChunkPolicy::LeadingFull, "Full chunks first, smaller remainder at end")
+      .value("Guarded", ChunkPolicy::Guarded,
+             "Single loop over ceil(N/C) chunks with per-iteration if-guard (default)")
       .export_values();
 
   // ChunkConfig struct (must be before ForStmt which uses it)
   nb::class_<ChunkConfig>(ir, "ChunkConfig", "Chunk configuration for parallel loop splitting")
-      .def(nb::init<ExprPtr, ChunkPolicy>(), nb::arg("size"), nb::arg("policy") = ChunkPolicy::LeadingFull,
+      .def(nb::init<ExprPtr, ChunkPolicy>(), nb::arg("size"), nb::arg("policy") = ChunkPolicy::Guarded,
            "Create a chunk configuration")
       .def_ro("size", &ChunkConfig::size, "Chunk size expression")
       .def_ro("policy", &ChunkConfig::policy, "Chunk distribution policy");
@@ -870,7 +872,7 @@ void BindIR(nb::module_& m) {
       },
       nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("iter_args"),
       nb::arg("body"), nb::arg("return_vars"), nb::arg("span"), nb::arg("kind") = ForKind::Sequential,
-      nb::arg("chunk_size") = nb::none(), nb::arg("chunk_policy") = ChunkPolicy::LeadingFull,
+      nb::arg("chunk_size") = nb::none(), nb::arg("chunk_policy") = ChunkPolicy::Guarded,
       nb::arg("attrs") = nb::none(), "Create a for loop statement");
   BindFields<ForStmt>(for_stmt_class);
   // Custom attrs property: convert vector<pair<string, any>> to Python dict
@@ -897,7 +899,7 @@ void BindIR(nb::module_& m) {
       "chunk_policy",
       [](const ForStmtPtr& self) -> ChunkPolicy {
         if (self->chunk_config_.has_value()) return self->chunk_config_->policy;
-        return ChunkPolicy::LeadingFull;
+        return ChunkPolicy::Guarded;
       },
       "Chunk distribution policy");
 

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -112,7 +112,7 @@ void BindIRBuilder(nb::module_& m) {
           },
           nb::arg("loop_var"), nb::arg("start"), nb::arg("stop"), nb::arg("step"), nb::arg("span"),
           nb::arg("kind") = ForKind::Sequential, nb::arg("chunk_size") = nb::none(),
-          nb::arg("chunk_policy") = ChunkPolicy::LeadingFull, nb::arg("attrs") = nb::none(),
+          nb::arg("chunk_policy") = ChunkPolicy::Guarded, nb::arg("attrs") = nb::none(),
           "Begin building a for loop.\n\n"
           "Creates a new for loop context. Must be closed with end_for_loop().\n\n"
           "Args:\n"
@@ -123,7 +123,7 @@ void BindIRBuilder(nb::module_& m) {
           "    span: Source location for loop definition\n"
           "    kind: Loop kind (Sequential or Parallel, default: Sequential)\n"
           "    chunk_size: Optional chunk size for loop chunking\n"
-          "    chunk_policy: Chunk distribution policy (default: LeadingFull)\n"
+          "    chunk_policy: Chunk distribution policy (default: Guarded)\n"
           "    attrs: Loop-level attributes (default: empty)\n\n"
           "Raises:\n"
           "    RuntimeError: If not inside a valid context")

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -111,7 +111,7 @@ class IRBuilder:
         span: ir.Span | None = None,
         kind: ir.ForKind = ir.ForKind.Sequential,
         chunk_size: int | ir.Expr | None = None,
-        chunk_policy: str = "leading_full",
+        chunk_policy: str = "guarded",
         attrs: dict[str, object] | None = None,
     ) -> Iterator["ForLoopBuilder"]:
         """Context manager for building for loops.
@@ -124,7 +124,7 @@ class IRBuilder:
             span: Optional explicit span. If None, automatically captured.
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
-            chunk_policy: Chunk distribution policy (default: "leading_full")
+            chunk_policy: Chunk distribution policy (default: "guarded")
             attrs: Loop-level attributes (key-value metadata, default: empty)
 
         Yields:
@@ -148,8 +148,14 @@ class IRBuilder:
         # Normalize chunk_size if provided
         chunk_size_expr = _normalize_expr(chunk_size, begin_span) if chunk_size is not None else None
 
-        if chunk_policy != "leading_full":
-            raise ValueError(f"Unsupported chunk_policy: {chunk_policy!r}, expected 'leading_full'")
+        if chunk_policy == "leading_full":
+            policy_enum = ir.ChunkPolicy.LeadingFull
+        elif chunk_policy == "guarded":
+            policy_enum = ir.ChunkPolicy.Guarded
+        else:
+            raise ValueError(
+                f"Unsupported chunk_policy: {chunk_policy!r}, expected 'leading_full' or 'guarded'"
+            )
 
         attrs_list = list((attrs or {}).items())
         self._builder.begin_for_loop(
@@ -160,7 +166,7 @@ class IRBuilder:
             begin_span,
             kind,
             chunk_size_expr,
-            ir.ChunkPolicy.LeadingFull,
+            policy_enum,
             attrs_list,
         )
         builder_obj = ForLoopBuilder(self)

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -95,7 +95,7 @@ class RangeIterator(Generic[T]):
         step: RangeArg = 1,
         init_values: tuple[Any, ...] | None = None,
         chunk: int | None = None,
-        chunk_policy: str = "leading_full",
+        chunk_policy: str = "guarded",
     ):
         """Initialize range iterator.
 
@@ -105,7 +105,7 @@ class RangeIterator(Generic[T]):
             step: Step value (default 1, int or Scalar)
             init_values: Initial values for iter_args
             chunk: Chunk size for loop chunking (None = no chunking)
-            chunk_policy: Chunk distribution policy (default: "leading_full")
+            chunk_policy: Chunk distribution policy (default: "guarded")
         """
         self.start = start
         self.stop = stop
@@ -170,7 +170,7 @@ def _make_range_iterator(
     *args: RangeArg,
     init_values: tuple[Any, ...] | None = None,
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
     func_name: str = "range",
 ) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Shared implementation for range(), parallel(), and unroll()."""
@@ -192,19 +192,19 @@ def _make_range_iterator(
 
 @overload
 def range(
-    *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[Scalar]: ...
 
 
 @overload
 def range(
-    *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[tuple[Scalar, tuple[T1]]]: ...
 
 
 @overload
 def range(
-    *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2]]]: ...
 
 
@@ -213,7 +213,7 @@ def range(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3]]]: ...
 
 
@@ -222,7 +222,7 @@ def range(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3, T4],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4]]]: ...
 
 
@@ -231,7 +231,7 @@ def range(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3, T4, T5],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4, T5]]]: ...
 
 
@@ -239,7 +239,7 @@ def range(
     *args: RangeArg,
     init_values: tuple[Any, ...] | None = None,
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Create a range iterator for for loops.
 
@@ -258,7 +258,7 @@ def range(
             Each argument can be an int literal or a pl.Scalar value.
         init_values: Initial values for iteration arguments
         chunk: Chunk size for loop chunking (splits loop into nested loops)
-        chunk_policy: Chunk distribution policy (default: "leading_full")
+        chunk_policy: Chunk distribution policy (default: "guarded")
 
     Returns:
         If no init_values: RangeIterator yielding loop variable (Scalar)
@@ -271,19 +271,19 @@ def range(
 
 @overload
 def parallel(
-    *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: None = None, chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[Scalar]: ...
 
 
 @overload
 def parallel(
-    *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: tuple[T1], chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[tuple[Scalar, tuple[T1]]]: ...
 
 
 @overload
 def parallel(
-    *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "leading_full"
+    *args: RangeArg, init_values: tuple[T1, T2], chunk: int | None = None, chunk_policy: str = "guarded"
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2]]]: ...
 
 
@@ -292,7 +292,7 @@ def parallel(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3]]]: ...
 
 
@@ -301,7 +301,7 @@ def parallel(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3, T4],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4]]]: ...
 
 
@@ -310,7 +310,7 @@ def parallel(
     *args: RangeArg,
     init_values: tuple[T1, T2, T3, T4, T5],
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[tuple[Scalar, tuple[T1, T2, T3, T4, T5]]]: ...
 
 
@@ -318,7 +318,7 @@ def parallel(
     *args: RangeArg,
     init_values: tuple[Any, ...] | None = None,
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[Scalar] | RangeIterator[tuple[Scalar, tuple[Any, ...]]]:
     """Create a parallel range iterator for parallel for loops.
 
@@ -330,7 +330,7 @@ def parallel(
             Each argument can be an int literal or a pl.Scalar value.
         init_values: Initial values for iteration arguments
         chunk: Chunk size for loop chunking
-        chunk_policy: Chunk distribution policy (default: "leading_full")
+        chunk_policy: Chunk distribution policy (default: "guarded")
 
     Returns:
         If no init_values: RangeIterator yielding loop variable (Scalar)
@@ -344,7 +344,7 @@ def parallel(
 def unroll(
     *args: RangeArg,
     chunk: int | None = None,
-    chunk_policy: str = "leading_full",
+    chunk_policy: str = "guarded",
 ) -> RangeIterator[Scalar]:
     """Create an unroll range iterator for compile-time loop unrolling.
 
@@ -357,7 +357,7 @@ def unroll(
         *args: Positional arguments (stop) or (start, stop) or (start, stop, step).
             Each argument must be an int literal (compile-time constant).
         chunk: Chunk size for loop chunking
-        chunk_policy: Chunk distribution policy (default: "leading_full")
+        chunk_policy: Chunk distribution policy (default: "guarded")
 
     Returns:
         RangeIterator yielding loop variable (Scalar)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -875,7 +875,7 @@ class ASTParser:
 
         # Validate chunk arguments
         chunk_expr = range_args.get("chunk")
-        chunk_policy_str = range_args.get("chunk_policy", "leading_full")
+        chunk_policy_str = range_args.get("chunk_policy", "guarded")
         if chunk_expr is not None:
             self._validate_chunk_args(chunk_expr, range_args["init_values"], iter_call)
 
@@ -998,7 +998,7 @@ class ASTParser:
             result["chunk"] = self.parse_expression(keyword.value)
         elif keyword.arg == "chunk_policy":
             if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                _VALID_CHUNK_POLICIES = {"leading_full"}
+                _VALID_CHUNK_POLICIES = {"leading_full", "guarded"}
                 if keyword.value.value not in _VALID_CHUNK_POLICIES:
                     raise ParserSyntaxError(
                         f"Unsupported chunk_policy: {keyword.value.value!r}",
@@ -1059,7 +1059,7 @@ class ASTParser:
         result: dict[str, Any] = {
             "init_values": [],
             "chunk": None,
-            "chunk_policy": "leading_full",
+            "chunk_policy": "guarded",
             "attrs": {},
         }
         for keyword in call.keywords:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -792,7 +792,10 @@ class ChunkPolicy(enum.Enum):
     """
 
     LeadingFull = ...
-    """Full chunks first, smaller remainder at end."""
+    """Full chunks first, smaller remainder at end (splits into main + remainder kernels)."""
+
+    Guarded = ...
+    """Single loop over ceil(N/C) chunks with per-iteration if-guard (default)."""
 
 class ChunkConfig:
     """Chunk configuration for parallel loop splitting."""
@@ -803,12 +806,12 @@ class ChunkConfig:
     policy: Final[ChunkPolicy]
     """Chunk distribution policy."""
 
-    def __init__(self, size: Expr, policy: ChunkPolicy = ChunkPolicy.LeadingFull) -> None:
+    def __init__(self, size: Expr, policy: ChunkPolicy = ChunkPolicy.Guarded) -> None:
         """Create a chunk configuration.
 
         Args:
             size: Chunk size expression
-            policy: Chunk distribution policy (default: LeadingFull)
+            policy: Chunk distribution policy (default: Guarded)
         """
 
 class LoopOrigin(enum.Enum):
@@ -1702,7 +1705,7 @@ class ForStmt(Stmt):
         span: Span,
         kind: ForKind = ForKind.Sequential,
         chunk_size: Expr | None = None,
-        chunk_policy: ChunkPolicy = ChunkPolicy.LeadingFull,
+        chunk_policy: ChunkPolicy = ChunkPolicy.Guarded,
         attrs: dict[str, object] | list[tuple[str, object]] | None = None,
     ) -> None:
         """Create a for loop statement.
@@ -1718,7 +1721,7 @@ class ForStmt(Stmt):
             span: Source location
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
-            chunk_policy: Chunk distribution policy (default: LeadingFull)
+            chunk_policy: Chunk distribution policy (default: Guarded)
             attrs: Loop-level attributes (default: empty)
         """
 
@@ -2435,7 +2438,7 @@ class IRBuilder:
         span: Span,
         kind: ForKind = ForKind.Sequential,
         chunk_size: Expr | None = None,
-        chunk_policy: ChunkPolicy = ChunkPolicy.LeadingFull,
+        chunk_policy: ChunkPolicy = ChunkPolicy.Guarded,
         attrs: dict[str, object] | list[tuple[str, object]] | None = None,
     ) -> None:
         """Begin building a for loop.
@@ -2448,7 +2451,7 @@ class IRBuilder:
             span: Source location for loop definition
             kind: Loop kind (default: Sequential)
             chunk_size: Optional chunk size for loop chunking
-            chunk_policy: Chunk distribution policy (default: LeadingFull)
+            chunk_policy: Chunk distribution policy (default: Guarded)
             attrs: Loop-level attributes (default: empty)
         """
 

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -473,7 +473,7 @@ static IRNodePtr DeserializeForStmt(const msgpack::object& fields_obj, msgpack::
   if (chunk_config_obj.has_value() && chunk_config_obj->type == msgpack::type::MAP) {
     auto size_obj = ctx.GetFieldObj(*chunk_config_obj, "size");
     auto chunk_size = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(size_obj, zone));
-    ChunkPolicy chunk_policy = ChunkPolicy::LeadingFull;
+    ChunkPolicy chunk_policy = ChunkPolicy::Guarded;
     auto policy_obj = GetOptionalFieldObj(*chunk_config_obj, "policy", ctx);
     if (policy_obj.has_value()) {
       chunk_policy = static_cast<ChunkPolicy>(policy_obj->via.u64);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -925,8 +925,18 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
   if (op->chunk_config_.has_value()) {
     stream_ << ", chunk=";
     VisitExpr(op->chunk_config_->size);
-    if (op->chunk_config_->policy != ChunkPolicy::LeadingFull) {
-      stream_ << ", chunk_policy=\"" << ChunkPolicyToString(op->chunk_config_->policy) << "\"";
+    if (op->chunk_config_->policy != ChunkPolicy::Guarded) {
+      // Emit lowercase policy string to match DSL/parser convention.
+      stream_ << ", chunk_policy=\"";
+      switch (op->chunk_config_->policy) {
+        case ChunkPolicy::LeadingFull:
+          stream_ << "leading_full";
+          break;
+        case ChunkPolicy::Guarded:
+          stream_ << "guarded";
+          break;
+      }
+      stream_ << "\"";
     }
   }
 

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -375,11 +375,11 @@ class ChunkedLoopSplitter : public IRMutator {
     }
 
     if (!has_iter_args) {
-      return SplitGuarded(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, chunk_expr,
-                          stop_expr, n_total, prev_loop_sub, sp);
+      return SplitGuarded(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, step,
+                          chunk_expr, stop_expr, n_total, prev_loop_sub, sp);
     }
     return SplitGuardedWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
-                                    chunk_expr, stop_expr, n_total, prev_loop_sub, prev_ia_subs, sp);
+                                    step, chunk_expr, stop_expr, n_total, prev_loop_sub, prev_ia_subs, sp);
   }
 
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
@@ -658,8 +658,9 @@ class ChunkedLoopSplitter : public IRMutator {
    */
   StmtPtr SplitGuarded(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
                        const std::optional<int>& loop_version, const ExprPtr& start_expr,
-                       const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& stop_expr,
-                       const ExprPtr& n_total, const SavedSubstitution& prev_loop_sub, const Span& sp) {
+                       const ExprPtr& step_expr, int64_t step, const ExprPtr& chunk_expr,
+                       const ExprPtr& stop_expr, const ExprPtr& n_total,
+                       const SavedSubstitution& prev_loop_sub, const Span& sp) {
     auto zero = MakeConstIndex(0, sp);
     auto one = MakeConstIndex(1, sp);
 
@@ -671,12 +672,13 @@ class ChunkedLoopSplitter : public IRMutator {
         std::make_shared<ScalarType>(DataType::INDEX), sp);
 
     // idx = start + (out_var * C + in_var) * step
-    ExprPtr idx_expr = MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
+    ExprPtr idx_expr = MakeAdd(
+        start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr, sp), in_var, sp), step_expr, sp), sp);
     substitution_map_[loop_var_key] = idx_expr;
     auto visited_body = VisitStmt(op->body_);
 
-    // Guard: if (idx < stop) { body }
-    auto cond = MakeLt(idx_expr, stop_expr, sp);
+    // Guard: for step > 0 use `idx < stop`, for step < 0 use `idx > stop`.
+    auto cond = step > 0 ? MakeLt(idx_expr, stop_expr, sp) : MakeGt(idx_expr, stop_expr, sp);
     auto if_stmt =
         std::make_shared<IfStmt>(cond, visited_body, std::optional<StmtPtr>{}, std::vector<VarPtr>{}, sp);
 
@@ -702,7 +704,7 @@ class ChunkedLoopSplitter : public IRMutator {
    */
   StmtPtr SplitGuardedWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key,
                                    const std::string& base_name, const std::optional<int>& loop_version,
-                                   const ExprPtr& start_expr, const ExprPtr& step_expr,
+                                   const ExprPtr& start_expr, const ExprPtr& step_expr, int64_t step,
                                    const ExprPtr& chunk_expr, const ExprPtr& stop_expr,
                                    const ExprPtr& n_total, const SavedSubstitution& prev_loop_sub,
                                    const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
@@ -752,7 +754,8 @@ class ChunkedLoopSplitter : public IRMutator {
     }
 
     // idx = start + (out_var * C + in_var) * step
-    ExprPtr idx_expr = MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
+    ExprPtr idx_expr = MakeAdd(
+        start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr, sp), in_var, sp), step_expr, sp), sp);
     substitution_map_[loop_var_key] = idx_expr;
     auto visited_body = VisitStmt(op->body_);
 
@@ -761,7 +764,8 @@ class ChunkedLoopSplitter : public IRMutator {
     auto else_yield = std::make_shared<YieldStmt>(std::move(else_yield_values), sp);
 
     // Guarded IfStmt with phi return_vars.
-    auto cond = MakeLt(idx_expr, stop_expr, sp);
+    // For step > 0 use `idx < stop`, for step < 0 use `idx > stop`.
+    auto cond = step > 0 ? MakeLt(idx_expr, stop_expr, sp) : MakeGt(idx_expr, stop_expr, sp);
     auto if_stmt =
         std::make_shared<IfStmt>(cond, visited_body, std::optional<StmtPtr>{else_yield}, if_return_vars, sp);
 

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -284,29 +284,6 @@ class ChunkedLoopSplitter : public IRMutator {
     ExprPtr start_expr = VisitExpr(op->start_);
     ExprPtr stop_expr = VisitExpr(op->stop_);
 
-    // Compute n_full and n_rem as ExprPtr.
-    // When start/stop are constants, produce ConstInt nodes directly for cleaner IR.
-    // When dynamic, produce FloorDiv/FloorMod expression trees.
-    ExprPtr n_full;
-    ExprPtr n_rem;
-    auto start_c = TryGetConstInt(start_expr);
-    auto stop_c = TryGetConstInt(stop_expr);
-    if (start_c && stop_c) {
-      int64_t tc = ComputeStaticTripCount(*start_c, *stop_c, step);
-      n_full = MakeConstIndex(tc / chunk_size, sp);
-      n_rem = MakeConstIndex(tc % chunk_size, sp);
-    } else {
-      ExprPtr trip_count = BuildTripCountExpr(start_expr, stop_expr, step, sp);
-      n_full = MakeFloorDiv(trip_count, chunk_expr, sp);
-      n_rem = MakeFloorMod(trip_count, chunk_expr, sp);
-    }
-
-    // Determine which loops to emit. Dynamic bounds always emit both.
-    auto n_full_c = TryGetConstInt(n_full);
-    auto n_rem_c = TryGetConstInt(n_rem);
-    bool emit_full = !n_full_c || *n_full_c > 0;
-    bool emit_rem = !n_rem_c || *n_rem_c > 0;
-
     const Var* loop_var_key = op->loop_var_.get();
     auto loop_name = auto_name::Parse(op->loop_var_->name_hint_);
     std::string base_name = loop_name.base_name;
@@ -318,26 +295,91 @@ class ChunkedLoopSplitter : public IRMutator {
     }
 
     bool has_iter_args = !op->iter_args_.empty();
+    ChunkPolicy policy = op->chunk_config_->policy;
 
-    if (!has_iter_args) {
-      return SplitSimple(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, chunk_expr,
-                         n_full, n_rem, emit_full, emit_rem, prev_loop_sub, sp);
+    if (policy == ChunkPolicy::LeadingFull) {
+      // Compute n_full and n_rem as ExprPtr.
+      ExprPtr n_full;
+      ExprPtr n_rem;
+      auto start_c = TryGetConstInt(start_expr);
+      auto stop_c = TryGetConstInt(stop_expr);
+      if (start_c && stop_c) {
+        int64_t tc = ComputeStaticTripCount(*start_c, *stop_c, step);
+        n_full = MakeConstIndex(tc / chunk_size, sp);
+        n_rem = MakeConstIndex(tc % chunk_size, sp);
+      } else {
+        ExprPtr trip_count = BuildTripCountExpr(start_expr, stop_expr, step, sp);
+        n_full = MakeFloorDiv(trip_count, chunk_expr, sp);
+        n_rem = MakeFloorMod(trip_count, chunk_expr, sp);
+      }
+
+      auto n_full_c = TryGetConstInt(n_full);
+      auto n_rem_c = TryGetConstInt(n_rem);
+      bool emit_full = !n_full_c || *n_full_c > 0;
+      bool emit_rem = !n_rem_c || *n_rem_c > 0;
+
+      if (!has_iter_args) {
+        return SplitLeadingFull(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
+                                chunk_expr, n_full, n_rem, emit_full, emit_rem, prev_loop_sub, sp);
+      }
+
+      // Zero-trip optimization: when statically known, skip loop emission entirely
+      if (n_full_c && n_rem_c && *n_full_c == 0 && *n_rem_c == 0) {
+        INTERNAL_CHECK_SPAN(op->return_vars_.size() == op->iter_args_.size(), op->span_)
+            << "ForStmt return_vars/iter_args size mismatch in zero-trip chunk split";
+        for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+          substitution_map_[op->return_vars_[i].get()] = VisitExpr(op->iter_args_[i]->initValue_);
+        }
+        RestoreSubstitution(prev_loop_sub);
+        RestoreSubstitutions(prev_ia_subs);
+        return SeqStmts::Flatten(std::vector<StmtPtr>{}, sp);
+      }
+
+      return SplitLeadingFullWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr,
+                                          step_expr, chunk_expr, n_full, n_rem, emit_full, emit_rem,
+                                          prev_loop_sub, prev_ia_subs, sp);
     }
 
-    // Zero-trip optimization: when statically known, skip loop emission entirely
-    if (n_full_c && n_rem_c && *n_full_c == 0 && *n_rem_c == 0) {
-      INTERNAL_CHECK_SPAN(op->return_vars_.size() == op->iter_args_.size(), op->span_)
-          << "ForStmt return_vars/iter_args size mismatch in zero-trip chunk split";
-      for (size_t i = 0; i < op->return_vars_.size(); ++i) {
-        substitution_map_[op->return_vars_[i].get()] = VisitExpr(op->iter_args_[i]->initValue_);
+    INTERNAL_CHECK_SPAN(policy == ChunkPolicy::Guarded, op->span_)
+        << "Unexpected ChunkPolicy in SplitChunkedLoops: " << ChunkPolicyToString(policy);
+
+    // Compute n_total = ceil(trip_count / chunk_size).
+    ExprPtr n_total;
+    auto start_c = TryGetConstInt(start_expr);
+    auto stop_c = TryGetConstInt(stop_expr);
+    if (start_c && stop_c) {
+      int64_t tc = ComputeStaticTripCount(*start_c, *stop_c, step);
+      int64_t nt = (tc + chunk_size - 1) / chunk_size;
+      n_total = MakeConstIndex(nt, sp);
+    } else {
+      ExprPtr trip_count = BuildTripCountExpr(start_expr, stop_expr, step, sp);
+      ExprPtr numerator = MakeAdd(trip_count, MakeConstIndex(chunk_size - 1, sp), sp);
+      n_total = MakeFloorDiv(numerator, chunk_expr, sp);
+    }
+
+    auto n_total_c = TryGetConstInt(n_total);
+    bool emit = !n_total_c || *n_total_c > 0;
+
+    if (!emit) {
+      // Statically zero iterations: emit nothing and forward iter_arg initial values.
+      if (has_iter_args) {
+        INTERNAL_CHECK_SPAN(op->return_vars_.size() == op->iter_args_.size(), op->span_)
+            << "ForStmt return_vars/iter_args size mismatch in zero-trip guarded chunk split";
+        for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+          substitution_map_[op->return_vars_[i].get()] = VisitExpr(op->iter_args_[i]->initValue_);
+        }
       }
       RestoreSubstitution(prev_loop_sub);
       RestoreSubstitutions(prev_ia_subs);
       return SeqStmts::Flatten(std::vector<StmtPtr>{}, sp);
     }
 
-    return SplitWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
-                             chunk_expr, n_full, n_rem, emit_full, emit_rem, prev_loop_sub, prev_ia_subs, sp);
+    if (!has_iter_args) {
+      return SplitGuarded(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr, chunk_expr,
+                          stop_expr, n_total, prev_loop_sub, sp);
+    }
+    return SplitGuardedWithIterArgs(op, loop_var_key, base_name, loop_name.version, start_expr, step_expr,
+                                    chunk_expr, stop_expr, n_total, prev_loop_sub, prev_ia_subs, sp);
   }
 
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
@@ -417,11 +459,11 @@ class ChunkedLoopSplitter : public IRMutator {
    *
    * n_full and n_rem are ExprPtr — either ConstInt or dynamic expressions.
    */
-  StmtPtr SplitSimple(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
-                      const std::optional<int>& loop_version, const ExprPtr& start_expr,
-                      const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
-                      const ExprPtr& n_rem, bool emit_full, bool emit_rem,
-                      const SavedSubstitution& prev_loop_sub, const Span& sp) {
+  StmtPtr SplitLeadingFull(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
+                           const std::optional<int>& loop_version, const ExprPtr& start_expr,
+                           const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
+                           const ExprPtr& n_rem, bool emit_full, bool emit_rem,
+                           const SavedSubstitution& prev_loop_sub, const Span& sp) {
     auto zero = MakeConstIndex(0, sp);
     auto one = MakeConstIndex(1, sp);
     std::vector<StmtPtr> result_stmts;
@@ -479,12 +521,12 @@ class ChunkedLoopSplitter : public IRMutator {
    *
    * n_full and n_rem are ExprPtr — either ConstInt or dynamic expressions.
    */
-  StmtPtr SplitWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
-                            const std::optional<int>& loop_version, const ExprPtr& start_expr,
-                            const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& n_full,
-                            const ExprPtr& n_rem, bool emit_full, bool emit_rem,
-                            const SavedSubstitution& prev_loop_sub,
-                            const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
+  StmtPtr SplitLeadingFullWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key,
+                                       const std::string& base_name, const std::optional<int>& loop_version,
+                                       const ExprPtr& start_expr, const ExprPtr& step_expr,
+                                       const ExprPtr& chunk_expr, const ExprPtr& n_full, const ExprPtr& n_rem,
+                                       bool emit_full, bool emit_rem, const SavedSubstitution& prev_loop_sub,
+                                       const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
     auto zero = MakeConstIndex(0, sp);
     auto one = MakeConstIndex(1, sp);
     std::vector<StmtPtr> result_stmts;
@@ -604,6 +646,152 @@ class ChunkedLoopSplitter : public IRMutator {
     RestoreSubstitutions(prev_ia_subs);
 
     return MakeResultStmt(result_stmts, sp);
+  }
+
+  /**
+   * @brief Guarded split without iter_args.
+   *
+   * Emits a single outer loop over ceil(trip_count / C) chunks and an inner loop
+   * of size C, with the body wrapped in `if (idx < stop)` so out-of-range
+   * iterations become no-ops. This preserves a single-kernel outline for dynamic
+   * bounds and loops with cross-iteration state.
+   */
+  StmtPtr SplitGuarded(const ForStmtPtr& op, const Var* loop_var_key, const std::string& base_name,
+                       const std::optional<int>& loop_version, const ExprPtr& start_expr,
+                       const ExprPtr& step_expr, const ExprPtr& chunk_expr, const ExprPtr& stop_expr,
+                       const ExprPtr& n_total, const SavedSubstitution& prev_loop_sub, const Span& sp) {
+    auto zero = MakeConstIndex(0, sp);
+    auto one = MakeConstIndex(1, sp);
+
+    auto out_var = std::make_shared<Var>(
+        auto_name::BuildName(base_name, auto_name::ChunkOuterQualifier(), "idx", loop_version),
+        std::make_shared<ScalarType>(DataType::INDEX), sp);
+    auto in_var = std::make_shared<Var>(
+        auto_name::BuildName(base_name, auto_name::ChunkInnerQualifier(), "idx", loop_version),
+        std::make_shared<ScalarType>(DataType::INDEX), sp);
+
+    // idx = start + (out_var * C + in_var) * step
+    ExprPtr idx_expr = MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
+    substitution_map_[loop_var_key] = idx_expr;
+    auto visited_body = VisitStmt(op->body_);
+
+    // Guard: if (idx < stop) { body }
+    auto cond = MakeLt(idx_expr, stop_expr, sp);
+    auto if_stmt =
+        std::make_shared<IfStmt>(cond, visited_body, std::optional<StmtPtr>{}, std::vector<VarPtr>{}, sp);
+
+    auto inner_for = std::make_shared<ForStmt>(in_var, zero, chunk_expr, one, std::vector<IterArgPtr>{},
+                                               if_stmt, std::vector<VarPtr>{}, sp, op->kind_, std::nullopt,
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkInner));
+    auto outer_for = std::make_shared<ForStmt>(out_var, zero, n_total, one, std::vector<IterArgPtr>{},
+                                               inner_for, std::vector<VarPtr>{}, sp, op->kind_, std::nullopt,
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkOuter));
+
+    RestoreSubstitution(prev_loop_sub);
+    return outer_for;
+  }
+
+  /**
+   * @brief Guarded split with iter_args (SSA propagation through IfStmt phi).
+   *
+   * Wraps the body in an IfStmt whose return_vars act as phi nodes. The then
+   * branch ends with the user body's own YieldStmt; the else branch yields the
+   * unchanged inner iter_args. The inner loop's trailing YieldStmt references
+   * the IfStmt's phi return_vars, threading loop-carried state through both
+   * guarded and skipped iterations.
+   */
+  StmtPtr SplitGuardedWithIterArgs(const ForStmtPtr& op, const Var* loop_var_key,
+                                   const std::string& base_name, const std::optional<int>& loop_version,
+                                   const ExprPtr& start_expr, const ExprPtr& step_expr,
+                                   const ExprPtr& chunk_expr, const ExprPtr& stop_expr,
+                                   const ExprPtr& n_total, const SavedSubstitution& prev_loop_sub,
+                                   const std::vector<SavedSubstitution>& prev_ia_subs, const Span& sp) {
+    auto zero = MakeConstIndex(0, sp);
+    auto one = MakeConstIndex(1, sp);
+
+    auto out_var = std::make_shared<Var>(
+        auto_name::BuildName(base_name, auto_name::ChunkOuterQualifier(), "idx", loop_version),
+        std::make_shared<ScalarType>(DataType::INDEX), sp);
+    auto in_var = std::make_shared<Var>(
+        auto_name::BuildName(base_name, auto_name::ChunkInnerQualifier(), "idx", loop_version),
+        std::make_shared<ScalarType>(DataType::INDEX), sp);
+
+    std::vector<IterArgPtr> outer_iter_args;
+    std::vector<VarPtr> outer_return_vars;
+    std::vector<IterArgPtr> inner_iter_args;
+    std::vector<VarPtr> inner_return_vars;
+    std::vector<VarPtr> if_return_vars;
+
+    for (const auto& ia : op->iter_args_) {
+      auto visited_init = VisitExpr(ia->initValue_);
+      auto ia_name = auto_name::Parse(ia->name_hint_);
+      auto outer_ia = std::make_shared<IterArg>(
+          auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "iter", ia_name.version),
+          ia->GetType(), visited_init, ia->span_);
+      auto outer_rv = std::make_shared<Var>(
+          auto_name::BuildName(ia_name.base_name, auto_name::ChunkOuterQualifier(), "rv", ia_name.version),
+          ia->GetType(), ia->span_);
+      outer_iter_args.push_back(outer_ia);
+      outer_return_vars.push_back(outer_rv);
+
+      auto inner_ia = std::make_shared<IterArg>(
+          auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "iter", ia_name.version),
+          ia->GetType(), ExprPtr(outer_ia), ia->span_);
+      auto inner_rv = std::make_shared<Var>(
+          auto_name::BuildName(ia_name.base_name, auto_name::ChunkInnerQualifier(), "rv", ia_name.version),
+          ia->GetType(), ia->span_);
+      inner_iter_args.push_back(inner_ia);
+      inner_return_vars.push_back(inner_rv);
+
+      auto if_rv = std::make_shared<Var>(
+          auto_name::BuildName(ia_name.base_name, auto_name::ChunkGuardQualifier(), "rv", ia_name.version),
+          ia->GetType(), ia->span_);
+      if_return_vars.push_back(if_rv);
+
+      substitution_map_[ia.get()] = inner_ia;
+    }
+
+    // idx = start + (out_var * C + in_var) * step
+    ExprPtr idx_expr = MakeAdd(start_expr, MakeMul(MakeAdd(MakeMul(out_var, chunk_expr), in_var), step_expr));
+    substitution_map_[loop_var_key] = idx_expr;
+    auto visited_body = VisitStmt(op->body_);
+
+    // Else branch: pass through current inner iter_args unchanged.
+    std::vector<ExprPtr> else_yield_values(inner_iter_args.begin(), inner_iter_args.end());
+    auto else_yield = std::make_shared<YieldStmt>(std::move(else_yield_values), sp);
+
+    // Guarded IfStmt with phi return_vars.
+    auto cond = MakeLt(idx_expr, stop_expr, sp);
+    auto if_stmt =
+        std::make_shared<IfStmt>(cond, visited_body, std::optional<StmtPtr>{else_yield}, if_return_vars, sp);
+
+    // Inner loop body: SeqStmts { IfStmt, YieldStmt(if_return_vars) }
+    auto inner_trailing_yield =
+        std::make_shared<YieldStmt>(std::vector<ExprPtr>(if_return_vars.begin(), if_return_vars.end()), sp);
+    auto inner_body = SeqStmts::Flatten(std::vector<StmtPtr>{if_stmt, inner_trailing_yield}, sp);
+
+    auto inner_for = std::make_shared<ForStmt>(in_var, zero, chunk_expr, one, inner_iter_args, inner_body,
+                                               inner_return_vars, sp, op->kind_, std::nullopt,
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkInner));
+
+    // Outer loop body: SeqStmts { inner_for, YieldStmt(inner_return_vars) }
+    auto outer_yield = std::make_shared<YieldStmt>(
+        std::vector<ExprPtr>(inner_return_vars.begin(), inner_return_vars.end()), sp);
+    auto outer_body = SeqStmts::Flatten(std::vector<StmtPtr>{inner_for, outer_yield}, sp);
+
+    auto outer_for = std::make_shared<ForStmt>(out_var, zero, n_total, one, outer_iter_args, outer_body,
+                                               outer_return_vars, sp, op->kind_, std::nullopt,
+                                               MakeLoopAttrs(op->attrs_, LoopOrigin::ChunkOuter));
+
+    INTERNAL_CHECK_SPAN(op->return_vars_.size() == outer_return_vars.size(), op->span_)
+        << "SplitChunkedLoops guarded produced mismatched return vars";
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      substitution_map_[op->return_vars_[i].get()] = outer_return_vars[i];
+    }
+
+    RestoreSubstitution(prev_loop_sub);
+    RestoreSubstitutions(prev_ia_subs);
+    return outer_for;
   }
 };
 

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -149,7 +149,7 @@ class C2VLRProgram:
         with pl.at(
             level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
         ):
-            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
                 b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
@@ -201,7 +201,7 @@ class C2VUDProgram:
         with pl.at(
             level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
         ):
-            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
                 b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
@@ -252,7 +252,7 @@ class BiDirectUDProgram:
         with pl.at(
             level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
         ):
-            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
                 a_add = pl.add(a, 1.0)
@@ -304,7 +304,7 @@ class BiDirectLRProgram:
         with pl.at(
             level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
         ):
-            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
                 a_add = pl.add(a, 1.0)

--- a/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
+++ b/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
@@ -98,7 +98,7 @@ def build_qwen3_scope3_program(
                         resid1_tile = pl.assemble(resid1_tile, zero_resid1, [0, o0])
 
                     # Output projection: attn_out × wo, tiled by Q_OUT_CHUNK.
-                    for ob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8):
+                    for ob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8, chunk_policy="leading_full"):
                         o0 = ob * Q_OUT_CHUNK
                         o_acc = pl.full([BATCH_TILE, Q_OUT_CHUNK], dtype=pl.FP32, value=0.0)
                         for kb in pl.range(HIDDEN_BLOCKS):
@@ -159,7 +159,7 @@ def build_qwen3_scope3_program(
                         mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
                         mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
 
-                        for dob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4):
+                        for dob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                             d0 = dob * K_CHUNK
                             for doff in pl.range(0, K_CHUNK, DOWN_OUT_CHUNK):
                                 d1 = d0 + doff
@@ -169,7 +169,7 @@ def build_qwen3_scope3_program(
                                 down_proj_tile = pl.assemble(down_proj_tile, down_next, [0, d1])
 
                     # Final residual: down_proj + resid1, write to output.
-                    for ob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4):
+                    for ob in pl.parallel(0, HIDDEN_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                         o0 = ob * K_CHUNK
                         down_acc = pl.add(
                             pl.slice(down_proj_tile, [BATCH_TILE, K_CHUNK], [0, o0]),

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1170,7 +1170,7 @@ class TestOrchestration:
                 output_tensor: pl.Tensor[[1024, 256], pl.FP32],
             ) -> pl.Tensor[[1024, 256], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for r in pl.parallel(0, 1024, 1, chunk=64):
+                    for r in pl.parallel(0, 1024, 1, chunk=64, chunk_policy="leading_full"):
                         row_tile = pl.slice(input_tensor, [1, 256], [r, 0])
                         row_result = pl.add(row_tile, 1.0)
                         output_tensor = pl.assemble(output_tensor, row_result, [r, 0])

--- a/tests/ut/ir/parser/test_parse_pl_at.py
+++ b/tests/ut/ir/parser/test_parse_pl_at.py
@@ -222,7 +222,7 @@ def test_parse_pl_at_core_group_chunked_loop_optimizer_bare():
     @pl.function
     def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
         with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-            for i in pl.parallel(0, 8, 1, chunk=4):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                 x = pl.add(x, x)
         return x
 
@@ -241,7 +241,7 @@ def test_parse_pl_at_core_group_chunked_loop_optimizer_with_split():
             level=pl.Level.CORE_GROUP,
             optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT),
         ):
-            for i in pl.parallel(0, 8, 1, chunk=4):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                 x = pl.add(x, x)
         return x
 
@@ -283,7 +283,7 @@ def test_parse_pl_at_split_mode_none_errors():
                 level=pl.Level.CORE_GROUP,
                 optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
             ):
-                for i in pl.parallel(0, 8, 1, chunk=4):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                     x = pl.add(x, x)
             return x
 
@@ -322,7 +322,7 @@ def test_auto_incore_deprecation_warning():
         @pl.function
         def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             with pl.auto_incore():
-                for i in pl.parallel(0, 8, 1, chunk=4):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                     x = pl.add(x, x)
             return x
 

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -49,7 +49,7 @@ class TestSingleParallelChunk:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -85,8 +85,8 @@ class TestNestedParallelChunks:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
-                        for j in pl.parallel(0, 12, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -131,8 +131,8 @@ class TestNestedParallelChunks:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
-                        for j in pl.parallel(0, 12, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -182,8 +182,8 @@ class TestNestedChunkChainsInitSubstitution:
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for b in pl.parallel(0, 8, 1, chunk=4):
-                        for h in pl.parallel(0, 12, 1, chunk=4):
+                    for b in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for h in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
                 return x
 
@@ -216,8 +216,8 @@ class TestNestedChunkChainsInitSubstitution:
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for b in pl.parallel(0, 8, 1, chunk=4):
-                        for h in pl.parallel(0, 12, 1, chunk=4):
+                    for b in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for h in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
                 return x
 
@@ -241,8 +241,8 @@ class TestNestedChunkChainsInitSubstitution:
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for b in pl.parallel(0, 6, 1, chunk=4):
-                        for h in pl.parallel(0, 14, 1, chunk=4):
+                    for b in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):
+                        for h in pl.parallel(0, 14, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
                 return x
 
@@ -268,9 +268,9 @@ class TestNestedChunksWithInterveningStatements:
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for b in pl.parallel(0, 16, 1, chunk=4):
+                    for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, y)
-                        for h in pl.parallel(0, 8, 1, chunk=2):
+                        for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, y)
                 return x
 
@@ -307,8 +307,8 @@ class TestChunkWithRemainderInChain:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
-                        for j in pl.parallel(0, 1, 1, chunk=2):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(0, 1, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -343,8 +343,8 @@ class TestChunkWithRemainderInChain:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
-                        for j in pl.parallel(0, 1, 1, chunk=2):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(0, 1, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -368,8 +368,8 @@ class TestRemainderLoops:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 6, 1, chunk=4):
-                        for j in pl.parallel(0, 14, 1, chunk=4):
+                    for i in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(0, 14, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -433,7 +433,7 @@ class TestSequentialChunks:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 8, 1, chunk=4):
+                    for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -454,8 +454,8 @@ class TestSequentialChunks:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 8, 1, chunk=4):
-                        for j in pl.range(0, 12, 1, chunk=4):
+                    for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.range(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -479,7 +479,7 @@ class TestExistingInCore:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         with pl.at(level=pl.Level.CORE_GROUP):
                             x = pl.add(x, 1.0)
                 return x
@@ -503,7 +503,7 @@ class TestAutoIncoreConsumed:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -551,7 +551,7 @@ class TestNoNestedIncoreVerifier:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -576,9 +576,9 @@ class TestNoNestedIncoreVerifier:
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for b in pl.parallel(0, 16, 1, chunk=4):
+                    for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, y)
-                        for h in pl.parallel(0, 8, 1, chunk=2):
+                        for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, y)
                 return x
 
@@ -622,7 +622,7 @@ class TestNonChunkStatementsWrapping:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     x = pl.add(x, 1.0)
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
                 return x
 
@@ -647,7 +647,7 @@ class TestNonChunkStatementsWrapping:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
                     x = pl.mul(x, 3.0)
                 return x
@@ -679,7 +679,7 @@ class TestNonChunkStatementsWrapping:
                     [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
                 )
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 4, 1, chunk=2):
+                    for i in pl.parallel(0, 4, 1, chunk=2, chunk_policy="leading_full"):
                         x = pl.tensor.adds(x, 1.0)
                     out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])
                 return out_1
@@ -700,9 +700,9 @@ class TestNonChunkStatementsWrapping:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
-                    for j in pl.parallel(0, 12, 1, chunk=4):
+                    for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.mul(x, 2.0)
                 return x
 
@@ -747,9 +747,9 @@ class TestNonChunkStatementsWrapping:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
-                    for j in pl.range(0, 12, 1, chunk=4):
+                    for j in pl.range(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.mul(x, 2.0)
                 return x
 
@@ -782,7 +782,7 @@ class TestScalarAssignmentNotWrapped:
                     for ob in pl.range(0, 8):
                         offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
                         x = pl.add(x, 1.0)
-                        for i in pl.parallel(0, 8, 1, chunk=4):
+                        for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 2.0)
                 return x
 
@@ -818,7 +818,7 @@ class TestScalarAssignmentNotWrapped:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for ob in pl.range(0, 8):
                         offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
-                        for i in pl.parallel(0, 8, 1, chunk=4):
+                        for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 2.0)
                 return x
 
@@ -889,7 +889,7 @@ class TestEndToEndNoComputeLeaks:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     x = pl.add(x, 1.0)
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
                 return x
 
@@ -904,7 +904,7 @@ class TestEndToEndNoComputeLeaks:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 8, 1, chunk=4):
+                    for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 

--- a/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
+++ b/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
@@ -63,12 +63,12 @@ class TestNonParallelCodeBetweenChunks:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
                         # Parallel chunk 1 → gets InCore after interchange
-                        for i in pl.parallel(4, chunk=2):
+                        for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                         # Non-parallel op → should ALSO get InCore
                         y: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.muls(x, 2.0)
                         # Parallel chunk 2 → gets InCore after interchange
-                        for j in pl.parallel(4, chunk=2):
+                        for j in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.add(x, y)
                 return x
 
@@ -104,13 +104,13 @@ class TestNonParallelCodeBetweenChunks:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
                         # Parallel chunk → gets InCore
-                        for i in pl.parallel(4, chunk=2):
+                        for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                         # Non-parallel range loop with matmul → should get InCore
                         for k in pl.range(2):
                             x = pl.tensor.matmul(x, w)
                         # Parallel chunk → gets InCore
-                        for j in pl.parallel(4, chunk=2):
+                        for j in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                 return x
 
@@ -146,11 +146,11 @@ class TestNonParallelCodeBetweenChunks:
             ) -> pl.Tensor[[8, 64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
-                        for i in pl.parallel(4, chunk=2):
+                        for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                         # Straight-line op between chunks
                         y: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.muls(x, 2.0)
-                        for j in pl.parallel(4, chunk=2):
+                        for j in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.add(x, y)
                 return x
 
@@ -196,11 +196,11 @@ class TestNestedForStmtRecursion:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
                         for c in pl.range(2):
-                            for i in pl.parallel(4, chunk=2):
+                            for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                                 x = pl.tensor.adds(x, 1.0)
                             # Non-parallel op deep inside nested range
                             y: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.muls(x, 3.0)
-                            for j in pl.parallel(4, chunk=2):
+                            for j in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                                 x = pl.tensor.add(x, y)
                 return x
 
@@ -233,7 +233,7 @@ class TestNestedForStmtRecursion:
             ) -> pl.Tensor[[8, 64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
-                        for i in pl.parallel(4, chunk=2):
+                        for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                         x = pl.tensor.muls(x, 2.0)
                 return x
@@ -264,13 +264,13 @@ class TestNestedForStmtRecursion:
             ) -> pl.Tensor[[8, 64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     for b in pl.range(0, 8, 4):
-                        for i in pl.parallel(4, chunk=2):
+                        for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                         # Multiple non-parallel ops in sequence
                         y: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.muls(x, 2.0)
                         z: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.add(x, y)
                         x = pl.tensor.muls(z, 0.5)
-                        for j in pl.parallel(4, chunk=2):
+                        for j in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
                 return x
 
@@ -335,7 +335,7 @@ class TestHostSideTailOps:
                     [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
                 )
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 4, 1, chunk=2):
+                    for i in pl.parallel(0, 4, 1, chunk=2, chunk_policy="leading_full"):
                         x = pl.tensor.adds(x, 1.0)
                     out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])
                 return out_1

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -662,7 +662,7 @@ class TestSplitIncoreOrchVerifier:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                     x = pl.add(x, 1.0)
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
                 return x
 

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -851,9 +851,20 @@ class TestDynamicChunking:
 
 
 class TestGuardedPolicy:
-    """Tests for the `guarded` chunk policy: single outer loop over ceil(T/C) chunks
-    with an internal `if idx < stop` guard instead of a separate remainder kernel.
+    """Tests for the `guarded` chunk policy.
+
+    Guarded mode emits a single outer loop over ceil(T/C) chunks and an inner
+    loop of size C, with the body wrapped in `if idx < stop` so out-of-range
+    iterations become no-ops. With iter_args, the guard becomes an IfStmt phi
+    whose else branch passes the inner iter_args through unchanged.
     """
+
+    @staticmethod
+    def _split_and_simplify(program):
+        """Prepare, split, then simplify so conditions compare cleanly."""
+        prepared = _prepare_for_split(program)
+        split = passes.split_chunked_loops()(prepared)
+        return passes.simplify()(split)
 
     def test_guarded_is_default(self):
         """Omitting chunk_policy selects Guarded."""
@@ -863,78 +874,478 @@ class TestGuardedPolicy:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 7, 1, chunk=5):
+                    for _i in pl.range(7, chunk=5):
                         x = pl.add(x, 1.0)
                 return x
 
-        Before = _prepare_for_split(Input)
-        After = passes.split_chunked_loops()(Before)
-        printed = python_print(After)
-        # Guarded mode emits ceil(7/5)=2 outer chunks with an if-guard.
-        assert "if " in printed, "Guarded mode should emit an if-guard"
-        assert "ChunkRemainder" not in printed, "Guarded mode should not emit a remainder loop"
+        @pl.program
+        class InputExplicit:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
 
-    def test_guarded_static_no_iter_args(self):
-        """Static bound, no iter_args: emits outer/inner ForStmts + IfStmt guard."""
+        # Default and explicit "guarded" must produce identical IR.
+        After = passes.split_chunked_loops()(_prepare_for_split(Input))
+        AfterExplicit = passes.split_chunked_loops()(_prepare_for_split(InputExplicit))
+        ir.assert_structural_equal(After, AfterExplicit, enable_auto_mapping=True)
+
+    def test_guarded_divisible_iter_args(self):
+        """Static bound, trip_count divisible by chunk_size, with iter_args."""
 
         @pl.program
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 7, 1, chunk=5, chunk_policy="guarded"):
+                    for _i in pl.range(10, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
 
-        Before = _prepare_for_split(Input)
-        After = passes.split_chunked_loops()(Before)
-        printed = python_print(After)
-        # ceil(7/5) == 2 outer chunks, inner chunk size 5, and an if-guard.
-        assert "pl.range(2," in printed or "pl.range(2)" in printed
-        assert "pl.range(5," in printed or "pl.range(5)" in printed
-        assert "if " in printed and "< 7" in printed
-        assert "ChunkRemainder" not in printed
+        After = self._split_and_simplify(Input)
 
-    def test_guarded_with_iter_args(self):
-        """Iter_args thread through IfStmt phi with else pass-through yield."""
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            5,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if i_out * 5 + i_in < 10:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_non_divisible_iter_args(self):
+        """Static bound, trip_count NOT divisible by chunk_size: ceil(7/5)=2 outer chunks.
+
+        The guard `idx < 7` disables lanes 7..9 in the second outer chunk,
+        and the else branch threads the inner iter_args through unchanged.
+        """
 
         @pl.program
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i, (s,) in pl.range(7, init_values=(x,), chunk=5, chunk_policy="guarded"):
-                        s = pl.add(s, 1.0)
-                        s = pl.yield_(s)
-                return s
+                    for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
 
-        Before = _prepare_for_split(Input)
-        After = passes.split_chunked_loops()(Before)
-        printed = python_print(After)
-        # Outer + inner with init_values (iter_args), an if-guard, and an else branch.
-        assert "init_values=" in printed
-        assert "if " in printed and "< 7" in printed
-        assert "else:" in printed
-        assert "ChunkRemainder" not in printed
+        After = self._split_and_simplify(Input)
 
-    def test_guarded_dynamic_bound(self):
-        """Dynamic bound `n`: outer stop is ceil((n - 0) / C)."""
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            5,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if i_out * 5 + i_in < 7:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_trip_less_than_chunk(self):
+        """trip_count < chunk_size: ceil(3/5)=1 outer chunk, inner guard masks lanes >= 3."""
 
         @pl.program
         class Input:
             @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INT64]) -> pl.Tensor[[64], pl.FP32]:
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, n, 1, chunk=4, chunk_policy="guarded"):
+                    for _i in pl.range(3, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            5,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            # Simplify proves i_out is always 0 (outer range [0,1)).
+                            if i_in < 3:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_no_iter_args(self):
+        """No iter_args: IfStmt has no phi and no else branch — body runs or is skipped."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
+                        _tmp = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out in pl.range(2, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
+                        for i_in in pl.range(5, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
+                            if i_out * 5 + i_in < 7:
+                                _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
+                return x_0
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_with_step(self):
+        """Non-unit step: guard compares `idx * step < stop`, idx = (out*C + in)."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(0, 20, 2, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            5,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if (i_out * 5 + i_in) * 2 < 20:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_parallel(self):
+        """pl.parallel: both outer and inner guarded loops are Parallel kind."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.parallel(8, chunk=4, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.parallel(
+                        2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.parallel(
+                            4,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if i_out * 4 + i_in < 8:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_dynamic_stop(self):
+        """Dynamic stop `n`: outer count = ceil(n/4) = (n + 3) // 4."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(n, chunk=4, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        (n_0 + 3) // 4,
+                        init_values=(x_0,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkOuter},
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            4,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if i_out * 4 + i_in < n_0:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_dynamic_start_and_stop(self):
+        """Dynamic start AND stop: outer count = ceil(max(hi-lo, 0) / 4)."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                lo: pl.Scalar[pl.INDEX],
+                hi: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(lo, hi, 1, chunk=4, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x_0: pl.Tensor[[64], pl.FP32],
+                lo_0: pl.Scalar[pl.INDEX],
+                hi_0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        (pl.max(hi_0 - lo_0, 0) + 3) // 4,
+                        init_values=(x_0,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkOuter},
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            4,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if lo_0 + (i_out * 4 + i_in) < hi_0:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_dynamic_no_iter_args(self):
+        """Dynamic bound with no iter_args: IfStmt has no phi."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(n, chunk=4, chunk_policy="guarded"):
+                        _tmp = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out in pl.range((n_0 + 3) // 4, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
+                        for i_in in pl.range(4, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
+                            if i_out * 4 + i_in < n_0:
+                                _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
+                return x_0
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_nested(self):
+        """Nested guarded loops: inner guarded loop lives inside outer's then-branch.
+
+        Verifies iter_args thread correctly through both levels of IfStmt phi.
+        """
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.parallel(8, chunk=4, chunk_policy="guarded"):
+                        for _j in pl.parallel(3, chunk=2, chunk_policy="guarded"):
+                            x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.parallel(
+                        2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.parallel(
+                            4,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if i_out * 4 + i_in < 8:
+                                for j_out, (x_j_outer,) in pl.parallel(
+                                    2,
+                                    init_values=(x_inner,),
+                                    attrs={"loop_origin": pl.LoopOrigin.ChunkOuter},
+                                ):
+                                    for j_in, (x_j_inner,) in pl.parallel(
+                                        2,
+                                        init_values=(x_j_outer,),
+                                        attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                                    ):
+                                        if j_out * 2 + j_in < 3:
+                                            x_5: pl.Tensor[[64], pl.FP32] = pl.add(x_j_inner, 1.0)
+                                            x_j_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_5)
+                                        else:
+                                            x_j_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_j_inner)
+                                        x_j_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_j_if)
+                                    x_j_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_j_inner_rv)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_j_outer_rv)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_origin_attrs(self):
+        """Guarded mode sets ChunkOuter/ChunkInner attrs and never emits ChunkRemainder."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
 
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
+
+        # Navigate: [ScopeStmt, return]; ScopeStmt.body = outer_for (guarded is a single for)
+        stmts = _top_level_stmts(After)
+        scope = cast(ir.ScopeStmt, stmts[0])
+        outer_for = cast(ir.ForStmt, scope.body)
+        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
+
+        inner_for = cast(ir.ForStmt, _body_stmts(outer_for.body)[0])
+        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
+
+        # No remainder loop should exist.
         printed = python_print(After)
-        # Dynamic bound always emits the outer loop with a FloorDiv ceiling.
-        assert "// 4" in printed or "FloorDiv" in printed
         assert "ChunkRemainder" not in printed
+
+    def test_guarded_printer_omits_default(self):
+        """Printer omits `chunk_policy="guarded"` (it's the default) but prints `leading_full`."""
+
+        @pl.program
+        class Guarded:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(10, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        @pl.program
+        class LeadingFull:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(10, chunk=5, chunk_policy="leading_full"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        guarded_printed = python_print(Guarded)
+        leading_printed = python_print(LeadingFull)
+        assert "chunk_policy" not in guarded_printed
+        assert 'chunk_policy="leading_full"' in leading_printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -58,7 +58,7 @@ class TestBasicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 10, 1, chunk=5):
+                    for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -95,7 +95,7 @@ class TestBasicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 7, 1, chunk=5):
+                    for i in pl.range(0, 7, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -141,7 +141,7 @@ class TestBasicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 5, 1, chunk=5):
+                    for i in pl.range(0, 5, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -182,7 +182,7 @@ class TestChunkingWithStep:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 20, 2, chunk=5):
+                    for i in pl.range(0, 20, 2, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -219,7 +219,7 @@ class TestChunkingWithStep:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 3, 1, chunk=5):
+                    for i in pl.range(0, 3, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -252,7 +252,7 @@ class TestChunkingWithKind:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -295,7 +295,7 @@ class TestChunkingWithKind:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.unroll(0, 12, 1, chunk=4):
+                    for i in pl.unroll(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -345,7 +345,7 @@ class TestPrinterRoundTrip:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 10, 1, chunk=5):
+                    for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -360,7 +360,7 @@ class TestPrinterRoundTrip:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, 8, 1, chunk=4):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -380,7 +380,7 @@ class TestParserErrors:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i, (s,) in pl.range(10, init_values=(x,), chunk=5):
+                    for i, (s,) in pl.range(10, init_values=(x,), chunk=5, chunk_policy="leading_full"):
                         s = pl.add(s, 1.0)
                         s = pl.yield_(s)
                 return x
@@ -394,7 +394,7 @@ class TestParserErrors:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                        for i in pl.range(0, 10, 1, chunk=0):
+                        for i in pl.range(0, 10, 1, chunk=0, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                     return x
 
@@ -439,7 +439,7 @@ class TestLoopOrigin:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 10, 1, chunk=5):
+                    for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -464,7 +464,7 @@ class TestLoopOrigin:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 7, 1, chunk=5):
+                    for i in pl.range(0, 7, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -492,7 +492,7 @@ class TestLoopOrigin:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 3, 1, chunk=5):
+                    for i in pl.range(0, 3, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -538,8 +538,8 @@ class TestNestedChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(8, chunk=4):
-                        for j in pl.parallel(1, chunk=2):
+                    for i in pl.parallel(8, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -584,8 +584,8 @@ class TestNestedChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(8, chunk=4):
-                        for j in pl.parallel(12, chunk=4):
+                    for i in pl.parallel(8, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(12, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -642,8 +642,8 @@ class TestNestedChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(6, chunk=4):
-                        for j in pl.parallel(3, chunk=2):
+                    for i in pl.parallel(6, chunk=4, chunk_policy="leading_full"):
+                        for j in pl.parallel(3, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                 return x
 
@@ -679,7 +679,7 @@ class TestDynamicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, n, 1, chunk=4):
+                    for i in pl.range(0, n, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -727,7 +727,7 @@ class TestDynamicChunking:
                 hi: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(lo, hi, 1, chunk=4):
+                    for i in pl.range(lo, hi, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -777,7 +777,7 @@ class TestDynamicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.parallel(0, n, 1, chunk=4):
+                    for i in pl.parallel(0, n, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -820,7 +820,7 @@ class TestDynamicChunking:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for i in pl.range(0, 10, 1, chunk=5):
+                    for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
 
@@ -848,6 +848,93 @@ class TestDynamicChunking:
                 return x_iter_1_outer_rv
 
         ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+
+class TestGuardedPolicy:
+    """Tests for the `guarded` chunk policy: single outer loop over ceil(T/C) chunks
+    with an internal `if idx < stop` guard instead of a separate remainder kernel.
+    """
+
+    def test_guarded_is_default(self):
+        """Omitting chunk_policy selects Guarded."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i in pl.range(0, 7, 1, chunk=5):
+                        x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_split(Input)
+        After = passes.split_chunked_loops()(Before)
+        printed = python_print(After)
+        # Guarded mode emits ceil(7/5)=2 outer chunks with an if-guard.
+        assert "if " in printed, "Guarded mode should emit an if-guard"
+        assert "ChunkRemainder" not in printed, "Guarded mode should not emit a remainder loop"
+
+    def test_guarded_static_no_iter_args(self):
+        """Static bound, no iter_args: emits outer/inner ForStmts + IfStmt guard."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i in pl.range(0, 7, 1, chunk=5, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_split(Input)
+        After = passes.split_chunked_loops()(Before)
+        printed = python_print(After)
+        # ceil(7/5) == 2 outer chunks, inner chunk size 5, and an if-guard.
+        assert "pl.range(2," in printed or "pl.range(2)" in printed
+        assert "pl.range(5," in printed or "pl.range(5)" in printed
+        assert "if " in printed and "< 7" in printed
+        assert "ChunkRemainder" not in printed
+
+    def test_guarded_with_iter_args(self):
+        """Iter_args thread through IfStmt phi with else pass-through yield."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i, (s,) in pl.range(7, init_values=(x,), chunk=5, chunk_policy="guarded"):
+                        s = pl.add(s, 1.0)
+                        s = pl.yield_(s)
+                return s
+
+        Before = _prepare_for_split(Input)
+        After = passes.split_chunked_loops()(Before)
+        printed = python_print(After)
+        # Outer + inner with init_values (iter_args), an if-guard, and an else branch.
+        assert "init_values=" in printed
+        assert "if " in printed and "< 7" in printed
+        assert "else:" in printed
+        assert "ChunkRemainder" not in printed
+
+    def test_guarded_dynamic_bound(self):
+        """Dynamic bound `n`: outer stop is ceil((n - 0) / C)."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INT64]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i in pl.range(0, n, 1, chunk=4, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        Before = _prepare_for_split(Input)
+        After = passes.split_chunked_loops()(Before)
+        printed = python_print(After)
+        # Dynamic bound always emits the outer loop with a FloorDiv ceiling.
+        assert "// 4" in printed or "FloorDiv" in printed
+        assert "ChunkRemainder" not in printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -1293,6 +1293,77 @@ class TestGuardedPolicy:
 
         ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
 
+    def test_guarded_negative_step(self):
+        """Descending chunked range: guard uses `idx > stop` since step < 0.
+
+        Regression test: the initial implementation built the guard as `idx < stop`
+        unconditionally, which made every iteration of a descending loop a no-op.
+        """
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(10, 0, -1, chunk=4, chunk_policy="guarded"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            4,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            # Original guard: 10 + (i_out*4 + i_in) * -1 > 0
+                            # Simplify rearranges stop to the left-hand side.
+                            if -10 < (i_out * 4 + i_in) * -1:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
+    def test_guarded_negative_step_no_iter_args(self):
+        """Descending chunked range without iter_args: guard still uses `idx > stop`."""
+
+        @pl.program
+        class Input:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for _i in pl.range(10, 0, -1, chunk=4, chunk_policy="guarded"):
+                        _tmp = pl.add(x, 1.0)
+                return x
+
+        After = self._split_and_simplify(Input)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out in pl.range(3, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
+                        for i_in in pl.range(4, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
+                            if -10 < (i_out * 4 + i_in) * -1:
+                                _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
+                return x_0
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+
     def test_guarded_origin_attrs(self):
         """Guarded mode sets ChunkOuter/ChunkInner attrs and never emits ChunkRemainder."""
 

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -135,7 +135,7 @@ class ChunkedLoopProgram:
         x: pl.Tensor[[16, 4], pl.FP32],
         seq_lens: pl.Tensor[[16], pl.INT32],
     ) -> pl.Tensor[[16, 4], pl.FP32]:
-        for b in pl.parallel(0, 16, 1, chunk=4):
+        for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
             _ctx_len = pl.tensor.read(seq_lens, [b])
         return x
 """


### PR DESCRIPTION
## Summary

Adds `ChunkPolicy::Guarded` as the new default for `pl.range`/`pl.parallel` with `chunk=C`. Instead of splitting a dynamic-bound chunked loop into a main + remainder kernel (`leading_full`), guarded mode emits a **single** outer loop over `ceil(T/C)` chunks with an inner `if (idx < stop)` guard on the body. With iter_args, loop-carried state threads through an `IfStmt` phi whose else branch yields the iter_args unchanged.

Fixes #930. Partially addresses #928 (cross-iteration inout accumulation under `pl.auto_incore()`).

### Why

- `leading_full` under dynamic bounds breaks cross-iteration inout accumulation (#928): the remainder kernel receives loop-carried state as input-only copies and writes to freshly allocated output tensors.
- It also doubles kernel count under `pl.auto_incore()` (e.g. Qwen3-32B decode scope2 went from 9 → 13 kernels after migrating four sequential stages to `pl.parallel`).

Guarded mode keeps a single outlined kernel.

### Key changes

- New `ChunkPolicy::Guarded` enum value; flipped `ChunkConfig::policy` default from `LeadingFull` to `Guarded` across C++ / bindings / stubs / DSL.
- `SplitChunkedLoops` pass dispatches on policy. Renamed the existing code paths `SplitSimple` → `SplitLeadingFull`, `SplitWithIterArgs` → `SplitLeadingFullWithIterArgs` for parity with the new `SplitGuarded` / `SplitGuardedWithIterArgs` implementations.
- Static and dynamic `n_total = ceil(T/C)` computation; guard `start + (i_out * C + i_in) * step < stop`.
- IfStmt phi threads iter_args through both branches (`then` yields updated values, `else` yields inner iter_args unchanged) — SSA-correct.
- Printer emits `chunk_policy="leading_full"` when explicit; `guarded` is omitted as the default.

### Test plan

- [x] 36 unit tests in `tests/ut/ir/transforms/test_split_chunked_loops.py` pass, including 13 new `TestGuardedPolicy` tests using Before/Expected + `ir.assert_structural_equal`:
  - default policy selection, static divisible/non-divisible/trip<chunk with iter_args
  - no iter_args (static + dynamic)
  - non-unit step, `pl.parallel` kind
  - dynamic stop, dynamic start+stop
  - nested guarded loops (inner guard inside outer's then-branch)
  - `loop_origin` attrs (no `ChunkRemainder` emitted)
  - printer default omission
- [x] Existing tests retrofitted with explicit `chunk_policy="leading_full"` where they verify split shape.
- [x] `test_interchange_chunk_loops.py` passes (no regression from policy change).
- [x] Pre-commit hooks: clang-format, cpplint, ruff, pyright, headers, english-only all pass.
- [x] System tests skipped per user direction.

### Out of scope / follow-ups

- Orchestration-level confirmation that guarded output preserves `add_inout()` across chunk boundary (closes #928).
- Pass-level analysis to auto-select `LeadingFull` when the compiler can prove `T % C == 0` (avoids dead guarded iterations).

Fixes #930