### PR TITLE
feat(ir): add tile.set_validshape op for metadata-only valid-shape update

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -245,6 +245,10 @@ with ib.function("tensor_example") as f:
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations |
 | **Unary** | `tile.sqrt` | Element-wise square root |
+| **Transform** | `tile.slice` | Extract a sub-tile with static shape and optional dynamic valid_shape |
+| - | `tile.reshape` | Reshape tile to new dimensions (element count must match) |
+| - | `tile.transpose` | Swap two axes of a tile |
+| - | `tile.set_validshape` | Update valid-shape metadata without data movement |
 | **Reduction** | `tile.sum` | Reduction along axis (axis, keepdim) |
 
 **Data Flow:** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -245,6 +245,10 @@ with ib.function("tensor_example") as f:
 | **逐元素** | `tile.add/sub/mul/div` | Tile-Tile 操作 |
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
+| **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
+| - | `tile.reshape` | 重塑 tile 维度（元素总数须一致） |
+| - | `tile.transpose` | 交换 tile 的两个轴 |
+| - | `tile.set_validshape` | 更新 valid_shape 元数据，不搬移数据 |
 | **规约** | `tile.sum` | 沿轴规约（axis, keepdim） |
 
 **数据流：** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1874,6 +1874,33 @@ def transpose(tile: Expr, axis1: int, axis2: int, span: Span | None = None) -> C
     return _ir_core.create_op_call("tile.transpose", args, {}, actual_span)
 
 
