### PR TITLE
refactor(tests): drop redundant auto_mapping from self-contained tests

### DIFF
--- a/tests/ut/ir/high_level/test_builder.py
+++ b/tests/ut/ir/high_level/test_builder.py
@@ -1184,7 +1184,7 @@ class TestIRBuilderSerialization:
         assert isinstance(restored, ir.Function)
 
         # Check structure is preserved
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
 
 
 class TestIRBuilderProgram:

--- a/tests/ut/ir/high_level/test_function.py
+++ b/tests/ut/ir/high_level/test_function.py
@@ -554,7 +554,7 @@ class TestFunctionStructuralEqual:
         func1 = ir.Function("f", [(x1, ir.ParamDirection.InOut)], [], assign1, span)
         func2 = ir.Function("f", [(x2, ir.ParamDirection.InOut)], [], assign2, span)
 
-        ir.assert_structural_equal(func1, func2, enable_auto_mapping=True)
+        ir.assert_structural_equal(func1, func2)
 
     def test_function_different_directions_not_equal(self):
         """Test Function nodes with different param directions are not equal."""
@@ -587,7 +587,7 @@ class TestFunctionSerialization:
         data = ir.serialize(func)
         restored = cast(ir.Function, ir.deserialize(data))
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
         assert len(restored.param_directions) == 2
         assert restored.param_directions[0] == ir.ParamDirection.In
         assert restored.param_directions[1] == ir.ParamDirection.In
@@ -603,7 +603,7 @@ class TestFunctionSerialization:
         data = ir.serialize(func)
         restored = cast(ir.Function, ir.deserialize(data))
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
         assert restored.param_directions[0] == ir.ParamDirection.Out
 
     def test_serialize_function_with_inout_direction(self):
@@ -617,7 +617,7 @@ class TestFunctionSerialization:
         data = ir.serialize(func)
         restored = cast(ir.Function, ir.deserialize(data))
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
         assert restored.param_directions[0] == ir.ParamDirection.InOut
 
     def test_serialize_function_mixed_directions(self):
@@ -640,7 +640,7 @@ class TestFunctionSerialization:
         data = ir.serialize(func)
         restored = cast(ir.Function, ir.deserialize(data))
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
         assert restored.param_directions[0] == ir.ParamDirection.In
         assert restored.param_directions[1] == ir.ParamDirection.InOut
         assert restored.param_directions[2] == ir.ParamDirection.Out

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -700,7 +700,7 @@ class TestMemRefStandaloneSerialization:
         data = ir.serialize(program)
         restored = ir.deserialize(data)
 
-        ir.assert_structural_equal(program, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(program, restored)
 
 
 class TestMemRefStructuralComparison:
@@ -1796,7 +1796,7 @@ class TestMemRefRoundTrip:
         assert 'pl.MemRef("mem_vec_0", 0, 16384)' in printed
         assert "pl.Mem.Vec" in printed
         reparsed = pl.parse(printed)
-        ir.assert_structural_equal(program, reparsed, enable_auto_mapping=True)
+        ir.assert_structural_equal(program, reparsed)
 
     def test_parse_tensor_layout_and_memref(self):
         """Parse 4-arg: pl.Tensor[[64], pl.FP32, pl.NZ, pl.MemRef(...)]."""
@@ -1836,7 +1836,7 @@ class TestMemRefRoundTrip:
         parsed1 = pl.parse(code)
         printed = parsed1.as_python()
         parsed2 = pl.parse(printed)
-        ir.assert_structural_equal(parsed1, parsed2, enable_auto_mapping=True)
+        ir.assert_structural_equal(parsed1, parsed2)
 
     def test_roundtrip_tensor_memref(self):
         """Parse → print → parse → assert_structural_equal for tensor with memref."""
@@ -1851,7 +1851,7 @@ class TestMemRefRoundTrip:
         parsed1 = pl.parse(code)
         printed = parsed1.as_python()
         parsed2 = pl.parse(printed)
-        ir.assert_structural_equal(parsed1, parsed2, enable_auto_mapping=True)
+        ir.assert_structural_equal(parsed1, parsed2)
 
     def test_all_memory_spaces(self):
         """Test all supported tile memory spaces round-trip through as_python()."""
@@ -1878,7 +1878,7 @@ class TestMemRefRoundTrip:
                 f"Expected pl.Mem.{space_name} in printed output, got: {printed}"
             )
             parsed2 = pl.parse(printed)
