### PR TITLE
chore(ci): cache ptoas binary, bump pto-isa-commit, fix kernel_compiler import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_VERSION: v0.24
+      PTOAS_SHA256: 31a1f14767f23f0e530faeea0b0dea481ec22c09f9bee5045287b444df00b5bd
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -110,14 +112,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -v .[dev]
 
+      - name: Cache ptoas binary
+        id: cache-ptoas
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ptoas-bin
+          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
+
       - name: Install ptoas
+        if: steps.cache-ptoas.outputs.cache-hit != 'true'
         run: |
-          PTOAS_VERSION=v0.24
-          PTOAS_SHA256=31a1f14767f23f0e530faeea0b0dea481ec22c09f9bee5045287b444df00b5bd
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
              -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${PTOAS_SHA256}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
+          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
@@ -133,18 +141,20 @@ jobs:
           pip install -v .
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=38fcfb17
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=d96c8784
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device=$DEVICE_ID --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=38fcfb17
+            -v --device=$DEVICE_ID --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=d96c8784
 
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:
       SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_VERSION: v0.16
+      PTOAS_SHA256: 37bae58a015fe64be1cc105898317fb38f422992e87963ac90fcef5d595d00ec
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:
@@ -157,14 +167,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -v .[dev]
 
+      - name: Cache ptoas binary
+        id: cache-ptoas
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ptoas-bin
+          key: ptoas-x86_64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
+
       - name: Install ptoas
+        if: steps.cache-ptoas.outputs.cache-hit != 'true'
         run: |
-          PTOAS_VERSION=v0.16
-          PTOAS_SHA256=37bae58a015fe64be1cc105898317fb38f422992e87963ac90fcef5d595d00ec
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
+            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-x86_64.tar.gz \
              -o /tmp/ptoas-bin-x86_64.tar.gz
-          echo "${PTOAS_SHA256}  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
+          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
@@ -177,7 +193,7 @@ jobs:
           pip install -v .
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=38fcfb17 -m a5
+        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=d96c8784 -m a5
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -667,7 +667,7 @@ def _execute_on_device(
                 sys.path.insert(0, p)
 
     CodeRunner = importlib.import_module("code_runner").CodeRunner
-    KernelCompiler = importlib.import_module("kernel_compiler").KernelCompiler
+    KernelCompiler = importlib.import_module("simpler.kernel_compiler").KernelCompiler
     RuntimeBuilder = importlib.import_module("runtime_builder").RuntimeBuilder
 
     _install_golden_inputs_patch(CodeRunner)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -383,7 +383,7 @@ def prebuild_binaries(
 
     try:
         code_runner_mod = importlib.import_module("code_runner")
-        kernel_compiler_mod = importlib.import_module("kernel_compiler")
+        kernel_compiler_mod = importlib.import_module("simpler.kernel_compiler")
         runtime_builder_mod = importlib.import_module("runtime_builder")
     except ImportError:
         return 0


### PR DESCRIPTION
## Summary
- Cache ptoas binary downloads using `actions/cache@v4` keyed by architecture and version, avoiding redundant downloads on CI
- Extract `PTOAS_VERSION` and `PTOAS_SHA256` into job-level env vars for clarity
- Bump `--pto-isa-commit` from `38fcfb17` to `d96c8784` across all system test steps
- Fix `kernel_compiler` import path to `simpler.kernel_compiler` in runner and test harness

## Testing
- [x] Unit tests pass (3454 passed)
- [x] Build succeeds
- [x] CI validates ptoas caching and new pto-isa-commit