### PR TITLE
fix(verifier): count MemRef-annotated base Ptrs as used

### DIFF
--- a/src/ir/verifier/warning_unused_var.cpp
+++ b/src/ir/verifier/warning_unused_var.cpp
@@ -18,9 +18,11 @@
 
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 #include "pypto/ir/verifier/warning_verifier_registry.h"
 
@@ -47,8 +49,14 @@ class UseCollector : public IRVisitor {
 
  protected:
   void VisitVarLike_(const VarPtr& op) override {
-    if (op) {
-      used_vars.insert(op.get());
+    if (!op) return;
+    used_vars.insert(op.get());
+    // A shaped-type MemRef annotation references the allocation Ptr via base_
+    // — a real data-flow use (e.g., `tile: Tile[..., MemRef(mem_vec, 0, 64)]`).
+    if (auto shaped_type = As<ShapedType>(op->GetType()); shaped_type && shaped_type->memref_.has_value()) {
+      const auto& memref = *shaped_type->memref_;
+      if (memref->base_) used_vars.insert(memref->base_.get());
+      if (memref->byte_offset_) VisitExpr(memref->byte_offset_);
     }
     // Don't recurse into type shape expressions — they aren't data-flow uses.
   }

--- a/tests/ut/ir/transforms/test_unused_var_warning.py
+++ b/tests/ut/ir/transforms/test_unused_var_warning.py
@@ -9,6 +9,7 @@
 
 """Unit tests for the unused variable warning verifier."""
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir import builder
@@ -86,6 +87,31 @@ def test_no_warning_loop_var():
     # 'dummy' IS unused but 'i' should not be warned about
     names = _warning_names(_run_unused_var_check(program))
     assert "i" not in names
+
+
+def test_no_warning_ptr_used_in_memref_annotation():
+    """A Ptr var referenced only inside a shaped type's MemRef annotation is used."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def main(
+            self,
+            x: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(x, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(tile_a, tile_a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(tile_b, [0, 0], out)
+            return result
+
+    # After init_mem_ref, tile.alloc Ptr vars are referenced only via MemRef
+    # annotations in the types of subsequent tile vars.
+    after = passes.init_mem_ref()(Prog)
+    names = _warning_names(_run_unused_var_check(after))
+    assert not any(n.startswith("mem_") for n in names), (
+        f"mem_vec_* Ptr vars incorrectly flagged as unused: {names}"
+    )
 
 
 def test_no_warning_var_used_in_rhs():


### PR DESCRIPTION
## Summary

- `UnusedVariableCheck` emitted false-positive warnings for allocation `Ptr` vars (e.g., `mem_vec_3`) whose only references lived inside shaped-type `MemRef` annotations after `InitMemRef`:
  ```
  mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 64)   # warned as unused
  row: pl.Tile[[1, 16], pl.FP32, pl.MemRef(mem_vec_3, 0, 64), ...] = pl.tile.load(...)
  ```
- Root cause: `UseCollector::VisitVarLike_` deliberately skipped type traversal but never handled `ShapedType::memref_`, so `memref->base_` (the allocation identity) was missed.
- Fix: when visiting a var with a `ShapedType` carrying a `MemRef`, mark `memref->base_` as used and traverse `memref->byte_offset_` to capture any `Var` references in view offsets.

## Testing

- [x] Added regression test `test_no_warning_ptr_used_in_memref_annotation` using `@pl.program` + `passes.init_mem_ref()` to produce the exact pattern.
- [x] All 14 unused-var tests pass; full transform suite (978 tests) green.
- [x] Full repo test suite: 3470 passed, 0 failed.
- [x] `clang-tidy` clean on changed C++ file.