### PR TITLE
feat(ir,codegen): add SPMD dispatch via pl.cluster(core_num=...)

### DIFF
--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -301,7 +301,8 @@ class IRBuilder {
    */
   void BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level = std::nullopt,
                   std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-                  std::string name_hint = "");
+                  std::string name_hint = "",
+                  std::optional<int> core_num = std::nullopt, std::optional<bool> sync_start = std::nullopt);
 
   /**
    * @brief End building a scope statement
@@ -671,13 +672,16 @@ class ScopeContext : public BuildContext {
  public:
   ScopeContext(ScopeKind scope_kind, Span span, std::optional<Level> level = std::nullopt,
                std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-               std::string name_hint = "")
+               std::string name_hint = "",
+               std::optional<int> core_num = std::nullopt, std::optional<bool> sync_start = std::nullopt)
       : BuildContext(Type::SCOPE, std::move(span)),
         scope_kind_(scope_kind),
         level_(level),
         role_(role),
         split_(split),
-        name_hint_(std::move(name_hint)) {}
+        name_hint_(std::move(name_hint)),
+        core_num_(core_num),
+        sync_start_(sync_start) {}
 
   void AddStmt(const StmtPtr& stmt) override { stmts_.push_back(stmt); }
 
@@ -686,6 +690,8 @@ class ScopeContext : public BuildContext {
   [[nodiscard]] std::optional<Role> GetRole() const { return role_; }
   [[nodiscard]] std::optional<SplitMode> GetSplit() const { return split_; }
   [[nodiscard]] const std::string& GetNameHint() const { return name_hint_; }
+  [[nodiscard]] std::optional<int> GetCoreNum() const { return core_num_; }
+  [[nodiscard]] std::optional<bool> GetSyncStart() const { return sync_start_; }
   [[nodiscard]] const std::vector<StmtPtr>& GetStmts() const { return stmts_; }
 
  private:
@@ -694,6 +700,8 @@ class ScopeContext : public BuildContext {
   std::optional<Role> role_;
   std::optional<SplitMode> split_;
   std::string name_hint_;
+  std::optional<int> core_num_;
+  std::optional<bool> sync_start_;
   std::vector<StmtPtr> stmts_;
 };
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -721,18 +721,26 @@ class ScopeStmt : public Stmt {
    * @param level Hierarchy level (for Hierarchy scopes)
    * @param role Function role (for Hierarchy scopes)
    * @param split Split mode for cross-core transfer (for AutoInCore scopes)
+   * @param core_num Number of SPMD blocks (for Cluster scopes)
+   * @param sync_start Whether to require sync-start for SPMD dispatch
    */
   ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span, std::optional<Level> level,
             std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-            std::string name_hint = "")
+            std::string name_hint = "",
+            std::optional<int> core_num = std::nullopt, std::optional<bool> sync_start = std::nullopt)
       : Stmt(std::move(span)),
         scope_kind_(scope_kind),
         body_(std::move(body)),
         level_(level),
         role_(role),
         split_(split),
-        name_hint_(std::move(name_hint)) {
+        name_hint_(std::move(name_hint)),
+        core_num_(core_num),
+        sync_start_(sync_start) {
     CHECK(scope_kind != ScopeKind::Hierarchy || level_.has_value()) << "Hierarchy scope requires a level";
+    if (core_num_.has_value()) {
+      CHECK(*core_num_ > 0) << "core_num must be positive, got " << *core_num_;
+    }
   }
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ScopeStmt; }
@@ -750,6 +758,8 @@ class ScopeStmt : public Stmt {
                                           reflection::UsualField(&ScopeStmt::role_, "role"),
                                           reflection::UsualField(&ScopeStmt::split_, "split"),
                                           reflection::UsualField(&ScopeStmt::name_hint_, "name_hint"),
+                                          reflection::UsualField(&ScopeStmt::core_num_, "core_num"),
+                                          reflection::UsualField(&ScopeStmt::sync_start_, "sync_start"),
                                           reflection::UsualField(&ScopeStmt::body_, "body")));
   }
 
@@ -759,6 +769,8 @@ class ScopeStmt : public Stmt {
   std::optional<Role> role_;        // Function role (nullopt for non-Hierarchy scopes)
   std::optional<SplitMode> split_;  // Split mode (nullopt or None for no split)
   std::string name_hint_;           // User-provided scope name hint (empty = auto-generate)
+  std::optional<int> core_num_;        // SPMD block count (for Cluster scopes)
+  std::optional<bool> sync_start_;     // Require sync-start for SPMD dispatch
   StmtPtr body_;                    // The nested statements
 };
 

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -535,10 +535,16 @@ class ScopeOutliner : public IRMutator {
       outlined_body = std::make_shared<SeqStmts>(body_stmts, op->span_);
     }
 
-    // Register the outlined function (propagate level/role from ScopeStmt, convert split to attrs)
+    // Register the outlined function (propagate level/role from ScopeStmt, convert split/core_num to attrs)
     std::vector<std::pair<std::string, std::any>> outlined_attrs;
     if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
       outlined_attrs.emplace_back("split", static_cast<int>(op->split_.value()));
