### PR TITLE
fix(pass): fix 3D+ stride/shape propagation in AssembleParentStrides and RewriteCreateToSlice

### DIFF
--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -17,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -292,14 +294,22 @@ class FuseCreateAssembleMutator : public IRMutator {
 
     size_t ndim = result_type->shape_.size();
 
+    auto offset_tuple = std::static_pointer_cast<const MakeTuple>(info.offset_tuple);
+    size_t offset_ndim = offset_tuple->elements_.size();
+
+    // When the assemble target has higher rank than the created tile
+    // (e.g. 2D tile assembled into a 3D tensor), pad the shape with
+    // leading singleton dimensions so that shape and offset ranks match
+    // in the resulting tensor.slice.
     std::vector<ExprPtr> shape_elements;
-    shape_elements.reserve(ndim);
+    shape_elements.reserve(std::max(ndim, offset_ndim));
+    for (size_t i = ndim; i < offset_ndim; ++i) {
+      shape_elements.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, assign->span_));
+    }
     for (const auto& dim : result_type->shape_) {
       shape_elements.push_back(dim);
     }
     auto shape_tuple = std::make_shared<MakeTuple>(std::move(shape_elements), assign->span_);
-
-    auto offset_tuple = std::static_pointer_cast<const MakeTuple>(info.offset_tuple);
 
     ExprPtr target = VisitExpr(info.target_expr);
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -706,11 +706,19 @@ class AssembleParentStridesOptimizer {
         auto shape_it = return_idx_to_shape.find(opm.return_index);
         if (shape_it == return_idx_to_shape.end()) continue;
 
-        auto strides = ComputeStrides(shape_it->second);
-        if (strides.empty()) continue;
+        auto full_strides = ComputeStrides(shape_it->second);
+        if (full_strides.empty()) continue;
 
         auto tensor_type = As<TensorType>(func->params_[opm.param_index]->GetType());
         if (!tensor_type) continue;
+
+        // Extract trailing strides matching the output tensor's rank.
+        // For a 3D parent [B, M, N] with strides [M*N, N, 1] and a 2D output [M', N'],
+        // we need the last 2 strides: [N, 1].
+        size_t out_rank = tensor_type->shape_.size();
+        if (out_rank > full_strides.size()) continue;
+        std::vector<ExprPtr> strides(full_strides.end() - static_cast<std::ptrdiff_t>(out_rank),
+                                     full_strides.end());
 
         TensorView view(std::move(strides), TensorLayout::ND);
         auto new_type = std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_,

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -301,6 +301,74 @@ class TestFuseCreateAssembleToSlice:
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
 
+    def test_3d_target_2d_tile_offset_padded(self):
+        """2D create assembled into 3D target → slice shape padded with leading 1.
+
+        Reproduces the prefill projection bug where a [TOK, CHUNK] tile is
+        assembled into a [B, S, H] output at offset [b, p, q].  Before the
+        fix the fused slice had shape=[TOK,CHUNK] (2D) but offset=[b,p,q]
+        (3D), causing a rank mismatch in codegen.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 4], pl.FP32]:
+                t: pl.Tile[[2, 4], pl.FP32] = pl.load(x, [0, 0], [2, 4])
+                out_1: pl.Tensor[[2, 4], pl.FP32] = pl.store(t, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[2, 4, 8], pl.FP32]],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP32]:
+                for b in pl.range(2):
+                    for c in pl.range(2):
+                        col = c * 4
+                        chunk: pl.Tensor[[2, 4], pl.FP32] = pl.create_tensor([2, 4], dtype=pl.FP32)
+                        chunk = self.compute(x, chunk)
+                        out = pl.assemble(out, chunk, [b, 0, col])
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+
+        # After fusion: tensor.create + tensor.assemble should become tensor.slice.
+        ops = _collect_tensor_ops_in_orch(after)
+        assert "tensor.slice" in ops, f"Expected tensor.slice after fusion, got {ops}"
+        assert "tensor.create" not in ops, f"tensor.create should be fused away, got {ops}"
+        assert "tensor.assemble" not in ops, f"tensor.assemble should be fused away, got {ops}"
+
+        # Verify the generated tensor.slice has matching shape/offset ranks (both 3D).
+        class SliceRankChecker(ir_core.IRVisitor):
+            def __init__(self):
+                super().__init__()
+                self.checked = False
+
+            def visit_assign_stmt(self, stmt):
+                if hasattr(stmt.value, "op") and stmt.value.op.name == "tensor.slice":
+                    args = stmt.value.args
+                    shape_rank = len(args[1].elements)
+                    offset_rank = len(args[2].elements)
+                    assert shape_rank == offset_rank, (
+                        f"tensor.slice shape rank ({shape_rank}) != offset rank ({offset_rank})"
+                    )
+                    # shape should be [1, 2, 4] (padded with leading 1)
+                    assert shape_rank == 3, f"Expected rank 3 after padding, got {shape_rank}"
+                    self.checked = True
+                super().visit_assign_stmt(stmt)
+
+        for func in after.functions.values():
+            if func.func_type == ir_core.FunctionType.Orchestration:
+                checker = SliceRankChecker()
+                checker.visit_stmt(func.body)
+                assert checker.checked, "No tensor.slice found in orch function"
+
     def test_no_orchestration_function_noop(self):
         """Pass should be a no-op when there are no Orchestration functions."""
 

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -372,6 +372,84 @@ class TestAssembleParentStrides:
         After = passes.optimize_orch_tensors()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_3d_parent_out_param_gets_trailing_stride(self):
+        """When parent tensor is 3D and output tile is 2D, only trailing strides are applied."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def proj_incore_0(
+                self,
+                x: pl.Tensor[[16, 5120], pl.FP32],
+                q0: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, q0], [16, 64])
+                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(x__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def proj(
+                self,
+                x: pl.Tensor[[16, 5120], pl.FP32],
+                q_proj: pl.Out[pl.Tensor[[4, 128, 5120], pl.FP32]],
+            ) -> pl.Tensor[[4, 128, 5120], pl.FP32]:
+                for b in pl.range(4):
+                    for p0 in pl.range(0, 128, 16):
+                        for q0, (q_iter,) in pl.range(0, 5120, 64, init_values=(q_proj,)):
+                            ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                                [16, 64], dtype=pl.FP32
+                            )
+                            result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(x, q0, ret0__out)
+                            q_next: pl.Tensor[[4, 128, 5120], pl.FP32] = pl.assemble(
+                                q_iter, result, [b, p0, q0]
+                            )
+                            q_rv = pl.yield_(q_next)
+                return q_rv
+
+        # fmt: off
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def proj_incore_0(
+                self,
+                x: pl.Tensor[[16, 5120], pl.FP32],
+                q0: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[  # noqa: E501
+                    pl.Tensor[[16, 64], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)]
+                ],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, q0], [16, 64])
+                ret0__store: pl.Tensor[  # noqa: E501
+                    [16, 64], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                ] = pl.store(x__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def proj(
+                self,
+                x: pl.Tensor[[16, 5120], pl.FP32],
+                q_proj: pl.Out[pl.Tensor[[4, 128, 5120], pl.FP32]],
+            ) -> pl.Tensor[[4, 128, 5120], pl.FP32]:
+                for b in pl.range(4):
+                    for p0 in pl.range(0, 128, 16):
+                        for q0, (q_iter,) in pl.range(0, 5120, 64, init_values=(q_proj,)):
+                            ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                                [16, 64], dtype=pl.FP32
+                            )
+                            result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(
+                                x, q0, ret0__out
+                            )
+                            q_next: pl.Tensor[[4, 128, 5120], pl.FP32] = pl.assemble(
+                                q_iter, result, [b, p0, q0]
+                            )
+                            q_rv = pl.yield_(q_next)
+                return q_rv
+        # fmt: on
+
+        After = passes.optimize_orch_tensors()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestAssembleLoopRewrite:
     """Pattern 3: Rewrite tile.assemble loops to tile.store loops."""


