### PR TITLE
feat(passes): Append Simplify pass to tile optimization pipeline

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | InsertSync | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| Simplify | — | — | — |
 
 > **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
 
@@ -371,6 +372,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 9. `MemoryReuse`
 10. `LegalizePTOBufferReuse`
 11. `AllocateMemoryAddr`
+12. `Simplify`
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | InsertSync | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| FuseCreateAssembleToSlice | — | — | — |
 | Simplify | — | — | — |
 
 > **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
@@ -365,14 +366,16 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 2. `InferTileMemorySpace`
 3. `ResolveTransposeLayout`
 4. `ResolveBackendOpLayouts`
-5. `ExpandMixedKernel`
-6. `SplitVectorKernel`
-7. `NormalizeReturnOrder`
-8. `InitMemRef`
-9. `MemoryReuse`
-10. `LegalizePTOBufferReuse`
-11. `AllocateMemoryAddr`
-12. `Simplify`
+5. `NormalizeStmtStructure`
+6. `ExpandMixedKernel`
+7. `SplitVectorKernel`
+8. `NormalizeReturnOrder`
+9. `InitMemRef`
+10. `MemoryReuse`
+11. `LegalizePTOBufferReuse`
+12. `AllocateMemoryAddr`
+13. `FuseCreateAssembleToSlice`
+14. `Simplify`
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | InsertSync | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| FuseCreateAssembleToSlice | — | — | — |
 | Simplify | — | — | — |
 
 > **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
@@ -365,14 +366,16 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 2. `InferTileMemorySpace`
 3. `ResolveTransposeLayout`
 4. `ResolveBackendOpLayouts`
-5. `ExpandMixedKernel`
-6. `SplitVectorKernel`
-7. `NormalizeReturnOrder`
-8. `InitMemRef`
-9. `MemoryReuse`
-10. `LegalizePTOBufferReuse`
-11. `AllocateMemoryAddr`
-12. `Simplify`
+5. `NormalizeStmtStructure`
+6. `ExpandMixedKernel`
+7. `SplitVectorKernel`
+8. `NormalizeReturnOrder`
+9. `InitMemRef`
+10. `MemoryReuse`
+11. `LegalizePTOBufferReuse`
+12. `AllocateMemoryAddr`
+13. `FuseCreateAssembleToSlice`
+14. `Simplify`
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | InsertSync | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| Simplify | — | — | — |
 
 > **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
 
@@ -371,6 +372,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 9. `MemoryReuse`
 10. `LegalizePTOBufferReuse`
 11. `AllocateMemoryAddr`
+12. `Simplify`
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -146,6 +146,7 @@ class PassManager:
             ("LegalizePTOBufferReuse", lambda: passes.legalize_pto_buffer_reuse()),
             ("AllocateMemoryAddr", lambda: passes.allocate_memory_addr()),
             ("FuseCreateAssembleToSlice", lambda: passes.fuse_create_assemble_to_slice()),
+            ("Simplify", lambda: passes.simplify()),
         ]
         cls._strategy_passes = {
             OptimizationStrategy.Default: tensor_prefix_passes + tensor_only_passes + tile_pto_passes,

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -46,6 +46,7 @@ TENSOR_OPTIMIZATION_PASSES = [
     "LegalizePTOBufferReuse",
     "AllocateMemoryAddr",
     "FuseCreateAssembleToSlice",
+    "Simplify",
 ]
 
 DEBUG_TILE_OPTIMIZATION_PASSES = [
@@ -67,6 +68,7 @@ DEBUG_TILE_OPTIMIZATION_PASSES = [
     "LegalizePTOBufferReuse",
     "AllocateMemoryAddr",
     "FuseCreateAssembleToSlice",
+    "Simplify",
 ]
 
 


### PR DESCRIPTION
## Summary
- Add `Simplify` as the final pass in `tile_pto_passes`, so it runs at the end of both `Default` and `DebugTileOptimization` strategies.
- Update `docs/en/dev/passes/00-pass_manager.md` and its `zh-cn` counterpart: add `Simplify` to the per-pass properties table (empty required/produced/invalidated, matching `kSimplifyProperties{}`) and append it as step 12 of the PTO tile stage list.
- Update `TENSOR_OPTIMIZATION_PASSES` and `DEBUG_TILE_OPTIMIZATION_PASSES` in `tests/ut/ir/transforms/test_pass_manager.py` so the pipeline inventory tests reflect the new pass.

## Testing
- [x] `pytest tests/ut/ir/transforms/test_pass_manager.py` — 12 passed
- [x] Full suite via /testing skill — 3481/3499 passed prior to test-inventory fix; pass-manager tests now green after update
- [x] Code review completed
- [x] Docs (en + zh-cn) updated in sync