-            ir.assert_structural_equal(parsed1, parsed2, enable_auto_mapping=True)
+            ir.assert_structural_equal(parsed1, parsed2)
 
     def test_backwards_compat_two_args(self):
         """Existing 2-arg [shape, dtype] still works."""

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -10,7 +10,9 @@
 """Unit tests for ConvertToSSA pass.
 
 Tests use the Before/Expected pattern with @pl.program decorator.
-Uses assert_structural_equal with enable_auto_mapping=True to compare.
+Uses assert_structural_equal to compare. Both Before and Expected are complete
+self-contained programs, so the default strict-identity mode (with DefField
+auto-mapping at def sites) is sufficient.
 """
 
 import pypto.language as pl
@@ -1422,7 +1424,7 @@ class TestEscapingVariables:
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_single_branch_escaping_var_gets_phi(self):
         """Variable defined only in one if-branch inside a loop must still escape.

--- a/tests/ut/ir/transforms/test_deep_clone.py
+++ b/tests/ut/ir/transforms/test_deep_clone.py
@@ -156,7 +156,7 @@ class TestDeepCloneWithExpandMixedKernel:
         After2 = passes.expand_mixed_kernel()(passes.infer_tile_memory_space()(Before))
 
         # Whole-program structural equality should work now that DeepClone is used
-        ir.assert_structural_equal(After, After2, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, After2)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_insert_sync.py
+++ b/tests/ut/ir/transforms/test_insert_sync.py
@@ -119,7 +119,7 @@ def test_insert_sync_cross_pipe():
     backend.set_backend_type(BackendType.Ascend910B)
     After = passes.insert_sync()(Before)
 
-    # Build Expected IR (reuse vars from Before since auto_mapping handles mapping)
+    # Build Expected IR (reuse vars from Before so def/use identity is preserved)
     expected_body = ir.SeqStmts(
         [
             ir.AssignStmt(tile_a, tile.load(input_a, offsets=[0, 0], shapes=[64, 64]), span),
@@ -143,7 +143,7 @@ def test_insert_sync_cross_pipe():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_insert_sync_intra_pipe():
@@ -214,7 +214,7 @@ def test_insert_sync_intra_pipe():
     expected_func = ir.Function("test_intra_pipe_sync", [t_a, t_b], [t_d.type], expected_body, span)
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_insert_sync_cube_pipe():
@@ -336,7 +336,7 @@ def test_insert_sync_cube_pipe():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_if_both_branches():
@@ -438,7 +438,7 @@ def test_if_both_branches():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_if_one_branch():
@@ -520,7 +520,7 @@ def test_if_one_branch():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_branch_merge():
@@ -634,7 +634,7 @@ def test_branch_merge():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_for_loop():
@@ -736,7 +736,7 @@ def test_for_loop():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_for_cross_iteration():
@@ -822,7 +822,7 @@ def test_for_cross_iteration():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_for_cross_iteration_wait_moves_past_scalar_stmt():
@@ -896,7 +896,7 @@ def test_for_cross_iteration_wait_moves_past_scalar_stmt():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_for_cross_iteration_mte3_to_mte2():
@@ -994,7 +994,7 @@ def test_for_cross_iteration_mte3_to_mte2():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_for_with_if_branches():
@@ -1127,7 +1127,7 @@ def test_for_with_if_branches():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_if_scope_crossing_dedup():
@@ -1230,7 +1230,7 @@ def test_if_scope_crossing_dedup():
     )
     Expected = ir.Program([expected_func], "test_program", span)
 
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -81,7 +81,7 @@ def test_normalize_simple_function():
 
     # Apply pass and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_normalize_seqstmts_with_bare_assigns():
@@ -167,7 +167,7 @@ def test_normalize_seqstmts_with_bare_assigns():
 
     # Apply pass and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_idempotence():
@@ -229,11 +229,11 @@ def test_idempotence():
 
     # Apply pass once and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
     # Apply pass again and verify idempotence
     After2 = passes.normalize_stmt_structure()(After)
-    ir.assert_structural_equal(After2, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After2, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -312,7 +312,7 @@ class TestStatementSerialization:
         data = ir.serialize(for_stmt)
         restored = ir.deserialize(data)
 
-        ir.assert_structural_equal(for_stmt, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(for_stmt, restored)
 
     def test_serialize_for_stmt_with_iter_args(self):
         """Test serialization of ForStmt with iter_args."""
@@ -338,7 +338,7 @@ class TestStatementSerialization:
         restored = ir.deserialize(data)
         restored_for_stmt = cast(ir.ForStmt, restored)
 
-        ir.assert_structural_equal(for_stmt, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(for_stmt, restored)
         assert len(restored_for_stmt.iter_args) == 2
         assert restored_for_stmt.iter_args[0].name_hint == "arg1"
         assert restored_for_stmt.iter_args[1].name_hint == "arg2"
@@ -362,7 +362,7 @@ class TestStatementSerialization:
         restored = ir.deserialize(data)
         restored_for_stmt = cast(ir.ForStmt, restored)
 
-        ir.assert_structural_equal(for_stmt, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(for_stmt, restored)
         assert len(restored_for_stmt.iter_args) == 0
 
     def test_serialize_yield_stmt(self):
@@ -465,7 +465,7 @@ class TestStatementSerialization:
         data = ir.serialize(seq)
         restored = ir.deserialize(data)
 
-        ir.assert_structural_equal(seq, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(seq, restored)
 
 
 class TestFunctionSerialization:
@@ -497,7 +497,7 @@ class TestFunctionSerialization:
         data = ir.serialize(func)
         restored = ir.deserialize(data)
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
 
     def test_serialize_function_with_return_stmt(self):
         """Test serialization of Function with ReturnStmt."""
@@ -520,7 +520,7 @@ class TestFunctionSerialization:
         restored = ir.deserialize(data)
         restored_func = cast(ir.Function, restored)
 
-        ir.assert_structural_equal(func, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(func, restored)
         assert isinstance(restored_func.body, ir.ReturnStmt)
         assert len(cast(ir.ReturnStmt, restored_func.body).value) == 1
 
@@ -539,7 +539,7 @@ class TestFunctionSerialization:
         data = ir.serialize(program)
         restored = ir.deserialize(data)
 
-        ir.assert_structural_equal(program, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(program, restored)
 
 
 class TestSpanSerialization:
@@ -669,7 +669,7 @@ class TestEdgeCases:
         for_stmt_empty = ir.ForStmt(i, start, stop, step, [], body, [], ir.Span.unknown())
         data = ir.serialize(for_stmt_empty)
         restored = ir.deserialize(data)
-        ir.assert_structural_equal(for_stmt_empty, restored, enable_auto_mapping=True)
+        ir.assert_structural_equal(for_stmt_empty, restored)
 
     def test_serialize_global_var(self):
         """Test serialization of GlobalVar in Call."""

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -85,7 +85,7 @@ class TestBasicChunking:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_non_divisible_chunk(self):
         """Chunk a loop where trip_count is NOT divisible by chunk_size."""
@@ -131,7 +131,7 @@ class TestBasicChunking:
                         x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3_f)
                 return x_iter_1_rem_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_single_chunk(self):
         """Chunk a loop where trip_count equals chunk_size."""
@@ -168,7 +168,7 @@ class TestBasicChunking:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
 
 class TestChunkingWithStep:
@@ -209,7 +209,7 @@ class TestChunkingWithStep:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_chunk_all_remainder(self):
         """Chunk where trip_count < chunk_size -> only remainder loop."""
@@ -238,7 +238,7 @@ class TestChunkingWithStep:
                         x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
                 return x_iter_1_rem_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
 
 class TestChunkingWithKind:
@@ -279,7 +279,7 @@ class TestChunkingWithKind:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     @pytest.mark.filterwarnings("ignore:.*RoundtripInstrument.*IR not printable:UserWarning")
     def test_unroll_chunk(self):
@@ -574,7 +574,7 @@ class TestNestedChunking:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_nested_both_divisible(self):
         """Nested chunks: both outer and inner divisible."""
@@ -628,7 +628,7 @@ class TestNestedChunking:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_nested_both_remainder(self):
         """Nested chunks: both outer and inner have remainders.