+def set_validshape(
+    tile: Expr,
+    valid_rows: int | Expr,
+    valid_cols: int | Expr,
+    span: Span | None = None,
+) -> Call:
+    """Update valid-shape metadata of a tile without data movement.
+
+    Args:
+        tile: Input tile expression (must be 2D TileType)
+        valid_rows: Number of valid rows (int or Scalar INDEX expression)
+        valid_cols: Number of valid columns (int or Scalar INDEX expression)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for tile.set_validshape
+    """
+    actual_span = _get_span_or_capture(span)
+    vr_expr = (
+        valid_rows if isinstance(valid_rows, Expr) else ConstInt(valid_rows, DataType.INDEX, actual_span)
+    )
+    vc_expr = (
+        valid_cols if isinstance(valid_cols, Expr) else ConstInt(valid_cols, DataType.INDEX, actual_span)
+    )
+    return _ir_core.create_op_call("tile.set_validshape", [tile, vr_expr, vc_expr], {}, actual_span)
+
+
 # ============================================================================
 # Cross-core tpush / tpop operations
 # ============================================================================

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -82,6 +82,7 @@ __all__ = [
     "slice",
     "reshape",
     "transpose",
+    "set_validshape",
     "rem",
     "rems",
     "and_",
@@ -1180,6 +1181,24 @@ def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
     """
     tile_expr = tile.unwrap()
     call_expr = _ir_ops.transpose(tile_expr, axis1, axis2)
+    return Tile(expr=call_expr)
+
+
+def set_validshape(tile: Tile, valid_rows: IntLike, valid_cols: IntLike) -> Tile:
+    """Update valid-shape metadata of a tile without data movement.
+
+    Args:
+        tile: Input tile (must be 2D)
+        valid_rows: Number of valid rows (int or Scalar[INDEX])
+        valid_cols: Number of valid columns (int or Scalar[INDEX])
+
+    Returns:
+        Tile with updated valid_shape metadata
+    """
+    tile_expr = tile.unwrap()
+    vr = valid_rows.unwrap() if isinstance(valid_rows, Scalar) else valid_rows
+    vc = valid_cols.unwrap() if isinstance(valid_cols, Scalar) else valid_cols
+    call_expr = _ir_ops.set_validshape(tile_expr, vr, vc)
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1615,6 +1615,32 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     codegen.Emit(oss.str());
     return std::string("");
   });
+  reg("tile.set_validshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 3)
+        << "tile.set_validshape requires 3 arguments (tile, valid_rows, valid_cols), but got "
+        << op->args_.size();
+
+    std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
+    std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+
+    auto emit_index_arg = [&](const ir::ExprPtr& arg) -> std::string {
+      if (auto var = ir::As<ir::Var>(arg)) {
+        std::string mlir_name = codegen.GetVarName(var);
+        return codegen.EmitCastToIndex(var, mlir_name);
+      }
+      if (auto c = ir::As<ir::ConstInt>(arg)) {
+        return codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
+      }
+      return codegen.GetExprAsCode(arg);
+    };
+
+    std::string vr = emit_index_arg(op->args_[1]);
+    std::string vc = emit_index_arg(op->args_[2]);
+
+    codegen.Emit("pto.set_validshape " + tile_buf + ", " + vr + ", " + vc + " : " + tile_buf_type);
+    return std::string("");
+  });
 }
 
 }  // namespace backend

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1632,7 +1632,16 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       if (auto c = ir::As<ir::ConstInt>(arg)) {
         return codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
       }
-      return codegen.GetExprAsCode(arg);
+      std::string ssa = codegen.GetExprAsCode(arg);
+      if (auto st = ir::As<ir::ScalarType>(arg->GetType())) {
+        if (st->dtype_ != DataType::INDEX) {
+          std::string src_type = codegen.GetTypeString(st->dtype_);
+          std::string idx = codegen.NewTemp();
+          codegen.Emit(idx + " = arith.index_cast " + ssa + " : " + src_type + " to index");
+          return idx;
+        }
+      }
+      return ssa;
     };
 
     std::string vr = emit_index_arg(op->args_[1]);

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -490,5 +490,52 @@ REGISTER_OP("tile.concat")
       return DeduceTileConcatType(args, kwargs);
     });
 
+TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3)
+      << "tile.set_validshape requires exactly 3 arguments (tile, valid_rows, valid_cols), but got "
+      << args.size();
+
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "tile.set_validshape requires first argument to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+  CHECK(tile_type->shape_.size() == 2)
+      << "tile.set_validshape requires a 2D tile, but got rank " << tile_type->shape_.size();
+
+  auto vr_type = As<ScalarType>(args[1]->GetType());
+  CHECK(vr_type) << "tile.set_validshape valid_rows must be ScalarType, but got "
+                 << args[1]->GetType()->TypeName();
+  CHECK(IsIndexLikeDtype(vr_type->dtype_))
+      << "tile.set_validshape valid_rows must have dtype INT64, UINT64, or INDEX, but got "
+      << vr_type->dtype_.ToString();
+
+  auto vc_type = As<ScalarType>(args[2]->GetType());
+  CHECK(vc_type) << "tile.set_validshape valid_cols must be ScalarType, but got "
+                 << args[2]->GetType()->TypeName();
+  CHECK(IsIndexLikeDtype(vc_type->dtype_))
+      << "tile.set_validshape valid_cols must have dtype INT64, UINT64, or INDEX, but got "
+      << vc_type->dtype_.ToString();
+
+  TileView tile_view;
+  if (tile_type->tile_view_.has_value()) {
+    tile_view = *tile_type->tile_view_;
+  }
+  tile_view.valid_shape = {args[1], args[2]};
+
+  return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
+}
+
+REGISTER_OP("tile.set_validshape")
+    .set_op_category("TileOp")
+    .set_description("Update valid-shape metadata of a tile without data movement")
+    .add_argument("tile", "Input tile (TileType, 2D)")
+    .add_argument("valid_rows", "Number of valid rows (ScalarType INDEX/INT64/UINT64)")
+    .add_argument("valid_cols", "Number of valid columns (ScalarType INDEX/INT64/UINT64)")
+    .set_output_memory_inherit_input()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileSetValidShapeType(args, kwargs);
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -516,6 +516,18 @@ TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
       << "tile.set_validshape valid_cols must have dtype INT64, UINT64, or INDEX, but got "
       << vc_type->dtype_.ToString();
 
+  auto check_const_bound = [&](const char* name, const ExprPtr& valid, const ExprPtr& bound) {
+    if (auto c = As<ConstInt>(valid)) {
+      CHECK(c->value_ >= 0) << "tile.set_validshape " << name << " must be >= 0, got " << c->value_;
+      if (auto b = As<ConstInt>(bound)) {
+        CHECK(c->value_ <= b->value_)
+            << "tile.set_validshape " << name << " (" << c->value_ << ") exceeds tile bound " << b->value_;
+      }
+    }
+  };
+  check_const_bound("valid_rows", args[1], tile_type->shape_[0]);
+  check_const_bound("valid_cols", args[2], tile_type->shape_[1]);
+
   TileView tile_view;
   if (tile_type->tile_view_.has_value()) {
     tile_view = *tile_type->tile_view_;

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -779,6 +779,47 @@ class TestTileSliceCodegen:
             )
 
 
+class TestSetValidShapeCodegen:
+    """Tests for tile.set_validshape PTO code generation."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_set_validshape_codegen(self):
+        """tile.set_validshape should generate pto.set_validshape."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[32, 32], pl.FP32],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+                dst: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                src_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(src, [0, 0], [32, 32])
+                narrowed: pl.Tile[[32, 32], pl.FP32] = pl.tile.set_validshape(
+                    src_tile, valid_rows, valid_cols
+                )
+                return pl.store(narrowed, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.set_validshape" in mlir, (
+            f"tile.set_validshape should generate pto.set_validshape, got:\n{mlir}"
+        )
+
+
 class TestMrgSortCodegen:
     """Tests for mrgsort format1 code generation with constant and variable block_len."""
 

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -495,6 +495,7 @@ class TestOpMemorySpecRegistry:
             "tile.slice",
             "tile.transpose",
             "tile.assemble",
+            "tile.set_validshape",
         ],
     )
     def test_view_ops_inherit_from_input(self, op_name):
@@ -725,6 +726,7 @@ class TestRegistryInfrastructure:
             "tile.reshape",
             "tile.transpose",
             "tile.assemble",
+            "tile.set_validshape",
             "tile.add",
             "tile.sub",
             "tile.mul",

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1007,11 +1007,68 @@ class TestTileSliceReshapeOps:
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
 
+    def test_tile_set_validshape(self):
+        """Test tile.set_validshape with constant valid dimensions."""
+        span = ir.Span.unknown()
+
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+        tile_type = ir.TileType([dim32, dim32], DataType.FP32)
+        tile_var = ir.Var("tile", tile_type, span)
+
+        call = tile.set_validshape(tile_var, 16, 24)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.set_validshape"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP32
+        assert len(result_type.shape) == 2
+        assert result_type.tile_view is not None
+        assert len(result_type.tile_view.valid_shape) == 2
+
+    def test_tile_set_validshape_dynamic(self):
+        """Test tile.set_validshape with dynamic Scalar[INDEX] dimensions."""
+        span = ir.Span.unknown()
+
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+        tile_type = ir.TileType([dim32, dim32], DataType.FP32)
+        tile_var = ir.Var("tile", tile_type, span)
+        valid_rows = ir.Var("vr", ir.ScalarType(DataType.INDEX), span)
+        valid_cols = ir.Var("vc", ir.ScalarType(DataType.INDEX), span)
+
+        call = tile.set_validshape(tile_var, valid_rows, valid_cols)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.set_validshape"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        assert result_type.tile_view.valid_shape[0] is valid_rows
+        assert result_type.tile_view.valid_shape[1] is valid_cols
+
+    def test_tile_set_validshape_preserves_physical_shape(self):
+        """Physical shape is unchanged; only valid_shape metadata is updated."""
+        span = ir.Span.unknown()
+
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+        tile_type = ir.TileType([dim16, dim64], DataType.FP16)
+        tile_var = ir.Var("tile", tile_type, span)
+
+        call = tile.set_validshape(tile_var, 8, 32)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert isinstance(result_type.shape[0], ir.ConstInt)
+        assert result_type.shape[0].value == 16
+        assert isinstance(result_type.shape[1], ir.ConstInt)
+        assert result_type.shape[1].value == 64
+
     def test_transform_operators_registered(self):
         """Test that transform operators are registered."""
         assert ir.is_op_registered("tile.slice")
         assert ir.is_op_registered("tile.reshape")
         assert ir.is_op_registered("tile.transpose")
+        assert ir.is_op_registered("tile.set_validshape")
 
 
 class TestTileBatchMatMulOps:

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1063,6 +1063,28 @@ class TestTileSliceReshapeOps:
         assert isinstance(result_type.shape[1], ir.ConstInt)
         assert result_type.shape[1].value == 64
 
+    def test_tile_set_validshape_rejects_negative(self):
+        """Negative constant valid dimensions are rejected."""
+        span = ir.Span.unknown()
+
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        tile_type = ir.TileType([dim16, dim16], DataType.FP32)
+        tile_var = ir.Var("tile", tile_type, span)
+
+        with pytest.raises(Exception, match="must be >= 0"):
+            tile.set_validshape(tile_var, -1, 8)
+
+    def test_tile_set_validshape_rejects_exceeding_bound(self):
+        """Valid dimensions exceeding physical shape are rejected."""
+        span = ir.Span.unknown()
+
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        tile_type = ir.TileType([dim16, dim16], DataType.FP32)
+        tile_var = ir.Var("tile", tile_type, span)
+
+        with pytest.raises(Exception, match="exceeds tile bound"):
+            tile.set_validshape(tile_var, 32, 8)
+
     def test_transform_operators_registered(self):
         """Test that transform operators are registered."""
         assert ir.is_op_registered("tile.slice")


### PR DESCRIPTION
Add a new tile-level operation that updates the valid_shape metadata of a tile without moving or copying data. This maps directly to the existing pto.set_validshape PTO ISA instruction.

The op is classified as a view operation (inherit_from_input memory spec), so InitMemRef shares the MemRef with the input tile automatically.

Changes across all layers:
- C++ registration in tile_ops/transform.cpp
- Python IR wrapper in ir/op/tile_ops.py
- Python DSL wrapper in language/op/tile_ops.py
- PTO codegen in pto_ops_common.cpp
- Unit tests for tile op, registry, and codegen
- EN/ZH-CN documentation updates

Fixes #991

Made-with: Cursor