### PR TITLE
feat(runtime): persist golden tensor data as .pt files with reusable data_dir

### DIFF
--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -109,7 +109,10 @@ def write_golden(
         The resolved ``output_path`` after writing.
     """
     output_path = Path(output_path)
-    resolved_dir = Path(data_dir).resolve() if data_dir is not None else output_path.parent / "data"
+    if data_dir is not None:
+        resolved_dir = Path(data_dir).resolve()
+    else:
+        resolved_dir = (output_path.parent / "data").resolve()
 
     if not _data_dir_has_files(resolved_dir, tensor_specs):
         data = _materialize_tensors(tensor_specs)
@@ -121,7 +124,8 @@ def write_golden(
         rtol,
         atol,
         scalar_specs=scalar_specs,
-        data_dir=resolved_dir,
+        data_dir=resolved_dir if data_dir is not None else None,
+        use_data_files=True,
     )
     output_path.write_text(content, encoding="utf-8")
     return output_path
@@ -136,6 +140,7 @@ def generate_golden_source(
     compute_golden_src: str | None = None,
     scalar_specs: list[ScalarSpec] | None = None,
     data_dir: Path | None = None,
+    use_data_files: bool = False,
 ) -> str:
     """Build the full content of golden.py as a string.
 
@@ -152,14 +157,19 @@ def generate_golden_source(
         scalar_specs: Optional list of scalar TaskArg specifications.  Entries are
             placed after all tensor entries in the returned list, matching the
             TaskArg slot order produced by orchestration codegen.
-        data_dir: When set, the generated ``generate_inputs`` loads all tensors
-            from ``.pt`` files via ``torch.load`` using a ``_DATA_DIR`` constant
-            pointing to this path.  When ``None`` (default), the legacy
-            inline-expression mode is used.
+        data_dir: When set, the generated ``_DATA_DIR`` constant uses this
+            absolute path.  When ``None`` and *use_data_files* is ``True``,
+            a portable ``Path(__file__).parent / "data"`` expression is used.
+        use_data_files: When ``True``, the generated ``generate_inputs``
+            loads all tensors from ``.pt`` files via ``torch.load``.
+            Defaults to ``False`` for backward compatibility with callers
+            that rely on inline expressions.
 
     Returns:
         Full Python source for ``golden.py`` as a string.
     """
+    emit_data_dir = use_data_files or data_dir is not None
+
     scalars = scalar_specs or []
     output_names = [spec.name for spec in tensor_specs if spec.is_output]
 
@@ -172,14 +182,14 @@ def generate_golden_source(
     imports = _compute_golden_imports(compute_golden_src)
     if scalars:
         imports.append("import ctypes")
-    if data_dir is not None:
+    if emit_data_dir:
         imports.append("from pathlib import Path")
     imports.append("import torch")
 
     # Pre-compute init expressions so that helper function preambles (e.g. for
     # callable init_values) are collected before we start building the output.
     preambles: dict[str, str] = {}
-    init_exprs = [_init_expr(spec, preambles, use_data_dir=data_dir is not None) for spec in tensor_specs]
+    init_exprs = [_init_expr(spec, preambles, use_data_dir=emit_data_dir) for spec in tensor_specs]
 
     lines: list[str] = [
         '"""',
@@ -191,10 +201,13 @@ def generate_golden_source(
         *imports,
     ]
 
-    if data_dir is not None:
+    if emit_data_dir:
         lines.append("")
-        escaped = str(data_dir).replace("\\", "\\\\")
-        lines.append(f'_DATA_DIR = Path("{escaped}")')
+        if data_dir is not None:
+            escaped = str(data_dir).replace("\\", "\\\\")
+            lines.append(f'_DATA_DIR = Path("{escaped}")')
+        else:
+            lines.append('_DATA_DIR = Path(__file__).parent / "data"')
 
     lines.extend(
         [

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -13,17 +13,28 @@ Golden script writer for the PyPTO runtime module.
 Generates a ``golden.py`` file compatible with Simpler's CodeRunner from a list
 of :class:`TensorSpec` objects and a user-supplied golden function.
 
-Generated file format::
+:func:`write_golden` materialises all tensor data via
+:meth:`TensorSpec.create_tensor` and saves them as ``.pt`` files.  By default
+data goes to a ``data/`` directory co-located with ``golden.py``; an explicit
+``data_dir`` can redirect storage to any path.  When the target directory
+already contains the required files they are reused.  The generated
+``generate_inputs`` function loads tensors via ``torch.load``, ensuring
+deterministic and reproducible inputs across runs.
 
+Generated file format (data-file mode)::
+
+    from pathlib import Path
     import torch
+
+    _DATA_DIR = Path(__file__).parent / "data"
 
     __outputs__ = ["out"]
     RTOL = 1e-5
     ATOL = 1e-5
 
     def generate_inputs(params):
-        query = torch.randn((32, 128), dtype=torch.bfloat16)
-        out   = torch.zeros((32, 128), dtype=torch.float32)
+        query = torch.load(_DATA_DIR / "query.pt", weights_only=True)
+        out   = torch.load(_DATA_DIR / "out.pt", weights_only=True)
         return [
             ("query", query),
             ("out", out),
@@ -66,8 +77,17 @@ def write_golden(
     rtol: float = 1e-5,
     atol: float = 1e-5,
     scalar_specs: list[ScalarSpec] | None = None,
+    data_dir: Path | str | None = None,
 ) -> Path:
     """Generate and write a ``golden.py`` file for Simpler's CodeRunner.
+
+    By default, all tensor data is materialised and saved as ``.pt`` files in a
+    ``data/`` subdirectory alongside the generated ``golden.py``.
+
+    When *data_dir* is provided the generated ``golden.py`` always references
+    that directory.  If the directory already contains ``.pt`` files they are
+    reused; otherwise the directory is created and data files are generated
+    there.
 
     Args:
         tensor_specs: Ordered list of tensor specifications matching the program's
@@ -79,12 +99,30 @@ def write_golden(
         atol: Absolute tolerance used by CodeRunner for result comparison.
         scalar_specs: Optional list of scalar parameter specifications.  Scalar
             TaskArg entries appear after all tensor entries in the generated list.
+        data_dir: Target directory for ``.pt`` data files.  If the directory
+            exists and already contains data, it is reused without regeneration.
+            If it does not exist it is created and data is generated there.
+            The generated ``golden.py`` always references this path.
+            When ``None`` (default), data is saved to ``<output_path>/../data/``.
 
     Returns:
         The resolved ``output_path`` after writing.
     """
-    content = generate_golden_source(tensor_specs, golden_fn, rtol, atol, scalar_specs=scalar_specs)
     output_path = Path(output_path)
+    resolved_dir = Path(data_dir).resolve() if data_dir is not None else output_path.parent / "data"
+
+    if not _data_dir_has_files(resolved_dir, tensor_specs):
+        data = _materialize_tensors(tensor_specs)
+        _save_data_files(data, resolved_dir)
+
+    content = generate_golden_source(
+        tensor_specs,
+        golden_fn,
+        rtol,
+        atol,
+        scalar_specs=scalar_specs,
+        data_dir=resolved_dir,
+    )
     output_path.write_text(content, encoding="utf-8")
     return output_path
 
@@ -97,6 +135,7 @@ def generate_golden_source(
     *,
     compute_golden_src: str | None = None,
     scalar_specs: list[ScalarSpec] | None = None,
+    data_dir: Path | None = None,
 ) -> str:
     """Build the full content of golden.py as a string.
 
@@ -113,6 +152,10 @@ def generate_golden_source(
         scalar_specs: Optional list of scalar TaskArg specifications.  Entries are
             placed after all tensor entries in the returned list, matching the
             TaskArg slot order produced by orchestration codegen.
+        data_dir: When set, the generated ``generate_inputs`` loads all tensors
+            from ``.pt`` files via ``torch.load`` using a ``_DATA_DIR`` constant
+            pointing to this path.  When ``None`` (default), the legacy
+            inline-expression mode is used.
 
     Returns:
         Full Python source for ``golden.py`` as a string.
@@ -129,12 +172,14 @@ def generate_golden_source(
     imports = _compute_golden_imports(compute_golden_src)
     if scalars:
         imports.append("import ctypes")
+    if data_dir is not None:
+        imports.append("from pathlib import Path")
     imports.append("import torch")
 
     # Pre-compute init expressions so that helper function preambles (e.g. for
     # callable init_values) are collected before we start building the output.
     preambles: dict[str, str] = {}
-    init_exprs = [_init_expr(spec, preambles) for spec in tensor_specs]
+    init_exprs = [_init_expr(spec, preambles, use_data_dir=data_dir is not None) for spec in tensor_specs]
 
     lines: list[str] = [
         '"""',
@@ -144,11 +189,21 @@ def generate_golden_source(
         '"""',
         "",
         *imports,
-        "",
-        f"__outputs__ = {output_names!r}",
-        f"RTOL = {rtol}",
-        f"ATOL = {atol}",
     ]
+
+    if data_dir is not None:
+        lines.append("")
+        escaped = str(data_dir).replace("\\", "\\\\")
+        lines.append(f'_DATA_DIR = Path("{escaped}")')
+
+    lines.extend(
+        [
+            "",
+            f"__outputs__ = {output_names!r}",
+            f"RTOL = {rtol}",
+            f"ATOL = {atol}",
+        ]
+    )
 
     # Helper functions referenced by init expressions (e.g. copied from
     # callable init_values).
@@ -191,6 +246,27 @@ def generate_golden_source(
 # ---------------------------------------------------------------------------
 
 
+def _data_dir_has_files(data_dir: Path, tensor_specs: list[TensorSpec]) -> bool:
+    """Return ``True`` if *data_dir* already contains all required ``.pt`` files."""
+    if not data_dir.is_dir():
+        return False
+    return all((data_dir / f"{spec.name}.pt").exists() for spec in tensor_specs)
+
+
+def _materialize_tensors(tensor_specs: list[TensorSpec]) -> dict[str, torch.Tensor]:
+    """Create concrete tensors from specs and return them keyed by name."""
+    return {spec.name: spec.create_tensor() for spec in tensor_specs}
+
+
+def _save_data_files(data_files: dict[str, torch.Tensor], data_dir: Path) -> None:
+    """Save materialised tensors to ``data_dir/{name}.pt``."""
+    if not data_files:
+        return
+    data_dir.mkdir(parents=True, exist_ok=True)
+    for name, tensor in data_files.items():
+        torch.save(tensor, data_dir / f"{name}.pt")
+
+
 def _compute_golden_imports(compute_golden_src: str) -> list[str]:
     """Return import lines required by the generated compute_golden body."""
     return [
@@ -200,13 +276,24 @@ def _compute_golden_imports(compute_golden_src: str) -> list[str]:
     ]
 
 
-def _init_expr(spec: TensorSpec, preambles: dict[str, str]) -> str:
+def _init_expr(
+    spec: TensorSpec,
+    preambles: dict[str, str],
+    *,
+    use_data_dir: bool = False,
+) -> str:
     """Return the Python expression (string) used to initialise this tensor in golden.py.
 
-    For callable init_values that are not built-in factories, the function
-    source is extracted and appended to *preambles* so it can be emitted
-    before ``generate_inputs`` in the generated file.
+    When *use_data_dir* is ``True``, returns a ``torch.load(...)`` expression
+    referencing a ``.pt`` file via the ``_DATA_DIR`` constant.
+
+    When ``False`` (legacy mode), callable init_values that are not built-in
+    factories have their source extracted and appended to *preambles* for
+    emission before ``generate_inputs``.
     """
+    if use_data_dir:
+        return f'torch.load(_DATA_DIR / "{spec.name}.pt", weights_only=True)'
+
     dtype_str = _torch_dtype_str(spec.dtype)
     shape_str = repr(tuple(spec.shape))
 

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -255,6 +255,13 @@ class RunConfig:
             default (``PrePipeline``, or ``PYPTO_WARNING_LEVEL`` env var).
         disabled_warnings: Set of warning checks to disable during compilation.
             ``None`` uses the default (``UnusedControlFlowResult`` disabled).
+        golden_data_dir: Target directory for ``.pt`` data files.  When set,
+            the generated ``golden.py`` always loads tensors from this path.
+            If the directory already contains all required ``.pt`` files they
+            are reused; otherwise the directory is created and data is generated
+            there.  Use a path from a previous run
+            (e.g. ``build_output/<name>_<ts>/data``) to reuse existing golden
+            data, or specify a new path to persist data to a fixed location.
     """
 
     __test__ = False  # Not a pytest test class
@@ -274,6 +281,7 @@ class RunConfig:
     compile_profiling: bool = False
     warning_level: WarningLevel | None = None
     disabled_warnings: WarningCheckSet | None = None
+    golden_data_dir: str | None = None
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
@@ -446,7 +454,14 @@ def run(
         # 3. Write golden.py
         golden_path = work_dir / "golden.py"
         with _stage("golden_write"):
-            write_golden(tensor_specs, golden, golden_path, rtol=config.rtol, atol=config.atol)
+            write_golden(
+                tensor_specs,
+                golden,
+                golden_path,
+                rtol=config.rtol,
+                atol=config.atol,
+                data_dir=config.golden_data_dir,
+            )
 
         # 4. Execute via Simpler's CodeRunner
         with _stage("device_execution"):

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -167,7 +167,7 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
         test_case.config.atol,
         compute_golden_src=compute_golden_src,
         scalar_specs=test_case.scalar_specs or None,
-        data_dir=data_dir.resolve(),
+        use_data_files=True,
     )
     output_path.write_text(write_golden_src, encoding="utf-8")
 

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -35,7 +35,12 @@ import pytest
 import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
-from pypto.runtime.golden_writer import _extract_compute_golden, generate_golden_source
+from pypto.runtime.golden_writer import (
+    _extract_compute_golden,
+    _materialize_tensors,
+    _save_data_files,
+    generate_golden_source,
+)
 from pypto.runtime.runner import (
     _BINARY_RUNTIME_CACHE,
     RunConfig,
@@ -152,6 +157,9 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
         lines.append('    raise NotImplementedError("compute_expected source extraction failed")')
         compute_golden_src = "\n".join(lines)
 
+    data_dir = output_path.parent / "data"
+    data = _materialize_tensors(runtime_specs)
+    _save_data_files(data, data_dir)
     write_golden_src = generate_golden_source(
         runtime_specs,
         None,
@@ -159,6 +167,7 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
         test_case.config.atol,
         compute_golden_src=compute_golden_src,
         scalar_specs=test_case.scalar_specs or None,
+        data_dir=data_dir.resolve(),
     )
     output_path.write_text(write_golden_src, encoding="utf-8")
 

--- a/tests/ut/codegen/test_golden_writer.py
+++ b/tests/ut/codegen/test_golden_writer.py
@@ -15,6 +15,7 @@ from pypto.runtime.golden_writer import (
     _extract_closure_constants,
     _extract_compute_golden,
     generate_golden_source,
+    write_golden,
 )
 from pypto.runtime.tensor_spec import ScalarSpec, TensorSpec
 
@@ -324,6 +325,223 @@ class TestExtractClosureConstants:
         src = _extract_compute_golden(my_golden)
         assert "factor = 5" in src
         assert src.index("factor = 5") < src.index("def compute_golden(")
+
+
+class TestDataFileMode:
+    """Tests for data-file persistence mode (data_dir parameter)."""
+
+    def test_golden_source_uses_torch_load(self, tmp_path):
+        """All tensor init expressions use torch.load when data_dir is set."""
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=1.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        src = generate_golden_source(
+            specs,
+            _dummy_golden,
+            1e-5,
+            1e-5,
+            data_dir=tmp_path,
+        )
+
+        assert 'torch.load(_DATA_DIR / "a.pt"' in src
+        assert 'torch.load(_DATA_DIR / "out.pt"' in src
+        assert "torch.full" not in src
+        assert "torch.zeros" not in src
+
+    def test_data_dir_constant_present(self, tmp_path):
+        """Generated source includes _DATA_DIR when data_dir is set."""
+        specs = [TensorSpec("x", [2], torch.float32, init_value=1.0)]
+        src = generate_golden_source(
+            specs,
+            _dummy_golden,
+            1e-5,
+            1e-5,
+            data_dir=tmp_path,
+        )
+
+        assert f'_DATA_DIR = Path("{tmp_path.resolve()}")' in src
+        assert "from pathlib import Path" in src
+
+    def test_no_data_dir_legacy_mode(self):
+        """_DATA_DIR is absent when data_dir is None (legacy mode)."""
+        specs = [TensorSpec("x", [2], torch.float32, init_value=1.0)]
+        src = generate_golden_source(specs, _dummy_golden, 1e-5, 1e-5)
+
+        assert "_DATA_DIR" not in src
+        assert "from pathlib import Path" not in src
+
+    def test_legacy_mode_preserves_inline(self):
+        """Legacy mode (data_dir=None) keeps inline expressions."""
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=1.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        src = generate_golden_source(specs, _dummy_golden, 1e-5, 1e-5)
+
+        assert "torch.full" in src
+        assert "torch.zeros" in src
+        assert "torch.load" not in src
+
+    def test_write_golden_creates_data_dir(self, tmp_path):
+        """write_golden creates data/ directory with .pt files."""
+        specs = [
+            TensorSpec("a", [8], torch.float32, init_value=torch.randn),
+            TensorSpec("b", [8], torch.float32, init_value=2.0),
+            TensorSpec("out", [8], torch.float32, is_output=True),
+        ]
+        golden_path = tmp_path / "golden.py"
+        write_golden(specs, _dummy_golden, golden_path)
+
+        data_dir = tmp_path / "data"
+        assert data_dir.is_dir()
+        assert (data_dir / "a.pt").exists()
+        assert (data_dir / "b.pt").exists()
+        assert (data_dir / "out.pt").exists()
+
+    def test_write_golden_roundtrip(self, tmp_path):
+        """Generated golden.py is executable and loads persisted data."""
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=3.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        golden_path = tmp_path / "golden.py"
+        write_golden(specs, _dummy_golden, golden_path)
+
+        src = golden_path.read_text(encoding="utf-8")
+        namespace: dict[str, object] = {"__file__": str(golden_path)}
+        exec(compile(src, str(golden_path), "exec"), namespace)  # noqa: S102
+
+        result = namespace["generate_inputs"](None)
+        a_tensor = result[0][1]
+        assert torch.equal(a_tensor, torch.full((4,), 3.0, dtype=torch.float32))
+
+        out_tensor = result[1][1]
+        assert torch.equal(out_tensor, torch.zeros(4, dtype=torch.float32))
+
+    def test_write_golden_large_tensor(self, tmp_path):
+        """Large tensors (>100 elements) work in data-file mode."""
+        large = torch.arange(0, 200, dtype=torch.float32)
+        specs = [
+            TensorSpec("big", [200], torch.float32, init_value=large),
+            TensorSpec("out", [200], torch.float32, is_output=True),
+        ]
+        golden_path = tmp_path / "golden.py"
+        write_golden(specs, _dummy_golden, golden_path)
+
+        data_dir = tmp_path / "data"
+        assert (data_dir / "big.pt").exists()
+
+        loaded = torch.load(data_dir / "big.pt", weights_only=True)
+        assert torch.equal(loaded, large)
+
+    def test_write_golden_random_factory_persisted(self, tmp_path):
+        """torch.randn init_value is materialised once and persisted."""
+        specs = [
+            TensorSpec("r", [16], torch.float32, init_value=torch.randn),
+            TensorSpec("out", [16], torch.float32, is_output=True),
+        ]
+        golden_path = tmp_path / "golden.py"
+        write_golden(specs, _dummy_golden, golden_path)
+
+        saved = torch.load(tmp_path / "data" / "r.pt", weights_only=True)
+
+        src = golden_path.read_text(encoding="utf-8")
+        namespace: dict[str, object] = {"__file__": str(golden_path)}
+        exec(compile(src, str(golden_path), "exec"), namespace)  # noqa: S102
+        result = namespace["generate_inputs"](None)
+        loaded = result[0][1]
+
+        assert torch.equal(loaded, saved)
+
+    def test_scalars_still_inline_in_data_file_mode(self, tmp_path):
+        """ScalarSpec entries remain inline ctypes even with data_dir."""
+        specs = [
+            TensorSpec("x", [4], torch.float32, init_value=1.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        scalars = [ScalarSpec("factor", 3, ctype="int64")]
+        src = generate_golden_source(
+            specs,
+            _dummy_golden,
+            1e-5,
+            1e-5,
+            scalar_specs=scalars,
+            data_dir=tmp_path,
+        )
+
+        assert "factor = ctypes.c_int64(3)" in src
+        assert "import ctypes" in src
+
+    def test_external_data_dir_generates_absolute_path(self, tmp_path):
+        """When data_dir is specified, generated source uses absolute path."""
+        ext_dir = tmp_path / "external_data"
+        ext_dir.mkdir()
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=1.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        src = generate_golden_source(
+            specs,
+            _dummy_golden,
+            1e-5,
+            1e-5,
+            data_dir=ext_dir,
+        )
+
+        assert f'_DATA_DIR = Path("{ext_dir.resolve()}")' in src
+        assert 'torch.load(_DATA_DIR / "a.pt"' in src
+        assert "from pathlib import Path" in src
+
+    def test_write_golden_reuses_existing_data_dir(self, tmp_path):
+        """write_golden with existing data_dir reuses files without regeneration."""
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        expected = torch.full((4,), 7.0, dtype=torch.float32)
+        torch.save(expected, ext_dir / "a.pt")
+        torch.save(torch.zeros(4, dtype=torch.float32), ext_dir / "out.pt")
+
+        golden_path = tmp_path / "out" / "golden.py"
+        golden_path.parent.mkdir()
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=1.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        write_golden(specs, _dummy_golden, golden_path, data_dir=ext_dir)
+
+        assert not (golden_path.parent / "data").exists()
+
+        src = golden_path.read_text(encoding="utf-8")
+        namespace: dict[str, object] = {"__file__": str(golden_path)}
+        exec(compile(src, str(golden_path), "exec"), namespace)  # noqa: S102
+
+        result = namespace["generate_inputs"](None)
+        a_tensor = result[0][1]
+        assert torch.equal(a_tensor, expected)
+
+    def test_write_golden_creates_missing_data_dir(self, tmp_path):
+        """write_golden creates data_dir and generates data when dir is absent."""
+        ext_dir = tmp_path / "new_data"
+        golden_path = tmp_path / "golden.py"
+        specs = [
+            TensorSpec("a", [4], torch.float32, init_value=3.0),
+            TensorSpec("out", [4], torch.float32, is_output=True),
+        ]
+        write_golden(specs, _dummy_golden, golden_path, data_dir=ext_dir)
+
+        assert ext_dir.is_dir()
+        assert (ext_dir / "a.pt").exists()
+        assert (ext_dir / "out.pt").exists()
+        assert not (tmp_path / "data").exists()
+
+        src = golden_path.read_text(encoding="utf-8")
+        assert f'_DATA_DIR = Path("{ext_dir.resolve()}")' in src
+
+        namespace: dict[str, object] = {"__file__": str(golden_path)}
+        exec(compile(src, str(golden_path), "exec"), namespace)  # noqa: S102
+        result = namespace["generate_inputs"](None)
+        a_tensor = result[0][1]
+        assert torch.equal(a_tensor, torch.full((4,), 3.0, dtype=torch.float32))
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_golden_writer.py
+++ b/tests/ut/codegen/test_golden_writer.py
@@ -349,8 +349,8 @@ class TestDataFileMode:
         assert "torch.full" not in src
         assert "torch.zeros" not in src
 
-    def test_data_dir_constant_present(self, tmp_path):
-        """Generated source includes _DATA_DIR when data_dir is set."""
+    def test_explicit_data_dir_uses_absolute_path(self, tmp_path):
+        """Explicit data_dir generates _DATA_DIR with absolute path."""
         specs = [TensorSpec("x", [2], torch.float32, init_value=1.0)]
         src = generate_golden_source(
             specs,
@@ -362,6 +362,21 @@ class TestDataFileMode:
 
         assert f'_DATA_DIR = Path("{tmp_path.resolve()}")' in src
         assert "from pathlib import Path" in src
+
+    def test_use_data_files_generates_relative_path(self):
+        """use_data_files=True without data_dir generates portable relative path."""
+        specs = [TensorSpec("x", [2], torch.float32, init_value=1.0)]
+        src = generate_golden_source(
+            specs,
+            _dummy_golden,
+            1e-5,
+            1e-5,
+            use_data_files=True,
+        )
+
+        assert '_DATA_DIR = Path(__file__).parent / "data"' in src
+        assert "from pathlib import Path" in src
+        assert 'torch.load(_DATA_DIR / "x.pt"' in src
 
     def test_no_data_dir_legacy_mode(self):
         """_DATA_DIR is absent when data_dir is None (legacy mode)."""
@@ -409,6 +424,8 @@ class TestDataFileMode:
         write_golden(specs, _dummy_golden, golden_path)
 
         src = golden_path.read_text(encoding="utf-8")
+        assert '_DATA_DIR = Path(__file__).parent / "data"' in src
+
         namespace: dict[str, object] = {"__file__": str(golden_path)}
         exec(compile(src, str(golden_path), "exec"), namespace)  # noqa: S102
 


### PR DESCRIPTION
Materialise all TensorSpec tensors to .pt files so golden inputs are deterministic across runs.  write_golden() saves data to a co-located data/ directory by default; a new data_dir parameter (exposed via RunConfig.golden_data_dir) lets callers redirect storage to a fixed path.  When the target directory already contains the required files they are reused without regeneration.

- Add _materialize_tensors / _save_data_files / _data_dir_has_files helpers
- generate_golden_source accepts data_dir to emit torch.load expressions
- RunConfig gains golden_data_dir; run() forwards it to write_golden
- ST harness test_runner uses the same data_dir flow
- 12 new unit tests covering roundtrip, reuse, and missing-dir creation