### PR TITLE
refactor(st): eliminate platform wrapper classes with parametrized backends

### DIFF
--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -44,6 +44,7 @@ from harness.core.environment import (  # noqa: E402
 from harness.core.harness import PTOTestCase  # noqa: E402
 from harness.core.test_runner import (  # noqa: E402
     TestRunner,
+    _cache_key,
     _precompile_cache,
     prebuild_binaries,
     precompile_test_cases,
@@ -330,9 +331,9 @@ def _collect_test_case_from_item(item: pytest.Item, seen: dict[str, PTOTestCase]
             instance = cls(**valid)
         except Exception:
             continue  # constructor mismatch — skip
-        name = instance.get_name()
-        if name not in seen:
-            seen[name] = instance
+        key = _cache_key(instance)
+        if key not in seen:
+            seen[key] = instance
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:
@@ -354,7 +355,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         return
 
     # ── discover PTOTestCase instances ───────────────────────────────────────
-    seen: dict[str, PTOTestCase] = {}  # test_name → instance (deduped)
+    seen: dict[str, PTOTestCase] = {}  # cache_key → instance (deduped)
 
     for item in session.items:
         _collect_test_case_from_item(item, seen)
@@ -401,7 +402,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         ok_cases = [
             tc
             for tc in test_cases
-            if tc.get_name() in _precompile_cache and _precompile_cache[tc.get_name()][1] is None
+            if _cache_key(tc) in _precompile_cache and _precompile_cache[_cache_key(tc)][1] is None
         ]
         print(
             f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s)"

--- a/tests/st/harness/core/__init__.py
+++ b/tests/st/harness/core/__init__.py
@@ -12,10 +12,22 @@
 from pypto.runtime.runner import RunConfig, RunResult
 
 from harness.core.environment import ensure_simpler_available
-from harness.core.harness import PTOTestCase, ScalarSpec, TensorSpec
+from harness.core.harness import (
+    A2A3_ONLY,
+    A5_ONLY,
+    ALL_PLATFORMS,
+    PLATFORMS,
+    PTOTestCase,
+    ScalarSpec,
+    TensorSpec,
+)
 from harness.core.test_runner import TestRunner
 
 __all__ = [
+    "A2A3_ONLY",
+    "A5_ONLY",
+    "ALL_PLATFORMS",
+    "PLATFORMS",
     "PTOTestCase",
     "TensorSpec",
     "ScalarSpec",

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -20,11 +20,33 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+import pytest
 import torch
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime.runner import RunConfig
 from pypto.runtime.tensor_spec import ScalarSpec
+
+# ---------------------------------------------------------------------------
+# Pre-defined platform parameter lists for @pytest.mark.parametrize.
+#
+# Usage:
+#     @pytest.mark.parametrize("backend", PLATFORMS)
+#     def test_foo(self, test_runner, backend):
+#         result = test_runner.run(MyTestCase(backend_type=backend))
+#         assert result.passed
+# ---------------------------------------------------------------------------
+
+PLATFORMS = [
+    pytest.param(BackendType.Ascend910B, id="a2a3"),
+    pytest.param(BackendType.Ascend950, id="a5", marks=pytest.mark.a5),
+]
+
+ALL_PLATFORMS = PLATFORMS
+
+A2A3_ONLY = [pytest.param(BackendType.Ascend910B, id="a2a3")]
+
+A5_ONLY = [pytest.param(BackendType.Ascend950, id="a5", marks=pytest.mark.a5)]
 
 
 class DataType(Enum):
@@ -125,13 +147,27 @@ class PTOTestCase(ABC):
                 tensors["c"][:] = tensors["a"] + tensors["b"]
     """
 
-    def __init__(self, config: RunConfig | None = None):
+    def __init__(
+        self,
+        config: RunConfig | None = None,
+        *,
+        backend_type: BackendType | None = None,
+        strategy: OptimizationStrategy | None = None,
+    ):
         """Initialize test case.
 
         Args:
             config: Test configuration. If None, uses default config.
+            backend_type: Override the backend type for code generation.
+                If None, falls back to the class-level ``get_backend_type()``
+                default (Ascend910B).  Pass explicitly to run the same test
+                case on a different platform without subclassing.
+            strategy: Override the optimization strategy.  If None, falls
+                back to the class-level ``get_strategy()`` default (Default).
         """
         self.config = config or RunConfig()
+        self._override_backend = backend_type
+        self._override_strategy = strategy
         self._tensor_specs: list[TensorSpec] | None = None
         self._scalar_specs: list[ScalarSpec] | None = None
 
@@ -161,23 +197,31 @@ class PTOTestCase(ABC):
     def get_strategy(self) -> OptimizationStrategy:
         """Return the optimization strategy for the pass pipeline.
 
-        Override to use a different strategy.
-        Default is OptimizationStrategy.Default.
+        If *strategy* was passed to the constructor, that value takes
+        precedence.  Otherwise falls back to ``OptimizationStrategy.Default``.
+        Subclasses may still override this method; the constructor override
+        only applies when the subclass does **not** redefine the method.
 
         Returns:
             OptimizationStrategy enum value.
         """
+        if self._override_strategy is not None:
+            return self._override_strategy
         return OptimizationStrategy.Default
 
     def get_backend_type(self) -> BackendType:
         """Return the backend type for code generation.
 
-        Override to target a different backend.
-        Default is BackendType.Ascend910B.
+        If *backend_type* was passed to the constructor, that value takes
+        precedence.  Otherwise falls back to ``BackendType.Ascend910B``.
+        Subclasses may still override this method; the constructor override
+        only applies when the subclass does **not** redefine the method.
 
         Returns:
             BackendType enum value.
         """
+        if self._override_backend is not None:
+            return self._override_backend
         return BackendType.Ascend910B
 
     def define_scalars(self) -> list[ScalarSpec]:

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -61,7 +61,10 @@ _log = logging.getLogger(__name__)
 # Pre-compilation cache (Phase 1 / Phase 2 split)
 # ---------------------------------------------------------------------------
 
-# Maps test_name → (work_dir, error_str | None).
+# Maps cache_key → (work_dir, error_str | None).
+# The cache key combines test name and backend architecture (e.g.
+# "matmul_64x64x64@a2a3") so the same PTOTestCase can be compiled for
+# multiple backends without collisions.
 # Populated by precompile_test_cases() in the parent process during
 # pytest_collection_finish, before any test forks.  Forked children inherit
 # the populated dict via os.fork() copy-on-write and find their pre-compiled
@@ -80,6 +83,17 @@ _BACKEND_TO_ARCH: dict[BackendType, str] = {
     BackendType.Ascend910B: "a2a3",
     BackendType.Ascend950: "a5",
 }
+
+
+def _cache_key(tc: PTOTestCase) -> str:
+    """Return a unique cache key combining test name and backend architecture.
+
+    Using a composite key allows the same ``PTOTestCase`` (same ``get_name()``)
+    to be compiled for multiple backends (e.g. Ascend910B *and* Ascend950)
+    without cache-key collisions.
+    """
+    arch = _BACKEND_TO_ARCH.get(tc.get_backend_type(), "unknown")
+    return f"{tc.get_name()}@{arch}"
 
 
 def _resolve_platform(config_platform: str, backend_type: BackendType) -> str:
@@ -210,10 +224,10 @@ def precompile_test_cases(
     groups via ``reset_for_testing()``.
 
     Args:
-        test_cases: Instances to compile (should be deduplicated by ``get_name``
-            before calling).
+        test_cases: Instances to compile (should be deduplicated by
+            ``_cache_key`` before calling).
         cache_dir: Root output directory; each test case is compiled into
-            ``cache_dir / <test_name>``.
+            ``cache_dir / <cache_key>``.
         dump_passes: If ``True``, dump intermediate IR after each pass.
         max_workers: Thread-pool size per backend group.  Defaults to
             ``os.cpu_count()``.
@@ -224,14 +238,14 @@ def precompile_test_cases(
         groups.setdefault(tc.get_backend_type(), []).append(tc)
 
     def _compile_one(tc: "PTOTestCase") -> tuple[str, Path, str | None]:
-        name = tc.get_name()
-        work_dir = cache_dir / name
+        key = _cache_key(tc)
+        work_dir = cache_dir / key
         work_dir.mkdir(parents=True, exist_ok=True)
         try:
             _compile_for_cache(tc, work_dir, dump_passes)
-            return name, work_dir, None
+            return key, work_dir, None
         except Exception as exc:
-            return name, work_dir, f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+            return key, work_dir, f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
 
     for backend_type, group in groups.items():
         # Set the backend type once for the whole group (idempotent if already
@@ -241,8 +255,8 @@ def precompile_test_cases(
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
                 futures = {pool.submit(_compile_one, tc): tc for tc in group}
                 for fut in concurrent.futures.as_completed(futures):
-                    name, work_dir, error = fut.result()
-                    _precompile_cache[name] = (work_dir, error)
+                    key, work_dir, error = fut.result()
+                    _precompile_cache[key] = (work_dir, error)
         finally:
             # Reset so the next group can set a different backend type.
             reset_for_testing()
@@ -270,7 +284,7 @@ def pregenerate_golden_inputs(
     the (potentially expensive) ``generate_inputs`` call at test execution time.
 
     Args:
-        test_cases: Test case instances (should be deduplicated by ``get_name``).
+        test_cases: Test case instances (should be deduplicated by cache key).
         cache_dir: Root output directory used during precompilation.
         max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
 
@@ -294,12 +308,13 @@ def pregenerate_golden_inputs(
     already_cached = 0
 
     for tc in test_cases:
-        work_dir = cache_dir / tc.get_name()
+        key = _cache_key(tc)
+        work_dir = cache_dir / key
         golden_path = work_dir / "golden.py"
         if not golden_path.exists():
             continue
         try:
-            module = _load_module(golden_path, f"_pregolden_{tc.get_name()}")
+            module = _load_module(golden_path, f"_pregolden_{key}")
         except Exception:
             continue
         if module is None:
@@ -362,7 +377,7 @@ def prebuild_binaries(
     in :mod:`pypto.runtime.runner`.
 
     Args:
-        test_cases: Test case instances (deduplicated by ``get_name``).
+        test_cases: Test case instances (deduplicated by cache key).
         cache_dir: Root output directory used during precompilation.
         platform: Session platform string (e.g. ``"a2a3"``).
         max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
@@ -414,10 +429,10 @@ def prebuild_binaries(
     seen_runtimes: set[tuple[str, str]] = set()
 
     for tc in test_cases:
-        name = tc.get_name()
-        if name not in _precompile_cache or _precompile_cache[name][1] is not None:
+        key = _cache_key(tc)
+        if key not in _precompile_cache or _precompile_cache[key][1] is not None:
             continue
-        work_dir = _precompile_cache[name][0]
+        work_dir = _precompile_cache[key][0]
         mod = _load_kc(work_dir)
         if mod is None:
             continue
@@ -522,10 +537,11 @@ class TestRunner:
         """
         start_time = time.time()
         test_name = test_case.get_name()
+        cache_k = _cache_key(test_case)
 
         # --- Phase 2: pre-compiled artifacts available — skip compilation ---
-        if test_name in _precompile_cache:
-            cached_dir, cached_error = _precompile_cache[test_name]
+        if cache_k in _precompile_cache:
+            cached_dir, cached_error = _precompile_cache[cache_k]
             if cached_error is not None:
                 return RunResult(
                     passed=False,

--- a/tests/st/runtime/test_broadcast.py
+++ b/tests/st/runtime/test_broadcast.py
@@ -16,18 +16,17 @@ from typing import Any
 import pypto.language as pl
 import pytest
 import torch
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TestTileRowExpand(PTOTestCase):
-    """Base test case for tile.row_expand."""
+    """Test case for tile.row_expand."""
 
     __test__ = False
 
-    def __init__(self, m: int = 16, n: int = 16, config=None):
-        super().__init__(config)
+    def __init__(self, m: int = 16, n: int = 16, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.N = n
 
@@ -71,43 +70,13 @@ class TestTileRowExpand(PTOTestCase):
         tensors["y"][:] = tensors["x"][:, :1].repeat(1, self.N)
 
 
-class TestTileRowExpandPTO(TestTileRowExpand):
-    """Test tile.row_expand with PTO backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"tile_row_expand_pto_{self.M}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestTileRowExpandA5(TestTileRowExpand):
-    """Test tile.row_expand with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"tile_row_expand_a5_{self.M}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestTileColExpand(PTOTestCase):
-    """Base test case for tile.col_expand."""
+    """Test case for tile.col_expand."""
 
     __test__ = False
 
-    def __init__(self, m: int = 16, n: int = 16, config=None):
-        super().__init__(config)
+    def __init__(self, m: int = 16, n: int = 16, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.N = n
 
@@ -155,64 +124,20 @@ class TestTileColExpand(PTOTestCase):
         tensors["y"][:] = tensors["col_vec"].repeat(self.M, 1)
 
 
-class TestTileColExpandPTO(TestTileColExpand):
-    """Test tile.col_expand with PTO backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"tile_col_expand_pto_{self.M}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestTileColExpandA5(TestTileColExpand):
-    """Test tile.col_expand with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"tile_col_expand_a5_{self.M}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestBroadcastOperations:
     """Test suite for tile broadcast operations."""
 
-    def test_tile_row_expand_pto(self, test_runner):
-        """Test tile.row_expand with PTO backend."""
-        test_case = TestTileRowExpandPTO()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (row_expand): {result.error}"
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_row_expand(self, test_runner, backend):
+        """Test tile.row_expand across platforms."""
+        result = test_runner.run(TestTileRowExpand(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_col_expand_pto(self, test_runner):
-        """Test tile.col_expand with PTO backend."""
-        test_case = TestTileColExpandPTO()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (col_expand): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_row_expand_a5(self, test_runner):
-        """Test tile.row_expand with A5 (Ascend 950) backend."""
-        test_case = TestTileRowExpandA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5 row_expand): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_col_expand_a5(self, test_runner):
-        """Test tile.col_expand with A5 (Ascend 950) backend."""
-        test_case = TestTileColExpandA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5 col_expand): {result.error}"
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_col_expand(self, test_runner, backend):
+        """Test tile.col_expand across platforms."""
+        result = test_runner.run(TestTileColExpand(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_concat.py
+++ b/tests/st/runtime/test_concat.py
@@ -15,13 +15,17 @@ from typing import Any
 
 import pytest
 from examples.kernels.concat import TileConcat32x32Program
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TileConcatTestCase(PTOTestCase):
     """Test case for tile column-wise concatenation (32x16 + 32x16 -> 32x32)."""
+
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "tile_concat_32x32"
@@ -36,48 +40,20 @@ class TileConcatTestCase(PTOTestCase):
     def get_program(self) -> Any:
         return TileConcat32x32Program
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:, :16] = tensors["a"]
         tensors["c"][:, 16:] = tensors["b"]
-
-
-class TileConcatA5TestCase(TileConcatTestCase):
-    """Test case for tile concat on A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_concat_a5_32x32"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
 
 
 class TestConcatOperations:
     """Test suite for concat operations."""
 
     @pytest.mark.skip(reason="PTOAS doesn't support tconcat now.")
-    def test_tile_concat_32x32(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_concat_32x32(self, test_runner, backend):
         """Test tile concatenation: 32x16 + 32x16 -> 32x32."""
-        test_case = TileConcatTestCase()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TileConcatTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    @pytest.mark.skip(reason="PTOAS doesn't support tconcat now.")
-    def test_tile_concat_32x32_a5(self, test_runner):
-        """Test tile concatenation on A5 (Ascend 950) backend."""
-        test_case = TileConcatA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_ctrl_flow.py
+++ b/tests/st/runtime/test_ctrl_flow.py
@@ -29,9 +29,8 @@ from typing import Any
 
 import pypto.language as pl
 import pytest
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TestForLoopAdd(PTOTestCase):
@@ -42,6 +41,9 @@ class TestForLoopAdd(PTOTestCase):
     """
 
     __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "for_loop_add_64x64"
@@ -87,21 +89,6 @@ class TestForLoopAdd(PTOTestCase):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
 
-class TestForLoopAddPTO(TestForLoopAdd):
-    """Test for loop add with PTO backend and Default optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_add_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
 class TestForLoopMul(PTOTestCase):
     """Test tile mul inside a for loop (1 iteration).
 
@@ -110,6 +97,9 @@ class TestForLoopMul(PTOTestCase):
     """
 
     __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "for_loop_mul_64x64"
@@ -155,21 +145,6 @@ class TestForLoopMul(PTOTestCase):
         tensors["c"][:] = tensors["a"] * tensors["b"]
 
 
-class TestForLoopMulPTO(TestForLoopMul):
-    """Test for loop mul with PTO backend and Default optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_mul_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
 class TestForLoopYieldAdd(PTOTestCase):
     """Test for loop with yield carrying a tensor across iterations.
 
@@ -179,6 +154,9 @@ class TestForLoopYieldAdd(PTOTestCase):
     """
 
     __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "for_loop_yield_add_64x64"
@@ -235,6 +213,9 @@ class TestForLoopYieldTileAccum(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "for_loop_yield_tile_accum"
 
@@ -286,6 +267,9 @@ class TestIfYieldTensor(PTOTestCase):
     """
 
     __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "if_yield_tensor"
@@ -342,6 +326,9 @@ class TestForIfElseNested(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "for_if_else_nested"
 
@@ -396,21 +383,6 @@ class TestForIfElseNested(PTOTestCase):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
 
-class TestForIfElseNestedPTO(TestForIfElseNested):
-    """Test if-else nested inside a for loop with PTO backend and PTOAS."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_if_else_nested_pto"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
 class TestWhileLoopAdd(PTOTestCase):
     """Test while loop performing tile add over 4 chunks.
 
@@ -422,14 +394,11 @@ class TestWhileLoopAdd(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
-        return "while_loop_add_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
+        return "while_loop_add_64x64"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -484,14 +453,11 @@ class TestForLoopBreak(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
-        return "for_loop_break_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
+        return "for_loop_break_64x64"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -533,7 +499,6 @@ class TestForLoopBreak(PTOTestCase):
         return ForLoopBreakProgram
 
     def compute_expected(self, tensors, params=None):
-        # Only first 2 chunks (rows 0-127) are processed
         tensors["c"][:128] = tensors["a"][:128] + tensors["b"][:128]
         tensors["c"][128:] = 0.0
 
@@ -548,14 +513,11 @@ class TestForLoopContinue(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
-        return "for_loop_continue_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
+        return "for_loop_continue_64x64"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -597,7 +559,6 @@ class TestForLoopContinue(PTOTestCase):
         return ForLoopContinueProgram
 
     def compute_expected(self, tensors, params=None):
-        # Only even chunks (rows 0-63, 128-191) are processed
         tensors["c"][:64] = tensors["a"][:64] + tensors["b"][:64]
         tensors["c"][64:128] = 0.0
         tensors["c"][128:192] = tensors["a"][128:192] + tensors["b"][128:192]
@@ -615,14 +576,11 @@ class TestForLoopBreakContinue(PTOTestCase):
 
     __test__ = False
 
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
-        return "for_loop_break_continue_pto_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
+        return "for_loop_break_continue_64x64"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -666,312 +624,78 @@ class TestForLoopBreakContinue(PTOTestCase):
         return ForLoopBreakContinueProgram
 
     def compute_expected(self, tensors, params=None):
-        # break at i>=3, continue at odd i -> only i=0 and i=2 are processed
         tensors["c"][:64] = tensors["a"][:64] + tensors["b"][:64]
         tensors["c"][64:128] = 0.0
         tensors["c"][128:192] = tensors["a"][128:192] + tensors["b"][128:192]
         tensors["c"][192:] = 0.0
 
 
-class TestForLoopAddA5(TestForLoopAdd):
-    """Test for loop add with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_add_a5_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopMulA5(TestForLoopMul):
-    """Test for loop mul with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_mul_a5_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopYieldAddA5(TestForLoopYieldAdd):
-    """Test for loop yield add with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_yield_add_a5_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopYieldTileAccumA5(TestForLoopYieldTileAccum):
-    """Test for loop yield tile accumulator with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_yield_tile_accum_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestIfYieldTensorA5(TestIfYieldTensor):
-    """Test if-else with yield on A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "if_yield_tensor_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForIfElseNestedA5(TestForIfElseNested):
-    """Test if-else nested in for loop with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_if_else_nested_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestWhileLoopAddA5(TestWhileLoopAdd):
-    """Test while loop add with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "while_loop_add_a5_64x64"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopBreakA5(TestForLoopBreak):
-    """Test for loop with break on A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_break_a5_64x64"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopContinueA5(TestForLoopContinue):
-    """Test for loop with continue on A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_continue_a5_64x64"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestForLoopBreakContinueA5(TestForLoopBreakContinue):
-    """Test for loop with break and continue on A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "for_loop_break_continue_a5_64x64"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestCtrlFlowOperations:
     """Test suite for control flow operations."""
 
-    def test_for_loop_add(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_add(self, test_runner, backend):
         """Test for loop wrapping tile add."""
-        test_case = TestForLoopAdd()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestForLoopAdd(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_for_loop_add_pto(self, test_runner):
-        """Test for loop add with PTO backend and PTOAS."""
-        test_case = TestForLoopAddPTO()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    def test_for_loop_mul(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_mul(self, test_runner, backend):
         """Test for loop wrapping tile mul."""
-        test_case = TestForLoopMul()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestForLoopMul(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_for_loop_mul_pto(self, test_runner):
-        """Test for loop mul with PTO backend and PTOAS."""
-        test_case = TestForLoopMulPTO()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    def test_for_loop_yield_add(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_yield_add(self, test_runner, backend):
         """Test for loop with yield carrying tensor across iterations."""
-        test_case = TestForLoopYieldAdd()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestForLoopYieldAdd(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_for_loop_yield_tile_accum(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_yield_tile_accum(self, test_runner, backend):
         """Test for loop with yield carrying tile accumulator across iterations."""
-        test_case = TestForLoopYieldTileAccum()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestForLoopYieldTileAccum(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_if_yield_tensor(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_if_yield_tensor(self, test_runner, backend):
         """Test if-else with yield carrying tensors."""
-        test_case = TestIfYieldTensor()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestIfYieldTensor(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_for_if_else_nested(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_if_else_nested(self, test_runner, backend):
         """Test if-else nested inside a for loop."""
-        test_case = TestForIfElseNested()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestForIfElseNested(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_if_else_nested_pto(self, test_runner):
-        """Test if-else nested inside a for loop with PTO backend and PTOAS."""
-        test_case = TestForIfElseNestedPTO()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_while_loop_add(self, test_runner, backend):
+        """Test while loop add (scf.while codegen)."""
+        result = test_runner.run(TestWhileLoopAdd(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.skip(reason="PTOAS BUG")
-    def test_while_loop_add_pto(self, test_runner):
-        """Test while loop add with PTO backend (scf.while codegen)."""
-        test_case = TestWhileLoopAdd()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_break(self, test_runner, backend):
+        """Test for loop with break."""
+        result = test_runner.run(TestForLoopBreak(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_break_pto(self, test_runner):
-        """Test for loop with break using PTO backend."""
-        test_case = TestForLoopBreak()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_continue(self, test_runner, backend):
+        """Test for loop with continue."""
+        result = test_runner.run(TestForLoopContinue(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_continue_pto(self, test_runner):
-        """Test for loop with continue using PTO backend."""
-        test_case = TestForLoopContinue()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_break_continue_pto(self, test_runner):
-        """Test for loop with break and continue using PTO backend."""
-        test_case = TestForLoopBreakContinue()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    def test_for_loop_add_a5(self, test_runner):
-        """Test for loop add with A5 (Ascend 950) backend."""
-        test_case = TestForLoopAddA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_for_loop_mul_a5(self, test_runner):
-        """Test for loop mul with A5 (Ascend 950) backend."""
-        test_case = TestForLoopMulA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_for_loop_yield_add_a5(self, test_runner):
-        """Test for loop yield add with A5 (Ascend 950) backend."""
-        test_case = TestForLoopYieldAddA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_for_loop_yield_tile_accum_a5(self, test_runner):
-        """Test for loop yield tile accumulator with A5 (Ascend 950) backend."""
-        test_case = TestForLoopYieldTileAccumA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_if_yield_tensor_a5(self, test_runner):
-        """Test if-else with yield on A5 (Ascend 950) backend."""
-        test_case = TestIfYieldTensorA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_for_if_else_nested_a5(self, test_runner):
-        """Test if-else nested in for loop with A5 (Ascend 950) backend."""
-        test_case = TestForIfElseNestedA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.skip(reason="PTOAS BUG")
-    def test_while_loop_add_a5(self, test_runner):
-        """Test while loop add with A5 (Ascend 950) backend."""
-        test_case = TestWhileLoopAddA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_break_a5(self, test_runner):
-        """Test for loop with break on A5 (Ascend 950) backend."""
-        test_case = TestForLoopBreakA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_continue_a5(self, test_runner):
-        """Test for loop with continue on A5 (Ascend 950) backend."""
-        test_case = TestForLoopContinueA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.skip(reason="PTOAS BUG")
-    def test_for_loop_break_continue_a5(self, test_runner):
-        """Test for loop with break and continue on A5 (Ascend 950) backend."""
-        test_case = TestForLoopBreakContinueA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_for_loop_break_continue(self, test_runner, backend):
+        """Test for loop with break and continue."""
+        result = test_runner.run(TestForLoopBreakContinue(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_dag.py
+++ b/tests/st/runtime/test_dag.py
@@ -21,9 +21,8 @@ from typing import Any
 
 import pytest
 from examples.models.vector_dag import VectorDAGProgram
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class VectorDAGTestCase(PTOTestCase):
@@ -38,6 +37,11 @@ class VectorDAGTestCase(PTOTestCase):
       t3: g = kernel_mul(d, e)
       t4: f = kernel_add(g, c)
     """
+
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "vector_dag_128x128"
@@ -61,57 +65,14 @@ class VectorDAGTestCase(PTOTestCase):
         tensors["f"][:] = g + c
 
 
-class VectorDAGPTOTestCase(VectorDAGTestCase):
-    """Test vector DAG with PTO backend and PTOAS optimization."""
-
-    def get_name(self) -> str:
-        return "vector_dag_pto_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class VectorDAGA5TestCase(VectorDAGTestCase):
-    """Test vector DAG with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "vector_dag_a5_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestDAGOperations:
     """Test suite for DAG operations."""
 
-    def test_vector_dag_128x128(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_vector_dag(self, test_runner, backend):
         """Test vector DAG computation with 128x128 shape."""
-        test_case = VectorDAGTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for vector DAG: {result.error}"
-
-    def test_vector_dag_pto_128x128(self, test_runner):
-        """Test vector DAG with PTO backend and PTOAS optimization."""
-        test_case = VectorDAGPTOTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for vector DAG (PTO): {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    def test_vector_dag_a5_128x128(self, test_runner):
-        """Test vector DAG with A5 (Ascend 950) backend."""
-        test_case = VectorDAGA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
+        result = test_runner.run(VectorDAGTestCase(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_dyn_orch_shape.py
+++ b/tests/st/runtime/test_dyn_orch_shape.py
@@ -53,9 +53,8 @@ from examples.models.paged_attention import (
     kernel_qk_matmul,
     kernel_softmax_prepare,
 )
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime.runner import RunConfig
 
 M = pl.dynamic("M")
@@ -87,8 +86,14 @@ class DynOrchAddTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, shape: tuple[int, int], config: RunConfig | None = None):
-        super().__init__(config)
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
 
     def get_name(self) -> str:
@@ -102,7 +107,6 @@ class DynOrchAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Captured as closure variables for tile load/store sizes.
         rows = self._rows
         cols = self._cols
 
@@ -134,12 +138,6 @@ class DynOrchAddTestCase(PTOTestCase):
 
         return DynOrchAddProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
@@ -159,9 +157,11 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
         self,
         shape: tuple[int, int],
         valid_shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
         config: RunConfig | None = None,
     ):
-        super().__init__(config)
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
         self._valid_rows, self._valid_cols = valid_shape
 
@@ -184,7 +184,6 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Tile size baked in as closure variables.
         rows = self._rows
         cols = self._cols
 
@@ -221,12 +220,6 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
 
         return DynOrchValidShapeProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         vr = int(tensors["vs"][0])
         vc = int(tensors["vs"][1])
@@ -246,8 +239,14 @@ class DynOrchLoopMixedDimsAddTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, shape: tuple[int, int], config: RunConfig | None = None):
-        super().__init__(config)
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
 
     def get_name(self) -> str:
@@ -261,7 +260,6 @@ class DynOrchLoopMixedDimsAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # cols is baked as a static integer in the type annotation [M, cols].
         cols = self._cols
 
         @pl.program
@@ -296,12 +294,6 @@ class DynOrchLoopMixedDimsAddTestCase(PTOTestCase):
 
         return DynOrchLoopProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
@@ -318,8 +310,14 @@ class DynOrchDimOnDynParamAddTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, shape: tuple[int, int], config: RunConfig | None = None):
-        super().__init__(config)
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
 
     def get_name(self) -> str:
@@ -333,7 +331,6 @@ class DynOrchDimOnDynParamAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Captured as closure variables for tile load/store sizes.
         rows = self._rows
         cols = self._cols
 
@@ -367,12 +364,6 @@ class DynOrchDimOnDynParamAddTestCase(PTOTestCase):
 
         return DynOrchDimProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
@@ -398,9 +389,11 @@ class DynOrchPagedAttentionTestCase(PTOTestCase):
         context_len: int = 256,
         max_model_len: int = 1024,
         scale: float = 1.0,
+        *,
+        backend_type: BackendType | None = None,
         config: RunConfig | None = None,
     ):
-        super().__init__(config)
+        super().__init__(config, backend_type=backend_type)
         self.config.atol = 2e-2
         self.config.rtol = 2e-2
         self._batch = batch
@@ -453,7 +446,6 @@ class DynOrchPagedAttentionTestCase(PTOTestCase):
                 out: pl.Out[pl.Tensor[[QR, HD], pl.FP32]],
             ) -> pl.Tensor[[QR, HD], pl.FP32]:
                 """Paged attention orchestration with tensor.dim-derived runtime values."""
-                # Derive all runtime config from tensor shapes
                 batch_cfg: pl.Scalar[pl.INT64] = pl.tensor.dim(context_lens, 0)
                 query_rows: pl.Scalar[pl.INT64] = pl.tensor.dim(query, 0)
                 head_dim_cfg: pl.Scalar[pl.INT64] = pl.tensor.dim(query, 1)
@@ -540,14 +532,7 @@ class DynOrchPagedAttentionTestCase(PTOTestCase):
 
         return DynOrchPagedAttentionProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
-        # Derive all config from tensor shapes (mirrors orchestration logic)
         batch = tensors["context_lens"].shape[0]
         query_rows = tensors["query"].shape[0]
         head_dim = tensors["query"].shape[1]
@@ -605,71 +590,6 @@ class DynOrchPagedAttentionTestCase(PTOTestCase):
         tensors["out"][:] = out.reshape(batch * num_heads, head_dim)
 
 
-class DynOrchAddA5TestCase(DynOrchAddTestCase):
-    """Test add with dynamic M×N orchestration on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"dyn_orch_add_a5_{self._rows}x{self._cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class DynOrchValidShapeAddA5TestCase(DynOrchValidShapeAddTestCase):
-    """Test add with dynamic M×N orchestration and valid_shapes on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return (
-            f"dyn_orch_valid_shape_add_a5_{self._rows}x{self._cols}"
-            f"_valid_{self._valid_rows}x{self._valid_cols}"
-        )
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class DynOrchLoopMixedDimsAddA5TestCase(DynOrchLoopMixedDimsAddTestCase):
-    """Test add with dynamic M / static cols on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"dyn_orch_loop_mixed_dims_add_a5_{self._rows}x{self._cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class DynOrchDimOnDynParamAddA5TestCase(DynOrchDimOnDynParamAddTestCase):
-    """Test add with tensor.dim on dynamic params on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"dyn_orch_dim_on_dyn_param_add_a5_{self._rows}x{self._cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class DynOrchPagedAttentionA5TestCase(DynOrchPagedAttentionTestCase):
-    """Paged attention with fully dynamic dims on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return (
-            f"dyn_orch_paged_attn_a5_{self._batch}b_{self._num_heads}h_{self._head_dim}d_{self._block_size}bs"
-        )
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 # =============================================================================
 # pytest test suite
 # =============================================================================
@@ -678,32 +598,32 @@ class DynOrchPagedAttentionA5TestCase(DynOrchPagedAttentionTestCase):
 class TestDynOrchShapeOperations:
     """Test suite for dynamic orchestration shape operations."""
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape", _DYN_SHAPES)
-    def test_dyn_orch_add(self, test_runner, shape):
+    def test_dyn_orch_add(self, test_runner, shape, backend):
         """Test add where both InCore and orchestration use dynamic M×N dims."""
-        test_case = DynOrchAddTestCase(shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(DynOrchAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape,valid_shape", [((32, 32), (16, 16))])
-    def test_dyn_orch_valid_shape_add(self, test_runner, shape, valid_shape):
+    def test_dyn_orch_valid_shape_add(self, test_runner, shape, valid_shape, backend):
         """Test add with dynamic M×N orchestration and valid_shapes from INT64 tensor."""
-        test_case = DynOrchValidShapeAddTestCase(shape, valid_shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(DynOrchValidShapeAddTestCase(shape, valid_shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}, valid_shape {valid_shape}: {result.error}"
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape", _MIXED_SHAPES)
-    def test_dyn_orch_loop_mixed_dims_add(self, test_runner, shape):
+    def test_dyn_orch_loop_mixed_dims_add(self, test_runner, shape, backend):
         """Test add with dynamic M / static cols=16 in orchestration, loop in InCore."""
-        test_case = DynOrchLoopMixedDimsAddTestCase(shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(DynOrchLoopMixedDimsAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape", _DYN_SHAPES)
-    def test_dyn_orch_dim_on_dyn_param_add(self, test_runner, shape):
+    def test_dyn_orch_dim_on_dyn_param_add(self, test_runner, shape, backend):
         """Test add where orchestration reads tensor dims via pl.tensor.dim."""
-        test_case = DynOrchDimOnDynParamAddTestCase(shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(DynOrchDimOnDynParamAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
 
     @pytest.mark.parametrize(
@@ -714,50 +634,17 @@ class TestDynOrchShapeOperations:
         self, test_runner, batch, num_heads, head_dim, block_size, context_len, max_model_len
     ):
         """Test paged attention with fully dynamic dims in the orchestration signature."""
-        test_case = DynOrchPagedAttentionTestCase(
-            batch=batch,
-            num_heads=num_heads,
-            head_dim=head_dim,
-            block_size=block_size,
-            context_len=context_len,
-            max_model_len=max_model_len,
+        result = test_runner.run(
+            DynOrchPagedAttentionTestCase(
+                batch=batch,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                block_size=block_size,
+                context_len=context_len,
+                max_model_len=max_model_len,
+            )
         )
-        result = test_runner.run(test_case)
         assert result.passed, f"Dyn orch paged attention test failed: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape", _DYN_SHAPES)
-    def test_dyn_orch_add_a5(self, test_runner, shape):
-        """Test add with dynamic M×N orchestration on A5 (Ascend 950)."""
-        test_case = DynOrchAddA5TestCase(shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}: {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape,valid_shape", [((32, 32), (16, 16))])
-    def test_dyn_orch_valid_shape_add_a5(self, test_runner, shape, valid_shape):
-        """Test add with dynamic M×N orchestration and valid_shapes on A5 (Ascend 950)."""
-        test_case = DynOrchValidShapeAddA5TestCase(shape, valid_shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}, valid_shape {valid_shape}: {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape", _MIXED_SHAPES)
-    def test_dyn_orch_loop_mixed_dims_add_a5(self, test_runner, shape):
-        """Test add with dynamic M / static cols on A5 (Ascend 950)."""
-        test_case = DynOrchLoopMixedDimsAddA5TestCase(shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}: {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape", _DYN_SHAPES)
-    def test_dyn_orch_dim_on_dyn_param_add_a5(self, test_runner, shape):
-        """Test add with tensor.dim on dynamic params on A5 (Ascend 950)."""
-        test_case = DynOrchDimOnDynParamAddA5TestCase(shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}: {result.error}"
 
     @pytest.mark.a5
     @pytest.mark.skip(reason="CPU sim path bug: TMATMUL does not support bf16 data type")
@@ -769,15 +656,17 @@ class TestDynOrchShapeOperations:
         self, test_runner, batch, num_heads, head_dim, block_size, context_len, max_model_len
     ):
         """Test paged attention with fully dynamic dims on A5 (Ascend 950)."""
-        test_case = DynOrchPagedAttentionA5TestCase(
-            batch=batch,
-            num_heads=num_heads,
-            head_dim=head_dim,
-            block_size=block_size,
-            context_len=context_len,
-            max_model_len=max_model_len,
+        result = test_runner.run(
+            DynOrchPagedAttentionTestCase(
+                batch=batch,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                block_size=block_size,
+                context_len=context_len,
+                max_model_len=max_model_len,
+                backend_type=BackendType.Ascend950,
+            )
         )
-        result = test_runner.run(test_case)
         assert result.passed, f"Dyn orch paged attention A5 test failed: {result.error}"
 
 

--- a/tests/st/runtime/test_dynamic_shape.py
+++ b/tests/st/runtime/test_dynamic_shape.py
@@ -29,9 +29,8 @@ from typing import Any
 import pypto.language as pl
 import pytest
 import torch
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime.runner import RunConfig
 
 M = pl.dynamic("M")
@@ -50,8 +49,14 @@ class DynShapeAddTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, shape: tuple[int, int], config: RunConfig | None = None):
-        super().__init__(config)
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
 
     def get_name(self) -> str:
@@ -65,7 +70,6 @@ class DynShapeAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Captured as closure variables by @pl.function / @pl.program decorators.
         rows = self._rows
         cols = self._cols
 
@@ -97,12 +101,6 @@ class DynShapeAddTestCase(PTOTestCase):
 
         return DynShapeAddProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
@@ -122,9 +120,11 @@ class ValidShapeAddTestCase(PTOTestCase):
         self,
         shape: tuple[int, int],
         valid_shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
         config: RunConfig | None = None,
     ):
-        super().__init__(config)
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
         self._valid_rows, self._valid_cols = valid_shape
 
@@ -145,7 +145,6 @@ class ValidShapeAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Captured as closure variables by @pl.function / @pl.program decorators.
         rows = self._rows
         cols = self._cols
 
@@ -182,12 +181,6 @@ class ValidShapeAddTestCase(PTOTestCase):
 
         return ValidShapeAddProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         vr = tensors["valid_shape"][0]
         vc = tensors["valid_shape"][1]
@@ -205,8 +198,14 @@ class LoopDynShapeAddTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, shape: tuple[int, int], config: RunConfig | None = None):
-        super().__init__(config)
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
         self._rows, self._cols = shape
 
     def get_name(self) -> str:
@@ -220,7 +219,6 @@ class LoopDynShapeAddTestCase(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        # Captured as closure variables by @pl.function / @pl.program decorators.
         rows = self._rows
         cols = self._cols
 
@@ -255,50 +253,8 @@ class LoopDynShapeAddTestCase(PTOTestCase):
 
         return LoopDynShapeAddProgram
 
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
-
-
-class DynShapeAddA5TestCase(DynShapeAddTestCase):
-    """Test add kernel with fully dynamic M*N tensor shapes on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"dyn_shape_add_a5_{self._rows}x{self._cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class ValidShapeAddA5TestCase(ValidShapeAddTestCase):
-    """Test add kernel with static tensors and valid_shapes on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"valid_shape_add_a5_{self._rows}x{self._cols}_valid_{self._valid_rows}x{self._valid_cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class LoopDynShapeAddA5TestCase(LoopDynShapeAddTestCase):
-    """Test add kernel with dynamic M dim and scf.for loop on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"loop_dyn_shape_add_a5_{self._rows}x{self._cols}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
 
 
 # =============================================================================
@@ -309,52 +265,26 @@ class LoopDynShapeAddA5TestCase(LoopDynShapeAddTestCase):
 class TestDynamicShapeOperations:
     """Test suite for dynamic shape kernel operations."""
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape", _SHAPES)
-    def test_dyn_shape_add(self, test_runner, shape):
+    def test_dyn_shape_add(self, test_runner, shape, backend):
         """Test add with fully dynamic M×N tensor shapes."""
-        test_case = DynShapeAddTestCase(shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(DynShapeAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape,valid_shape", [((128, 128), (64, 64))])
-    def test_valid_shape_add(self, test_runner, shape, valid_shape):
+    def test_valid_shape_add(self, test_runner, shape, valid_shape, backend):
         """Test add with static tensors and valid_shapes read from an input tensor."""
-        test_case = ValidShapeAddTestCase(shape, valid_shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(ValidShapeAddTestCase(shape, valid_shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}, valid_shape {valid_shape}: {result.error}"
 
+    @pytest.mark.parametrize("backend", PLATFORMS)
     @pytest.mark.parametrize("shape", _SHAPES)
-    def test_loop_dyn_shape_add(self, test_runner, shape):
+    def test_loop_dyn_shape_add(self, test_runner, shape, backend):
         """Test add with dynamic M dim iterated in pairs via scf.for."""
-        test_case = LoopDynShapeAddTestCase(shape)
-        result = test_runner.run(test_case)
+        result = test_runner.run(LoopDynShapeAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape", _SHAPES)
-    def test_dyn_shape_add_a5(self, test_runner, shape):
-        """Test add with fully dynamic M×N tensor shapes on A5 (Ascend 950)."""
-        test_case = DynShapeAddA5TestCase(shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}: {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape,valid_shape", [((128, 128), (64, 64))])
-    def test_valid_shape_add_a5(self, test_runner, shape, valid_shape):
-        """Test add with static tensors and valid_shapes on A5 (Ascend 950)."""
-        test_case = ValidShapeAddA5TestCase(shape, valid_shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}, valid_shape {valid_shape}: {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize("shape", _SHAPES)
-    def test_loop_dyn_shape_add_a5(self, test_runner, shape):
-        """Test add with dynamic M dim iterated in pairs on A5 (Ascend 950)."""
-        test_case = LoopDynShapeAddA5TestCase(shape)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5) for shape {shape}: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_elementwise.py
+++ b/tests/st/runtime/test_elementwise.py
@@ -11,8 +11,9 @@
 Runtime tests for tile-based elementwise operations using the PyPTO frontend.
 
 This module defines integration tests for elementwise add and multiply
-kernels implemented with the internal PTOTestCase harness, including
-variants for different shapes and optimization strategies.
+kernels implemented with the internal PTOTestCase harness.  Each test case
+accepts an optional ``backend_type`` parameter so a single class can run
+on multiple platforms via ``@pytest.mark.parametrize``.
 """
 
 from typing import Any
@@ -25,260 +26,87 @@ from examples.kernels.elementwise import (
     TileMul64Program,
     TileMul128Program,
 )
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 
 class TileAddTestCase(PTOTestCase):
-    """Test case for tile element-wise addition (128x128)."""
+    """Test case for tile element-wise addition."""
+
+    __test__ = False
+
+    def __init__(self, size: int = 128, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+        self.size = size
 
     def get_name(self) -> str:
-        return "tile_add_128x128"
+        return f"tile_add_{self.size}x{self.size}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        s = self.size
         return [
-            TensorSpec("a", [128, 128], DataType.FP32, init_value=2.0),
-            TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
-            TensorSpec("c", [128, 128], DataType.FP32, is_output=True),
+            TensorSpec("a", [s, s], DataType.FP32, init_value=2.0),
+            TensorSpec("b", [s, s], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [s, s], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return TileAdd128Program
-
-    def compute_expected(self, tensors, params=None):
-        tensors["c"][:] = tensors["a"] + tensors["b"]
-
-
-class TileAdd64x64TestCase(PTOTestCase):
-    """Test case for tile element-wise addition (64x64)."""
-
-    def get_name(self) -> str:
-        return "tile_add_64x64"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("a", [64, 64], DataType.FP32, init_value=2.0),
-            TensorSpec("b", [64, 64], DataType.FP32, init_value=3.0),
-            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return TileAdd64Program
+        return TileAdd128Program if self.size == 128 else TileAdd64Program
 
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
 
 class TileMulTestCase(PTOTestCase):
-    """Test case for tile element-wise multiplication (128x128)."""
+    """Test case for tile element-wise multiplication."""
+
+    __test__ = False
+
+    def __init__(self, size: int = 128, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+        self.size = size
 
     def get_name(self) -> str:
-        return "tile_mul_128x128"
+        return f"tile_mul_{self.size}x{self.size}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        s = self.size
         return [
-            TensorSpec(
-                "a",
-                [128, 128],
-                DataType.FP32,
-                init_value=torch.randn,
-            ),
-            TensorSpec("b", [128, 128], DataType.FP32, init_value=3.0),
-            TensorSpec("c", [128, 128], DataType.FP32, is_output=True),
+            TensorSpec("a", [s, s], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [s, s], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [s, s], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:
-        return TileMul128Program
+        return TileMul128Program if self.size == 128 else TileMul64Program
 
     def compute_expected(self, tensors, params=None):
         tensors["c"][:] = tensors["a"] * tensors["b"]
-
-
-class TileMul64x64TestCase(PTOTestCase):
-    """Test case for tile element-wise multiplication (64x64)."""
-
-    def get_name(self) -> str:
-        return "tile_mul_64x64"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec(
-                "a",
-                [64, 64],
-                DataType.FP32,
-                init_value=torch.randn,
-            ),
-            TensorSpec("b", [64, 64], DataType.FP32, init_value=3.0),
-            TensorSpec("c", [64, 64], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return TileMul64Program
-
-    def compute_expected(self, tensors, params=None):
-        tensors["c"][:] = tensors["a"] * tensors["b"]
-
-
-class TileAddPTOASTestCase(TileAddTestCase):
-    """Test case for tile add with PTO backend and PTOAS optimization strategy."""
-
-    def get_name(self) -> str:
-        return "tile_add_ptoas_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TileMulPTOASTestCase(TileMulTestCase):
-    """Test case for tile mul with PTO backend and PTOAS optimization strategy."""
-
-    def get_name(self) -> str:
-        return "tile_mul_ptoas_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TileAddA5TestCase(TileAddTestCase):
-    """Test case for tile add with A5 (Ascend 950) backend (128x128)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_add_a5_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TileAdd64x64A5TestCase(TileAdd64x64TestCase):
-    """Test case for tile add with A5 (Ascend 950) backend (64x64)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_add_a5_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TileMulA5TestCase(TileMulTestCase):
-    """Test case for tile mul with A5 (Ascend 950) backend (128x128)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_mul_a5_128x128"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TileMul64x64A5TestCase(TileMul64x64TestCase):
-    """Test case for tile mul with A5 (Ascend 950) backend (64x64)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_mul_a5_64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
 
 
 # =============================================================================
 # pytest test functions
 # =============================================================================
 
+_SIZES = [64, 128]
+
 
 class TestElementwiseOperations:
-    """Test suite for elementwise operations."""
+    """Test suite for elementwise operations across all platforms."""
 
-    def test_tile_add_64x64(self, test_runner):
-        """Test tile addition with 64x64 shape."""
-        test_case = TileAdd64x64TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for 64x64: {result.error}"
-
-    def test_tile_add_128x128(self, test_runner):
-        """Test tile addition with 128x128 shape."""
-        test_case = TileAddTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for 128x128: {result.error}"
-
-    def test_tile_mul_64x64(self, test_runner):
-        """Test tile multiplication with 64x64 shape."""
-        test_case = TileMul64x64TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for 64x64: {result.error}"
-
-    def test_tile_mul_128x128(self, test_runner):
-        """Test tile multiplication with 128x128 shape."""
-        test_case = TileMulTestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed for 128x128: {result.error}"
-
-    def test_tile_add_ptoas_strategy(self, test_runner):
-        """Test tile addition with PTO backend and PTOAS optimization."""
-        test_case = TileAddPTOASTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("size", _SIZES)
+    def test_tile_add(self, test_runner, backend, size):
+        """Test tile addition with configurable shape and platform."""
+        result = test_runner.run(TileAddTestCase(size=size, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_mul_ptoas_strategy(self, test_runner):
-        """Test tile multiplication with PTO backend and PTOAS optimization."""
-        test_case = TileMulPTOASTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("size", _SIZES)
+    def test_tile_mul(self, test_runner, backend, size):
+        """Test tile multiplication with configurable shape and platform."""
+        result = test_runner.run(TileMulTestCase(size=size, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    def test_tile_add_64x64_a5(self, test_runner):
-        """Test tile addition with 64x64 shape on A5 (Ascend 950)."""
-        test_case = TileAdd64x64A5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_add_128x128_a5(self, test_runner):
-        """Test tile addition with 128x128 shape on A5 (Ascend 950)."""
-        test_case = TileAddA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_mul_64x64_a5(self, test_runner):
-        """Test tile multiplication with 64x64 shape on A5 (Ascend 950)."""
-        test_case = TileMul64x64A5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_mul_128x128_a5(self, test_runner):
-        """Test tile multiplication with 128x128 shape on A5 (Ascend 950)."""
-        test_case = TileMulA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_elementwise_nd.py
+++ b/tests/st/runtime/test_elementwise_nd.py
@@ -20,9 +20,8 @@ from typing import Any
 import pypto.language as pl
 import pytest
 import torch
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Programs (partial coverage) ---
 
@@ -42,10 +41,8 @@ class Tile4DMulPartialProgram:
         a: pl.Tensor[[4, 3, 8, 64], pl.FP32],
         out: pl.Out[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
     ) -> pl.Tensor[[4, 3, 8, 64], pl.FP32]:
-        # Load first half of outer dim: [0:2, 0:3, 0:8, 0:64]
         a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
         c_tile = pl.tile.mul(a_tile, a_tile)
-        # Store to second half: offset [2,0,0,0], tile covers [2,3,8,64] elements
         out = pl.store(c_tile, [2, 0, 0, 0], out)
         return out
 
@@ -79,10 +76,8 @@ class Tile4DQuadrantProgram:
         a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
         out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
-        # Load top-right quadrant: a[0, 1, :, :]
         tile = pl.load(a, [0, 1, 0, 0], [1, 1, 8, 16])
         result_tile = pl.tile.mul(tile, tile)
-        # Store to bottom-left quadrant: out[1, 0, :, :]
         out = pl.store(result_tile, [1, 0, 0, 0], out)
         return out
 
@@ -117,12 +112,9 @@ class Tile4DTopToBottomProgram:
         b: pl.Tensor[[2, 2, 8, 16], pl.FP32],
         out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
-        # Load entire top row as one tile: a[0, :, :, :] and b[0, :, :, :]
         a_tile = pl.load(a, [0, 0, 0, 0], [1, 2, 8, 16])
         b_tile = pl.load(b, [0, 0, 0, 0], [1, 2, 8, 16])
-        # Multiply element-wise so ResolveBackendOpLayouts can infer TileView
         result_tile = pl.tile.mul(a_tile, b_tile)
-        # Store to bottom row in one shot: out[1, :, :, :]
         out = pl.store(result_tile, [1, 0, 0, 0], out)
         return out
 
@@ -153,11 +145,9 @@ class Tile2DStoreTo3DProgram:
         b: pl.Tensor[[4, 16], pl.FP32],
         out: pl.Out[pl.Tensor[[2, 4, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
-        # Load row 0 from each input: natively 2D tiles [1, 16]
         a_tile = pl.load(a, [0, 0], [1, 16])
         b_tile = pl.load(b, [0, 0], [1, 16])
         c_tile = pl.tile.mul(a_tile, b_tile)
-        # Store into slot [1, 2, 0] of the 3D tensor
         out = pl.store(c_tile, [1, 2, 0], out)
         return out
 
@@ -178,14 +168,13 @@ class Tile2DStoreTo3DProgram:
 class Tile4DMulPartialTestCase(PTOTestCase):
     """4D tile partial coverage: tile [2,3,8,64] stores to offset [2,0,0,0] of a [4,3,8,64] tensor."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "tile_4d_mul_partial"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -197,22 +186,19 @@ class Tile4DMulPartialTestCase(PTOTestCase):
         return Tile4DMulPartialProgram
 
     def compute_expected(self, tensors, params=None):
-        # First half of dim-0 is unsquared (out[:2] unchanged / zero-initialized)
-        # Second half of dim-0 = a[:2, ...] ** 2
         tensors["out"][2:, ...] = tensors["a"][:2, ...] * tensors["a"][:2, ...]
 
 
 class Tile4DTopToBottomTestCase(PTOTestCase):
     """4D tensor [2,2,8,16]; mul top row a*b via one [1,2,8,16] tile, store to bottom row."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "tile_4d_top_to_bottom"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -225,21 +211,19 @@ class Tile4DTopToBottomTestCase(PTOTestCase):
         return Tile4DTopToBottomProgram
 
     def compute_expected(self, tensors, params=None):
-        # Only bottom row is written; top row stays zero-initialized.
         tensors["out"][1] = tensors["a"][0] * tensors["b"][0]
 
 
 class Tile4DQuadrantTestCase(PTOTestCase):
     """4D tensor [2,2,8,16] split into 4 blocks; load top-right, store squared to bottom-left."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "tile_4d_quadrant"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -251,7 +235,6 @@ class Tile4DQuadrantTestCase(PTOTestCase):
         return Tile4DQuadrantProgram
 
     def compute_expected(self, tensors, params=None):
-        # Only bottom-left quadrant is written; the rest stays zero-initialized.
         tensors["out"][1, 0] = tensors["a"][0, 1] ** 2
 
 
@@ -264,14 +247,13 @@ class Tile2DStoreTo3DTestCase(PTOTestCase):
     'tile.store on ND tensor requires shapes tuple (args[3])'.
     """
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "tile_2d_store_to_3d"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -287,150 +269,35 @@ class Tile2DStoreTo3DTestCase(PTOTestCase):
         tensors["out"][1, 2, :] = tensors["a"][0, :] * tensors["b"][0, :]
 
 
-# --- A5 (Ascend 950) Test Cases ---
-
-
-class Tile4DMulPartialA5TestCase(Tile4DMulPartialTestCase):
-    """4D tile partial coverage with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_4d_mul_partial_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class Tile4DTopToBottomA5TestCase(Tile4DTopToBottomTestCase):
-    """4D tensor top-to-bottom with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_4d_top_to_bottom_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class Tile4DQuadrantA5TestCase(Tile4DQuadrantTestCase):
-    """4D tensor quadrant with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_4d_quadrant_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class Tile2DStoreTo3DA5TestCase(Tile2DStoreTo3DTestCase):
-    """2D tile store to 3D tensor with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "tile_2d_store_to_3d_a5"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 # --- Tests ---
 
 
 class TestElementwise4D:
     """End-to-end tests for elementwise ops on 4D tiles (exercises FlattenTileNdTo2D pass)."""
 
-    def test_tile_4d_top_to_bottom(self, test_runner):
-        """4D tensor [2,2,8,16]; a*b on top row via a single [1,2,8,16] tile, store to bottom row.
-
-        Loads a[0,:,:,:] and b[0,:,:,:] with tile shape [1,2,8,16] from offset
-        [0,0,0,0], multiplies them, and stores to out[1,:,:,:] at offset
-        [1,0,0,0].  Partition_view sizes for the store must be [1,2,8,16]
-        (tile shape), not [2,2,8,16] (full tensor shape).
-        """
-        test_case = Tile4DTopToBottomTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_4d_top_to_bottom(self, test_runner, backend):
+        """4D tensor [2,2,8,16]; a*b on top row via a single [1,2,8,16] tile, store to bottom row."""
+        result = test_runner.run(Tile4DTopToBottomTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_4d_quadrant(self, test_runner):
-        """4D tensor [2,2,8,16] divided into 4 blocks of [1,1,8,16].
-
-        Loads top-right block a[0,1,:,:], squares it, stores to bottom-left
-        block out[1,0,:,:].  Partition_view sizes for the store must be
-        [1,1,8,16] (tile shape).  With the current bug, sizes=[2,2,8,16] and
-        offset[0]=1 gives offset+size=3 > tensor_dim=2 (out of bounds).
-        """
-        test_case = Tile4DQuadrantTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_4d_quadrant(self, test_runner, backend):
+        """4D tensor [2,2,8,16] divided into 4 blocks of [1,1,8,16]."""
+        result = test_runner.run(Tile4DQuadrantTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_4d_mul_partial(self, test_runner):
-        """Partial-coverage 4D tile store: tile [2,3,8,64] at offset [2,0,0,0] of [4,3,8,64] tensor.
-
-        Verifies that partition_view sizes match the tile shape [2,3,8,64] (not the full
-        tensor [4,3,8,64]). With the bug, sizes=[4,3,8,64] and offset=[2,0,0,0] would
-        produce offset+size=[6,...] > tensor_dim[4,...], causing ptoas to reject the IR.
-        """
-        test_case = Tile4DMulPartialTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_4d_mul_partial(self, test_runner, backend):
+        """Partial-coverage 4D tile store: tile [2,3,8,64] at offset [2,0,0,0] of [4,3,8,64] tensor."""
+        result = test_runner.run(Tile4DMulPartialTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_tile_2d_store_to_3d(self, test_runner):
-        """2D tile [1, 16] stored into a 3D tensor [2, 4, 16].
-
-        Regression test for the bug where FlattenTileNdTo2D only injected the
-        shapes tuple when the *tile* was ND, missing the case where the tile is
-        natively 2D but the output tensor is ND (rank > 2).
-        """
-        test_case = Tile2DStoreTo3DTestCase()
-        result = test_runner.run(test_case)
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tile_2d_store_to_3d(self, test_runner, backend):
+        """2D tile [1, 16] stored into a 3D tensor [2, 4, 16]."""
+        result = test_runner.run(Tile2DStoreTo3DTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    def test_tile_4d_mul_partial_a5(self, test_runner):
-        """Test 4D tile partial store with A5 (Ascend 950) backend."""
-        test_case = Tile4DMulPartialA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_4d_top_to_bottom_a5(self, test_runner):
-        """Test 4D tile top-to-bottom with A5 (Ascend 950) backend."""
-        test_case = Tile4DTopToBottomA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_4d_quadrant_a5(self, test_runner):
-        """Test 4D tile quadrant with A5 (Ascend 950) backend."""
-        test_case = Tile4DQuadrantA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_tile_2d_store_to_3d_a5(self, test_runner):
-        """Test 2D tile store to 3D tensor with A5 (Ascend 950) backend."""
-        test_case = Tile2DStoreTo3DA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_fillpad.py
+++ b/tests/st/runtime/test_fillpad.py
@@ -22,9 +22,8 @@ from typing import Any
 import pypto.language as pl
 import pytest
 import torch
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Programs ---
 
@@ -116,14 +115,13 @@ class FillpadMinProgram:
 class FillpadZeroTestCase(PTOTestCase):
     """Test fillpad - padding region should be filled with 0.0."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "fillpad_zero"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -135,7 +133,6 @@ class FillpadZeroTestCase(PTOTestCase):
         return FillpadZeroProgram
 
     def compute_expected(self, tensors, params=None):
-        """Expected: rows 0-47 = input, rows 48-63 = 0.0"""
         expected = torch.zeros(64, 64, dtype=torch.float32)
         expected[:48, :] = tensors["input_tensor"]
         tensors["output"][:] = expected
@@ -144,14 +141,13 @@ class FillpadZeroTestCase(PTOTestCase):
 class FillpadMaxTestCase(PTOTestCase):
     """Test fillpad - padding region should be filled with FP32 max."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "fillpad_max"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -163,7 +159,6 @@ class FillpadMaxTestCase(PTOTestCase):
         return FillpadMaxProgram
 
     def compute_expected(self, tensors, params=None):
-        """Expected: rows 0-47 = input, rows 48-63 = FP32 max"""
         expected = torch.full((64, 64), float("inf"), dtype=torch.float32)
         expected[:48, :] = tensors["input_tensor"]
         tensors["output"][:] = expected
@@ -172,14 +167,13 @@ class FillpadMaxTestCase(PTOTestCase):
 class FillpadMinTestCase(PTOTestCase):
     """Test fillpad - padding region should be filled with FP32 min (-inf)."""
 
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
     def get_name(self) -> str:
         return "fillpad_min"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -191,49 +185,9 @@ class FillpadMinTestCase(PTOTestCase):
         return FillpadMinProgram
 
     def compute_expected(self, tensors, params=None):
-        """Expected: rows 0-47 = input, rows 48-63 = -inf"""
         expected = torch.full((64, 64), float("-inf"), dtype=torch.float32)
         expected[:48, :] = tensors["input_tensor"]
         tensors["output"][:] = expected
-
-
-# --- A5 (Ascend 950) Test Cases ---
-
-
-class FillpadZeroA5TestCase(FillpadZeroTestCase):
-    """Test fillpad zero on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "fillpad_zero_a5"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class FillpadMaxA5TestCase(FillpadMaxTestCase):
-    """Test fillpad max on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "fillpad_max_a5"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class FillpadMinA5TestCase(FillpadMinTestCase):
-    """Test fillpad min on A5 (Ascend 950)."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "fillpad_min_a5"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
 
 
 # --- Tests ---
@@ -242,46 +196,23 @@ class FillpadMinA5TestCase(FillpadMinTestCase):
 class TestFillpad:
     """Test suite to verify fillpad fills padding region with different pad values."""
 
-    def test_fillpad_zero(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_fillpad_zero(self, test_runner, backend):
         """Verify fillpad fills the padding region with 0.0."""
-        test_case = FillpadZeroTestCase()
-        result = test_runner.run(test_case)
+        result = test_runner.run(FillpadZeroTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_fillpad_max(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_fillpad_max(self, test_runner, backend):
         """Verify fillpad fills the padding region with FP32 max value."""
-        test_case = FillpadMaxTestCase()
-        result = test_runner.run(test_case)
+        result = test_runner.run(FillpadMaxTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    def test_fillpad_min(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_fillpad_min(self, test_runner, backend):
         """Verify fillpad fills the padding region with FP32 min value (-inf)."""
-        test_case = FillpadMinTestCase()
-        result = test_runner.run(test_case)
+        result = test_runner.run(FillpadMinTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    def test_fillpad_zero_a5(self, test_runner):
-        """Verify fillpad fills padding with 0.0 on A5 (Ascend 950)."""
-        test_case = FillpadZeroA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_fillpad_max_a5(self, test_runner):
-        """Verify fillpad fills padding with FP32 max on A5 (Ascend 950)."""
-        test_case = FillpadMaxA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_fillpad_min_a5(self, test_runner):
-        """Verify fillpad fills padding with FP32 min on A5 (Ascend 950)."""
-        test_case = FillpadMinA5TestCase()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_matmul.py
+++ b/tests/st/runtime/test_matmul.py
@@ -12,6 +12,8 @@ Tests for matrix multiplication operation using PyPTO frontend.
 
 This test validates the matmul operation implementation through the
 pto-testing-framework, ensuring correct code generation and execution.
+Each test case accepts an optional ``backend_type`` parameter so a single
+class can run on multiple platforms via ``@pytest.mark.parametrize``.
 """
 
 from typing import Any
@@ -20,16 +22,16 @@ import pypto.language as pl
 import pytest
 import torch
 from examples.kernels.matmul import MatmulaccProgram
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
-from pypto.ir.pass_manager import OptimizationStrategy
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 
 
 class TestMatmul(PTOTestCase):
-    __test__ = False  # Not a pytest test class
+    """Matmul: C = A @ B."""
 
-    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
-        super().__init__(config)
+    __test__ = False
+
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, backend_type=None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.K = k
         self.N = n
@@ -61,7 +63,6 @@ class TestMatmul(PTOTestCase):
                 tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
                 tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
-                # store can support l0c -> GM directly
                 out_c = pl.store(tile_c_l0c, offsets=[0, 0], output_tensor=c)
                 return out_c
 
@@ -89,8 +90,8 @@ class TestMatmulBTranspose(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
-        super().__init__(config)
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, backend_type=None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.K = k
         self.N = n
@@ -151,8 +152,8 @@ class TestMatmulATranspose(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
-        super().__init__(config)
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, backend_type=None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.K = k
         self.N = n
@@ -213,8 +214,8 @@ class TestMatmulABTranspose(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, m: int = 64, k: int = 64, n: int = 64, config=None):
-        super().__init__(config)
+    def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, backend_type=None, config=None):
+        super().__init__(config, backend_type=backend_type)
         self.M = m
         self.K = k
         self.N = n
@@ -269,126 +270,6 @@ class TestMatmulABTranspose(PTOTestCase):
         tensors["c"][:] = torch.matmul(tensors["a"].to(torch.float32).T, tensors["b"].to(torch.float32).T)
 
 
-class TestMatmulPTO(TestMatmul):
-    """Test matmul with PTO backend and PTOAS optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_pto_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestMatmulBTransposePTO(TestMatmulBTranspose):
-    """Test matmul B transpose with PTO backend and PTOAS optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_btranspose_pto_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestMatmulATransposePTO(TestMatmulATranspose):
-    """Test matmul A transpose with PTO backend and PTOAS optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_atranspose_pto_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestMatmulABTransposePTO(TestMatmulABTranspose):
-    """Test matmul AB transpose with PTO backend and PTOAS optimization."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_abtranspose_pto_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestMatmulA5(TestMatmul):
-    """Test matmul with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_a5_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestMatmulBTransposeA5(TestMatmulBTranspose):
-    """Test matmul B transpose with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_btranspose_a5_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestMatmulATransposeA5(TestMatmulATranspose):
-    """Test matmul A transpose with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_atranspose_a5_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
-class TestMatmulABTransposeA5(TestMatmulABTranspose):
-    """Test matmul AB transpose with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"matmul_abtranspose_a5_{self.M}x{self.K}x{self.N}"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestMatmulAcc(PTOTestCase):
     """Test matmul with accumulation (K-split into two chunks).
 
@@ -397,6 +278,9 @@ class TestMatmulAcc(PTOTestCase):
     """
 
     __test__ = False
+
+    def __init__(self, *, backend_type=None, config=None):
+        super().__init__(config, backend_type=backend_type)
 
     def get_name(self) -> str:
         return "matmulacc_64x64x64"
@@ -415,191 +299,50 @@ class TestMatmulAcc(PTOTestCase):
         tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
 
 
-class TestMatmulAccPTO(TestMatmulAcc):
-    """Test matmul_acc with PTO backend."""
+# =============================================================================
+# pytest test functions
+# =============================================================================
 
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "matmulacc_pto_64x64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class TestMatmulAccA5(TestMatmulAcc):
-    """Test matmul_acc with A5 (Ascend 950) backend."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "matmulacc_a5_64x64x64"
-
-    def get_strategy(self) -> OptimizationStrategy:
-        return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
+_MATMUL_SHAPES = [(64, 64, 64), (128, 64, 128), (64, 128, 64)]
+_TRANSPOSE_SHAPES = [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)]
 
 
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [
-            (64, 64, 64),
-            (128, 64, 128),
-            (64, 128, 64),
-        ],
-    )
-    def test_matmul(self, test_runner, m, k, n):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", _MATMUL_SHAPES)
+    def test_matmul(self, test_runner, backend, m, k, n):
         """Test matmul with configurable matrix dimensions."""
-        test_case = TestMatmul(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestMatmul(m=m, k=k, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_transpose(self, test_runner, m, k, n):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", _TRANSPOSE_SHAPES)
+    def test_matmul_btranspose(self, test_runner, backend, m, k, n):
         """Test matmul with B transposed (C = A @ B^T)."""
-        test_case = TestMatmulBTranspose(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestMatmulBTranspose(m=m, k=k, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [
-            (64, 64, 64),
-            (128, 64, 128),
-            (64, 128, 64),
-        ],
-    )
-    def test_matmul_pto(self, test_runner, m, k, n):
-        """Test matmul with PTO backend and PTOAS optimization."""
-        test_case = TestMatmulPTO(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_transpose_pto(self, test_runner, m, k, n):
-        """Test matmul with B transposed (C = A @ B^T)."""
-        test_case = TestMatmulBTransposePTO(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
-
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_atranspose(self, test_runner, m, k, n):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", _TRANSPOSE_SHAPES)
+    def test_matmul_atranspose(self, test_runner, backend, m, k, n):
         """Test matmul with A transposed (C = A^T @ B)."""
-        test_case = TestMatmulATranspose(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestMatmulATranspose(m=m, k=k, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_abtranspose(self, test_runner, m, k, n):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", _TRANSPOSE_SHAPES)
+    def test_matmul_abtranspose(self, test_runner, backend, m, k, n):
         """Test matmul with both A and B transposed (C = A^T @ B^T)."""
-        test_case = TestMatmulABTranspose(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestMatmulABTranspose(m=m, k=k, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_atranspose_pto(self, test_runner, m, k, n):
-        """Test matmul A transpose with PTO backend."""
-        test_case = TestMatmulATransposePTO(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
-
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_abtranspose_pto(self, test_runner, m, k, n):
-        """Test matmul AB transpose with PTO backend."""
-        test_case = TestMatmulABTransposePTO(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed: {result.error}"
-
-    def test_matmulacc_64x64x64(self, test_runner):
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_matmulacc(self, test_runner, backend):
         """Test matmul with accumulation (K split into two chunks)."""
-        test_case = TestMatmulAcc()
-        result = test_runner.run(test_case)
+        result = test_runner.run(TestMatmulAcc(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
-
-    def test_matmulacc_pto_64x64x64(self, test_runner):
-        """Test matmul_acc with PTO backend."""
-        test_case = TestMatmulAccPTO()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (PTO): {result.error}"
-
-    # ---- A5 (Ascend 950) tests ----
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64)],
-    )
-    def test_matmul_a5(self, test_runner, m, k, n):
-        """Test matmul with A5 (Ascend 950) backend."""
-        test_case = TestMatmulA5(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_btranspose_a5(self, test_runner, m, k, n):
-        """Test matmul B transpose with A5 (Ascend 950) backend."""
-        test_case = TestMatmulBTransposeA5(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_atranspose_a5(self, test_runner, m, k, n):
-        """Test matmul A transpose with A5 (Ascend 950) backend."""
-        test_case = TestMatmulATransposeA5(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    @pytest.mark.parametrize(
-        "m,k,n",
-        [(64, 64, 64), (128, 64, 128), (64, 128, 64), (32, 64, 32)],
-    )
-    def test_matmul_abtranspose_a5(self, test_runner, m, k, n):
-        """Test matmul AB transpose with A5 (Ascend 950) backend."""
-        test_case = TestMatmulABTransposeA5(m=m, k=k, n=n)
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
-
-    @pytest.mark.a5
-    def test_matmulacc_a5_64x64x64(self, test_runner):
-        """Test matmul_acc with A5 (Ascend 950) backend."""
-        test_case = TestMatmulAccA5()
-        result = test_runner.run(test_case)
-        assert result.passed, f"Test failed (A5): {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
+++ b/tests/st/runtime/test_qwen3_decode_scope3_mixed.py
@@ -28,8 +28,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Mirror tests/st/conftest.py so direct `python <file>.py` execution can
-# resolve the local harness package before pytest takes over.
 _ST_DIR = Path(__file__).resolve().parents[1]
 if str(_ST_DIR) not in sys.path:
     sys.path.insert(0, str(_ST_DIR))
@@ -38,9 +36,6 @@ _PROJECT_ROOT = _ST_DIR.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-# These imports intentionally follow sys.path bootstrapping so direct
-# `python tests/st/runtime/test_qwen3_decode_scope3_mixed.py` execution can
-# resolve the local harness package and worktree sources.
 import pypto.language as pl  # noqa: E402
 import pytest  # noqa: E402
 import torch  # noqa: E402
@@ -112,7 +107,6 @@ def build_qwen3_scope3_program(
                         )
                         resid1_tile = pl.assemble(resid1_tile, pl.add(o_acc, resid), [0, o0])
 
-                    # Post-attention RMSNorm: compute inv_rms over resid1_tile.
                     sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
                     for kb in pl.range(HIDDEN_BLOCKS):
                         k0 = kb * K_CHUNK
@@ -122,7 +116,6 @@ def build_qwen3_scope3_program(
                         )
                     inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS))
 
-                    # Normalize and zero-init down_proj accumulator.
                     post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.BF16)
                     down_proj_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
                     for zi in pl.range(HIDDEN_BLOCKS):
@@ -141,7 +134,6 @@ def build_qwen3_scope3_program(
                             post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0]
                         )
 
-                    # MLP: gate/up projections + SiLU + down projection.
                     for ob in pl.range(MLP_OUT_BLOCKS):
                         o0 = ob * MLP_OUT_CHUNK
                         gate_acc = pl.full([BATCH_TILE, MLP_OUT_CHUNK], dtype=pl.FP32, value=0.0)
@@ -191,32 +183,28 @@ def golden(tensors: dict, params: dict | None = None) -> None:
       3. SwiGLU MLP: gate/up projections → silu(gate) * up → down projection
       4. Final residual addition → BF16 output
     """
-    attn_out = tensors["attn_out"]  # [B, H], BF16
-    hidden_states = tensors["hidden_states"]  # [B, H], BF16
-    wo = tensors["wo"]  # [H, H], BF16
-    post_rms_weight = tensors["post_rms_weight"]  # [1, H], FP32
-    w_gate = tensors["w_gate"]  # [H, I], BF16
-    w_up = tensors["w_up"]  # [H, I], BF16
-    w_down = tensors["w_down"]  # [I, H], BF16
+    attn_out = tensors["attn_out"]
+    hidden_states = tensors["hidden_states"]
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
 
     eps = 1e-6
 
-    # 1. Output projection (BF16 inputs, FP32 accumulation) + residual.
     o_proj = torch.matmul(attn_out.float(), wo.float())
     resid1 = o_proj + hidden_states.float()
 
-    # 2. Post-attention RMSNorm.
     variance = resid1.pow(2).mean(dim=-1, keepdim=True)
     inv_rms = torch.rsqrt(variance + eps)
     normed_bf16 = (resid1 * inv_rms * post_rms_weight).bfloat16()
 
-    # 3. SwiGLU MLP: gate/up projections, silu activation, down projection.
     gate = torch.matmul(normed_bf16.float(), w_gate.float())
     up = torch.matmul(normed_bf16.float(), w_up.float())
     mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
     down = torch.matmul(mlp_bf16.float(), w_down.float())
 
-    # 4. Final residual + cast to BF16.
     tensors["out"][:] = (down + resid1).bfloat16()
 
 
@@ -273,7 +261,7 @@ def build_tensor_specs(
     ]
 
 
-class _Qwen3DecodeScope3MixedBase(PTOTestCase):
+class Qwen3DecodeScope3MixedTestCase(PTOTestCase):
     """Shared ST test case for Qwen3 decode scope-3 mixed kernel."""
 
     __test__ = False
@@ -284,13 +272,17 @@ class _Qwen3DecodeScope3MixedBase(PTOTestCase):
         batch: int = BATCH,
         hidden_size: int = HIDDEN,
         intermediate_size: int = INTERMEDIATE,
+        *,
+        backend_type: BackendType | None = None,
         config: RunConfig | None = None,
     ):
-        # Preserve the original standalone script tolerances.
-        super().__init__(config or RunConfig(rtol=1e-3, atol=1e-3))
+        super().__init__(config or RunConfig(rtol=1e-3, atol=1e-3), backend_type=backend_type)
         self._batch = batch
         self._hidden_size = hidden_size
         self._intermediate_size = intermediate_size
+
+    def get_name(self) -> str:
+        return f"qwen3_decode_scope3_mixed_b{self._batch}_h{self._hidden_size}_i{self._intermediate_size}"
 
     def define_tensors(self) -> list[TensorSpec]:
         return build_tensor_specs(
@@ -307,37 +299,13 @@ class _Qwen3DecodeScope3MixedBase(PTOTestCase):
         )
 
 
-class Qwen3DecodeScope3MixedTestCase(_Qwen3DecodeScope3MixedBase):
-    """Ascend 910B runtime test for Qwen3 decode scope-3 mixed kernel."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"qwen3_decode_scope3_mixed_b{self._batch}_h{self._hidden_size}_i{self._intermediate_size}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
-
-class Qwen3DecodeScope3MixedA5TestCase(_Qwen3DecodeScope3MixedBase):
-    """Ascend 950 runtime test for Qwen3 decode scope-3 mixed kernel."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return f"qwen3_decode_scope3_mixed_a5_b{self._batch}_h{self._hidden_size}_i{self._intermediate_size}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
-
-
 class TestQwen3DecodeScope3Mixed:
     """Pytest entry points for the Qwen3 decode scope-3 ST coverage."""
 
     @pytest.mark.hardware
     def test_qwen3_decode_scope3_mixed(self, test_runner):
         """Run the original a2a3 hardware case under the shared ST harness."""
-        result = test_runner.run(Qwen3DecodeScope3MixedTestCase())
+        result = test_runner.run(Qwen3DecodeScope3MixedTestCase(backend_type=BackendType.Ascend910B))
         assert result.passed, f"Qwen3 decode scope-3 mixed test failed: {result.error}"
 
     @pytest.mark.a5
@@ -345,7 +313,7 @@ class TestQwen3DecodeScope3Mixed:
         """Run the same scope-3 test on the Ascend 950 backend."""
         if test_runner.config.platform.endswith("sim"):
             pytest.skip("a5sim CPU stub does not support BF16 TMATMUL for this mixed-kernel case yet")
-        result = test_runner.run(Qwen3DecodeScope3MixedA5TestCase())
+        result = test_runner.run(Qwen3DecodeScope3MixedTestCase(backend_type=BackendType.Ascend950))
         assert result.passed, f"Qwen3 decode scope-3 mixed A5 test failed: {result.error}"
 
 


### PR DESCRIPTION
PTOTestCase now accepts backend_type/strategy via constructor injection, enabling @pytest.mark.parametrize("backend", PLATFORMS) to replace 43 thin A5/PTO wrapper subclasses across 11 test files. Precompile cache key updated to name@arch to avoid cross-backend collisions.