### PR TITLE
feat(ir): add tensor.set_validshape op with tensor-to-tile conversion

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -210,7 +210,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (update valid-shape metadata without data movement)
 
 **Example:**
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -210,7 +210,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (update valid-shape metadata without data movement)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only)
 
 **Example:**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -210,7 +210,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（更新 valid_shape 元数据，不搬移数据）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用）
 
 **示例：**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -210,7 +210,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（更新 valid_shape 元数据，不搬移数据）
 
 **示例：**
 

--- a/include/pypto/core/dtype.h
+++ b/include/pypto/core/dtype.h
@@ -299,6 +299,15 @@ class DataType {
   [[nodiscard]] bool IsInt() const { return IsSignedInt() || IsUnsignedInt(); }
 
   /**
+   * @brief Check if this data type is suitable for indexing (INT64, UINT64, or INDEX)
+   *
+   * @return true if this type can represent index values
+   */
+  [[nodiscard]] bool IsIndexLike() const {
+    return *this == DataType::INT64 || *this == DataType::UINT64 || *this == DataType::INDEX;
+  }
+
+  /**
    * @brief Equality comparison operator
    *
    * @param other The other DataType to compare with

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -879,6 +879,33 @@ def transpose(
     return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)
 
 
+def set_validshape(
+    tensor: Expr,
+    valid_rows: int | Expr,
+    valid_cols: int | Expr,
+    span: Span | None = None,
+) -> Call:
+    """Update valid-shape metadata of a tensor without data movement.
+
+    Args:
+        tensor: Input tensor expression (must be 2D TensorType)
+        valid_rows: Number of valid rows (int or Scalar INDEX expression)
+        valid_cols: Number of valid columns (int or Scalar INDEX expression)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for tensor.set_validshape
+    """
+    actual_span = _get_span_or_capture(span)
+    vr_expr = (
+        valid_rows if isinstance(valid_rows, Expr) else ConstInt(valid_rows, DataType.INDEX, actual_span)
+    )
+    vc_expr = (
+        valid_cols if isinstance(valid_cols, Expr) else ConstInt(valid_cols, DataType.INDEX, actual_span)
+    )
+    return _ir_core.create_op_call("tensor.set_validshape", [tensor, vr_expr, vc_expr], {}, actual_span)
+
+
 def scatter_update(
     input: Expr,
     *args: Expr | int,

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -887,6 +887,10 @@ def set_validshape(
 ) -> Call:
     """Update valid-shape metadata of a tensor without data movement.
 
+    .. note::
+        Internal API — this op is intended for compiler-generated code only
+        and should not be exposed to end users in future releases.
+
     Args:
         tensor: Input tensor expression (must be 2D TensorType)
         valid_rows: Number of valid rows (int or Scalar INDEX expression)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1882,6 +1882,10 @@ def set_validshape(
 ) -> Call:
     """Update valid-shape metadata of a tile without data movement.
 
+    .. note::
+        Internal API — this op is intended for compiler-generated code only
+        and should not be exposed to end users in future releases.
+
     Args:
         tile: Input tile expression (must be 2D TileType)
         valid_rows: Number of valid rows (int or Scalar INDEX expression)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -59,6 +59,7 @@ __all__ = [
     "reshape",
     "transpose",
     "scatter_update",
+    "set_validshape",
     "alloc",
 ]
 
@@ -187,6 +188,24 @@ def fillpad(tensor: Tensor, pad_value: PadValue = PadValue.zero) -> Tensor:
         Tensor wrapping the fillpad operation
     """
     call_expr = _ir_ops.fillpad(tensor.unwrap(), pad_value=pad_value)
+    return Tensor(expr=call_expr)
+
+
+def set_validshape(tensor: Tensor, valid_rows: IntLike, valid_cols: IntLike) -> Tensor:
+    """Update valid-shape metadata of a tensor without data movement.
+
+    Args:
+        tensor: Input tensor (must be 2D)
+        valid_rows: Number of valid rows (int or Scalar[INDEX])
+        valid_cols: Number of valid columns (int or Scalar[INDEX])
+
+    Returns:
+        Tensor with updated valid_shape metadata
+    """
+    tensor_expr = tensor.unwrap()
+    vr = valid_rows.unwrap() if isinstance(valid_rows, Scalar) else valid_rows
+    vc = valid_cols.unwrap() if isinstance(valid_cols, Scalar) else valid_cols
+    call_expr = _ir_ops.set_validshape(tensor_expr, vr, vc)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -194,6 +194,10 @@ def fillpad(tensor: Tensor, pad_value: PadValue = PadValue.zero) -> Tensor:
 def set_validshape(tensor: Tensor, valid_rows: IntLike, valid_cols: IntLike) -> Tensor:
     """Update valid-shape metadata of a tensor without data movement.
 
+    .. note::
+        Internal API — this op is intended for compiler-generated code only
+        and should not be exposed to end users in future releases.
+
     Args:
         tensor: Input tensor (must be 2D)
         valid_rows: Number of valid rows (int or Scalar[INDEX])

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1187,6 +1187,10 @@ def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
 def set_validshape(tile: Tile, valid_rows: IntLike, valid_cols: IntLike) -> Tile:
     """Update valid-shape metadata of a tile without data movement.
 
+    .. note::
+        Internal API — this op is intended for compiler-generated code only
+        and should not be exposed to end users in future releases.
+
     Args:
         tile: Input tile (must be 2D)
         valid_rows: Number of valid rows (int or Scalar[INDEX])

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -260,5 +260,57 @@ REGISTER_OP("tensor.concat")
       return DeduceTensorConcatType(args, kwargs);
     });
 
+TypePtr DeduceTensorSetValidShapeType(const std::vector<ExprPtr>& args,
+                                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3)
+      << "tensor.set_validshape requires exactly 3 arguments (tensor, valid_rows, valid_cols), but got "
+      << args.size();
+
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.set_validshape requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type->shape_.size() == 2)
+      << "tensor.set_validshape requires a 2D tensor, but got rank " << tensor_type->shape_.size();
+
+  auto check_scalar_index = [](const ExprPtr& arg, const char* name) {
+    auto st = As<ScalarType>(arg->GetType());
+    CHECK(st) << "tensor.set_validshape " << name << " must be ScalarType, but got "
+              << arg->GetType()->TypeName();
+    CHECK(st->dtype_ == DataType::INT64 || st->dtype_ == DataType::UINT64 || st->dtype_ == DataType::INDEX)
+        << "tensor.set_validshape " << name << " must have dtype INT64, UINT64, or INDEX, but got "
+        << st->dtype_.ToString();
+  };
+  check_scalar_index(args[1], "valid_rows");
+  check_scalar_index(args[2], "valid_cols");
+
+  auto check_const_bound = [&](const char* name, const ExprPtr& valid, const ExprPtr& bound) {
+    if (auto c = As<ConstInt>(valid)) {
+      CHECK(c->value_ >= 0) << "tensor.set_validshape " << name << " must be >= 0, got " << c->value_;
+      if (auto b = As<ConstInt>(bound)) {
+        CHECK(c->value_ <= b->value_) << "tensor.set_validshape " << name << " (" << c->value_
+                                      << ") exceeds tensor bound " << b->value_;
+      }
+    }
+  };
+  check_const_bound("valid_rows", args[1], tensor_type->shape_[0]);
+  check_const_bound("valid_cols", args[2], tensor_type->shape_[1]);
+
+  TensorView tensor_view({}, TensorLayout::ND, {args[1], args[2]});
+
+  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, std::nullopt,
+                                      std::make_optional(std::move(tensor_view)));
+}
+
+REGISTER_OP("tensor.set_validshape")
+    .set_op_category("TensorOp")
+    .set_description("Update valid-shape metadata of a tensor without data movement")
+    .add_argument("tensor", "Input tensor (TensorType, 2D)")
+    .add_argument("valid_rows", "Number of valid rows (ScalarType INDEX/INT64/UINT64)")
+    .add_argument("valid_cols", "Number of valid columns (ScalarType INDEX/INT64/UINT64)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorSetValidShapeType(args, kwargs);
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -301,9 +301,10 @@ TypePtr DeduceTensorSetValidShapeType(const std::vector<ExprPtr>& args,
                                       std::make_optional(std::move(tensor_view)));
 }
 
+// NOTE: Internal op for compiler-generated code only; should not be exposed to end users in future releases.
 REGISTER_OP("tensor.set_validshape")
     .set_op_category("TensorOp")
-    .set_description("Update valid-shape metadata of a tensor without data movement")
+    .set_description("Update valid-shape metadata of a tensor without data movement (internal)")
     .add_argument("tensor", "Input tensor (TensorType, 2D)")
     .add_argument("valid_rows", "Number of valid rows (ScalarType INDEX/INT64/UINT64)")
     .add_argument("valid_cols", "Number of valid columns (ScalarType INDEX/INT64/UINT64)")

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -276,9 +276,9 @@ TypePtr DeduceTensorSetValidShapeType(const std::vector<ExprPtr>& args,
     auto st = As<ScalarType>(arg->GetType());
     CHECK(st) << "tensor.set_validshape " << name << " must be ScalarType, but got "
               << arg->GetType()->TypeName();
-    CHECK(st->dtype_ == DataType::INT64 || st->dtype_ == DataType::UINT64 || st->dtype_ == DataType::INDEX)
-        << "tensor.set_validshape " << name << " must have dtype INT64, UINT64, or INDEX, but got "
-        << st->dtype_.ToString();
+    CHECK(st->dtype_.IsIndexLike()) << "tensor.set_validshape " << name
+                                    << " must have dtype INT64, UINT64, or INDEX, but got "
+                                    << st->dtype_.ToString();
   };
   check_scalar_index(args[1], "valid_rows");
   check_scalar_index(args[2], "valid_cols");
@@ -295,9 +295,13 @@ TypePtr DeduceTensorSetValidShapeType(const std::vector<ExprPtr>& args,
   check_const_bound("valid_rows", args[1], tensor_type->shape_[0]);
   check_const_bound("valid_cols", args[2], tensor_type->shape_[1]);
 
-  TensorView tensor_view({}, TensorLayout::ND, {args[1], args[2]});
+  TensorView tensor_view;
+  if (tensor_type->tensor_view_.has_value()) {
+    tensor_view = *tensor_type->tensor_view_;
+  }
+  tensor_view.valid_shape = {args[1], args[2]};
 
-  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, std::nullopt,
+  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, tensor_type->memref_,
                                       std::make_optional(std::move(tensor_view)));
 }
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -537,9 +537,10 @@ TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
+// NOTE: Internal op for compiler-generated code only; should not be exposed to end users in future releases.
 REGISTER_OP("tile.set_validshape")
     .set_op_category("TileOp")
-    .set_description("Update valid-shape metadata of a tile without data movement")
+    .set_description("Update valid-shape metadata of a tile without data movement (internal)")
     .add_argument("tile", "Input tile (TileType, 2D)")
     .add_argument("valid_rows", "Number of valid rows (ScalarType INDEX/INT64/UINT64)")
     .add_argument("valid_cols", "Number of valid columns (ScalarType INDEX/INT64/UINT64)")

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -77,16 +77,6 @@ int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
   return product;
 }
 
-/**
- * @brief Check whether a DataType is a valid index-like integer type
- *
- * INDEX, INT64, and UINT64 are all accepted as dimension/offset types
- * in tile operations.
- */
-bool IsIndexLikeDtype(DataType dtype) {
-  return dtype == DataType::INT64 || dtype == DataType::UINT64 || dtype == DataType::INDEX;
-}
-
 TileLayout InferTileLayoutFromShape(const std::vector<ExprPtr>& shape) {
   if (shape.size() != 2) {
     return TileLayout::row_major;
@@ -113,7 +103,7 @@ void ValidateIndexTupleElements(const TupleTypePtr& tuple_type, const std::strin
     auto scalar_type = As<ScalarType>(tuple_type->types_[i]);
     CHECK(scalar_type) << op_name << " " << arg_name << " tuple element " << i
                        << " must be ScalarType, but got " << tuple_type->types_[i]->TypeName();
-    CHECK(IsIndexLikeDtype(scalar_type->dtype_))
+    CHECK(scalar_type->dtype_.IsIndexLike())
         << op_name << " " << arg_name << " tuple element " << i
         << " must have dtype INT64, UINT64, or INDEX, but got " << scalar_type->dtype_.ToString();
   }
@@ -505,14 +495,14 @@ TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
   auto vr_type = As<ScalarType>(args[1]->GetType());
   CHECK(vr_type) << "tile.set_validshape valid_rows must be ScalarType, but got "
                  << args[1]->GetType()->TypeName();
-  CHECK(IsIndexLikeDtype(vr_type->dtype_))
+  CHECK(vr_type->dtype_.IsIndexLike())
       << "tile.set_validshape valid_rows must have dtype INT64, UINT64, or INDEX, but got "
       << vr_type->dtype_.ToString();
 
   auto vc_type = As<ScalarType>(args[2]->GetType());
   CHECK(vc_type) << "tile.set_validshape valid_cols must be ScalarType, but got "
                  << args[2]->GetType()->TypeName();
-  CHECK(IsIndexLikeDtype(vc_type->dtype_))
+  CHECK(vc_type->dtype_.IsIndexLike())
       << "tile.set_validshape valid_cols must have dtype INT64, UINT64, or INDEX, but got "
       << vc_type->dtype_.ToString();
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -124,6 +124,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterSimple("tensor.reshape", "tile.reshape");
   RegisterSimple("tensor.transpose", "tile.transpose");
   RegisterSimple("tensor.concat", "tile.concat");
+  RegisterSimple("tensor.set_validshape", "tile.set_validshape");
 
   // Memory creation ops
   RegisterSimple("tensor.full", "tile.full");

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1058,6 +1058,35 @@ def test_tensor_set_validshape_rejects_exceeding_bound():
         ir.op.tensor.set_validshape(tensor_var, 16, 64)
 
 
+def test_tensor_set_validshape_preserves_existing_view():
+    """Test tensor.set_validshape preserves existing TensorView stride and layout."""
+    span = ir.Span.unknown()
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    existing_view = ir.TensorView(
+        stride=[ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(1, DataType.INT32, span)],
+        layout=ir.TensorLayout.ND,
+        valid_shape=[dim32, dim32],
+    )
+    tensor_type = ir.TensorType([dim32, dim32], DataType.FP32, None, existing_view)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.set_validshape(tensor_var, 16, 24)
+
+    assert isinstance(call, ir.Call)
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert result_type.tensor_view.layout == ir.TensorLayout.ND
+    assert len(result_type.tensor_view.stride) == 2
+    stride_0 = result_type.tensor_view.stride[0]
+    stride_1 = result_type.tensor_view.stride[1]
+    assert isinstance(stride_0, ir.ConstInt)
+    assert isinstance(stride_1, ir.ConstInt)
+    assert stride_0.value == 64
+    assert stride_1.value == 1
+    assert len(result_type.tensor_view.valid_shape) == 2
+
+
 def test_tensor_reshape_with_valid_shape():
     """Test tensor.reshape with valid_shape parameter."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -840,6 +840,7 @@ def test_operator_registration():
     assert ir.is_op_registered("tensor.cast")
     assert ir.is_op_registered("tensor.assemble")
     assert ir.is_op_registered("tensor.fillpad")
+    assert ir.is_op_registered("tensor.set_validshape")
     assert ir.is_op_registered("tensor.maximum")
     assert ir.is_op_registered("tensor.row_expand_mul")
     assert ir.is_op_registered("tensor.row_expand_div")
@@ -996,6 +997,65 @@ def test_tensor_fillpad_clears_valid_shape():
     assert len(result_type.tensor_view.valid_shape) == 2
     assert result_type.tensor_view.valid_shape[0] == dim8
     assert result_type.tensor_view.valid_shape[1] == dim16
+
+
+def test_tensor_set_validshape():
+    """Test tensor.set_validshape sets valid-shape metadata on a 2D tensor."""
+    span = ir.Span.unknown()
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.set_validshape(tensor_var, 16, 24)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.set_validshape"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert result_type.tensor_view is not None
+    assert len(result_type.tensor_view.valid_shape) == 2
+
+
+def test_tensor_set_validshape_dynamic():
+    """Test tensor.set_validshape with dynamic scalar arguments."""
+    span = ir.Span.unknown()
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+    vr = ir.Var("vr", ir.ScalarType(DataType.INDEX), span)
+    vc = ir.Var("vc", ir.ScalarType(DataType.INDEX), span)
+
+    call = ir.op.tensor.set_validshape(tensor_var, vr, vc)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.set_validshape"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert len(result_type.tensor_view.valid_shape) == 2
+
+
+def test_tensor_set_validshape_rejects_negative():
+    """Test tensor.set_validshape rejects negative constant bounds."""
+    span = ir.Span.unknown()
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    with pytest.raises(Exception, match="must be >= 0"):
+        ir.op.tensor.set_validshape(tensor_var, -1, 16)
+
+
+def test_tensor_set_validshape_rejects_exceeding_bound():
+    """Test tensor.set_validshape rejects bounds exceeding physical shape."""
+    span = ir.Span.unknown()
+    dim32 = ir.ConstInt(32, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    with pytest.raises(Exception, match="exceeds tensor bound"):
+        ir.op.tensor.set_validshape(tensor_var, 16, 64)
 
 
 def test_tensor_reshape_with_valid_shape():

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1686,6 +1686,43 @@ class TestGmLocalTensorConversion:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_tensor_set_validshape_converts_to_tile_set_validshape(self):
+        """tensor.set_validshape should lower to tile.set_validshape via RegisterSimple."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[32, 32], pl.FP32]) -> pl.Tensor[[32, 32], pl.FP32]:
+                y: pl.Tensor[[32, 32], pl.FP32] = pl.tensor.set_validshape(x, 16, 24)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 32], pl.FP32]) -> pl.Tensor[[32, 32], pl.FP32]:
+                y: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[32, 32], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                x_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(x, [0, 0], [32, 32])
+                y_tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.set_validshape(x_tile, 16, 24)
+                out_0_store: pl.Tensor[[32, 32], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 32], pl.FP32]) -> pl.Tensor[[32, 32], pl.FP32]:
+                out_0: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor([32, 32], dtype=pl.FP32)
+                y: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_consecutive_slice_converts_to_tile_slice(self):
         """Consecutive tensor.slice: first becomes tile.load, second becomes tile.slice."""
 


### PR DESCRIPTION
Add tensor-level set_validshape for users who write tensor-level programs.
Includes C++ type deduction, Python IR/DSL wrappers, RegisterSimple
conversion to tile.set_validshape, unit tests, and documentation.