@@ -712,7 +712,7 @@ class TestDynamicChunking:
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_dynamic_start_and_stop(self):
         """Both start and stop are dynamic."""
@@ -767,7 +767,7 @@ class TestDynamicChunking:
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_dynamic_stop_parallel(self):
         """Dynamic stop with pl.parallel should also work."""
@@ -810,7 +810,7 @@ class TestDynamicChunking:
                         x_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_4)
                 return x_rem_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_static_still_works(self):
         """Regression: static bounds should continue to produce same IR as before."""
@@ -847,7 +847,7 @@ class TestDynamicChunking:
                         x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
                 return x_iter_1_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
 
 class TestGuardedPolicy:
@@ -890,7 +890,7 @@ class TestGuardedPolicy:
         # Default and explicit "guarded" must produce identical IR.
         After = passes.split_chunked_loops()(_prepare_for_split(Input))
         AfterExplicit = passes.split_chunked_loops()(_prepare_for_split(InputExplicit))
-        ir.assert_structural_equal(After, AfterExplicit, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, AfterExplicit)
 
     def test_guarded_divisible_iter_args(self):
         """Static bound, trip_count divisible by chunk_size, with iter_args."""
@@ -928,7 +928,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_non_divisible_iter_args(self):
         """Static bound, trip_count NOT divisible by chunk_size: ceil(7/5)=2 outer chunks.
@@ -970,7 +970,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_trip_less_than_chunk(self):
         """trip_count < chunk_size: ceil(3/5)=1 outer chunk, inner guard masks lanes >= 3."""
@@ -1009,7 +1009,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_no_iter_args(self):
         """No iter_args: IfStmt has no phi and no else branch — body runs or is skipped."""
@@ -1036,7 +1036,7 @@ class TestGuardedPolicy:
                                 _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
                 return x_0
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_with_step(self):
         """Non-unit step: guard compares `idx * step < stop`, idx = (out*C + in)."""
@@ -1074,7 +1074,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_parallel(self):
         """pl.parallel: both outer and inner guarded loops are Parallel kind."""
@@ -1112,7 +1112,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_dynamic_stop(self):
         """Dynamic stop `n`: outer count = ceil(n/4) = (n + 3) // 4."""
