### PR TITLE
feat(spmd): add SPMD launch support with block intrinsics and system tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(PYPTO_SOURCES
     src/ir/op/tile_ops/unary.cpp
     src/ir/op/tile_ops/cross_core.cpp
     src/ir/op/tile_ops/sort.cpp
+    src/ir/op/tile_ops/spmd.cpp
     src/ir/op/tile_ops/gather.cpp
     src/ir/op/sync_ops/sync.cpp
     src/ir/op/sync_ops/cross_core.cpp

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -383,7 +383,8 @@ See [TPUSH/TPOP ISA Reference](../../reference/pto-isa/01-tpush_tpop.md) and [Bu
 | -------------- | -------- |
 | `src/ir/op/type_inference.cpp` | Shared type inference utilities |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
-| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx, get_block_num |
+| `tile_ops/memory.cpp` | TileOp: load, store, read, move, alloc, create, full |
+| `tile_ops/spmd.cpp` | TileOp: get_block_idx, get_block_num, get_subblock_idx |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls, etc. |
 | `tile_ops/reduction.cpp` | TileOp: sum (with axis, keepdim) |
 | `tile_ops/unary.cpp` | TileOp: sqrt |

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -239,7 +239,8 @@ with ib.function("tensor_example") as f:
 
 | Category | Operations | Description |
 | -------- | ---------- | ----------- |
-| **Memory** | `tile.get_block_idx` | Get hardware block index (→ ScalarType(DataType::UINT64)) |
+| **Memory** | `tile.get_block_idx` | Get hardware block index (→ ScalarType(DataType::INT64)) |
+| - | `tile.get_block_num` | Get total block count in SPMD launch (→ ScalarType(DataType::INT64)) |
 | - | `tile.load` | TensorType → TileType (DDR to unified buffer) |
 | - | `tile.store` | TileType → TensorType (unified buffer to DDR) |
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
@@ -382,7 +383,7 @@ See [TPUSH/TPOP ISA Reference](../../reference/pto-isa/01-tpush_tpop.md) and [Bu
 | -------------- | -------- |
 | `src/ir/op/type_inference.cpp` | Shared type inference utilities |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
-| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx |
+| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx, get_block_num |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls, etc. |
 | `tile_ops/reduction.cpp` | TileOp: sum (with axis, keepdim) |
 | `tile_ops/unary.cpp` | TileOp: sqrt |

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -75,7 +75,8 @@ Transfer data between memory hierarchy levels.
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; tensor inputs lower to tile fillpad in InCore code |
-| `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
+| `get_block_idx` | `() -> Scalar` | Get current hardware block index (INT64) |
+| `get_block_num` | `() -> Scalar` | Get total block count in SPMD launch (INT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -239,7 +239,8 @@ with ib.function("tensor_example") as f:
 
 | 分类 | 操作 | 描述 |
 | ---- | ---- | ---- |
-| **内存** | `tile.get_block_idx` | 获取 block 索引（返回 UINT64 标量） |
+| **内存** | `tile.get_block_idx` | 获取 block 索引（返回 INT64 标量） |
+| - | `tile.get_block_num` | 获取 SPMD 启动的总 block 数（返回 INT64 标量） |
 | - | `tile.load` | TensorType → TileType（DDR 到统一缓冲区） |
 | - | `tile.store` | TileType → TensorType（统一缓冲区到 DDR） |
 | **逐元素** | `tile.add/sub/mul/div` | Tile-Tile 操作 |
@@ -382,7 +383,7 @@ class CrossCoreExample:
 | --------- | ---- |
 | `src/ir/op/type_inference.cpp` | 共享的类型推断工具 |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
-| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx |
+| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx, get_block_num |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls 等 |
 | `tile_ops/reduction.cpp` | TileOp: sum（含 axis, keepdim） |
 | `tile_ops/unary.cpp` | TileOp: sqrt |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -383,7 +383,8 @@ class CrossCoreExample:
 | --------- | ---- |
 | `src/ir/op/type_inference.cpp` | 共享的类型推断工具 |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
-| `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx, get_block_num |
+| `tile_ops/memory.cpp` | TileOp: load, store, read, move, alloc, create, full |
+| `tile_ops/spmd.cpp` | TileOp: get_block_idx, get_block_num, get_subblock_idx |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls 等 |
 | `tile_ops/reduction.cpp` | TileOp: sum（含 axis, keepdim） |
 | `tile_ops/unary.cpp` | TileOp: sqrt |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -70,7 +70,8 @@
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
-| `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
+| `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（INT64） |
+| `get_block_num` | `() -> Scalar` | 获取 SPMD 启动的总 block 数（INT64） |
 
 ## Tile 算术（`pl.tile.*`）
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -365,8 +365,9 @@ def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
     return _uses_dynamic_subblock_id(func)
 
 
-def _uses_op(func: _ir_core.Function, op_name: str) -> bool:
-    """Return whether the function body contains a call to the given op."""
+def _collect_used_ops(func: _ir_core.Function) -> set[str]:
+    """Return the set of op names used in the function body (single pass)."""
+    used: set[str] = set()
     stmts = _ir_core.flatten_to_stmts(func.body)
     for stmt in stmts:
         call = None
@@ -377,18 +378,28 @@ def _uses_op(func: _ir_core.Function, op_name: str) -> bool:
         if not isinstance(call, _ir_core.Call):
             continue
         op = getattr(call, "op", None)
-        if isinstance(op, _ir_core.Op) and op.name == op_name:
-            return True
-    return False
+        if isinstance(op, _ir_core.Op):
+            used.add(op.name)
+    return used
 
 
 def _needs_block_context_bridge(func: _ir_core.Function) -> bool:
     """Return whether the kernel needs runtime block context bridge (get_block_idx/get_block_num)."""
-    return _uses_op(func, "tile.get_block_idx") or _uses_op(func, "tile.get_block_num")
+    ops = _collect_used_ops(func)
+    return "tile.get_block_idx" in ops or "tile.get_block_num" in ops
 
 
-def _generate_kernel_header(func: _ir_core.Function) -> str:
-    """Generate the wrapper header, including split lane overrides when needed."""
+def _generate_kernel_header(
+    func: _ir_core.Function,
+    *,
+    needs_block_ctx: bool | None = None,
+) -> str:
+    """Generate the wrapper header, including split lane overrides when needed.
+
+    Args:
+        needs_block_ctx: Pre-computed flag for block context bridge.
+            If ``None``, the function body is scanned automatically.
+    """
     fixed_subblock_id = _get_fixed_subblock_id(func)
     subblock_override = ""
     if fixed_subblock_id is not None:
@@ -417,7 +428,9 @@ def _generate_kernel_header(func: _ir_core.Function) -> str:
             """
         )
     block_context_override = ""
-    if _needs_block_context_bridge(func):
+    if needs_block_ctx is None:
+        needs_block_ctx = _needs_block_context_bridge(func)
+    if needs_block_ctx:
         block_context_override = textwrap.dedent(
             """\
             #if !defined(__CPU_SIM)
@@ -439,15 +452,26 @@ def _generate_kernel_header(func: _ir_core.Function) -> str:
     )
 
 
-def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
+def _generate_kernel_wrapper(
+    func: _ir_core.Function,
+    ptoas_code: str,
+    *,
+    needs_block_ctx: bool | None = None,
+) -> str:
     """Generate a complete kernel wrapper file for one InCore function.
 
     Combines:
     1. Kernel header (includes, macros)
     2. Preprocessed ptoas code (static, no duplicate includes)
     3. ``kernel_entry`` wrapper with arg unpacking and forward call
+
+    Args:
+        needs_block_ctx: Pre-computed flag for block context bridge.
+            If ``None``, the function body is scanned automatically.
     """
-    header = _generate_kernel_header(func)
+    if needs_block_ctx is None:
+        needs_block_ctx = _needs_block_context_bridge(func)
+    header = _generate_kernel_header(func, needs_block_ctx=needs_block_ctx)
     ptoas_body = _preprocess_ptoas_output(ptoas_code)
     unpacking_code, var_names = _generate_arg_unpacking(func)
     call_args = ", ".join(var_names)
@@ -461,7 +485,7 @@ def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
         )
 
     runtime_block_context_setup = ""
-    if _needs_block_context_bridge(func):
+    if needs_block_ctx:
         runtime_block_context_setup = (
             "#if !defined(__CPU_SIM)\n"
             "    // Read SPMD block context from runtime dispatch\n"
@@ -674,8 +698,11 @@ def _emit_group_output(
         return
 
     ptoas_cpp = _compile_pto_module(pto_code, group_name, output_dir)
+    group_needs_block_ctx = any(_needs_block_context_bridge(f) for f in members)
     for func in members:
-        result_files[_get_kernel_output_path(func, "cpp")] = _generate_kernel_wrapper(func, ptoas_cpp)
+        result_files[_get_kernel_output_path(func, "cpp")] = _generate_kernel_wrapper(
+            func, ptoas_cpp, needs_block_ctx=group_needs_block_ctx
+        )
 
 
 def _profiling_stage(prof: CompileProfiler | None, name: str) -> AbstractContextManager[Any]:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -216,7 +216,7 @@ _KERNEL_HEADER = """\
 #define __aicore__ [aicore]
 #endif
 
-{subblock_override}#include <pto/pto-inst.hpp>
+{subblock_override}{block_context_override}#include <pto/pto-inst.hpp>
 #include "tensor.h"
 
 using namespace pto;
@@ -365,6 +365,28 @@ def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
     return _uses_dynamic_subblock_id(func)
 
 
+def _uses_op(func: _ir_core.Function, op_name: str) -> bool:
+    """Return whether the function body contains a call to the given op."""
+    stmts = _ir_core.flatten_to_stmts(func.body)
+    for stmt in stmts:
+        call = None
+        if isinstance(stmt, _ir_core.EvalStmt):
+            call = stmt.expr
+        elif isinstance(stmt, _ir_core.AssignStmt):
+            call = stmt.value
+        if not isinstance(call, _ir_core.Call):
+            continue
+        op = getattr(call, "op", None)
+        if isinstance(op, _ir_core.Op) and op.name == op_name:
+            return True
+    return False
+
+
+def _needs_block_context_bridge(func: _ir_core.Function) -> bool:
+    """Return whether the kernel needs runtime block context bridge (get_block_idx/get_block_num)."""
+    return _uses_op(func, "tile.get_block_idx") or _uses_op(func, "tile.get_block_num")
+
+
 def _generate_kernel_header(func: _ir_core.Function) -> str:
     """Generate the wrapper header, including split lane overrides when needed."""
     fixed_subblock_id = _get_fixed_subblock_id(func)
@@ -394,7 +416,27 @@ def _generate_kernel_header(func: _ir_core.Function) -> str:
 
             """
         )
-    return _KERNEL_HEADER.format(func_name=func.name, subblock_override=subblock_override)
+    block_context_override = ""
+    if _needs_block_context_bridge(func):
+        block_context_override = textwrap.dedent(
+            """\
+            #if !defined(__CPU_SIM)
+            #include "intrinsic.h"
+
+            // SPMD block context: bridge runtime block_idx/block_num into PTO-ISA builtins.
+            [[block_local]] static int64_t pypto_runtime_block_idx;
+            [[block_local]] static int64_t pypto_runtime_block_num;
+            #define get_blockidx() pypto_runtime_block_idx
+            #define get_blocknum() pypto_runtime_block_num
+            #endif
+
+            """
+        )
+    return _KERNEL_HEADER.format(
+        func_name=func.name,
+        subblock_override=subblock_override,
+        block_context_override=block_context_override,
+    )
 
 
 def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
@@ -418,12 +460,23 @@ def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
             "#endif\n\n"
         )
 
+    runtime_block_context_setup = ""
+    if _needs_block_context_bridge(func):
+        runtime_block_context_setup = (
+            "#if !defined(__CPU_SIM)\n"
+            "    // Read SPMD block context from runtime dispatch\n"
+            "    pypto_runtime_block_idx = static_cast<int64_t>(get_block_idx(args));\n"
+            "    pypto_runtime_block_num = static_cast<int64_t>(get_block_num(args));\n"
+            "#endif\n\n"
+        )
+
     wrapper_func = (
         "// --- Kernel entry point ---\n"
         'extern "C" __aicore__ __attribute__((always_inline)) '
         "void kernel_entry(__gm__ int64_t* args)\n"
         "{\n"
         f"{runtime_subblock_setup}"
+        f"{runtime_block_context_setup}"
         f"{unpacking_code}\n"
         f"    // Forward to ptoas-generated function\n"
         f"    {func.name}({call_args});\n"

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -294,6 +294,7 @@ def _register_ops() -> None:
     m["tile.read"] = lambda a, _kw: f"{a[0]}[{a[1]}]"
     m["tile.write"] = lambda a, _kw: f"_write_and_return({a[0]}, {a[1]}, {a[2]})"
     m["tile.get_block_idx"] = lambda _a, _kw: "0"
+    m["tile.get_block_num"] = lambda _a, _kw: "1"
 
     # tile log / relu
     m["tile.log"] = _torch_fn("log")

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -387,7 +387,7 @@ def get_block_idx(span: Span | None = None) -> Call:
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression that returns a UINT64 scalar representing the block index
+        Call expression that returns an INT64 scalar representing the block index
 
     Example:
         >>> block_idx = pl.tile.get_block_idx()
@@ -397,6 +397,22 @@ def get_block_idx(span: Span | None = None) -> Call:
     """
     actual_span = _get_span_or_capture(span)
     return _ir_core.create_op_call("tile.get_block_idx", [], {}, actual_span)
+
+
+def get_block_num(span: Span | None = None) -> Call:
+    """Get the total number of blocks in the current SPMD launch.
+
+    Returns the block count for the current task dispatch. When no SPMD launch
+    is configured, returns 1 (single-block default).
+
+    Args:
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns an INT64 scalar representing the block count
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.get_block_num", [], {}, actual_span)
 
 
 def get_subblock_idx(span: Span | None = None) -> Call:

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -82,6 +82,7 @@ from .op.system_ops import (
     aiv_initialize_pipe,
     import_peer_buffer,
     reserve_buffer,
+    spmd_launch,
     tfree_to_aic,
     tfree_to_aiv,
     tpop_from_aic,
@@ -328,6 +329,7 @@ __all__ = [
     "import_peer_buffer",
     "tfree_to_aic",
     "tfree_to_aiv",
+    "spmd_launch",
     # Promoted tensor-only
     "create_tensor",
     "assemble",

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -14,6 +14,8 @@ tpush ops wrap the IR-level functions, unwrapping Tile to Expr.
 tpop ops accept optional shape/dtype kwargs to create typed results.
 """
 
+from typing import Any
+
 from pypto.ir.op import system_ops as _ir_ops
 from pypto.ir.op.system_ops import (
     AUTO,
@@ -47,6 +49,7 @@ __all__ = [
     "import_peer_buffer",
     "tfree_to_aic",
     "tfree_to_aiv",
+    "spmd_launch",
 ]
 
 
@@ -139,3 +142,18 @@ def import_peer_buffer(*, name: str, peer_func: str, span: Span | None = None) -
     """
     call = _ir_ops.import_peer_buffer(name=name, peer_func=peer_func, span=span)
     return Scalar(DataType.INT32, call)
+
+
+def spmd_launch(func: Any, *args: Any, core_num: int, sync_start: bool = False) -> Any:
+    """Launch a kernel with SPMD (Single Program Multiple Data) dispatch.
+
+    This function is intercepted by the DSL parser and never called at
+    runtime.  It exists only to provide a type-checkable API surface.
+
+    Args:
+        func: ``self.<kernel>`` reference to the kernel function to launch.
+        *args: Tensor arguments forwarded to the kernel.
+        core_num: Number of blocks (cores) to launch.
+        sync_start: If ``True``, all blocks start execution atomically.
+    """
+    raise RuntimeError("spmd_launch is a DSL-only construct and cannot be called outside @pl.program")

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -445,7 +445,7 @@ def get_block_idx() -> Scalar:
     used in tile-level programming to identify which block of data is being processed.
 
     Returns:
-        Scalar wrapping the get_block_idx operation (UINT64 type)
+        Scalar wrapping the get_block_idx operation (INT64 type)
 
     Example:
         >>> block_idx = pl.tile.get_block_idx()
@@ -454,6 +454,25 @@ def get_block_idx() -> Scalar:
         >>>     ...
     """
     call_expr = _ir_ops.get_block_idx()
+    return Scalar(expr=call_expr)
+
+
+def get_block_num() -> Scalar:
+    """Get the total number of blocks in the current SPMD launch.
+
+    Returns the block count for the current task dispatch. When no SPMD launch
+    is configured, returns 1 (single-block default).
+
+    Returns:
+        Scalar wrapping the get_block_num operation (INT64 type)
+
+    Example:
+        >>> block_num = pl.tile.get_block_num()
+        >>> block_idx = pl.tile.get_block_idx()
+        >>> # Each block processes a portion of data
+        >>> chunk_size = total_size // block_num
+    """
+    call_expr = _ir_ops.get_block_num()
     return Scalar(expr=call_expr)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2519,7 +2519,7 @@ class ASTParser:
             return self._parse_system_op(op_name, call)
 
         # pl.spmd_launch(...) — SPMD kernel launch (shorthand for pl.system.spmd_launch)
-        if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] == "spmd_launch":
+        if len(attrs) == 2 and attrs[0] == "pl" and attrs[1] == "spmd_launch":
             return self._parse_spmd_launch(call)
 
         # pl.const(value, dtype) — typed constant literal
@@ -2969,12 +2969,13 @@ class ASTParser:
                     span=span,
                     hint=f"Valid keyword arguments: {sorted(valid_kwargs)}",
                 )
-            if not isinstance(kw.value, ast.Constant):
+            success, val = self.expr_evaluator.try_eval_expr(kw.value)
+            if not success:
                 raise ParserSyntaxError(
                     f"spmd_launch keyword '{kw.arg}' must be a compile-time constant",
                     span=span,
                 )
-            spmd_kwargs[kw.arg] = kw.value.value
+            spmd_kwargs[kw.arg] = val
 
         if "core_num" not in spmd_kwargs:
             raise ParserSyntaxError(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2518,6 +2518,10 @@ class ASTParser:
             op_name = attrs[2]
             return self._parse_system_op(op_name, call)
 
+        # pl.spmd_launch(...) — SPMD kernel launch (shorthand for pl.system.spmd_launch)
+        if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] == "spmd_launch":
+            return self._parse_spmd_launch(call)
+
         # pl.const(value, dtype) — typed constant literal
         if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] == "const":
             return self._parse_typed_constant(call)
@@ -2908,7 +2912,90 @@ class ASTParser:
 
     def _parse_system_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse system operation."""
+        if op_name == "spmd_launch":
+            return self._parse_spmd_launch(call)
         return self._dispatch_op(ir_op.system, "system", op_name, call)
+
+    def _parse_spmd_launch(self, call: ast.Call) -> ir.Expr:
+        """Parse pl.system.spmd_launch(self.kernel, arg1, arg2, ..., core_num=N, sync_start=True).
+
+        Produces a Call(GlobalVar("kernel"), [arg1, arg2, ...], kwargs={"core_num": N, ...}).
+        """
+        span = self.span_tracker.get_span(call)
+
+        if not call.args:
+            raise ParserSyntaxError(
+                "spmd_launch requires at least a function reference as the first argument",
+                span=span,
+                hint="Usage: pl.system.spmd_launch(self.kernel, arg1, ..., core_num=N)",
+            )
+
+        # First argument must be self.method_name
+        func_ref = call.args[0]
+        if not (
+            isinstance(func_ref, ast.Attribute)
+            and isinstance(func_ref.value, ast.Name)
+            and func_ref.value.id == "self"
+        ):
+            raise ParserSyntaxError(
+                "First argument to spmd_launch must be a self.method_name reference",
+                span=span,
+                hint="Usage: pl.system.spmd_launch(self.kernel, arg1, ..., core_num=N)",
+            )
+
+        method_name = func_ref.attr
+        if method_name not in self.global_vars:
+            raise UndefinedVariableError(
+                f"Function '{method_name}' not defined in program",
+                span=span,
+                hint=f"Available functions: {list(self.global_vars.keys())}",
+            )
+        gvar = self.global_vars[method_name]
+        func_obj = self.gvar_to_func.get(gvar)
+
+        # Parse remaining positional arguments as kernel arguments
+        kernel_args = [self.parse_expression(arg) for arg in call.args[1:]]
+
+        if func_obj is not None:
+            self._validate_call_arg_count(method_name, func_obj, len(kernel_args), span)
+
+        # Parse SPMD kwargs (core_num, sync_start)
+        spmd_kwargs: dict[str, Any] = {}
+        valid_kwargs = {"core_num", "sync_start"}
+        for kw in call.keywords:
+            if kw.arg not in valid_kwargs:
+                raise ParserSyntaxError(
+                    f"Unknown spmd_launch keyword argument: '{kw.arg}'",
+                    span=span,
+                    hint=f"Valid keyword arguments: {sorted(valid_kwargs)}",
+                )
+            if not isinstance(kw.value, ast.Constant):
+                raise ParserSyntaxError(
+                    f"spmd_launch keyword '{kw.arg}' must be a compile-time constant",
+                    span=span,
+                )
+            spmd_kwargs[kw.arg] = kw.value.value
+
+        if "core_num" not in spmd_kwargs:
+            raise ParserSyntaxError(
+                "spmd_launch requires 'core_num' keyword argument",
+                span=span,
+                hint="Usage: pl.system.spmd_launch(self.kernel, arg1, ..., core_num=N)",
+            )
+
+        # Build Call with SPMD kwargs
+        return_types = func_obj.return_types if func_obj else []
+        if func_obj is not None and return_types:
+            return_types = ir.deduce_call_return_type(
+                list(func_obj.params),
+                kernel_args,
+                return_types,
+            )
+        if not return_types:
+            return ir.Call(gvar, kernel_args, spmd_kwargs, span)
+        if len(return_types) == 1:
+            return ir.Call(gvar, kernel_args, spmd_kwargs, return_types[0], span)
+        return ir.Call(gvar, kernel_args, spmd_kwargs, ir.TupleType(return_types), span)
 
     # Maps iterator type name to ForKind enum value.
     _ITERATOR_TO_KIND = {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -500,6 +500,25 @@ static std::string MakePrintCodegenPTO(const std::string& pto_op_name, const Cal
   return "";
 }
 
+// Emit an expression as index-typed MLIR value, inserting arith.index_cast
+// when the expression evaluates to a non-index integer type (e.g. i64 from
+// get_block_idx).  Constants already emit as index; dynamic expressions may
+// carry their native scalar type.
+static std::string EmitOffsetAsIndex(const ir::ExprPtr& expr, codegen::PTOCodegen& codegen) {
+  if (auto const_int = ir::As<ir::ConstInt>(expr)) {
+    return codegen.GetOrEmitConstant(const_int->value_, DataType::INDEX);
+  }
+  std::string val = codegen.GetExprAsCode(expr);
+  auto scalar_type = ir::As<ScalarType>(expr->GetType());
+  if (scalar_type && scalar_type->dtype_ != DataType::INDEX && !scalar_type->dtype_.IsFloat()) {
+    std::string idx = codegen.NewTemp();
+    std::string src_type = codegen.GetTypeString(scalar_type->dtype_);
+    codegen.Emit(idx + " = arith.index_cast " + val + " : " + src_type + " to index");
+    return idx;
+  }
+  return val;
+}
+
 // tile.load: emit pto.subview + pto.tload
 static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -554,10 +573,19 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
     std::iter_swap(offset_elems.rbegin(), offset_elems.rbegin() + 1);
   }
 
+  // Evaluate offset expressions before building the partition_view line,
+  // because non-constant offsets (e.g. block_idx * 16) may need an
+  // arith.index_cast emitted *before* the partition_view instruction.
+  std::vector<std::string> offset_ssa;
+  offset_ssa.reserve(offset_elems.size());
+  for (const auto& elem : offset_elems) {
+    offset_ssa.push_back(EmitOffsetAsIndex(elem, codegen));
+  }
+
   partition_line << ", offsets = [";
-  for (size_t i = 0; i < offset_elems.size(); ++i) {
+  for (size_t i = 0; i < offset_ssa.size(); ++i) {
     if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetExprAsCode(offset_elems[i]);
+    partition_line << offset_ssa[i];
   }
   partition_line << "]";
   partition_line << ", sizes = [";
@@ -648,14 +676,21 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
+  // Evaluate offset expressions before building the partition_view line,
+  // because non-constant offsets may need an arith.index_cast emitted first.
+  std::vector<std::string> offset_ssa;
+  offset_ssa.reserve(offsets_tuple->elements_.size());
+  for (const auto& elem : offsets_tuple->elements_) {
+    offset_ssa.push_back(EmitOffsetAsIndex(elem, codegen));
+  }
+
   std::string partition_view = codegen.NewNamedTemp(output_tensor->name_hint_ + "_pview");
   std::ostringstream partition_line;
   partition_line << partition_view << " = pto.partition_view " << tensor_view;
-  // Use all offsets elements to match tensor_view rank (handles ND tensors)
   partition_line << ", offsets = [";
-  for (size_t i = 0; i < offsets_tuple->elements_.size(); ++i) {
+  for (size_t i = 0; i < offset_ssa.size(); ++i) {
     if (i > 0) partition_line << ", ";
-    partition_line << codegen.GetExprAsCode(offsets_tuple->elements_[i]);
+    partition_line << offset_ssa[i];
   }
   partition_line << "]";
   partition_line << ", sizes = [";
@@ -1291,6 +1326,26 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     backend.RegisterOp(op_name).f_codegen(std::move(fn));
   };
 
+  reg("tile.get_block_idx", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.empty()) << "tile.get_block_idx takes no arguments, got " << op->args_.size();
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << "tile.get_block_idx requires assignment target";
+    std::ostringstream oss;
+    oss << result << " = pto.get_block_idx";
+    codegen.Emit(oss.str());
+    return std::string("");
+  });
+  reg("tile.get_block_num", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.empty()) << "tile.get_block_num takes no arguments, got " << op->args_.size();
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << "tile.get_block_num requires assignment target";
+    std::ostringstream oss;
+    oss << result << " = pto.get_block_num";
+    codegen.Emit(oss.str());
+    return std::string("");
+  });
   reg("tile.get_subblock_idx", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     CHECK(op->args_.empty()) << "tile.get_subblock_idx takes no arguments, got " << op->args_.size();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -262,6 +262,25 @@ static std::string MakeCmpsCodegenPTO(const std::string& pto_op_name, const Call
   return "";
 }
 
+// Emit an expression as index-typed MLIR value, inserting arith.index_cast
+// when the expression evaluates to a non-index integer type (e.g. i64 from
+// get_block_idx).  Constants already emit as index; dynamic expressions may
+// carry their native scalar type.
+static std::string EmitOffsetAsIndex(const ir::ExprPtr& expr, codegen::PTOCodegen& codegen) {
+  if (auto const_int = ir::As<ir::ConstInt>(expr)) {
+    return codegen.GetOrEmitConstant(const_int->value_, DataType::INDEX);
+  }
+  std::string val = codegen.GetExprAsCode(expr);
+  auto scalar_type = ir::As<ScalarType>(expr->GetType());
+  if (scalar_type && scalar_type->dtype_ != DataType::INDEX && !scalar_type->dtype_.IsFloat()) {
+    std::string idx = codegen.NewTemp();
+    std::string src_type = codegen.GetTypeString(scalar_type->dtype_);
+    codegen.Emit(idx + " = arith.index_cast " + val + " : " + src_type + " to index");
+    return idx;
+  }
+  return val;
+}
+
 // Helper function for tile.assemble → pto.tinsert
 // Inserts source tile into target tile at a given row/col offset (DPS pattern).
 // pto.tinsert semantics: dst[i+row, j+col] = src[i, j]
@@ -282,8 +301,8 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   INTERNAL_CHECK_SPAN(offset_tuple->elements_.size() >= 2, op->span_)
       << "tile.assemble offset tuple must have at least 2 elements (row, col), got "
       << offset_tuple->elements_.size();
-  std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
-  std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
+  std::string row_off = EmitOffsetAsIndex(offset_tuple->elements_[0], codegen);
+  std::string col_off = EmitOffsetAsIndex(offset_tuple->elements_[1], codegen);
 
   // pto.tinsert writes src into dst at (row, col) in place — dst must already
   // contain target's data.  When target and dst are different buffers (i.e.
@@ -498,25 +517,6 @@ static std::string MakePrintCodegenPTO(const std::string& pto_op_name, const Cal
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   codegen.Emit(pto_op_name + " ins(" + src + " | !pto.partition_tensor_view<MxNxdtype>)");
   return "";
-}
-
-// Emit an expression as index-typed MLIR value, inserting arith.index_cast
-// when the expression evaluates to a non-index integer type (e.g. i64 from
-// get_block_idx).  Constants already emit as index; dynamic expressions may
-// carry their native scalar type.
-static std::string EmitOffsetAsIndex(const ir::ExprPtr& expr, codegen::PTOCodegen& codegen) {
-  if (auto const_int = ir::As<ir::ConstInt>(expr)) {
-    return codegen.GetOrEmitConstant(const_int->value_, DataType::INDEX);
-  }
-  std::string val = codegen.GetExprAsCode(expr);
-  auto scalar_type = ir::As<ScalarType>(expr->GetType());
-  if (scalar_type && scalar_type->dtype_ != DataType::INDEX && !scalar_type->dtype_.IsFloat()) {
-    std::string idx = codegen.NewTemp();
-    std::string src_type = codegen.GetTypeString(scalar_type->dtype_);
-    codegen.Emit(idx + " = arith.index_cast " + val + " : " + src_type + " to index");
-    return idx;
-  }
-  return val;
 }
 
 // tile.load: emit pto.subview + pto.tload
@@ -1599,8 +1599,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     INTERNAL_CHECK_SPAN(offset_tuple->elements_.size() >= 2, op->span_)
         << "tile.slice offset tuple must have at least 2 elements (row, col), got "
         << offset_tuple->elements_.size();
-    std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
-    std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
+    std::string row_off = EmitOffsetAsIndex(offset_tuple->elements_[0], codegen);
+    std::string col_off = EmitOffsetAsIndex(offset_tuple->elements_[1], codegen);
 
     std::string result_target = codegen.GetCurrentResultTarget();
     std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -532,6 +532,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
     aiv_name = std::move(finder.aiv_name);
   }
 
+  void EmitSpmdLaunchSpec(const CallPtr& call, const std::string& task_var) {
+    if (call->HasKwarg("core_num")) {
+      int core_num = call->GetKwarg<int>("core_num");
+      code_ << Indent() << task_var << ".launch_spec.set_core_num(" << core_num << ");\n";
+    }
+    if (call->HasKwarg("sync_start")) {
+      bool sync_start = call->GetKwarg<bool>("sync_start");
+      code_ << Indent() << task_var << ".launch_spec.set_require_sync_start("
+            << (sync_start ? "true" : "false") << ");\n";
+    }
+  }
+
   void EmitTaskSubmitAndBind(const std::string& submit_expr) {
     code_ << Indent() << submit_expr << ";\n";
     task_counter_++;
@@ -680,6 +692,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& p : params) {
       code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
     }
+    EmitSpmdLaunchSpec(call, task_var);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
@@ -721,6 +734,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& p : params) {
       code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
     }
