### PR TITLE
fix(pass): preserve dynamic-shape Var pointer identity in InitMemRef

### DIFF
--- a/python/pypto/ir/instruments.py
+++ b/python/pypto/ir/instruments.py
@@ -32,15 +32,6 @@ def make_roundtrip_instrument() -> _passes.CallbackInstrument:
       with SSA ``iter_args`` after ``ConvertToSSA``) have no valid Python DSL syntax.
       The instrument cannot roundtrip what it cannot print; it warns and skips.
 
-    - **Variable pointer mismatch**: Dynamic-shape ``Var`` nodes (e.g. ``M``
-      in ``pl.Tensor[[M, N], pl.FP32]``) appear in multiple places (params,
-      return type, body).  The original IR shares a single ``Var`` pointer
-      across all occurrences, but the parser may create separate ``Var``
-      objects for each occurrence.  ``structural_equal`` uses pointer-based
-      bijection and detects this as a mismatch.  This is a parser limitation
-      — it should reuse the same ``Var`` object for same-named dynamic-shape
-      parameters across all scopes.
-
     Returns:
         A ``CallbackInstrument`` named ``"RoundtripInstrument"``.
     """
@@ -97,14 +88,6 @@ def make_roundtrip_instrument() -> _passes.CallbackInstrument:
             _ir.assert_structural_equal(program, reparsed)
         except Exception as exc:
             error_msg = str(exc)
-            # Variable pointer mismatch: dynamic-shape Var nodes (e.g. M in
-            # Tensor[[M, N], FP32]) share a single pointer in the original IR,
-            # but the parser may create separate Var objects for each occurrence.
-            # The bijection in structural_equal detects this as a mismatch.
-            # TODO(#929): fix the parser to reuse same-named dynamic-shape Var
-            # objects across param types, return types, and body — then remove.
-            if "Variable pointer mismatch" in error_msg:
-                return
             raise RuntimeError(
                 f"[RoundtripInstrument] Structural equality failed after pass '{pass_name}'.\n"
                 f"\n"

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -170,6 +170,11 @@ class InitMemRefMutator : public IRMutator {
       auto memref = CreateMemRef(shaped_type, var, memory_space);
       new_type = CloneTypeWithMemRefAndRemapExprs(
           var_expr->GetType(), memref, [this](const ExprPtr& expr) { return VisitExpr(expr); }, memory_space);
+    } else {
+      // Non-shaped types (e.g. ScalarType for dynamic-shape dimensions like M, N)
+      // don't need MemRef initialization — return the original Var to preserve
+      // pointer identity across all type annotations that reference it.
+      return var;
     }
 
     return std::make_shared<Var>(var->name_hint_, new_type, var->span_);


### PR DESCRIPTION
## Summary

Closes #970

`InitMemRef::ProcessNormalVar` was creating new `Var` objects for non-ShapedType variables (e.g. `ScalarType(INDEX)` for dynamic dimensions like `M`, `N`) even though they don't need MemRef initialization. This fragmented a single shared `M` pointer into 4 distinct pointers across param types, return types, and body — breaking `structural_equal` bijection during roundtrip checks.

Fix: return the original `Var` for non-ShapedType variables. This also removes the last `Variable pointer mismatch` suppression from `RoundtripInstrument` — all roundtrip checks now run with **zero suppressions**.

## Test plan

- [x] All 3419 unit tests pass
- [x] Verified M pointer count stays at 1 through entire pass pipeline (was 4 after InitMemRef before fix)