@@ -1154,7 +1154,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_dynamic_start_and_stop(self):
         """Dynamic start AND stop: outer count = ceil(max(hi-lo, 0) / 4)."""
@@ -1204,7 +1204,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_dynamic_no_iter_args(self):
         """Dynamic bound with no iter_args: IfStmt has no phi."""
@@ -1233,7 +1233,7 @@ class TestGuardedPolicy:
                                 _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
                 return x_0
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_nested(self):
         """Nested guarded loops: inner guarded loop lives inside outer's then-branch.
@@ -1291,7 +1291,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_negative_step(self):
         """Descending chunked range: guard uses `idx > stop` since step < 0.
@@ -1335,7 +1335,7 @@ class TestGuardedPolicy:
                         x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
                 return x_outer_rv
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_negative_step_no_iter_args(self):
         """Descending chunked range without iter_args: guard still uses `idx > stop`."""
@@ -1362,7 +1362,7 @@ class TestGuardedPolicy:
                                 _tmp: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
                 return x_0
 
-        ir.assert_structural_equal(After, _normalize_expected(Expected), enable_auto_mapping=True)
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_origin_attrs(self):
         """Guarded mode sets ChunkOuter/ChunkInner attrs and never emits ChunkRemainder."""


### PR DESCRIPTION
## Summary

Removes `enable_auto_mapping=True` from ~65 `ir.assert_structural_equal` / `ir.structural_hash` call sites across 9 test files where the compared IR is **self-contained** — every `Var` use has its `DefField` def point inside the compared subtree.

## Why the flag was redundant

`DefField` fields (function params, `AssignStmt::var_`, `ForStmt::loop_var_`/`iter_args_`/`return_vars_`, `IfStmt`/`WhileStmt::return_vars_`, etc.) always auto-map internally — `VisitDefField` in `src/ir/transforms/structural_equal.cpp:608-614` temporarily flips the flag during field visitation. So for a self-contained subtree, each use is reached after its def has already established a bijection, and `enable_auto_mapping=False` gives the same result as `=True`.

Keeping the flag weakens the tests: a pass that accidentally replaces a `Var` that should be preserved (e.g., returns a clone instead of the original) would still compare equal under `=True`. Removing it makes the checks strictly stronger without changing which IRs compare equal in correct runs.

## Files changed

| File | Sites | Rationale |
|---|---:|---|
| `test_split_chunked_loops.py` | 25 | Before/Expected are complete `@pl.program`s |
| `test_insert_sync.py` | 13 | Expected reuses Before's vars (doubly redundant) |
| `test_serialization.py` | 8 | Self-contained `ForStmt`/`SeqStmts`/`Function`/`Program` roundtrips |
| `test_memref.py` | 5 | Complete `Program` roundtrip + parse→print→parse |
| `test_function.py` | 5 | Function serde + `test_function_same_directions_equal` |
| `test_normalize_stmt_structure_pass.py` | 4 | Complete `ir.Program` Before/Expected |
| `test_convert_to_ssa_pass.py` | 2 | Complete `@pl.program` Before/Expected (+ docstring) |
| `test_deep_clone.py` | 1 | Two cloned whole programs are self-contained |
| `test_builder.py` | 1 | Builder-produced `Function` with no free vars |

## Retained

`enable_auto_mapping=True` is kept in ~150 call sites that genuinely need it: standalone `Var`/`IterArg`/`MemRef` comparisons, subtrees with free variables (e.g., `Add(x,y)`, `YieldStmt([x,y])` without enclosing def), and tests explicitly verifying the auto-mapping feature itself (most of `test_equality.py`, `test_hash.py`, and `TestAutoMapping*` blocks in statement tests).

## Test plan

- [x] All 3469 tests pass (16 skipped — pre-existing), verified via `pytest -n auto --maxprocesses 8`
- [x] No production code touched — tests-only refactor
- [x] No new files; no cross-layer impact (C++, bindings, and stubs untouched)