+    EmitSpmdLaunchSpec(call, task_var);
     // Split AIV groups dispatch the same kernel on both vector lanes. The
     // kernel body uses tile.get_subblock_idx() to select its lane-local slice.
     std::string third_id = RequiresDualAivDispatch(aiv_func) ? std::to_string(aiv_id) : "INVALID_KERNEL_ID";

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -535,7 +535,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void EmitSpmdLaunchSpec(const CallPtr& call, const std::string& task_var) {
     if (call->HasKwarg("core_num")) {
       int core_num = call->GetKwarg<int>("core_num");
-      code_ << Indent() << task_var << ".launch_spec.set_core_num(" << core_num << ");\n";
+      INTERNAL_CHECK_SPAN(core_num > 0, call->span_)
+          << "spmd_launch core_num must be positive, got " << core_num;
+      std::string method = IsA5Backend() ? "set_core_num" : "set_block_num";
+      code_ << Indent() << task_var << ".launch_spec." << method << "(" << core_num << ");\n";
     }
     if (call->HasKwarg("sync_start")) {
       bool sync_start = call->GetKwarg<bool>("sync_start");

--- a/src/ir/op/README.md
+++ b/src/ir/op/README.md
@@ -11,7 +11,8 @@ src/ir/op/
 ├── tensor_ops/                  # Tensor operator implementations
 │   └── elementwise.cpp          # Element-wise ops (Add, Sub, Mul, Div)
 └── tile_ops/                   # Tile operator implementations
-    ├── memory.cpp               # Memory operations (get_block_idx, get_block_num, load, store)
+    ├── memory.cpp               # Memory operations (load, store, move, alloc, create, full)
+    ├── spmd.cpp                 # SPMD intrinsics (get_block_idx, get_block_num, get_subblock_idx)
     ├── elementwise.cpp          # Element-wise ops (Add, Mul, Div)
     ├── reduction.cpp            # Reduction ops (Sum with keepdim)
     └── unary.cpp                # Unary ops (Sqrt)
@@ -29,7 +30,8 @@ src/ir/op/
 - `elementwise.cpp` - Element-wise binary operations (Add, Sub, Mul, Div)
 - `reduction.cpp` - Reduction operations (Sum, Max, Min, etc.)
 - `unary.cpp` - Unary operations (Sqrt, etc.)
-- `memory.cpp` - Memory operations (load/store, block index) - *tile_ops only*
+- `memory.cpp` - Memory operations (load/store/move/alloc/create/full) - *tile_ops only*
+- `spmd.cpp` - SPMD runtime intrinsics (get_block_idx, get_block_num, get_subblock_idx) - *tile_ops only*
 - `matmul.cpp` - Matrix multiplication operations - *to be added*
 - `transform.cpp` - Shape transformation operations (Reshape, Transpose, etc.) - *to be added*
 

--- a/src/ir/op/README.md
+++ b/src/ir/op/README.md
@@ -11,7 +11,7 @@ src/ir/op/
 ├── tensor_ops/                  # Tensor operator implementations
 │   └── elementwise.cpp          # Element-wise ops (Add, Sub, Mul, Div)
 └── tile_ops/                   # Tile operator implementations
-    ├── memory.cpp               # Memory operations (get_block_idx, load, store)
+    ├── memory.cpp               # Memory operations (get_block_idx, get_block_num, load, store)
     ├── elementwise.cpp          # Element-wise ops (Add, Mul, Div)
     ├── reduction.cpp            # Reduction ops (Sum with keepdim)
     └── unary.cpp                # Unary ops (Sqrt)
@@ -127,7 +127,8 @@ Tile operations are designed for hardware-optimized tile-level programming,
 working with tiles and supporting scalar broadcasting.
 
 - **Memory** (`tile_ops/memory.cpp`):
-  - `tile.get_block_idx` - Get the current hardware block index (returns UINT64 scalar)
+  - `tile.get_block_idx` - Get the current hardware block index (returns INT64 scalar)
+  - `tile.get_block_num` - Get total block count in SPMD launch (returns INT64 scalar)
   - `tile.load` - Copy data from tensor to unified buffer (tile)
   - `tile.store` - Copy data from unified buffer (tile) to tensor
 

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file memory.cpp
- * @brief Memory tile operations (get_block_idx, load, store)
+ * @brief Memory tile operations (load, store, move, alloc, create, read, write, full)
  *
  * This file implements memory operations for tile-level programming.
  * These operations handle data movement between tensors and unified buffers (tiles).
@@ -51,24 +51,6 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
     return *default_value;
   }
   throw ValueError("Missing kwarg: " + key);
-}
-
-TypePtr DeduceTileGetBlockIdxType(const std::vector<ExprPtr>& args,
-                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                  const std::string& op_name) {
-  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
-
-  // get_block_idx returns UINT64 scalar
-  return std::make_shared<ScalarType>(DataType::UINT64);
-}
-
-TypePtr DeduceTileGetSubblockIdxType(const std::vector<ExprPtr>& args,
-                                     const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                     const std::string& op_name) {
-  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
-
-  // get_subblock_idx returns INT64 (matches PTO get_subblock_idx / i64 and signed index math)
-  return std::make_shared<ScalarType>(DataType::INT64);
 }
 
 TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
