### PR TITLE
fix(ci): update daily CI workflow to use qwen3 decode script (#980)

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -76,7 +76,7 @@ jobs:
             examples/models/qwen3/qwen3_32b_decode_scope1.py \
             examples/models/qwen3/qwen3_32b_decode_scope2.py \
             examples/models/qwen3/qwen3_32b_decode_scope3.py \
-            examples/models/qwen3/qwen3_32b_decode_scope12.py; do
+            examples/models/qwen3/qwen3_32b_decode.py; do
             echo "::group::$f"
             python "$f" -p a2a3 -d $DEVICE_ID
             echo "::endgroup::"


### PR DESCRIPTION
Replaced the reference to `qwen3_32b_decode_scope12.py` with `qwen3_32b_decode.py` in the daily CI workflow. This change ensures that the correct decoding script is executed during the CI process.