### PR TITLE
feat: add tile scatter_update PTO lowering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.32
-      PTOAS_SHA256: 325198dff677d7d163e16ce0aed27aa08c119764a4f50a60092b0edcd2e0784b
+      PTOAS_VERSION: v0.33
+      PTOAS_SHA256: 3207eafb4db5363c74c20d694c34d5e33622e2f3f225bf6b609727263832fdc5
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -172,8 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.32
-      PTOAS_SHA256: 631b19f9112e5533da3585b4ac422a0ab24ba7ac53b7d251c085390335946950
+      PTOAS_VERSION: v0.33
+      PTOAS_SHA256: 4b8bf09389b524fb5c7004083ec18ee8b0615723326ea763295bbc3c1390af4a
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -73,7 +73,7 @@ Transfer data between memory hierarchy levels.
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat). Both `offsets` and `shapes` use the source tensor's coordinate system. |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source` |
-| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
+| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile, scratch: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer; `scratch`: 2D `[1, d]` Vec tile used as a per-row temporary (created via `pl.tile.create([1, d], dtype, target_memory=Mem.Vec)`). Only `dim=-2` is supported |
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices. Sugar: `A[i, j]` |
 | `write` | `(tile: Tile, indices: IntLike \| Sequence[IntLike], value: Scalar) -> None` | Write scalar at indices. Sugar: `A[i, j] = v` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | Move tile between memory levels (including Vec→Vec) |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -70,7 +70,7 @@
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat）。`offsets` 和 `shapes` 均使用源 tensor 的坐标系。 |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source` |
-| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
+| `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile, scratch: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型；`scratch`：2D `[1, d]` Vec tile，作为逐行临时缓冲（通过 `pl.tile.create([1, d], dtype, target_memory=Mem.Vec)` 创建）。当前仅支持 `dim=-2` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -294,6 +294,10 @@ class PTOCodegen : public CodegenBase {
    */
   [[nodiscard]] std::string GetGMSlotBufferSSA() const;
 
+  /// Increase/decrease the current indentation level (used by op codegen helpers that emit scf.for blocks)
+  void IncreaseIndent() { indent_level_++; }
+  void DecreaseIndent() { indent_level_--; }
+
   /**
    * @brief Get the split value for a tile var produced by a matching tpop operation
    * @param var Raw pointer to the tile variable

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -271,6 +271,7 @@ def scatter_update(
     dim: int | Expr | None = None,
     index: Expr | None = None,
     src: Expr | None = None,
+    scratch: Expr | None = None,
     span: Span | None = None,
 ) -> Call:
     """Update tile rows at positions specified by 2D index tile with values from src.
@@ -280,34 +281,35 @@ def scatter_update(
     - 4D: input [blockNum, blockSize, 1, d], src [b, s, 1, d], index [b, s]
 
     Accepts both call forms:
-    - scatter_update(input, dim, index, src)
-    - scatter_update(input, index, src, dim=-2)
+    - scatter_update(input, dim, index, src, scratch)
+    - scatter_update(input, index, src, scratch, dim=-2)
 
     Args:
         input: Destination tile (TileType, 2D or 4D)
         dim: Dimension to scatter along (currently only -2 is supported)
         index: 2D index tile [b, s] of integer dtype
         src: Source tile (same rank as input)
+        scratch: [1, d] scratch row tile (Vec memory) used as the per-row staging buffer
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression returning a TileType with the same shape/dtype as input
     """
-    if len(args) == 3 and dim is None and index is None and src is None:
-        dim, index, src = args
-    elif len(args) == 2 and dim is not None and index is None and src is None:
-        index, src = args
-    elif len(args) == 1 and dim is None and index is not None and src is not None:
-        # (input, dim, index=..., src=...) — dim passed positionally
+    if len(args) == 4 and dim is None and index is None and src is None and scratch is None:
+        dim, index, src, scratch = args
+    elif len(args) == 3 and dim is not None and index is None and src is None and scratch is None:
+        index, src, scratch = args
+    elif len(args) == 1 and dim is None and index is not None and src is not None and scratch is not None:
+        # (input, dim, index=..., src=..., scratch=...) — dim passed positionally
         dim = args[0]
     elif len(args) != 0:
         raise TypeError(
-            "scatter_update expects (input, dim, index, src), "
-            "(input, index, src, dim=...), or (input, dim, index=..., src=...)"
+            "scatter_update expects (input, dim, index, src, scratch), "
+            "(input, index, src, scratch, dim=...), or (input, dim, index=..., src=..., scratch=...)"
         )
 
-    if dim is None or index is None or src is None:
-        raise TypeError("scatter_update requires input, dim, index, and src")
+    if dim is None or index is None or src is None or scratch is None:
+        raise TypeError("scatter_update requires input, dim, index, src, and scratch")
 
     actual_span = _get_span_or_capture(span)
     if isinstance(dim, ConstInt):
@@ -321,7 +323,9 @@ def scatter_update(
         raise TypeError(f"index must be Expr, got {type(index)}")
     if not isinstance(src, Expr):
         raise TypeError(f"src must be Expr, got {type(src)}")
-    op_args: list[Expr] = [input, index, src]
+    if not isinstance(scratch, Expr):
+        raise TypeError(f"scratch must be Expr, got {type(scratch)}")
+    op_args: list[Expr] = [input, index, src, scratch]
     kwargs: dict[str, Any] = {"dim": dim_val}
     return _ir_core.create_op_call("tile.scatter_update", op_args, kwargs, actual_span)
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -384,6 +384,7 @@ def scatter_update(
     dim: int,
     index: Tile,
     src: Tile,
+    scratch: Tile,
 ) -> Tile:
     """Update tile rows at positions specified by 2D index tile with values from src.
 
@@ -392,11 +393,12 @@ def scatter_update(
         dim: Dimension to scatter along (currently only -2 is supported)
         index: 2D index tile [b, s] of integer dtype
         src: Source tile (same rank as input)
+        scratch: [1, d] scratch row tile (Vec memory) used as the per-row staging buffer
 
     Returns:
         Tile wrapping the scatter_update operation
     """
-    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
+    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap(), scratch.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -285,6 +286,40 @@ static std::string EmitPartitionViewPTO(const std::string& name_hint, const std:
   oss << " : " << tensor_view_type << " -> " << partition_type;
   codegen.Emit(oss.str());
   return partition_view;
+}
+
+// Emit SSA ops that compute a row-major flat offset from lowered SSA index
+// values and the container shape. This mirrors GetFlatOffsetSSA(...) but uses
+// explicit arith.muli/arith.addi so the result is valid MLIR SSA, not a raw
+// textual expression.
+static std::string EmitFlatOffsetSSAFromValues(const std::vector<std::string>& indices,
+                                               const std::vector<ir::ExprPtr>& shape,
+                                               codegen::PTOCodegen& codegen, const std::string& name_hint) {
+  INTERNAL_CHECK(indices.size() == shape.size())
+      << "Index count (" << indices.size() << ") must match shape rank (" << shape.size() << ")";
+
+  INTERNAL_CHECK(!indices.empty()) << "EmitFlatOffsetSSAFromValues requires at least one index";
+  if (indices.size() == 1) {
+    return indices[0];
+  }
+
+  std::string acc = indices[0];
+  for (size_t i = 1; i < indices.size(); ++i) {
+    std::string dim_ssa;
+    if (auto c = As<ir::ConstInt>(shape[i])) {
+      dim_ssa = codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
+    } else {
+      dim_ssa = codegen.GetExprAsCode(shape[i]);
+    }
+
+    std::string mul = codegen.NewNamedTemp(name_hint + "_mul");
+    codegen.Emit(mul + " = arith.muli " + acc + ", " + dim_ssa + " : index");
+
+    std::string add = codegen.NewNamedTemp(name_hint);
+    codegen.Emit(add + " = arith.addi " + mul + ", " + indices[i] + " : index");
+    acc = add;
+  }
+  return acc;
 }
 
 // Helper function for input & output generation (with type annotations)
@@ -935,6 +970,121 @@ static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const 
   oss << ")";
 
   codegen.Emit(oss.str());
+  return "";
+}
+
+// Helper function for tile.scatter_update:
+// Implements scatter_update as an in-place update on the input tile in Vec memory:
+//   for i in [0, b):
+//     for j in [0, s):
+//       row = index[i, j]
+//       row_tile = pto.textract(src, i*s + j, 0)   // whole [1, d] row
+//       pto.tinsert(row_tile -> input, row, 0)     // write [1, d] row in-place
+//
+// Using pto.textract / pto.tinsert avoids an inner per-element scalar loop over
+// the feature dim (d), which is the performance-sensitive axis.
+static std::string MakeScatterUpdateCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 4) << op->op_->name_ << " requires 4 arguments (input, index, src, scratch), got "
+                               << op->args_.size();
+
+  auto input_type = ir::As<ir::TileType>(op->args_[0]->GetType());
+  auto index_type = ir::As<ir::TileType>(op->args_[1]->GetType());
+  auto src_type = ir::As<ir::TileType>(op->args_[2]->GetType());
+  INTERNAL_CHECK(input_type && index_type && src_type)
+      << "Internal error: tile.scatter_update arguments must be TileType";
+  CHECK(input_type->shape_.size() == 2 && src_type->shape_.size() == 2)
+      << "tile.scatter_update PTO lowering currently supports 2D input/src only, got input rank "
+      << input_type->shape_.size() << ", src rank " << src_type->shape_.size();
+
+  std::string index_ssa = codegen.GetExprAsCode(op->args_[1]);
+  std::string src_ssa = codegen.GetExprAsCode(op->args_[2]);
+
+  std::string index_type_str = codegen.GetExprTypeAnnotation(op->args_[1]);
+  std::string src_type_str = codegen.GetExprTypeAnnotation(op->args_[2]);
+
+  std::string input_ssa = codegen.GetExprAsCode(op->args_[0]);
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type_str = codegen.GetCurrentResultTileBufTypeString();
+
+  // Dimensions: index is [b, s], input is [rows, d], src is [b*s, d].
+  int64_t b_val = codegen.GetConstIntValue(index_type->shape_[0]);
+  int64_t s_val = codegen.GetConstIntValue(index_type->shape_[1]);
+
+  // Emit constants
+  std::string c0 = codegen.GetOrEmitConstant(int64_t{0}, DataType::INDEX);
+  std::string c1 = codegen.GetOrEmitConstant(int64_t{1}, DataType::INDEX);
+  std::string cb = codegen.GetOrEmitConstant(int64_t{b_val}, DataType::INDEX);
+  std::string cs = codegen.GetOrEmitConstant(int64_t{s_val}, DataType::INDEX);
+
+  // Scalar type for the scalar index read
+  std::string index_scalar_type = codegen.GetTypeString(index_type->dtype_);
+
+  // scatter_update is marked output_reuses_input(0), so dst aliases input in Vec memory.
+  INTERNAL_CHECK(!dst.empty()) << "tile.scatter_update requires a result buffer";
+  INTERNAL_CHECK(dst == input_ssa)
+      << "Internal error: tile.scatter_update result SSA must alias input SSA, got dst=" << dst
+      << ", input=" << input_ssa;
+
+  // Caller-allocated [1, d] scratch tile (4th arg) — gives PTO an addressed alloc_tile
+  // for the per-row staging buffer, avoiding ad-hoc codegen-side allocations.
+  std::string row_tile = codegen.GetExprAsCode(op->args_[3]);
+  std::string row_tile_type_str = codegen.GetExprTypeAnnotation(op->args_[3]);
+
+  // for i in [0, b)
+  std::string i_var = codegen.NewNamedTemp("i");
+  codegen.Emit("scf.for " + i_var + " = " + c0 + " to " + cb + " step " + c1 + " {");
+  codegen.IncreaseIndent();
+
+  // for j in [0, s)
+  std::string j_var = codegen.NewNamedTemp("j");
+  codegen.Emit("scf.for " + j_var + " = " + c0 + " to " + cs + " step " + c1 + " {");
+  codegen.IncreaseIndent();
+
+  // idx = i * s + j  — flat offset into index and also src row index (src is [b*s, d]).
+  std::string idx = EmitFlatOffsetSSAFromValues({i_var, j_var}, index_type->shape_, codegen, "idx");
+
+  // row_i32 = index[i, j]  (scalar read from the index tile)
+  std::string row_i32 = codegen.NewNamedTemp("row_i32");
+  {
+    std::ostringstream tgetval;
+    tgetval << row_i32 << " = pto.tgetval ins(" << index_ssa << ", " << idx;
+    if (!index_type_str.empty()) tgetval << " : " << index_type_str << ", index";
+    tgetval << ") outs : " << index_scalar_type;
+    codegen.Emit(tgetval.str());
+  }
+
+  std::string row_idx = codegen.NewNamedTemp("row_idx");
+  codegen.Emit(row_idx + " = arith.index_cast " + row_i32 + " : " + index_scalar_type + " to index");
+
+  // row_tile = src[idx, 0 : 1, d]
+  {
+    std::ostringstream textract;
+    textract << "pto.textract ins(" << src_ssa << ", " << idx << ", " << c0;
+    if (!src_type_str.empty()) textract << " : " << src_type_str << ", index, index";
+    textract << ") outs(" << row_tile;
+    if (!row_tile_type_str.empty()) textract << " : " << row_tile_type_str;
+    textract << ")";
+    codegen.Emit(textract.str());
+  }
+
+  // dst[row_idx, 0 : 1, d] = row_tile
+  {
+    std::ostringstream tinsert;
+    tinsert << "pto.tinsert ins(" << row_tile << ", " << row_idx << ", " << c0;
+    if (!row_tile_type_str.empty()) tinsert << " : " << row_tile_type_str << ", index, index";
+    tinsert << ") outs(" << dst;
+    if (!dst_type_str.empty()) tinsert << " : " << dst_type_str;
+    tinsert << ")";
+    codegen.Emit(tinsert.str());
+  }
+
+  codegen.DecreaseIndent();
+  codegen.Emit("}");
+
+  codegen.DecreaseIndent();
+  codegen.Emit("}");
+
   return "";
 }
 
@@ -2014,6 +2164,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   // tile.gather_mask (TGATHER mask form): only src operand + maskPattern attribute
   reg("tile.gather_mask", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGatherMaskCodegenPTO(op, codegen);
+  });
+  // tile.scatter_update: update input rows at scatter indices with src rows
+  reg("tile.scatter_update", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeScatterUpdateCodegenPTO(op, codegen);
   });
   // tile.mrgsort_format2 (TMRGSORT format2): all inputs and output must be row_major per ISA
   if (exclude_ops.count("tile.mrgsort_format2") == 0) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -80,8 +80,7 @@ bool IsSameDimExpr(const ExprPtr& lhs, const ExprPtr& rhs) {
 // Returns nullptr for a dimension when it is missing or is a ConstInt (static).
 // Non-ConstInt expressions (Var, Call, BinaryOp, ...) flow through as dynamic
 // and must be lowered to MLIR via GetExprAsCode at the call site.
-std::pair<ExprPtr, ExprPtr> GetTileValidShapeExprs(
-    const std::shared_ptr<const ir::TileType>& tile_type) {
+std::pair<ExprPtr, ExprPtr> GetTileValidShapeExprs(const std::shared_ptr<const ir::TileType>& tile_type) {
   ExprPtr valid_row_expr;
   ExprPtr valid_col_expr;
   if (!tile_type || !tile_type->tile_view_.has_value()) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -76,6 +76,52 @@ bool IsSameDimExpr(const ExprPtr& lhs, const ExprPtr& rhs) {
   return lhs_const && rhs_const && lhs_const->value_ == rhs_const->value_;
 }
 
+// Extract the (row, col) valid_shape expressions from a TileType's tile_view.
+// Returns nullptr for a dimension when it is missing or is a ConstInt (static).
+// Non-ConstInt expressions (Var, Call, BinaryOp, ...) flow through as dynamic
+// and must be lowered to MLIR via GetExprAsCode at the call site.
+std::pair<ExprPtr, ExprPtr> GetTileValidShapeExprs(
+    const std::shared_ptr<const ir::TileType>& tile_type) {
+  ExprPtr valid_row_expr;
+  ExprPtr valid_col_expr;
+  if (!tile_type || !tile_type->tile_view_.has_value()) {
+    return {valid_row_expr, valid_col_expr};
+  }
+
+  const auto& tile_view = tile_type->tile_view_.value();
+  if (tile_view.valid_shape.size() >= 1 && tile_view.valid_shape[0] &&
+      !As<ir::ConstInt>(tile_view.valid_shape[0])) {
+    valid_row_expr = tile_view.valid_shape[0];
+  }
+  if (tile_view.valid_shape.size() >= 2 && tile_view.valid_shape[1] &&
+      !As<ir::ConstInt>(tile_view.valid_shape[1])) {
+    valid_col_expr = tile_view.valid_shape[1];
+  }
+  return {valid_row_expr, valid_col_expr};
+}
+
+bool HasDynamicTileValidShape(const std::shared_ptr<const ir::TileType>& tile_type) {
+  auto [valid_row_expr, valid_col_expr] = GetTileValidShapeExprs(tile_type);
+  return valid_row_expr || valid_col_expr;
+}
+
+bool ShouldAliasScatterUpdateResultToInput(const AssignStmtPtr& stmt) {
+  auto call = As<ir::Call>(stmt->value_);
+  if (!call || call->op_->name_ != "tile.scatter_update" || call->args_.empty()) {
+    return false;
+  }
+
+  auto result_tile_type = ir::GetTileTypeWithMemRef(stmt->var_->GetType());
+  auto input_tile_type = ir::GetTileTypeWithMemRef(call->args_[0]->GetType());
+  if (!result_tile_type || !input_tile_type) {
+    return false;
+  }
+
+  auto result_memref = ir::GetDefinedMemRef(result_tile_type);
+  auto input_memref = ir::GetDefinedMemRef(input_tile_type);
+  return result_memref && input_memref && result_memref->base_.get() == input_memref->base_.get();
+}
+
 }  // namespace
 
 // Visitor to collect all MemRef objects from TileType variables
@@ -873,9 +919,11 @@ void PTOCodegen::EmitExtraAllocTiles() {
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   auto call = As<ir::Call>(op->value_);
   const bool is_set_validshape = call && call->op_->name_ == "tile.set_validshape";
+  const bool alias_scatter_result_to_input = ShouldAliasScatterUpdateResultToInput(op);
 
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-    if (!is_set_validshape && fs_.tpop_result_vars.count(op->var_.get()) == 0) {
+    if (!is_set_validshape && fs_.tpop_result_vars.count(op->var_.get()) == 0 &&
+        !alias_scatter_result_to_input) {
       EmitAllocTileForVar(op->var_, tile_type);
     }
   }
@@ -886,12 +934,19 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
           op->var_->name_hint_;  // Seed for readable MLIR names when no tile buffer exists.
       std::shared_ptr<const TileType> result_tile_type;
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-        // Prefer per-var SSA name from fs_.var_to_mlir (set during per-var alloc binding)
-        auto var_it = fs_.var_to_mlir.find(GetVarKey(op->var_));
-        if (var_it != fs_.var_to_mlir.end()) {
-          result_buf = var_it->second;
+        if (alias_scatter_result_to_input) {
+          result_buf = GetExprAsCode(call->args_[0]);
+          INTERNAL_CHECK(!result_buf.empty())
+              << "Internal error: tile.scatter_update result must alias the input tile SSA";
+          BindVarToMlir(op->var_, result_buf);
         } else {
-          result_buf = GetTileBufForMemRef(ir::GetDefinedMemRef(tile_type));
+          // Prefer per-var SSA name from fs_.var_to_mlir (set during per-var alloc binding)
+          auto var_it = fs_.var_to_mlir.find(GetVarKey(op->var_));
+          if (var_it != fs_.var_to_mlir.end()) {
+            result_buf = var_it->second;
+          } else {
+            result_buf = GetTileBufForMemRef(ir::GetDefinedMemRef(tile_type));
+          }
         }
         result_tile_type = tile_type;
       } else if (auto tile_type = As<TileType>(op->var_->GetType())) {

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -492,12 +492,13 @@ REGISTER_OP("tile.extract")
 
 TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
                                     const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.scatter_update(input, index, src) -> TileType same as input
-  // input: TileType 2D [rows, d] or 4D [blockNum, blockSize, 1, d]
-  // index: TileType 2D [b, s] of integer dtype
-  // src:   TileType 2D [b*s, d] or 4D [b, s, 1, d] (same rank as input)
-  CHECK(args.size() == 3) << "tile.scatter_update requires exactly 3 arguments (input, index, src), got "
-                          << args.size();
+  // tile.scatter_update(input, index, src, scratch) -> TileType same as input
+  // input:   TileType 2D [rows, d] or 4D [blockNum, blockSize, 1, d]
+  // index:   TileType 2D [b, s] of integer dtype
+  // src:     TileType 2D [b*s, d] or 4D [b, s, 1, d] (same rank as input)
+  // scratch: TileType 2D [1, d] with same dtype as input (caller-allocated row buffer)
+  CHECK(args.size() == 4)
+      << "tile.scatter_update requires exactly 4 arguments (input, index, src, scratch), got " << args.size();
 
   auto input_type = As<TileType>(args[0]->GetType());
   CHECK(input_type) << "tile.scatter_update: input must be TileType, got " << args[0]->GetType()->TypeName();
@@ -520,6 +521,19 @@ TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
       << "tile.scatter_update: src dtype (" << src_type->dtype_.ToString() << ") must match input dtype ("
       << input_type->dtype_.ToString() << ")";
 
+  auto scratch_type = As<TileType>(args[3]->GetType());
+  CHECK(scratch_type) << "tile.scatter_update: scratch must be TileType, got "
+                      << args[3]->GetType()->TypeName();
+  CHECK(scratch_type->shape_.size() == 2)
+      << "tile.scatter_update: scratch must be 2D [1, d], got rank " << scratch_type->shape_.size();
+  auto scratch_rows = As<ConstInt>(scratch_type->shape_[0]);
+  CHECK(scratch_rows && scratch_rows->value_ == 1) << "tile.scatter_update: scratch rows must be 1";
+  CHECK(AreExprsEqual(scratch_type->shape_[1], input_type->shape_.back()))
+      << "tile.scatter_update: scratch cols must match input feature dimension";
+  CHECK(scratch_type->dtype_ == input_type->dtype_)
+      << "tile.scatter_update: scratch dtype (" << scratch_type->dtype_.ToString()
+      << ") must match input dtype (" << input_type->dtype_.ToString() << ")";
+
   for (const auto& [key, val] : kwargs) {
     if (key == "dim") {
       int dim_val = AnyCast<int>(val, "kwarg key: dim");
@@ -527,7 +541,17 @@ TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
     }
   }
 
-  return std::make_shared<TileType>(input_type->shape_, input_type->dtype_);
+  // Inherit tile_view (with valid_shape = input shape) and memory_space from input,
+  // same pattern as tile.assemble — ensures tile.store can read valid_shape downstream.
+  TileView tile_view;
+  if (input_type->tile_view_.has_value()) {
+    tile_view = *input_type->tile_view_;
+  }
+  if (tile_view.valid_shape.empty()) {
+    tile_view.valid_shape = input_type->shape_;
+  }
+  return std::make_shared<TileType>(input_type->shape_, input_type->dtype_, std::nullopt, tile_view,
+                                    input_type->memory_space_);
 }
 
 REGISTER_OP("tile.scatter_update")
@@ -535,15 +559,19 @@ REGISTER_OP("tile.scatter_update")
     .set_description(
         "Update input tile rows at positions given by 2D index tile with values from src. "
         "Supports 2D input [rows, d] with 2D src [b*s, d], and 4D input [blockNum, blockSize, 1, d] "
-        "with 4D src [b, s, 1, d]. Index is always 2D [b, s] of integer dtype.")
+        "with 4D src [b, s, 1, d]. Index is always 2D [b, s] of integer dtype. Caller must pass a "
+        "[1, d] scratch tile for the per-row staging buffer.")
     .add_argument("input", "Destination tile (2D [rows, d] or 4D [blockNum, blockSize, 1, d])")
     .add_argument("index", "2D index tile [b, s] of integer dtype")
     .add_argument("src", "Source tile (2D [b*s, d] or 4D [b, s, 1, d])")
+    .add_argument("scratch", "Scratch row tile [1, d] with same dtype as input")
     .set_attr<int>("dim")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
+    .set_input_memory(3, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .set_output_reuses_input(0)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileScatterUpdateType(args, kwargs);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1481,12 +1481,13 @@ class WrapperForwardMutator : public TypePropagatingMutator {
                                     : std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
 
     auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
-    auto new_assign = MutableCopy(op);
+    std::shared_ptr<AssignStmt> new_assign = MutableCopy(op);
     new_assign->var_ = new_assign_var;
     new_assign->value_ = new_call;
     var_remap_[op->var_.get()] = new_assign_var;
     applied_ = true;
-    return new_assign;
+    StmtPtr result = new_assign;
+    return result;
   }
 
  private:

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -205,6 +205,12 @@ void OpConversionRegistry::RegisterElementwiseBinaryOps() {
 // ============================================================================
 
 void OpConversionRegistry::RegisterMemoryOps() {
+  std::unordered_map<size_t, InputSpaceReq> scatter_update_input_reqs = {
+      {0, {MemorySpace::Vec, std::nullopt}},
+      {1, {MemorySpace::Vec, std::nullopt}},
+      {2, {MemorySpace::Vec, std::nullopt}},
+  };
+
   // tensor.slice → tile.load (gm_tensor) or tile.slice (local_tensor)
   RegisterCustom(
       "tensor.slice",
@@ -304,7 +310,9 @@ void OpConversionRegistry::RegisterMemoryOps() {
         return ConversionResult{op_reg.Create("tensor.assemble", args, kwargs, span)};
       });
 
-  // tensor.scatter_update → tile.scatter_update (local) or passthrough (global)
+  // tensor.scatter_update → tile.create + tile.scatter_update(input, index, src, scratch).
+  // Mirrors the rsqrt high-precision pattern: prologue allocates a [1, d] scratch row tile
+  // via tile.create, which is then passed as the 4th arg to tile.scatter_update.
   RegisterCustom(
       "tensor.scatter_update",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -316,47 +324,38 @@ void OpConversionRegistry::RegisterMemoryOps() {
         const auto& index = args[1];
         const auto& src = args[2];
 
-        auto input_tensor_type = As<TensorType>(input->GetType());
+        auto input_tile_type = As<TileType>(input->GetType());
+        CHECK(input_tile_type) << "tensor.scatter_update: unexpected input type: "
+                               << input->GetType()->TypeName();
+        CHECK(As<TileType>(index->GetType()))
+            << "tensor.scatter_update conversion: index must become TileType, got "
+            << index->GetType()->TypeName();
+        auto src_tile_type = As<TileType>(src->GetType());
+        CHECK(src_tile_type) << "tensor.scatter_update conversion: src must become TileType, got "
+                             << src->GetType()->TypeName();
+        CHECK(src_tile_type->shape_.size() == 2)
+            << "tensor.scatter_update conversion currently supports 2D src tiles, got rank "
+            << src_tile_type->shape_.size();
 
-        if (input_tensor_type) {
-          if (kwargs.empty()) {
-            return ConversionResult{op_reg.Create("tensor.scatter_update", args, span)};
-          }
-          return ConversionResult{op_reg.Create("tensor.scatter_update", args, kwargs, span)};
-        }
+        // Allocate the [1, d] scratch row tile that tile.scatter_update needs as its
+        // per-row staging buffer. Same dtype + Vec memory as the input.
+        auto row_shape = std::make_shared<MakeTuple>(
+            std::vector<ExprPtr>{std::make_shared<ConstInt>(1, DataType::INDEX, span),
+                                 input_tile_type->shape_.back()},
+            span);
+        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", input_tile_type->dtype_},
+                                                                       {"target_memory", MemorySpace::Vec}};
+        auto create_call = op_reg.Create("tile.create", {row_shape}, create_kwargs, span);
 
-        CHECK(As<TileType>(input->GetType()))
-            << "tensor.scatter_update: unexpected input type: " << input->GetType()->TypeName();
-
+        auto scratch_var = std::make_shared<Var>("scatter_row", create_call->GetType(), span);
         std::vector<StmtPtr> prologue;
+        prologue.push_back(std::make_shared<AssignStmt>(scratch_var, create_call, span));
 
-        ExprPtr index_tile = index;
-        if (auto index_tensor_type = As<TensorType>(index->GetType())) {
-          auto offsets = MakeZeroOffsets(index_tensor_type->shape_.size(), span);
-          auto shapes = MakeShapeTuple(index_tensor_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", MemorySpace::Vec},
-                                                                   {"transpose", false}};
-          auto load = op_reg.Create("tile.load", {index, offsets, shapes, shapes}, load_kw, span);
-          auto idx_var = std::make_shared<Var>("scatter_idx", load->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(idx_var, load, span));
-          index_tile = idx_var;
-        }
-
-        ExprPtr src_tile = src;
-        if (auto src_tensor_type = As<TensorType>(src->GetType())) {
-          auto offsets = MakeZeroOffsets(src_tensor_type->shape_.size(), span);
-          auto shapes = MakeShapeTuple(src_tensor_type->shape_, span);
-          std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", MemorySpace::Vec},
-                                                                   {"transpose", false}};
-          auto load = op_reg.Create("tile.load", {src, offsets, shapes, shapes}, load_kw, span);
-          auto src_var = std::make_shared<Var>("scatter_src", load->GetType(), span);
-          prologue.push_back(std::make_shared<AssignStmt>(src_var, load, span));
-          src_tile = src_var;
-        }
-
-        auto scatter_call = op_reg.Create("tile.scatter_update", {input, index_tile, src_tile}, kwargs, span);
+        auto scatter_call =
+            op_reg.Create("tile.scatter_update", {input, index, src, scratch_var}, kwargs, span);
         return ConversionResult{std::move(prologue), scatter_call};
-      });
+      },
+      std::move(scatter_update_input_reqs));
 
   // tensor.create → tile.create with static buffer size validation
   RegisterCustom(

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -205,12 +205,6 @@ void OpConversionRegistry::RegisterElementwiseBinaryOps() {
 // ============================================================================
 
 void OpConversionRegistry::RegisterMemoryOps() {
-  std::unordered_map<size_t, InputSpaceReq> scatter_update_input_reqs = {
-      {0, {MemorySpace::Vec, std::nullopt}},
-      {1, {MemorySpace::Vec, std::nullopt}},
-      {2, {MemorySpace::Vec, std::nullopt}},
-  };
-
   // tensor.slice → tile.load (gm_tensor) or tile.slice (local_tensor)
   RegisterCustom(
       "tensor.slice",
@@ -313,6 +307,11 @@ void OpConversionRegistry::RegisterMemoryOps() {
   // tensor.scatter_update → tile.create + tile.scatter_update(input, index, src, scratch).
   // Mirrors the rsqrt high-precision pattern: prologue allocates a [1, d] scratch row tile
   // via tile.create, which is then passed as the 4th arg to tile.scatter_update.
+  std::unordered_map<size_t, InputSpaceReq> scatter_update_input_reqs = {
+      {0, {MemorySpace::Vec, std::nullopt}},
+      {1, {MemorySpace::Vec, std::nullopt}},
+      {2, {MemorySpace::Vec, std::nullopt}},
+  };
   RegisterCustom(
       "tensor.scatter_update",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,

--- a/tests/st/runtime/test_scatter_update.py
+++ b/tests/st/runtime/test_scatter_update.py
@@ -1,0 +1,575 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for tile.scatter_update.
+
+tile.scatter_update(input, index, src) updates rows in input at positions
+specified by a 2D index tile with corresponding rows from src.
+
+Hardware semantics (PTO backend):
+  tile.scatter_update generates nested scf.for loops with pto.tgetval +
+  pto.tsetval to copy src elements into dst at scattered row positions.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+
+def make_scatter_update_src_fp32() -> torch.Tensor:
+    """Return unique row-major FP32 values for scatter_update source."""
+    return torch.arange(0, 512, dtype=torch.float32).reshape(16, 32)
+
+
+def make_scatter_update_src_fp16() -> torch.Tensor:
+    """Return unique row-major FP16 values for scatter_update source."""
+    return torch.arange(0, 512, dtype=torch.float16).reshape(16, 32)
+
+
+def make_scatter_update_src_fp32_8x32() -> torch.Tensor:
+    """Return unique row-major FP32 values for single-batch scatter_update source."""
+    return torch.arange(0, 256, dtype=torch.float32).reshape(8, 32)
+
+
+def make_scatter_update_index_single_batch() -> torch.Tensor:
+    """Return index tensor for single-batch scatter_update (b=1, s=8)."""
+    return torch.tensor([[0, 4, 8, 12, 16, 20, 24, 28]], dtype=torch.int32)
+
+
+# ---------------------------------------------------------------------------
+# Kernel programs
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class TileScatterUpdateFP16Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP16],
+        index_t: pl.Tensor[[2, 8], pl.INT32],
+        src_t: pl.Tensor[[16, 32], pl.FP16],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP16]],
+    ) -> pl.Tensor[[32, 32], pl.FP16]:
+        input_tile: pl.Tile[[32, 32], pl.FP16] = pl.load(input_t, [0, 0], [32, 32])
+        index_tile: pl.Tile[[2, 8], pl.INT32] = pl.load(index_t, [0, 0], [2, 8])
+        src_tile: pl.Tile[[16, 32], pl.FP16] = pl.load(src_t, [0, 0], [16, 32])
+        scratch_tile: pl.Tile[[1, 32], pl.FP16] = pl.tile.create(
+            [1, 32], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
+        )
+        result: pl.Tile[[32, 32], pl.FP16] = pl.tile.scatter_update(
+            input_tile, dim=-2, index=index_tile, src=src_tile, scratch=scratch_tile
+        )
+        return pl.store(result, [0, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP16],
+        index_t: pl.Tensor[[2, 8], pl.INT32],
+        src_t: pl.Tensor[[16, 32], pl.FP16],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP16]],
+    ) -> pl.Tensor[[32, 32], pl.FP16]:
+        dst_t = self.kernel(input_t, index_t, src_t, dst_t)
+        return dst_t
+
+
+@pl.program
+class TileScatterUpdateSingleBatchProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[8, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        input_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(input_t, [0, 0], [32, 32])
+        index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
+        src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+        scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+            [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        result: pl.Tile[[32, 32], pl.FP32] = pl.tile.scatter_update(
+            input_tile, dim=-2, index=index_tile, src=src_tile, scratch=scratch_tile
+        )
+        return pl.store(result, [0, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[8, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(input_t, index_t, src_t, dst_t)
+        return dst_t
+
+
+@pl.program
+class TileScatterUpdateProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[2, 8], pl.INT32],
+        src_t: pl.Tensor[[16, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        input_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(input_t, [0, 0], [32, 32])
+        index_tile: pl.Tile[[2, 8], pl.INT32] = pl.load(index_t, [0, 0], [2, 8])
+        src_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(src_t, [0, 0], [16, 32])
+        scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+            [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        result: pl.Tile[[32, 32], pl.FP32] = pl.tile.scatter_update(
+            input_tile, dim=-2, index=index_tile, src=src_tile, scratch=scratch_tile
+        )
+        return pl.store(result, [0, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[2, 8], pl.INT32],
+        src_t: pl.Tensor[[16, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(input_t, index_t, src_t, dst_t)
+        return dst_t
+
+
+@pl.program
+class TensorScatterUpdateProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[2, 8], pl.INT32],
+        src_t: pl.Tensor[[16, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            result: pl.Tensor[[32, 32], pl.FP32] = pl.scatter_update(input_t, -2, index_t, src_t)
+            dst_t = pl.assemble(dst_t, result, [0, 0])
+        return dst_t
+
+
+@pl.program
+class IndexCastFromTileReadProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
+        src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
+        row: pl.Scalar[pl.INT32] = pl.tile.read(index_tile, [0, 0])
+        row_idx: pl.Scalar[pl.INDEX] = pl.cast(row, pl.INDEX)
+        return pl.store(src_tile, [row_idx, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(index_t, src_t, dst_t)
+        return dst_t
+
+
+@pl.program
+class IndexCastToTileInsertProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        input_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(input_t, [0, 0], [32, 32])
+        index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
+        src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
+        row: pl.Scalar[pl.INT32] = pl.tile.read(index_tile, [0, 0])
+        row_idx: pl.Scalar[pl.INDEX] = pl.cast(row, pl.INDEX)
+        result: pl.Tile[[32, 32], pl.FP32] = pl.tile.assemble(input_tile, src_tile, [row_idx, 0])
+        return pl.store(result, [0, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_t: pl.Tensor[[32, 32], pl.FP32],
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(input_t, index_t, src_t, dst_t)
+        return dst_t
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TileScatterUpdateTestCase(PTOTestCase):
+    """Basic scatter_update: update rows of input[32,32] at indices from index[2,8] with src[16,32].
+
+    index contains 16 row indices (b=2, s=8, total b*s=16).
+    For each flat position k in [0, 16): input[index[k], :] = src[k, :].
+    """
+
+    def get_name(self) -> str:
+        return "tile_scatter_update"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        # index values must be valid row indices into input (0..31), dtype INT32
+        # INT32 tile needs cols >= 8 for 32-byte alignment (4 bytes * 8 = 32)
+        index_data = torch.tensor(
+            [[0, 2, 4, 6, 8, 10, 12, 14], [16, 18, 20, 22, 24, 26, 28, 30]], dtype=torch.int32
+        )
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP32, init_value=torch.ones),
+            TensorSpec("index_t", [2, 8], DataType.INT32, init_value=index_data),
+            TensorSpec("src_t", [16, 32], DataType.FP32, init_value=make_scatter_update_src_fp32),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileScatterUpdateProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        input_t = tensors["input_t"].clone()
+        index_t = tensors["index_t"]
+        src_t = tensors["src_t"]
+        flat_index = index_t.reshape(-1)
+        for k in range(flat_index.shape[0]):
+            row = int(flat_index[k].item())
+            input_t[row] = src_t[k]
+        tensors["dst_t"][:] = input_t
+
+
+class TileScatterUpdateFP16TestCase(PTOTestCase):
+    """scatter_update with FP16 data type.
+
+    FP16 tiles have different alignment requirements (cols >= 16 for 32-byte alignment).
+    Validates that tgetval/tsetval correctly handle 2-byte element width.
+    """
+
+    def get_name(self) -> str:
+        return "tile_scatter_update_fp16"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        index_data = torch.tensor(
+            [[0, 2, 4, 6, 8, 10, 12, 14], [16, 18, 20, 22, 24, 26, 28, 30]], dtype=torch.int32
+        )
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP16, init_value=1.0),
+            TensorSpec("index_t", [2, 8], DataType.INT32, init_value=index_data),
+            TensorSpec("src_t", [16, 32], DataType.FP16, init_value=make_scatter_update_src_fp16),
+            TensorSpec("dst_t", [32, 32], DataType.FP16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileScatterUpdateFP16Program
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        input_t = tensors["input_t"].clone()
+        index_t = tensors["index_t"]
+        src_t = tensors["src_t"]
+        flat_index = index_t.reshape(-1)
+        for k in range(flat_index.shape[0]):
+            row = int(flat_index[k].item())
+            input_t[row] = src_t[k]
+        tensors["dst_t"][:] = input_t
+
+
+class TileScatterUpdateDuplicateIndicesTestCase(PTOTestCase):
+    """scatter_update with duplicate indices (multiple writes to the same row).
+
+    When multiple index entries point to the same row, last-write-wins semantics apply.
+    This is common in embedding lookup / attention scenarios.
+    """
+
+    def get_name(self) -> str:
+        return "tile_scatter_update_duplicate_indices"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        # Rows 0 and 1 are written multiple times; last writer (higher flat index) wins.
+        index_data = torch.tensor([[0, 1, 0, 1, 2, 3, 4, 5], [0, 1, 6, 7, 8, 9, 10, 11]], dtype=torch.int32)
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP32, init_value=torch.ones),
+            TensorSpec("index_t", [2, 8], DataType.INT32, init_value=index_data),
+            TensorSpec("src_t", [16, 32], DataType.FP32, init_value=make_scatter_update_src_fp32),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileScatterUpdateProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        input_t = tensors["input_t"].clone()
+        index_t = tensors["index_t"]
+        src_t = tensors["src_t"]
+        flat_index = index_t.reshape(-1)
+        for k in range(flat_index.shape[0]):
+            row = int(flat_index[k].item())
+            input_t[row] = src_t[k]
+        tensors["dst_t"][:] = input_t
+
+
+class TileScatterUpdateSingleBatchTestCase(PTOTestCase):
+    """scatter_update with b=1 (single batch, degenerate outer loop).
+
+    index shape [1, 8]: only one row in the batch dimension.
+    Validates that the outer loop (i in [0, b)) handles b=1 correctly.
+    """
+
+    def get_name(self) -> str:
+        return "tile_scatter_update_single_batch"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        # INT32 cols=8 satisfies 32-byte alignment (4 * 8 = 32)
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP32, init_value=torch.ones),
+            TensorSpec("index_t", [1, 8], DataType.INT32, init_value=make_scatter_update_index_single_batch),
+            TensorSpec("src_t", [8, 32], DataType.FP32, init_value=make_scatter_update_src_fp32_8x32),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileScatterUpdateSingleBatchProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        input_t = tensors["input_t"].clone()
+        index_t = tensors["index_t"]
+        src_t = tensors["src_t"]
+        flat_index = index_t.reshape(-1)
+        for k in range(flat_index.shape[0]):
+            row = int(flat_index[k].item())
+            input_t[row] = src_t[k]
+        tensors["dst_t"][:] = input_t
+
+
+class TileScatterUpdateShuffledIndicesTestCase(PTOTestCase):
+    """scatter_update with non-monotonic, shuffled indices.
+
+    Validates that flat offset calculation is correct when indices are not
+    in ascending order, which is the common case in real workloads.
+    """
+
+    def get_name(self) -> str:
+        return "tile_scatter_update_shuffled_indices"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        index_data = torch.tensor(
+            [[31, 5, 20, 3, 11, 27, 8, 15], [1, 22, 9, 30, 17, 6, 25, 13]], dtype=torch.int32
+        )
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP32, init_value=torch.ones),
+            TensorSpec("index_t", [2, 8], DataType.INT32, init_value=index_data),
+            TensorSpec("src_t", [16, 32], DataType.FP32, init_value=make_scatter_update_src_fp32),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileScatterUpdateProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        input_t = tensors["input_t"].clone()
+        index_t = tensors["index_t"]
+        src_t = tensors["src_t"]
+        flat_index = index_t.reshape(-1)
+        for k in range(flat_index.shape[0]):
+            row = int(flat_index[k].item())
+            input_t[row] = src_t[k]
+        tensors["dst_t"][:] = input_t
+
+
+class TensorScatterUpdateTestCase(TileScatterUpdateTestCase):
+    """Tensor-level scatter_update lowering should allocate addressed scratch row tile."""
+
+    def get_name(self) -> str:
+        return "tensor_scatter_update"
+
+    def get_program(self) -> Any:
+        return TensorScatterUpdateProgram
+
+
+class IndexCastFromTileReadTestCase(PTOTestCase):
+    """Isolate INT32 tile.read used as tensor offset, forcing i32 -> index cast."""
+
+    def get_name(self) -> str:
+        return "index_cast_from_tile_read"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "index_t",
+                [1, 8],
+                DataType.INT32,
+                init_value=torch.tensor([[7, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32),
+            ),
+            TensorSpec(
+                "src_t",
+                [1, 32],
+                DataType.FP32,
+                init_value=lambda: torch.arange(32, dtype=torch.float32).reshape(1, 32),
+            ),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, init_value=torch.zeros, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return IndexCastFromTileReadProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = torch.zeros_like(tensors["dst_t"])
+        row = int(tensors["index_t"][0, 0].item())
+        expected[row] = tensors["src_t"][0]
+        tensors["dst_t"][:] = expected
+
+
+class IndexCastToTileInsertTestCase(PTOTestCase):
+    """Isolate tgetval -> index_cast -> tinsert dynamic row path."""
+
+    def get_name(self) -> str:
+        return "index_cast_to_tile_insert"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("input_t", [32, 32], DataType.FP32, init_value=torch.ones),
+            TensorSpec(
+                "index_t",
+                [1, 8],
+                DataType.INT32,
+                init_value=torch.tensor([[7, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32),
+            ),
+            TensorSpec(
+                "src_t",
+                [1, 32],
+                DataType.FP32,
+                init_value=lambda: torch.arange(32, dtype=torch.float32).reshape(1, 32),
+            ),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return IndexCastToTileInsertProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = tensors["input_t"].clone()
+        row = int(tensors["index_t"][0, 0].item())
+        expected[row] = tensors["src_t"][0]
+        tensors["dst_t"][:] = expected
+
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+
+
+class TestScatterUpdateOperations:
+    """Test suite for tile.scatter_update."""
+
+    def test_tile_scatter_update(self, test_runner):
+        """Basic scatter update: 16 src rows written into input at even-numbered indices."""
+        result = test_runner.run(TileScatterUpdateTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_scatter_update_fp16(self, test_runner):
+        """Scatter update with FP16 data type (2-byte elements, different alignment)."""
+        result = test_runner.run(TileScatterUpdateFP16TestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_scatter_update_duplicate_indices(self, test_runner):
+        """Scatter update with duplicate indices (last-write-wins semantics)."""
+        result = test_runner.run(TileScatterUpdateDuplicateIndicesTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_scatter_update_single_batch(self, test_runner):
+        """Scatter update with b=1 (degenerate outer loop)."""
+        result = test_runner.run(TileScatterUpdateSingleBatchTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tile_scatter_update_shuffled_indices(self, test_runner):
+        """Scatter update with non-monotonic, shuffled index order."""
+        result = test_runner.run(TileScatterUpdateShuffledIndicesTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tensor_scatter_update(self, test_runner):
+        """Tensor-level scatter_update lowers through explicit scratch row tile."""
+        result = test_runner.run(TensorScatterUpdateTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_index_cast_from_tile_read(self, test_runner):
+        """tile.read INT32 scalar used as store offset isolates arith.index_cast lowering."""
+        result = test_runner.run(IndexCastFromTileReadTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_index_cast_to_tile_insert(self, test_runner):
+        """tile.read INT32 scalar used as tile.assemble row offset isolates tinsert lowering."""
+        result = test_runner.run(IndexCastToTileInsertTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1324,6 +1324,7 @@ class TestTileExtractCodegen:
     """Tests for tile.extract PTO code generation (pto.textract)."""
 
     def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1373,6 +1374,231 @@ class TestTileExtractCodegen:
         assert operand_count == 3, (
             f"pto.textract should have 3 ins operands (src, row, col), got {operand_count}: {line}"
         )
+
+
+class TestTileScatterUpdateCodegen:
+    """Tests for tile.scatter_update PTO code generation.
+
+    tile.scatter_update(input, index, src) should update the input tile in place.
+    PTO codegen lowers this to nested scf.for loops plus pto.tgetval/pto.textract/pto.tinsert.
+    """
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        # ExpandMixedKernel may wrap the kernel in a Group function plus AIC/AIV
+        # variants. PTOCodegen rejects Group; pick the first InCore-variant func.
+        target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
+        single = ir.Program([target], target.name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_scatter_update_emits_scf_for(self):
+        """tile.scatter_update should generate a scf.for loop over b*s iterations."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                input_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(input_t, [0, 0], [16, 32])
+                index_tile: pl.Tile[[2, 4], pl.INT32] = pl.load(index_t, [0, 0], [2, 4])
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        assert "scf.for" in mlir, f"scatter_update should generate scf.for loop, got:\n{mlir}"
+
+    def test_tile_scatter_update_emits_row_extract_and_insert(self):
+        """tile.scatter_update should read index scalar, extract src row, and insert row into dst."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                input_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(input_t, [0, 0], [16, 32])
+                index_tile: pl.Tile[[2, 4], pl.INT32] = pl.load(index_t, [0, 0], [2, 4])
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tgetval" in mlir, f"scatter_update should emit pto.tgetval for index read, got:\n{mlir}"
+        assert "pto.textract" in mlir, (
+            f"scatter_update should emit pto.textract for src row read, got:\n{mlir}"
+        )
+        assert "pto.tinsert" in mlir, (
+            f"scatter_update should emit pto.tinsert for dst row write, got:\n{mlir}"
+        )
+        assert "pto.tsetval" not in mlir, f"scatter_update should not emit scalar row writes, got:\n{mlir}"
+
+    def test_tensor_scatter_update_scratch_has_alloc_addr(self):
+        """tensor.scatter_update lowering should materialize an addressed scratch row tile."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                result: pl.Tensor[[16, 32], pl.FP32] = pl.scatter_update(input_t, -2, index_t, src_t)
+                return result
+
+        mlir = self._generate_mlir(Prog)
+        scatter_allocs = [
+            line.strip() for line in mlir.splitlines() if "scatter_row" in line and "pto.alloc_tile" in line
+        ]
+        assert scatter_allocs, f"Expected scatter_row alloc_tile, got:\n{mlir}"
+        assert all("addr =" in line for line in scatter_allocs), (
+            f"scatter_row alloc_tile must carry addr operand, got: {scatter_allocs}"
+        )
+
+    def test_tile_scatter_update_loop_bound(self):
+        """scf.for upper bound should equal b*s (here 2*4=8)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                input_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(input_t, [0, 0], [16, 32])
+                index_tile: pl.Tile[[2, 4], pl.INT32] = pl.load(index_t, [0, 0], [2, 4])
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        # b=2, s=4 → b*s=8; constant "8" should appear as loop upper bound
+        assert "8" in mlir, f"Expected loop bound 8 (b*s=2*4) in MLIR:\n{mlir}"
+
+    def test_tile_scatter_update_index_cast(self):
+        """arith.index_cast should be emitted to convert i32 index to index type."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                input_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(input_t, [0, 0], [16, 32])
+                index_tile: pl.Tile[[2, 4], pl.INT32] = pl.load(index_t, [0, 0], [2, 4])
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        assert "arith.index_cast" in mlir, f"Expected arith.index_cast in MLIR:\n{mlir}"
+
+    def test_tile_scatter_update_is_inplace(self):
+        """tile.scatter_update should reuse the input tile buffer instead of copying it."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[16, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 4], pl.INT32],
+                src_t: pl.Tensor[[8, 32], pl.FP32],
+                dst_t: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                input_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(input_t, [0, 0], [16, 32])
+                index_tile: pl.Tile[[2, 4], pl.INT32] = pl.load(index_t, [0, 0], [2, 4])
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src_t, [0, 0], [8, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tmov" not in mlir, f"scatter_update should update in place, got:\n{mlir}"
+        assert "result = pto.alloc_tile" not in mlir, (
+            f"scatter_update result should alias input tile, got:\n{mlir}"
+        )
+
+    def test_tile_scatter_update_avoids_runtime_treshape(self):
+        """tile.scatter_update should access original 2D tile buffers directly."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                input_t: pl.Tensor[[32, 32], pl.FP32],
+                index_t: pl.Tensor[[2, 8], pl.INT32],
+                src_t: pl.Tensor[[16, 32], pl.FP32],
+                dst_t: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                input_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(input_t, [0, 0], [32, 32])
+                index_tile: pl.Tile[[2, 8], pl.INT32] = pl.load(index_t, [0, 0], [2, 8])
+                src_tile: pl.Tile[[16, 32], pl.FP32] = pl.load(src_t, [0, 0], [16, 32])
+                scratch_tile: pl.Tile[[1, 32], pl.FP32] = pl.tile.create(
+                    [1, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[32, 32], pl.FP32] = pl.tile.scatter_update(
+                    input_tile, index_tile, src_tile, scratch_tile, dim=-2
+                )
+                return pl.store(result, [0, 0], dst_t)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.treshape" not in mlir, f"scatter_update should not emit runtime treshape, got:\n{mlir}"
+        assert "rows=2, cols=8" in mlir, f"Expected original index tile shape in MLIR:\n{mlir}"
+        assert "rows=16, cols=32" in mlir, f"Expected original src tile shape in MLIR:\n{mlir}"
+        assert "rows=32, cols=32" in mlir, f"Expected original dst tile shape in MLIR:\n{mlir}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2387,12 +2387,14 @@ class TestTileScatterUpdateOps:
         input_type = ir.TileType(_const_dims(span, *input_shape), dtype)
         index_type = ir.TileType(_const_dims(span, 2, 4), DataType.INT32)
         src_type = ir.TileType(_const_dims(span, *src_shape), dtype)
+        scratch_type = ir.TileType(_const_dims(span, 1, input_shape[-1]), dtype)
 
         call = tile.scatter_update(
             ir.Var("inp", input_type, span),
             -2,
             ir.Var("idx", index_type, span),
             ir.Var("src", src_type, span),
+            ir.Var("scratch", scratch_type, span),
         )
 
         assert isinstance(call, ir.Call)
@@ -2418,6 +2420,7 @@ class TestTileScatterUpdateOps:
         input_type = ir.TileType(_const_dims(span, 16, 64), DataType.FP16)
         index_type = ir.TileType(_const_dims(span, 2, 4), DataType.INT32)
         src_type = ir.TileType(_const_dims(span, 8, 64), src_dtype)
+        scratch_type = ir.TileType(_const_dims(span, 1, 64), DataType.FP16)
 
         with pytest.raises(ValueError, match=match):
             tile.scatter_update(
@@ -2425,6 +2428,7 @@ class TestTileScatterUpdateOps:
                 dim,
                 ir.Var("idx", index_type, span),
                 ir.Var("src", src_type, span),
+                ir.Var("scratch", scratch_type, span),
             )
 
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1781,14 +1781,45 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP16]],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                buf__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.create(
+                    [16, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
+                )
+                index__tile: pl.Tile[[2, 4], pl.INT32] = pl.load(
+                    index, [0, 0], [2, 4], [2, 4], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                src__tile: pl.Tile[[8, 64], pl.FP16] = pl.load(
+                    src, [0, 0], [8, 64], [8, 64], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                scatter_row: pl.Tile[[1, 64], pl.FP16] = pl.tile.create(
+                    [1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
+                )
+                result__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.scatter_update(
+                    buf__tile, -2, index__tile, src__tile, scatter_row
+                )
+                ret0__store: pl.Tensor[[16, 64], pl.FP16] = pl.store(result__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                ret0__out: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
+                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src, ret0__out)
+                return result
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        after_str = str(After)
-        # ConvertTensorToTileOps emits a tile.create([1, d]) scratch row plus a
-        # 4-arg tile.scatter_update(input, index, src, scratch) — no separate
-        # legalization pass.
-        assert "tile.scatter_update" in after_str
-        assert "scatter_row" in after_str
-        assert "tensor.scatter_update" not in after_str
+        ir.assert_structural_equal(After, Expected)
 
     def test_scatter_update_global_tensor_stays(self):
         """tensor.scatter_update on a global tensor also converts to tile.scatter_update
@@ -1816,12 +1847,47 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(kv_cache, index, src)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                kv_cache: pl.Tensor[[16, 64], pl.FP16],
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP16]],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                kv_cache__tile: pl.Tile[[16, 64], pl.FP16] = pl.load(
+                    kv_cache, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                index__tile: pl.Tile[[2, 4], pl.INT32] = pl.load(
+                    index, [0, 0], [2, 4], [2, 4], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                src__tile: pl.Tile[[8, 64], pl.FP16] = pl.load(
+                    src, [0, 0], [8, 64], [8, 64], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                scatter_row: pl.Tile[[1, 64], pl.FP16] = pl.tile.create(
+                    [1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
+                )
+                result__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.scatter_update(
+                    kv_cache__tile, -2, index__tile, src__tile, scatter_row
+                )
+                ret0__store: pl.Tensor[[16, 64], pl.FP16] = pl.store(result__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                kv_cache: pl.Tensor[[16, 64], pl.FP16],
+                index: pl.Tensor[[2, 4], pl.INT32],
+                src: pl.Tensor[[8, 64], pl.FP16],
+            ) -> pl.Tensor[[16, 64], pl.FP16]:
+                ret0__out: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
+                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(kv_cache, index, src, ret0__out)
+                return result
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        after_str = str(After)
-        # ConvertTensorToTileOps loads tensor parameters into tiles and emits a
-        # tile.create([1, d]) scratch row + 4-arg tile.scatter_update directly.
-        assert "tile.scatter_update" in after_str
-        assert "scatter_row" in after_str
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestTensorFullConversion:

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1783,7 +1783,11 @@ class TestScatterUpdateConversion:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         after_str = str(After)
+        # ConvertTensorToTileOps emits a tile.create([1, d]) scratch row plus a
+        # 4-arg tile.scatter_update(input, index, src, scratch) — no separate
+        # legalization pass.
         assert "tile.scatter_update" in after_str
+        assert "scatter_row" in after_str
         assert "tensor.scatter_update" not in after_str
 
     def test_scatter_update_global_tensor_stays(self):
@@ -1814,8 +1818,10 @@ class TestScatterUpdateConversion:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         after_str = str(After)
-        # The pass loads all tensor parameters to tiles, so scatter_update becomes tile.scatter_update
+        # ConvertTensorToTileOps loads tensor parameters into tiles and emits a
+        # tile.create([1, d]) scratch row + 4-arg tile.scatter_update directly.
         assert "tile.scatter_update" in after_str
+        assert "scatter_row" in after_str
 
 
 class TestTensorFullConversion:


### PR DESCRIPTION
## Summary

Add PTO codegen lowering for `tile.scatter_update` and the supporting IR / DSL plumbing. The op now performs a true in-place row-wise scatter using `pto.textract` + `pto.tinsert`, with a caller-allocated `[1, d]` Vec scratch row for staging.

## API change

`pl.tile.scatter_update` (and the IR `tile.scatter_update`) now takes a 5th positional argument `scratch: Tile[[1, d], dtype, Vec]`:

```python
scratch = pl.tile.create([1, d], dtype=input.dtype, target_memory=pl.Mem.Vec)
pl.tile.scatter_update(input, index, src, scratch, dim=-2)
```

`tensor.scatter_update` users are unaffected — the conversion rule allocates the scratch tile automatically. English/Chinese operation references are updated.

## What changed

### IR / op definition (`src/ir/op/tile_ops/transform.cpp`)
- `tile.scatter_update` requires 4 positional args (`input`, `index`, `src`, `scratch`); `DeduceTileScatterUpdateType` validates `scratch` shape (`[1, d]`), dtype, and feature-dim alignment with `input`.
- `set_input_memory(3, Vec)` and `set_output_reuses_input(0)`. The result `TileType` inherits `tile_view` / `memory_space` from the input (with `valid_shape` defaulted to the input shape) so downstream `tile.store` sees the correct extent.

### Tensor → tile lowering (`src/ir/transforms/op_conversion_registry.cpp`)
- The `tensor.scatter_update` rewrite rule emits a `tile.create([1, d], dtype, target_memory=Vec)` prologue producing a `scatter_row` SSA and a 4-arg `tile.scatter_update(input, index, src, scratch_var)` call. Memory-space requirements are declared via `InputSpaceReq`. No separate legalization pass is needed — scratch insertion lives in the rewrite rule itself.

### PTO codegen (`src/backend/common/pto_ops_common.cpp`, `src/codegen/pto/pto_codegen.cpp`)
- `MakeScatterUpdateCodegenPTO` emits nested `scf.for i ∈ [0, b)` / `scf.for j ∈ [0, s)`, computes the flat index via a new `EmitFlatOffsetSSAFromValues` helper (proper `arith.muli` / `arith.addi` SSA — not textual), reads `index[i, j]` with `pto.tgetval` + `arith.index_cast`, then **`pto.textract` of a `[1, d]` row from `src` into `scratch`, followed by `pto.tinsert` of that row into the input/result tile**. Replaces the prior per-element `pto.tgetval` / `pto.tsetval` inner loop.
- `pto_codegen` detects scatter_update results that share a MemRef base with their input and **suppresses the result `pto.alloc_tile`**, binding the result var's MLIR name directly to the input SSA — enforcing true in-place semantics with no aliasing surprises.
- Exposes `IncreaseIndent` / `DecreaseIndent` on `PtoCodegen` so per-op emitters can format `scf.for` blocks consistently.

### Python bindings / DSL
- `python/pypto/ir/op/tile_ops.py` and `python/pypto/language/op/tile_ops.py` updated for the 4-arg IR call form, with type checks for `scratch`.

### Tests
- New `tests/st/runtime/test_scatter_update.py` runs end-to-end through PTOAS:
  - **Tile-level scatter cases**: basic FP32, FP16 dtype, duplicate indices (last-write-wins), single-batch (`b=1`), and shuffled (non-monotonic) indices.
  - **Tensor-level end-to-end case**: `TensorScatterUpdateTestCase` exercises the full `tensor.scatter_update` → `tile.create` + `tile.scatter_update` lowering path.
  - **Isolated `arith.index_cast` lowering cases**: `IndexCastFromTileReadTestCase` (i32 tile read used as a tensor store offset) and `IndexCastToTileInsertTestCase` (i32 tile read drives a `tile.assemble` row offset, exercising the `tgetval → index_cast → tinsert` path in isolation).
- New `TestTileScatterUpdateCodegen` UT class in `tests/ut/codegen/test_pto_codegen_ops.py` asserting:
  - emitted MLIR contains `scf.for`, `pto.tgetval`, `pto.textract`, `pto.tinsert`, `arith.index_cast`,
  - emitted MLIR does **not** contain `pto.tsetval`, `pto.tmov`, or `pto.treshape`,
  - result `pto.alloc_tile` is suppressed,
  - `scatter_row` `pto.alloc_tile` is present and carries an `addr =` operand,
  - loop upper bound matches `b * s`,
  - original 2D tile shapes (`rows=…, cols=…`) are preserved (no runtime reshape).
- `tests/ut/ir/operators/test_tile_ops.py` and `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py` updated to pass / verify the `scratch` argument and the new `scatter_row` prologue.

### CI
- `PTOAS_VERSION` bumped from `v0.32` to `v0.33` in `.github/workflows/ci.yml` (with matching SHA256), required for the updated `TLOAD → SetValue` sync handling that this lowering depends on.

## Testing
- `cmake --build build --parallel`
- `export PYTHONPATH=$(pwd)/python:$PYTHONPATH && python -m pytest tests/ut/codegen/test_pto_codegen_ops.py -k scatter_update tests/ut/ir/operators/test_tile_ops.py -k scatter tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py -k scatter -v`
- `task-submit --device auto --run pytest tests/st/runtime/test_scatter_update.py -v --platform=a2a3 --save-kernels --device TASK_DEVICE`

Fixes #920