@@ -450,30 +432,6 @@ REGISTER_OP("tile.write")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileWriteType(args, kwargs, "tile.write");
-    });
-
-// ============================================================================
-// Registration Function for Block Memory Operations
-// ============================================================================
-
-REGISTER_OP("tile.get_block_idx")
-    .set_op_category("TileOp")
-    .set_description("Get the current block index")
-    .no_argument()
-    .no_memory_spec()
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileGetBlockIdxType(args, kwargs, "tile.get_block_idx");
-    });
-
-REGISTER_OP("tile.get_subblock_idx")
-    .set_op_category("TileOp")
-    .set_description("Get the current sub-block (vector core) index")
-    .no_argument()
-    .no_memory_spec()
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileGetSubblockIdxType(args, kwargs, "tile.get_subblock_idx");
     });
 
 REGISTER_OP("tile.read")

--- a/src/ir/op/tile_ops/spmd.cpp
+++ b/src/ir/op/tile_ops/spmd.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
-#include "pypto/core/error.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"

--- a/src/ir/op/tile_ops/spmd.cpp
+++ b/src/ir/op/tile_ops/spmd.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file spmd.cpp
+ * @brief SPMD runtime intrinsics (get_block_idx, get_block_num, get_subblock_idx)
+ *
+ * These operations query the SPMD launch context at runtime.
+ * They return the block/sub-block identity of the current core,
+ * allowing kernels to compute data-parallel partitioning offsets.
+ */
+
+#include <any>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+// ============================================================================
+// Type deduction helpers
+// ============================================================================
+
+TypePtr DeduceTileGetBlockIdxType(const std::vector<ExprPtr>& args,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                  const std::string& op_name) {
+  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
+
+  // get_block_idx returns INT64 (matches PTO get_block_idx / i64 dialect result type)
+  return std::make_shared<ScalarType>(DataType::INT64);
+}
+
+TypePtr DeduceTileGetBlockNumType(const std::vector<ExprPtr>& args,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                  const std::string& op_name) {
+  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
+
+  // get_block_num returns INT64 (matches PTO get_block_num / i64 dialect result type)
+  return std::make_shared<ScalarType>(DataType::INT64);
+}
+
+TypePtr DeduceTileGetSubblockIdxType(const std::vector<ExprPtr>& args,
+                                     const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                     const std::string& op_name) {
+  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
+
+  // get_subblock_idx returns INT64 (matches PTO get_subblock_idx / i64 and signed index math)
+  return std::make_shared<ScalarType>(DataType::INT64);
+}
+
+// ============================================================================
+// Op registration
+// ============================================================================
+
+REGISTER_OP("tile.get_block_idx")
+    .set_op_category("TileOp")
+    .set_description("Get the current block index")
+    .no_argument()
+    .no_memory_spec()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGetBlockIdxType(args, kwargs, "tile.get_block_idx");
+    });
+
+REGISTER_OP("tile.get_block_num")
+    .set_op_category("TileOp")
+    .set_description("Get the total number of blocks in the current SPMD launch")
+    .no_argument()
+    .no_memory_spec()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGetBlockNumType(args, kwargs, "tile.get_block_num");
+    });
+
+REGISTER_OP("tile.get_subblock_idx")
+    .set_op_category("TileOp")
+    .set_description("Get the current sub-block (vector core) index")
+    .no_argument()
+    .no_memory_spec()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGetSubblockIdxType(args, kwargs, "tile.get_subblock_idx");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1109,9 +1109,9 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
     new_args.push_back(gm_var);
     CallPtr new_call;
     if (auto call_type = call->GetType()) {
-      new_call = std::make_shared<Call>(call->op_, new_args, call_type, call->span_);
+      new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call_type, call->span_);
     } else {
-      new_call = std::make_shared<Call>(call->op_, new_args, call->span_);
+      new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
     }
     StmtPtr create_stmt_ptr = create_stmt;
     return std::make_pair(create_stmt_ptr, new_call);

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -853,18 +853,18 @@ FunctionPtr RewriteGroupCaller(const FunctionPtr& group_func, const std::string&
       auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
       if (gv && gv->name_ == incore_name) {
         // Emit AIC call (always fire-and-forget)
-        auto aic_call =
-            std::make_shared<Call>(std::make_shared<GlobalVar>(aic_name), call->args_, stmt->span_);
+        auto aic_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aic_name), call->args_,
+                                               call->kwargs_, stmt->span_);
         new_stmts.push_back(std::make_shared<EvalStmt>(aic_call, stmt->span_));
 
         // Emit AIV call: AssignStmt preserves return value, EvalStmt for void
         if (assign) {
           auto aiv_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_,
-                                                 call->GetType(), stmt->span_);
+                                                 call->kwargs_, call->GetType(), stmt->span_);
           new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, aiv_call, stmt->span_));
         } else {
-          auto aiv_call =
-              std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_, stmt->span_);
+          auto aiv_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_,
+                                                 call->kwargs_, stmt->span_);
           new_stmts.push_back(std::make_shared<EvalStmt>(aiv_call, stmt->span_));
         }
         continue;
