### PR TITLE
feat(runtime): migrate CCEC compilation pipeline from Simpler into PyPTO

### DIFF
--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -36,12 +36,13 @@ Example::
 """
 
 from .runner import RunConfig, RunResult, compile_program, run
-from .tensor_spec import TensorSpec
+from .tensor_spec import ScalarSpec, TensorSpec
 
 __all__ = [
     "run",
     "compile_program",
     "RunConfig",
     "RunResult",
+    "ScalarSpec",
     "TensorSpec",
 ]

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -29,13 +29,12 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
-import fcntl
 import importlib.util
 import logging
 import os
 import subprocess
 import tempfile
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -162,20 +161,8 @@ def _get_pto_isa_clone_path() -> Path:
     return Path(__file__).parent.parent.parent.parent / "_deps" / "pto-isa"
 
 
-@contextmanager
-def _pto_isa_lock(clone_path: Path) -> Iterator[None]:
-    """Acquire an exclusive file lock for PTO-ISA operations on *clone_path*."""
-    lock_path = clone_path.parent / ".pto-isa.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        yield
-
-
 def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https") -> str | None:
     """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
-
-    Uses a file lock to prevent parallel processes from racing on the clone.
 
     Args:
         commit: If provided, checkout this specific commit.
@@ -187,14 +174,11 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     existing_root = os.environ.get("PTO_ISA_ROOT")
     if existing_root:
         if commit:
-            # Still need to checkout the requested commit even if PTO_ISA_ROOT is set
-            with _pto_isa_lock(Path(existing_root)):
-                _checkout_pto_isa_commit(Path(existing_root), commit)
+            _checkout_pto_isa_commit(Path(existing_root), commit)
         return existing_root
 
     clone_path = _get_pto_isa_clone_path()