+    }
+    if (op->core_num_.has_value()) {
+      outlined_attrs.emplace_back("core_num", *op->core_num_);
+    }
+    if (op->sync_start_.has_value() && *op->sync_start_) {
+      outlined_attrs.emplace_back("sync_start", true);
     }
     auto outlined_func = std::make_shared<Function>(
         outlined_func_name, input_params, input_param_directions, return_types, outlined_body, op->span_,

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -931,9 +931,12 @@ void BindIR(nb::module_& m) {
   auto scope_stmt_class = nb::class_<ScopeStmt, Stmt>(
       ir, "ScopeStmt", "Scope statement: marks a region with specific execution context");
   scope_stmt_class.def(nb::init<ScopeKind, const StmtPtr&, const Span&, std::optional<Level>,
-                                std::optional<Role>, std::optional<SplitMode>, std::string>(),
+                                std::optional<Role>, std::optional<SplitMode>, std::string,
+                                std::optional<int>, std::optional<bool>>(),
                        nb::arg("scope_kind"), nb::arg("body"), nb::arg("span"), nb::arg("level") = nb::none(),
-                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(), nb::arg("name_hint") = "",
+                       nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
+                       nb::arg("name_hint") = "",
+                       nb::arg("core_num") = nb::none(), nb::arg("sync_start") = nb::none(),
                        "Create a scope statement");
   BindFields<ScopeStmt>(scope_stmt_class);
 

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -243,6 +243,7 @@ void BindIRBuilder(nb::module_& m) {
       .def("begin_scope", &IRBuilder::BeginScope, nb::arg("scope_kind"), nb::arg("span"),
            nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("split") = nb::none(),
            nb::arg("name_hint") = "",
+           nb::arg("core_num") = nb::none(), nb::arg("sync_start") = nb::none(),
            "Begin building a scope statement.\n\n"
            "Creates a new scope context. Must be closed with end_scope().\n\n"
            "Args:\n"
@@ -251,7 +252,9 @@ void BindIRBuilder(nb::module_& m) {
            "    level: Hierarchy level (default: None)\n"
            "    role: Hierarchy scope role (default: None)\n"
            "    split: Split mode for cross-core transfer (default: None)\n"
-           "    name_hint: User-provided scope name hint (default: empty, auto-generated)\n\n"
+           "    name_hint: User-provided scope name hint (default: empty, auto-generated)\n"
+           "    core_num: SPMD block count (default: None)\n"
+           "    sync_start: Require sync-start for SPMD dispatch (default: None)\n\n"
            "Raises:\n"
            "    RuntimeError: If not inside a function or loop")
       .def("end_scope", &IRBuilder::EndScope, nb::arg("end_span"),

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -353,6 +353,32 @@ def _uses_dynamic_subblock_id(func: _ir_core.Function) -> bool:
     return False
 
 
+_SPMD_BLOCK_OPS = frozenset({"tile.get_block_idx", "tile.get_block_num"})
+
+
+def _uses_spmd_block_ops(func: _ir_core.Function) -> bool:
+    """Return whether the function uses SPMD block identity ops (get_block_idx/num).
+
+    These ops compile to ccec built-ins that return physical core indices.
+    In the tensormap_and_ringbuffer runtime the logical block index must be
+    read from the dispatch payload via ``get_block_idx(args)`` / ``get_block_num(args)``
+    (defined in ``intrinsic.h``), so the wrapper needs a macro bridge.
+    """
+    stmts = _ir_core.flatten_to_stmts(func.body)
+    for stmt in stmts:
+        call = None
+        if isinstance(stmt, _ir_core.EvalStmt):
+            call = stmt.expr
+        elif isinstance(stmt, _ir_core.AssignStmt):
+            call = stmt.value
+        if not isinstance(call, _ir_core.Call):
+            continue
+        op = getattr(call, "op", None)
+        if isinstance(op, _ir_core.Op) and op.name in _SPMD_BLOCK_OPS:
+            return True
+    return False
+
+
 def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
     """Return whether A2A3 split AIV wrappers must source subblock id from runtime context."""
     split_mode = getattr(func, "split", None)
@@ -394,7 +420,34 @@ def _generate_kernel_header(func: _ir_core.Function) -> str:
 
             """
         )
-    return _KERNEL_HEADER.format(func_name=func.name, subblock_override=subblock_override)
+
+    # SPMD block ops bridge: redirect ccec built-in get_block_idx()/get_block_num()
+    # to runtime intrinsics that read from the dispatch payload (LocalContext).
+    # AICore has no writable static data segment for GM pointers, so we store
+    # the scalar values in [[block_local]] variables (same pattern as subblock bridge).
+    spmd_override = ""
+    if _uses_spmd_block_ops(func):
+        spmd_override = textwrap.dedent(
+            """\
+            #if !defined(__CPU_SIM)
+            #include "intrinsic.h"
+
+            // SPMD runtime bridge: ccec get_block_idx()/get_block_num() return physical
+            // core indices; the runtime dispatches logical indices via LocalContext.
+            // Store scalar values in [[block_local]] and redirect via macros.
+            [[block_local]] static int32_t __pypto_spmd_block_idx;
+            [[block_local]] static int32_t __pypto_spmd_block_num;
+            #define get_block_idx() ((int64_t)__pypto_spmd_block_idx)
+            #define get_block_num() ((int64_t)__pypto_spmd_block_num)
+            #endif
+
+            """
+        )
+
+    return _KERNEL_HEADER.format(
+        func_name=func.name,
+        subblock_override=subblock_override + spmd_override,
+    )
 
 
 def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
@@ -418,12 +471,31 @@ def _generate_kernel_wrapper(func: _ir_core.Function, ptoas_code: str) -> str:
             "#endif\n\n"
         )
 
+    spmd_args_setup = ""
+    if _uses_spmd_block_ops(func):
+        # Use undef/redefine dance: temporarily remove our macros so we can call
+        # the intrinsic.h functions that take args, then restore the macros.
+        spmd_args_setup = (
+            "#if !defined(__CPU_SIM)\n"
+            "    // Read logical SPMD block identity from runtime dispatch payload\n"
+            "    #pragma push_macro(\"get_block_idx\")\n"
+            "    #pragma push_macro(\"get_block_num\")\n"
+            "    #undef get_block_idx\n"
+            "    #undef get_block_num\n"
+            "    __pypto_spmd_block_idx = get_block_idx(args);\n"
+            "    __pypto_spmd_block_num = get_block_num(args);\n"
+            "    #pragma pop_macro(\"get_block_idx\")\n"
+            "    #pragma pop_macro(\"get_block_num\")\n"
+            "#endif\n\n"
+        )
+
     wrapper_func = (
         "// --- Kernel entry point ---\n"
         'extern "C" __aicore__ __attribute__((always_inline)) '
         "void kernel_entry(__gm__ int64_t* args)\n"
         "{\n"
         f"{runtime_subblock_setup}"
+        f"{spmd_args_setup}"
         f"{unpacking_code}\n"
         f"    // Forward to ptoas-generated function\n"
         f"    {func.name}({call_args});\n"

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -260,6 +260,8 @@ class IRBuilder:
         role: ir.Role | None = None,
         split: ir.SplitMode | None = None,
         name_hint: str = "",
+        core_num: int | None = None,
+        sync_start: bool | None = None,
     ) -> Iterator["ScopeBuilder"]:
         """Context manager for building scope statements.
 
@@ -270,6 +272,8 @@ class IRBuilder:
             role: Function role (for ScopeKind.Hierarchy)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
             name_hint: User-provided scope name hint (empty = auto-generate)
+            core_num: SPMD block count (for Cluster scopes)
+            sync_start: Require sync-start for SPMD dispatch
 
         Yields:
             ScopeBuilder: Helper object for building the scope statement
@@ -284,7 +288,7 @@ class IRBuilder:
         self._ctx_counter += 1
         self._begin_spans[ctx_id] = begin_span
 
-        self._builder.begin_scope(scope_kind, begin_span, level, role, split, name_hint)
+        self._builder.begin_scope(scope_kind, begin_span, level, role, split, name_hint, core_num, sync_start)
         builder_obj = ScopeBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -414,6 +414,19 @@ def get_subblock_idx(span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.get_subblock_idx", [], {}, actual_span)
 
 
+def get_block_num(span: Span | None = None) -> Call:
+    """Get the total number of blocks in the current SPMD task.
+
+    Args:
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns a UINT64 scalar representing the total block count
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.get_block_num", [], {}, actual_span)
+
+
 def full(
     shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     dtype: DataType,

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -694,7 +694,9 @@ class ClusterContext:
     The parser recognizes this pattern and creates a ScopeStmt(Cluster).
     """
 
-    def __init__(self, name_hint: str = "") -> None:
+    def __init__(self, core_num: int | None = None, sync_start: bool = False, name_hint: str = "") -> None:
+        self.core_num = core_num
+        self.sync_start = sync_start
         self.name_hint = name_hint
 
     def __enter__(self) -> None:
@@ -706,12 +708,17 @@ class ClusterContext:
         pass
 
 
-def cluster(*, name_hint: str = "") -> ClusterContext:
+def cluster(core_num: int | None = None, sync_start: bool = False, *, name_hint: str = "") -> ClusterContext:
     """Mark a region of code as belonging to a Cluster execution context.
 
     A cluster groups co-scheduled AIC (Cube) and AIV (Vector) kernels that
     share the same physical cluster resources. The OutlineClusterScopes pass
     extracts Cluster scopes into separate Group-typed functions.
+
+    Args:
+        core_num: Number of blocks for SPMD dispatch (default: None = single block).
+            Must be a positive integer.
+        sync_start: If True, all blocks start execution simultaneously (default: False).
 
     Returns:
         Context manager for Cluster scope
@@ -720,8 +727,15 @@ def cluster(*, name_hint: str = "") -> ClusterContext:
         >>> with pl.cluster():
         ...     with pl.incore():
         ...         y = pl.add(x, x)
+        >>> with pl.cluster(core_num=8, sync_start=True):
+        ...     with pl.incore():
+        ...         block_idx = pl.tile.get_block_idx()
+        ...         block_num = pl.tile.get_block_num()
     """
-    return ClusterContext(name_hint=name_hint)
+    if core_num is not None:
+        if not isinstance(core_num, int) or isinstance(core_num, bool) or core_num <= 0:
+            raise ValueError(f"core_num must be a positive integer, got {core_num!r}")
+    return ClusterContext(core_num=core_num, sync_start=sync_start, name_hint=name_hint)
 
 
 class AtContext:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -36,6 +36,7 @@ __all__ = [
     "fillpad_inplace",
     "get_block_idx",
     "get_subblock_idx",
+    "get_block_num",
     "add",
     "sub",
     "mul",
@@ -467,6 +468,23 @@ def get_subblock_idx() -> Scalar:
         Scalar wrapping the get_subblock_idx operation (INT64 type)
     """
     call_expr = _ir_ops.get_subblock_idx()
+    return Scalar(expr=call_expr)
+
+
+def get_block_num() -> Scalar:
+    """Get the total number of blocks in the current SPMD task.
+
+    This operation returns the total count of blocks dispatched for the current
+    task. Used with get_block_idx() for SPMD work partitioning.
+
+    Returns:
+        Scalar wrapping the get_block_num operation (UINT64 type)
+
+    Example:
+        >>> block_idx = pl.tile.get_block_idx()
+        >>> block_num = pl.tile.get_block_num()
+    """
+    call_expr = _ir_ops.get_block_num()
     return Scalar(expr=call_expr)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1809,15 +1809,44 @@ class ASTParser:
                     span=self.span_tracker.get_span(stmt),
                     hint=f"Use 'with pl.{func_attr}():'",
                 )
+            core_num = None
+            sync_start = None
             for kw in context_expr.keywords:
                 if kw.arg == "name_hint":
                     name_hint = self._parse_scope_name_hint(kw.value, f"pl.{func_attr}()")
+                elif kw.arg == "core_num":
+                    if not isinstance(kw.value, ast.Constant) or not isinstance(
+                        kw.value.value, int
+                    ):
+                        raise ParserSyntaxError(
+                            "core_num must be an integer literal",
+                            span=self.span_tracker.get_span(stmt),
+                            hint="Use 'with pl.cluster(core_num=8):'",
+                        )
+                    core_num = kw.value.value
+                elif kw.arg == "sync_start":
+                    if not isinstance(kw.value, ast.Constant) or not isinstance(
+                        kw.value.value, bool
+                    ):
+                        raise ParserSyntaxError(
+                            "sync_start must be a boolean literal (True/False)",
+                            span=self.span_tracker.get_span(stmt),
+                            hint="Use 'with pl.cluster(sync_start=True):'",
+                        )
+                    sync_start = kw.value.value
                 else:
                     raise ParserSyntaxError(
                         f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
                         span=self.span_tracker.get_span(stmt),
-                        hint="Supported keywords: 'name_hint'",
+                        hint="Supported keywords: 'name_hint', 'core_num', 'sync_start'",
                     )
+            scope_kind = scope_kind_map[func_attr]
+            span = self.span_tracker.get_span(stmt)
+            self._parse_scope_body(
+                stmt, scope_kind, span, name_hint=name_hint,
+                core_num=core_num, sync_start=sync_start,
+            )
+            return
         elif context_expr.args or context_expr.keywords:
             raise ParserSyntaxError(
                 f"pl.{func_attr}() does not accept arguments",
@@ -1838,9 +1867,14 @@ class ASTParser:
         role: "ir.Role | None" = None,
         split: "ir.SplitMode | None" = None,
         name_hint: str = "",
+        core_num: int | None = None,
+        sync_start: bool | None = None,
     ) -> None:
         """Build a scope statement from a with-statement body."""
-        with self.builder.scope(scope_kind, span, level=level, role=role, split=split, name_hint=name_hint):
+        with self.builder.scope(
+            scope_kind, span, level=level, role=role, split=split,
+            name_hint=name_hint, core_num=core_num, sync_start=sync_start,
+        ):
             with self._scope_kind_context(scope_kind):
                 self.scope_manager.enter_scope("scope")
                 for body_stmt in stmt.body:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1803,6 +1803,12 @@ class ScopeStmt(Stmt):
     name_hint: Final[str]
     """User-provided scope name hint (empty string = auto-generate)."""
 
+    core_num: Final[int | None]
+    """SPMD block count (None for single block)."""
+
+    sync_start: Final[bool | None]
+    """Require sync-start for SPMD dispatch (None or False for default)."""
+
     body: Final[Stmt]
     """The nested statements."""
 
@@ -1815,6 +1821,8 @@ class ScopeStmt(Stmt):
         role: Role | None = None,
         split: SplitMode | None = None,
         name_hint: str = "",
+        core_num: int | None = None,
+        sync_start: bool | None = None,
     ) -> None:
         """Create a scope statement.
 
@@ -1826,6 +1834,8 @@ class ScopeStmt(Stmt):
             role: Function role (for Hierarchy scopes)
             split: Split mode for cross-core transfer (for AutoInCore scopes)
             name_hint: User-provided scope name hint (empty = auto-generate)
+            core_num: SPMD block count (for Cluster scopes)
+            sync_start: Require sync-start for SPMD dispatch
         """
 
 class SeqStmts(Stmt):
@@ -2572,6 +2582,8 @@ class IRBuilder:
         role: Role | None = None,
         split: SplitMode | None = None,
         name_hint: str = "",
+        core_num: int | None = None,
+        sync_start: bool | None = None,
     ) -> None:
         """Begin building a scope statement.
 
@@ -2582,6 +2594,8 @@ class IRBuilder:
             role: Hierarchy scope role (default: None)
             split: Split mode for cross-core transfer (default: None)
             name_hint: User-provided scope name hint (default: empty, auto-generated)
+            core_num: SPMD block count (default: None)
+            sync_start: Require sync-start for SPMD dispatch (default: None)
         """
 
     def end_scope(self, end_span: Span) -> ScopeStmt:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1295,12 +1295,33 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     CHECK(op->args_.empty()) << "tile.get_subblock_idx takes no arguments, got " << op->args_.size();
     std::string result = codegen.GetCurrentResultTarget();
-    INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << "tile.get_subblock_idx requires assignment target";
-    std::ostringstream oss;
-    // No trailing `-> type`: PTOAS only accepts that form on some ops (e.g. reserve_buffer) and
-    // reports "expected operation name in quotes" for get_subblock_idx. The dialect result is i64.
-    oss << result << " = pto.get_subblock_idx";
-    codegen.Emit(oss.str());
+    INTERNAL_CHECK(!result.empty()) << "tile.get_subblock_idx requires assignment target";
+    // pto.get_subblock_idx returns i64; cast to index so offset arithmetic stays in index type
+    std::string i64_tmp = codegen.NewTemp();
+    codegen.Emit(i64_tmp + " = pto.get_subblock_idx");
+    codegen.Emit(result + " = arith.index_cast " + i64_tmp + " : i64 to index");
+    return std::string("");
+  });
+  reg("tile.get_block_num", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.empty()) << "tile.get_block_num takes no arguments, got " << op->args_.size();
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK(!result.empty()) << "tile.get_block_num requires assignment target";
+    // pto.get_block_num returns i64; cast to index so offset arithmetic stays in index type
+    std::string i64_tmp = codegen.NewTemp();
+    codegen.Emit(i64_tmp + " = pto.get_block_num");
+    codegen.Emit(result + " = arith.index_cast " + i64_tmp + " : i64 to index");
+    return std::string("");
+  });
+  reg("tile.get_block_idx", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.empty()) << "tile.get_block_idx takes no arguments, got " << op->args_.size();
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK(!result.empty()) << "tile.get_block_idx requires assignment target";
+    // pto.get_block_idx returns i64; cast to index so offset arithmetic stays in index type
+    std::string i64_tmp = codegen.NewTemp();
+    codegen.Emit(i64_tmp + " = pto.get_block_idx");
+    codegen.Emit(result + " = arith.index_cast " + i64_tmp + " : i64 to index");
     return std::string("");
   });
   reg("tile.read", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -681,6 +681,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
     }
 
+    // Emit SPMD launch_spec if core_num is set on the callee function
+    int core_num = callee_func->GetAttr<int>("core_num", 0);
+    bool sync_start = callee_func->GetAttr<bool>("sync_start", false);
+    if (core_num > 0) {
+      std::string method = IsA5Backend() ? "set_core_num" : "set_block_num";
+      code_ << ind << task_var << ".launch_spec." << method << "(" << core_num << ");\n";
+    }
+    if (sync_start) {
+      code_ << ind << task_var << ".launch_spec.set_require_sync_start(true);\n";
+    }
+
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
     EmitTaskSubmitAndBind(submit_expr);
@@ -692,6 +703,45 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string aic_name;
     std::string aiv_name;
     FindGroupCallees(group_func, aic_name, aiv_name);
+
+    // AIV-only Group: pure vector SPMD kernel (no AIC callee).
+    // Dispatch as a single AIV task with core_num/sync_start from the Group.
+    // Use pto2_rt_submit_aiv_task which dispatches across independent AIV cores,
+    // unlike pto2_rt_submit_task (MixedKernels) which dispatches full clusters.
+    if (aic_name.empty() && !aiv_name.empty()) {
+      FunctionPtr aiv_func = program_->GetFunction(aiv_name);
+      INTERNAL_CHECK(aiv_func != nullptr)
+          << "Internal error: AIV function '" << aiv_name << "' not found for Group '" << group_name << "'";
+
+      (*func_name_to_core_type_)[aiv_name] = CoreType::VECTOR;
+      int aiv_id = GetOrCreateFuncId(aiv_name, func_name_to_id_, next_func_id_);
+      auto params = BuildTaskParams(call, aiv_func);
+
+      std::string ind = Indent();
+      std::string task_var = "params_t" + std::to_string(task_counter_);
+      code_ << "\n";
+      code_ << ind << "// Group " << group_name << ": AIV-only SPMD\n";
+      code_ << ind << "Arg " << task_var << ";\n";
+      for (const auto& p : params) {
+        code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
+      }
+
+      int core_num = group_func->GetAttr<int>("core_num", 0);
+      bool sync_start = group_func->GetAttr<bool>("sync_start", false);
+      if (core_num > 0) {
+        std::string method = IsA5Backend() ? "set_core_num" : "set_block_num";
+        code_ << ind << task_var << ".launch_spec." << method << "(" << core_num << ");\n";
+      }
+      if (sync_start) {
+        code_ << ind << task_var << ".launch_spec.set_require_sync_start(true);\n";
+      }
+
+      std::string submit_expr =
+          CoreTypeToSubmitPrefix(CoreType::VECTOR) + std::to_string(aiv_id) + ", " + task_var + ")";
+      EmitTaskSubmitAndBind(submit_expr);
+      return;
+    }
+
     INTERNAL_CHECK_SPAN(!aic_name.empty(), call->span_)
         << "Internal error: no AIC callee found in Group '" << group_name << "' body";
     INTERNAL_CHECK_SPAN(!aiv_name.empty(), call->span_)
@@ -726,6 +776,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string third_id = RequiresDualAivDispatch(aiv_func) ? std::to_string(aiv_id) : "INVALID_KERNEL_ID";
     code_ << ind << "MixedKernels mixed_" << task_counter_ << " = {" << aic_id << ", " << aiv_id << ", "
           << third_id << "};\n";
+
+    // Emit SPMD launch_spec if core_num is set on the Group function
+    int core_num = group_func->GetAttr<int>("core_num", 0);
+    bool sync_start = group_func->GetAttr<bool>("sync_start", false);
+    if (core_num > 0) {
+      std::string method = IsA5Backend() ? "set_core_num" : "set_block_num";
+      code_ << ind << task_var << ".launch_spec." << method << "(" << core_num << ");\n";
+    }
+    if (sync_start) {
+      code_ << ind << task_var << ".launch_spec.set_require_sync_start(true);\n";
+    }
 
     std::string submit_expr =
         "pto2_rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -43,6 +43,8 @@ std::string DataTypeToMLIR(DataType dtype) {
     return "index";
   } else if (dtype == DataType::INT64) {
     return "i64";
+  } else if (dtype == DataType::UINT64) {
+    return "i64";
   } else if (dtype == DataType::INT8) {
     return "i8";
   } else if (dtype == DataType::UINT8) {

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -288,13 +288,15 @@ StmtPtr IRBuilder::EndIf(const Span& end_span) {
 // ========== Scope Building ==========
 
 void IRBuilder::BeginScope(ScopeKind scope_kind, const Span& span, std::optional<Level> level,
-                           std::optional<Role> role, std::optional<SplitMode> split, std::string name_hint) {
+                           std::optional<Role> role, std::optional<SplitMode> split,
+                           std::string name_hint,
+                           std::optional<int> core_num, std::optional<bool> sync_start) {
   CHECK(!context_stack_.empty()) << "Cannot begin scope: not inside a function or another valid context at "
                                  << span.to_string();
   CHECK(scope_kind != ScopeKind::Hierarchy || level.has_value())
       << "Hierarchy scope requires a level at " << span.to_string();
   context_stack_.push_back(
-      std::make_unique<ScopeContext>(scope_kind, span, level, role, split, std::move(name_hint)));
+      std::make_unique<ScopeContext>(scope_kind, span, level, role, split, std::move(name_hint), core_num, sync_start));
 }
 
 StmtPtr IRBuilder::EndScope(const Span& end_span) {
@@ -315,7 +317,8 @@ StmtPtr IRBuilder::EndScope(const Span& end_span) {
   // Create scope statement
   auto scope_stmt =
       std::make_shared<ScopeStmt>(scope_ctx->GetScopeKind(), body, combined_span, scope_ctx->GetLevel(),
-                                  scope_ctx->GetRole(), scope_ctx->GetSplit(), scope_ctx->GetNameHint());
+                                  scope_ctx->GetRole(), scope_ctx->GetSplit(), scope_ctx->GetNameHint(),
+                                  scope_ctx->GetCoreNum(), scope_ctx->GetSyncStart());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -58,8 +58,18 @@ TypePtr DeduceTileGetBlockIdxType(const std::vector<ExprPtr>& args,
                                   const std::string& op_name) {
   CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
 
-  // get_block_idx returns UINT64 scalar
-  return std::make_shared<ScalarType>(DataType::UINT64);
+  // get_block_idx returns INDEX scalar (maps to index type in PTO codegen,
+  // consistent with offset arithmetic used in tile.load/tile.store)
+  return std::make_shared<ScalarType>(DataType::INDEX);
+}
+
+TypePtr DeduceTileGetBlockNumType(const std::vector<ExprPtr>& args,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                  const std::string& op_name) {
+  CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
+
+  // get_block_num returns INDEX scalar (same type as get_block_idx)
+  return std::make_shared<ScalarType>(DataType::INDEX);
 }
 
 TypePtr DeduceTileGetSubblockIdxType(const std::vector<ExprPtr>& args,
@@ -67,8 +77,8 @@ TypePtr DeduceTileGetSubblockIdxType(const std::vector<ExprPtr>& args,
                                      const std::string& op_name) {
   CHECK(args.size() == 0) << "The operator " << op_name << " requires no arguments, but got " << args.size();
 
-  // get_subblock_idx returns INT64 (matches PTO get_subblock_idx / i64 and signed index math)
-  return std::make_shared<ScalarType>(DataType::INT64);
+  // get_subblock_idx returns INDEX scalar (maps to index type in PTO codegen)
+  return std::make_shared<ScalarType>(DataType::INDEX);
 }
 
 TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
@@ -474,6 +484,16 @@ REGISTER_OP("tile.get_subblock_idx")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileGetSubblockIdxType(args, kwargs, "tile.get_subblock_idx");
+    });
+
+REGISTER_OP("tile.get_block_num")
+    .set_op_category("TileOp")
+    .set_description("Get the total number of blocks in the current SPMD task")
+    .no_argument()
+    .no_memory_spec()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileGetBlockNumType(args, kwargs, "tile.get_block_num");
     });
 
 REGISTER_OP("tile.read")

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -99,6 +99,8 @@ class FieldSerializerVisitor {
   result_type VisitLeafField(const std::optional<Role>& field);
   result_type VisitLeafField(const SplitMode& field);
   result_type VisitLeafField(const std::optional<SplitMode>& field);
+  result_type VisitLeafField(const std::optional<int>& field);
+  result_type VisitLeafField(const std::optional<bool>& field);
   result_type VisitLeafField(const ParamDirection& field);
   result_type VisitLeafField(const std::vector<ParamDirection>& field);
   result_type VisitLeafField(const TypePtr& field);
@@ -592,6 +594,20 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(const SplitMode& field) {
 msgpack::object FieldSerializerVisitor::VisitLeafField(const std::optional<SplitMode>& field) {
   if (field.has_value()) {
     return msgpack::object(static_cast<uint8_t>(*field), zone_);
+  }
+  return msgpack::object();  // null
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const std::optional<int>& field) {
+  if (field.has_value()) {
+    return msgpack::object(*field, zone_);
+  }
+  return msgpack::object();  // null
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const std::optional<bool>& field) {
+  if (field.has_value()) {
+    return msgpack::object(*field, zone_);
   }
   return msgpack::object();  // null
 }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -569,10 +569,24 @@ static IRNodePtr DeserializeScopeStmt(const msgpack::object& fields_obj, msgpack
     name_hint = name_hint_obj->as<std::string>();
   }
 
+  // Deserialize optional core_num
+  std::optional<int> core_num = std::nullopt;
+  auto core_num_obj = GetOptionalFieldObj(fields_obj, "core_num", ctx);
+  if (core_num_obj.has_value() && core_num_obj->type != msgpack::type::NIL) {
+    core_num = static_cast<int>(core_num_obj->via.i64);
+  }
+
+  // Deserialize optional sync_start
+  std::optional<bool> sync_start = std::nullopt;
+  auto sync_start_obj = GetOptionalFieldObj(fields_obj, "sync_start", ctx);
+  if (sync_start_obj.has_value() && sync_start_obj->type != msgpack::type::NIL) {
+    sync_start = sync_start_obj->via.boolean;
+  }
+
   // Deserialize body
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
-  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name_hint));
+  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name_hint), core_num, sync_start);
 }
 
 // Deserialize SeqStmts

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -578,7 +578,8 @@ StmtPtr IRMutator::VisitStmt_(const ScopeStmtPtr& op) {
   INTERNAL_CHECK_SPAN(new_body, op->span_) << "ScopeStmt body mutated to null";
   if (new_body.get() != op->body_.get()) {
     return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_, op->name_hint_);
+                                             op->role_, op->split_, op->name_hint_,
+                                             op->core_num_, op->sync_start_);
   }
   return op;
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1061,7 +1061,18 @@ void IRPythonPrinter::VisitStmt_(const ScopeStmtPtr& op) {
     stream_ << "):\n";
   } else if (op->scope_kind_ == ScopeKind::Cluster) {
     stream_ << "with " << prefix_ << ".cluster(";
+    bool first_kwarg = true;
+    if (op->core_num_.has_value()) {
+      stream_ << "core_num=" << *op->core_num_;
+      first_kwarg = false;
+    }
+    if (op->sync_start_.has_value() && *op->sync_start_) {
+      if (!first_kwarg) stream_ << ", ";
+      stream_ << "sync_start=True";
+      first_kwarg = false;
+    }
     if (!op->name_hint_.empty()) {
+      if (!first_kwarg) stream_ << ", ";
       stream_ << "name_hint=\"" << op->name_hint_ << "\"";
     }
     stream_ << "):\n";
@@ -1209,11 +1220,11 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
     bool has_type = func->func_type_ != FunctionType::Opaque;
     bool has_level = func->level_.has_value();
     bool has_role = func->role_.has_value();
-    // NOTE: Currently only the "split" attr is printed. Other attrs in func->attrs_
-    // will be silently dropped during printing. Extend here when new attrs are added.
     auto func_split_mode = func->GetSplitMode();
     bool has_split = func_split_mode.has_value();
-    if (has_type || has_level || has_role || has_split) {
+    bool has_core_num = func->HasAttr("core_num");
+    bool has_sync_start = func->HasAttr("sync_start") && func->GetAttr<bool>("sync_start", false);
+    if (has_type || has_level || has_role || has_split || has_core_num || has_sync_start) {
       stream_ << "(";
       bool first = true;
       if (has_type) {
@@ -1230,10 +1241,25 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         stream_ << "role=" << prefix_ << ".Role." << RoleToString(*func->role_);
         first = false;
       }
-      if (has_split) {
+      if (has_split || has_core_num || has_sync_start) {
         if (!first) stream_ << ", ";
-        stream_ << "attrs={\"split\": " << prefix_ << ".SplitMode."
-                << SplitModeToPythonString(*func_split_mode) << "}";
+        stream_ << "attrs={";
+        bool first_attr = true;
+        if (has_split) {
+          stream_ << "\"split\": " << prefix_ << ".SplitMode."
+                  << SplitModeToPythonString(*func_split_mode);
+          first_attr = false;
+        }
+        if (has_core_num) {
+          if (!first_attr) stream_ << ", ";
+          stream_ << "\"core_num\": " << func->GetAttr<int>("core_num", 0);
+          first_attr = false;
+        }
+        if (has_sync_start) {
+          if (!first_attr) stream_ << ", ";
+          stream_ << "\"sync_start\": True";
+        }
+        stream_ << "}";
       }
       stream_ << ")";
     }

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -449,6 +449,38 @@ class StructuralEqualImpl {
     return true;
   }
 
+  result_type VisitLeafField(const std::optional<int>& lhs, const std::optional<int>& rhs) {
+    if (lhs.has_value() != rhs.has_value()) {
+      if constexpr (AssertMode) {
+        ThrowMismatch("optional<int> presence mismatch", IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    if (lhs.has_value() && *lhs != *rhs) {
+      if constexpr (AssertMode) {
+        ThrowMismatch("optional<int> value mismatch", IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    return true;
+  }
+
+  result_type VisitLeafField(const std::optional<bool>& lhs, const std::optional<bool>& rhs) {
+    if (lhs.has_value() != rhs.has_value()) {
+      if constexpr (AssertMode) {
+        ThrowMismatch("optional<bool> presence mismatch", IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    if (lhs.has_value() && *lhs != *rhs) {
+      if constexpr (AssertMode) {
+        ThrowMismatch("optional<bool> value mismatch", IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    return true;
+  }
+
   result_type VisitLeafField(const ParamDirection& lhs, const ParamDirection& rhs) {
     if (lhs != rhs) {
       if constexpr (AssertMode) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -239,6 +239,20 @@ class StructuralHasher {
     return static_cast<result_type>(0);
   }
 
+  result_type VisitLeafField(const std::optional<int>& field) {
+    if (field.has_value()) {
+      return hash_combine(1, static_cast<result_type>(std::hash<int>{}(*field)));
+    }
+    return static_cast<result_type>(0);
+  }
+
+  result_type VisitLeafField(const std::optional<bool>& field) {
+    if (field.has_value()) {
+      return hash_combine(1, static_cast<result_type>(std::hash<bool>{}(*field)));
+    }
+    return static_cast<result_type>(0);
+  }
+
   result_type VisitLeafField(const ParamDirection& field) {
     return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
   }

--- a/tests/st/runtime/test_spmd.py
+++ b/tests/st/runtime/test_spmd.py
@@ -1,0 +1,184 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for SPMD (Single Program Multiple Data) execution.
+
+This module tests multi-block data-parallel dispatch using pl.cluster(core_num=N)
+and pl.tile.get_block_idx(). Each block processes a different slice of the input
+tensors and writes its result to the corresponding output region.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# --- Programs ---
+
+CORE_NUM = 4
+TILE_ROWS = 128
+TILE_COLS = 128
+TOTAL_ROWS = CORE_NUM * TILE_ROWS  # 512
+
+
+@pl.program
+class SPMDAddTensorProgram:
+    """SPMD elementwise add (tensor-level): 4 blocks each process a [128, 128] slice."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def spmd_add(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        b: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
+            for block_idx in pl.parallel(0, CORE_NUM, 1, chunk=1, chunk_policy="leading_full"):
+                offset = block_idx * TILE_ROWS
+                tile_a = pl.slice(a, [TILE_ROWS, TILE_COLS], [offset, 0])
+                tile_b = pl.slice(b, [TILE_ROWS, TILE_COLS], [offset, 0])
+                tile_c = pl.add(tile_a, tile_b)
+                out = pl.assemble(out, tile_c, [offset, 0])
+        return out
+
+
+@pl.program
+class SPMDAddProgram:
+    """SPMD elementwise add: 4 blocks each process a [128, 128] slice of a [512, 128] tensor."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def spmd_add(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        b: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        block_idx = pl.tile.get_block_idx()
+        offset = block_idx * 128
+        tile_a = pl.load(a, [offset, 0], [128, 128])
+        tile_b = pl.load(b, [offset, 0], [128, 128])
+        tile_c = pl.add(tile_a, tile_b)
+        out = pl.store(tile_c, [offset, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        b: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        with pl.cluster(core_num=4):
+            out = self.spmd_add(a, b, out)
+        return out
+
+
+# --- Test Cases ---
+
+
+class SPMDAddTestCase(PTOTestCase):
+    """SPMD add: 4 blocks, each processes [128, 128] of a [512, 128] tensor."""
+
+    def get_name(self) -> str:
+        return "spmd_add_512x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TOTAL_ROWS, TILE_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDAddProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["a"] + tensors["b"]
+
+
+class SPMDAddTensorTestCase(PTOTestCase):
+    """SPMD add (tensor-level): 4 blocks, each processes [128, 128] of a [512, 128] tensor."""
+
+    def get_name(self) -> str:
+        return "spmd_add_tensor_512x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TOTAL_ROWS, TILE_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDAddTensorProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["a"] + tensors["b"]
+
+
+class SPMDAddA5TestCase(SPMDAddTestCase):
+    """SPMD add with A5 (Ascend 950) backend."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_add_a5_512x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend950
+
+
+# --- Tests ---
+
+
+class TestSPMDOperations:
+    """Test suite for SPMD multi-block dispatch."""
+
+    def test_spmd_add(self, test_runner):
+        """SPMD add: 4 blocks each process a [128, 128] slice via get_block_idx."""
+        test_case = SPMDAddTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_spmd_add_tensor(self, test_runner):
+        """SPMD add (tensor-level): 4 blocks via pl.parallel + pl.slice/assemble."""
+        test_case = SPMDAddTensorTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.a5
+    def test_spmd_add_a5(self, test_runner):
+        """SPMD add with A5 (Ascend 950) backend."""
+        test_case = SPMDAddA5TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed (A5): {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -326,7 +326,7 @@ class TestFlattenCallInIfCondition:
             def main(
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                t__tmp_v0: pl.Scalar[pl.UINT64] = pl.tile.get_block_idx()
+                t__tmp_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
                 if t__tmp_v0 < 10:
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
@@ -390,7 +390,7 @@ class TestFlattenCallInForRange:
             def main(
                 self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                t__tmp_v0: pl.Scalar[pl.UINT64] = pl.tile.get_block_idx()
+                t__tmp_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
                 for _i in pl.range(t__tmp_v0):
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)


### PR DESCRIPTION
Add end-to-end SPMD (Single Program Multiple Data) support:

IR & Builder:
- Add Guarded chunk policy (single loop with if-guard, replaces LeadingFull as default)
- Add core_num / sync_start fields to ScopeStmt for SPMD dispatch
- Extend IRBuilder and ScopeContext with SPMD parameters

DSL:
- Add pl.spmd() context manager for SPMD block scoping
- Change default chunk_policy from "leading_full" to "guarded"
- Parse spmd() calls with core_num and sync_start arguments

Passes:
- Implement guarded chunk splitting in SplitChunkedLoopsPass
- Update ConvertTensorToTileOps for SPMD scope handling
- Propagate core_num/sync_start through outline and codegen passes

Codegen:
- Emit launch_spec with core_num/sync_start for task submission
- Support AIV-only Group dispatch for pure vector SPMD kernels
- Handle A5 vs non-A5 backend method naming (set_core_num vs set_block_num)

Tests:
- Add SPMD system test (test_spmd.py)
- Add comprehensive guarded chunk policy unit tests