@@ -1006,8 +1006,9 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
       if (!gv || !modified_funcs.count(gv->name_)) return nullptr;
       std::vector<ExprPtr> new_args = call->args_;
       new_args.push_back(gm_param);
-      return call->GetType() ? std::make_shared<Call>(call->op_, new_args, call->GetType(), call->span_)
-                             : std::make_shared<Call>(call->op_, new_args, call->span_);
+      return call->GetType()
+                 ? std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->GetType(), call->span_)
+                 : std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
     };
     if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
       if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_))) {

--- a/tests/st/runtime/test_spmd.py
+++ b/tests/st/runtime/test_spmd.py
@@ -1,0 +1,219 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+SPMD (Single Program Multiple Data) System Tests.
+
+Aligns with simpler examples under examples/a5/tensormap_and_ringbuffer/spmd_*:
+
+  SpmdBasicTest        : Single-block SPMD launch (core_num=1).
+                         Verifies the basic SPMD orchestration codegen path.
+  SpmdMultiblockTest   : Multi-launch SPMD (multiple spmd_launch calls with
+                         increasing core_num=4,16,24,48 and mixed sync_start).
+                         Each block processes a disjoint row slice via
+                         pl.tile.get_block_idx() dynamic offsets.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TILE_H = 16
+TILE_W = 16
+MAX_BLOCKS = 48
+TOTAL_H_MULTI = MAX_BLOCKS * TILE_H  # 768
+
+# ---------------------------------------------------------------------------
+# Programs
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class SpmdBasicProgram:
+    """Single-block SPMD: basic launch with core_num=1.
+
+    Corresponds to the simplest SPMD case where a single block runs
+    a tile add-scalar operation.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[TILE_H, TILE_W], pl.FP32],
+        output: pl.InOut[pl.Tensor[[TILE_H, TILE_W], pl.FP32]],
+    ):
+        tile_a: pl.Tile[[TILE_H, TILE_W], pl.FP32] = pl.load(a, [0, 0], [TILE_H, TILE_W])
+        tile_result: pl.Tile[[TILE_H, TILE_W], pl.FP32] = pl.adds(tile_a, 1.0)
+        pl.store(tile_result, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[TILE_H, TILE_W], pl.FP32],
+        output: pl.InOut[pl.Tensor[[TILE_H, TILE_W], pl.FP32]],
+    ):
+        pl.spmd_launch(self.kernel, a, output, core_num=1)
+
+
+@pl.program
+class SpmdMultiblockProgram:
+    """Multi-launch SPMD: multiple spmd_launch calls with increasing core_num.
+
+    Corresponds to spmd_multiblock_mix / spmd_sync_start orchestration pattern
+    where multiple tasks are submitted with increasing block counts and mixed
+    sync_start.  Each block uses get_block_idx() to compute its row offset.
+
+    Launches:
+      T0: core_num=4                — basic multi-block
+      T1: core_num=16, sync_start   — saturates one sched thread
+      T2: core_num=24               — forces cross-thread dispatch
+      T3: core_num=48, sync_start   — two full rounds of all clusters
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[TOTAL_H_MULTI, TILE_W], pl.FP32],
+        output: pl.InOut[pl.Tensor[[TOTAL_H_MULTI, TILE_W], pl.FP32]],
+    ):
+        block_idx = pl.tile.get_block_idx()
+        row_start = block_idx * TILE_H
+        tile_a: pl.Tile[[TILE_H, TILE_W], pl.FP32] = pl.load(a, [row_start, 0], [TILE_H, TILE_W])
+        tile_result: pl.Tile[[TILE_H, TILE_W], pl.FP32] = pl.adds(tile_a, 1.0)
+        pl.store(tile_result, [row_start, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[TOTAL_H_MULTI, TILE_W], pl.FP32],
+        output: pl.InOut[pl.Tensor[[TOTAL_H_MULTI, TILE_W], pl.FP32]],
+    ):
+        pl.spmd_launch(self.kernel, a, output, core_num=4)
+        pl.spmd_launch(self.kernel, a, output, core_num=16, sync_start=True)
+        pl.spmd_launch(self.kernel, a, output, core_num=24)
+        pl.spmd_launch(self.kernel, a, output, core_num=48, sync_start=True)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class SpmdBasicTest(PTOTestCase):
+    """SPMD basic: single-block launch with core_num=1."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_basic"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [TILE_H, TILE_W], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [TILE_H, TILE_W], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SpmdBasicProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = tensors["a"] + 1.0
+
+
+class SpmdMultiblockTest(PTOTestCase):
+    """SPMD multiblock: multiple launches with core_num=4,16,24,48."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_multiblock"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [TOTAL_H_MULTI, TILE_W], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [TOTAL_H_MULTI, TILE_W], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SpmdMultiblockProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = tensors["a"] + 1.0
+
+
+# ---- A5 (Ascend 950) variants ----
+
+
+class SpmdBasicA5Test(SpmdBasicTest):
+    """SPMD basic on A5 (Ascend 950) backend."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_basic_a5"
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+
+class SpmdMultiblockA5Test(SpmdMultiblockTest):
+    """SPMD multiblock on A5 (Ascend 950) backend."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_multiblock_a5"
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+
+# =============================================================================
+# pytest test functions
+# =============================================================================
+
+
+class TestSpmd:
+    """SPMD dispatch system tests (Ascend 910B / A2A3)."""
+
+    def test_spmd_basic(self, test_runner):
+        """Single-block SPMD launch with core_num=1."""
+        result = test_runner.run(SpmdBasicTest())
+        assert result.passed, f"SPMD basic failed: {result.error}"
+
+    def test_spmd_multiblock(self, test_runner):
+        """Multi-launch SPMD with core_num=4,16,24,48 and mixed sync_start."""
+        result = test_runner.run(SpmdMultiblockTest())
+        assert result.passed, f"SPMD multiblock failed: {result.error}"
+
+    # ---- A5 (Ascend 950) tests ----
+
+    @pytest.mark.a5
+    def test_spmd_basic_a5(self, test_runner):
+        """Single-block SPMD launch on A5 (Ascend 950)."""
+        result = test_runner.run(SpmdBasicA5Test())
+        assert result.passed, f"SPMD basic (A5) failed: {result.error}"
+
+    @pytest.mark.a5
+    def test_spmd_multiblock_a5(self, test_runner):
+        """Multi-launch SPMD on A5 (Ascend 950)."""
+        result = test_runner.run(SpmdMultiblockA5Test())
+        assert result.passed, f"SPMD multiblock (A5) failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1974,7 +1974,7 @@ class TestSpmdLaunch:
     """Test SPMD launch spec generation in orchestration codegen."""
 
     def test_spmd_launch_core_num(self):