-    with _pto_isa_lock(clone_path):
-        return _ensure_pto_isa_root_locked(clone_path, commit=commit, clone_protocol=clone_protocol)
+    return _ensure_pto_isa_root_locked(clone_path, commit=commit, clone_protocol=clone_protocol)
 
 
 def _ensure_pto_isa_root_locked(

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -526,21 +526,22 @@ def validate_golden(
         expected = golden[name].cpu()
         logger.info(f"Comparing {name}: shape={actual.shape}, dtype={actual.dtype}")
 
-        if actual.numel() > 0:
-            flat_actual = actual.flatten()
-            flat_expected = expected.flatten()
-            n_show = min(10, flat_actual.numel())
-            logger.debug(f"  First {n_show} actual:   {flat_actual[:n_show].tolist()}")
-            logger.debug(f"  First {n_show} expected: {flat_expected[:n_show].tolist()}")
-
         if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
             close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
-            mismatches = (~close_mask).sum().item()
-            total = actual.numel()
+            mismatch_indices = torch.where(~close_mask.flatten())[0]
+            flat_actual = actual.flatten()
+            flat_expected = expected.flatten()
+            n_show = min(20, mismatch_indices.numel())
+            idx = mismatch_indices[:n_show]
+            lines = [
+                f"    [{i.item()}] actual={flat_actual[i].item()}, expected={flat_expected[i].item()}"
+                for i in idx
+            ]
             raise AssertionError(
                 f"Output '{name}' does not match golden.\n"
-                f"Mismatched elements: {mismatches}/{total}\n"
-                f"rtol={rtol}, atol={atol}"
+                f"Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}\n"
+                f"rtol={rtol}, atol={atol}\n"
+                f"First {n_show} mismatches:\n" + "\n".join(lines)
             )
 
         matched = torch.isclose(actual, expected, rtol=rtol, atol=atol).sum().item()

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -27,15 +27,18 @@ Simpler dependency remaining is:
 
 from __future__ import annotations
 
+import ctypes
 import fcntl
 import importlib.util
 import logging
 import os
 import subprocess
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import torch
 
@@ -50,6 +53,7 @@ from .task_interface import (
     make_tensor_arg,
     scalar_to_uint64,
 )
+from .tensor_spec import ScalarSpec, TensorSpec
 
 logger = logging.getLogger(__name__)
 
@@ -318,6 +322,109 @@ def _kernel_config_runtime_env(kernel_config_module, kernels_dir: Path) -> dict[
 
 
 # ---------------------------------------------------------------------------
+# Shared compilation functions
+# ---------------------------------------------------------------------------
+
+
+def compile_single_kernel(
+    kernel: dict,
+    compiler: KernelCompiler,
+    platform: str,
+    pto_isa_root: str,
+    runtime_name: str,
+    cache_dir: Path | None = None,
+) -> tuple[bytes, bytes]:
+    """Compile a single incore kernel with binary caching.
+
+    Checks for a cached ``.o``/``.so`` alongside the source file. On miss,
+    compiles via *compiler* and saves the result. For hardware platforms,
+    extracts the ``.text`` section to produce the final kernel binary.
+
+    When *cache_dir* is provided, the final (possibly stripped) binary is
+    additionally written to ``cache_dir/incore_{core_type}_{stem}.bin``.
+    This is the pre-build cache that :func:`compile_and_assemble` checks
+    before calling this function.
+
+    Args:
+        kernel: Kernel descriptor dict with keys ``"source"``, ``"core_type"``,
+            and optionally ``"signature"``, ``"func_id"``.
+        compiler: Configured :class:`KernelCompiler` instance.
+        platform: Target execution platform.
+        pto_isa_root: Resolved PTO-ISA root directory.
+        runtime_name: Runtime name (e.g. ``"host_build_graph"``).  Passed to
+            :meth:`KernelCompiler.compile_incore` for include-dir resolution.
+        cache_dir: Optional directory to write the final kernel binary for
+            pre-build caching.
+
+    Returns:
+        ``(raw_binary, kernel_binary)`` where *raw_binary* is the compiled
+        ``.o``/``.so`` and *kernel_binary* is the final binary (possibly
+        ``.text``-extracted) ready for ``CoreCallable.build()``.
+    """
+    source = Path(kernel["source"])
+    core_type = kernel["core_type"]
+
+    ext = ".so" if platform.endswith("sim") else ".o"
+    output_file = source.with_suffix(ext)
+
+    raw = _load_binary(output_file)
+    if raw is None:
+        raw = compiler.compile_incore(
+            kernel["source"],
+            core_type=core_type,
+            pto_isa_root=pto_isa_root,
+            runtime_name=runtime_name,
+        )
+        _save_binary(raw, output_file)
+
+    kernel_bin = raw if platform.endswith("sim") else extract_text_section(raw)
+
+    if cache_dir is not None:
+        cache_file = cache_dir / f"incore_{core_type}_{source.stem}.bin"
+        _save_binary(kernel_bin, cache_file)
+
+    return raw, kernel_bin
+
+
+def compile_single_orchestration(
+    source: str | Path,
+    compiler: KernelCompiler,
+    runtime_name: str,
+    cache_dir: Path | None = None,
+) -> bytes:
+    """Compile orchestration source to a shared library with binary caching.
+
+    Checks for a cached ``.so`` alongside the source file. On miss, compiles
+    via *compiler* and saves the result.
+
+    When *cache_dir* is provided, the binary is additionally written to
+    ``cache_dir/orch_{stem}.bin`` for the pre-build cache.
+
+    Args:
+        source: Path to the orchestration C++ source file.
+        compiler: Configured :class:`KernelCompiler` instance.
+        runtime_name: Runtime name (e.g. ``"host_build_graph"``).
+        cache_dir: Optional directory to write the binary for pre-build caching.
+
+    Returns:
+        Orchestration ``.so`` binary bytes.
+    """
+    source_path = Path(source)
+    output_file = source_path.with_suffix(".so")
+
+    raw = _load_binary(output_file)
+    if raw is None:
+        raw = compiler.compile_orchestration(runtime_name, str(source))
+        _save_binary(raw, output_file)
+
+    if cache_dir is not None:
+        cache_file = cache_dir / f"orch_{source_path.stem}.bin"
+        _save_binary(raw, cache_file)
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
 # compile_and_assemble
 # ---------------------------------------------------------------------------
 
@@ -372,25 +479,6 @@ def compile_and_assemble(
     # Create compiler
     compiler = KernelCompiler(platform=platform)
 
-    # Resolve runtime include dirs for kernel compilation
-    simpler_root = Path(os.environ["SIMPLER_ROOT"])
-    arch = "a5" if platform.startswith("a5") else "a2a3"
-    runtime_base_dir = simpler_root / "src" / arch / "runtime" / runtime_name
-    runtime_include_dirs: list[str] = []
-
-    build_config_path = runtime_base_dir / "build_config.py"
-    if build_config_path.is_file():
-        bc_spec = importlib.util.spec_from_file_location("build_config", str(build_config_path))
-        if bc_spec is not None and bc_spec.loader is not None:
-            bc_module = importlib.util.module_from_spec(bc_spec)
-            bc_spec.loader.exec_module(bc_module)
-            aicore_cfg = bc_module.BUILD_CONFIG.get("aicore", {})
-            for p in aicore_cfg.get("include_dirs", []):
-                runtime_include_dirs.append(str(runtime_base_dir / p))
-    else:
-        runtime_include_dirs.append(str(runtime_base_dir / "runtime"))
-    runtime_include_dirs.append(str(simpler_root / "src" / "common" / "task_interface"))
-
     # --- Parallel compilation ---
 
     def _compile_one_kernel(kernel: dict) -> tuple[int, CoreCallable]:
@@ -399,28 +487,15 @@ def compile_and_assemble(
         core_type = kernel["core_type"]
 
         # Check cache/ for pre-stripped binary (written by prebuild_binaries)
-        cache_dir = work_dir / "cache"
-        cache_file = cache_dir / f"incore_{core_type}_{source.stem}.bin"
+        prebuild_cache = work_dir / "cache"
+        cache_file = prebuild_cache / f"incore_{core_type}_{source.stem}.bin"
         cached_bin = _load_binary(cache_file)
         if cached_bin is not None:
             sig = kernel.get("signature", [])
             return (func_id, CoreCallable.build(signature=sig, binary=cached_bin))
 
-        # Compile → save .o/.so alongside source
-        ext = ".so" if platform.endswith("sim") else ".o"
-        output_file = source.with_suffix(ext)
-
-        raw = _load_binary(output_file)
-        if raw is None:
-            raw = compiler.compile_incore(
-                kernel["source"],
-                core_type=core_type,
-                pto_isa_root=pto_isa_root,
-                extra_include_dirs=runtime_include_dirs,
-            )
-            _save_binary(raw, output_file)
-
-        kernel_bin = raw if platform.endswith("sim") else extract_text_section(raw)
+        # Compile via shared function; skip secondary prebuild cache write
+        _, kernel_bin = compile_single_kernel(kernel, compiler, platform, pto_isa_root, runtime_name)
 
         sig = kernel.get("signature", [])
         return (func_id, CoreCallable.build(signature=sig, binary=kernel_bin))
@@ -429,20 +504,14 @@ def compile_and_assemble(
         source = Path(orchestration["source"])
 
         # Check cache/ for pre-built binary (written by prebuild_binaries)
-        cache_dir = work_dir / "cache"
-        cache_file = cache_dir / f"orch_{source.stem}.bin"
+        prebuild_cache = work_dir / "cache"
+        cache_file = prebuild_cache / f"orch_{source.stem}.bin"
         cached_bin = _load_binary(cache_file)
         if cached_bin is not None:
             return cached_bin
 
-        # Compile → save .so alongside source
-        output_file = source.with_suffix(".so")
-
-        raw = _load_binary(output_file)
-        if raw is None:
-            raw = compiler.compile_orchestration(runtime_name, orchestration["source"])
-            _save_binary(raw, output_file)
-        return raw
+        # Compile via shared function; skip secondary prebuild cache write
+        return compile_single_orchestration(orchestration["source"], compiler, runtime_name)
 
     max_workers = 1 + len(kernels)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -640,20 +709,59 @@ def validate_golden(
 # Tensor argument construction
 # ---------------------------------------------------------------------------
 
+# Return type shared by build_orch_args / build_orch_args_from_inputs.
+_OrchArgsTuple = tuple[ChipStorageTaskArgs, dict[str, Any], dict[str, torch.Tensor], dict[str, torch.Tensor]]
+
+
+def _collect_orch_args(
+    items: list[tuple[str, torch.Tensor | ctypes._SimpleCData]],
+    is_output: Callable[[str], bool],
+) -> _OrchArgsTuple:
+    """Shared logic for building ``ChipStorageTaskArgs`` from ``(name, value)`` pairs.
+
+    Args:
+        items: Ordered ``(name, value)`` pairs.  Each value is either a
+            ``torch.Tensor`` or a ``ctypes._SimpleCData`` scalar.
+        is_output: Predicate that returns ``True`` if the named tensor is an
+            output to be validated.
+
+    Returns:
+        ``(orch_args, all_tensors, inputs, outputs)``.
+    """
+    orch_args = ChipStorageTaskArgs()
+    all_tensors: dict[str, Any] = {}
+    inputs: dict[str, torch.Tensor] = {}
+    outputs: dict[str, torch.Tensor] = {}
+
+    for name, val in items:
+        if isinstance(val, torch.Tensor):
+            val = val.cpu().contiguous()
+            orch_args.add_tensor(make_tensor_arg(val))
+            all_tensors[name] = val
+            if is_output(name):
+                outputs[name] = val
+            else:
+                inputs[name] = val
+        elif isinstance(val, ctypes._SimpleCData):
+            orch_args.add_scalar(scalar_to_uint64(val))
+            all_tensors[name] = val.value
+
+    return orch_args, all_tensors, inputs, outputs
+
 
 def build_orch_args(
-    tensor_specs: list,
-    golden_func,
-) -> tuple[ChipStorageTaskArgs, dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
-    """Build ``ChipStorageTaskArgs`` from tensor specs and compute golden.
+    tensor_specs: list[TensorSpec],
+    scalar_specs: list[ScalarSpec] | None = None,
+) -> _OrchArgsTuple:
+    """Build ``ChipStorageTaskArgs`` from tensor and scalar specs.
 
     Creates tensors from *tensor_specs*, adds them to a ``ChipStorageTaskArgs``,
-    calls *golden_func* to compute expected outputs.
+    then appends any scalar arguments from *scalar_specs*.
 
     Args:
         tensor_specs: List of ``TensorSpec`` objects.
-        golden_func: ``golden(tensors, params)`` function that computes expected
-            outputs in-place.
+        scalar_specs: Optional list of ``ScalarSpec`` objects for scalar TaskArg
+            parameters.
 
     Returns:
         ``(orch_args, all_tensors, inputs, outputs)`` where:
@@ -662,26 +770,38 @@ def build_orch_args(
         - *inputs*: Non-output tensors.
         - *outputs*: Output tensors.
     """
-    orch_args = ChipStorageTaskArgs()
-    all_tensors: dict[str, torch.Tensor] = {}
-    inputs: dict[str, torch.Tensor] = {}
-    outputs: dict[str, torch.Tensor] = {}
+    output_names = {spec.name for spec in tensor_specs if spec.is_output}
 
-    for spec in tensor_specs:
-        tensor = spec.create_tensor()
-        tensor = tensor.cpu().contiguous()
-        orch_args.add_tensor(make_tensor_arg(tensor))
-        all_tensors[spec.name] = tensor
+    items: list[tuple[str, torch.Tensor | ctypes._SimpleCData]] = [
+        (spec.name, spec.create_tensor()) for spec in tensor_specs
+    ]
+    if scalar_specs:
+        for scalar_spec in scalar_specs:
+            ctype_cls = getattr(ctypes, f"c_{scalar_spec.ctype}")
+            items.append((scalar_spec.name, ctype_cls(scalar_spec.value)))
 
-        if spec.is_output:
-            outputs[spec.name] = tensor
-        else:
-            inputs[spec.name] = tensor
+    return _collect_orch_args(items, lambda name: name in output_names)
 
-    # Add scalar arguments from tensor specs
-    for spec in tensor_specs:
-        for scalar_name, scalar_val in spec.get_scalars():
-            orch_args.add_scalar(scalar_to_uint64(scalar_val))
-            all_tensors[scalar_name] = scalar_val
 
-    return orch_args, all_tensors, inputs, outputs
+def build_orch_args_from_inputs(
+    inputs_result: list[tuple[str, Any]],
+    output_names: set[str],
+) -> _OrchArgsTuple:
+    """Build ``ChipStorageTaskArgs`` from pre-generated ``(name, value)`` tuples.
+
+    This variant is used by the test harness path where inputs come from
+    ``golden.py``'s ``generate_inputs()`` function rather than ``TensorSpec``.
+
+    Args:
+        inputs_result: List of ``(name, value)`` tuples where each value is
+            either a ``torch.Tensor`` or a ``ctypes._SimpleCData`` scalar.
+        output_names: Set of tensor names that are outputs.
+
+    Returns:
+        ``(orch_args, all_tensors, inputs, outputs)`` — same layout as
+        :func:`build_orch_args`.
+    """
+    return _collect_orch_args(
+        inputs_result,
+        lambda name: name in output_names or name.startswith("out"),
+    )

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -52,7 +52,6 @@ from .task_interface import (
     make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
     scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
 )
-from .tensor_spec import ScalarSpec, TensorSpec
 
 logger = logging.getLogger(__name__)
 
@@ -552,7 +551,7 @@ def validate_golden(
 # Tensor argument construction
 # ---------------------------------------------------------------------------
 
-# Return type shared by build_orch_args / build_orch_args_from_inputs.
+# Return type for build_orch_args_from_inputs.
 _OrchArgsTuple = tuple[ChipStorageTaskArgs, dict[str, Any], dict[str, torch.Tensor], dict[str, torch.Tensor]]
 
 
@@ -592,40 +591,6 @@ def _collect_orch_args(
     return orch_args, all_tensors, inputs, outputs
 
 
-def build_orch_args(
-    tensor_specs: list[TensorSpec],
-    scalar_specs: list[ScalarSpec] | None = None,
-) -> _OrchArgsTuple:
-    """Build ``ChipStorageTaskArgs`` from tensor and scalar specs.
-
-    Creates tensors from *tensor_specs*, adds them to a ``ChipStorageTaskArgs``,
-    then appends any scalar arguments from *scalar_specs*.
-
-    Args:
-        tensor_specs: List of ``TensorSpec`` objects.
-        scalar_specs: Optional list of ``ScalarSpec`` objects for scalar TaskArg
-            parameters.
-
-    Returns:
-        ``(orch_args, all_tensors, inputs, outputs)`` where:
-        - *orch_args*: Ready for ``worker.run()``.
-        - *all_tensors*: All named tensors.
-        - *inputs*: Non-output tensors.
-        - *outputs*: Output tensors.
-    """
-    output_names = {spec.name for spec in tensor_specs if spec.is_output}
-
-    items: list[tuple[str, torch.Tensor | ctypes._SimpleCData]] = [
-        (spec.name, spec.create_tensor()) for spec in tensor_specs
-    ]
-    if scalar_specs:
-        for scalar_spec in scalar_specs:
-            ctype_cls = getattr(ctypes, f"c_{scalar_spec.ctype}")
-            items.append((scalar_spec.name, ctype_cls(scalar_spec.value)))
-
-    return _collect_orch_args(items, lambda name: name in output_names)
-
-
 def build_orch_args_from_inputs(
     inputs_result: list[tuple[str, Any]],
     output_names: set[str],
@@ -641,8 +606,7 @@ def build_orch_args_from_inputs(
         output_names: Set of tensor names that are outputs.
 
     Returns:
-        ``(orch_args, all_tensors, inputs, outputs)`` — same layout as
-        :func:`build_orch_args`.
+        ``(orch_args, all_tensors, inputs, outputs)``.
     """
     return _collect_orch_args(
         inputs_result,

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -1,0 +1,687 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Device compilation, execution, and golden validation pipeline.
+
+This module replaces Simpler's ``CodeRunner`` by providing PyPTO-internal
+implementations of:
+
+- :func:`compile_and_assemble`: Compile kernels + orchestration C++ → binaries,
+  assemble into ``ChipCallable``, locate runtime binaries.
+- :func:`execute_on_device`: Run a ``ChipCallable`` on device via ``ChipWorker``.
+- :func:`validate_golden`: Compare actual outputs against golden reference.
+- :func:`ensure_pto_isa_root`: Manage PTO-ISA repository (clone/checkout).
+
+These functions eliminate all Python-level imports from Simpler. The only
+Simpler dependency remaining is:
+
+- ``pip install simpler`` → provides the ``_task_interface`` nanobind C++ module.
+- ``SIMPLER_ROOT`` → provides C++ headers and pre-built runtime binaries.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import importlib.util
+import logging
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from .elf_parser import extract_text_section
+from .kernel_compiler import KernelCompiler
+from .task_interface import (
+    ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipCallConfig,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipWorker,
+    CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    make_tensor_arg,
+    scalar_to_uint64,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RuntimeBinaries
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuntimeBinaries:
+    """Paths to compiled runtime binaries (host, aicpu, aicore)."""
+
+    host_path: Path
+    aicpu_path: Path
+    aicore_path: Path
+    sim_context_path: Path | None = None
+
+
+# ---------------------------------------------------------------------------
+# Binary cache helpers
+# ---------------------------------------------------------------------------
+
+_BINARY_RUNTIME_CACHE = (
+    Path(__file__).parent.parent.parent.parent / "build_output" / "binary_cache" / "runtimes"
+)
+
+
+def _save_binary(data: bytes, path: Path) -> None:
+    """Save compiled binary bytes to *path* atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
+
+
+def _load_binary(path: Path) -> bytes | None:
+    """Load compiled binary bytes from *path*. Returns ``None`` on miss."""
+    if not path.exists():
+        return None
+    try:
+        return path.read_bytes()
+    except Exception:
+        return None
+
+
+def _get_simpler_stamp() -> str:
+    """Return Simpler's current git commit (short hash) as a cache-key stamp."""
+    simpler_root = os.environ.get("SIMPLER_ROOT", "")
+    if not simpler_root:
+        return "unknown"
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=simpler_root,
+            timeout=5,
+        )
+        return r.stdout.strip() if r.returncode == 0 else "unknown"
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
+
+_PLATFORM_MAP = {
+    "a2a3": ("a2a3", "onboard"),
+    "a2a3sim": ("a2a3", "sim"),
+    "a5": ("a5", "onboard"),
+    "a5sim": ("a5", "sim"),
+}
+
+
+def _parse_platform(platform: str) -> tuple[str, str]:
+    """Parse platform string into ``(arch, variant)``."""
+    if platform not in _PLATFORM_MAP:
+        raise ValueError(f"Unknown platform: {platform!r}. Expected one of {list(_PLATFORM_MAP)}")
+    return _PLATFORM_MAP[platform]
+
+
+# ---------------------------------------------------------------------------
+# PTO-ISA management
+# ---------------------------------------------------------------------------
+
+_PTO_ISA_HTTPS = "https://github.com/PTO-ISA/pto-isa.git"
+_PTO_ISA_SSH = "git@github.com:PTO-ISA/pto-isa.git"
+
+
+def _get_pto_isa_clone_path() -> Path:
+    """Return the default path where PTO-ISA is cloned."""
+    return Path(__file__).parent.parent.parent.parent / "_deps" / "pto-isa"
+
+
+def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https") -> str | None:
+    """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
+
+    Uses a file lock to prevent parallel processes from racing on the clone.
+
+    Args:
+        commit: If provided, checkout this specific commit.
+        clone_protocol: ``"https"`` or ``"ssh"``.
+
+    Returns:
+        PTO-ISA root path if successful, ``None`` otherwise.
+    """
+    existing_root = os.environ.get("PTO_ISA_ROOT")
+    if existing_root:
+        return existing_root
+
+    clone_path = _get_pto_isa_clone_path()
+    lock_path = clone_path.parent / ".pto-isa.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        return _ensure_pto_isa_root_locked(clone_path, commit=commit, clone_protocol=clone_protocol)
+
+
+def _ensure_pto_isa_root_locked(
+    clone_path: Path, commit: str | None = None, clone_protocol: str = "https"
+) -> str | None:
+    """Inner logic for :func:`ensure_pto_isa_root`, called while holding the file lock."""
+    include_dir = clone_path / "include"
+
+    if not (clone_path.exists() and include_dir.exists() and include_dir.is_dir()):
+        # Need to clone
+        repo_url = _PTO_ISA_HTTPS if clone_protocol == "https" else _PTO_ISA_SSH
+        clone_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            result = subprocess.run(
+                ["git", "clone", repo_url, str(clone_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                # Another process may have succeeded
+                if not include_dir.exists():
+                    logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
+                    return None
+            if commit:
+                subprocess.run(
+                    ["git", "checkout", commit],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    cwd=str(clone_path),
+                    timeout=30,
+                )
+        except (subprocess.TimeoutExpired, Exception) as e:
+            if not include_dir.exists():
+                logger.warning(f"Failed to clone pto-isa: {e}")
+                return None
+    elif commit:
+        _checkout_pto_isa_commit(clone_path, commit)
+    else:
+        _update_pto_isa_to_latest(clone_path)
+
+    if not include_dir.exists():
+        return None
+
+    resolved = str(clone_path.resolve())
+    os.environ["PTO_ISA_ROOT"] = resolved
+    return resolved
+
+
+def _checkout_pto_isa_commit(clone_path: Path, commit: str) -> None:
+    """Checkout the specified commit if the existing clone is at a different revision."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(clone_path),
+            timeout=5,
+        )
+        current = result.stdout.strip() if result.returncode == 0 else ""
+        if current and not commit.startswith(current) and not current.startswith(commit):
+            subprocess.run(
+                ["git", "fetch", "origin"],
+                capture_output=True,
+                text=True,
+                cwd=str(clone_path),
+                timeout=120,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "checkout", commit],
+                capture_output=True,
+                text=True,
+                cwd=str(clone_path),
+                timeout=30,
+                check=True,
+            )
+    except Exception as e:
+        logger.warning(f"Failed to checkout pto-isa commit {commit}: {e}")
+
+
+def _update_pto_isa_to_latest(clone_path: Path) -> None:
+    """Fetch and reset existing clone to the remote default branch."""
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            capture_output=True,
+            text=True,
+            cwd=str(clone_path),
+            timeout=120,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "reset", "--hard", "origin/HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(clone_path),
+            timeout=30,
+            check=True,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to update pto-isa to latest: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _temporary_env(env_updates: dict[str, str]):
+    """Temporarily apply env vars for the duration of the context."""
+    old = {k: os.environ.get(k) for k in env_updates}
+    for k, v in env_updates.items():
+        os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, prev in old.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _kernel_config_runtime_env(kernel_config_module, kernels_dir: Path) -> dict[str, str]:
+    """Extract optional per-example environment variables from kernel_config.py."""
+    runtime_env = getattr(kernel_config_module, "RUNTIME_ENV", None)
+    if not isinstance(runtime_env, dict):
+        return {}
+
+    out: dict[str, str] = {}
+    for k, v in runtime_env.items():
+        if not isinstance(k, str):
+            continue
+        s = str(v)
+        is_path_like = k.endswith("_DIR") or k.endswith("_PATH")
+        if is_path_like and s:
+            p = Path(s)
+            if not p.is_absolute():
+                s = str((kernels_dir / p).resolve())
+        out[k] = s
+    return out
+
+
+# ---------------------------------------------------------------------------
+# compile_and_assemble
+# ---------------------------------------------------------------------------
+
+
+def compile_and_assemble(
+    work_dir: Path,
+    platform: str,
+    pto_isa_commit: str | None = None,
+) -> tuple[ChipCallable, RuntimeBinaries]:
+    """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
+
+    Reads ``kernel_config.py`` from *work_dir* to discover kernel sources,
+    orchestration source, and runtime configuration.
+
+    Binary caching is integrated: cached binaries are served from
+    ``work_dir/cache/`` and ``build_output/binary_cache/runtimes/``.
+
+    Args:
+        work_dir: Root output directory containing ``kernels/``, ``orchestration/``,
+            and ``kernel_config.py`` (produced by :func:`compile_program`).
+        platform: Target execution platform.
+        pto_isa_commit: If set, pin the pto-isa clone to this commit.
+
+    Returns:
+        ``(chip_callable, runtime_binaries)`` ready for execution.
+    """
+    # Load kernel_config.py
+    config_path = work_dir / "kernel_config.py"
+    if not config_path.exists():
+        raise FileNotFoundError(f"kernel_config.py not found in {work_dir}")
+
+    spec = importlib.util.spec_from_file_location("_kernel_config", str(config_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load kernel_config.py from {config_path}")
+    kernel_config = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(kernel_config)
+
+    kernels = kernel_config.KERNELS
+    orchestration = kernel_config.ORCHESTRATION
+    runtime_config = getattr(kernel_config, "RUNTIME_CONFIG", {})
+    runtime_name = runtime_config.get("runtime", "host_build_graph")
+
+    # Ensure PTO-ISA root
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
+    if pto_isa_root is None:
+        raise OSError(
+            "PTO_ISA_ROOT could not be resolved.\n"
+            "Please set it to the PTO-ISA root directory, e.g.:\n"
+            "  export PTO_ISA_ROOT=/path/to/pto-isa"
+        )
+
+    # Create compiler
+    compiler = KernelCompiler(platform=platform)
+
+    # Resolve runtime include dirs for kernel compilation
+    simpler_root = Path(os.environ["SIMPLER_ROOT"])
+    arch = "a5" if platform.startswith("a5") else "a2a3"
+    runtime_base_dir = simpler_root / "src" / arch / "runtime" / runtime_name
+    runtime_include_dirs: list[str] = []
+
+    build_config_path = runtime_base_dir / "build_config.py"
+    if build_config_path.is_file():
+        bc_spec = importlib.util.spec_from_file_location("build_config", str(build_config_path))
+        if bc_spec is not None and bc_spec.loader is not None:
+            bc_module = importlib.util.module_from_spec(bc_spec)
+            bc_spec.loader.exec_module(bc_module)
+            aicore_cfg = bc_module.BUILD_CONFIG.get("aicore", {})
+            for p in aicore_cfg.get("include_dirs", []):
+                runtime_include_dirs.append(str(runtime_base_dir / p))
+    else:
+        runtime_include_dirs.append(str(runtime_base_dir / "runtime"))
+    runtime_include_dirs.append(str(simpler_root / "src" / "common" / "task_interface"))
+
+    # --- Parallel compilation ---
+
+    def _compile_one_kernel(kernel: dict) -> tuple[int, CoreCallable]:
+        func_id = kernel["func_id"]
+        source = Path(kernel["source"])
+        core_type = kernel["core_type"]
+
+        # Check cache/ for pre-stripped binary (written by prebuild_binaries)
+        cache_dir = work_dir / "cache"
+        cache_file = cache_dir / f"incore_{core_type}_{source.stem}.bin"
+        cached_bin = _load_binary(cache_file)
+        if cached_bin is not None:
+            sig = kernel.get("signature", [])
+            return (func_id, CoreCallable.build(signature=sig, binary=cached_bin))
+
+        # Compile → save .o/.so alongside source
+        ext = ".so" if platform.endswith("sim") else ".o"
+        output_file = source.with_suffix(ext)
+
+        raw = _load_binary(output_file)
+        if raw is None:
+            raw = compiler.compile_incore(
+                kernel["source"],
+                core_type=core_type,
+                pto_isa_root=pto_isa_root,
+                extra_include_dirs=runtime_include_dirs,
+            )
+            _save_binary(raw, output_file)
+
+        kernel_bin = raw if platform.endswith("sim") else extract_text_section(raw)
+
+        sig = kernel.get("signature", [])
+        return (func_id, CoreCallable.build(signature=sig, binary=kernel_bin))
+
+    def _compile_orchestration() -> bytes:
+        source = Path(orchestration["source"])
+
+        # Check cache/ for pre-built binary (written by prebuild_binaries)
+        cache_dir = work_dir / "cache"
+        cache_file = cache_dir / f"orch_{source.stem}.bin"
+        cached_bin = _load_binary(cache_file)
+        if cached_bin is not None:
+            return cached_bin
+
+        # Compile → save .so alongside source
+        output_file = source.with_suffix(".so")
+
+        raw = _load_binary(output_file)
+        if raw is None:
+            raw = compiler.compile_orchestration(runtime_name, orchestration["source"])
+            _save_binary(raw, output_file)
+        return raw
+
+    max_workers = 1 + len(kernels)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        fut_orch = executor.submit(_compile_orchestration)
+        fut_kernels = [executor.submit(_compile_one_kernel, k) for k in kernels]
+
+        orch_so_binary = fut_orch.result()
+        kernel_binaries = [f.result() for f in fut_kernels]
+
+    # Assemble ChipCallable
+    orch_sig = orchestration.get("signature", [])
+    chip_callable = ChipCallable.build(
+        signature=orch_sig,
+        func_name=orchestration["function_name"],
+        binary=orch_so_binary,
+        children=kernel_binaries,
+    )
+
+    # Locate runtime binaries
+    binaries = _find_runtime_binaries(platform, runtime_name)
+
+    return chip_callable, binaries
+
+
+# ---------------------------------------------------------------------------
+# Runtime binary lookup
+# ---------------------------------------------------------------------------
+
+
+def _find_runtime_binaries(platform: str, runtime_name: str) -> RuntimeBinaries:
+    """Find pre-built runtime binaries from ``SIMPLER_ROOT/build/lib/``.
+
+    Also checks the persistent binary cache under ``build_output/binary_cache/runtimes/``.
+    """
+    stamp = _get_simpler_stamp()
+    arch, variant = _parse_platform(platform)
+
+    # Check persistent cache first
+    cache_dir = _BINARY_RUNTIME_CACHE / stamp
+    host_cache = cache_dir / f"{runtime_name}_{platform}_host.bin"
+    aicpu_cache = cache_dir / f"{runtime_name}_{platform}_aicpu.bin"
+    aicore_cache = cache_dir / f"{runtime_name}_{platform}_aicore.bin"
+
+    if host_cache.exists() and aicpu_cache.exists() and aicore_cache.exists():
+        sim_ctx = _resolve_sim_context(arch, variant)
+        return RuntimeBinaries(
+            host_path=host_cache,
+            aicpu_path=aicpu_cache,
+            aicore_path=aicore_cache,
+            sim_context_path=sim_ctx,
+        )
+
+    # Look up from SIMPLER_ROOT/build/lib/
+    simpler_root = Path(os.environ["SIMPLER_ROOT"])
+    lib_dir = simpler_root / "build" / "lib" / arch / variant / runtime_name
+
+    # Binary names match RuntimeCompiler's target config
+    host_name = "libhost_runtime.so"
+    aicpu_name = "libaicpu_kernel.so"
+    aicore_name = "aicore_kernel.o" if variant == "onboard" else "libaicore_kernel.so"
+
+    host_path = lib_dir / host_name
+    aicpu_path = lib_dir / aicpu_name
+    aicore_path = lib_dir / aicore_name
+
+    missing = [str(p) for p in (host_path, aicpu_path, aicore_path) if not p.is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"Pre-built runtime binaries not found for '{runtime_name}' "
+            f"(platform={platform}):\n"
+            + "\n".join(f"  {m}" for m in missing)
+            + "\nRun 'cd $SIMPLER_ROOT && pip install .' to build them."
+        )
+
+    # Cache for future use
+    _save_binary(host_path.read_bytes(), host_cache)
+    _save_binary(aicpu_path.read_bytes(), aicpu_cache)
+    _save_binary(aicore_path.read_bytes(), aicore_cache)
+
+    sim_ctx = _resolve_sim_context(arch, variant)
+    return RuntimeBinaries(
+        host_path=host_path,
+        aicpu_path=aicpu_path,
+        aicore_path=aicore_path,
+        sim_context_path=sim_ctx,
+    )
+
+
+def _resolve_sim_context(arch: str, variant: str) -> Path | None:
+    """Return path to ``libcpu_sim_context.so`` for sim platforms, ``None`` for onboard."""
+    if variant != "sim":
+        return None
+    simpler_root = Path(os.environ.get("SIMPLER_ROOT", ""))
+    if not simpler_root:
+        return None
+    return simpler_root / "build" / "lib" / arch / variant / "libcpu_sim_context.so"
+
+
+# ---------------------------------------------------------------------------
+# execute_on_device
+# ---------------------------------------------------------------------------
+
+
+def execute_on_device(
+    chip_callable: ChipCallable,
+    orch_args: ChipStorageTaskArgs,
+    runtime_binaries: RuntimeBinaries,
+    device_id: int,
+    *,
+    block_dim: int = 24,
+    aicpu_thread_num: int = 3,
+    enable_profiling: bool = False,
+    runtime_env: dict[str, str] | None = None,
+) -> None:
+    """Execute *chip_callable* on device via ``ChipWorker``.
+
+    Args:
+        chip_callable: Assembled callable (orchestration + kernels).
+        orch_args: Tensor/scalar arguments.
+        runtime_binaries: Paths to host/aicpu/aicore runtime binaries.
+        device_id: NPU device index.
+        block_dim: Block dimension for execution.
+        aicpu_thread_num: Number of AICPU threads.
+        enable_profiling: Enable runtime profiling.
+        runtime_env: Optional per-example environment variable overrides.
+    """
+    worker = ChipWorker()
+    worker.init(
+        str(runtime_binaries.host_path),
+        str(runtime_binaries.aicpu_path),
+        str(runtime_binaries.aicore_path),
+        sim_context_lib_path=str(runtime_binaries.sim_context_path)
+        if runtime_binaries.sim_context_path
+        else "",
+    )
+    worker.set_device(device_id)
+
+    config = ChipCallConfig()
+    config.block_dim = block_dim
+    config.aicpu_thread_num = aicpu_thread_num
+    if enable_profiling:
+        config.enable_profiling = True
+
+    env = runtime_env or {}
+    with _temporary_env(env):
+        worker.run(chip_callable, orch_args, config)
+
+    worker.reset_device()
+    worker.finalize()
+
+
+# ---------------------------------------------------------------------------
+# Golden validation
+# ---------------------------------------------------------------------------
+
+
+def validate_golden(
+    outputs: dict[str, torch.Tensor],
+    golden: dict[str, torch.Tensor],
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+) -> None:
+    """Compare actual outputs against golden reference using ``torch.allclose``.
+
+    Raises:
+        AssertionError: If any output tensor does not match within tolerances.
+    """
+    for name, actual_tensor in outputs.items():
+        actual = actual_tensor.cpu()
+        expected = golden[name].cpu()
+        logger.info(f"Comparing {name}: shape={actual.shape}, dtype={actual.dtype}")
+
+        if actual.numel() > 0:
+            flat_actual = actual.flatten()
+            flat_expected = expected.flatten()
+            n_show = min(10, flat_actual.numel())
+            logger.debug(f"  First {n_show} actual:   {flat_actual[:n_show].tolist()}")
+            logger.debug(f"  First {n_show} expected: {flat_expected[:n_show].tolist()}")
+
+        if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
+            close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
+            mismatches = (~close_mask).sum().item()
+            total = actual.numel()
+            raise AssertionError(
+                f"Output '{name}' does not match golden.\n"
+                f"Mismatched elements: {mismatches}/{total}\n"
+                f"rtol={rtol}, atol={atol}"
+            )
+
+        matched = torch.isclose(actual, expected, rtol=rtol, atol=atol).sum().item()
+        logger.info(f"  {name}: PASS ({matched}/{actual.numel()} elements matched)")
+
+
+# ---------------------------------------------------------------------------
+# Tensor argument construction
+# ---------------------------------------------------------------------------
+
+
+def build_orch_args(
+    tensor_specs: list,
+    golden_func,
+) -> tuple[ChipStorageTaskArgs, dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """Build ``ChipStorageTaskArgs`` from tensor specs and compute golden.
+
+    Creates tensors from *tensor_specs*, adds them to a ``ChipStorageTaskArgs``,
+    calls *golden_func* to compute expected outputs.
+
+    Args:
+        tensor_specs: List of ``TensorSpec`` objects.
+        golden_func: ``golden(tensors, params)`` function that computes expected
+            outputs in-place.
+
+    Returns:
+        ``(orch_args, all_tensors, inputs, outputs)`` where:
+        - *orch_args*: Ready for ``worker.run()``.
+        - *all_tensors*: All named tensors.
+        - *inputs*: Non-output tensors.
+        - *outputs*: Output tensors.
+    """
+    orch_args = ChipStorageTaskArgs()
+    all_tensors: dict[str, torch.Tensor] = {}
+    inputs: dict[str, torch.Tensor] = {}
+    outputs: dict[str, torch.Tensor] = {}
+
+    for spec in tensor_specs:
+        tensor = spec.create_tensor()
+        tensor = tensor.cpu().contiguous()
+        orch_args.add_tensor(make_tensor_arg(tensor))
+        all_tensors[spec.name] = tensor
+
+        if spec.is_output:
+            outputs[spec.name] = tensor
+        else:
+            inputs[spec.name] = tensor
+
+    # Add scalar arguments from tensor specs
+    for spec in tensor_specs:
+        for scalar_name, scalar_val in spec.get_scalars():
+            orch_args.add_scalar(scalar_to_uint64(scalar_val))
+            all_tensors[scalar_name] = scalar_val
+
+    return orch_args, all_tensors, inputs, outputs

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -27,13 +27,15 @@ Simpler dependency remaining is:
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import fcntl
 import importlib.util
 import logging
 import os
 import subprocess
-from collections.abc import Callable
+import tempfile
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -85,9 +87,18 @@ _BINARY_RUNTIME_CACHE = (
 def _save_binary(data: bytes, path: Path) -> None:
     """Save compiled binary bytes to *path* atomically."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_bytes(data)
-    os.replace(tmp, path)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        os.write(fd, data)
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_name, path)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 def _load_binary(path: Path) -> bytes | None:
@@ -151,6 +162,16 @@ def _get_pto_isa_clone_path() -> Path:
     return Path(__file__).parent.parent.parent.parent / "_deps" / "pto-isa"
 
 
+@contextmanager
+def _pto_isa_lock(clone_path: Path) -> Iterator[None]:
+    """Acquire an exclusive file lock for PTO-ISA operations on *clone_path*."""
+    lock_path = clone_path.parent / ".pto-isa.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+
+
 def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https") -> str | None:
     """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
 
@@ -165,13 +186,14 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     """
     existing_root = os.environ.get("PTO_ISA_ROOT")
     if existing_root:
+        if commit:
+            # Still need to checkout the requested commit even if PTO_ISA_ROOT is set
+            with _pto_isa_lock(Path(existing_root)):
+                _checkout_pto_isa_commit(Path(existing_root), commit)
         return existing_root
 
     clone_path = _get_pto_isa_clone_path()
-    lock_path = clone_path.parent / ".pto-isa.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_fd:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    with _pto_isa_lock(clone_path):
         return _ensure_pto_isa_root_locked(clone_path, commit=commit, clone_protocol=clone_protocol)
 
 
@@ -199,7 +221,7 @@ def _ensure_pto_isa_root_locked(
                     logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
                     return None
             if commit:
-                subprocess.run(
+                result = subprocess.run(
                     ["git", "checkout", commit],
                     check=False,
                     capture_output=True,
@@ -207,7 +229,9 @@ def _ensure_pto_isa_root_locked(
                     cwd=str(clone_path),
                     timeout=30,
                 )
-        except (subprocess.TimeoutExpired, Exception) as e:
+                if result.returncode != 0:
+                    raise RuntimeError(f"Failed to checkout pto-isa commit {commit}:\n{result.stderr}")
+        except Exception as e:
             if not include_dir.exists():
                 logger.warning(f"Failed to clone pto-isa: {e}")
                 return None
@@ -513,7 +537,7 @@ def compile_and_assemble(
         # Compile via shared function; skip secondary prebuild cache write
         return compile_single_orchestration(orchestration["source"], compiler, runtime_name)
 
-    max_workers = 1 + len(kernels)
+    max_workers = min(64, 1 + len(kernels))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         fut_orch = executor.submit(_compile_orchestration)
         fut_kernels = [executor.submit(_compile_one_kernel, k) for k in kernels]
@@ -531,7 +555,7 @@ def compile_and_assemble(
     )
 
     # Locate runtime binaries
-    binaries = _find_runtime_binaries(platform, runtime_name)
+    binaries = _find_runtime_binaries(platform, runtime_name, compiler.runtime_root)
 
     return chip_callable, binaries
 
@@ -541,7 +565,7 @@ def compile_and_assemble(
 # ---------------------------------------------------------------------------
 
 
-def _find_runtime_binaries(platform: str, runtime_name: str) -> RuntimeBinaries:
+def _find_runtime_binaries(platform: str, runtime_name: str, simpler_root: Path) -> RuntimeBinaries:
     """Find pre-built runtime binaries from ``SIMPLER_ROOT/build/lib/``.
 
     Also checks the persistent binary cache under ``build_output/binary_cache/runtimes/``.
@@ -565,7 +589,6 @@ def _find_runtime_binaries(platform: str, runtime_name: str) -> RuntimeBinaries:
         )
 
     # Look up from SIMPLER_ROOT/build/lib/
-    simpler_root = Path(os.environ["SIMPLER_ROOT"])
     lib_dir = simpler_root / "build" / "lib" / arch / variant / runtime_name
 
     # Binary names match RuntimeCompiler's target config
@@ -639,28 +662,30 @@ def execute_on_device(
         runtime_env: Optional per-example environment variable overrides.
     """
     worker = ChipWorker()
-    worker.init(
-        str(runtime_binaries.host_path),
-        str(runtime_binaries.aicpu_path),
-        str(runtime_binaries.aicore_path),
-        sim_context_lib_path=str(runtime_binaries.sim_context_path)
-        if runtime_binaries.sim_context_path
-        else "",
-    )
-    worker.set_device(device_id)
+    try:
+        sim_ctx = runtime_binaries.sim_context_path
+        worker.init(
+            str(runtime_binaries.host_path),
+            str(runtime_binaries.aicpu_path),
+            str(runtime_binaries.aicore_path),
+            sim_context_lib_path=str(sim_ctx) if sim_ctx else "",
+        )
+        worker.set_device(device_id)
 
-    config = ChipCallConfig()
-    config.block_dim = block_dim
-    config.aicpu_thread_num = aicpu_thread_num
-    if enable_profiling:
-        config.enable_profiling = True
+        config = ChipCallConfig()
+        config.block_dim = block_dim
+        config.aicpu_thread_num = aicpu_thread_num
+        if enable_profiling:
+            config.enable_profiling = True
 
-    env = runtime_env or {}
-    with _temporary_env(env):
-        worker.run(chip_callable, orch_args, config)
-
-    worker.reset_device()
-    worker.finalize()
+        env = runtime_env or {}
+        with _temporary_env(env):
+            worker.run(chip_callable, orch_args, config)
+    finally:
+        if worker.device_set:
+            worker.reset_device()
+        if worker.initialized:
+            worker.finalize()
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -37,7 +37,6 @@ import tempfile
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,12 +46,11 @@ from .elf_parser import extract_text_section
 from .kernel_compiler import KernelCompiler
 from .task_interface import (
     ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
-    ChipCallConfig,  # pyright: ignore[reportAttributeAccessIssue]
     ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
-    ChipWorker,
     CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
-    make_tensor_arg,
-    scalar_to_uint64,
+    Worker,  # pyright: ignore[reportAttributeAccessIssue]
+    make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
+    scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
 )
 from .tensor_spec import ScalarSpec, TensorSpec
 
@@ -60,27 +58,8 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# RuntimeBinaries
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class RuntimeBinaries:
-    """Paths to compiled runtime binaries (host, aicpu, aicore)."""
-
-    host_path: Path
-    aicpu_path: Path
-    aicore_path: Path
-    sim_context_path: Path | None = None
-
-
-# ---------------------------------------------------------------------------
 # Binary cache helpers
 # ---------------------------------------------------------------------------
-
-_BINARY_RUNTIME_CACHE = (
-    Path(__file__).parent.parent.parent.parent / "build_output" / "binary_cache" / "runtimes"
-)
 
 
 def _save_binary(data: bytes, path: Path) -> None:
@@ -108,25 +87,6 @@ def _load_binary(path: Path) -> bytes | None:
         return path.read_bytes()
     except Exception:
         return None
-
-
-def _get_simpler_stamp() -> str:
-    """Return Simpler's current git commit (short hash) as a cache-key stamp."""
-    simpler_root = os.environ.get("SIMPLER_ROOT", "")
-    if not simpler_root:
-        return "unknown"
-    try:
-        r = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            check=False,
-            capture_output=True,
-            text=True,
-            cwd=simpler_root,
-            timeout=5,
-        )
-        return r.stdout.strip() if r.returncode == 0 else "unknown"
-    except Exception:
-        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -441,14 +401,11 @@ def compile_and_assemble(
     work_dir: Path,
     platform: str,
     pto_isa_commit: str | None = None,
-) -> tuple[ChipCallable, RuntimeBinaries]:
+) -> tuple[ChipCallable, str]:
     """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
 
     Reads ``kernel_config.py`` from *work_dir* to discover kernel sources,
     orchestration source, and runtime configuration.
-
-    Binary caching is integrated: cached binaries are served from
-    ``work_dir/cache/`` and ``build_output/binary_cache/runtimes/``.
 
     Args:
         work_dir: Root output directory containing ``kernels/``, ``orchestration/``,
@@ -457,7 +414,8 @@ def compile_and_assemble(
         pto_isa_commit: If set, pin the pto-isa clone to this commit.
 
     Returns:
-        ``(chip_callable, runtime_binaries)`` ready for execution.
+        ``(chip_callable, runtime_name)`` — the assembled callable and the
+        runtime name (e.g. ``"tensormap_and_ringbuffer"``).
     """
     # Load kernel_config.py
     config_path = work_dir / "kernel_config.py"
@@ -538,83 +496,7 @@ def compile_and_assemble(
         children=kernel_binaries,
     )
 
-    # Locate runtime binaries
-    binaries = _find_runtime_binaries(platform, runtime_name, compiler.runtime_root)
-
-    return chip_callable, binaries
-
-
-# ---------------------------------------------------------------------------
-# Runtime binary lookup
-# ---------------------------------------------------------------------------
-
-
-def _find_runtime_binaries(platform: str, runtime_name: str, simpler_root: Path) -> RuntimeBinaries:
-    """Find pre-built runtime binaries from ``SIMPLER_ROOT/build/lib/``.
-
-    Also checks the persistent binary cache under ``build_output/binary_cache/runtimes/``.
-    """
-    stamp = _get_simpler_stamp()
-    arch, variant = _parse_platform(platform)
-
-    # Check persistent cache first
-    cache_dir = _BINARY_RUNTIME_CACHE / stamp
-    host_cache = cache_dir / f"{runtime_name}_{platform}_host.bin"
-    aicpu_cache = cache_dir / f"{runtime_name}_{platform}_aicpu.bin"
-    aicore_cache = cache_dir / f"{runtime_name}_{platform}_aicore.bin"
-
-    if host_cache.exists() and aicpu_cache.exists() and aicore_cache.exists():
-        sim_ctx = _resolve_sim_context(arch, variant)
-        return RuntimeBinaries(
-            host_path=host_cache,
-            aicpu_path=aicpu_cache,
-            aicore_path=aicore_cache,
-            sim_context_path=sim_ctx,
-        )
-
-    # Look up from SIMPLER_ROOT/build/lib/
-    lib_dir = simpler_root / "build" / "lib" / arch / variant / runtime_name
-
-    # Binary names match RuntimeCompiler's target config
-    host_name = "libhost_runtime.so"
-    aicpu_name = "libaicpu_kernel.so"
-    aicore_name = "aicore_kernel.o" if variant == "onboard" else "libaicore_kernel.so"
-
-    host_path = lib_dir / host_name
-    aicpu_path = lib_dir / aicpu_name
-    aicore_path = lib_dir / aicore_name
-
-    missing = [str(p) for p in (host_path, aicpu_path, aicore_path) if not p.is_file()]
-    if missing:
-        raise FileNotFoundError(
-            f"Pre-built runtime binaries not found for '{runtime_name}' "
-            f"(platform={platform}):\n"
-            + "\n".join(f"  {m}" for m in missing)
-            + "\nRun 'cd $SIMPLER_ROOT && pip install .' to build them."
-        )
-
-    # Cache for future use
-    _save_binary(host_path.read_bytes(), host_cache)
-    _save_binary(aicpu_path.read_bytes(), aicpu_cache)
-    _save_binary(aicore_path.read_bytes(), aicore_cache)
-
-    sim_ctx = _resolve_sim_context(arch, variant)
-    return RuntimeBinaries(
-        host_path=host_path,
-        aicpu_path=aicpu_path,
-        aicore_path=aicore_path,
-        sim_context_path=sim_ctx,
-    )
-
-
-def _resolve_sim_context(arch: str, variant: str) -> Path | None:
-    """Return path to ``libcpu_sim_context.so`` for sim platforms, ``None`` for onboard."""
-    if variant != "sim":
-        return None
-    simpler_root = Path(os.environ.get("SIMPLER_ROOT", ""))
-    if not simpler_root:
-        return None
-    return simpler_root / "build" / "lib" / arch / variant / "libcpu_sim_context.so"
+    return chip_callable, runtime_name
 
 
 # ---------------------------------------------------------------------------
@@ -625,7 +507,8 @@ def _resolve_sim_context(arch: str, variant: str) -> Path | None:
 def execute_on_device(
     chip_callable: ChipCallable,
     orch_args: ChipStorageTaskArgs,
-    runtime_binaries: RuntimeBinaries,
+    platform: str,
+    runtime_name: str,
     device_id: int,
     *,
     block_dim: int = 24,
@@ -633,43 +516,33 @@ def execute_on_device(
     enable_profiling: bool = False,
     runtime_env: dict[str, str] | None = None,
 ) -> None:
-    """Execute *chip_callable* on device via ``ChipWorker``.
+    """Execute *chip_callable* on device via Simpler's unified ``Worker``.
 
     Args:
         chip_callable: Assembled callable (orchestration + kernels).
         orch_args: Tensor/scalar arguments.
-        runtime_binaries: Paths to host/aicpu/aicore runtime binaries.
+        platform: Target execution platform (e.g. ``"a2a3sim"``).
+        runtime_name: Runtime implementation name (e.g. ``"tensormap_and_ringbuffer"``).
         device_id: NPU device index.
         block_dim: Block dimension for execution.
         aicpu_thread_num: Number of AICPU threads.
         enable_profiling: Enable runtime profiling.
         runtime_env: Optional per-example environment variable overrides.
     """
-    worker = ChipWorker()
-    try:
-        sim_ctx = runtime_binaries.sim_context_path
-        worker.init(
-            str(runtime_binaries.host_path),
-            str(runtime_binaries.aicpu_path),
-            str(runtime_binaries.aicore_path),
-            sim_context_lib_path=str(sim_ctx) if sim_ctx else "",
+    worker = Worker(level=2, device_id=device_id, platform=platform, runtime=runtime_name)
+    worker.init()
+
+    env = runtime_env or {}
+    with _temporary_env(env):
+        worker.run(
+            chip_callable,
+            orch_args,
+            block_dim=block_dim,
+            aicpu_thread_num=aicpu_thread_num,
+            enable_profiling=enable_profiling,
         )
-        worker.set_device(device_id)
 
-        config = ChipCallConfig()
-        config.block_dim = block_dim
-        config.aicpu_thread_num = aicpu_thread_num
-        if enable_profiling:
-            config.enable_profiling = True
-
-        env = runtime_env or {}
-        with _temporary_env(env):
-            worker.run(chip_callable, orch_args, config)
-    finally:
-        if worker.device_set:
-            worker.reset_device()
-        if worker.initialized:
-            worker.finalize()
+    worker.close()
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -90,25 +90,6 @@ def _load_binary(path: Path) -> bytes | None:
 
 
 # ---------------------------------------------------------------------------
-# Platform helpers
-# ---------------------------------------------------------------------------
-
-_PLATFORM_MAP = {
-    "a2a3": ("a2a3", "onboard"),
-    "a2a3sim": ("a2a3", "sim"),
-    "a5": ("a5", "onboard"),
-    "a5sim": ("a5", "sim"),
-}
-
-
-def _parse_platform(platform: str) -> tuple[str, str]:
-    """Parse platform string into ``(arch, variant)``."""
-    if platform not in _PLATFORM_MAP:
-        raise ValueError(f"Unknown platform: {platform!r}. Expected one of {list(_PLATFORM_MAP)}")
-    return _PLATFORM_MAP[platform]
-
-
-# ---------------------------------------------------------------------------
 # PTO-ISA management
 # ---------------------------------------------------------------------------
 
@@ -267,26 +248,6 @@ def _temporary_env(env_updates: dict[str, str]):
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = prev
-
-
-def _kernel_config_runtime_env(kernel_config_module, kernels_dir: Path) -> dict[str, str]:
-    """Extract optional per-example environment variables from kernel_config.py."""
-    runtime_env = getattr(kernel_config_module, "RUNTIME_ENV", None)
-    if not isinstance(runtime_env, dict):
-        return {}
-
-    out: dict[str, str] = {}
-    for k, v in runtime_env.items():
-        if not isinstance(k, str):
-            continue
-        s = str(v)
-        is_path_like = k.endswith("_DIR") or k.endswith("_PATH")
-        if is_path_like and s:
-            p = Path(s)
-            if not p.is_absolute():
-                s = str((kernels_dir / p).resolve())
-        out[k] = s
-    return out
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/elf_parser.py
+++ b/python/pypto/runtime/elf_parser.py
@@ -1,0 +1,149 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""ELF / Mach-O object file parser for extracting .text sections.
+
+Pure Python implementation — no external dependencies.
+"""
+
+import logging
+import struct
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ELF Magic Numbers
+ELFMAG0 = 0x7F
+ELFMAG1 = ord("E")
+ELFMAG2 = ord("L")
+ELFMAG3 = ord("F")
+
+# Mach-O Magic Numbers
+MH_MAGIC_64 = 0xFEEDFACF
+
+# Mach-O Load Command types
+LC_SEGMENT_64 = 0x19
+
+
+def extract_text_section(obj_input: str | Path | bytes) -> bytes:
+    """Extract .text section from an ELF64 or Mach-O .o file.
+
+    Args:
+        obj_input: Either a path to the .o file (str/Path) or the binary data (bytes).
+
+    Returns:
+        Binary data of the .text section.
+
+    Raises:
+        FileNotFoundError: If file path is provided and does not exist.
+        ValueError: If data is not a valid object file or .text section not found.
+    """
+    if isinstance(obj_input, bytes):
+        obj_data = obj_input
+        source_name = "<bytes>"
+    else:
+        path = Path(obj_input)
+        if not path.exists():
+            raise FileNotFoundError(f"Object file not found: {obj_input}")
+        with open(obj_input, "rb") as f:
+            obj_data = f.read()
+        source_name = str(obj_input)
+
+    if len(obj_data) < 4:
+        raise ValueError(f"Data too small to be a valid object file: {source_name}")
+
+    # Detect format by magic number
+    magic32 = struct.unpack("<I", obj_data[:4])[0]
+    if magic32 == MH_MAGIC_64:
+        return _extract_text_macho64(obj_data, source_name)
+
+    if (
+        obj_data[0] == ELFMAG0
+        and obj_data[1] == ELFMAG1
+        and obj_data[2] == ELFMAG2
+        and obj_data[3] == ELFMAG3
+    ):
+        return _extract_text_elf64(obj_data, source_name)
+
+    raise ValueError(f"Not a valid ELF or Mach-O file: {source_name}")
+
+
+def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
+    """Extract .text section from ELF64 data."""
+    if len(elf_data) < 64:
+        raise ValueError(f"Data too small to be a valid ELF: {source_name}")
+
+    # Extract section header table info from ELF header
+    e_shoff = struct.unpack("<Q", elf_data[40:48])[0]
+    e_shnum = struct.unpack("<H", elf_data[60:62])[0]
+    e_shstrndx = struct.unpack("<H", elf_data[62:64])[0]
+
+    # Get string table section header
+    shstr_offset = e_shoff + e_shstrndx * 64
+    shstr_sh_offset = struct.unpack("<Q", elf_data[shstr_offset + 24 : shstr_offset + 32])[0]
+    shstr_sh_size = struct.unpack("<Q", elf_data[shstr_offset + 32 : shstr_offset + 40])[0]
+
+    # Extract string table
+    strtab = elf_data[shstr_sh_offset : shstr_sh_offset + shstr_sh_size]
+
+    # Find .text section
+    for i in range(e_shnum):
+        section_offset = e_shoff + i * 64
+        sh_name = struct.unpack("<I", elf_data[section_offset : section_offset + 4])[0]
+        sh_offset = struct.unpack("<Q", elf_data[section_offset + 24 : section_offset + 32])[0]
+        sh_size = struct.unpack("<Q", elf_data[section_offset + 32 : section_offset + 40])[0]
+
+        section_name = _extract_cstring(strtab, sh_name)
+        if section_name == ".text":
+            text_data = elf_data[sh_offset : sh_offset + sh_size]
+            logger.debug(f"Loaded .text section from {source_name} (size: {sh_size} bytes)")
+            return text_data
+
+    raise ValueError(f".text section not found in: {source_name}")
+
+
+def _extract_text_macho64(data: bytes, source_name: str) -> bytes:
+    """Extract __text section from Mach-O 64-bit data."""
+    if len(data) < 32:
+        raise ValueError(f"Data too small to be a valid Mach-O: {source_name}")
+
+    ncmds = struct.unpack("<I", data[16:20])[0]
+
+    # Walk load commands starting at offset 32
+    offset = 32
+    for _ in range(ncmds):
+        if offset + 8 > len(data):
+            break
+        cmd = struct.unpack("<I", data[offset : offset + 4])[0]
+        cmdsize = struct.unpack("<I", data[offset + 4 : offset + 8])[0]
+
+        if cmd == LC_SEGMENT_64:
+            nsects = struct.unpack("<I", data[offset + 64 : offset + 68])[0]
+            sect_base = offset + 72
+            for s in range(nsects):
+                sect_off = sect_base + s * 80
+                sectname = data[sect_off : sect_off + 16].split(b"\x00")[0].decode("ascii")
+                if sectname == "__text":
+                    s_size = struct.unpack("<Q", data[sect_off + 40 : sect_off + 48])[0]
+                    s_offset = struct.unpack("<I", data[sect_off + 48 : sect_off + 52])[0]
+                    text_data = data[s_offset : s_offset + s_size]
+                    logger.debug(f"Loaded __text section from {source_name} (size: {s_size} bytes)")
+                    return text_data
+
+        offset += cmdsize
+
+    raise ValueError(f"__text section not found in: {source_name}")
+
+
+def _extract_cstring(data: bytes, offset: int) -> str:
+    """Extract a null-terminated C string from bytes."""
+    end = data.find(b"\x00", offset)
+    if end == -1:
+        end = len(data)
+    return data[offset:end].decode("ascii", errors="ignore")

--- a/python/pypto/runtime/env_manager.py
+++ b/python/pypto/runtime/env_manager.py
@@ -1,0 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Environment variable caching utility.
+
+Provides :func:`ensure` to validate and cache required environment variables
+and :func:`get` to retrieve previously validated values.
+"""
+
+import os
+
+_cache: dict[str, str | None] = {}
+
+
+def get(name: str) -> str | None:
+    """Return the cached value for *name*. ``None`` if not yet ensured or env var was absent."""
+    return _cache.get(name)
+
+
+def ensure(name: str) -> str:
+    """Fetch env var, cache it, raise ``EnvironmentError`` if unset/empty."""
+    cached = _cache.get(name)
+    if cached is not None:
+        return cached
+    value = os.environ.get(name)
+    if not value:
+        raise OSError(f"Environment variable '{name}' is not set.")
+    _cache[name] = value
+    return value

--- a/python/pypto/runtime/kernel_compiler.py
+++ b/python/pypto/runtime/kernel_compiler.py
@@ -123,6 +123,44 @@ class KernelCompiler:
         common_dir = str(self.runtime_root / "src" / "common" / "task_interface")
         return [runtime_dir, common_dir] + self.get_platform_include_dirs()
 
+    def get_kernel_include_dirs(self, runtime_name: str) -> list[str]:
+        """Get include directories needed for incore kernel compilation.
+
+        Reads ``build_config.py`` from the runtime directory to discover
+        ``aicore`` include paths. Falls back to ``runtime/`` if no config
+        exists. Always appends ``common/task_interface``.
+
+        Args:
+            runtime_name: Name of the runtime (e.g., ``"host_build_graph"``).
+
+        Returns:
+            List of absolute include directory paths.
+        """
+        if self.platform in ("a2a3", "a2a3sim"):
+            arch = "a2a3"
+        elif self.platform in ("a5", "a5sim"):
+            arch = "a5"
+        else:
+            arch = "a2a3"
+
+        runtime_base_dir = self.runtime_root / "src" / arch / "runtime" / runtime_name
+        include_dirs: list[str] = []
+
+        build_config_path = runtime_base_dir / "build_config.py"
+        if build_config_path.is_file():
+            spec = importlib.util.spec_from_file_location("build_config", str(build_config_path))
+            if spec is not None and spec.loader is not None:
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                aicore_cfg = mod.BUILD_CONFIG.get("aicore", {})
+                for p in aicore_cfg.get("include_dirs", []):
+                    include_dirs.append(str(runtime_base_dir / p))
+        else:
+            include_dirs.append(str(runtime_base_dir / "runtime"))
+        include_dirs.append(str(self.runtime_root / "src" / "common" / "task_interface"))
+
+        return include_dirs
+
     def _get_orchestration_config(self, runtime_name: str) -> tuple[list[str], list[str]]:
         """Load the optional "orchestration" section from a runtime's build_config.py.
 
@@ -229,6 +267,7 @@ class KernelCompiler:
         source_path: str,
         core_type: str = "aiv",
         pto_isa_root: str | None = None,
+        runtime_name: str | None = None,
         extra_include_dirs: list[str] | None = None,
         build_dir: str | None = None,
     ) -> bytes:
@@ -242,12 +281,20 @@ class KernelCompiler:
             source_path: Path to kernel source file (.cpp).
             core_type: Core type: ``"aic"`` (cube) or ``"aiv"`` (vector).
             pto_isa_root: Path to PTO-ISA root directory.
+            runtime_name: Name of the runtime (e.g., ``"host_build_graph"``).
+                When provided, runtime include directories are resolved via
+                :meth:`get_kernel_include_dirs` and prepended to includes.
             extra_include_dirs: Additional include directories.
             build_dir: Optional build directory for output files.
 
         Returns:
             Binary contents of the compiled .o file.
         """
+        all_include_dirs: list[str] = []
+        if runtime_name is not None:
+            all_include_dirs.extend(self.get_kernel_include_dirs(runtime_name))
+        if extra_include_dirs:
+            all_include_dirs.extend(extra_include_dirs)
         incore_toolchain = self._get_toolchain(
             {
                 "a2a3": ToolchainType.CCEC,
@@ -262,7 +309,7 @@ class KernelCompiler:
                 source_path,
                 core_type=core_type,
                 pto_isa_root=pto_isa_root,
-                extra_include_dirs=extra_include_dirs,
+                extra_include_dirs=all_include_dirs or None,
                 build_dir=build_dir,
             )
 
@@ -284,8 +331,8 @@ class KernelCompiler:
         cmd = [self.ccec.cxx_path] + self.ccec.get_compile_flags(core_type=core_type)
         cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
 
-        if extra_include_dirs:
-            for inc_dir in extra_include_dirs:
+        if all_include_dirs:
+            for inc_dir in all_include_dirs:
                 cmd.append(f"-I{os.path.abspath(inc_dir)}")
 
         cmd.extend(["-o", output_path, source_path])

--- a/python/pypto/runtime/kernel_compiler.py
+++ b/python/pypto/runtime/kernel_compiler.py
@@ -1,0 +1,439 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Compiler for PTO kernels and orchestration functions.
+
+Public entry points:
+- :meth:`KernelCompiler.compile_incore`: Compile a kernel source file for AICore/AIVector
+- :meth:`KernelCompiler.compile_orchestration`: Compile an orchestration function
+
+Toolchain selection is determined by platform:
+- Hardware (a2a3/a5): CCEC for kernels, aarch64-g++ for orchestration
+- Simulation (a2a3sim/a5sim): g++-15 for kernels, g++ for orchestration
+
+Requires ``SIMPLER_ROOT`` environment variable pointing to the Simpler repository
+for C++ header paths (runtime headers, task_interface, platform includes).
+"""
+
+import importlib.util
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from . import env_manager
+from .toolchain import (
+    Aarch64GxxToolchain,
+    CCECToolchain,
+    Gxx15Toolchain,
+    GxxToolchain,
+    ToolchainType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_simpler_root() -> Path:
+    """Return the Simpler project root from ``SIMPLER_ROOT`` environment variable.
+
+    Raises:
+        EnvironmentError: If ``SIMPLER_ROOT`` is not set.
+    """
+    root = os.environ.get("SIMPLER_ROOT")
+    if not root:
+        raise OSError(
+            "SIMPLER_ROOT environment variable is not set.\n"
+            "Kernel and orchestration compilation requires C++ headers from the Simpler repository.\n"
+            "Set it to the root of your Simpler checkout:\n"
+            "  export SIMPLER_ROOT=/path/to/simpler"
+        )
+    return Path(root)
+
+
+class KernelCompiler:
+    """Compiler for PTO kernels and orchestration functions.
+
+    Args:
+        platform: Target platform (``"a2a3"``, ``"a2a3sim"``, ``"a5"``, or ``"a5sim"``).
+
+    Raises:
+        ValueError: If platform is unknown.
+        EnvironmentError: If ``ASCEND_HOME_PATH`` is not set for hardware platforms.
+        FileNotFoundError: If required compiler not found.
+    """
+
+    def __init__(self, platform: str = "a2a3"):
+        self.platform = platform
+        self.runtime_root = _get_simpler_root()
+
+        # Map platform to architecture directory
+        if platform in ("a2a3", "a2a3sim"):
+            self.platform_dir = self.runtime_root / "src" / "a2a3" / "platform"
+        elif platform in ("a5", "a5sim"):
+            self.platform_dir = self.runtime_root / "src" / "a5" / "platform"
+        else:
+            raise ValueError(f"Unknown platform: {platform}")
+
+        # Create toolchain objects based on platform
+        if platform in ("a2a3", "a5"):
+            env_manager.ensure("ASCEND_HOME_PATH")
+            self.ccec = CCECToolchain(platform)
+            self.aarch64 = Aarch64GxxToolchain()
+            self.host_gxx = GxxToolchain()
+        else:
+            self.ccec = None
+            self.aarch64 = None
+            self.host_gxx = GxxToolchain()
+
+        self.gxx15 = Gxx15Toolchain()
+
+    def get_platform_include_dirs(self) -> list[str]:
+        """Get platform-specific include directories for orchestration compilation."""
+        return [
+            str(self.platform_dir / "include"),
+        ]
+
+    def get_orchestration_include_dirs(self, runtime_name: str) -> list[str]:
+        """Get all include directories needed for orchestration compilation.
+
+        Combines the runtime-specific directory with platform include directories.
+
+        Args:
+            runtime_name: Name of the runtime (e.g., ``"host_build_graph"``).
+
+        Returns:
+            List of include directory paths.
+        """
+        if self.platform in ("a2a3", "a2a3sim"):
+            arch = "a2a3"
+        elif self.platform in ("a5", "a5sim"):
+            arch = "a5"
+        else:
+            arch = "a2a3"
+
+        runtime_dir = str(self.runtime_root / "src" / arch / "runtime" / runtime_name / "runtime")
+        common_dir = str(self.runtime_root / "src" / "common" / "task_interface")
+        return [runtime_dir, common_dir] + self.get_platform_include_dirs()
+
+    def _get_orchestration_config(self, runtime_name: str) -> tuple[list[str], list[str]]:
+        """Load the optional "orchestration" section from a runtime's build_config.py.
+
+        Returns:
+            ``(include_dirs, source_files)`` — both as absolute paths, or ``([], [])``.
+        """
+        if self.platform in ("a2a3", "a2a3sim"):
+            arch = "a2a3"
+        elif self.platform in ("a5", "a5sim"):
+            arch = "a5"
+        else:
+            arch = "a2a3"
+
+        config_path = self.runtime_root / "src" / arch / "runtime" / runtime_name / "build_config.py"
+        if not config_path.is_file():
+            return [], []
+
+        spec = importlib.util.spec_from_file_location("build_config", str(config_path))
+        if spec is None or spec.loader is None:
+            return [], []
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        build_config = getattr(mod, "BUILD_CONFIG", {})
+
+        orch_cfg = build_config.get("orchestration")
+        if orch_cfg is None:
+            return [], []
+
+        config_dir = config_path.parent
+
+        include_dirs = [str((config_dir / p).resolve()) for p in orch_cfg.get("include_dirs", [])]
+
+        source_files = []
+        for src_dir_rel in orch_cfg.get("source_dirs", []):
+            src_dir = (config_dir / src_dir_rel).resolve()
+            if src_dir.is_dir():
+                for f in sorted(src_dir.iterdir()):
+                    if f.suffix in (".cpp", ".c") and f.is_file():
+                        source_files.append(str(f))
+
+        return include_dirs, source_files
+
+    def _run_subprocess(
+        self, cmd: list[str], label: str, error_hint: str = "Compiler not found"
+    ) -> subprocess.CompletedProcess:
+        """Run a subprocess command with standardized logging and error handling."""
+        logger.debug(f"[{label}] Command: {' '.join(cmd)}")
+        try:
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+            if result.stdout and logger.isEnabledFor(10):
+                logger.debug(f"[{label}] stdout:\n{result.stdout}")
+            if result.stderr and logger.isEnabledFor(10):
+                logger.debug(f"[{label}] stderr:\n{result.stderr}")
+
+            if result.returncode != 0:
+                logger.error(f"[{label}] Compilation failed: {result.stderr}")
+                raise RuntimeError(
+                    f"{label} compilation failed with exit code {result.returncode}:\n{result.stderr}"
+                )
+
+            return result
+
+        except FileNotFoundError:
+            raise RuntimeError(error_hint)
+
+    def _compile_to_bytes(
+        self,
+        cmd: list[str],
+        output_path: str,
+        label: str,
+        error_hint: str = "Compiler not found",
+        delete_output: bool = True,
+    ) -> bytes:
+        """Run compilation command, read output file, clean up, return bytes."""
+        self._run_subprocess(cmd, label, error_hint)
+
+        if not os.path.isfile(output_path):
+            raise RuntimeError(f"Compilation succeeded but output file not found: {output_path}")
+
+        with open(output_path, "rb") as f:
+            binary_data = f.read()
+
+        if delete_output:
+            os.remove(output_path)
+        logger.info(f"[{label}] Compilation {output_path} successful: {len(binary_data)} bytes")
+        return binary_data
+
+    def _get_toolchain(self, toolchain_map: dict) -> ToolchainType:
+        """Get toolchain for the current platform."""
+        if self.platform not in toolchain_map:
+            raise ValueError(f"No toolchain for platform: {self.platform}")
+        return toolchain_map[self.platform]
+
+    @staticmethod
+    def _make_temp_path(prefix: str, suffix: str, build_dir: str | None = None) -> str:
+        """Create a unique temporary file path via mkstemp."""
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=build_dir or "/tmp")
+        os.close(fd)
+        return path
+
+    def compile_incore(
+        self,
+        source_path: str,
+        core_type: str = "aiv",
+        pto_isa_root: str | None = None,
+        extra_include_dirs: list[str] | None = None,
+        build_dir: str | None = None,
+    ) -> bytes:
+        """Compile a kernel source file.
+
+        Dispatches based on platform:
+        - Hardware (a2a3/a5): Uses ccec compiler (requires pto_isa_root)
+        - Simulation (a2a3sim/a5sim): Uses g++-15
+
+        Args:
+            source_path: Path to kernel source file (.cpp).
+            core_type: Core type: ``"aic"`` (cube) or ``"aiv"`` (vector).
+            pto_isa_root: Path to PTO-ISA root directory.
+            extra_include_dirs: Additional include directories.
+            build_dir: Optional build directory for output files.
+
+        Returns:
+            Binary contents of the compiled .o file.
+        """
+        incore_toolchain = self._get_toolchain(
+            {
+                "a2a3": ToolchainType.CCEC,
+                "a2a3sim": ToolchainType.HOST_GXX_15,
+                "a5": ToolchainType.CCEC,
+                "a5sim": ToolchainType.HOST_GXX_15,
+            },
+        )
+
+        if incore_toolchain == ToolchainType.HOST_GXX_15:
+            return self._compile_incore_sim(
+                source_path,
+                core_type=core_type,
+                pto_isa_root=pto_isa_root,
+                extra_include_dirs=extra_include_dirs,
+                build_dir=build_dir,
+            )
+
+        assert self.ccec is not None, "ccec toolchain is only available for hardware platforms"
+        source_path = os.path.abspath(source_path)
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(f"Source file not found: {source_path}")
+
+        if pto_isa_root is None:
+            raise ValueError("pto_isa_root is required for incore compilation")
+
+        pto_include = os.path.join(pto_isa_root, "include")
+        pto_pto_include = os.path.join(pto_isa_root, "include", "pto")
+
+        output_path = self._make_temp_path(
+            prefix=f"{os.path.basename(source_path)}.incore_", suffix=".o", build_dir=build_dir
+        )
+
+        cmd = [self.ccec.cxx_path] + self.ccec.get_compile_flags(core_type=core_type)
+        cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
+
+        if extra_include_dirs:
+            for inc_dir in extra_include_dirs:
+                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+
+        cmd.extend(["-o", output_path, source_path])
+
+        core_type_name = "AIV" if core_type == "aiv" else "AIC"
+        logger.info(f"[Incore] Compiling ({core_type_name}): {source_path}")
+
+        return self._compile_to_bytes(
+            cmd,
+            output_path,
+            "Incore",
+            error_hint=f"ccec compiler not found at {self.ccec.cxx_path}",
+            delete_output=build_dir is None,
+        )
+
+    def compile_orchestration(
+        self,
+        runtime_name: str,
+        source_path: str,
+        extra_include_dirs: list[str] | None = None,
+        build_dir: str | None = None,
+    ) -> bytes:
+        """Compile an orchestration function for the given runtime.
+
+        Args:
+            runtime_name: Name of the runtime (e.g., ``"tensormap_and_ringbuffer"``).
+            source_path: Path to orchestration source file (.cpp).
+            extra_include_dirs: Additional include directories.
+            build_dir: Optional build directory for output files.
+
+        Returns:
+            Binary contents of the compiled orchestration .so file.
+        """
+        include_dirs = self.get_orchestration_include_dirs(runtime_name)
+        if extra_include_dirs:
+            include_dirs = include_dirs + list(extra_include_dirs)
+
+        orch_includes, orch_sources = self._get_orchestration_config(runtime_name)
+        if orch_includes:
+            include_dirs = include_dirs + orch_includes
+
+        toolchain_type = self._get_toolchain(
+            {
+                "a2a3": ToolchainType.AARCH64_GXX,
+                "a2a3sim": ToolchainType.HOST_GXX,
+                "a5": ToolchainType.AARCH64_GXX,
+                "a5sim": ToolchainType.HOST_GXX,
+            },
+        )
+        toolchain: GxxToolchain | Aarch64GxxToolchain
+        if toolchain_type == ToolchainType.AARCH64_GXX:
+            assert self.aarch64 is not None, "aarch64 toolchain is only available for hardware platforms"
+            toolchain = self.aarch64
+        else:
+            toolchain = self.host_gxx
+
+        return self._compile_orchestration_shared_lib(
+            source_path,
+            toolchain,
+            extra_include_dirs=include_dirs,
+            extra_sources=orch_sources or None,
+            build_dir=build_dir,
+        )
+
+    def _compile_orchestration_shared_lib(
+        self,
+        source_path: str,
+        toolchain: GxxToolchain | Aarch64GxxToolchain,
+        extra_include_dirs: list[str] | None = None,
+        extra_sources: list[str] | None = None,
+        build_dir: str | None = None,
+    ) -> bytes:
+        """Compile an orchestration function to a shared library (.so)."""
+        source_path = os.path.abspath(source_path)
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(f"Source file not found: {source_path}")
+
+        output_path = self._make_temp_path(
+            prefix=f"{os.path.basename(source_path)}.orch_", suffix=".so", build_dir=build_dir
+        )
+
+        cmd = [toolchain.cxx_path] + toolchain.get_compile_flags()
+
+        if extra_sources:
+            for src in extra_sources:
+                src = os.path.abspath(src)
+                if os.path.isfile(src):
+                    cmd.append(src)
+                    logger.debug(f"  Including extra source: {os.path.basename(src)}")
+
+        if sys.platform == "darwin":
+            cmd.append("-undefined")
+            cmd.append("dynamic_lookup")
+
+        if extra_include_dirs:
+            for inc_dir in extra_include_dirs:
+                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+
+        cmd.extend(["-o", output_path, source_path])
+
+        logger.info(f"[Orchestration] Compiling: {source_path}")
+
+        return self._compile_to_bytes(
+            cmd,
+            output_path,
+            "Orchestration",
+            error_hint=f"{toolchain.cxx_path} not found. Please install it.",
+            delete_output=build_dir is None,
+        )
+
+    def _compile_incore_sim(
+        self,
+        source_path: str,
+        *,
+        core_type: str,
+        pto_isa_root: str | None = None,
+        extra_include_dirs: list[str] | None = None,
+        build_dir: str | None = None,
+    ) -> bytes:
+        """Compile a simulation kernel to .so/.dylib using g++-15."""
+        source_path = os.path.abspath(source_path)
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(f"Source file not found: {source_path}")
+
+        ext = ".dylib" if sys.platform == "darwin" else ".so"
+        output_path = self._make_temp_path(
+            prefix=f"{os.path.basename(source_path)}.sim_", suffix=ext, build_dir=build_dir
+        )
+
+        cmd = [self.gxx15.cxx_path] + self.gxx15.get_compile_flags(core_type=core_type)
+
+        if pto_isa_root:
+            pto_include = os.path.join(pto_isa_root, "include")
+            pto_pto_include = os.path.join(pto_isa_root, "include", "pto")
+            cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
+
+        if extra_include_dirs:
+            for inc_dir in extra_include_dirs:
+                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+
+        cmd.extend(["-o", output_path, source_path])
+
+        logger.info(f"[SimKernel] Compiling: {source_path}")
+
+        return self._compile_to_bytes(
+            cmd,
+            output_path,
+            "SimKernel",
+            error_hint=f"{self.gxx15.cxx_path} not found. Please install g++-15.",
+            delete_output=build_dir is None,
+        )

--- a/python/pypto/runtime/kernel_compiler.py
+++ b/python/pypto/runtime/kernel_compiler.py
@@ -76,11 +76,12 @@ class KernelCompiler:
 
         # Map platform to architecture directory
         if platform in ("a2a3", "a2a3sim"):
-            self.platform_dir = self.runtime_root / "src" / "a2a3" / "platform"
+            self.arch = "a2a3"
         elif platform in ("a5", "a5sim"):
-            self.platform_dir = self.runtime_root / "src" / "a5" / "platform"
+            self.arch = "a5"
         else:
             raise ValueError(f"Unknown platform: {platform}")
+        self.platform_dir = self.runtime_root / "src" / self.arch / "platform"
 
         # Create toolchain objects based on platform
         if platform in ("a2a3", "a5"):
@@ -112,14 +113,7 @@ class KernelCompiler:
         Returns:
             List of include directory paths.
         """
-        if self.platform in ("a2a3", "a2a3sim"):
-            arch = "a2a3"
-        elif self.platform in ("a5", "a5sim"):
-            arch = "a5"
-        else:
-            arch = "a2a3"
-
-        runtime_dir = str(self.runtime_root / "src" / arch / "runtime" / runtime_name / "runtime")
+        runtime_dir = str(self.runtime_root / "src" / self.arch / "runtime" / runtime_name / "runtime")
         common_dir = str(self.runtime_root / "src" / "common" / "task_interface")
         return [runtime_dir, common_dir] + self.get_platform_include_dirs()
 
@@ -136,14 +130,7 @@ class KernelCompiler:
         Returns:
             List of absolute include directory paths.
         """
-        if self.platform in ("a2a3", "a2a3sim"):
-            arch = "a2a3"
-        elif self.platform in ("a5", "a5sim"):
-            arch = "a5"
-        else:
-            arch = "a2a3"
-
-        runtime_base_dir = self.runtime_root / "src" / arch / "runtime" / runtime_name
+        runtime_base_dir = self.runtime_root / "src" / self.arch / "runtime" / runtime_name
         include_dirs: list[str] = []
 
         build_config_path = runtime_base_dir / "build_config.py"
@@ -167,14 +154,7 @@ class KernelCompiler:
         Returns:
             ``(include_dirs, source_files)`` — both as absolute paths, or ``([], [])``.
         """
-        if self.platform in ("a2a3", "a2a3sim"):
-            arch = "a2a3"
-        elif self.platform in ("a5", "a5sim"):
-            arch = "a5"
-        else:
-            arch = "a2a3"
-
-        config_path = self.runtime_root / "src" / arch / "runtime" / runtime_name / "build_config.py"
+        config_path = self.runtime_root / "src" / self.arch / "runtime" / runtime_name / "build_config.py"
         if not config_path.is_file():
             return [], []
 
@@ -258,7 +238,7 @@ class KernelCompiler:
     @staticmethod
     def _make_temp_path(prefix: str, suffix: str, build_dir: str | None = None) -> str:
         """Create a unique temporary file path via mkstemp."""
-        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=build_dir or "/tmp")
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=build_dir or tempfile.gettempdir())
         os.close(fd)
         return path
 

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -422,7 +422,7 @@ def run(
         )
 
         with _stage("binary_compilation"):
-            chip_callable, binaries = compile_and_assemble(
+            chip_callable, runtime_name = compile_and_assemble(
                 work_dir, config.platform, pto_isa_commit=config.pto_isa_commit
             )
 
@@ -444,7 +444,8 @@ def run(
             execute_on_device(
                 chip_callable,
                 orch_args,
-                binaries,
+                config.platform,
+                runtime_name,
                 config.device_id,
                 enable_profiling=config.runtime_profiling,
             )
@@ -514,7 +515,7 @@ def _execute_on_device(
         validate_golden,
     )
 
-    chip_callable, binaries = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
+    chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
 
     # Load golden.py to get generate_inputs and compute_golden
     import importlib.util  # noqa: PLC0415
@@ -550,7 +551,8 @@ def _execute_on_device(
     execute_on_device(
         chip_callable,
         orch_args,
-        binaries,
+        platform,
+        runtime_name,
         device_id,
         enable_profiling=runtime_profiling,
     )

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -36,8 +36,6 @@ Typical usage::
 """
 
 import ctypes
-import functools
-import importlib
 import os
 import subprocess
 import sys
@@ -61,43 +59,7 @@ from pypto.pypto_core.passes import WarningCheckSet, WarningLevel
 from .golden_writer import write_golden
 from .tensor_spec import TensorSpec
 
-# ---------------------------------------------------------------------------
-# Golden inputs pre-generation cache
-# ---------------------------------------------------------------------------
-# .pt files written by pregenerate_golden_inputs() (see test_runner.py) are
-# the persistent cache.  These flags prevent re-patching CodeRunner in
-# the same process.
-_code_runner_patched: list[bool] = [False]
-_binary_cache_patched: list[bool] = [False]
 _OUTPUTS_DIR = Path("outputs")
-
-
-@functools.lru_cache(maxsize=1)
-def _get_simpler_stamp() -> str:
-    """Return Simpler's current git commit (short hash) as a cache-key stamp.
-
-    The stamp is used to namespace the global runtime binary cache so that
-    stale binaries from an older Simpler version are never reused after an
-    update.  Falls back to ``"unknown"`` when git is unavailable or
-    ``SIMPLER_ROOT`` is not set.
-
-    The value is computed once and cached in-process.
-    """
-    simpler_root = os.environ.get("SIMPLER_ROOT", "")
-    if not simpler_root:
-        return "unknown"
-    try:
-        r = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            check=False,
-            capture_output=True,
-            text=True,
-            cwd=simpler_root,
-            timeout=5,
-        )
-        return r.stdout.strip() if r.returncode == 0 else "unknown"
-    except Exception:
-        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -201,24 +163,6 @@ def _load_golden(path: Path) -> dict | None:
         return None
     try:
         return torch.load(path, weights_only=False)
-    except Exception:
-        return None
-
-
-def _save_binary(data: bytes, path: Path) -> None:
-    """Save compiled binary bytes to *path* atomically."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_bytes(data)
-    os.replace(tmp, path)
-
-
-def _load_binary(path: Path) -> bytes | None:
-    """Load compiled binary bytes from *path*. Returns ``None`` on miss."""
-    if not path.exists():
-        return None
-    try:
-        return path.read_bytes()
     except Exception:
         return None
 
@@ -389,8 +333,9 @@ def run(
 
     1. Call :func:`ir.compile` to generate CCE C++ kernel and orchestration files.
     2. Patch the orchestration file with the required ``runtime.h`` header.
-    3. Write a ``golden.py`` file from *tensor_specs* and *golden*.
-    4. Invoke Simpler's ``CodeRunner`` to compile, load, execute, and validate.
+    3. If *codegen_only*, return immediately.
+    4. Compile kernels + orchestration to binaries, assemble ``ChipCallable``.
+    5. Build tensor arguments, compute golden, execute on device, validate.
 
     Args:
         program: A ``@pl.program`` decorated class or an ``ir.Program`` object.
@@ -451,7 +396,7 @@ def run(
                 profiling=config.compile_profiling,
             )
 
-        # 3. Write golden.py
+        # 3. Write golden.py (still used for test harness compatibility)
         golden_path = work_dir / "golden.py"
         with _stage("golden_write"):
             write_golden(
@@ -463,16 +408,59 @@ def run(
                 data_dir=config.golden_data_dir,
             )
 
-        # 4. Execute via Simpler's CodeRunner
-        with _stage("device_execution"):
-            _execute_on_device(
-                work_dir,
-                golden_path,
-                config.platform,
-                config.device_id,
-                config.pto_isa_commit,
-                config.runtime_profiling,
+        # 4. If codegen_only, stop here — no binary compilation or device execution
+        if config.codegen_only:
+            profile_data = prof.to_dict() if prof is not None else None
+            return RunResult(passed=True, execution_time=time.time() - start_time, profile=profile_data)
+
+        # 5. Compile C++ → binaries + assemble ChipCallable
+        from .device_runner import (  # noqa: PLC0415
+            compile_and_assemble,
+            execute_on_device,
+            validate_golden,
+        )
+        from .task_interface import (  # noqa: PLC0415
+            ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
+            make_tensor_arg,
+        )
+
+        with _stage("binary_compilation"):
+            chip_callable, binaries = compile_and_assemble(
+                work_dir, config.platform, pto_isa_commit=config.pto_isa_commit
             )
+
+        # 6. Build tensor arguments
+        orch_args = ChipStorageTaskArgs()
+        all_tensors: dict[str, Any] = {}
+        inputs: dict[str, torch.Tensor] = {}
+        outputs: dict[str, torch.Tensor] = {}
+
+        for spec in tensor_specs:
+            tensor = spec.create_tensor().cpu().contiguous()
+            orch_args.add_tensor(make_tensor_arg(tensor))
+            all_tensors[spec.name] = tensor
+            if spec.is_output:
+                outputs[spec.name] = tensor
+            else:
+                inputs[spec.name] = tensor
+
+        # 7. Compute golden
+        golden_outputs = {k: v.clone() for k, v in outputs.items()}
+        golden_with_inputs = {**inputs, **golden_outputs}
+        golden(golden_with_inputs, {})
+
+        # 8. Execute on device
+        with _stage("device_execution"):
+            execute_on_device(
+                chip_callable,
+                orch_args,
+                binaries,
+                config.device_id,
+                enable_profiling=config.runtime_profiling,
+            )
+
+        # 9. Validate
+        validate_golden(outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
 
         profile_data = prof.to_dict() if prof is not None else None
         return RunResult(passed=True, execution_time=time.time() - start_time, profile=profile_data)
@@ -498,157 +486,6 @@ def run(
 # ---------------------------------------------------------------------------
 
 
-def _install_golden_inputs_patch(CodeRunner) -> None:
-    """Monkey-patch CodeRunner.__init__ to serve generate_inputs and compute_golden from disk cache.
-
-    Idempotent — safe to call multiple times.  For each new CodeRunner instance:
-
-    - ``generate_inputs``: loads ``cache/{case}_inputs.pt`` when available,
-      falls through to the original on a cache miss.
-    - ``compute_golden``: copies cached output tensors from
-      ``cache/{case}_golden.pt`` into the tensors dict when available,
-      falls through to the original on a cache miss.
-
-    Each ``torch.load`` produces fresh tensors, so no cloning is needed.
-    """
-    if _code_runner_patched[0]:
-        return
-
-    orig_init = CodeRunner.__init__
-
-    def _patched_init(self, *args, **kwargs):
-        orig_init(self, *args, **kwargs)
-        golden_path = self.golden_path  # Path, already resolved
-
-        # --- patch generate_inputs -------------------------------------------
-        orig_gen = self._golden_module.generate_inputs
-
-        def _cached_gen(params):
-            case_name = params.get("name", "Default")
-            result = _load_inputs(_inputs_cache_file(golden_path, case_name))
-            return result if result is not None else orig_gen(params)
-
-        self._golden_module.generate_inputs = _cached_gen
-
-        # --- patch compute_golden --------------------------------------------
-        orig_compute = self._golden_module.compute_golden
-
-        def _cached_compute(tensors, params):
-            case_name = params.get("name", "Default")
-            cached = _load_golden(_golden_cache_file(golden_path, case_name))
-            if cached is not None:
-                for name, val in cached.items():
-                    if name in tensors:
-                        tensors[name].copy_(val)
-                return
-            orig_compute(tensors, params)
-
-        self._golden_module.compute_golden = _cached_compute
-
-    CodeRunner.__init__ = _patched_init
-    _code_runner_patched[0] = True
-
-
-# Persistent runtime binary cache — shared across test cases and sessions.
-# Root directory for persistent runtime binary cache.  Actual files live under
-# a Simpler-version subdirectory (see _get_simpler_stamp()) so that stale
-# binaries are automatically bypassed after a Simpler update.
-_BINARY_RUNTIME_CACHE = (
-    Path(__file__).parent.parent.parent.parent / "build_output" / "binary_cache" / "runtimes"
-)
-
-
-def _install_binary_cache_patch(KernelCompiler, RuntimeBuilder) -> None:
-    """Monkey-patch KernelCompiler and RuntimeBuilder to serve compiled binaries from disk.
-
-    Patches three methods with write-through caches:
-
-    - ``KernelCompiler.compile_incore``: caches at
-      ``work_dir/cache/incore_{core_type}_{stem}.bin``
-      (derived from the kernel source path structure
-      ``work_dir/kernels/{core_type}/{name}.cpp``).
-    - ``KernelCompiler.compile_orchestration``: caches at
-      ``work_dir/cache/orch_{stem}.bin``
-      (derived from ``work_dir/orchestration/{name}.cpp``).
-    - ``RuntimeBuilder.get_binaries``: caches at
-      ``build_output/binary_cache/runtimes/{name}_{platform}_{host|aicpu|aicore}.bin``
-      (global, shared across all test cases).
-
-    Idempotent — safe to call multiple times. Cache miss triggers compilation
-    and saves the result; subsequent calls serve from disk.
-    """
-    if _binary_cache_patched[0]:
-        return
-
-    RuntimeBinaries = getattr(sys.modules[RuntimeBuilder.__module__], "RuntimeBinaries")
-
-    # --- KernelCompiler.compile_incore ---
-    orig_incore = KernelCompiler.compile_incore
-
-    def _patched_incore(
-        self, source_path, core_type="aiv", pto_isa_root=None, extra_include_dirs=None, build_dir=None
-    ):
-        source = Path(source_path)
-        # Only cache for the expected structure: work_dir/kernels/{core_type}/{name}.cpp
-        if source.parent.parent.name == "kernels":
-            cache_file = source.parent.parent.parent / "cache" / f"incore_{core_type}_{source.stem}.bin"
-            cached = _load_binary(cache_file)
-            if cached is not None:
-                return cached
-            result = orig_incore(self, source_path, core_type, pto_isa_root, extra_include_dirs, build_dir)
-            _save_binary(result, cache_file)
-            return result
-        return orig_incore(self, source_path, core_type, pto_isa_root, extra_include_dirs, build_dir)
-
-    KernelCompiler.compile_incore = _patched_incore
-
-    # --- KernelCompiler.compile_orchestration ---
-    orig_orch = KernelCompiler.compile_orchestration
-
-    def _patched_orch(self, runtime_name, source_path, extra_include_dirs=None, build_dir=None):
-        source = Path(source_path)
-        # Only cache for the expected structure: work_dir/orchestration/{name}.cpp
-        if source.parent.name == "orchestration":
-            cache_file = source.parent.parent / "cache" / f"orch_{source.stem}.bin"
-            cached = _load_binary(cache_file)
-            if cached is not None:
-                return cached
-            result = orig_orch(self, runtime_name, source_path, extra_include_dirs, build_dir)
-            _save_binary(result, cache_file)
-            return result
-        return orig_orch(self, runtime_name, source_path, extra_include_dirs, build_dir)
-
-    KernelCompiler.compile_orchestration = _patched_orch
-
-    # --- RuntimeBuilder.get_binaries ---
-    orig_get_binaries = RuntimeBuilder.get_binaries
-
-    def _patched_get_binaries(self, name, build=False):
-        cache_dir = _BINARY_RUNTIME_CACHE / _get_simpler_stamp()
-        host_file = cache_dir / f"{name}_{self.platform}_host.bin"
-        aicpu_file = cache_dir / f"{name}_{self.platform}_aicpu.bin"
-        aicore_file = cache_dir / f"{name}_{self.platform}_aicore.bin"
-        if host_file.exists() and aicpu_file.exists() and aicore_file.exists():
-            # sim_context_path is a shared per-platform SO (not per-runtime-name),
-            # so resolve it from the builder rather than caching as bytes.
-            resolver = getattr(self, "_resolve_sim_context_path", None)
-            sim_context_path = resolver() if resolver is not None else None
-            return RuntimeBinaries(
-                host_path=host_file,
-                aicpu_path=aicpu_file,
-                aicore_path=aicore_file,
-                sim_context_path=sim_context_path,
-            )
-        result = orig_get_binaries(self, name, build=build)
-        _save_binary(result.host_path.read_bytes(), host_file)
-        _save_binary(result.aicpu_path.read_bytes(), aicpu_file)
-        _save_binary(result.aicore_path.read_bytes(), aicore_file)
-        return result
-
-    RuntimeBuilder.get_binaries = _patched_get_binaries
-    _binary_cache_patched[0] = True
-
-
 def _execute_on_device(
     work_dir: Path,
     golden_path: Path,
@@ -657,86 +494,87 @@ def _execute_on_device(
     pto_isa_commit: str | None = None,
     runtime_profiling: bool = False,
 ) -> None:
-    """Invoke Simpler's CodeRunner to compile, load, execute, and validate.
+    """Compile, load, execute, and validate via PyPTO's device runner.
 
-    Automatically adds SIMPLER_ROOT sub-paths to ``sys.path`` when the
-    ``SIMPLER_ROOT`` environment variable is set (mirrors conftest.py behaviour).
+    This function is used by the test harness (test_runner.py) to execute
+    pre-compiled test cases. For direct use, prefer :func:`run`.
 
     Args:
-        work_dir: Root output directory produced by :func:`compile_program`,
-            containing ``kernels/`` and ``orchestration/``.
+        work_dir: Root output directory containing ``kernels/`` and ``orchestration/``.
         golden_path: Path to the generated ``golden.py`` file.
-        platform: Target execution platform (``"a2a3sim"``, ``"a2a3"``,
-            ``"a5sim"``, or ``"a5"``).
+        platform: Target execution platform.
         device_id: Hardware device index.
-        pto_isa_commit: If set, pin the pto-isa clone to this specific git
-            commit (hash or tag).
-        runtime_profiling: If ``True``, enable runtime profiling
-            and generate ``swimlane.json`` after execution.
+        pto_isa_commit: If set, pin the pto-isa clone to this specific commit.
+        runtime_profiling: If ``True``, enable runtime profiling.
     """
-    simpler_root = os.environ.get("SIMPLER_ROOT")
-    if simpler_root:
-        for sub in ("examples/scripts", "python"):
-            p = str(Path(simpler_root) / sub)
-            if p not in sys.path:
-                sys.path.insert(0, p)
+    from .device_runner import compile_and_assemble, execute_on_device  # noqa: PLC0415
 
-    CodeRunner = importlib.import_module("code_runner").CodeRunner
-    KernelCompiler = importlib.import_module("simpler.kernel_compiler").KernelCompiler
-    RuntimeBuilder = importlib.import_module("runtime_builder").RuntimeBuilder
+    chip_callable, binaries = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
 
-    _install_golden_inputs_patch(CodeRunner)
-    _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
+    # Load golden.py to get generate_inputs and compute_golden
+    import importlib.util  # noqa: PLC0415
 
-    # Snapshot existing device logs before run so we can identify the new one
-    # (CANN writes device logs asynchronously after execution).
-    # Device logs are only available on real hardware, not on simulators.
-    pre_run_logs: set[Path] = set()
-    device_log_dir: Path | None = None
-    if runtime_profiling and not platform.endswith("sim"):
-        device_log_dir = _get_device_log_dir(device_id)
-        if device_log_dir.exists():
-            pre_run_logs = set(device_log_dir.glob("*.log"))
+    spec = importlib.util.spec_from_file_location("_golden", str(golden_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load golden.py from {golden_path}")
+    golden_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(golden_module)
 
-    # Snapshot existing perf_swimlane files so we can identify the new one
-    # produced by CodeRunner (written to _OUTPUTS_DIR).
-    pre_run_perf_files: set[Path] = set()
-    if runtime_profiling:
-        _OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
-        pre_run_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json"))
+    # Load golden input cache if available
+    params: dict = {"name": "Default"}
+    result = _load_inputs(_inputs_cache_file(golden_path, "Default"))
+    if result is None:
+        result = golden_module.generate_inputs(params)
 
-    CodeRunner(
-        kernels_dir=str(work_dir),
-        golden_path=str(golden_path),
-        platform=platform,
-        device_id=device_id,
-        clone_protocol="https",
-        pto_isa_commit=pto_isa_commit,
+    from .task_interface import (  # noqa: PLC0415
+        ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
+        make_tensor_arg,
+        scalar_to_uint64,
+    )
+
+    orch_args = ChipStorageTaskArgs()
+    all_tensors: dict = {}
+    inputs: dict = {}
+    outputs: dict = {}
+    output_names = set(getattr(golden_module, "__outputs__", []))
+
+    for name, val in result:
+        if isinstance(val, torch.Tensor):
+            val = val.cpu().contiguous()
+            orch_args.add_tensor(make_tensor_arg(val))
+            all_tensors[name] = val
+            if name in output_names or name.startswith("out"):
+                outputs[name] = val
+            else:
+                inputs[name] = val
+        elif isinstance(val, ctypes._SimpleCData):
+            orch_args.add_scalar(scalar_to_uint64(val))
+            all_tensors[name] = val.value
+
+    # Compute golden
+    golden_cache = _load_golden(_golden_cache_file(golden_path, "Default"))
+    if golden_cache is not None:
+        golden_out = golden_cache
+    else:
+        golden_out = {k: v.clone() for k, v in outputs.items()}
+        golden_with_inputs = {**inputs, **golden_out}
+        golden_module.compute_golden(golden_with_inputs, params)
+
+    # Execute
+    execute_on_device(
+        chip_callable,
+        orch_args,
+        binaries,
+        device_id,
         enable_profiling=runtime_profiling,
-    ).run()
+    )
 
-    if runtime_profiling:
-        swimlane_dir = work_dir / "swimlane_data"
-        swimlane_dir.mkdir(parents=True, exist_ok=True)
+    # Validate
+    from .device_runner import validate_golden  # noqa: PLC0415
 
-        # Move the newly created perf_swimlane_*.json into swimlane_data/.
-        new_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json")) - pre_run_perf_files
-        perf_file: Path | None = None
-        if new_perf_files:
-            perf_file = max(new_perf_files, key=lambda p: p.stat().st_mtime)
-            dest = swimlane_dir / perf_file.name
-            perf_file.rename(dest)
-            perf_file = dest
-            # Remove outputs/ if it is now empty (it is only a staging area).
-            try:
-                _OUTPUTS_DIR.rmdir()
-            except OSError:
-                pass
-
-        if not platform.endswith("sim"):
-            _generate_swimlane(
-                work_dir, device_id, device_log_dir, pre_run_logs, simpler_root, swimlane_dir, perf_file
-            )
+    rtol = getattr(golden_module, "RTOL", 1e-5)
+    atol = getattr(golden_module, "ATOL", 1e-5)
+    validate_golden(outputs, golden_out, rtol=rtol, atol=atol)
 
 
 def _get_device_log_dir(device_id: int) -> Path:

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -35,7 +35,7 @@ Typical usage::
     print(result)  # PASS / FAIL: ...
 """
 
-import ctypes
+import importlib.util
 import os
 import subprocess
 import sys
@@ -57,114 +57,26 @@ from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.pypto_core.passes import WarningCheckSet, WarningLevel
 
 from .golden_writer import write_golden
-from .tensor_spec import TensorSpec
+from .tensor_spec import ScalarSpec, TensorSpec
 
 _OUTPUTS_DIR = Path("outputs")
 
 
-# ---------------------------------------------------------------------------
-# Cache file helpers
-# ---------------------------------------------------------------------------
+def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[str, torch.Tensor] | None:
+    """Load pre-computed golden outputs from ``data/out/{name}.pt`` files.
 
-
-def _cache_dir(golden_path: Path) -> Path:
-    """Return the ``cache/`` subdirectory co-located with ``golden.py``."""
-    return golden_path.parent / "cache"
-
-
-def _inputs_cache_file(golden_path: Path, case_name: str) -> Path:
-    """Return the path for the pre-generated inputs ``.pt`` file.
-
-    All cache artefacts live under ``work_dir/cache/`` alongside the other
-    test-case outputs::
-
-        work_dir/
-          cache/
-            Default_inputs.pt
-            Default_golden.pt
-            Case1_inputs.pt
-            Case1_golden.pt
-          golden.py
-          kernels/
-          orchestration/
+    Returns ``None`` if the directory does not exist or any required file is
+    missing, allowing the caller to fall back to live computation.
     """
-    safe = case_name.replace("/", "_").replace(" ", "_")
-    return _cache_dir(golden_path) / f"{safe}_inputs.pt"
-
-
-def _golden_cache_file(golden_path: Path, case_name: str) -> Path:
-    """Return the path for the pre-computed golden outputs ``.pt`` file."""
-    safe = case_name.replace("/", "_").replace(" ", "_")
-    return _cache_dir(golden_path) / f"{safe}_golden.pt"
-
-
-def _save_inputs(result: list, path: Path) -> None:
-    """Serialise ``generate_inputs()`` result to *path* via ``torch.save``.
-
-    Each item in *result* is wrapped in a small dict so that ctypes scalars
-    can be reconstructed faithfully on load::
-
-        {"kind": "tensor", "name": "a",    "data": <torch.Tensor>}
-        {"kind": "ctypes", "name": "size", "ctype": "c_int64", "value": 1024}
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    serialisable = []
-    for name, val in result:
-        if isinstance(val, torch.Tensor):
-            serialisable.append({"kind": "tensor", "name": name, "data": val})
-        elif isinstance(val, ctypes._SimpleCData):
-            serialisable.append(
-                {
-                    "kind": "ctypes",
-                    "name": name,
-                    "ctype": type(val).__name__,
-                    "value": val.value,
-                }
-            )
-        else:
-            raise TypeError(f"Cannot serialise arg {name!r}: unsupported type {type(val)}")
-    torch.save(serialisable, path)
-
-
-def _load_inputs(path: Path) -> list | None:
-    """Load and reconstruct a ``generate_inputs()`` result from *path*.
-
-    Returns ``None`` if the file does not exist or cannot be read.
-    """
-    if not path.exists():
+    if not out_dir.is_dir():
         return None
-    try:
-        items = torch.load(path, weights_only=False)
-        result = []
-        for item in items:
-            name = item["name"]
-            if item["kind"] == "tensor":
-                result.append((name, item["data"]))
-            elif item["kind"] == "ctypes":
-                ctype_cls = getattr(ctypes, item["ctype"])
-                result.append((name, ctype_cls(item["value"])))
-        return result
-    except Exception:
-        return None
-
-
-def _save_golden(golden: dict, path: Path) -> None:
-    """Serialise pre-computed golden output tensors to *path*."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    torch.save(golden, path)
-
-
-def _load_golden(path: Path) -> dict | None:
-    """Load pre-computed golden output tensors from *path*.
-
-    Returns ``None`` if the file does not exist or cannot be read.
-    """
-    if not path.exists():
-        return None
-    try:
-        return torch.load(path, weights_only=False)
-    except Exception:
-        return None
+    result = {}
+    for name in output_names:
+        pt_file = out_dir / f"{name}.pt"
+        if not pt_file.exists():
+            return None
+        result[name] = torch.load(pt_file, weights_only=True)
+    return result
 
 
 @dataclass
@@ -326,6 +238,7 @@ def run(
     tensor_specs: list[TensorSpec],
     golden: Callable,
     config: RunConfig | None = None,
+    scalar_specs: list[ScalarSpec] | None = None,
 ) -> RunResult:
     """Compile *program* and run it on device, validating against *golden*.
 
@@ -345,6 +258,10 @@ def run(
             computes the expected outputs in-place (writes to
             ``tensors[output_name]``).  The function name does not matter.
         config: Run configuration.  Uses default :class:`RunConfig` if ``None``.
+        scalar_specs: Optional list of scalar parameter specifications.  Scalar
+            TaskArg entries appear after all tensor entries in the generated
+            ``golden.py``, matching the TaskArg slot order produced by
+            orchestration codegen.
 
     Returns:
         :class:`RunResult` with ``passed=True`` on success, or ``passed=False``
@@ -405,6 +322,7 @@ def run(
                 golden_path,
                 rtol=config.rtol,
                 atol=config.atol,
+                scalar_specs=scalar_specs,
                 data_dir=config.golden_data_dir,
             )
 
@@ -414,54 +332,24 @@ def run(
             return RunResult(passed=True, execution_time=time.time() - start_time, profile=profile_data)
 
         # 5. Compile C++ → binaries + assemble ChipCallable
-        from .device_runner import (  # noqa: PLC0415
-            build_orch_args,
-            compile_and_assemble,
-            execute_on_device,
-            validate_golden,
-        )
+        from .device_runner import compile_and_assemble  # noqa: PLC0415
 
         with _stage("binary_compilation"):
             chip_callable, runtime_name = compile_and_assemble(
                 work_dir, config.platform, pto_isa_commit=config.pto_isa_commit
             )
 
-        # 6. Build tensor arguments
-        orch_args, all_tensors, inputs, outputs = build_orch_args(tensor_specs)
-
-        # 7. Compute golden
-        golden_outputs = {k: v.clone() for k, v in outputs.items()}
-        golden_with_inputs = {**inputs, **golden_outputs}
-        golden(golden_with_inputs, {})
-
-        # 8. Execute on device
-        if config.runtime_profiling:
-            pre_run_logs, device_log_dir, pre_run_perf_files = _snapshot_profiling_state(
-                config.platform, config.device_id
-            )
-
+        # 6–9. Load inputs, execute, validate
         with _stage("device_execution"):
-            execute_on_device(
-                chip_callable,
-                orch_args,
-                config.platform,
-                runtime_name,
-                config.device_id,
-                enable_profiling=config.runtime_profiling,
-            )
-
-        if config.runtime_profiling:
-            _collect_swimlane_data(
+            _execute_on_device(
                 work_dir,
+                golden_path,
+                chip_callable,
+                runtime_name,
                 config.platform,
                 config.device_id,
-                pre_run_logs,
-                device_log_dir,
-                pre_run_perf_files,
+                runtime_profiling=config.runtime_profiling,
             )
-
-        # 9. Validate
-        validate_golden(outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
 
         profile_data = prof.to_dict() if prof is not None else None
         return RunResult(passed=True, execution_time=time.time() - start_time, profile=profile_data)
@@ -490,56 +378,53 @@ def run(
 def _execute_on_device(
     work_dir: Path,
     golden_path: Path,
+    chip_callable: Any,
+    runtime_name: str,
     platform: str,
     device_id: int,
-    pto_isa_commit: str | None = None,
     runtime_profiling: bool = False,
 ) -> None:
-    """Compile, load, execute, and validate via PyPTO's device runner.
+    """Load inputs, execute on device, and validate against golden.
 
-    This function is used by the test harness (test_runner.py) to execute
-    pre-compiled test cases. For direct use, prefer :func:`run`.
+    Shared execution logic used by both :func:`run` and the test harness
+    (``test_runner.py``).  The caller is responsible for compiling binaries
+    via ``compile_and_assemble`` and passing the result here.
+
+    Tolerances (``RTOL``, ``ATOL``) are read from the generated ``golden.py``.
 
     Args:
-        work_dir: Root output directory containing ``kernels/`` and ``orchestration/``.
+        work_dir: Root output directory containing ``data/``, ``golden.py``, etc.
         golden_path: Path to the generated ``golden.py`` file.
+        chip_callable: Pre-compiled ``ChipCallable`` from ``compile_and_assemble``.
+        runtime_name: Runtime name from ``compile_and_assemble``.
         platform: Target execution platform.
         device_id: Hardware device index.
-        pto_isa_commit: If set, pin the pto-isa clone to this specific commit.
         runtime_profiling: If ``True``, enable runtime profiling.
     """
     from .device_runner import (  # noqa: PLC0415
         build_orch_args_from_inputs,
-        compile_and_assemble,
         execute_on_device,
         validate_golden,
     )
 
-    chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
-
     # Load golden.py to get generate_inputs and compute_golden
-    import importlib.util  # noqa: PLC0415
-
     spec = importlib.util.spec_from_file_location("_golden", str(golden_path))
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load golden.py from {golden_path}")
     golden_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(golden_module)
 
-    # Load golden input cache if available
-    params: dict = {"name": "Default"}
-    result = _load_inputs(_inputs_cache_file(golden_path, "Default"))
-    if result is None:
-        result = golden_module.generate_inputs(params)
+    # Generate inputs (loads from data/in/ when use_data_files golden.py)
+    params: dict[str, str] = {"name": "Default"}
+    result = golden_module.generate_inputs(params)
 
     output_names = set(getattr(golden_module, "__outputs__", []))
     orch_args, all_tensors, inputs, outputs = build_orch_args_from_inputs(result, output_names)
 
-    # Compute golden
-    golden_cache = _load_golden(_golden_cache_file(golden_path, "Default"))
-    if golden_cache is not None:
-        golden_out = golden_cache
-    else:
+    # Load pre-computed golden from data/out/ if available
+    out_dir = golden_path.parent / "data" / "out"
+    golden_out = _load_golden_from_data_dir(out_dir, output_names)
+    if golden_out is None:
         golden_out = {k: v.clone() for k, v in outputs.items()}
         golden_with_inputs = {**inputs, **golden_out}
         golden_module.compute_golden(golden_with_inputs, params)
@@ -568,9 +453,12 @@ def _execute_on_device(
         )
 
     # Validate
-    rtol = getattr(golden_module, "RTOL", 1e-5)
-    atol = getattr(golden_module, "ATOL", 1e-5)
-    validate_golden(outputs, golden_out, rtol=rtol, atol=atol)
+    validate_golden(
+        outputs,
+        golden_out,
+        rtol=getattr(golden_module, "RTOL", 1e-5),
+        atol=getattr(golden_module, "ATOL", 1e-5),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -415,13 +415,10 @@ def run(
 
         # 5. Compile C++ → binaries + assemble ChipCallable
         from .device_runner import (  # noqa: PLC0415
+            build_orch_args,
             compile_and_assemble,
             execute_on_device,
             validate_golden,
-        )
-        from .task_interface import (  # noqa: PLC0415
-            ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
-            make_tensor_arg,
         )
 
         with _stage("binary_compilation"):
@@ -430,19 +427,7 @@ def run(
             )
 
         # 6. Build tensor arguments
-        orch_args = ChipStorageTaskArgs()
-        all_tensors: dict[str, Any] = {}
-        inputs: dict[str, torch.Tensor] = {}
-        outputs: dict[str, torch.Tensor] = {}
-
-        for spec in tensor_specs:
-            tensor = spec.create_tensor().cpu().contiguous()
-            orch_args.add_tensor(make_tensor_arg(tensor))
-            all_tensors[spec.name] = tensor
-            if spec.is_output:
-                outputs[spec.name] = tensor
-            else:
-                inputs[spec.name] = tensor
+        orch_args, all_tensors, inputs, outputs = build_orch_args(tensor_specs)
 
         # 7. Compute golden
         golden_outputs = {k: v.clone() for k, v in outputs.items()}
@@ -450,6 +435,11 @@ def run(
         golden(golden_with_inputs, {})
 
         # 8. Execute on device
+        if config.runtime_profiling:
+            pre_run_logs, device_log_dir, pre_run_perf_files = _snapshot_profiling_state(
+                config.platform, config.device_id
+            )
+
         with _stage("device_execution"):
             execute_on_device(
                 chip_callable,
@@ -457,6 +447,16 @@ def run(
                 binaries,
                 config.device_id,
                 enable_profiling=config.runtime_profiling,
+            )
+
+        if config.runtime_profiling:
+            _collect_swimlane_data(
+                work_dir,
+                config.platform,
+                config.device_id,
+                pre_run_logs,
+                device_log_dir,
+                pre_run_perf_files,
             )
 
         # 9. Validate
@@ -507,7 +507,12 @@ def _execute_on_device(
         pto_isa_commit: If set, pin the pto-isa clone to this specific commit.
         runtime_profiling: If ``True``, enable runtime profiling.
     """
-    from .device_runner import compile_and_assemble, execute_on_device  # noqa: PLC0415
+    from .device_runner import (  # noqa: PLC0415
+        build_orch_args_from_inputs,
+        compile_and_assemble,
+        execute_on_device,
+        validate_golden,
+    )
 
     chip_callable, binaries = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
 
@@ -526,30 +531,8 @@ def _execute_on_device(
     if result is None:
         result = golden_module.generate_inputs(params)
 
-    from .task_interface import (  # noqa: PLC0415
-        ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
-        make_tensor_arg,
-        scalar_to_uint64,
-    )
-
-    orch_args = ChipStorageTaskArgs()
-    all_tensors: dict = {}
-    inputs: dict = {}
-    outputs: dict = {}
     output_names = set(getattr(golden_module, "__outputs__", []))
-
-    for name, val in result:
-        if isinstance(val, torch.Tensor):
-            val = val.cpu().contiguous()
-            orch_args.add_tensor(make_tensor_arg(val))
-            all_tensors[name] = val
-            if name in output_names or name.startswith("out"):
-                outputs[name] = val
-            else:
-                inputs[name] = val
-        elif isinstance(val, ctypes._SimpleCData):
-            orch_args.add_scalar(scalar_to_uint64(val))
-            all_tensors[name] = val.value
+    orch_args, all_tensors, inputs, outputs = build_orch_args_from_inputs(result, output_names)
 
     # Compute golden
     golden_cache = _load_golden(_golden_cache_file(golden_path, "Default"))
@@ -561,6 +544,9 @@ def _execute_on_device(
         golden_module.compute_golden(golden_with_inputs, params)
 
     # Execute
+    if runtime_profiling:
+        pre_run_logs, device_log_dir, pre_run_perf_files = _snapshot_profiling_state(platform, device_id)
+
     execute_on_device(
         chip_callable,
         orch_args,
@@ -569,12 +555,85 @@ def _execute_on_device(
         enable_profiling=runtime_profiling,
     )
 
-    # Validate
-    from .device_runner import validate_golden  # noqa: PLC0415
+    if runtime_profiling:
+        _collect_swimlane_data(
+            work_dir,
+            platform,
+            device_id,
+            pre_run_logs,
+            device_log_dir,
+            pre_run_perf_files,
+        )
 
+    # Validate
     rtol = getattr(golden_module, "RTOL", 1e-5)
     atol = getattr(golden_module, "ATOL", 1e-5)
     validate_golden(outputs, golden_out, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Swimlane profiling helpers
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_profiling_state(platform: str, device_id: int) -> tuple[set[Path], Path | None, set[Path]]:
+    """Snapshot device logs and perf files before a profiled execution.
+
+    Returns:
+        ``(pre_run_logs, device_log_dir, pre_run_perf_files)``
+    """
+    pre_run_logs: set[Path] = set()
+    device_log_dir: Path | None = None
+    if not platform.endswith("sim"):
+        device_log_dir = _get_device_log_dir(device_id)
+        if device_log_dir.exists():
+            pre_run_logs = set(device_log_dir.glob("*.log"))
+
+    _OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
+    pre_run_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json"))
+
+    return pre_run_logs, device_log_dir, pre_run_perf_files
+
+
+def _collect_swimlane_data(
+    work_dir: Path,
+    platform: str,
+    device_id: int,
+    pre_run_logs: set[Path],
+    device_log_dir: Path | None,
+    pre_run_perf_files: set[Path],
+) -> None:
+    """Collect swimlane profiling data after a profiled device execution.
+
+    Moves ``perf_swimlane_*.json`` into ``work_dir/swimlane_data/`` and runs
+    Simpler's ``swimlane_converter.py`` (if available) to produce merged JSON.
+    """
+    simpler_root = os.environ.get("SIMPLER_ROOT")
+    swimlane_dir = work_dir / "swimlane_data"
+    swimlane_dir.mkdir(parents=True, exist_ok=True)
+
+    new_perf_files = set(_OUTPUTS_DIR.glob("perf_swimlane_*.json")) - pre_run_perf_files
+    perf_file: Path | None = None
+    if new_perf_files:
+        perf_file = max(new_perf_files, key=lambda p: p.stat().st_mtime)
+        dest = swimlane_dir / perf_file.name
+        perf_file.rename(dest)
+        perf_file = dest
+        try:
+            _OUTPUTS_DIR.rmdir()
+        except OSError:
+            pass
+
+    if not platform.endswith("sim"):
+        _generate_swimlane(
+            work_dir,
+            device_id,
+            device_log_dir,
+            pre_run_logs,
+            simpler_root,
+            swimlane_dir,
+            perf_file,
+        )
 
 
 def _get_device_log_dir(device_id: int) -> Path:

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -15,41 +15,19 @@ torch-aware helpers (make_tensor_arg, scalar_to_uint64) come from the
 """
 
 from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
-    CONTINUOUS_TENSOR_MAX_DIMS,
-    ArgDirection,
     ChipCallable,
-    ChipCallConfig,
     ChipStorageTaskArgs,
-    ContinuousTensor,
     CoreCallable,
-    DataType,
-    DynamicTaskArgs,
-    TaggedTaskArgs,
-    TensorArgType,
-    arg_direction_name,
-    get_dtype_name,
-    get_element_size,
     make_tensor_arg,
     scalar_to_uint64,
 )
 from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
 
 __all__ = [
-    "DataType",
-    "get_element_size",
-    "get_dtype_name",
-    "CONTINUOUS_TENSOR_MAX_DIMS",
-    "ContinuousTensor",
-    "ChipStorageTaskArgs",
-    "TensorArgType",
-    "DynamicTaskArgs",
-    "TaggedTaskArgs",
-    "ArgDirection",
-    "CoreCallable",
     "ChipCallable",
-    "ChipCallConfig",
+    "ChipStorageTaskArgs",
+    "CoreCallable",
     "Worker",
-    "arg_direction_name",
     "make_tensor_arg",
     "scalar_to_uint64",
 ]

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -6,16 +6,15 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: PLW0603, PLC0415
 
-"""Python API for task_interface nanobind bindings.
+"""Re-exports from ``simpler.task_interface`` and ``simpler.worker``.
 
-Re-exports C++ types (DataType, ContinuousTensor, ChipStorageTaskArgs, etc.)
-from the ``_task_interface`` nanobind module (installed via ``pip install simpler``)
-and adds torch-aware convenience helpers.
+All C++ nanobind types (DataType, ChipCallable, ChipStorageTaskArgs, etc.) and
+torch-aware helpers (make_tensor_arg, scalar_to_uint64) come from the
+``simpler`` package installed via ``pip install simpler``.
 """
 
-from _task_interface import (  # pyright: ignore[reportMissingImports]
+from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     CONTINUOUS_TENSOR_MAX_DIMS,
     ArgDirection,
     ChipCallable,
@@ -27,11 +26,13 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     DynamicTaskArgs,
     TaggedTaskArgs,
     TensorArgType,
-    _ChipWorker,
     arg_direction_name,
     get_dtype_name,
     get_element_size,
+    make_tensor_arg,
+    scalar_to_uint64,
 )
+from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
 
 __all__ = [
     "DataType",
@@ -47,139 +48,8 @@ __all__ = [
     "CoreCallable",
     "ChipCallable",
     "ChipCallConfig",
-    "ChipWorker",
+    "Worker",
     "arg_direction_name",
-    "torch_dtype_to_datatype",
     "make_tensor_arg",
     "scalar_to_uint64",
 ]
-
-
-# Lazy-loaded torch dtype → DataType map (avoids importing torch at module load)
-_TORCH_DTYPE_MAP = None
-
-
-def _ensure_torch_map():
-    global _TORCH_DTYPE_MAP
-    if _TORCH_DTYPE_MAP is not None:
-        return
-    import torch
-
-    _TORCH_DTYPE_MAP = {
-        torch.float32: DataType.FLOAT32,
-        torch.float16: DataType.FLOAT16,
-        torch.int32: DataType.INT32,
-        torch.int16: DataType.INT16,
-        torch.int8: DataType.INT8,
-        torch.uint8: DataType.UINT8,
-        torch.bfloat16: DataType.BFLOAT16,
-        torch.int64: DataType.INT64,
-    }
-
-
-def torch_dtype_to_datatype(dt) -> DataType:
-    """Convert a ``torch.dtype`` to a ``DataType`` enum value.
-
-    Raises ``KeyError`` for unsupported dtypes.
-    """
-    _ensure_torch_map()
-    return _TORCH_DTYPE_MAP[dt]  # pyright: ignore[reportOptionalSubscript]
-
-
-def make_tensor_arg(tensor) -> ContinuousTensor:
-    """Create a ``ContinuousTensor`` from a ``torch.Tensor``.
-
-    The tensor must be CPU-contiguous.
-    """
-    _ensure_torch_map()
-    dt = _TORCH_DTYPE_MAP.get(tensor.dtype)  # pyright: ignore[reportOptionalMemberAccess]
-    if dt is None:
-        raise ValueError(f"Unsupported tensor dtype for ContinuousTensor: {tensor.dtype}")
-    shapes = tuple(int(s) for s in tensor.shape)
-    return ContinuousTensor.make(tensor.data_ptr(), shapes, dt)
-
-
-def scalar_to_uint64(value) -> int:
-    """Convert a scalar value to ``uint64``.
-
-    *value* can be a Python int, float, a ctypes scalar (``c_int64``,
-    ``c_float``, etc.), or any object convertible to ``int``.
-
-    Python float values are converted to IEEE 754 single precision (32-bit)
-    and their bit pattern is zero-extended to uint64.
-    """
-    import struct as _struct
-
-    if isinstance(value, float):
-        bits = _struct.unpack("<I", _struct.pack("<f", value))[0]
-        return bits
-    import ctypes as _ct
-
-    if isinstance(value, _ct._SimpleCData):
-        if isinstance(value, (_ct.c_float, _ct.c_double)):
-            uint_type = _ct.c_uint32 if isinstance(value, _ct.c_float) else _ct.c_uint64
-            return uint_type.from_buffer_copy(value).value
-        return int(value.value) & 0xFFFFFFFFFFFFFFFF
-    return int(value) & 0xFFFFFFFFFFFFFFFF
-
-
-class ChipWorker:
-    """Unified execution interface wrapping the host runtime C API.
-
-    Usage::
-
-        worker = ChipWorker()
-        worker.init(host_path="build/lib/.../host.so",
-                    aicpu_path="build/lib/.../aicpu.so",
-                    aicore_path="build/lib/.../aicore.o")
-        worker.set_device(device_id=0)
-        worker.run(chip_callable, orch_args, block_dim=24)
-        worker.reset_device()
-        worker.finalize()
-    """
-
-    def __init__(self):
-        self._impl = _ChipWorker()
-
-    def init(self, host_path, aicpu_path, aicore_path, sim_context_lib_path=""):
-        """Load host runtime library and cache platform binaries."""
-        self._impl.init(str(host_path), str(aicpu_path), str(aicore_path), str(sim_context_lib_path))
-
-    def set_device(self, device_id):
-        """Set the target NPU device."""
-        self._impl.set_device(device_id)
-
-    def reset_device(self):
-        """Release device resources. The runtime binding remains intact."""
-        self._impl.reset_device()
-
-    def finalize(self):
-        """Tear down everything: device resources and runtime library."""
-        self._impl.finalize()
-
-    def run(self, callable, args, config=None, **kwargs):
-        """Execute a callable synchronously.
-
-        Args:
-            callable: ChipCallable built from orchestration + kernel binaries.
-            args: ChipStorageTaskArgs for this invocation.
-            config: Optional ChipCallConfig. If ``None``, a default is created.
-            **kwargs: Overrides applied to config (e.g. ``block_dim=24``).
-        """
-        if config is None:
-            config = ChipCallConfig()
-        for k, v in kwargs.items():
-            setattr(config, k, v)
-        self._impl.run(callable, args, config)
-
-    @property
-    def device_id(self):
-        return self._impl.device_id
-
-    @property
-    def initialized(self):
-        return self._impl.initialized
-
-    @property
-    def device_set(self):
-        return self._impl.device_set

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -1,0 +1,185 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLW0603, PLC0415
+
+"""Python API for task_interface nanobind bindings.
+
+Re-exports C++ types (DataType, ContinuousTensor, ChipStorageTaskArgs, etc.)
+from the ``_task_interface`` nanobind module (installed via ``pip install simpler``)
+and adds torch-aware convenience helpers.
+"""
+
+from _task_interface import (  # pyright: ignore[reportMissingImports]
+    CONTINUOUS_TENSOR_MAX_DIMS,
+    ArgDirection,
+    ChipCallable,
+    ChipCallConfig,
+    ChipStorageTaskArgs,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    DynamicTaskArgs,
+    TaggedTaskArgs,
+    TensorArgType,
+    _ChipWorker,
+    arg_direction_name,
+    get_dtype_name,
+    get_element_size,
+)
+
+__all__ = [
+    "DataType",
+    "get_element_size",
+    "get_dtype_name",
+    "CONTINUOUS_TENSOR_MAX_DIMS",
+    "ContinuousTensor",
+    "ChipStorageTaskArgs",
+    "TensorArgType",
+    "DynamicTaskArgs",
+    "TaggedTaskArgs",
+    "ArgDirection",
+    "CoreCallable",
+    "ChipCallable",
+    "ChipCallConfig",
+    "ChipWorker",
+    "arg_direction_name",
+    "torch_dtype_to_datatype",
+    "make_tensor_arg",
+    "scalar_to_uint64",
+]
+
+
+# Lazy-loaded torch dtype → DataType map (avoids importing torch at module load)
+_TORCH_DTYPE_MAP = None
+
+
+def _ensure_torch_map():
+    global _TORCH_DTYPE_MAP
+    if _TORCH_DTYPE_MAP is not None:
+        return
+    import torch
+
+    _TORCH_DTYPE_MAP = {
+        torch.float32: DataType.FLOAT32,
+        torch.float16: DataType.FLOAT16,
+        torch.int32: DataType.INT32,
+        torch.int16: DataType.INT16,
+        torch.int8: DataType.INT8,
+        torch.uint8: DataType.UINT8,
+        torch.bfloat16: DataType.BFLOAT16,
+        torch.int64: DataType.INT64,
+    }
+
+
+def torch_dtype_to_datatype(dt) -> DataType:
+    """Convert a ``torch.dtype`` to a ``DataType`` enum value.
+
+    Raises ``KeyError`` for unsupported dtypes.
+    """
+    _ensure_torch_map()
+    return _TORCH_DTYPE_MAP[dt]  # pyright: ignore[reportOptionalSubscript]
+
+
+def make_tensor_arg(tensor) -> ContinuousTensor:
+    """Create a ``ContinuousTensor`` from a ``torch.Tensor``.
+
+    The tensor must be CPU-contiguous.
+    """
+    _ensure_torch_map()
+    dt = _TORCH_DTYPE_MAP.get(tensor.dtype)  # pyright: ignore[reportOptionalMemberAccess]
+    if dt is None:
+        raise ValueError(f"Unsupported tensor dtype for ContinuousTensor: {tensor.dtype}")
+    shapes = tuple(int(s) for s in tensor.shape)
+    return ContinuousTensor.make(tensor.data_ptr(), shapes, dt)
+
+
+def scalar_to_uint64(value) -> int:
+    """Convert a scalar value to ``uint64``.
+
+    *value* can be a Python int, float, a ctypes scalar (``c_int64``,
+    ``c_float``, etc.), or any object convertible to ``int``.
+
+    Python float values are converted to IEEE 754 single precision (32-bit)
+    and their bit pattern is zero-extended to uint64.
+    """
+    import struct as _struct
+
+    if isinstance(value, float):
+        bits = _struct.unpack("<I", _struct.pack("<f", value))[0]
+        return bits
+    import ctypes as _ct
+
+    if isinstance(value, _ct._SimpleCData):
+        if isinstance(value, (_ct.c_float, _ct.c_double)):
+            uint_type = _ct.c_uint32 if isinstance(value, _ct.c_float) else _ct.c_uint64
+            return uint_type.from_buffer_copy(value).value
+        return int(value.value) & 0xFFFFFFFFFFFFFFFF
+    return int(value) & 0xFFFFFFFFFFFFFFFF
+
+
+class ChipWorker:
+    """Unified execution interface wrapping the host runtime C API.
+
+    Usage::
+
+        worker = ChipWorker()
+        worker.init(host_path="build/lib/.../host.so",
+                    aicpu_path="build/lib/.../aicpu.so",
+                    aicore_path="build/lib/.../aicore.o")
+        worker.set_device(device_id=0)
+        worker.run(chip_callable, orch_args, block_dim=24)
+        worker.reset_device()
+        worker.finalize()
+    """
+
+    def __init__(self):
+        self._impl = _ChipWorker()
+
+    def init(self, host_path, aicpu_path, aicore_path, sim_context_lib_path=""):
+        """Load host runtime library and cache platform binaries."""
+        self._impl.init(str(host_path), str(aicpu_path), str(aicore_path), str(sim_context_lib_path))
+
+    def set_device(self, device_id):
+        """Set the target NPU device."""
+        self._impl.set_device(device_id)
+
+    def reset_device(self):
+        """Release device resources. The runtime binding remains intact."""
+        self._impl.reset_device()
+
+    def finalize(self):
+        """Tear down everything: device resources and runtime library."""
+        self._impl.finalize()
+
+    def run(self, callable, args, config=None, **kwargs):
+        """Execute a callable synchronously.
+
+        Args:
+            callable: ChipCallable built from orchestration + kernel binaries.
+            args: ChipStorageTaskArgs for this invocation.
+            config: Optional ChipCallConfig. If ``None``, a default is created.
+            **kwargs: Overrides applied to config (e.g. ``block_dim=24``).
+        """
+        if config is None:
+            config = ChipCallConfig()
+        for k, v in kwargs.items():
+            setattr(config, k, v)
+        self._impl.run(callable, args, config)
+
+    @property
+    def device_id(self):
+        return self._impl.device_id
+
+    @property
+    def initialized(self):
+        return self._impl.initialized
+
+    @property
+    def device_set(self):
+        return self._impl.device_set

--- a/python/pypto/runtime/toolchain.py
+++ b/python/pypto/runtime/toolchain.py
@@ -1,0 +1,238 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Compiler toolchain definitions for kernel and orchestration compilation.
+
+Defines toolchain wrappers for:
+- CCEC: Ascend AICore compiler (hardware)
+- g++-15: Host simulation kernels
+- g++: Host orchestration shared libraries
+- aarch64-g++: Cross-compilation for device orchestration
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from enum import IntEnum
+
+from . import env_manager
+
+
+# Must match compile_strategy.h
+class ToolchainType(IntEnum):
+    """Toolchain types matching the C enum in compile_strategy.h."""
+
+    CCEC = 0  # ccec (Ascend AICore compiler)
+    HOST_GXX_15 = 1  # g++-15 (host, simulation kernels)
+    HOST_GXX = 2  # g++ (host, orchestration .so)
+    AARCH64_GXX = 3  # aarch64-target-linux-gnu-g++ (cross-compile)
+
+
+def _is_gcc(cxx_path: str) -> bool:
+    """Return True if *cxx_path* is a real GCC (not clang masquerading as g++)."""
+    try:
+        out = subprocess.run(
+            [cxx_path, "--version"], check=False, capture_output=True, text=True, timeout=5
+        ).stdout.lower()
+        return "clang" not in out
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+class Toolchain:
+    """Base class for all compile toolchains.
+
+    A Toolchain represents a compiler identity: which compiler binary to use,
+    what flags to pass, and what CMake -D arguments to generate.
+
+    The Ascend SDK path is managed by env_manager. Call
+    env_manager.ensure("ASCEND_HOME_PATH") before creating toolchains that
+    need the Ascend SDK (CCECToolchain, Aarch64GxxToolchain, GxxToolchain
+    with Ascend includes).
+    """
+
+    cxx_path: str
+
+    def __init__(self):
+        self.ascend_home_path = env_manager.get("ASCEND_HOME_PATH")
+
+    def get_compile_flags(self, **kwargs) -> list[str]:
+        """Return base compiler flags for direct invocation."""
+        raise NotImplementedError
+
+    def get_cmake_args(self) -> list[str]:
+        """Return compiler-specific CMake -D arguments."""
+        raise NotImplementedError
+
+
+class CCECToolchain(Toolchain):
+    """Ascend ccec compiler for AICore kernels."""
+
+    def __init__(self, platform: str = "a2a3"):
+        super().__init__()
+        self.platform = platform
+
+        if self.ascend_home_path is None:
+            raise RuntimeError("ASCEND_HOME_PATH is required for CCEC toolchain")
+
+        self.cxx_path = os.path.join(self.ascend_home_path, "bin", "ccec")
+        self.linker_path = os.path.join(self.ascend_home_path, "bin", "ld.lld")
+
+        if not os.path.isfile(self.cxx_path):
+            raise FileNotFoundError(f"ccec compiler not found: {self.cxx_path}")
+        if not os.path.isfile(self.linker_path):
+            raise FileNotFoundError(f"ccec linker not found: {self.linker_path}")
+
+    def get_compile_flags(self, core_type: str = "aiv", **kwargs) -> list[str]:
+        # A5 uses dav-c310 architecture, A2A3 uses dav-c220
+        if self.platform in ("a5", "a5sim"):
+            arch = "dav-c310-vec" if core_type == "aiv" else "dav-c310-cube"
+        elif self.platform in ("a2a3", "a2a3sim"):
+            arch = "dav-c220-vec" if core_type == "aiv" else "dav-c220-cube"
+        else:
+            raise ValueError(f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+
+        return [
+            "-c",
+            "-O3",
+            "-g",
+            "-x",
+            "cce",
+            "-Wall",
+            "-std=c++17",
+            "--cce-aicore-only",
+            f"--cce-aicore-arch={arch}",
+            "-mllvm",
+            "-cce-aicore-stack-size=0x8000",
+            "-mllvm",
+            "-cce-aicore-function-stack-size=0x8000",
+            "-mllvm",
+            "-cce-aicore-record-overflow=false",
+            "-mllvm",
+            "-cce-aicore-addr-transform",
+            "-mllvm",
+            "-cce-aicore-dcci-insert-for-scalar=false",
+            "-DMEMORY_BASE",
+        ]
+
+    def get_cmake_args(self) -> list[str]:
+        return [
+            f"-DBISHENG_CC={self.cxx_path}",
+            f"-DBISHENG_LD={self.linker_path}",
+        ]
+
+
+class Gxx15Toolchain(Toolchain):
+    """g++-15 compiler for simulation kernels."""
+
+    def __init__(self):
+        super().__init__()
+        self.cxx_path = "g++-15"
+
+    def get_compile_flags(self, core_type: str = "", **kwargs) -> list[str]:
+        flags = [
+            "-shared",
+            "-O2",
+            "-fPIC",
+            "-std=c++23",
+            "-fpermissive",
+            "-Wno-macro-redefined",
+            "-Wno-ignored-attributes",
+            "-D__CPU_SIM",
+            "-DPTO_CPU_MAX_THREADS=1",
+            "-DNDEBUG",
+        ]
+        # g++ does not define __DAV_VEC__/__DAV_CUBE__ like ccec does,
+        # so we must add them explicitly based on core_type.
+        if core_type == "aiv":
+            flags.append("-D__DAV_VEC__")
+        elif core_type == "aic":
+            flags.append("-D__DAV_CUBE__")
+        return flags
+
+    def get_cmake_args(self) -> list[str]:
+        cc = os.environ.get("CC", "gcc")
+        cxx = os.environ.get("CXX", "g++")
+        return [
+            f"-DCMAKE_C_COMPILER={cc}",
+            f"-DCMAKE_CXX_COMPILER={cxx}",
+        ]
+
+
+class GxxToolchain(Toolchain):
+    """g++ compiler for host compilation."""
+
+    def __init__(self):
+        super().__init__()
+        self.cxx_path = "g++"
+        self._gcc = _is_gcc(self.cxx_path)
+
+    def get_compile_flags(self, **kwargs) -> list[str]:
+        flags = ["-shared", "-fPIC", "-O3", "-g", "-std=c++17"]
+        # -fno-gnu-unique: prevent STB_GNU_UNIQUE binding so dlclose actually
+        # unloads the SO.  GCC-only; clang does not produce STB_GNU_UNIQUE.
+        if self._gcc:
+            flags.append("-fno-gnu-unique")
+        return flags
+
+    def get_cmake_args(self) -> list[str]:
+        cc = os.environ.get("CC", "gcc")
+        cxx = os.environ.get("CXX", "g++")
+        args = [
+            f"-DCMAKE_C_COMPILER={cc}",
+            f"-DCMAKE_CXX_COMPILER={cxx}",
+        ]
+        if self.ascend_home_path:
+            args.append(f"-DASCEND_HOME_PATH={self.ascend_home_path}")
+        return args
+
+
+class Aarch64GxxToolchain(Toolchain):
+    """aarch64 cross-compiler for device code."""
+
+    def __init__(self):
+        super().__init__()
+
+        if self.ascend_home_path is None:
+            raise RuntimeError("ASCEND_HOME_PATH is required for aarch64 toolchain")
+
+        self.cxx_path = os.path.join(
+            self.ascend_home_path,
+            "tools",
+            "hcc",
+            "bin",
+            "aarch64-target-linux-gnu-g++",
+        )
+        self.cc_path = os.path.join(
+            self.ascend_home_path,
+            "tools",
+            "hcc",
+            "bin",
+            "aarch64-target-linux-gnu-gcc",
+        )
+        if not os.path.isfile(self.cc_path):
+            raise FileNotFoundError(f"aarch64 C compiler not found: {self.cc_path}")
+        if not os.path.isfile(self.cxx_path):
+            raise FileNotFoundError(f"aarch64 C++ compiler not found: {self.cxx_path}")
+        self._gcc = _is_gcc(self.cxx_path)
+
+    def get_compile_flags(self, **kwargs) -> list[str]:
+        flags = ["-shared", "-fPIC", "-O3", "-g", "-std=c++17"]
+        # -fno-gnu-unique: prevent STB_GNU_UNIQUE binding so dlclose actually unloads the SO.
+        if self._gcc:
+            flags.append("-fno-gnu-unique")
+        return flags
+
+    def get_cmake_args(self) -> list[str]:
+        return [
+            f"-DCMAKE_C_COMPILER={self.cc_path}",
+            f"-DCMAKE_CXX_COMPILER={self.cxx_path}",
+            f"-DASCEND_HOME_PATH={self.ascend_home_path}",
+        ]

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -48,7 +48,6 @@ from harness.core.test_runner import (  # noqa: E402
     _precompile_cache,
     prebuild_binaries,
     precompile_test_cases,
-    pregenerate_golden_inputs,
 )
 from pypto import LogLevel, set_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
@@ -392,40 +391,29 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     n_fail = len(_precompile_cache) - n_ok
     print(f"[PyPTO] Pre-compilation done — {n_ok} ok, {n_fail} failed\n")
 
-    # ── Phase 0: pre-generate golden inputs ──────────────────────────────────
-    # Only makes sense when there are successful pre-compilations (golden.py
-    # files must exist before we can load and call generate_inputs).
-    if n_ok > 0:
+    # ── Phase 2: pre-build binary artifacts ──────────────────────────────
+    # Compile incore kernels and orchestration .so in parallel.
+    # Results are saved to work_dir/cache/.
+    if n_ok > 0 and not session.config.getoption("--codegen-only"):
         ok_cases = [
             tc
             for tc in test_cases
             if _cache_key(tc) in _precompile_cache and _precompile_cache[_cache_key(tc)][1] is None
         ]
+        platform: str = session.config.getoption("--platform")
+        pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
+        # Ensure SIMPLER_ROOT is available before prebuild_binaries checks it.
+        # This hook runs before session fixtures, so setup_simpler_dependency
+        # may not have set it yet.
+        _init_simpler_root_if_needed()
         print(
-            f"[PyPTO] Pre-generating golden inputs for {len(ok_cases)} test case(s)"
+            f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
             f" in parallel (workers={workers_str})…"
         )
-        n_gen = pregenerate_golden_inputs(ok_cases, cache_dir, max_workers=max_workers)
-        print(f"[PyPTO] Golden inputs pre-generated — {n_gen} case(s) cached\n")
-
-        # ── Phase 2: pre-build binary artifacts ──────────────────────────────
-        # Compile incore kernels and orchestration .so in parallel.
-        # Results are saved to work_dir/cache/.
-        if not session.config.getoption("--codegen-only"):
-            platform: str = session.config.getoption("--platform")
-            pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
-            # Ensure SIMPLER_ROOT is available before prebuild_binaries checks it.
-            # This hook runs before session fixtures, so setup_simpler_dependency
-            # may not have set it yet.
-            _init_simpler_root_if_needed()
-            print(
-                f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
-                f" in parallel (workers={workers_str})…"
-            )
-            n_built = prebuild_binaries(
-                ok_cases, cache_dir, platform, max_workers=max_workers, pto_isa_commit=pto_isa_commit
-            )
-            print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")
+        n_built = prebuild_binaries(
+            ok_cases, cache_dir, platform, max_workers=max_workers, pto_isa_commit=pto_isa_commit
+        )
+        print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -215,10 +215,7 @@ def test_config(request) -> RunConfig:
 def test_runner(test_config) -> TestRunner:
     """Session-scoped fixture providing a test runner instance.
 
-    Session scope is used because:
-    1. The runner caches compiled runtime binaries
-    2. Building the runtime takes significant time
-    3. The same runner can be reused across all tests
+    Session scope is used because the same runner can be reused across all tests.
     """
     return TestRunner(test_config)
 
@@ -412,10 +409,8 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         print(f"[PyPTO] Golden inputs pre-generated — {n_gen} case(s) cached\n")
 
         # ── Phase 2: pre-build binary artifacts ──────────────────────────────
-        # Compile incore kernels, orchestration .so, and runtime binaries in parallel.
-        # Results are saved to work_dir/cache/ and the global binary_cache/runtimes/
-        # directory. _execute_on_device installs a write-through patch so subsequent
-        # CodeRunner calls serve from disk without recompiling.
+        # Compile incore kernels and orchestration .so in parallel.
+        # Results are saved to work_dir/cache/.
         if not session.config.getoption("--codegen-only"):
             platform: str = session.config.getoption("--platform")
             pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -35,8 +35,8 @@ import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.device_runner import (
-    _load_binary,
-    _save_binary,
+    compile_single_kernel,
+    compile_single_orchestration,
     ensure_pto_isa_root,
 )
 from pypto.runtime.golden_writer import (
@@ -437,53 +437,27 @@ def prebuild_binaries(
         return 0
 
     # ── Submit ALL tasks to a single flat pool ────────────────────────────────
-    def _compile_incore_task(compiler, tc_platform, kernel, runtime_includes):
+    def _compile_incore_task(compiler, tc_platform, kernel, runtime_name):
         source = Path(kernel["source"])
-        core_type = kernel["core_type"]
-        ext = ".so" if tc_platform.endswith("sim") else ".o"
-        output_file = source.with_suffix(ext)
-
-        # 1. Compile → save .o/.so alongside source
-        cached = _load_binary(output_file)
-        if cached is not None:
-            incore_o = cached
-        else:
-            incore_o = compiler.compile_incore(
-                kernel["source"],
-                core_type=core_type,
-                pto_isa_root=pto_isa_root,
-                extra_include_dirs=runtime_includes,
-            )
-            _save_binary(incore_o, output_file)
-
-        # 2. Extract stripped binary → save to cache/ for fast assembly later
-        from pypto.runtime.elf_parser import extract_text_section  # noqa: PLC0415
-
-        if tc_platform.endswith("sim"):
-            kernel_bin = incore_o
-        else:
-            kernel_bin = extract_text_section(incore_o)
-
-        cache_dir = source.parent.parent.parent / "cache"
-        cache_file = cache_dir / f"incore_{core_type}_{source.stem}.bin"
-        _save_binary(kernel_bin, cache_file)
+        prebuild_cache = source.parent.parent.parent / "cache"
+        compile_single_kernel(
+            kernel,
+            compiler,
+            tc_platform,
+            pto_isa_root,
+            runtime_name,
+            cache_dir=prebuild_cache,
+        )
 
     def _compile_orch_task(compiler, runtime_name, orch_source):
         source = Path(orch_source)
-        output_file = source.with_suffix(".so")
-
-        # 1. Compile → save .so alongside source
-        cached = _load_binary(output_file)
-        if cached is not None:
-            orch_bin = cached
-        else:
-            orch_bin = compiler.compile_orchestration(runtime_name, orch_source)
-            _save_binary(orch_bin, output_file)
-
-        # 2. Also save to cache/ for fast assembly later
-        cache_dir = source.parent.parent / "cache"
-        cache_file = cache_dir / f"orch_{source.stem}.bin"
-        _save_binary(orch_bin, cache_file)
+        prebuild_cache = source.parent.parent / "cache"
+        compile_single_orchestration(
+            orch_source,
+            compiler,
+            runtime_name,
+            cache_dir=prebuild_cache,
+        )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         all_futs: list = []
@@ -491,9 +465,8 @@ def prebuild_binaries(
         # Per-test-case: each kernel and orchestration as independent tasks
         tc_kernel_futs: list[tuple[list, concurrent.futures.Future]] = []
         for tc, compiler, tc_platform, runtime_name, kernels, orch_source in case_configs:
-            runtime_includes = compiler.get_orchestration_include_dirs(runtime_name)[:2]
             kfuts = [
-                pool.submit(_compile_incore_task, compiler, tc_platform, k, runtime_includes) for k in kernels
+                pool.submit(_compile_incore_task, compiler, tc_platform, k, runtime_name) for k in kernels
             ]
             ofut = pool.submit(_compile_orch_task, compiler, runtime_name, orch_source)
             tc_kernel_futs.append((kfuts, ofut))

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -23,7 +23,6 @@ import importlib.util
 import logging
 import os
 import shutil
-import sys
 import tempfile
 import threading
 import time
@@ -35,21 +34,24 @@ import pytest
 import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
+from pypto.runtime.device_runner import (
+    _load_binary,
+    _save_binary,
+    ensure_pto_isa_root,
+)
 from pypto.runtime.golden_writer import (
     _extract_compute_golden,
     _materialize_tensors,
     _save_data_files,
     generate_golden_source,
 )
+from pypto.runtime.kernel_compiler import KernelCompiler
 from pypto.runtime.runner import (
-    _BINARY_RUNTIME_CACHE,
     RunConfig,
     RunResult,
     _execute_on_device,
-    _get_simpler_stamp,
     _golden_cache_file,
     _inputs_cache_file,
-    _install_binary_cache_patch,
     _save_golden,
     _save_inputs,
 )
@@ -381,10 +383,9 @@ def prebuild_binaries(
     """Phase 2: pre-compile binary artifacts for all test cases in parallel.
 
     Must be called AFTER :func:`precompile_test_cases` so kernel/orchestration
-    C++ sources exist under ``work_dir``. Imports KernelCompiler/RuntimeBuilder
-    from Simpler and compiles incore kernels, the orchestration ``.so``, and
-    runtime binaries, saving results via the write-through binary cache patch
-    in :mod:`pypto.runtime.runner`.
+    C++ sources exist under ``work_dir``. Uses PyPTO's local KernelCompiler
+    to compile incore kernels and orchestration ``.so`` files, with binary
+    caching integrated into :mod:`pypto.runtime.device_runner`.
 
     Args:
         test_cases: Test case instances (deduplicated by cache key).
@@ -401,25 +402,8 @@ def prebuild_binaries(
     simpler_root = os.environ.get("SIMPLER_ROOT", "")
     if not simpler_root:
         return 0
-    for sub in ("examples/scripts", "python"):
-        p = str(Path(simpler_root) / sub)
-        if p not in sys.path:
-            sys.path.insert(0, p)
 
-    try:
-        code_runner_mod = importlib.import_module("code_runner")
-        kernel_compiler_mod = importlib.import_module("simpler.kernel_compiler")
-        runtime_builder_mod = importlib.import_module("runtime_builder")
-    except ImportError:
-        return 0
-
-    _ensure_pto_isa_root = code_runner_mod._ensure_pto_isa_root
-    KernelCompiler = kernel_compiler_mod.KernelCompiler
-    RuntimeBuilder = runtime_builder_mod.RuntimeBuilder
-
-    _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
-
-    pto_isa_root = _ensure_pto_isa_root(verbose=False, clone_protocol="https", commit=pto_isa_commit)
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
     if pto_isa_root is None:
         return 0
 
@@ -433,11 +417,7 @@ def prebuild_binaries(
         return mod
 
     # ── Collect configs for all valid test cases ──────────────────────────────
-    # Load each kernel_config.py once in the main thread (not thread-safe to do
-    # it concurrently via importlib).
-    case_configs: list[tuple] = []  # (tc, compiler, runtime_name, kernels, orch_source)
-    seen_runtimes: set[tuple[str, str]] = set()
-
+    case_configs: list[tuple] = []
     for tc in test_cases:
         key = _cache_key(tc)
         if key not in _precompile_cache or _precompile_cache[key][1] is not None:
@@ -448,62 +428,84 @@ def prebuild_binaries(
             continue
         tc_platform = _resolve_platform(platform, tc.get_backend_type())
         runtime_name = getattr(mod, "RUNTIME_CONFIG", {}).get("runtime", "host_build_graph")
-        seen_runtimes.add((tc_platform, runtime_name))
         compiler = KernelCompiler(platform=tc_platform)
-        case_configs.append((tc, compiler, runtime_name, mod.KERNELS, mod.ORCHESTRATION["source"]))
+        case_configs.append(
+            (tc, compiler, tc_platform, runtime_name, mod.KERNELS, mod.ORCHESTRATION["source"])
+        )
 
     if not case_configs:
         return 0
 
     # ── Submit ALL tasks to a single flat pool ────────────────────────────────
-    # - One task per incore kernel (kernels across all test cases run in parallel)
-    # - One task per orchestration .so
-    # - One task per unique (platform, runtime_name) build
-    # This way runtime compilation overlaps with kernel/orch compilation, and
-    # with a single test case (common case) all kernels still run in parallel.
-    def _compile_incore_task(compiler, kernel, runtime_includes):
-        compiler.compile_incore(
-            kernel["source"],
-            core_type=kernel["core_type"],
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=runtime_includes,
-        )
+    def _compile_incore_task(compiler, tc_platform, kernel, runtime_includes):
+        source = Path(kernel["source"])
+        core_type = kernel["core_type"]
+        ext = ".so" if tc_platform.endswith("sim") else ".o"
+        output_file = source.with_suffix(ext)
+
+        # 1. Compile → save .o/.so alongside source
+        cached = _load_binary(output_file)
+        if cached is not None:
+            incore_o = cached
+        else:
+            incore_o = compiler.compile_incore(
+                kernel["source"],
+                core_type=core_type,
+                pto_isa_root=pto_isa_root,
+                extra_include_dirs=runtime_includes,
+            )
+            _save_binary(incore_o, output_file)
+
+        # 2. Extract stripped binary → save to cache/ for fast assembly later
+        from pypto.runtime.elf_parser import extract_text_section  # noqa: PLC0415
+
+        if tc_platform.endswith("sim"):
+            kernel_bin = incore_o
+        else:
+            kernel_bin = extract_text_section(incore_o)
+
+        cache_dir = source.parent.parent.parent / "cache"
+        cache_file = cache_dir / f"incore_{core_type}_{source.stem}.bin"
+        _save_binary(kernel_bin, cache_file)
 
     def _compile_orch_task(compiler, runtime_name, orch_source):
-        compiler.compile_orchestration(runtime_name, orch_source)
+        source = Path(orch_source)
+        output_file = source.with_suffix(".so")
 
-    def _build_runtime_task(tc_platform, runtime_name):
-        host_file = _BINARY_RUNTIME_CACHE / _get_simpler_stamp() / f"{runtime_name}_{tc_platform}_host.bin"
-        if not host_file.exists():
-            RuntimeBuilder(platform=tc_platform).build(runtime_name)
+        # 1. Compile → save .so alongside source
+        cached = _load_binary(output_file)
+        if cached is not None:
+            orch_bin = cached
+        else:
+            orch_bin = compiler.compile_orchestration(runtime_name, orch_source)
+            _save_binary(orch_bin, output_file)
+
+        # 2. Also save to cache/ for fast assembly later
+        cache_dir = source.parent.parent / "cache"
+        cache_file = cache_dir / f"orch_{source.stem}.bin"
+        _save_binary(orch_bin, cache_file)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         all_futs: list = []
 
-        # Runtime builds (independent of test-case kernels)
-        for tc_platform, runtime_name in seen_runtimes:
-            all_futs.append(pool.submit(_build_runtime_task, tc_platform, runtime_name))
-
         # Per-test-case: each kernel and orchestration as independent tasks
         tc_kernel_futs: list[tuple[list, concurrent.futures.Future]] = []
-        for tc, compiler, runtime_name, kernels, orch_source in case_configs:
+        for tc, compiler, tc_platform, runtime_name, kernels, orch_source in case_configs:
             runtime_includes = compiler.get_orchestration_include_dirs(runtime_name)[:2]
-            kfuts = [pool.submit(_compile_incore_task, compiler, k, runtime_includes) for k in kernels]
+            kfuts = [
+                pool.submit(_compile_incore_task, compiler, tc_platform, k, runtime_includes) for k in kernels
+            ]
             ofut = pool.submit(_compile_orch_task, compiler, runtime_name, orch_source)
             tc_kernel_futs.append((kfuts, ofut))
             all_futs.extend(kfuts)
             all_futs.append(ofut)
 
-        # Wait for everything; individual failures are logged but non-fatal:
-        # the write-through patch simply won't cache on failure and the test
-        # falls back to live compilation.
         for fut in concurrent.futures.as_completed(all_futs):
             try:
                 fut.result()
             except Exception as e:
                 _log.debug("Pre-build task failed (will fall back to live compilation): %s", e)
 
-    # Count test cases where all kernels AND orchestration succeeded
     n_ok = sum(
         1
         for kfuts, ofut in tc_kernel_futs

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -33,12 +33,6 @@ from pathlib import Path
 import pytest
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
-from pypto.runtime.device_runner import (
-    compile_and_assemble,
-    compile_single_kernel,
-    compile_single_orchestration,
-    ensure_pto_isa_root,
-)
 from pypto.runtime.golden_writer import (
     _data_dir_has_files,
     _extract_compute_golden,
@@ -309,6 +303,12 @@ def prebuild_binaries(
     if not simpler_root:
         return 0
 
+    from pypto.runtime.device_runner import (  # noqa: PLC0415
+        compile_single_kernel,
+        compile_single_orchestration,
+        ensure_pto_isa_root,
+    )
+
     pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
     if pto_isa_root is None:
         return 0
@@ -454,6 +454,8 @@ class TestRunner:
                 # tolerances (1e-5) because pytest_collection_finish instantiates
                 # test cases without their RunConfig constructor args.
                 _write_golden_for_test_case(test_case, cached_dir / "golden.py")
+                from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
                 chip_callable, runtime_name = compile_and_assemble(
                     cached_dir, platform, pto_isa_commit=self.config.pto_isa_commit
                 )
@@ -538,6 +540,8 @@ class TestRunner:
                 )
 
             platform = _resolve_platform(self.config.platform, backend_type)
+            from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
             chip_callable, runtime_name = compile_and_assemble(
                 work_dir, platform, pto_isa_commit=self.config.pto_isa_commit
             )

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -31,15 +31,16 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.device_runner import (
+    compile_and_assemble,
     compile_single_kernel,
     compile_single_orchestration,
     ensure_pto_isa_root,
 )
 from pypto.runtime.golden_writer import (
+    _data_dir_has_files,
     _extract_compute_golden,
     _materialize_tensors,
     _save_data_files,
@@ -50,10 +51,6 @@ from pypto.runtime.runner import (
     RunConfig,
     RunResult,
     _execute_on_device,
-    _golden_cache_file,
-    _inputs_cache_file,
-    _save_golden,
-    _save_inputs,
 )
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
@@ -160,9 +157,16 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
         compute_golden_src = "\n".join(lines)
 
     data_dir = output_path.parent / "data"
-    data = _materialize_tensors(runtime_specs)
-    in_data = {s.name: data[s.name] for s in runtime_specs if not s.is_output or s.init_value is not None}
-    _save_data_files(in_data, data_dir / "in")
+    if not _data_dir_has_files(data_dir, runtime_specs):
+        data = _materialize_tensors(runtime_specs)
+        in_data = {s.name: data[s.name] for s in runtime_specs if not s.is_output or s.init_value is not None}
+        _save_data_files(in_data, data_dir / "in")
+
+        # Compute golden outputs and save to data/out/
+        test_case.compute_expected(data)
+        out_data = {s.name: data[s.name] for s in runtime_specs if s.is_output}
+        _save_data_files(out_data, data_dir / "out")
+
     write_golden_src = generate_golden_source(
         runtime_specs,
         None,
@@ -272,104 +276,6 @@ def precompile_test_cases(
         finally:
             # Reset so the next group can set a different backend type.
             reset_for_testing()
-
-
-def pregenerate_golden_inputs(
-    test_cases: "list[PTOTestCase]",
-    cache_dir: Path,
-    *,
-    max_workers: int | None = None,
-) -> int:
-    """Phase 0: pre-generate golden inputs for all test cases in parallel.
-
-    Must be called AFTER :func:`precompile_test_cases` so that golden.py files
-    have been written to ``cache_dir / <test_name> / golden.py``.
-
-    For each test case the golden module is loaded with importlib (no simpler
-    dependency needed — generated golden.py only imports torch/ctypes) and
-    ``generate_inputs(params)`` is called for every entry in ``ALL_CASES``.
-    Results are stored in :data:`pypto.runtime.runner._golden_inputs_cache`
-    keyed by ``(resolved_golden_path_str, case_name)``.  Forked worker
-    processes inherit the populated cache via copy-on-write and the
-    :func:`pypto.runtime.runner._install_golden_inputs_patch` monkey-patch
-    makes each ``CodeRunner`` instance serve inputs from the cache, skipping
-    the (potentially expensive) ``generate_inputs`` call at test execution time.
-
-    Args:
-        test_cases: Test case instances (should be deduplicated by cache key).
-        cache_dir: Root output directory used during precompilation.
-        max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
-
-    Returns:
-        Number of (test_case, case_name) pairs successfully pre-generated.
-    """
-
-    def _load_module(path: Path, name: str):
-        spec = importlib.util.spec_from_file_location(name, path)
-        if spec is None or spec.loader is None:
-            return None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-
-    # ── Collect work items (main thread) ─────────────────────────────────────
-    # Each item is (module, golden_path, case_name, params) for cases whose
-    # .pt file does not yet exist.  Module loading happens here (single thread)
-    # to avoid importlib races.
-    work_items: list[tuple] = []
-    already_cached = 0
-
-    for tc in test_cases:
-        key = _cache_key(tc)
-        work_dir = cache_dir / key
-        golden_path = work_dir / "golden.py"
-        if not golden_path.exists():
-            continue
-        try:
-            module = _load_module(golden_path, f"_pregolden_{key}")
-        except Exception:
-            continue
-        if module is None:
-            continue
-
-        all_cases = getattr(module, "ALL_CASES", {"Default": {}})
-        for case_name, case_params in all_cases.items():
-            inputs_file = _inputs_cache_file(golden_path, case_name)
-            golden_file = _golden_cache_file(golden_path, case_name)
-            if inputs_file.exists() and golden_file.exists():
-                already_cached += 1
-                continue
-            params = {"name": case_name, **case_params}
-            work_items.append((module, golden_path, case_name, params))
-
-    # ── Generate in parallel (one task per (test_case, case_name) pair) ──────
-    def _gen_case(module, golden_path: Path, case_name: str, params: dict) -> bool:
-        inputs_file = _inputs_cache_file(golden_path, case_name)
-        golden_file = _golden_cache_file(golden_path, case_name)
-        try:
-            result = module.generate_inputs(params)
-            _save_inputs(result, inputs_file)
-
-            # Compute golden: replicate the logic in CodeRunner.run()
-            output_names = set(getattr(module, "__outputs__", []))
-            tensors = {name: val for name, val in result if isinstance(val, torch.Tensor)}
-            # Clone output tensors so compute_golden modifies the clones (not the originals)
-            golden_with_inputs = {
-                name: val.clone() if name in output_names else val for name, val in tensors.items()
-            }
-            module.compute_golden(golden_with_inputs, params)
-            # Save only the output tensors (which now contain the computed values)
-            golden = {name: golden_with_inputs[name] for name in output_names if name in golden_with_inputs}
-            _save_golden(golden, golden_file)
-            return True
-        except Exception:
-            return False  # fallback: live generation at test time
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futs = [pool.submit(_gen_case, *item) for item in work_items]
-        n_generated = sum(f.result() for f in concurrent.futures.as_completed(futs))
-
-    return already_cached + n_generated
 
 
 def prebuild_binaries(
@@ -548,12 +454,16 @@ class TestRunner:
                 # tolerances (1e-5) because pytest_collection_finish instantiates
                 # test cases without their RunConfig constructor args.
                 _write_golden_for_test_case(test_case, cached_dir / "golden.py")
+                chip_callable, runtime_name = compile_and_assemble(
+                    cached_dir, platform, pto_isa_commit=self.config.pto_isa_commit
+                )
                 _execute_on_device(
                     cached_dir,
                     cached_dir / "golden.py",
+                    chip_callable,
+                    runtime_name,
                     platform,
                     self.config.device_id,
-                    self.config.pto_isa_commit,
                 )
                 return RunResult(
                     passed=True,
@@ -628,13 +538,17 @@ class TestRunner:
                 )
 
             platform = _resolve_platform(self.config.platform, backend_type)
+            chip_callable, runtime_name = compile_and_assemble(
+                work_dir, platform, pto_isa_commit=self.config.pto_isa_commit
+            )
             _execute_on_device(
                 work_dir,
                 golden_path,
+                chip_callable,
+                runtime_name,
                 platform,
                 self.config.device_id,
-                self.config.pto_isa_commit,
-                self.config.runtime_profiling,
+                runtime_profiling=self.config.runtime_profiling,
             )
 
             return RunResult(


### PR DESCRIPTION
## Summary

Migrate the entire kernel/orchestration compilation, device execution, and golden validation pipeline into PyPTO, eliminating Python-level imports from the Simpler repository.

- Add 6 new modules in `python/pypto/runtime/`: `kernel_compiler.py`, `toolchain.py`, `elf_parser.py`, `env_manager.py`, `task_interface.py`, `device_runner.py`
- Refactor `runner.py` to use local `device_runner` pipeline instead of Simpler's `CodeRunner`, with `codegen_only` support in `run()`
- Unify `compile_single_kernel()` / `compile_single_orchestration()` shared between pytest and `run()` paths
- Replace PyPTO's local `ChipWorker` wrapper with `simpler.worker.Worker`, simplifying `execute_on_device()` and removing manual `RuntimeBinaries` management
- Unify tensor data caching to `data/in/` + `data/out/` directory structure, replacing the dual `data/in/` + `cache/*.pt` system
- Lazy-import `device_runner` in `test_runner.py` so `--codegen-only` runs do not require simpler installed
- Remove dead code: unused `_parse_platform()`, `_PLATFORM_MAP`, `_kernel_config_runtime_env()`, cache helpers, and stale Simpler imports
- Improve `validate_golden()` to print mismatch index and value on failure
- adopt to simpler 1d4c218456451fa99de3ace9601b01fd210a31dd

Remaining external dependencies:
- `pip install simpler`: provides `_task_interface` nanobind C++ module and `simpler.worker.Worker`
- `SIMPLER_ROOT`: provides C++ headers and pre-built runtime binaries

## Test plan
- [x] Unit tests pass (3469 passed, 16 skipped)
- [x] All pre-commit hooks pass (ruff, pyright, headers)
- [x] System tests with `SIMPLER_ROOT` set: full compilation + execution works
- [x] `codegen_only=True`: verify C++ source generation without SIMPLER_ROOT
- [x] CI: all 8 checks green after review fixes

Fixes #888