### PR DESCRIPTION
## Summary
- Fix stride propagation in `AssembleParentStridesOptimizer` for 3D+ parent tensors
- Fix shape/offset rank mismatch in `RewriteCreateToSlice` when fusing 2D tile create + 3D offset assemble into tensor.slice
- Add regression tests for both fixes

## Root Cause

### AssembleParentStrides
`AssembleParentStridesOptimizer::Apply()` computed full parent strides (e.g., `[655360, 5120, 1]` for a 3D `[4, 128, 5120]` tensor) and applied all of them to a 2D output parameter. The rank mismatch caused TSTORE to use wrong addresses, producing ~47% element mismatches in prefill projections.

### RewriteCreateToSlice
When `tensor.create` (2D tile) + `tensor.assemble` (3D offset) were fused into `tensor.slice`, the `shape_tuple` kept the original 2 dimensions while `offset_tuple` had 3 dimensions. Downstream `tensor_slice` codegen used `ndim = shape_tuple.size()` to iterate offsets, causing the third offset value (e.g., `q0`) to be discarded — all writes landed at offset `[b, p0]` instead of `[b, p0, q0]`.

## Fix

### AssembleParentStrides
Extract only the trailing `output_rank` strides from the parent strides vector. For a 3D parent with strides `[655360, 5120, 1]` and a 2D output `[16, 64]`, the output now correctly gets strides `[5120, 1]`.

### RewriteCreateToSlice
Pad the shape with leading singleton dimensions when offset rank exceeds tile rank. For example, a 2D shape `[64, 64]` with 3D offset `[b, p0, q0]` becomes `[1, 64, 64]`, so downstream codegen emits all offset values.

| | Before | After |
|---|---|---|
| shape | `[64, 64]` | `[1, 64, 64]` |
| offset | `[b, p0, q0]` | `[b, p0, q0]` |
| Generated C++ | `offsets = {b, p0}` | `offsets = {b, p0, q0}` |

## Testing
- [x] New test `test_3d_parent_out_param_gets_trailing_stride` validates the 3D→2D stride case
- [x] New test `test_2d_tile_3d_offset_pads_shape` validates the shape padding case
- [x] All existing tests pass
- [x] Code review completed

## Related Issues
Fixes #950