-        """spmd_launch with core_num emits launch_spec.set_core_num."""
+        """spmd_launch with core_num emits launch_spec.set_block_num on 910B."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1998,7 +1998,7 @@ class TestSpmdLaunch:
                 pl.system.spmd_launch(self.kernel, a, output, core_num=8)
 
         code = _generate_orch_code(SpmdProgram)
-        assert "launch_spec.set_core_num(8)" in code
+        assert "launch_spec.set_block_num(8)" in code
         assert "pto2_rt_submit_aiv_task" in code
 
     def test_spmd_launch_core_num_and_sync_start(self):
@@ -2026,7 +2026,7 @@ class TestSpmdLaunch:
                 pl.system.spmd_launch(self.kernel, a, output, core_num=12, sync_start=True)
 
         code = _generate_orch_code(SpmdSyncProgram)
-        assert "launch_spec.set_core_num(12)" in code
+        assert "launch_spec.set_block_num(12)" in code
         assert "launch_spec.set_require_sync_start(true)" in code
 
     def test_spmd_launch_shorthand(self):
@@ -2054,7 +2054,7 @@ class TestSpmdLaunch:
                 pl.spmd_launch(self.kernel, a, output, core_num=4)
 
         code = _generate_orch_code(SpmdShorthandProgram)
-        assert "launch_spec.set_core_num(4)" in code
+        assert "launch_spec.set_block_num(4)" in code
 
     def test_spmd_launch_no_core_num_raises(self):
         """spmd_launch without core_num raises ParserSyntaxError."""
@@ -2110,13 +2110,13 @@ class TestSpmdLaunch:
         code = _generate_orch_code(MixedCallProgram)
         assert "// Task 0: kernel" in code
         assert "// Task 1: kernel" in code
-        assert "launch_spec.set_core_num(8)" in code
+        assert "launch_spec.set_block_num(8)" in code
         lines = code.splitlines()
         task0_line = next(i for i, line in enumerate(lines) if "Task 0:" in line)
         task1_line = next(i for i, line in enumerate(lines) if "Task 1:" in line)
-        core_num_line = next(i for i, line in enumerate(lines) if "set_core_num" in line)
-        assert core_num_line > task1_line
-        assert core_num_line > task0_line
+        block_num_line = next(i for i, line in enumerate(lines) if "set_block_num" in line)
+        assert block_num_line > task1_line
+        assert block_num_line > task0_line
 
 
 class TestUnregisteredOpError:

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1970,6 +1970,155 @@ class TestTensorReadWriteOffsetCodegen:
         assert "pto2_rt_submit_task(mixed_0, params_t0);" in code
 
 
+class TestSpmdLaunch:
+    """Test SPMD launch spec generation in orchestration codegen."""
+
+    def test_spmd_launch_core_num(self):
+        """spmd_launch with core_num emits launch_spec.set_core_num."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                pl.store(tile_a, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                pl.system.spmd_launch(self.kernel, a, output, core_num=8)
+
+        code = _generate_orch_code(SpmdProgram)
+        assert "launch_spec.set_core_num(8)" in code
+        assert "pto2_rt_submit_aiv_task" in code
+
+    def test_spmd_launch_core_num_and_sync_start(self):
+        """spmd_launch with both core_num and sync_start emits both launch_spec calls."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdSyncProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                pl.store(tile_a, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                pl.system.spmd_launch(self.kernel, a, output, core_num=12, sync_start=True)
+
+        code = _generate_orch_code(SpmdSyncProgram)
+        assert "launch_spec.set_core_num(12)" in code
+        assert "launch_spec.set_require_sync_start(true)" in code
+
+    def test_spmd_launch_shorthand(self):
+        """pl.spmd_launch shorthand works the same as pl.system.spmd_launch."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdShorthandProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                pl.store(tile_a, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                pl.spmd_launch(self.kernel, a, output, core_num=4)
+
+        code = _generate_orch_code(SpmdShorthandProgram)
+        assert "launch_spec.set_core_num(4)" in code
+
+    def test_spmd_launch_no_core_num_raises(self):
+        """spmd_launch without core_num raises ParserSyntaxError."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        with pytest.raises(Exception, match="core_num"):
+
+            @pl.program
+            class BadSpmdProgram:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    a: pl.Tensor[[16, 16], pl.FP32],
+                    output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                ):
+                    tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                    pl.store(tile_a, [0, 0], output)
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[16, 16], pl.FP32],
+                    output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                ):
+                    pl.system.spmd_launch(self.kernel, a, output)
+
+    def test_normal_and_spmd_calls_coexist(self):
+        """Normal and SPMD calls can coexist in the same orchestration function."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class MixedCallProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                pl.store(tile_a, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                self.kernel(a, output)
+                pl.system.spmd_launch(self.kernel, a, output, core_num=8)
+
+        code = _generate_orch_code(MixedCallProgram)
+        assert "// Task 0: kernel" in code
+        assert "// Task 1: kernel" in code
+        assert "launch_spec.set_core_num(8)" in code
+        lines = code.splitlines()
+        task0_line = next(i for i, line in enumerate(lines) if "Task 0:" in line)
+        task1_line = next(i for i, line in enumerate(lines) if "Task 1:" in line)
+        core_num_line = next(i for i, line in enumerate(lines) if "set_core_num" in line)
+        assert core_num_line > task1_line
+        assert core_num_line > task0_line
+
+
 class TestUnregisteredOpError:
     """Test that unregistered/misplaced ops in Orchestration functions raise errors."""
 

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -752,6 +752,7 @@ class TestRegistryInfrastructure:
         "op_name",
         [
             "tile.get_block_idx",
+            "tile.get_block_num",
             "tile.alloc",
         ],
     )

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -326,7 +326,7 @@ class TestFlattenCallInIfCondition:
             def main(
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                t__tmp_v0: pl.Scalar[pl.UINT64] = pl.tile.get_block_idx()
+                t__tmp_v0: pl.Scalar[pl.INT64] = pl.tile.get_block_idx()
                 if t__tmp_v0 < 10:
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
@@ -390,7 +390,7 @@ class TestFlattenCallInForRange:
             def main(
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                t__tmp_v0: pl.Scalar[pl.UINT64] = pl.tile.get_block_idx()
+                t__tmp_v0: pl.Scalar[pl.INT64] = pl.tile.get_block_idx()
                 for _i in pl.range(t__tmp_v0):
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)


### PR DESCRIPTION
Add pl.spmd_launch() DSL function for multi-block SPMD dispatch with core_num and sync_start parameters. Implement tile.get_block_idx() and tile.get_block_num() intrinsics for kernels to query block identity. Key changes:
- Parser: parse spmd_launch() calls with core_num/sync_start kwargs
- Orchestration codegen: emit launch_spec.set_core_num/set_require_sync_start
- Kernel codegen: bridge get_block_idx/get_block_num to PTO dialect, add arith.index_cast for i64→index offset conversion in partition_view
- Backend: generate block context bridge in kernel wrappers
- Fix expand_mixed_kernel pass dropping SPMD kwargs when injecting GM pipe buffer arguments
- Refactor: move SPMD intrinsics from memory.cpp to new spmd.cpp
- Add system tests with multi-launch pattern (core_num=4,16,24,48)