### PR TITLE
feat(ir): Preserve DSL comments as Stmt leading_comments metadata

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -164,28 +164,40 @@ field from the `Stmt` base class. See [Leading comments on statements](#leading-
 
 Each `Stmt` carries an optional `leading_comments_: vector<string>` field that
 preserves source-level `#` comments and bare-string docstrings from the Python
-DSL. The printer emits each line as `# <text>` directly above the stmt; passes
-rebuilding stmts through `IRMutator` propagate the field automatically via the
-`MakeLikeStmt` helper.
+DSL. The printer emits each line as `# <text>` directly above the stmt.
 
-- **Not reflected.** The field is intentionally excluded from `GetFieldDescriptors`,
-  so it does not participate in `structural_equal`, structural hashing, or
-  serialization. Two stmts that differ only in `leading_comments_` compare and
-  hash equal.
+- **Constructor arg (symmetric with `span_`).** Every `Stmt` subclass
+  constructor takes `leading_comments` as its last parameter (defaulted to
+  `{}`). Deserializers read `"leading_comments"` from the fields map and pass
+  it alongside `"span"` — the field is initialized at construction time, not
+  attached after the fact.
+- **Registered as `IgnoreField`.** Comments survive binary serialization
+  (`serialize_to_file`), but do NOT participate in `structural_equal` or
+  structural hashing. Two stmts that differ only in `leading_comments_`
+  compare and hash equal.
 - **Read-only from Python.** `stmt.leading_comments` is exposed read-only. The
-  sanctioned mutation channel is the free function `ir.attach_leading_comments(stmt, comments)`.
+  sanctioned mutation channel is the free function `ir.attach_leading_comments(stmt, comments)`,
+  used by the parser builder and comment-merging passes for late binding.
 - **Parser attachment rules.** Comments on lines up to the stmt's first line are
   drained as leading. Same-line trailing comments (`y = 1  # note`) are promoted
   into the next stmt's leading list. Bare-string expressions (docstrings) anywhere
   in the body become leading comments on the next stmt.
+- **Tail-of-block comments.** Comments after the last stmt in a block (at the
+  block's indentation) have no natural attachment target and are dropped with a
+  `UserWarning`. Move them above a stmt or into the outer scope to retain them.
+  Column info is used to distinguish genuine tail-of-block comments from
+  outer-scope comments that merely appear on intervening lines (e.g. `# fallback`
+  between a then-body and `else:`).
 - **SeqStmts invariant.** `SeqStmts` is a transparent container and must not
   carry `leading_comments_`; comments always attach to inner (non-Seq) stmts.
-- **Known limitations (v1).**
-  - Tail-of-block `#` comments (after the last stmt in a block) are dropped.
-  - `IRMutator` *subclasses* that construct stmts directly instead of going
-    through `MakeLikeStmt` may drop comments on rebuilt stmts.
-  - Comments do not survive binary serialization (`serialize_to_file`); they are
-    DSL-level annotations for human-readable dumps.
+- **Pass propagation.** IR passes that rebuild stmts use `MutableCopy(op)` +
+  field assignment — the copy auto-preserves `leading_comments_` together with
+  every other unchanged field. When a pass splits one stmt into several (e.g.
+  `expand_mixed_kernel` expanding an `InCore` call into AIC + AIV), construct
+  the split-first stmt via `std::make_shared<NewT>(..., orig->leading_comments_)`
+  so the origin's comments attach there. When a pass erases a compound stmt
+  (e.g. `unroll_loops` eliminating a `ForStmt`), its comments are forwarded
+  onto the first surviving body stmt via `AttachLeadingComments`.
 
 ```python
 # DSL

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -178,10 +178,13 @@ DSL. The printer emits each line as `# <text>` directly above the stmt.
 - **Read-only from Python.** `stmt.leading_comments` is exposed read-only. The
   sanctioned mutation channel is the free function `ir.attach_leading_comments(stmt, comments)`,
   used by the parser builder and comment-merging passes for late binding.
-- **Parser attachment rules.** Comments on lines up to the stmt's first line are
-  drained as leading. Same-line trailing comments (`y = 1  # note`) are promoted
-  into the next stmt's leading list. Bare-string expressions (docstrings) anywhere
-  in the body become leading comments on the next stmt.
+- **Parser attachment rules.** For simple stmts, comments on lines up to the
+  stmt's `end_lineno` are drained as leading — this means same-line trailing
+  comments (`y = 1  # note`) attach to the same stmt, not the next one. For
+  compound stmts (`for`/`while`/`if`/`with`), draining caps at the header's
+  first line so body-inner comments are left for the body stmts. Bare-string
+  expressions (docstrings) anywhere in the body become leading comments on
+  the next stmt.
 - **Tail-of-block comments.** Comments after the last stmt in a block (at the
   block's indentation) have no natural attachment target and are dropped with a
   `UserWarning`. Move them above a stmt or into the outer scope to retain them.

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -144,6 +144,9 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 
 ## Statement Nodes
 
+All `Stmt` subclasses inherit a `leading_comments_: vector<string>` metadata
+field from the `Stmt` base class. See [Leading comments on statements](#leading-comments-on-statements) below.
+
 | Node Type | Fields | Description |
 | --------- | ------ | ----------- |
 | **AssignStmt** | `var_` (DefField), `value_` (UsualField) | Variable assignment |
@@ -156,6 +159,49 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 | **SeqStmts** | `stmts_` | General statement sequence |
 | **BreakStmt** | *(none)* | Exit loop |
 | **ContinueStmt** | *(none)* | Skip to next loop iteration |
+
+### Leading comments on statements
+
+Each `Stmt` carries an optional `leading_comments_: vector<string>` field that
+preserves source-level `#` comments and bare-string docstrings from the Python
+DSL. The printer emits each line as `# <text>` directly above the stmt; passes
+rebuilding stmts through `IRMutator` propagate the field automatically via the
+`MakeLikeStmt` helper.
+
+- **Not reflected.** The field is intentionally excluded from `GetFieldDescriptors`,
+  so it does not participate in `structural_equal`, structural hashing, or
+  serialization. Two stmts that differ only in `leading_comments_` compare and
+  hash equal.
+- **Read-only from Python.** `stmt.leading_comments` is exposed read-only. The
+  sanctioned mutation channel is the free function `ir.attach_leading_comments(stmt, comments)`.
+- **Parser attachment rules.** Comments on lines up to the stmt's first line are
+  drained as leading. Same-line trailing comments (`y = 1  # note`) are promoted
+  into the next stmt's leading list. Bare-string expressions (docstrings) anywhere
+  in the body become leading comments on the next stmt.
+- **SeqStmts invariant.** `SeqStmts` is a transparent container and must not
+  carry `leading_comments_`; comments always attach to inner (non-Seq) stmts.
+- **Known limitations (v1).**
+  - Tail-of-block `#` comments (after the last stmt in a block) are dropped.
+  - `IRMutator` *subclasses* that construct stmts directly instead of going
+    through `MakeLikeStmt` may drop comments on rebuilt stmts.
+  - Comments do not survive binary serialization (`serialize_to_file`); they are
+    DSL-level annotations for human-readable dumps.
+
+```python
+# DSL
+"""cache intermediate"""
+# reuse later
+y = x + 1  # for performance
+
+# Parsed
+# AssignStmt.leading_comments == ["cache intermediate", "reuse later", "for performance"]
+
+# Printed
+# cache intermediate
+# reuse later
+# for performance
+y: f32 = x + 1
+```
 
 ### ForStmt Details
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -144,6 +144,8 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 
 ## 语句节点
 
+所有 `Stmt` 子类都从 `Stmt` 基类继承一个 `leading_comments_: vector<string>` 元数据字段。详见下文 [语句的前导注释](#语句的前导注释)。
+
 | 节点类型 | 字段 | 说明 |
 | -------- | ---- | ---- |
 | **AssignStmt** | `var_` (DefField), `value_` (UsualField) | 变量赋值 |
@@ -156,6 +158,35 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 | **SeqStmts** | `stmts_` | 通用语句序列 |
 | **BreakStmt** | *(无)* | 退出循环 |
 | **ContinueStmt** | *(无)* | 跳至下一次循环迭代 |
+
+### 语句的前导注释
+
+每个 `Stmt` 都带有一个可选的 `leading_comments_: vector<string>` 字段，用于保留 Python DSL 中的源码级 `#` 注释和裸字符串文档字符串（docstring）。打印器会将每一行以 `# <text>` 的形式输出在该语句上方；通过 `IRMutator` 重建语句的 pass 会经由 `MakeLikeStmt` 辅助自动传递该字段。
+
+- **不参与反射。** 该字段特意从 `GetFieldDescriptors` 中排除，因此不参与 `structural_equal`、结构哈希或序列化。两个仅在 `leading_comments_` 上有差异的语句相等且哈希一致。
+- **Python 侧只读。** `stmt.leading_comments` 仅暴露为只读。官方的修改通道是自由函数 `ir.attach_leading_comments(stmt, comments)`。
+- **解析器附着规则。** 不晚于该语句首行的注释会被作为前导注释收集。同一行的尾随注释（`y = 1  # note`）被提升到下一条语句的前导列表中。函数体中任何位置的裸字符串表达式（docstring）都会成为下一条语句的前导注释。
+- **SeqStmts 不变式。** `SeqStmts` 是一个透明容器，不应直接持有 `leading_comments_`；注释始终附着到其内部的（非 Seq）语句上。
+- **已知限制（v1）。**
+  - 块末尾的 `#` 注释（最后一条语句之后）会被丢弃。
+  - 直接构造语句而绕过 `MakeLikeStmt` 的 `IRMutator` *子类* 可能会在重建的语句上丢失注释。
+  - 注释不会在二进制序列化（`serialize_to_file`）中保留；它们是面向人类可读转储的 DSL 级注解。
+
+```python
+# DSL
+"""cache intermediate"""
+# reuse later
+y = x + 1  # for performance
+
+# Parsed
+# AssignStmt.leading_comments == ["cache intermediate", "reuse later", "for performance"]
+
+# Printed
+# cache intermediate
+# reuse later
+# for performance
+y: f32 = x + 1
+```
 
 ### ForStmt 详细说明
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -166,7 +166,7 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 - **构造函数参数（与 `span_` 对称）。** 每个 `Stmt` 子类的构造函数都在最后增加了 `leading_comments` 形参（默认值为 `{}`）。反序列化器从字段表中读取 `"leading_comments"`，与 `"span"` 一起传入构造函数——该字段在构造时即完成初始化，而非事后附加。
 - **注册为 `IgnoreField`。** 注释会在二进制序列化（`serialize_to_file`）中保留，但不参与 `structural_equal` 或结构哈希。两个仅在 `leading_comments_` 上有差异的语句相等且哈希一致。
 - **Python 侧只读。** `stmt.leading_comments` 仅暴露为只读。官方的修改通道是自由函数 `ir.attach_leading_comments(stmt, comments)`，供解析器构造器和合并注释的 pass 在晚期绑定时使用。
-- **解析器附着规则。** 不晚于该语句首行的注释会被作为前导注释收集。同一行的尾随注释（`y = 1  # note`）被提升到下一条语句的前导列表中。函数体中任何位置的裸字符串表达式（docstring）都会成为下一条语句的前导注释。
+- **解析器附着规则。** 对于简单语句，不晚于该语句 `end_lineno` 的注释会被作为前导注释收集——这意味着同一行的尾随注释（`y = 1  # note`）附着到当前语句本身，而非下一条语句。对于复合语句（`for`/`while`/`if`/`with`），收集上限为首行行号，以便函数体内部的注释由内部语句自身收集。函数体中任何位置的裸字符串表达式（docstring）都会成为下一条语句的前导注释。
 - **块末尾注释。** 出现在块中最后一条语句之后（并与块同级缩进）的注释没有合适的附着目标，将被丢弃并发出 `UserWarning`。将它们移到某条语句之上或外层作用域以保留它们。列信息用于区分真正的块末尾注释和仅仅出现在中间行的外层注释（例如 `else:` 前的 `# fallback`）。
 - **SeqStmts 不变式。** `SeqStmts` 是一个透明容器，不应直接持有 `leading_comments_`；注释始终附着到其内部的（非 Seq）语句上。
 - **Pass 传递。** 重建语句的 IR pass 采用 `MutableCopy(op)` + 字段赋值——副本会自动保留 `leading_comments_` 以及其他所有未改动的字段。当一个 pass 将一条语句拆分为多条时（例如 `expand_mixed_kernel` 将 `InCore` 调用拆为 AIC + AIV），通过 `std::make_shared<NewT>(..., orig->leading_comments_)` 构造第一条新语句，使原语句的注释附着到第一条发出的语句上。当一个 pass 删除一条复合语句时（例如 `unroll_loops` 消除 `ForStmt`），其注释通过 `AttachLeadingComments` 转移到第一条留存的 body 语句上。

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -161,16 +161,15 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 
 ### 语句的前导注释
 
-每个 `Stmt` 都带有一个可选的 `leading_comments_: vector<string>` 字段，用于保留 Python DSL 中的源码级 `#` 注释和裸字符串文档字符串（docstring）。打印器会将每一行以 `# <text>` 的形式输出在该语句上方；通过 `IRMutator` 重建语句的 pass 会经由 `MakeLikeStmt` 辅助自动传递该字段。
+每个 `Stmt` 都带有一个可选的 `leading_comments_: vector<string>` 字段，用于保留 Python DSL 中的源码级 `#` 注释和裸字符串文档字符串（docstring）。打印器会将每一行以 `# <text>` 的形式输出在该语句上方。
 
-- **不参与反射。** 该字段特意从 `GetFieldDescriptors` 中排除，因此不参与 `structural_equal`、结构哈希或序列化。两个仅在 `leading_comments_` 上有差异的语句相等且哈希一致。
-- **Python 侧只读。** `stmt.leading_comments` 仅暴露为只读。官方的修改通道是自由函数 `ir.attach_leading_comments(stmt, comments)`。
+- **构造函数参数（与 `span_` 对称）。** 每个 `Stmt` 子类的构造函数都在最后增加了 `leading_comments` 形参（默认值为 `{}`）。反序列化器从字段表中读取 `"leading_comments"`，与 `"span"` 一起传入构造函数——该字段在构造时即完成初始化，而非事后附加。
+- **注册为 `IgnoreField`。** 注释会在二进制序列化（`serialize_to_file`）中保留，但不参与 `structural_equal` 或结构哈希。两个仅在 `leading_comments_` 上有差异的语句相等且哈希一致。
+- **Python 侧只读。** `stmt.leading_comments` 仅暴露为只读。官方的修改通道是自由函数 `ir.attach_leading_comments(stmt, comments)`，供解析器构造器和合并注释的 pass 在晚期绑定时使用。
 - **解析器附着规则。** 不晚于该语句首行的注释会被作为前导注释收集。同一行的尾随注释（`y = 1  # note`）被提升到下一条语句的前导列表中。函数体中任何位置的裸字符串表达式（docstring）都会成为下一条语句的前导注释。
+- **块末尾注释。** 出现在块中最后一条语句之后（并与块同级缩进）的注释没有合适的附着目标，将被丢弃并发出 `UserWarning`。将它们移到某条语句之上或外层作用域以保留它们。列信息用于区分真正的块末尾注释和仅仅出现在中间行的外层注释（例如 `else:` 前的 `# fallback`）。
 - **SeqStmts 不变式。** `SeqStmts` 是一个透明容器，不应直接持有 `leading_comments_`；注释始终附着到其内部的（非 Seq）语句上。
-- **已知限制（v1）。**
-  - 块末尾的 `#` 注释（最后一条语句之后）会被丢弃。
-  - 直接构造语句而绕过 `MakeLikeStmt` 的 `IRMutator` *子类* 可能会在重建的语句上丢失注释。
-  - 注释不会在二进制序列化（`serialize_to_file`）中保留；它们是面向人类可读转储的 DSL 级注解。
+- **Pass 传递。** 重建语句的 IR pass 采用 `MutableCopy(op)` + 字段赋值——副本会自动保留 `leading_comments_` 以及其他所有未改动的字段。当一个 pass 将一条语句拆分为多条时（例如 `expand_mixed_kernel` 将 `InCore` 调用拆为 AIC + AIV），通过 `std::make_shared<NewT>(..., orig->leading_comments_)` 构造第一条新语句，使原语句的注释附着到第一条发出的语句上。当一个 pass 删除一条复合语句时（例如 `unroll_loops` 消除 `ForStmt`），其注释通过 `AttachLeadingComments` 转移到第一条留存的 body 语句上。
 
 ```python
 # DSL

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -327,21 +327,33 @@ class IRBuilder {
   void Emit(const StmtPtr& stmt);
 
   /**
-   * @brief Attach leading comments to the most recently emitted statement
-   *        in the current context.
+   * @brief Push leading comments onto the pending stack.
    *
-   * Used by the DSL parser to associate extracted source comments with the
-   * stmt that has just been emitted (the outer stmt of a compound block, or
-   * the simple stmt itself). Mutates the stmt's IgnoreField metadata only —
-   * no effect on structural equality or hashing.
+   * The DSL parser calls this before dispatching to a ``parse_*`` helper.
+   * The first stmt emitted in the same context as the push (e.g. the outer
+   * compound stmt) absorbs the queued comments through its ctor path. If
+   * the helper emits nothing (e.g. ``pl.static_assert``), call
+   * ``PopPendingLeadingComments`` afterward to recover the unconsumed entry.
    *
-   * No-op if the current context has no statements yet or the comments list
-   * is empty.
+   * The stack lets nested ``parse_statement`` calls (parent + body stmts)
+   * keep their pending entries independent: the parent's queue waits on the
+   * outer context while inner-stmt queues consume in the inner body
+   * context. Without a stack, the outer entry would be clobbered when the
+   * body parse sets its own pending.
    *
    * @param comments Comment lines (without leading '#')
-   * @throws RuntimeError if not inside a valid context
    */
-  void AttachLeadingCommentsToLast(std::vector<std::string> comments);
+  void PushPendingLeadingComments(std::vector<std::string> comments);
+
+  /**
+   * @brief Pop the top pending entry, returning whatever stayed unconsumed.
+   *
+   * The parser pairs one pop with every push. If the dispatched helper
+   * emitted a matching stmt, the popped entry is empty. Otherwise the
+   * parser re-queues the returned comments onto the next line so they
+   * land on the next source stmt instead of being silently dropped.
+   */
+  [[nodiscard]] std::vector<std::string> PopPendingLeadingComments();
 
   /**
    * @brief Create an assignment statement and emit it
@@ -507,6 +519,27 @@ class IRBuilder {
  private:
   std::vector<std::unique_ptr<BuildContext>> context_stack_;
 
+  // Stack of pending leading-comment entries. The parser pushes one entry
+  // per ``parse_statement`` call (before dispatching) and pops it afterward.
+  // Each entry is bound to the context that was current at push time — Emit
+  // consumes only when the top-of-stack entry's target matches the context
+  // receiving the new stmt. This lets nested parse_statement calls coexist:
+  // outer push waits on the outer (FunctionContext etc.) for the compound
+  // stmt, inner push waits on the inner (ForContext etc.) for the body
+  // stmt. Without the target binding, inner-body emits would steal the
+  // outer queue and leave the compound stmt without its comments.
+  struct PendingLeadingCommentsEntry {
+    std::vector<std::string> comments;
+    BuildContext* target;
+  };
+  std::vector<PendingLeadingCommentsEntry> pending_leading_stack_;
+
+  // If the current context matches pending_target_context_, apply the queued
+  // leading comments to `stmt`. Called from Emit() and from every compound-stmt
+  // exit path (EndForLoop / EndWhileLoop / EndIf / EndScope) before appending
+  // the synthesized stmt to the outer context.
+  void ApplyPendingLeadingComments(const StmtPtr& stmt);
+
   // Helper to get current context with type checking
   template <typename T>
   T* GetCurrentContextAs();
@@ -538,13 +571,6 @@ class BuildContext {
   // Accumulate statements in this context
   virtual void AddStmt(const StmtPtr& stmt) = 0;
   [[nodiscard]] const std::vector<StmtPtr>& GetStmts() const { return stmts_; }
-
-  // Return the most recently emitted stmt in this context, or nullptr if none.
-  // Subclasses that split stmts across multiple vectors (e.g., IfStmtContext's
-  // then/else branches) should override to return the right one.
-  [[nodiscard]] virtual StmtPtr GetLastEmittedStmt() const {
-    return stmts_.empty() ? nullptr : stmts_.back();
-  }
 
  protected:
   Type type_;
@@ -676,10 +702,6 @@ class IfStmtContext : public BuildContext {
   void AddReturnVar(const VarPtr& var) { return_vars_.push_back(var); }
 
   void AddStmt(const StmtPtr& stmt) override { (in_else_branch_ ? else_stmts_ : stmts_).push_back(stmt); }
-  [[nodiscard]] StmtPtr GetLastEmittedStmt() const override {
-    const auto& active = in_else_branch_ ? else_stmts_ : stmts_;
-    return active.empty() ? nullptr : active.back();
-  }
   [[nodiscard]] const ExprPtr& GetCondition() const { return condition_; }
   [[nodiscard]] bool InElseBranch() const { return in_else_branch_; }
   [[nodiscard]] const std::vector<StmtPtr>& GetElseStmts() const { return else_stmts_; }

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -327,6 +327,23 @@ class IRBuilder {
   void Emit(const StmtPtr& stmt);
 
   /**
+   * @brief Attach leading comments to the most recently emitted statement
+   *        in the current context.
+   *
+   * Used by the DSL parser to associate extracted source comments with the
+   * stmt that has just been emitted (the outer stmt of a compound block, or
+   * the simple stmt itself). Mutates the stmt's IgnoreField metadata only —
+   * no effect on structural equality or hashing.
+   *
+   * No-op if the current context has no statements yet or the comments list
+   * is empty.
+   *
+   * @param comments Comment lines (without leading '#')
+   * @throws RuntimeError if not inside a valid context
+   */
+  void AttachLeadingCommentsToLast(std::vector<std::string> comments);
+
+  /**
    * @brief Create an assignment statement and emit it
    *
    * Convenience method that creates an assignment and emits it.
@@ -522,6 +539,13 @@ class BuildContext {
   virtual void AddStmt(const StmtPtr& stmt) = 0;
   [[nodiscard]] const std::vector<StmtPtr>& GetStmts() const { return stmts_; }
 
+  // Return the most recently emitted stmt in this context, or nullptr if none.
+  // Subclasses that split stmts across multiple vectors (e.g., IfStmtContext's
+  // then/else branches) should override to return the right one.
+  [[nodiscard]] virtual StmtPtr GetLastEmittedStmt() const {
+    return stmts_.empty() ? nullptr : stmts_.back();
+  }
+
  protected:
   Type type_;
   Span begin_span_;
@@ -652,6 +676,10 @@ class IfStmtContext : public BuildContext {
   void AddReturnVar(const VarPtr& var) { return_vars_.push_back(var); }
 
   void AddStmt(const StmtPtr& stmt) override { (in_else_branch_ ? else_stmts_ : stmts_).push_back(stmt); }
+  [[nodiscard]] StmtPtr GetLastEmittedStmt() const override {
+    const auto& active = in_else_branch_ ? else_stmts_ : stmts_;
+    return active.empty() ? nullptr : active.back();
+  }
   [[nodiscard]] const ExprPtr& GetCondition() const { return condition_; }
   [[nodiscard]] bool InElseBranch() const { return in_else_branch_; }
   [[nodiscard]] const std::vector<StmtPtr>& GetElseStmts() const { return else_stmts_; }

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -308,6 +308,16 @@ class Stmt : public IRNode {
    */
   [[nodiscard]] std::string TypeName() const override { return "Stmt"; }
 
+  // Source-level comments printed above this statement.
+  //
+  // This field is INTENTIONALLY NOT registered in GetFieldDescriptors(): it is
+  // pure DSL-level annotation metadata that must not participate in structural
+  // equality, hashing, or serialization, and is exposed to Python manually as a
+  // read-only property (see python/bindings/modules/ir.cpp). Set while the stmt
+  // is still held as shared_ptr<X> (non-const) by the parser / IRMutator; the
+  // sanctioned mutation channel from Python is AttachLeadingComments.
+  std::vector<std::string> leading_comments_;
+
   static constexpr auto GetFieldDescriptors() { return IRNode::GetFieldDescriptors(); }
 };
 
@@ -899,6 +909,35 @@ class ContinueStmt : public Stmt {
 };
 
 using ContinueStmtPtr = std::shared_ptr<const ContinueStmt>;
+
+/**
+ * @brief Attach leading comments to an existing statement
+ *
+ * Stmts are handed around as `shared_ptr<const Stmt>` to discourage mutation of
+ * semantic fields, but `leading_comments_` is IgnoreField metadata that has no
+ * effect on structural equality or hashing. This helper is the single sanctioned
+ * mutation channel (e.g., for the Python parser attaching extracted comments
+ * after building a stmt). The `const_cast` is safe because the helper requires
+ * the caller already holds a StmtPtr referencing a concrete, owned stmt.
+ *
+ * Rejects `SeqStmts` targets: it is a transparent container and the printer
+ * enforces that its leading_comments_ is always empty. Attach comments to an
+ * inner stmt instead.
+ *
+ * Not thread-safe: concurrent callers must coordinate since the mutation is
+ * performed through `const_cast` on the shared target.
+ *
+ * @param stmt Statement to annotate (must be non-null, not a SeqStmts)
+ * @param comments Comment lines (without leading '#')
+ * @return The same StmtPtr, with `leading_comments_` replaced by `comments`
+ */
+inline StmtPtr AttachLeadingComments(StmtPtr stmt, std::vector<std::string> comments) {
+  CHECK(stmt) << "AttachLeadingComments: stmt must not be null";
+  CHECK(stmt->GetKind() != ObjectKind::SeqStmts)
+      << "AttachLeadingComments: cannot attach to SeqStmts; attach to an inner stmt instead";
+  const_cast<Stmt&>(*stmt).leading_comments_ = std::move(comments);
+  return stmt;
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -799,7 +799,11 @@ class SeqStmts : public Stmt {
    * @param span Source location
    */
   SeqStmts(std::vector<StmtPtr> stmts, Span span, std::vector<std::string> leading_comments = {})
-      : Stmt(std::move(span), std::move(leading_comments)), stmts_(std::move(stmts)) {}
+      : Stmt(std::move(span), std::move(leading_comments)), stmts_(std::move(stmts)) {
+    INTERNAL_CHECK(leading_comments_.empty())
+        << "SeqStmts is a transparent container and must not carry leading comments; "
+           "attach to an inner (non-Seq) stmt instead";
+  }
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::SeqStmts; }
   [[nodiscard]] std::string TypeName() const override { return "SeqStmts"; }

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -297,8 +297,10 @@ class Stmt : public IRNode {
    * @brief Create a statement
    *
    * @param span Source location
+   * @param leading_comments Source-level comments to print above this statement (defaults to empty)
    */
-  explicit Stmt(Span s) : IRNode(std::move(s)) {}
+  explicit Stmt(Span s, std::vector<std::string> leading_comments = {})
+      : IRNode(std::move(s)), leading_comments_(std::move(leading_comments)) {}
   ~Stmt() override = default;
 
   /**
@@ -310,15 +312,18 @@ class Stmt : public IRNode {
 
   // Source-level comments printed above this statement.
   //
-  // This field is INTENTIONALLY NOT registered in GetFieldDescriptors(): it is
-  // pure DSL-level annotation metadata that must not participate in structural
-  // equality, hashing, or serialization, and is exposed to Python manually as a
-  // read-only property (see python/bindings/modules/ir.cpp). Set while the stmt
-  // is still held as shared_ptr<X> (non-const) by the parser / IRMutator; the
-  // sanctioned mutation channel from Python is AttachLeadingComments.
+  // Registered as IgnoreField so it does NOT participate in structural equality
+  // or hashing (purely DSL-level annotation metadata). It IS serialized/deserialized
+  // so comments survive `serialize_to_file` round-trips. Passed through the Stmt
+  // constructor (symmetric with span_). Exposed to Python as read-only; the
+  // late-binding mutation channel is AttachLeadingComments (used by the parser
+  // builder and comment-merging passes).
   std::vector<std::string> leading_comments_;
 
-  static constexpr auto GetFieldDescriptors() { return IRNode::GetFieldDescriptors(); }
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(IRNode::GetFieldDescriptors(), std::make_tuple(reflection::IgnoreField(
+                                                             &Stmt::leading_comments_, "leading_comments")));
+  }
 };
 
 using StmtPtr = std::shared_ptr<const Stmt>;
@@ -341,8 +346,8 @@ class AssignStmt : public Stmt {
    * @param value Expression
    * @param span Source location
    */
-  AssignStmt(VarPtr var, ExprPtr value, Span span)
-      : Stmt(std::move(span)), var_(std::move(var)), value_(std::move(value)) {}
+  AssignStmt(VarPtr var, ExprPtr value, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), var_(std::move(var)), value_(std::move(value)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::AssignStmt; }
   [[nodiscard]] std::string TypeName() const override { return "AssignStmt"; }
@@ -379,8 +384,8 @@ class IfStmt : public Stmt {
    * @param span Source location
    */
   IfStmt(ExprPtr condition, StmtPtr then_body, std::optional<StmtPtr> else_body,
-         std::vector<VarPtr> return_vars, Span span)
-      : Stmt(std::move(span)),
+         std::vector<VarPtr> return_vars, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)),
         condition_(std::move(condition)),
         then_body_(std::move(then_body)),
         else_body_(std::move(else_body)),
@@ -425,14 +430,16 @@ class YieldStmt : public Stmt {
    * @param value List of variables to yield (can be empty)
    * @param span Source location
    */
-  YieldStmt(std::vector<ExprPtr> value, Span span) : Stmt(std::move(span)), value_(std::move(value)) {}
+  YieldStmt(std::vector<ExprPtr> value, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), value_(std::move(value)) {}
 
   /**
    * @brief Create a yield statement without values
    *
    * @param span Source location
    */
-  explicit YieldStmt(Span span) : Stmt(std::move(span)), value_() {}
+  explicit YieldStmt(Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), value_() {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::YieldStmt; }
   [[nodiscard]] std::string TypeName() const override { return "YieldStmt"; }
@@ -467,14 +474,16 @@ class ReturnStmt : public Stmt {
    * @param value List of expressions to return (can be empty)
    * @param span Source location
    */
-  ReturnStmt(std::vector<ExprPtr> value, Span span) : Stmt(std::move(span)), value_(std::move(value)) {}
+  ReturnStmt(std::vector<ExprPtr> value, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), value_(std::move(value)) {}
 
   /**
    * @brief Create a return statement without values
    *
    * @param span Source location
    */
-  explicit ReturnStmt(Span span) : Stmt(std::move(span)), value_() {}
+  explicit ReturnStmt(Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), value_() {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ReturnStmt; }
   [[nodiscard]] std::string TypeName() const override { return "ReturnStmt"; }
@@ -535,8 +544,9 @@ class ForStmt : public Stmt {
   ForStmt(VarPtr loop_var, ExprPtr start, ExprPtr stop, ExprPtr step, std::vector<IterArgPtr> iter_args,
           StmtPtr body, std::vector<VarPtr> return_vars, Span span, ForKind kind = ForKind::Sequential,
           std::optional<ChunkConfig> chunk_config = std::nullopt,
-          std::vector<std::pair<std::string, std::any>> attrs = {})
-      : Stmt(std::move(span)),
+          std::vector<std::pair<std::string, std::any>> attrs = {},
+          std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)),
         loop_var_(std::move(loop_var)),
         start_(std::move(start)),
         stop_(std::move(stop)),
@@ -648,8 +658,8 @@ class WhileStmt : public Stmt {
    * @param span Source location
    */
   WhileStmt(ExprPtr condition, std::vector<IterArgPtr> iter_args, StmtPtr body,
-            std::vector<VarPtr> return_vars, Span span)
-      : Stmt(std::move(span)),
+            std::vector<VarPtr> return_vars, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)),
         condition_(std::move(condition)),
         iter_args_(std::move(iter_args)),
         body_(std::move(body)),
@@ -719,8 +729,8 @@ class ScopeStmt : public Stmt {
    * @param body The nested statements
    * @param span Source location
    */
-  ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span)
-      : Stmt(std::move(span)), scope_kind_(scope_kind), body_(std::move(body)) {}
+  ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), scope_kind_(scope_kind), body_(std::move(body)) {}
 
   /**
    * @brief Create a scope statement with hierarchy level, role, and split mode
@@ -734,8 +744,8 @@ class ScopeStmt : public Stmt {
    */
   ScopeStmt(ScopeKind scope_kind, StmtPtr body, Span span, std::optional<Level> level,
             std::optional<Role> role = std::nullopt, std::optional<SplitMode> split = std::nullopt,
-            std::string name_hint = "")
-      : Stmt(std::move(span)),
+            std::string name_hint = "", std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)),
         scope_kind_(scope_kind),
         body_(std::move(body)),
         level_(level),
@@ -788,7 +798,8 @@ class SeqStmts : public Stmt {
    * @param stmts List of statements
    * @param span Source location
    */
-  SeqStmts(std::vector<StmtPtr> stmts, Span span) : Stmt(std::move(span)), stmts_(std::move(stmts)) {}
+  SeqStmts(std::vector<StmtPtr> stmts, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), stmts_(std::move(stmts)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::SeqStmts; }
   [[nodiscard]] std::string TypeName() const override { return "SeqStmts"; }
@@ -855,7 +866,8 @@ class EvalStmt : public Stmt {
    * @param expr Expression to execute
    * @param span Source location
    */
-  EvalStmt(ExprPtr expr, Span span) : Stmt(std::move(span)), expr_(std::move(expr)) {}
+  EvalStmt(ExprPtr expr, Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)), expr_(std::move(expr)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::EvalStmt; }
   [[nodiscard]] std::string TypeName() const override { return "EvalStmt"; }
@@ -883,7 +895,8 @@ using EvalStmtPtr = std::shared_ptr<const EvalStmt>;
  */
 class BreakStmt : public Stmt {
  public:
-  explicit BreakStmt(Span span) : Stmt(std::move(span)) {}
+  explicit BreakStmt(Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::BreakStmt; }
   [[nodiscard]] std::string TypeName() const override { return "BreakStmt"; }
@@ -900,7 +913,8 @@ using BreakStmtPtr = std::shared_ptr<const BreakStmt>;
  */
 class ContinueStmt : public Stmt {
  public:
-  explicit ContinueStmt(Span span) : Stmt(std::move(span)) {}
+  explicit ContinueStmt(Span span, std::vector<std::string> leading_comments = {})
+      : Stmt(std::move(span), std::move(leading_comments)) {}
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::ContinueStmt; }
   [[nodiscard]] std::string TypeName() const override { return "ContinueStmt"; }

--- a/include/pypto/ir/transforms/base/mutator.h
+++ b/include/pypto/ir/transforms/base/mutator.h
@@ -12,9 +12,7 @@
 #ifndef PYPTO_IR_TRANSFORMS_BASE_MUTATOR_H_
 #define PYPTO_IR_TRANSFORMS_BASE_MUTATOR_H_
 
-#include <memory>
 #include <unordered_map>
-#include <utility>
 
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -117,16 +115,6 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   /// (e.g., when IterArg's initValue_ changes, creating a new IterArg object).
   /// Checked in both VisitExpr_(VarPtr) and VisitExpr_(IterArgPtr) for extensibility.
   std::unordered_map<const Expr*, ExprPtr> var_remap_;
-
-  /// Construct a new stmt of type T, preserving leading_comments_ from the original.
-  /// Returns a non-const shared_ptr<T> so callers can still mutate if needed;
-  /// implicitly converts to shared_ptr<const T> on return.
-  template <typename T, typename... Args>
-  static std::shared_ptr<T> MakeLikeStmt(const std::shared_ptr<const T>& orig, Args&&... args) {
-    auto new_stmt = std::make_shared<T>(std::forward<Args>(args)...);
-    new_stmt->leading_comments_ = orig->leading_comments_;
-    return new_stmt;
-  }
 };
 
 }  // namespace ir

--- a/include/pypto/ir/transforms/base/mutator.h
+++ b/include/pypto/ir/transforms/base/mutator.h
@@ -12,7 +12,9 @@
 #ifndef PYPTO_IR_TRANSFORMS_BASE_MUTATOR_H_
 #define PYPTO_IR_TRANSFORMS_BASE_MUTATOR_H_
 
+#include <memory>
 #include <unordered_map>
+#include <utility>
 
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -115,6 +117,16 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   /// (e.g., when IterArg's initValue_ changes, creating a new IterArg object).
   /// Checked in both VisitExpr_(VarPtr) and VisitExpr_(IterArgPtr) for extensibility.
   std::unordered_map<const Expr*, ExprPtr> var_remap_;
+
+  /// Construct a new stmt of type T, preserving leading_comments_ from the original.
+  /// Returns a non-const shared_ptr<T> so callers can still mutate if needed;
+  /// implicitly converts to shared_ptr<const T> on return.
+  template <typename T, typename... Args>
+  static std::shared_ptr<T> MakeLikeStmt(const std::shared_ptr<const T>& orig, Args&&... args) {
+    auto new_stmt = std::make_shared<T>(std::forward<Args>(args)...);
+    new_stmt->leading_comments_ = orig->leading_comments_;
+    return new_stmt;
+  }
 };
 
 }  // namespace ir

--- a/include/pypto/ir/transforms/utils/mutable_copy.h
+++ b/include/pypto/ir/transforms/utils/mutable_copy.h
@@ -14,7 +14,6 @@
 
 #include <memory>
 #include <type_traits>
-#include <utility>
 
 namespace pypto {
 namespace ir {

--- a/include/pypto/ir/transforms/utils/mutable_copy.h
+++ b/include/pypto/ir/transforms/utils/mutable_copy.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 namespace pypto {
 namespace ir {

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -793,6 +793,19 @@ void BindIR(nb::module_& m) {
   // Stmt - abstract base, const shared_ptr
   auto stmt_class = nb::class_<Stmt, IRNode>(ir, "Stmt", "Base class for all statements");
   BindFields<Stmt>(stmt_class);
+  // Manually expose leading_comments as read-only (intentionally outside
+  // GetFieldDescriptors — see stmt.h).
+  stmt_class.def_ro("leading_comments", &Stmt::leading_comments_,
+                    "Source-level comments printed above this statement (read-only; "
+                    "use ir.attach_leading_comments to modify).");
+
+  // Free function: attach leading comments to an existing statement.
+  // Python-side `Stmt.leading_comments` is read-only; this helper is the one
+  // sanctioned mutation channel (e.g., for the Python parser after building a
+  // stmt). See stmt.h:AttachLeadingComments for the const-safety rationale.
+  ir.def("attach_leading_comments", &AttachLeadingComments, nb::arg("stmt"), nb::arg("comments"),
+         "Attach leading comments to an existing statement (mutates IgnoreField metadata only). "
+         "Returns the same statement for convenient chaining.");
 
   // AssignStmt - const shared_ptr
   auto assign_stmt_class =

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -273,11 +273,17 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
-      .def("attach_leading_comments_to_last", &IRBuilder::AttachLeadingCommentsToLast, nb::arg("comments"),
-           "Attach leading comments to the most recently emitted stmt in the current context.\n\n"
-           "Used by the DSL parser to associate source comments with the stmt just emitted\n"
-           "(the outer stmt of a compound block, or the simple stmt itself). No-op if the\n"
-           "current context has no stmts or if comments is empty.")
+      .def("push_pending_leading_comments", &IRBuilder::PushPendingLeadingComments, nb::arg("comments"),
+           "Push leading comments onto the pending stack.\n\n"
+           "The DSL parser calls this before dispatching to a parse_* helper.\n"
+           "The first stmt emitted in the same context as the push absorbs the\n"
+           "queued comments through its ctor path. Pair every push with exactly\n"
+           "one pop_pending_leading_comments.")
+
+      .def("pop_pending_leading_comments", &IRBuilder::PopPendingLeadingComments,
+           "Pop the top pending entry, returning whatever stayed unconsumed.\n\n"
+           "If the dispatched helper emitted a matching stmt, the result is empty.\n"
+           "Otherwise the parser re-queues the returned comments onto the next line.")
 
       .def("assign", &IRBuilder::Assign, nb::arg("var"), nb::arg("value"), nb::arg("span"),
            "Create an assignment statement and emit it.\n\n"

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -273,6 +273,12 @@ void BindIRBuilder(nb::module_& m) {
            "Raises:\n"
            "    RuntimeError: If not inside a valid context")
 
+      .def("attach_leading_comments_to_last", &IRBuilder::AttachLeadingCommentsToLast, nb::arg("comments"),
+           "Attach leading comments to the most recently emitted stmt in the current context.\n\n"
+           "Used by the DSL parser to associate source comments with the stmt just emitted\n"
+           "(the outer stmt of a compound block, or the simple stmt itself). No-op if the\n"
+           "current context has no stmts or if comments is empty.")
+
       .def("assign", &IRBuilder::Assign, nb::arg("var"), nb::arg("value"), nb::arg("span"),
            "Create an assignment statement and emit it.\n\n"
            "Convenience method that creates and emits an assignment.\n\n"

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -491,17 +491,23 @@ class IRBuilder:
         """
         self._builder.emit(stmt)
 
-    def attach_leading_comments_to_last(self, comments: list[str]) -> None:
-        """Attach source-level comments to the most recently emitted stmt.
+    def push_pending_leading_comments(self, comments: list[str]) -> None:
+        """Push leading comments onto the pending stack.
 
-        Used by the DSL parser to associate extracted comments with the stmt
-        just emitted in the current context. No-op when ``comments`` is empty
-        or no stmt has been emitted yet.
+        The DSL parser calls this before dispatching to a ``parse_*`` helper.
+        Pair every push with exactly one ``pop_pending_leading_comments``.
 
         Args:
             comments: Comment lines (without leading ``#``)
         """
-        self._builder.attach_leading_comments_to_last(comments)
+        self._builder.push_pending_leading_comments(comments)
+
+    def pop_pending_leading_comments(self) -> list[str]:
+        """Pop the top pending entry, returning whatever stayed unconsumed.
+
+        Returns ``[]`` when the matching emit already consumed the queue.
+        """
+        return self._builder.pop_pending_leading_comments()
 
     def return_stmt(
         self,

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -491,6 +491,18 @@ class IRBuilder:
         """
         self._builder.emit(stmt)
 
+    def attach_leading_comments_to_last(self, comments: list[str]) -> None:
+        """Attach source-level comments to the most recently emitted stmt.
+
+        Used by the DSL parser to associate extracted comments with the stmt
+        just emitted in the current context. No-op when ``comments`` is empty
+        or no stmt has been emitted yet.
+
+        Args:
+            comments: Comment lines (without leading ``#``)
+        """
+        self._builder.attach_leading_comments_to_last(comments)
+
     def return_stmt(
         self,
         values: int | float | ir.Expr | Sequence[int | float | ir.Expr] | None = None,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -382,9 +382,10 @@ class ASTParser:
             # Parse function body. Docstrings (bare-string expressions anywhere
             # in the body) are rerouted as leading_comments on the next stmt by
             # parse_statement — no separate skip is needed here.
-            for stmt in func_def.body:
-                self.parse_statement(stmt)
-            self._discard_tail_block_comments(func_def.body)
+            self._parse_body_siblings(func_def.body)
+            # Function body is the outermost scope — sweep all remaining
+            # pending comments (including any beyond end_lineno) as tails.
+            self._discard_tail_block_comments(func_def.body, upper_line=None)
 
         # Exit function scope
         self.scope_manager.exit_scope()
@@ -465,6 +466,90 @@ class ASTParser:
         if residue:
             self._requeue_comments_after(stmt, residue)
 
+    def _parse_body_siblings(self, body: Sequence[ast.stmt]) -> None:
+        """Parse a block's body stmts, applying stale-pending sweeps between siblings.
+
+        The inter-sibling sweep catches tail-of-block comments that live in the
+        gap between one sibling's body (which has already closed) and the next
+        sibling. Skipped for the first sibling since there is no prior closed
+        block — any pending comments at that point belong to the enclosing
+        compound stmt's header or leading attachments.
+        """
+        for i, stmt in enumerate(body):
+            if i > 0:
+                self._discard_stale_pending_before(stmt)
+            self.parse_statement(stmt)
+
+    def _then_branch_tail_upper(self, stmt: ast.If) -> int:
+        """Inclusive upper-bound line for the then-branch's tail-drop range.
+
+        Points to the line just before the ``else:`` keyword when an else
+        clause is present (so the then-branch tail does not extend into
+        else-body leading comments), and falls back to the if-stmt's end line
+        when there is no else clause.
+        """
+        if not stmt.orelse:
+            return stmt.end_lineno or stmt.lineno
+        else_line = self._find_else_keyword_line(stmt)
+        if else_line is not None:
+            return else_line - 1
+        return stmt.orelse[0].lineno - 1
+
+    def _find_else_keyword_line(self, stmt: ast.If) -> int | None:
+        """Return the source line of the ``else:`` keyword for an if-stmt.
+
+        Python's AST has no node for the ``else:`` keyword itself; its line can
+        only be recovered by scanning the source text between the last then-body
+        stmt and the first orelse stmt. Used to compute the exact upper bound of
+        the then-branch for :meth:`_discard_tail_block_comments` so that
+        comments physically inside the else branch (e.g. leading comments for
+        the first else stmt) are not mistaken for then-branch tails.
+
+        Returns ``None`` if not found (e.g. ``elif`` chains lack an ``else:``
+        keyword line).
+        """
+        if not stmt.orelse:
+            return None
+        src = self.span_tracker.source_lines
+        start = (stmt.body[-1].end_lineno or stmt.body[-1].lineno) + 1
+        end = stmt.orelse[0].lineno  # exclusive
+        for line_no in range(start, end):
+            idx = line_no - 1
+            if not (0 <= idx < len(src)):
+                continue
+            stripped = src[idx].lstrip()
+            # Match `else:` (optionally followed by whitespace/comment) but not
+            # `elif ...` (which is a separate else-branch chain lowered into
+            # ast.If.orelse[0] and has no `else:` keyword).
+            if stripped.startswith("else") and stripped[4:5] in (":", " ", "\t"):
+                return line_no
+        return None
+
+    @staticmethod
+    def _header_ast_end_line(stmt: ast.stmt) -> int:
+        """Last AST line of a compound stmt's header, before the body's colon.
+
+        For a wrapped multi-line header (e.g. ``for i in pl.range(\n  10,\n):``)
+        this returns the line of the closing ``)``/``:``; for a simple
+        single-line header it returns ``stmt.lineno``.
+
+        Used to classify comments between ``stmt.lineno`` and ``body[0].lineno``:
+        comments on a line ``<= header_ast_end`` belong to the header; comments
+        on later lines are body-leading for ``body[0]``.
+        """
+        ends: list[int] = [stmt.lineno]
+        if isinstance(stmt, ast.For):
+            ends.append(stmt.target.end_lineno or stmt.target.lineno)
+            ends.append(stmt.iter.end_lineno or stmt.iter.lineno)
+        elif isinstance(stmt, (ast.While, ast.If)):
+            ends.append(stmt.test.end_lineno or stmt.test.lineno)
+        elif isinstance(stmt, ast.With):
+            for item in stmt.items:
+                ends.append(item.context_expr.end_lineno or item.context_expr.lineno)
+                if item.optional_vars is not None:
+                    ends.append(item.optional_vars.end_lineno or item.optional_vars.lineno)
+        return max(ends)
+
     def _drain_pending_comments(self, stmt: ast.stmt) -> list[str]:
         """Collect pending comments whose line numbers fall at or before ``stmt``.
 
@@ -487,14 +572,24 @@ class ASTParser:
         leading: list[str] = []
         if isinstance(body, list) and body:
             header_end = body[0].lineno - 1
+            header_ast_end = self._header_ast_end_line(stmt)
             body_col = body[0].col_offset
             for line in sorted(k for k in self._pending_comments if k <= header_end):
-                if line == stmt.lineno:
-                    # Inline trailer on the header's first line (e.g.
-                    # `for i in range(16):  # tiles`) — always attach, regardless
-                    # of the high column where tokenize reports it.
+                if stmt.lineno <= line <= header_ast_end:
+                    # Header-level comment: either an inline trailer on the
+                    # header's first line (e.g. `for i in range(16):  # tiles`)
+                    # or a continuation-line comment inside a wrapped multi-line
+                    # header (e.g. `for i in pl.range(\n  10,  # comment\n):`).
+                    # Attach to the compound stmt regardless of column.
                     leading.extend(text for _col, text in self._pending_comments.pop(line))
                     continue
+                if line > header_ast_end:
+                    # Past the header but before body[0] — this is a body-leading
+                    # comment for body[0]. Leave pending for body[0] to pick up.
+                    continue
+                # line < stmt.lineno: pre-stmt leftover. Split by column —
+                # shallower-than-body attaches to this compound stmt; same-or-
+                # deeper stays pending (belongs to body).
                 kept: list[tuple[int, str]] = []
                 for col, text in self._pending_comments[line]:
                     if col < body_col:
@@ -528,23 +623,33 @@ class ASTParser:
         existing = self._pending_comments.setdefault(next_line, [])
         self._pending_comments[next_line] = [*entries, *existing]
 
-    def _discard_tail_block_comments(self, body: list[ast.stmt]) -> None:
-        """Drop pending comments at or deeper than ``body``'s indentation.
+    def _discard_tail_block_comments(self, body: list[ast.stmt], upper_line: int | None) -> None:
+        """Drop pending tail comments inside a block's physical line range.
 
-        Called after a block's body finishes parsing. Any pending comment whose
-        column is ``>= body[0].col_offset`` sat at the block's indent but was
-        not drained by any body stmt — a tail-of-block comment that has no
-        natural attachment target. We emit a warning and drop these, while
-        leaving shallower-indent comments (belonging to an outer scope) in
-        place so they can attach to the next outer-scope stmt.
+        Called after a block's body finishes parsing. Sweeps pending comments on
+        lines in ``[body[0].lineno, upper_line]`` whose column is
+        ``>= body[0].col_offset`` and drops them with a warning.
 
-        No-op when ``body`` is empty (nothing to determine the block indent).
+        ``upper_line`` must be the inclusive upper bound of the block's physical
+        extent (typically the enclosing compound stmt's ``end_lineno``, or the
+        line before the next sibling clause such as ``else:``). Passing ``None``
+        means "no upper bound" — sweep all remaining pending comments from
+        ``body_start`` onward; used for the function body (outermost scope).
+
+        Bounding is necessary because ``_pending_comments`` is populated
+        up-front from the entire source, so comments in yet-to-parse sibling
+        blocks at the same indent would otherwise be swept in error.
         """
         if not body or not self._pending_comments:
             return
         block_col = body[0].col_offset
+        block_start = body[0].lineno
         tail: list[tuple[int, str]] = []
-        for line in sorted(self._pending_comments):
+        if upper_line is None:
+            candidates = [k for k in self._pending_comments if k >= block_start]
+        else:
+            candidates = [k for k in self._pending_comments if block_start <= k <= upper_line]
+        for line in sorted(candidates):
             remaining: list[tuple[int, str]] = []
             for col, text in self._pending_comments[line]:
                 if col >= block_col:
@@ -555,6 +660,41 @@ class ASTParser:
                 self._pending_comments[line] = remaining
             else:
                 del self._pending_comments[line]
+        self._emit_tail_warning(tail)
+
+    def _discard_stale_pending_before(self, stmt: ast.stmt) -> None:
+        """Drop pending comments on earlier lines at deeper indent than ``stmt``.
+
+        When parsing advances to ``stmt``, any pending comment on a line
+        ``< stmt.lineno`` whose column is strictly greater than
+        ``stmt.col_offset`` physically lives inside a previous sibling block
+        whose body has already closed (dedent). Those comments cannot attach to
+        ``stmt`` (wrong indent level) and would otherwise be misattributed by
+        the simple-stmt drain, so sweep them here as tail-of-block.
+
+        This is the mechanism that catches tail comments in the "gap" between
+        one block's body and the next outer-scope stmt — complementing the
+        bounded :meth:`_discard_tail_block_comments` that runs at block exit.
+        """
+        if not self._pending_comments:
+            return
+        stale: list[tuple[int, str]] = []
+        for line in sorted(k for k in self._pending_comments if k < stmt.lineno):
+            remaining: list[tuple[int, str]] = []
+            for col, text in self._pending_comments[line]:
+                if col > stmt.col_offset:
+                    stale.append((line, text))
+                else:
+                    remaining.append((col, text))
+            if remaining:
+                self._pending_comments[line] = remaining
+            else:
+                del self._pending_comments[line]
+        self._emit_tail_warning(stale)
+
+    @staticmethod
+    def _emit_tail_warning(tail: list[tuple[int, str]]) -> None:
+        """Emit a UserWarning summarizing dropped tail-of-block comments."""
         if not tail:
             return
         preview = ", ".join(f"line {line}: {text!r}" for line, text in tail[:3])
@@ -1076,9 +1216,8 @@ class ASTParser:
                 self._setup_iter_args(loop, iter_args_node, range_args["init_values"])
 
             with self._yield_tracking_scope():
-                for body_stmt in stmt.body:
-                    self.parse_statement(body_stmt)
-                self._discard_tail_block_comments(stmt.body)
+                self._parse_body_siblings(stmt.body)
+                self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
                 assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
                 loop_output_vars = self._current_yield_vars[:]
 
@@ -1518,17 +1657,16 @@ class ASTParser:
     def _parse_while_body_statements(self, stmt: ast.For) -> list[str]:
         """Parse body statements for pl.while_() loop, return yielded vars."""
         with self._yield_tracking_scope():
-            # Parse body (skip first statement which is pl.cond())
+            # Validate body (skip first statement which is pl.cond()).
             for body_stmt in stmt.body[1:]:
-                # Check if pl.cond() appears anywhere else in body
                 if self._is_cond_call(body_stmt):
                     raise ParserSyntaxError(
                         "pl.cond() can only be the first statement in a pl.while_() loop body",
                         span=self.span_tracker.get_span(body_stmt),
                         hint="Remove this pl.cond() - condition is already specified at the start",
                     )
-                self.parse_statement(body_stmt)
-            self._discard_tail_block_comments(stmt.body[1:])
+            self._parse_body_siblings(stmt.body[1:])
+            self._discard_tail_block_comments(stmt.body[1:], upper_line=stmt.end_lineno)
 
             assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
             return self._current_yield_vars[:]
@@ -1646,9 +1784,8 @@ class ASTParser:
             self.scope_manager.enter_scope("while")
 
             # Parse body statements
-            for body_stmt in stmt.body:
-                self.parse_statement(body_stmt)
-            self._discard_tail_block_comments(stmt.body)
+            self._parse_body_siblings(stmt.body)
+            self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
 
             # Variables leak to outer scope (ConvertToSSA will handle)
             self.scope_manager.exit_scope(leak_vars=True)
@@ -1698,18 +1835,16 @@ class ASTParser:
 
                 # Parse then branch (yield types captured via _current_yield_types)
                 self.scope_manager.enter_scope("if")
-                for then_stmt in stmt.body:
-                    self.parse_statement(then_stmt)
-                self._discard_tail_block_comments(stmt.body)
+                self._parse_body_siblings(stmt.body)
+                self._discard_tail_block_comments(stmt.body, upper_line=self._then_branch_tail_upper(stmt))
                 self.scope_manager.exit_scope(leak_vars=should_leak)
 
                 # Parse else branch if present
                 if stmt.orelse:
                     if_builder.else_()
                     self.scope_manager.enter_scope("else")
-                    for else_stmt in stmt.orelse:
-                        self.parse_statement(else_stmt)
-                    self._discard_tail_block_comments(stmt.orelse)
+                    self._parse_body_siblings(stmt.orelse)
+                    self._discard_tail_block_comments(stmt.orelse, upper_line=stmt.end_lineno)
                     self.scope_manager.exit_scope(leak_vars=should_leak)
 
                 # Declare return vars AFTER parsing branches so captured yield types
@@ -2004,9 +2139,8 @@ class ASTParser:
         with self.builder.scope(scope_kind, span, level=level, role=role, split=split, name_hint=name_hint):
             with self._scope_kind_context(scope_kind):
                 self.scope_manager.enter_scope("scope")
-                for body_stmt in stmt.body:
-                    self.parse_statement(body_stmt)
-                self._discard_tail_block_comments(stmt.body)
+                self._parse_body_siblings(stmt.body)
+                self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
                 self.scope_manager.exit_scope(leak_vars=True)
 
     def _parse_at_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -191,7 +191,7 @@ class ASTParser:
         closure_vars: dict[str, Any] | None = None,
         buffer_name_meta: dict[tuple[str, str], dict[str, Any]] | None = None,
         dyn_var_cache: dict[str, ir.Var] | None = None,
-        pending_comments: dict[int, list[str]] | None = None,
+        pending_comments: dict[int, list[tuple[int, str]]] | None = None,
     ):
         """Initialize AST parser.
 
@@ -262,7 +262,9 @@ class ASTParser:
         self._func_name: str = ""
 
         # Pending comments keyed by 1-based line number, drained by parse_statement.
-        self._pending_comments: dict[int, list[str]] = pending_comments or {}
+        # Each entry is (col_offset, text) so the parser can distinguish
+        # tail-of-block comments (inside body indent) from outer-scope comments.
+        self._pending_comments: dict[int, list[tuple[int, str]]] = pending_comments or {}
 
     @contextmanager
     def _yield_tracking_scope(self) -> Iterator[None]:
@@ -382,6 +384,7 @@ class ASTParser:
             # parse_statement — no separate skip is needed here.
             for stmt in func_def.body:
                 self.parse_statement(stmt)
+            self._discard_tail_block_comments(func_def.body)
 
         # Exit function scope
         self.scope_manager.exit_scope()
@@ -472,7 +475,7 @@ class ASTParser:
             end_line = stmt.end_lineno or stmt.lineno
         leading: list[str] = []
         for line in sorted(k for k in self._pending_comments if k <= end_line):
-            leading.extend(self._pending_comments.pop(line))
+            leading.extend(text for _col, text in self._pending_comments.pop(line))
         return leading
 
     def _requeue_comments_after(self, stmt: ast.stmt, comments: list[str]) -> None:
@@ -480,13 +483,57 @@ class ASTParser:
 
         Used when a stmt does not produce IR (docstring reroute, bare ``pass``)
         but may have collected leading comments that must survive to the next
-        stmt. No-op when ``comments`` is empty.
+        stmt. No-op when ``comments`` is empty. Synthetic comments inherit the
+        stmt's column offset so they are treated as body-level for tail-drop
+        purposes.
         """
         if not comments:
             return
         next_line = (stmt.end_lineno or stmt.lineno) + 1
+        col = stmt.col_offset
+        entries = [(col, text) for text in comments]
         existing = self._pending_comments.setdefault(next_line, [])
-        self._pending_comments[next_line] = [*comments, *existing]
+        self._pending_comments[next_line] = [*entries, *existing]
+
+    def _discard_tail_block_comments(self, body: list[ast.stmt]) -> None:
+        """Drop pending comments at or deeper than ``body``'s indentation.
+
+        Called after a block's body finishes parsing. Any pending comment whose
+        column is ``>= body[0].col_offset`` sat at the block's indent but was
+        not drained by any body stmt — a tail-of-block comment that has no
+        natural attachment target. We emit a warning and drop these, while
+        leaving shallower-indent comments (belonging to an outer scope) in
+        place so they can attach to the next outer-scope stmt.
+
+        No-op when ``body`` is empty (nothing to determine the block indent).
+        """
+        if not body or not self._pending_comments:
+            return
+        block_col = body[0].col_offset
+        tail: list[tuple[int, str]] = []
+        for line in sorted(self._pending_comments):
+            remaining: list[tuple[int, str]] = []
+            for col, text in self._pending_comments[line]:
+                if col >= block_col:
+                    tail.append((line, text))
+                else:
+                    remaining.append((col, text))
+            if remaining:
+                self._pending_comments[line] = remaining
+            else:
+                del self._pending_comments[line]
+        if not tail:
+            return
+        preview = ", ".join(f"line {line}: {text!r}" for line, text in tail[:3])
+        if len(tail) > 3:
+            preview += f", … (+{len(tail) - 3} more)"
+        warnings.warn(
+            f"Dropped {len(tail)} tail-of-block comment(s): {preview}. "
+            "Tail-of-block comments are not preserved in IR; move them above a "
+            "statement or into the outer scope to retain them.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:  # noqa: PLR0912
         """Parse annotated assignment: var: type = value.
@@ -998,6 +1045,7 @@ class ASTParser:
             with self._yield_tracking_scope():
                 for body_stmt in stmt.body:
                     self.parse_statement(body_stmt)
+                self._discard_tail_block_comments(stmt.body)
                 assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
                 loop_output_vars = self._current_yield_vars[:]
 
@@ -1447,6 +1495,7 @@ class ASTParser:
                         hint="Remove this pl.cond() - condition is already specified at the start",
                     )
                 self.parse_statement(body_stmt)
+            self._discard_tail_block_comments(stmt.body[1:])
 
             assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
             return self._current_yield_vars[:]
@@ -1566,6 +1615,7 @@ class ASTParser:
             # Parse body statements
             for body_stmt in stmt.body:
                 self.parse_statement(body_stmt)
+            self._discard_tail_block_comments(stmt.body)
 
             # Variables leak to outer scope (ConvertToSSA will handle)
             self.scope_manager.exit_scope(leak_vars=True)
@@ -1617,6 +1667,7 @@ class ASTParser:
                 self.scope_manager.enter_scope("if")
                 for then_stmt in stmt.body:
                     self.parse_statement(then_stmt)
+                self._discard_tail_block_comments(stmt.body)
                 self.scope_manager.exit_scope(leak_vars=should_leak)
 
                 # Parse else branch if present
@@ -1625,6 +1676,7 @@ class ASTParser:
                     self.scope_manager.enter_scope("else")
                     for else_stmt in stmt.orelse:
                         self.parse_statement(else_stmt)
+                    self._discard_tail_block_comments(stmt.orelse)
                     self.scope_manager.exit_scope(leak_vars=should_leak)
 
                 # Declare return vars AFTER parsing branches so captured yield types
@@ -1921,6 +1973,7 @@ class ASTParser:
                 self.scope_manager.enter_scope("scope")
                 for body_stmt in stmt.body:
                     self.parse_statement(body_stmt)
+                self._discard_tail_block_comments(stmt.body)
                 self.scope_manager.exit_scope(leak_vars=True)
 
     def _parse_at_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -417,6 +417,16 @@ class ASTParser:
             self._requeue_comments_after(stmt, [*leading, *doc_lines])
             return
 
+        # Push leading comments onto the builder's pending stack BEFORE
+        # dispatching. The first stmt the helper emits in the same context as
+        # this push absorbs the queued comments through its ctor path. The
+        # stack (rather than a single slot) lets nested parse_statement calls
+        # (this compound stmt + its body stmts) each have their own pending
+        # entry without clobbering the outer one. If the helper emits nothing
+        # (e.g. pl.static_assert, pass), pop returns the entry untouched and
+        # we re-queue it into _pending_comments so the next stmt picks it up.
+        self.builder.push_pending_leading_comments(leading)
+
         if isinstance(stmt, ast.AnnAssign):
             self.parse_annotated_assignment(stmt)
         elif isinstance(stmt, ast.Assign):
@@ -438,10 +448,7 @@ class ASTParser:
         elif isinstance(stmt, ast.Continue):
             self.parse_continue(stmt)
         elif isinstance(stmt, ast.Pass):
-            # No-op: pass statements produce no IR. Re-enqueue any collected
-            # comments for the following stmt so they don't get silently dropped.
-            self._requeue_comments_after(stmt, leading)
-            return
+            pass  # Produces no IR; residue handling below re-queues the comments.
         else:
             raise UnsupportedFeatureError(
                 f"Unsupported statement type: {type(stmt).__name__}",
@@ -450,32 +457,58 @@ class ASTParser:
                 "with statements, returns, break, continue, and pass are supported in DSL functions",
             )
 
-        if leading:
-            self.builder.attach_leading_comments_to_last(leading)
+        # Pop the pending entry we pushed above. If the helper emitted a
+        # matching stmt, the result is empty. Otherwise the unconsumed
+        # comments get re-queued into _pending_comments so the next source
+        # stmt picks them up.
+        residue = self.builder.pop_pending_leading_comments()
+        if residue:
+            self._requeue_comments_after(stmt, residue)
 
     def _drain_pending_comments(self, stmt: ast.stmt) -> list[str]:
         """Collect pending comments whose line numbers fall at or before ``stmt``.
 
-        For compound stmts (``for``/``while``/``if``/``with``), only comments
-        whose line is ``<= stmt.lineno`` (the header's first line) are drained;
-        body-inner comments are left for the body stmts' own drains. For simple
-        stmts, drain through ``stmt.end_lineno`` so trailing comments on the
-        last logical line (e.g. ``y = 1  # note``) are captured.
+        For simple stmts, drain through ``stmt.end_lineno`` so trailing comments
+        on the last logical line (e.g. ``y = 1  # note``) attach to the stmt.
 
-        Returns comments in source order and removes them from the pending map.
+        For compound stmts (``for``/``while``/``if``/``with``) with a non-empty
+        body, the header can span multiple physical lines. We drain up to the
+        line just before the first body stmt and split by column: comments at
+        a column *less than* the body's indent are header-level and attach to
+        the compound stmt; comments at the body's indent are left pending for
+        the first body stmt to pick up.
+
+        Returns comments in source order and removes header/simple entries from
+        the pending map.
         """
         if not self._pending_comments:
             return []
-        # Compound stmts expose a non-empty ``body`` list; drain only through
-        # the header line so body-inner comments stay pending.
         body = getattr(stmt, "body", None)
+        leading: list[str] = []
         if isinstance(body, list) and body:
-            end_line = stmt.lineno
+            header_end = body[0].lineno - 1
+            body_col = body[0].col_offset
+            for line in sorted(k for k in self._pending_comments if k <= header_end):
+                if line == stmt.lineno:
+                    # Inline trailer on the header's first line (e.g.
+                    # `for i in range(16):  # tiles`) — always attach, regardless
+                    # of the high column where tokenize reports it.
+                    leading.extend(text for _col, text in self._pending_comments.pop(line))
+                    continue
+                kept: list[tuple[int, str]] = []
+                for col, text in self._pending_comments[line]:
+                    if col < body_col:
+                        leading.append(text)
+                    else:
+                        kept.append((col, text))
+                if kept:
+                    self._pending_comments[line] = kept
+                else:
+                    del self._pending_comments[line]
         else:
             end_line = stmt.end_lineno or stmt.lineno
-        leading: list[str] = []
-        for line in sorted(k for k in self._pending_comments if k <= end_line):
-            leading.extend(text for _col, text in self._pending_comments.pop(line))
+            for line in sorted(k for k in self._pending_comments if k <= end_line):
+                leading.extend(text for _col, text in self._pending_comments.pop(line))
         return leading
 
     def _requeue_comments_after(self, stmt: ast.stmt, comments: list[str]) -> None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -179,7 +179,7 @@ def _normalize_inferred_type_for_annotation(
 class ASTParser:
     """Parses Python AST and builds IR using IRBuilder."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         source_file: str,
         source_lines: list[str],
@@ -191,6 +191,7 @@ class ASTParser:
         closure_vars: dict[str, Any] | None = None,
         buffer_name_meta: dict[tuple[str, str], dict[str, Any]] | None = None,
         dyn_var_cache: dict[str, ir.Var] | None = None,
+        pending_comments: dict[int, list[str]] | None = None,
     ):
         """Initialize AST parser.
 
@@ -209,6 +210,9 @@ class ASTParser:
             dyn_var_cache: Optional shared cache mapping dynamic var names to ir.Var objects.
                 When multiple functions in a @pl.program share this dict, the same DynVar
                 produces the same ir.Var across functions.
+            pending_comments: Map from 1-based line number to ``#``-stripped comment lines
+                (produced by :func:`extract_line_comments`). Drained in source order and
+                attached as ``leading_comments`` metadata to the stmt that follows.
         """
         self.span_tracker = SpanTracker(source_file, source_lines, line_offset, col_offset)
         self.scope_manager = ScopeManager(strict_ssa=strict_ssa)
@@ -256,6 +260,9 @@ class ASTParser:
         )
         # Current function name (set during parse_function)
         self._func_name: str = ""
+
+        # Pending comments keyed by 1-based line number, drained by parse_statement.
+        self._pending_comments: dict[int, list[str]] = pending_comments or {}
 
     @contextmanager
     def _yield_tracking_scope(self) -> Iterator[None]:
@@ -370,12 +377,10 @@ class ASTParser:
                 else:
                     f.return_type(return_type)
 
-            # Parse function body (skip docstrings)
-            for i, stmt in enumerate(func_def.body):
-                # Skip docstrings (string constants as first statement or after decorators)
-                if i == 0 and isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
-                    if isinstance(stmt.value.value, str):
-                        continue  # Skip docstring
+            # Parse function body. Docstrings (bare-string expressions anywhere
+            # in the body) are rerouted as leading_comments on the next stmt by
+            # parse_statement — no separate skip is needed here.
+            for stmt in func_def.body:
                 self.parse_statement(stmt)
 
         # Exit function scope
@@ -386,9 +391,29 @@ class ASTParser:
     def parse_statement(self, stmt: ast.stmt) -> None:
         """Parse a statement node.
 
+        Drains pending ``#`` comments on lines up to ``stmt.end_lineno`` and
+        attaches them as leading comments on the emitted IR stmt. Bare-string
+        expressions (docstrings) are not emitted as IR; their text is rerouted
+        into ``_pending_comments`` so the next stmt picks them up as leading
+        comments.
+
         Args:
             stmt: AST statement node
         """
+        leading = self._drain_pending_comments(stmt)
+
+        if (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        ):
+            # Bare-string expression — treat as comment text on the next stmt.
+            # Prepend any `#` comments already collected for this line so the
+            # printed order matches source order.
+            doc_lines = stmt.value.value.splitlines() or [""]
+            self._requeue_comments_after(stmt, [*leading, *doc_lines])
+            return
+
         if isinstance(stmt, ast.AnnAssign):
             self.parse_annotated_assignment(stmt)
         elif isinstance(stmt, ast.Assign):
@@ -410,7 +435,10 @@ class ASTParser:
         elif isinstance(stmt, ast.Continue):
             self.parse_continue(stmt)
         elif isinstance(stmt, ast.Pass):
-            pass  # No-op: pass statements produce no IR
+            # No-op: pass statements produce no IR. Re-enqueue any collected
+            # comments for the following stmt so they don't get silently dropped.
+            self._requeue_comments_after(stmt, leading)
+            return
         else:
             raise UnsupportedFeatureError(
                 f"Unsupported statement type: {type(stmt).__name__}",
@@ -418,6 +446,47 @@ class ASTParser:
                 hint="Only assignments, for loops, while loops, if statements, "
                 "with statements, returns, break, continue, and pass are supported in DSL functions",
             )
+
+        if leading:
+            self.builder.attach_leading_comments_to_last(leading)
+
+    def _drain_pending_comments(self, stmt: ast.stmt) -> list[str]:
+        """Collect pending comments whose line numbers fall at or before ``stmt``.
+
+        For compound stmts (``for``/``while``/``if``/``with``), only comments
+        whose line is ``<= stmt.lineno`` (the header's first line) are drained;
+        body-inner comments are left for the body stmts' own drains. For simple
+        stmts, drain through ``stmt.end_lineno`` so trailing comments on the
+        last logical line (e.g. ``y = 1  # note``) are captured.
+
+        Returns comments in source order and removes them from the pending map.
+        """
+        if not self._pending_comments:
+            return []
+        # Compound stmts expose a non-empty ``body`` list; drain only through
+        # the header line so body-inner comments stay pending.
+        body = getattr(stmt, "body", None)
+        if isinstance(body, list) and body:
+            end_line = stmt.lineno
+        else:
+            end_line = stmt.end_lineno or stmt.lineno
+        leading: list[str] = []
+        for line in sorted(k for k in self._pending_comments if k <= end_line):
+            leading.extend(self._pending_comments.pop(line))
+        return leading
+
+    def _requeue_comments_after(self, stmt: ast.stmt, comments: list[str]) -> None:
+        """Re-enqueue ``comments`` onto the line after ``stmt`` ends.
+
+        Used when a stmt does not produce IR (docstring reroute, bare ``pass``)
+        but may have collected leading comments that must survive to the next
+        stmt. No-op when ``comments`` is empty.
+        """
+        if not comments:
+            return
+        next_line = (stmt.end_lineno or stmt.lineno) + 1
+        existing = self._pending_comments.setdefault(next_line, [])
+        self._pending_comments[next_line] = [*comments, *existing]
 
     def parse_annotated_assignment(self, stmt: ast.AnnAssign) -> None:  # noqa: PLR0912
         """Parse annotated assignment: var: type = value.

--- a/python/pypto/language/parser/comment_extractor.py
+++ b/python/pypto/language/parser/comment_extractor.py
@@ -10,16 +10,17 @@
 """Extract ``#`` comments from DSL source text.
 
 The Python ``ast`` module discards comments, so we run ``tokenize`` independently
-and key each comment by its (1-based) line number. The parser later drains this
-map per stmt and attaches the comments as ``leading_comments_`` metadata.
+and key each comment by its (1-based) line number. Each entry carries the column
+offset so the parser can distinguish tail-of-block comments (inside body indent)
+from outer-scope comments (at the enclosing indent).
 """
 
 import io
 import tokenize
 
 
-def extract_line_comments(source: str) -> dict[int, list[str]]:
-    """Return a mapping from 1-based line number to comment text(s) on that line.
+def extract_line_comments(source: str) -> dict[int, list[tuple[int, str]]]:
+    """Return a mapping from 1-based line number to ``(col_offset, text)`` tuples.
 
     The leading ``#`` and any single space after it are stripped from each
     comment. Trailing whitespace is preserved (comments are emitted verbatim).
@@ -28,10 +29,10 @@ def extract_line_comments(source: str) -> dict[int, list[str]]:
         source: Python source code (same text that will be fed to :func:`ast.parse`)
 
     Returns:
-        Dict keyed by line number. Lines without comments are absent from the map.
-        Multiple comments on the same line are returned in source order.
+        Dict keyed by line number. Each value is a list of ``(col_offset, text)``
+        pairs in source order. Lines without comments are absent from the map.
     """
-    result: dict[int, list[str]] = {}
+    result: dict[int, list[tuple[int, str]]] = {}
     try:
         tokens = tokenize.generate_tokens(io.StringIO(source).readline)
         for tok in tokens:
@@ -39,7 +40,7 @@ def extract_line_comments(source: str) -> dict[int, list[str]]:
                 text = tok.string.lstrip("#")
                 if text.startswith(" "):
                     text = text[1:]
-                result.setdefault(tok.start[0], []).append(text)
+                result.setdefault(tok.start[0], []).append((tok.start[1], text))
     except (tokenize.TokenError, IndentationError, SyntaxError):
         # Malformed source — caller's ast.parse will surface a clearer error.
         return result

--- a/python/pypto/language/parser/comment_extractor.py
+++ b/python/pypto/language/parser/comment_extractor.py
@@ -1,0 +1,46 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Extract ``#`` comments from DSL source text.
+
+The Python ``ast`` module discards comments, so we run ``tokenize`` independently
+and key each comment by its (1-based) line number. The parser later drains this
+map per stmt and attaches the comments as ``leading_comments_`` metadata.
+"""
+
+import io
+import tokenize
+
+
+def extract_line_comments(source: str) -> dict[int, list[str]]:
+    """Return a mapping from 1-based line number to comment text(s) on that line.
+
+    The leading ``#`` and any single space after it are stripped from each
+    comment. Trailing whitespace is preserved (comments are emitted verbatim).
+
+    Args:
+        source: Python source code (same text that will be fed to :func:`ast.parse`)
+
+    Returns:
+        Dict keyed by line number. Lines without comments are absent from the map.
+        Multiple comments on the same line are returned in source order.
+    """
+    result: dict[int, list[str]] = {}
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for tok in tokens:
+            if tok.type == tokenize.COMMENT:
+                text = tok.string.lstrip("#")
+                if text.startswith(" "):
+                    text = text[1:]
+                result.setdefault(tok.start[0], []).append(text)
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        # Malformed source — caller's ast.parse will surface a clearer error.
+        return result
+    return result

--- a/python/pypto/language/parser/comment_extractor.py
+++ b/python/pypto/language/parser/comment_extractor.py
@@ -37,7 +37,10 @@ def extract_line_comments(source: str) -> dict[int, list[tuple[int, str]]]:
         tokens = tokenize.generate_tokens(io.StringIO(source).readline)
         for tok in tokens:
             if tok.type == tokenize.COMMENT:
-                text = tok.string.lstrip("#")
+                # Strip exactly one leading '#' and at most one following space.
+                # Multi-hash forms like "## heading" keep their extra hashes so
+                # the printed comment still reads "# heading" after re-emission.
+                text = tok.string[1:] if tok.string.startswith("#") else tok.string
                 if text.startswith(" "):
                     text = text[1:]
                 result.setdefault(tok.start[0], []).append((tok.start[1], text))

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -880,6 +880,21 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
             # ir.Var objects for dynamic dimension variables (issue #618).
             dyn_var_cache: dict[str, ir.Var] = {}
 
+            # Compute per-method line-range boundaries. Each method owns comments from
+            # its first-line up to the line just before the next method (or end of
+            # class for the last one). This captures tail-of-block comments inside
+            # the method body that AST end_lineno excludes, without letting earlier-
+            # or later-method comments leak across.
+            method_boundaries: dict[int, tuple[int, int]] = {}
+            sorted_defs = sorted(func_defs, key=lambda d: d.lineno)
+            for idx, fd in enumerate(sorted_defs):
+                start = fd.lineno
+                if idx + 1 < len(sorted_defs):
+                    end = sorted_defs[idx + 1].lineno - 1
+                else:
+                    end = max((fd.end_lineno or fd.lineno), max(pending_comments, default=fd.lineno))
+                method_boundaries[id(fd)] = (start, end)
+
             for func_def in func_defs:
                 # Extract function type, level/role, and attrs from decorator
                 func_type = _extract_function_type_from_decorator(func_def)
@@ -889,8 +904,10 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                 # Strip 'self' parameter if present (must be done before parsing)
                 func_def_to_parse = _strip_self_parameter(func_def)
 
-                # Create parser with global_vars and gvar_to_func map for cross-function call resolution.
-                # Copy pending_comments so each function consumes comments independently.
+                method_start, method_end = method_boundaries[id(func_def)]
+                method_comments = {
+                    k: list(v) for k, v in pending_comments.items() if method_start <= k <= method_end
+                }
                 parser = ASTParser(
                     source_file,
                     source_lines,
@@ -902,7 +919,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                     closure_vars=closure_vars,
                     buffer_name_meta=buffer_name_meta,
                     dyn_var_cache=dyn_var_cache,
-                    pending_comments={k: list(v) for k, v in pending_comments.items()},
+                    pending_comments=method_comments,
                 )
 
                 try:

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -22,6 +22,7 @@ from pypto.compile_profiling import CompileProfiler, get_active_profiler
 from pypto.pypto_core import ir
 
 from .ast_parser import ASTParser
+from .comment_extractor import extract_line_comments
 from .diagnostics import ParserError, ParserSyntaxError, concise_error_message
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
 
@@ -671,6 +672,7 @@ def function(
                 col_offset,
                 strict_ssa=strict_ssa,
                 closure_vars=closure_vars,
+                pending_comments=extract_line_comments(source_code),
             )
 
             # Normalize attrs: convert enum values to ints for storage
@@ -841,6 +843,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
         try:
             tree = _parse_ast_tree(source_code, "class")
             class_def = _find_ast_node(tree, ast.ClassDef, c.__name__, "class")
+            pending_comments = extract_line_comments(source_code)
 
             # Pass 1: Collect all @pl.function methods and create GlobalVars
             global_vars = {}
@@ -886,7 +889,8 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                 # Strip 'self' parameter if present (must be done before parsing)
                 func_def_to_parse = _strip_self_parameter(func_def)
 
-                # Create parser with global_vars and gvar_to_func map for cross-function call resolution
+                # Create parser with global_vars and gvar_to_func map for cross-function call resolution.
+                # Copy pending_comments so each function consumes comments independently.
                 parser = ASTParser(
                     source_file,
                     source_lines,
@@ -898,6 +902,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                     closure_vars=closure_vars,
                     buffer_name_meta=buffer_name_meta,
                     dyn_var_cache=dyn_var_cache,
+                    pending_comments={k: list(v) for k, v in pending_comments.items()},
                 )
 
                 try:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2684,16 +2684,20 @@ class IRBuilder:
             stmt: Statement to emit
         """
 
-    def attach_leading_comments_to_last(self, comments: list[str]) -> None:
-        """Attach leading comments to the most recently emitted statement.
+    def push_pending_leading_comments(self, comments: list[str]) -> None:
+        """Push leading comments onto the pending stack.
 
-        Used by the DSL parser to associate extracted source comments with the
-        stmt just emitted in the current context (outer stmt of a compound
-        block, or the simple stmt itself). No-op if the current context has no
-        statements yet or ``comments`` is empty.
+        The DSL parser calls this before dispatching to a ``parse_*`` helper.
+        Pair every push with exactly one ``pop_pending_leading_comments``.
 
         Args:
             comments: Comment lines (without leading ``#``)
+        """
+
+    def pop_pending_leading_comments(self) -> list[str]:
+        """Pop the top pending entry, returning whatever stayed unconsumed.
+
+        Returns ``[]`` when the matching emit already consumed the queue.
         """
 
     def assign(self, var: Var, value: Expr, span: Span) -> AssignStmt:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1545,6 +1545,13 @@ class Cast(UnaryExpr):
 class Stmt(IRNode):
     """Base class for all statements."""
 
+    leading_comments: Final[list[str]]
+    """Source-level comments printed above this statement.
+
+    IgnoreField metadata — never participates in structural_equal or hashing.
+    Read-only from Python; use :func:`attach_leading_comments` to modify.
+    """
+
     def __init__(self, span: Span) -> None:
         """Create a statement.
 
@@ -2119,6 +2126,22 @@ def assert_structural_equal(
         ValueError: If objects are not structurally equal, with detailed diagnostic message
     """
 
+def attach_leading_comments(stmt: Stmt, comments: list[str]) -> Stmt:
+    """Attach leading comments to an existing statement.
+
+    ``Stmt.leading_comments`` is read-only from Python; this helper is the
+    sanctioned mutation channel for IgnoreField metadata (e.g., used by the
+    DSL parser to attach extracted source comments). The input statement is
+    mutated in place and returned.
+
+    Args:
+        stmt: Statement to annotate
+        comments: Comment lines (without leading ``#``)
+
+    Returns:
+        The same statement, with ``leading_comments`` replaced by ``comments``
+    """
+
 @overload
 def memref_init(func: Function) -> Function: ...
 @overload
@@ -2659,6 +2682,18 @@ class IRBuilder:
 
         Args:
             stmt: Statement to emit
+        """
+
+    def attach_leading_comments_to_last(self, comments: list[str]) -> None:
+        """Attach leading comments to the most recently emitted statement.
+
+        Used by the DSL parser to associate extracted source comments with the
+        stmt just emitted in the current context (outer stmt of a compound
+        block, or the simple stmt itself). No-op if the current context has no
+        statements yet or ``comments`` is empty.
+
+        Args:
+            comments: Comment lines (without leading ``#``)
         """
 
     def assign(self, var: Var, value: Expr, span: Span) -> AssignStmt:

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -408,6 +408,16 @@ void IRBuilder::Emit(const StmtPtr& stmt) {
   ctx->AddStmt(stmt);
 }
 
+void IRBuilder::AttachLeadingCommentsToLast(std::vector<std::string> comments) {
+  if (comments.empty()) return;
+  if (context_stack_.empty()) {
+    throw pypto::RuntimeError("Cannot attach leading comments: not inside any context");
+  }
+  auto last = CurrentContext()->GetLastEmittedStmt();
+  if (!last) return;
+  AttachLeadingComments(last, std::move(comments));
+}
+
 AssignStmtPtr IRBuilder::Assign(const VarPtr& var, const ExprPtr& value, const Span& span) {
   auto assign = std::make_shared<AssignStmt>(var, value, span);
   Emit(assign);

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -151,6 +151,7 @@ StmtPtr IRBuilder::EndForLoop(const Span& end_span) {
 
   // Emit to parent context if it exists
   if (!context_stack_.empty()) {
+    ApplyPendingLeadingComments(for_stmt);
     CurrentContext()->AddStmt(for_stmt);
   }
 
@@ -217,6 +218,7 @@ StmtPtr IRBuilder::EndWhileLoop(const Span& end_span) {
 
   // Emit to parent context if it exists
   if (!context_stack_.empty()) {
+    ApplyPendingLeadingComments(while_stmt);
     CurrentContext()->AddStmt(while_stmt);
   }
 
@@ -279,6 +281,7 @@ StmtPtr IRBuilder::EndIf(const Span& end_span) {
 
   // Emit to parent context if it exists
   if (!context_stack_.empty()) {
+    ApplyPendingLeadingComments(if_stmt);
     CurrentContext()->AddStmt(if_stmt);
   }
 
@@ -322,6 +325,7 @@ StmtPtr IRBuilder::EndScope(const Span& end_span) {
 
   // Emit to parent context if it exists
   if (!context_stack_.empty()) {
+    ApplyPendingLeadingComments(scope_stmt);
     CurrentContext()->AddStmt(scope_stmt);
   }
 
@@ -403,19 +407,29 @@ void IRBuilder::Emit(const StmtPtr& stmt) {
   if (context_stack_.empty()) {
     throw pypto::RuntimeError("Cannot emit statement: not inside any context");
   }
-
-  auto* ctx = CurrentContext();
-  ctx->AddStmt(stmt);
+  ApplyPendingLeadingComments(stmt);
+  CurrentContext()->AddStmt(stmt);
 }
 
-void IRBuilder::AttachLeadingCommentsToLast(std::vector<std::string> comments) {
-  if (comments.empty()) return;
-  if (context_stack_.empty()) {
-    throw pypto::RuntimeError("Cannot attach leading comments: not inside any context");
-  }
-  auto last = CurrentContext()->GetLastEmittedStmt();
-  if (!last) return;
-  AttachLeadingComments(last, std::move(comments));
+void IRBuilder::ApplyPendingLeadingComments(const StmtPtr& stmt) {
+  if (pending_leading_stack_.empty() || context_stack_.empty()) return;
+  auto& top = pending_leading_stack_.back();
+  if (top.comments.empty() || top.target != CurrentContext()) return;
+  AttachLeadingComments(stmt, std::move(top.comments));
+  top.comments.clear();  // entry stays on the stack; Pop clears it
+}
+
+void IRBuilder::PushPendingLeadingComments(std::vector<std::string> comments) {
+  BuildContext* target = context_stack_.empty() ? nullptr : context_stack_.back().get();
+  pending_leading_stack_.push_back({std::move(comments), target});
+}
+
+std::vector<std::string> IRBuilder::PopPendingLeadingComments() {
+  INTERNAL_CHECK(!pending_leading_stack_.empty())
+      << "PopPendingLeadingComments called without a matching Push";
+  auto comments = std::move(pending_leading_stack_.back().comments);
+  pending_leading_stack_.pop_back();
+  return comments;
 }
 
 AssignStmtPtr IRBuilder::Assign(const VarPtr& var, const ExprPtr& value, const Span& span) {

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -107,7 +107,9 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
     INTERNAL_CHECK(has_id && has_type && has_fields)
         << "Missing required fields (id, type, or fields) in node";
 
-    // Use type registry to create the node
+    // Use type registry to create the node. Per-type Stmt deserializers read
+    // "leading_comments" from fields_obj and pass it to the constructor —
+    // symmetric with how they read "span".
     IRNodePtr node = TypeRegistry::Instance().Create(type_name, fields_obj, zone, *this);
 
     // Store in reference table

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -101,6 +101,7 @@ class FieldSerializerVisitor {
   result_type VisitLeafField(const std::optional<SplitMode>& field);
   result_type VisitLeafField(const ParamDirection& field);
   result_type VisitLeafField(const std::vector<ParamDirection>& field);
+  result_type VisitLeafField(const std::vector<std::string>& field);
   result_type VisitLeafField(const TypePtr& field);
   result_type VisitLeafField(const OpPtr& field);
   result_type VisitLeafField(const Span& field);
@@ -605,6 +606,15 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(const std::vector<ParamDi
   vec.reserve(field.size());
   for (const auto& dir : field) {
     vec.emplace_back(static_cast<uint8_t>(dir), zone_);
+  }
+  return msgpack::object(vec, zone_);
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const std::vector<std::string>& field) {
+  std::vector<msgpack::object> vec;
+  vec.reserve(field.size());
+  for (const auto& s : field) {
+    vec.emplace_back(s, zone_);
   }
   return msgpack::object(vec, zone_);
 }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -51,6 +51,10 @@ using DeserializerContext = serialization::detail::DeserializerContext;
 // Extract a stmt's "leading_comments" field (absent ⇒ empty vector). Symmetric with
 // DeserializeSpan — each Stmt deserializer passes the result as the last ctor arg so
 // leading_comments is initialized at construction time, not attached after the fact.
+//
+// A missing field silently defaults to empty (backward compat with older .pto blobs).
+// A present field with an unexpected type raises — silently treating malformed data
+// as "no comments" would hide serializer/deserializer mismatches.
 static std::vector<std::string> DeserializeLeadingComments(const msgpack::object& fields_obj) {
   std::vector<std::string> comments;
   if (fields_obj.type != msgpack::type::MAP) return comments;
@@ -60,9 +64,14 @@ static std::vector<std::string> DeserializeLeadingComments(const msgpack::object
     std::string key;
     p->key.convert(key);
     if (key != "leading_comments") continue;
-    if (p->val.type != msgpack::type::ARRAY) return comments;
+    CHECK(p->val.type == msgpack::type::ARRAY)
+        << "Deserializer: 'leading_comments' must be a string array, got msgpack type "
+        << static_cast<int>(p->val.type);
     comments.reserve(p->val.via.array.size);
     for (uint32_t i = 0; i < p->val.via.array.size; ++i) {
+      CHECK(p->val.via.array.ptr[i].type == msgpack::type::STR)
+          << "Deserializer: 'leading_comments[" << i << "]' must be a string, got msgpack type "
+          << static_cast<int>(p->val.via.array.ptr[i].type);
       std::string text;
       p->val.via.array.ptr[i].convert(text);
       comments.push_back(std::move(text));

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -48,6 +48,30 @@ using DeserializerContext = serialization::detail::DeserializerContext;
 #define GET_FIELD(Type, name) ctx.GetField<Type>(fields_obj, name)
 #define GET_FIELD_OBJ(name) ctx.GetFieldObj(fields_obj, name)
 
+// Extract a stmt's "leading_comments" field (absent ⇒ empty vector). Symmetric with
+// DeserializeSpan — each Stmt deserializer passes the result as the last ctor arg so
+// leading_comments is initialized at construction time, not attached after the fact.
+static std::vector<std::string> DeserializeLeadingComments(const msgpack::object& fields_obj) {
+  std::vector<std::string> comments;
+  if (fields_obj.type != msgpack::type::MAP) return comments;
+  msgpack::object_kv* p = fields_obj.via.map.ptr;
+  msgpack::object_kv* const pend = fields_obj.via.map.ptr + fields_obj.via.map.size;
+  for (; p < pend; ++p) {
+    std::string key;
+    p->key.convert(key);
+    if (key != "leading_comments") continue;
+    if (p->val.type != msgpack::type::ARRAY) return comments;
+    comments.reserve(p->val.via.array.size);
+    for (uint32_t i = 0; i < p->val.via.array.size; ++i) {
+      std::string text;
+      p->val.via.array.ptr[i].convert(text);
+      comments.push_back(std::move(text));
+    }
+    break;
+  }
+  return comments;
+}
+
 // Helper function to get optional field (returns nullopt if field doesn't exist or is null)
 static std::optional<msgpack::object> GetOptionalFieldObj(const msgpack::object& fields_obj,
                                                           const std::string& field_name,
@@ -363,7 +387,7 @@ static IRNodePtr DeserializeAssignStmt(const msgpack::object& fields_obj, msgpac
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
   auto var = std::static_pointer_cast<const Var>(ctx.DeserializeNode(GET_FIELD_OBJ("var"), zone));
   auto value = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("value"), zone));
-  return std::make_shared<AssignStmt>(var, value, span);
+  return std::make_shared<AssignStmt>(var, value, span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize IfStmt
@@ -393,7 +417,8 @@ static IRNodePtr DeserializeIfStmt(const msgpack::object& fields_obj, msgpack::z
     }
   }
 
-  return std::make_shared<IfStmt>(condition, then_body, else_body, return_vars, span);
+  return std::make_shared<IfStmt>(condition, then_body, else_body, return_vars, span,
+                                  DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize YieldStmt
@@ -410,7 +435,7 @@ static IRNodePtr DeserializeYieldStmt(const msgpack::object& fields_obj, msgpack
     }
   }
 
-  return std::make_shared<YieldStmt>(value, span);
+  return std::make_shared<YieldStmt>(value, span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize ReturnStmt
@@ -427,7 +452,7 @@ static IRNodePtr DeserializeReturnStmt(const msgpack::object& fields_obj, msgpac
     }
   }
 
-  return std::make_shared<ReturnStmt>(value, span);
+  return std::make_shared<ReturnStmt>(value, span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize ForStmt
@@ -498,7 +523,7 @@ static IRNodePtr DeserializeForStmt(const msgpack::object& fields_obj, msgpack::
   }
 
   return std::make_shared<ForStmt>(loop_var, start, stop, step, iter_args, body, return_vars, span, kind,
-                                   chunk_config, std::move(attrs));
+                                   chunk_config, std::move(attrs), DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize WhileStmt
@@ -529,7 +554,8 @@ static IRNodePtr DeserializeWhileStmt(const msgpack::object& fields_obj, msgpack
     }
   }
 
-  return std::make_shared<WhileStmt>(condition, iter_args, body, return_vars, span);
+  return std::make_shared<WhileStmt>(condition, iter_args, body, return_vars, span,
+                                     DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize ScopeStmt
@@ -572,7 +598,8 @@ static IRNodePtr DeserializeScopeStmt(const msgpack::object& fields_obj, msgpack
   // Deserialize body
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
-  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name_hint));
+  return std::make_shared<ScopeStmt>(scope_kind, body, span, level, role, split, std::move(name_hint),
+                                     DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize SeqStmts
@@ -597,21 +624,21 @@ static IRNodePtr DeserializeEvalStmt(const msgpack::object& fields_obj, msgpack:
                                      DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
   auto expr = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(GET_FIELD_OBJ("expr"), zone));
-  return std::make_shared<EvalStmt>(expr, span);
+  return std::make_shared<EvalStmt>(expr, span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize BreakStmt
 static IRNodePtr DeserializeBreakStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
                                       DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
-  return std::make_shared<BreakStmt>(span);
+  return std::make_shared<BreakStmt>(span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize ContinueStmt
 static IRNodePtr DeserializeContinueStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
                                          DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
-  return std::make_shared<ContinueStmt>(span);
+  return std::make_shared<ContinueStmt>(span, DeserializeLeadingComments(fields_obj));
 }
 
 // Deserialize Function

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -330,8 +330,9 @@ class TypePropagatingMutator : public IRMutator {
     return UpdateLoopReturnVars(
         new_while->iter_args_, new_while->return_vars_, op->return_vars_,
         [&](auto new_rv) {
-          return std::make_shared<WhileStmt>(new_while->condition_, new_while->iter_args_, new_while->body_,
-                                             std::move(new_rv), new_while->span_);
+          auto result = MutableCopy(new_while);
+          result->return_vars_ = std::move(new_rv);
+          return StmtPtr(result);
         },
         result);
   }
@@ -399,11 +400,16 @@ class TypePropagatingMutator : public IRMutator {
     if (new_value->GetType() != op->value_->GetType()) {
       auto new_var = std::make_shared<Var>(op->var_->name_hint_, new_value->GetType(), op->var_->span_);
       var_remap_[op->var_.get()] = new_var;
-      return std::make_shared<AssignStmt>(new_var, new_value, op->span_);
+      auto result = MutableCopy(op);
+      result->var_ = new_var;
+      result->value_ = new_value;
+      return result;
     }
     // Value changed but type did not — keep original Var, clear any stale remap.
     var_remap_.erase(op->var_.get());
-    return std::make_shared<AssignStmt>(op->var_, new_value, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = new_value;
+    return result;
   }
 
  private:
@@ -520,7 +526,10 @@ class TensorToTileMutator : public TypePropagatingMutator {
     auto new_expr = VisitExpr(op->expr_);
     // Helper: return updated EvalStmt only when the expression actually changed.
     auto maybe_update = [&]() -> StmtPtr {
-      return (new_expr.get() != op->expr_.get()) ? std::make_shared<EvalStmt>(new_expr, op->span_) : op;
+      if (new_expr.get() == op->expr_.get()) return StmtPtr(op);
+      auto result = MutableCopy(op);
+      result->expr_ = new_expr;
+      return result;
     };
 
     auto call = As<Call>(new_expr);
@@ -563,7 +572,10 @@ class TensorToTileMutator : public TypePropagatingMutator {
     auto tile_name = MakeTileValueName(op->var_->name_hint_);
     auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), op->var_->span_);
     var_remap_[op->var_.get()] = tile_var;
-    return std::make_shared<AssignStmt>(tile_var, load_call, op->span_);
+    auto result = MutableCopy(op);
+    result->var_ = tile_var;
+    result->value_ = load_call;
+    return result;
   }
 
   /// Auto-bridge TensorType args to the memory space required by input_reqs.
@@ -1119,12 +1131,16 @@ std::optional<ReturnedAssembleLoopRewrite> RewriteReturnedAssembleLoopToStore(
     new_body_stmts.reserve(body_stmts.size());
     for (const auto& body_stmt : body_stmts) {
       if (body_stmt == assemble_assign) {
-        new_body_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, assemble_assign->span_));
+        auto new_assign = MutableCopy(assemble_assign);
+        new_assign->var_ = store_var;
+        new_assign->value_ = store_call;
+        new_body_stmts.push_back(std::move(new_assign));
         continue;
       }
       if (body_stmt == yield_stmt) {
-        new_body_stmts.push_back(
-            std::make_shared<YieldStmt>(std::vector<ExprPtr>{store_var}, yield_stmt->span_));
+        auto new_yield = MutableCopy(yield_stmt);
+        new_yield->value_ = std::vector<ExprPtr>{store_var};
+        new_body_stmts.push_back(std::move(new_yield));
         continue;
       }
       new_body_stmts.push_back(body_stmt);
@@ -1305,7 +1321,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     }
 
     // Build new return statement
-    new_stmts.push_back(std::make_shared<ReturnStmt>(new_return_exprs, return_stmt->span_));
+    auto new_return = MutableCopy(return_stmt);
+    new_return->value_ = std::move(new_return_exprs);
+    new_stmts.push_back(std::move(new_return));
   } else {
     // Void function (e.g. cross-core producer): add empty return
     INTERNAL_CHECK_SPAN(func->return_types_.empty(), func->span_)
@@ -1403,7 +1421,10 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
     }
 
     auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
-    stmts.push_back(std::make_shared<AssignStmt>(new_assign_var, new_call, op->span_));
+    auto new_assign = MutableCopy(op);
+    new_assign->var_ = new_assign_var;
+    new_assign->value_ = new_call;
+    stmts.push_back(std::move(new_assign));
     var_remap_[op->var_.get()] = new_assign_var;
 
     return SeqStmts::Flatten(std::move(stmts), op->span_);

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -385,7 +385,10 @@ class SSAConverter {
     auto val = SubstExpr(op->value_);
     auto key = op->var_.get();
     auto var = AllocVersion(key, op->var_->GetType(), op->var_->span_);
-    return std::make_shared<AssignStmt>(var, val, op->span_);
+    auto result = MutableCopy(op);
+    result->var_ = var;
+    result->value_ = val;
+    return result;
   }
 
   // ── SeqStmts — computes future uses per-statement for escaping detection
@@ -840,18 +843,25 @@ class SSAConverter {
   StmtPtr ConvertReturn(const ReturnStmtPtr& op) {
     std::vector<ExprPtr> vals;
     for (const auto& v : op->value_) vals.push_back(SubstExpr(v));
-    return std::make_shared<ReturnStmt>(vals, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(vals);
+    return result;
   }
 
   StmtPtr ConvertYield(const YieldStmtPtr& op) {
     std::vector<ExprPtr> vals;
     for (const auto& v : op->value_) vals.push_back(SubstExpr(v));
-    return std::make_shared<YieldStmt>(vals, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(vals);
+    return result;
   }
 
   StmtPtr ConvertEval(const EvalStmtPtr& op) {
     auto e = SubstExpr(op->expr_);
-    return e != op->expr_ ? std::make_shared<EvalStmt>(e, op->span_) : op;
+    if (e == op->expr_) return op;
+    auto result = MutableCopy(op);
+    result->expr_ = e;
+    return result;
   }
 
   StmtPtr ConvertScope(const ScopeStmtPtr& op) {

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -852,12 +852,14 @@ FunctionPtr RewriteGroupCaller(const FunctionPtr& group_func, const std::string&
     if (call) {
       auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
       if (gv && gv->name_ == incore_name) {
-        // Emit AIC call (always fire-and-forget)
+        // Emit AIC call (always fire-and-forget). Original's leading_comments
+        // attach here — AIC is the semantic front of the split pair.
         auto aic_call =
             std::make_shared<Call>(std::make_shared<GlobalVar>(aic_name), call->args_, stmt->span_);
-        new_stmts.push_back(std::make_shared<EvalStmt>(aic_call, stmt->span_));
+        new_stmts.push_back(std::make_shared<EvalStmt>(aic_call, stmt->span_, stmt->leading_comments_));
 
-        // Emit AIV call: AssignStmt preserves return value, EvalStmt for void
+        // Emit AIV call: AssignStmt preserves return value, EvalStmt for void.
+        // AIV is a continuation of the same logical op, so no comments attach.
         if (assign) {
           auto aiv_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_,
                                                  call->GetType(), stmt->span_);
@@ -1011,13 +1013,17 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     };
     if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
       if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_))) {
-        new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, rw, assign->span_));
+        auto new_assign = MutableCopy(assign);
+        new_assign->value_ = rw;
+        new_stmts.push_back(std::move(new_assign));
         any_changed = true;
         continue;
       }
     } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
       if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_))) {
-        new_stmts.push_back(std::make_shared<EvalStmt>(rw, eval->span_));
+        auto new_eval = MutableCopy(eval);
+        new_eval->expr_ = rw;
+        new_stmts.push_back(std::move(new_eval));
         any_changed = true;
         continue;
       }
@@ -1122,7 +1128,9 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
       auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_));
       if (rw) {
         new_stmts.push_back(create);
-        new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, rw, assign->span_));
+        auto new_assign = MutableCopy(assign);
+        new_assign->value_ = rw;
+        new_stmts.push_back(std::move(new_assign));
         any_changed = true;
         continue;
       }
@@ -1130,7 +1138,9 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
       auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_));
       if (rw) {
         new_stmts.push_back(create);
-        new_stmts.push_back(std::make_shared<EvalStmt>(rw, eval->span_));
+        auto new_eval = MutableCopy(eval);
+        new_eval->expr_ = rw;
+        new_stmts.push_back(std::move(new_eval));
         any_changed = true;
         continue;
       }
@@ -1139,10 +1149,9 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
       auto nb = RewriteCallsWithPerCallGMBuffer(for_stmt->body_, modified_funcs, gm_buffer_bytes,
                                                 gm_buffer_elems, span, counter);
       if (nb != for_stmt->body_) {
-        new_stmts.push_back(
-            std::make_shared<ForStmt>(for_stmt->loop_var_, for_stmt->start_, for_stmt->stop_, for_stmt->step_,
-                                      for_stmt->iter_args_, nb, for_stmt->return_vars_, for_stmt->span_,
-                                      for_stmt->kind_, for_stmt->chunk_config_, for_stmt->attrs_));
+        auto new_for = MutableCopy(for_stmt);
+        new_for->body_ = nb;
+        new_stmts.push_back(std::move(new_for));
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);
@@ -1161,8 +1170,10 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
         body_changed = (*ne != *else_body);
       }
       if (body_changed) {
-        new_stmts.push_back(
-            std::make_shared<IfStmt>(if_stmt->condition_, nt, ne, if_stmt->return_vars_, if_stmt->span_));
+        auto new_if = MutableCopy(if_stmt);
+        new_if->then_body_ = nt;
+        new_if->else_body_ = ne;
+        new_stmts.push_back(std::move(new_if));
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);
@@ -1171,8 +1182,9 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
       auto nb = RewriteCallsWithPerCallGMBuffer(while_stmt->body_, modified_funcs, gm_buffer_bytes,
                                                 gm_buffer_elems, span, counter);
       if (nb != while_stmt->body_) {
-        new_stmts.push_back(std::make_shared<WhileStmt>(while_stmt->condition_, while_stmt->iter_args_, nb,
-                                                        while_stmt->return_vars_, while_stmt->span_));
+        auto new_while = MutableCopy(while_stmt);
+        new_while->body_ = nb;
+        new_stmts.push_back(std::move(new_while));
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -739,7 +739,8 @@ class YieldFixupMutator : public IRMutator {
     for (const auto& [idx, moved_var] : moves_to_insert) {
       new_yield_values[idx] = moved_var;
     }
-    auto new_yield = std::make_shared<YieldStmt>(new_yield_values, yield_stmt->span_);
+    auto new_yield = MutableCopy(yield_stmt);
+    new_yield->value_ = std::move(new_yield_values);
 
     // Insert tile.move stmts before yield and replace yield in body
     auto new_body = InsertMovesAndReplaceYield(for_stmt->body_, new_yield, move_stmts);
@@ -820,7 +821,8 @@ class YieldFixupMutator : public IRMutator {
       for (const auto& [idx, moved_var] : else_moves) {
         new_else_yield_values[idx] = moved_var;
       }
-      auto new_yield = std::make_shared<YieldStmt>(new_else_yield_values, else_yield->span_);
+      auto new_yield = MutableCopy(else_yield);
+      new_yield->value_ = std::move(new_else_yield_values);
       new_else_body = InsertMovesAndReplaceYield(if_stmt->else_body_.value(), new_yield, else_move_stmts);
     }
 

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/functor.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -314,7 +315,10 @@ StmtPtr IRMutator::VisitStmt_(const AssignStmtPtr& op) {
   }
   INTERNAL_CHECK_SPAN(new_var, op->span_) << "AssignStmt var is not a Var after mutation";
   if (new_var.get() != op->var_.get() || new_value.get() != op->value_.get()) {
-    return MakeLikeStmt<AssignStmt>(op, std::move(new_var), std::move(new_value), op->span_);
+    auto result = MutableCopy(op);
+    result->var_ = std::move(new_var);
+    result->value_ = std::move(new_value);
+    return result;
   }
   return op;
 }
@@ -358,13 +362,12 @@ StmtPtr IRMutator::VisitStmt_(const IfStmtPtr& op) {
   }
 
   if (new_condition.get() != op->condition_.get() || then_changed || else_changed || return_vars_changed) {
-    if (new_else_body.has_value()) {
-      return MakeLikeStmt<IfStmt>(op, std::move(new_condition), std::move(new_then_body), *new_else_body,
-                                  std::move(new_return_vars), op->span_);
-    } else {
-      return MakeLikeStmt<IfStmt>(op, std::move(new_condition), std::move(new_then_body), std::nullopt,
-                                  std::move(new_return_vars), op->span_);
-    }
+    auto result = MutableCopy(op);
+    result->condition_ = std::move(new_condition);
+    result->then_body_ = std::move(new_then_body);
+    result->else_body_ = new_else_body;
+    result->return_vars_ = std::move(new_return_vars);
+    return result;
   }
   return op;
 }
@@ -385,7 +388,9 @@ StmtPtr IRMutator::VisitStmt_(const YieldStmtPtr& op) {
   }
 
   if (changed) {
-    return MakeLikeStmt<YieldStmt>(op, std::move(new_value), op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(new_value);
+    return result;
   }
   return op;
 }
@@ -406,7 +411,9 @@ StmtPtr IRMutator::VisitStmt_(const ReturnStmtPtr& op) {
   }
 
   if (changed) {
-    return MakeLikeStmt<ReturnStmt>(op, std::move(new_value), op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(new_value);
+    return result;
   }
   return op;
 }
@@ -497,10 +504,16 @@ StmtPtr IRMutator::VisitStmt_(const ForStmtPtr& op) {
   if (new_loop_var.get() != op->loop_var_.get() || new_start.get() != op->start_.get() ||
       new_stop.get() != op->stop_.get() || new_step.get() != op->step_.get() || iter_args_changed ||
       body_changed || return_vars_changed || chunk_config_changed) {
-    return MakeLikeStmt<ForStmt>(op, std::move(new_loop_var), std::move(new_start), std::move(new_stop),
-                                 std::move(new_step), std::move(new_iter_args), std::move(new_body),
-                                 std::move(new_return_vars), op->span_, op->kind_,
-                                 std::move(new_chunk_config), op->attrs_);
+    auto result = MutableCopy(op);
+    result->loop_var_ = std::move(new_loop_var);
+    result->start_ = std::move(new_start);
+    result->stop_ = std::move(new_stop);
+    result->step_ = std::move(new_step);
+    result->iter_args_ = std::move(new_iter_args);
+    result->body_ = std::move(new_body);
+    result->return_vars_ = std::move(new_return_vars);
+    result->chunk_config_ = std::move(new_chunk_config);
+    return result;
   }
   return op;
 }
@@ -566,8 +579,12 @@ StmtPtr IRMutator::VisitStmt_(const WhileStmtPtr& op) {
   }
 
   if (condition_changed || iter_args_changed || body_changed || return_vars_changed) {
-    return MakeLikeStmt<WhileStmt>(op, std::move(new_condition), std::move(new_iter_args),
-                                   std::move(new_body), std::move(new_return_vars), op->span_);
+    auto result = MutableCopy(op);
+    result->condition_ = std::move(new_condition);
+    result->iter_args_ = std::move(new_iter_args);
+    result->body_ = std::move(new_body);
+    result->return_vars_ = std::move(new_return_vars);
+    return result;
   }
   return op;
 }
@@ -577,8 +594,9 @@ StmtPtr IRMutator::VisitStmt_(const ScopeStmtPtr& op) {
   auto new_body = StmtFunctor<StmtPtr>::VisitStmt(op->body_);
   INTERNAL_CHECK_SPAN(new_body, op->span_) << "ScopeStmt body mutated to null";
   if (new_body.get() != op->body_.get()) {
-    return MakeLikeStmt<ScopeStmt>(op, op->scope_kind_, std::move(new_body), op->span_, op->level_, op->role_,
-                                   op->split_, op->name_hint_);
+    auto result = MutableCopy(op);
+    result->body_ = std::move(new_body);
+    return result;
   }
   return op;
 }
@@ -609,7 +627,9 @@ StmtPtr IRMutator::VisitStmt_(const EvalStmtPtr& op) {
   INTERNAL_CHECK_SPAN(new_expr, op->span_) << "EvalStmt expr mutated to null";
 
   if (new_expr.get() != op->expr_.get()) {
-    return MakeLikeStmt<EvalStmt>(op, std::move(new_expr), op->span_);
+    auto result = MutableCopy(op);
+    result->expr_ = std::move(new_expr);
+    return result;
   }
   return op;
 }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -314,7 +314,7 @@ StmtPtr IRMutator::VisitStmt_(const AssignStmtPtr& op) {
   }
   INTERNAL_CHECK_SPAN(new_var, op->span_) << "AssignStmt var is not a Var after mutation";
   if (new_var.get() != op->var_.get() || new_value.get() != op->value_.get()) {
-    return std::make_shared<const AssignStmt>(std::move(new_var), std::move(new_value), op->span_);
+    return MakeLikeStmt<AssignStmt>(op, std::move(new_var), std::move(new_value), op->span_);
   }
   return op;
 }
@@ -359,11 +359,11 @@ StmtPtr IRMutator::VisitStmt_(const IfStmtPtr& op) {
 
   if (new_condition.get() != op->condition_.get() || then_changed || else_changed || return_vars_changed) {
     if (new_else_body.has_value()) {
-      return std::make_shared<const IfStmt>(std::move(new_condition), std::move(new_then_body),
-                                            *new_else_body, std::move(new_return_vars), op->span_);
+      return MakeLikeStmt<IfStmt>(op, std::move(new_condition), std::move(new_then_body), *new_else_body,
+                                  std::move(new_return_vars), op->span_);
     } else {
-      return std::make_shared<const IfStmt>(std::move(new_condition), std::move(new_then_body), std::nullopt,
-                                            std::move(new_return_vars), op->span_);
+      return MakeLikeStmt<IfStmt>(op, std::move(new_condition), std::move(new_then_body), std::nullopt,
+                                  std::move(new_return_vars), op->span_);
     }
   }
   return op;
@@ -385,7 +385,7 @@ StmtPtr IRMutator::VisitStmt_(const YieldStmtPtr& op) {
   }
 
   if (changed) {
-    return std::make_shared<const YieldStmt>(std::move(new_value), op->span_);
+    return MakeLikeStmt<YieldStmt>(op, std::move(new_value), op->span_);
   }
   return op;
 }
@@ -406,7 +406,7 @@ StmtPtr IRMutator::VisitStmt_(const ReturnStmtPtr& op) {
   }
 
   if (changed) {
-    return std::make_shared<const ReturnStmt>(std::move(new_value), op->span_);
+    return MakeLikeStmt<ReturnStmt>(op, std::move(new_value), op->span_);
   }
   return op;
 }
@@ -497,10 +497,10 @@ StmtPtr IRMutator::VisitStmt_(const ForStmtPtr& op) {
   if (new_loop_var.get() != op->loop_var_.get() || new_start.get() != op->start_.get() ||
       new_stop.get() != op->stop_.get() || new_step.get() != op->step_.get() || iter_args_changed ||
       body_changed || return_vars_changed || chunk_config_changed) {
-    return std::make_shared<const ForStmt>(std::move(new_loop_var), std::move(new_start), std::move(new_stop),
-                                           std::move(new_step), std::move(new_iter_args), std::move(new_body),
-                                           std::move(new_return_vars), op->span_, op->kind_,
-                                           std::move(new_chunk_config), op->attrs_);
+    return MakeLikeStmt<ForStmt>(op, std::move(new_loop_var), std::move(new_start), std::move(new_stop),
+                                 std::move(new_step), std::move(new_iter_args), std::move(new_body),
+                                 std::move(new_return_vars), op->span_, op->kind_,
+                                 std::move(new_chunk_config), op->attrs_);
   }
   return op;
 }
@@ -566,8 +566,8 @@ StmtPtr IRMutator::VisitStmt_(const WhileStmtPtr& op) {
   }
 
   if (condition_changed || iter_args_changed || body_changed || return_vars_changed) {
-    return std::make_shared<const WhileStmt>(std::move(new_condition), std::move(new_iter_args),
-                                             std::move(new_body), std::move(new_return_vars), op->span_);
+    return MakeLikeStmt<WhileStmt>(op, std::move(new_condition), std::move(new_iter_args),
+                                   std::move(new_body), std::move(new_return_vars), op->span_);
   }
   return op;
 }
@@ -577,8 +577,8 @@ StmtPtr IRMutator::VisitStmt_(const ScopeStmtPtr& op) {
   auto new_body = StmtFunctor<StmtPtr>::VisitStmt(op->body_);
   INTERNAL_CHECK_SPAN(new_body, op->span_) << "ScopeStmt body mutated to null";
   if (new_body.get() != op->body_.get()) {
-    return std::make_shared<const ScopeStmt>(op->scope_kind_, std::move(new_body), op->span_, op->level_,
-                                             op->role_, op->split_, op->name_hint_);
+    return MakeLikeStmt<ScopeStmt>(op, op->scope_kind_, std::move(new_body), op->span_, op->level_, op->role_,
+                                   op->split_, op->name_hint_);
   }
   return op;
 }
@@ -609,7 +609,7 @@ StmtPtr IRMutator::VisitStmt_(const EvalStmtPtr& op) {
   INTERNAL_CHECK_SPAN(new_expr, op->span_) << "EvalStmt expr mutated to null";
 
   if (new_expr.get() != op->expr_.get()) {
-    return std::make_shared<const EvalStmt>(std::move(new_expr), op->span_);
+    return MakeLikeStmt<EvalStmt>(op, std::move(new_expr), op->span_);
   }
   return op;
 }

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -822,7 +822,10 @@ class IterArgReuseOptimizer {
 
       auto new_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
       var_remap_[op->var_.get()] = new_var;
-      return std::make_shared<AssignStmt>(new_var, new_call, op->span_);
+      auto result = MutableCopy(op);
+      result->var_ = new_var;
+      result->value_ = new_call;
+      return result;
     }
 
     ExprPtr VisitExpr_(const VarPtr& op) override {
@@ -1001,7 +1004,10 @@ class AssembleParentStridesOptimizer {
       auto new_call = std::make_shared<Call>(call->op_, call->args_, call->kwargs_, out_type, call->span_);
       auto new_var = std::make_shared<Var>(assign->var_->name_hint_, out_type, assign->var_->span_);
       var_remap_[op->var_.get()] = new_var;
-      return std::make_shared<AssignStmt>(new_var, new_call, assign->span_);
+      auto result = MutableCopy(assign);
+      result->var_ = new_var;
+      result->value_ = new_call;
+      return result;
     }
 
    private:
@@ -1219,11 +1225,14 @@ class AssembleLoopRewriter {
       std::vector<StmtPtr> new_loop_stmts;
       for (const auto& body_stmt : loop_body_stmts) {
         if (body_stmt.get() == assemble_assign.get()) {
-          new_loop_stmts.push_back(
-              std::make_shared<AssignStmt>(store_result_var, store_call, assemble_assign->span_));
+          auto store_assign = MutableCopy(assemble_assign);
+          store_assign->var_ = store_result_var;
+          store_assign->value_ = store_call;
+          new_loop_stmts.push_back(std::move(store_assign));
         } else if (auto y = As<YieldStmt>(body_stmt)) {
-          new_loop_stmts.push_back(
-              std::make_shared<YieldStmt>(std::vector<ExprPtr>{store_result_var}, y->span_));
+          auto new_yield = MutableCopy(y);
+          new_yield->value_ = std::vector<ExprPtr>{store_result_var};
+          new_loop_stmts.push_back(std::move(new_yield));
         } else {
           new_loop_stmts.push_back(body_stmt);
         }
@@ -1232,10 +1241,11 @@ class AssembleLoopRewriter {
       auto new_loop_body = SeqStmts::Flatten(std::move(new_loop_stmts), op->body_->span_);
       auto new_return_var = return_var_remap_.at(store_info.store_var);
 
-      return std::make_shared<ForStmt>(op->loop_var_, op->start_, op->stop_, op->step_,
-                                       std::vector<IterArgPtr>{new_iter_arg}, new_loop_body,
-                                       std::vector<VarPtr>{new_return_var}, op->span_, op->kind_,
-                                       op->chunk_config_, op->attrs_);
+      auto result = MutableCopy(op);
+      result->iter_args_ = std::vector<IterArgPtr>{new_iter_arg};
+      result->body_ = new_loop_body;
+      result->return_vars_ = std::vector<VarPtr>{new_return_var};
+      return result;
     }
 
     StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
@@ -1278,7 +1288,9 @@ class AssembleLoopRewriter {
         new_ret_values.push_back(v);
       }
       if (!remapped) return op;
-      return std::make_shared<ReturnStmt>(std::move(new_ret_values), op->span_);
+      auto result = MutableCopy(op);
+      result->value_ = std::move(new_ret_values);
+      return result;
     }
 
    private:

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1139,6 +1139,7 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
     // If parent has return_vars, wrap yield as assignment
     if (!yield_stmt->value_.empty() && !return_vars.empty()) {
       stream_ << GetIndent();
+      PrintLeadingComments(yield_stmt);
       PrintYieldAssignmentVars(return_vars);
       stream_ << " = " << prefix_ << ".yield_(";
       for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {
@@ -1148,6 +1149,7 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
       stream_ << ")";
     } else {
       stream_ << GetIndent();
+      PrintLeadingComments(yield_stmt);
       VisitStmt(yield_stmt);
     }
   } else if (auto seq_stmts = As<SeqStmts>(body)) {
@@ -1165,6 +1167,7 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
         if (is_last && !yield_stmt->value_.empty() && !return_vars.empty()) {
           // Wrap as assignment
           stream_ << GetIndent();
+          PrintLeadingComments(yield_stmt);
           PrintYieldAssignmentVars(return_vars);
           stream_ << " = " << prefix_ << ".yield_(";
           for (size_t j = 0; j < yield_stmt->value_.size(); ++j) {
@@ -1174,6 +1177,7 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
           stream_ << ")";
         } else {
           stream_ << GetIndent();
+          PrintLeadingComments(yield_stmt);
           VisitStmt(stmt);
         }
       } else {
@@ -1304,7 +1308,9 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         for (size_t i = 0; i < seq_stmts->stmts_.size(); ++i) {
           // Convert yield to return in function context
           if (auto yield_stmt = As<YieldStmt>(seq_stmts->stmts_[i])) {
-            stream_ << GetIndent() << "return";
+            stream_ << GetIndent();
+            PrintLeadingComments(yield_stmt);
+            stream_ << "return";
             if (!yield_stmt->value_.empty()) {
               stream_ << " ";
               for (size_t j = 0; j < yield_stmt->value_.size(); ++j) {
@@ -1321,7 +1327,9 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         }
       }
     } else if (auto yield_stmt = As<YieldStmt>(func->body_)) {
-      stream_ << GetIndent() << "return";
+      stream_ << GetIndent();
+      PrintLeadingComments(yield_stmt);
+      stream_ << "return";
       if (!yield_stmt->value_.empty()) {
         stream_ << " ";
         for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -285,6 +285,10 @@ class IRPythonPrinter : public IRVisitor {
   // SeqStmts is a transparent container - recursed into without extra indent.
   void PrintStmtBlock(const StmtPtr& stmt);
 
+  // Emit each leading comment line of `stmt` as `# <text>` above the stmt itself.
+  // Assumes the current indent has already been written to the stream.
+  void PrintLeadingComments(const StmtPtr& stmt);
+
   // Statement body visitor with SSA-style handling
   void VisitStmtBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars = {});
   void PrintYieldAssignmentVars(const std::vector<VarPtr>& return_vars);
@@ -1084,14 +1088,22 @@ void IRPythonPrinter::VisitStmt_(const SeqStmtsPtr& op) {
   }
 }
 
+void IRPythonPrinter::PrintLeadingComments(const StmtPtr& stmt) {
+  for (const auto& line : stmt->leading_comments_) {
+    stream_ << "# " << line << "\n" << GetIndent();
+  }
+}
+
 void IRPythonPrinter::PrintStmtBlock(const StmtPtr& stmt) {
   if (auto seq = As<SeqStmts>(stmt)) {
+    INTERNAL_CHECK(seq->leading_comments_.empty()) << "SeqStmts should not carry leading comments directly";
     for (size_t i = 0; i < seq->stmts_.size(); ++i) {
       PrintStmtBlock(seq->stmts_[i]);
       if (i < seq->stmts_.size() - 1) stream_ << "\n";
     }
   } else {
     stream_ << GetIndent();
+    PrintLeadingComments(stmt);
     VisitStmt(stmt);
   }
 }

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -167,11 +167,15 @@ class BackendLayoutRepairMutator : public IRMutator {
       rewritten.push_back(std::make_shared<AssignStmt>(row_major_var, repaired_call, op->span_));
 
       auto reshape_back = CreateReshapeCall(row_major_var, result_tile_type->shape_, call->span_);
-      rewritten.push_back(std::make_shared<AssignStmt>(op->var_, reshape_back, op->span_));
+      auto replacement = MutableCopy(op);
+      replacement->value_ = reshape_back;
+      rewritten.push_back(std::move(replacement));
       return MakeSeqOrSingle(std::move(rewritten), op->span_);
     }
 
-    rewritten.push_back(std::make_shared<AssignStmt>(op->var_, repaired_call, op->span_));
+    auto replacement = MutableCopy(op);
+    replacement->value_ = repaired_call;
+    rewritten.push_back(std::move(replacement));
     return MakeSeqOrSingle(std::move(rewritten), op->span_);
   }
 
@@ -208,7 +212,9 @@ class BackendLayoutRepairMutator : public IRMutator {
 
     auto repaired_expr =
         OpRegistry::GetInstance().Create(call->op_->name_, new_args, call->kwargs_, call->span_);
-    rewritten.push_back(std::make_shared<EvalStmt>(repaired_expr, op->span_));
+    auto replacement = MutableCopy(op);
+    replacement->expr_ = repaired_expr;
+    rewritten.push_back(std::move(replacement));
     return MakeSeqOrSingle(std::move(rewritten), op->span_);
   }
 

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "pypto/ir/arith/analyzer.h"
@@ -53,7 +54,9 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     auto new_value = analyzer_->Simplify(op->value_);
     if (new_value.get() == op->value_.get()) return op;
-    return std::make_shared<AssignStmt>(op->var_, new_value, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = new_value;
+    return result;
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
@@ -153,7 +156,9 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
       if (new_val.get() != val.get()) changed = true;
     }
     if (!changed) return op;
-    return std::make_shared<ReturnStmt>(new_values, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(new_values);
+    return result;
   }
 
   StmtPtr VisitStmt_(const YieldStmtPtr& op) override {
@@ -166,13 +171,17 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
       if (new_val.get() != val.get()) changed = true;
     }
     if (!changed) return op;
-    return std::make_shared<YieldStmt>(new_values, op->span_);
+    auto result = MutableCopy(op);
+    result->value_ = std::move(new_values);
+    return result;
   }
 
   StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
     auto new_expr = analyzer_->Simplify(op->expr_);
     if (new_expr.get() == op->expr_.get()) return op;
-    return std::make_shared<EvalStmt>(new_expr, op->span_);
+    auto result = MutableCopy(op);
+    result->expr_ = new_expr;
+    return result;
   }
 };
 

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -599,6 +599,14 @@ class StructuralEqualImpl {
     return true;  // Never reached
   }
 
+  // Stub for IgnoreField metadata (Stmt::leading_comments_). Required by the
+  // template instantiation path even though VisitIgnoreField discards the
+  // lambda — the compiler still type-checks the lambda body.
+  result_type VisitLeafField(const std::vector<std::string>& /*lhs*/,
+                             const std::vector<std::string>& /*rhs*/) {
+    return true;
+  }
+
   // Field kind hooks
   template <typename FVisitOp>
   void VisitIgnoreField([[maybe_unused]] FVisitOp&& visit_op) {

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -599,12 +599,13 @@ class StructuralEqualImpl {
     return true;  // Never reached
   }
 
-  // Stub for IgnoreField metadata (Stmt::leading_comments_). Required by the
-  // template instantiation path even though VisitIgnoreField discards the
-  // lambda — the compiler still type-checks the lambda body.
+  // Required by the template instantiation path for Stmt::leading_comments_
+  // (IgnoreField). VisitIgnoreField discards the lambda at runtime, so this
+  // overload should never be called — guard it like the Span overload.
   result_type VisitLeafField(const std::vector<std::string>& /*lhs*/,
                              const std::vector<std::string>& /*rhs*/) {
-    return true;
+    INTERNAL_UNREACHABLE << "structural_equal should not visit leading_comments field";
+    return true;  // Never reached
   }
 
   // Field kind hooks

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -269,10 +269,13 @@ class StructuralHasher {
     return h;
   }
 
-  // Stub for IgnoreField metadata (Stmt::leading_comments_). Required by the
-  // template instantiation path even though VisitIgnoreField discards the
-  // lambda — the compiler still type-checks the lambda body.
-  result_type VisitLeafField(const std::vector<std::string>& /*field*/) { return 0; }
+  // Required by the template instantiation path for Stmt::leading_comments_
+  // (IgnoreField). VisitIgnoreField discards the lambda at runtime, so this
+  // overload should never be called — guard it like the Span overload.
+  result_type VisitLeafField(const std::vector<std::string>& /*field*/) {
+    INTERNAL_UNREACHABLE << "structural_hash should not visit leading_comments field";
+    return 0;  // Never reached
+  }
 
   // Hash kwargs (vector of pairs - order is preserved and matters)
   result_type VisitLeafField(const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -269,6 +269,11 @@ class StructuralHasher {
     return h;
   }
 
+  // Stub for IgnoreField metadata (Stmt::leading_comments_). Required by the
+  // template instantiation path even though VisitIgnoreField discards the
+  // lambda — the compiler still type-checks the lambda body.
+  result_type VisitLeafField(const std::vector<std::string>& /*field*/) { return 0; }
+
   // Hash kwargs (vector of pairs - order is preserved and matters)
   result_type VisitLeafField(const std::vector<std::pair<std::string, std::any>>& kwargs) {
     result_type h = 0;

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
@@ -127,7 +128,36 @@ class LoopUnrollMutator : public IRMutator {
     if (unrolled.empty()) {
       return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
     }
+    // The ForStmt is gone. Its leading_comments would otherwise vanish with it,
+    // so move them onto the first unrolled stmt so readers still see them above
+    // the expanded iterations. SeqStmts itself cannot carry comments (invariant).
+    if (!op->leading_comments_.empty()) {
+      AttachCommentsToFirstStmt(unrolled, op->leading_comments_);
+    }
     return std::make_shared<SeqStmts>(unrolled, op->span_);
+  }
+
+  // Prepend ``comments`` to the leading_comments of the first non-SeqStmts stmt
+  // reachable from ``stmts``. Used when replacing a commented compound stmt with
+  // a sequence that isn't itself allowed to carry comments.
+  static void AttachCommentsToFirstStmt(const std::vector<StmtPtr>& stmts,
+                                        const std::vector<std::string>& comments) {
+    StmtPtr first;
+    for (const auto& s : stmts) {
+      if (s) {
+        first = s;
+        break;
+      }
+    }
+    if (!first) return;
+    // Walk into nested SeqStmts to find the first terminal stmt.
+    while (auto seq = std::dynamic_pointer_cast<const SeqStmts>(first)) {
+      if (seq->stmts_.empty()) return;
+      first = seq->stmts_[0];
+    }
+    std::vector<std::string> merged = comments;
+    merged.insert(merged.end(), first->leading_comments_.begin(), first->leading_comments_.end());
+    AttachLeadingComments(first, std::move(merged));
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {

--- a/tests/ut/ir/parser/test_parse_comments.py
+++ b/tests/ut/ir/parser/test_parse_comments.py
@@ -34,18 +34,24 @@ def _body_stmts(prog: ir.Program) -> list[ir.Stmt]:
 class TestCommentExtractor:
     def test_basic_line_comment(self):
         src = "x = 1  # note\n"
-        assert extract_line_comments(src) == {1: ["note"]}
+        assert extract_line_comments(src) == {1: [(7, "note")]}
 
     def test_full_line_comment(self):
         src = "# first\n"
-        assert extract_line_comments(src) == {1: ["first"]}
+        assert extract_line_comments(src) == {1: [(0, "first")]}
 
     def test_no_space_after_hash(self):
         src = "#compact\n"
-        assert extract_line_comments(src) == {1: ["compact"]}
+        assert extract_line_comments(src) == {1: [(0, "compact")]}
 
     def test_empty_source(self):
         assert extract_line_comments("") == {}
+
+    def test_captures_column_offset(self):
+        src = "for i in range(1):\n    x = 1\n    # indented tail\n"
+        result = extract_line_comments(src)
+        # The comment is at column 4 (body indent).
+        assert result == {3: [(4, "indented tail")]}
 
 
 class TestAttachInParsedProgram:
@@ -154,6 +160,52 @@ class TestAttachInParsedProgram:
         # else body first stmt gets "fallback" (the comment above `else:` attaches to first else stmt)
         assert if_stmt.else_body is not None
         assert _first_of(if_stmt.else_body).leading_comments == ["fallback"]
+
+
+class TestTailOfBlockWarning:
+    """Tail-of-block comments are dropped with a UserWarning (documented v1 behavior)."""
+
+    def test_tail_in_for_body_warns_and_drops(self):
+        with pytest.warns(UserWarning, match="tail-of-block comment"):
+
+            @pl.program
+            class P:
+                @pl.function
+                def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                    for i in pl.range(4):
+                        x = x + 1.0
+                        # tail
+                    return x
+
+        # The tail comment must NOT attach to the outer return stmt.
+        stmts = _body_stmts(P)
+        ret = next(s for s in stmts if isinstance(s, ir.ReturnStmt))
+        assert ret.leading_comments == []
+
+    def test_tail_in_function_body_warns(self):
+        with pytest.warns(UserWarning, match="tail-of-block comment"):
+
+            @pl.program
+            class P:  # noqa: F841
+                @pl.function
+                def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                    y = x
+                    return y
+                    # trailing after return
+
+    def test_tail_in_if_then_branch_warns(self):
+        with pytest.warns(UserWarning, match="tail-of-block comment"):
+
+            @pl.program
+            class P:  # noqa: F841
+                @pl.function
+                def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                    if x > 0.0:
+                        y = x
+                        # tail in then
+                    else:
+                        y = -x
+                    return y
 
 
 class TestRoundTripIdempotency:

--- a/tests/ut/ir/parser/test_parse_comments.py
+++ b/tests/ut/ir/parser/test_parse_comments.py
@@ -214,6 +214,84 @@ class TestTailOfBlockWarning:
                     return y
 
 
+class TestSiblingBlockAttribution:
+    """Leading comments inside a later sibling block must not be swept by the
+    previous block's tail-drop (regression for codex P1)."""
+
+    def test_sibling_for_loops_preserve_inner_leading(self):
+        with pytest.warns(UserWarning, match="tail-of-block comment"):
+
+            @pl.program
+            class P:
+                @pl.function
+                def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                    for i in pl.range(4):
+                        x = x + 1.0
+                        # tail of first for
+                    for j in pl.range(4):
+                        # leading for y
+                        y = x * 2.0
+                    return y
+
+        stmts = _body_stmts(P)
+        # The second for-loop's first body stmt should carry the leading comment.
+        for_stmts = [s for s in stmts if isinstance(s, ir.ForStmt)]
+        assert len(for_stmts) == 2
+        second_body = for_stmts[1].body
+        first = second_body.stmts[0] if isinstance(second_body, ir.SeqStmts) else second_body
+        assert "leading for y" in first.leading_comments
+        # The "tail of first for" must NOT leak into the second loop's body.
+        assert "tail of first for" not in first.leading_comments
+
+    def test_sibling_if_blocks_preserve_inner_leading(self):
+        with pytest.warns(UserWarning, match="tail-of-block comment"):
+
+            @pl.program
+            class P:
+                @pl.function
+                def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                    if x > 0.0:
+                        y = x
+                        # tail in first if
+                    if x < 0.0:
+                        # leading in second if
+                        y = -x
+                    return y
+
+        stmts = _body_stmts(P)
+        if_stmts = [s for s in stmts if isinstance(s, ir.IfStmt)]
+        assert len(if_stmts) == 2
+        second_then = if_stmts[1].then_body
+        first = second_then.stmts[0] if isinstance(second_then, ir.SeqStmts) else second_then
+        assert "leading in second if" in first.leading_comments
+        assert "tail in first if" not in first.leading_comments
+
+
+class TestWrappedHeaderComments:
+    """Comments inside a wrapped multi-line header attach to the compound stmt,
+    not to the first body stmt (regression for codex P2)."""
+
+    def test_wrapped_for_header_comment_attaches_to_for(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                for i in pl.range(
+                    4,
+                    # wrap comment
+                ):
+                    x = x + 1.0
+                return x
+
+        stmts = _body_stmts(P)
+        for_stmt = next(s for s in stmts if isinstance(s, ir.ForStmt))
+        assert "wrap comment" in for_stmt.leading_comments
+        # The wrap comment must NOT attach to the inner body stmt.
+        body = for_stmt.body
+        first = body.stmts[0] if isinstance(body, ir.SeqStmts) else body
+        assert "wrap comment" not in first.leading_comments
+
+
 class TestRoundTripIdempotency:
     def test_leading_and_trailing_roundtrip(self):
         @pl.program

--- a/tests/ut/ir/parser/test_parse_comments.py
+++ b/tests/ut/ir/parser/test_parse_comments.py
@@ -53,6 +53,12 @@ class TestCommentExtractor:
         # The comment is at column 4 (body indent).
         assert result == {3: [(4, "indented tail")]}
 
+    def test_multi_hash_preserves_extra_hashes(self):
+        # Strip exactly one leading '#' so "## heading" re-emits as "# heading"
+        # rather than collapsing to "heading".
+        assert extract_line_comments("## heading\n") == {1: [(0, "# heading")]}
+        assert extract_line_comments("###section\n") == {1: [(0, "##section")]}
+
 
 class TestAttachInParsedProgram:
     def test_leading_comment(self):

--- a/tests/ut/ir/parser/test_parse_comments.py
+++ b/tests/ut/ir/parser/test_parse_comments.py
@@ -1,0 +1,177 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Parser round-trip tests for Stmt.leading_comments attached from DSL `#` and docstrings."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.language.parser.comment_extractor import extract_line_comments
+
+
+def _body_stmts(prog: ir.Program) -> list[ir.Stmt]:
+    """Flatten the main function body for easy per-stmt inspection."""
+    func = list(prog.functions.values())[0]
+    body = func.body
+
+    def _flatten(s: ir.Stmt) -> list[ir.Stmt]:
+        if isinstance(s, ir.SeqStmts):
+            out: list[ir.Stmt] = []
+            for inner in s.stmts:
+                out.extend(_flatten(inner))
+            return out
+        return [s]
+
+    return _flatten(body)
+
+
+class TestCommentExtractor:
+    def test_basic_line_comment(self):
+        src = "x = 1  # note\n"
+        assert extract_line_comments(src) == {1: ["note"]}
+
+    def test_full_line_comment(self):
+        src = "# first\n"
+        assert extract_line_comments(src) == {1: ["first"]}
+
+    def test_no_space_after_hash(self):
+        src = "#compact\n"
+        assert extract_line_comments(src) == {1: ["compact"]}
+
+    def test_empty_source(self):
+        assert extract_line_comments("") == {}
+
+
+class TestAttachInParsedProgram:
+    def test_leading_comment(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # annotate
+                y = x
+                return y
+
+        stmts = _body_stmts(P)
+        assert stmts[0].leading_comments == ["annotate"]
+
+    def test_trailing_comment_promoted(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                y = x  # trailing
+                return y
+
+        stmts = _body_stmts(P)
+        assert stmts[0].leading_comments == ["trailing"]
+
+    def test_docstring_becomes_comment_on_next_stmt(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                """hello world"""
+                y = x
+                return y
+
+        stmts = _body_stmts(P)
+        assert stmts[0].leading_comments == ["hello world"]
+
+    def test_mixed_docstring_and_hash_comment(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                """doc"""
+                # hash
+                y = x
+                return y
+
+        stmts = _body_stmts(P)
+        assert stmts[0].leading_comments == ["doc", "hash"]
+
+    def test_compound_for_loop(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                y = x
+                # main loop
+                for i in pl.range(16):  # tiles
+                    # body
+                    y = y + 1.0
+                return y
+
+        stmts = _body_stmts(P)
+        # stmts: [AssignStmt y=x, ForStmt, ReturnStmt]
+        for_stmt = next(s for s in stmts if isinstance(s, ir.ForStmt))
+        assert for_stmt.leading_comments == ["main loop", "tiles"]
+        # Body-inner comment lands on the first body stmt.
+        body_stmts: list[ir.Stmt] = []
+
+        def _flatten(s: ir.Stmt) -> None:
+            if isinstance(s, ir.SeqStmts):
+                for inner in s.stmts:
+                    _flatten(inner)
+            else:
+                body_stmts.append(s)
+
+        _flatten(for_stmt.body)
+        assert body_stmts[0].leading_comments == ["body"]
+
+    def test_if_else_branches(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # check positivity
+                if x > 0.0:  # positive
+                    # print x
+                    y = x
+                # fallback
+                else:
+                    y = -x
+                return y
+
+        stmts = _body_stmts(P)
+        if_stmt = next(s for s in stmts if isinstance(s, ir.IfStmt))
+        assert if_stmt.leading_comments == ["check positivity", "positive"]
+
+        # then body: first stmt gets "print x"
+        def _first_of(block: ir.Stmt) -> ir.Stmt:
+            if isinstance(block, ir.SeqStmts):
+                return block.stmts[0]
+            return block
+
+        assert _first_of(if_stmt.then_body).leading_comments == ["print x"]
+        # else body first stmt gets "fallback" (the comment above `else:` attaches to first else stmt)
+        assert if_stmt.else_body is not None
+        assert _first_of(if_stmt.else_body).leading_comments == ["fallback"]
+
+
+class TestRoundTripIdempotency:
+    def test_leading_and_trailing_roundtrip(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # outer
+                y = x  # trailing
+                return y
+
+        src1 = ir.python_print(P)
+        P2 = pl.parse_program(src1)
+        src2 = ir.python_print(P2)
+        assert src1 == src2, f"not idempotent:\n--- first ---\n{src1}\n--- second ---\n{src2}"
+        ir.assert_structural_equal(P, P2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_print_leading_comments.py
+++ b/tests/ut/ir/printing/test_print_leading_comments.py
@@ -1,0 +1,90 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Test that python_print emits leading_comments as `# ...` lines above stmts."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+
+
+class TestPrintLeadingComments:
+    def test_assign_leading_comment_printed(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # annotate
+                y = x
+                return y
+
+        out = ir.python_print(P)
+        assert "# annotate" in out
+        # Comment should appear above the assignment line
+        assign_idx = out.index("y: pl.Scalar[pl.FP32] = x")
+        comment_idx = out.index("# annotate")
+        assert comment_idx < assign_idx
+
+    def test_for_loop_header_comment_printed(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # main loop
+                for i in pl.range(16):  # tiles
+                    x = x + 1.0
+                return x
+
+        out = ir.python_print(P)
+        # Both comments appear above the for header
+        assert "# main loop" in out
+        assert "# tiles" in out
+        for_idx = out.index("for i in pl.range(16)")
+        assert out.index("# main loop") < for_idx
+        assert out.index("# tiles") < for_idx
+
+    def test_if_else_comments_printed(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # cond
+                if x > 0.0:  # positive
+                    y = x
+                # fallback
+                else:
+                    y = -x
+                return y
+
+        out = ir.python_print(P)
+        assert "# cond" in out
+        assert "# positive" in out
+        assert "# fallback" in out
+        # `# fallback` appears below the then body's closing
+        fallback_idx = out.index("# fallback")
+        else_idx = out.index("else:")
+        assert fallback_idx > else_idx
+
+    def test_docstring_prints_as_comment(self):
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                """preserved docstring"""
+                y = x
+                return y
+
+        out = ir.python_print(P)
+        assert "# preserved docstring" in out
+        # Printed `# preserved docstring` should not also appear as a raw docstring
+        assert '"""preserved docstring"""' not in out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_leading_comments.py
+++ b/tests/ut/ir/statements/test_leading_comments.py
@@ -1,0 +1,88 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for Stmt.leading_comments metadata and ir.attach_leading_comments helper."""
+
+import pytest
+from pypto import DataType, ir
+
+
+def _make_assign() -> ir.AssignStmt:
+    span = ir.Span("test.py", 1, 1, 1, 10)
+    x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+    y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+    return ir.AssignStmt(x, y, span)
+
+
+class TestLeadingComments:
+    def test_default_empty(self):
+        stmt = _make_assign()
+        assert stmt.leading_comments == []
+
+    def test_attach_sets_field(self):
+        stmt = _make_assign()
+        result = ir.attach_leading_comments(stmt, ["first", "second"])
+        assert stmt.leading_comments == ["first", "second"]
+        assert result is stmt
+
+    def test_attach_replaces_existing(self):
+        stmt = _make_assign()
+        ir.attach_leading_comments(stmt, ["one"])
+        ir.attach_leading_comments(stmt, ["two", "three"])
+        assert stmt.leading_comments == ["two", "three"]
+
+    def test_attach_empty_clears(self):
+        stmt = _make_assign()
+        ir.attach_leading_comments(stmt, ["x"])
+        ir.attach_leading_comments(stmt, [])
+        assert stmt.leading_comments == []
+
+    def test_python_field_is_read_only(self):
+        stmt = _make_assign()
+        with pytest.raises(AttributeError):
+            stmt.leading_comments = ["nope"]  # type: ignore[misc]
+
+    def test_structural_equal_ignores_comments(self):
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+        lhs = ir.AssignStmt(x, y, span)
+        rhs = ir.AssignStmt(x, y, span)
+        ir.attach_leading_comments(rhs, ["annotation"])
+        ir.assert_structural_equal(lhs, rhs)
+
+    def test_structural_hash_ignores_comments(self):
+        span = ir.Span("test.py", 1, 1, 1, 10)
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), span)
+        lhs = ir.AssignStmt(x, y, span)
+        rhs = ir.AssignStmt(x, y, span)
+        ir.attach_leading_comments(rhs, ["annotation"])
+        assert ir.structural_hash(lhs) == ir.structural_hash(rhs)
+
+    def test_works_on_all_simple_stmt_kinds(self):
+        span = ir.Span.unknown()
+        dtype = DataType.INT64
+        x = ir.Var("x", ir.ScalarType(dtype), span)
+
+        stmts: list[ir.Stmt] = [
+            ir.AssignStmt(x, x, span),
+            ir.ReturnStmt([x], span),
+            ir.BreakStmt(span),
+            ir.ContinueStmt(span),
+            ir.EvalStmt(x, span),
+        ]
+        for stmt in stmts:
+            assert stmt.leading_comments == []
+            ir.attach_leading_comments(stmt, ["c"])
+            assert stmt.leading_comments == ["c"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_comments_survive_mutator.py
+++ b/tests/ut/ir/transforms/test_comments_survive_mutator.py
@@ -40,12 +40,7 @@ def _collect_leading(stmt: ir.Stmt) -> list[list[str]]:
 class TestCommentsSurviveMutator:
     def test_base_mutator_rebuild_preserves_comments(self):
         """Comments on compound stmts rebuilt through IRMutator's base
-        VisitStmt_ path (via MakeLikeStmt) must survive transformation.
-
-        Documented v1 limitation: IRMutator *subclasses* that construct stmts
-        directly (bypassing MakeLikeStmt) may drop comments. The ``convert_to_ssa``
-        pass goes through the base path for ``ForStmt`` but not for ``AssignStmt``;
-        this test only asserts the preservation that the base path guarantees.
+        VisitStmt_ path (via MakeLikeStmt) survive transformation.
         """
 
         @pl.program
@@ -64,6 +59,45 @@ class TestCommentsSurviveMutator:
 
         after = _collect_leading(list(P2.functions.values())[0].body)
         assert ["loop annotation", "trailing"] in after
+
+    def test_convert_to_ssa_preserves_assign_comments(self):
+        """AssignStmt rebuilds in ConvertToSSA pass preserve leading_comments
+        after the pass was updated to use MakeLikeStmt instead of raw
+        std::make_shared<AssignStmt>.
+        """
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # first assign
+                y = x + 1.0
+                # second assign
+                z = y + 2.0
+                return z
+
+        P2 = passes.convert_to_ssa()(P)
+        after = _collect_leading(list(P2.functions.values())[0].body)
+        assert ["first assign"] in after
+        assert ["second assign"] in after
+
+    def test_simplify_preserves_comments(self):
+        """SimplifyMutator rebuilds (AssignStmt/ReturnStmt/YieldStmt/EvalStmt)
+        preserve leading_comments after the simplify pass was updated.
+        """
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # will simplify
+                y = x + 0.0  # adding zero — simplifies to `x`
+                return y
+
+        P2 = passes.simplify()(P)
+        after = _collect_leading(list(P2.functions.values())[0].body)
+        # Both leading + trailing comments get promoted as leading_comments on the assign.
+        assert ["will simplify", "adding zero — simplifies to `x`"] in after
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_comments_survive_mutator.py
+++ b/tests/ut/ir/transforms/test_comments_survive_mutator.py
@@ -1,0 +1,70 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Verify IRMutator base-class rebuild paths preserve Stmt.leading_comments."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir, passes
+
+
+def _collect_leading(stmt: ir.Stmt) -> list[list[str]]:
+    """Return leading_comments for every non-SeqStmts stmt, in DFS order."""
+    out: list[list[str]] = []
+
+    def _walk(s: ir.Stmt) -> None:
+        if isinstance(s, ir.SeqStmts):
+            for inner in s.stmts:
+                _walk(inner)
+            return
+        out.append(list(s.leading_comments))
+        if isinstance(s, ir.IfStmt):
+            _walk(s.then_body)
+            if s.else_body is not None:
+                _walk(s.else_body)
+        elif isinstance(s, (ir.ForStmt, ir.WhileStmt)):
+            _walk(s.body)
+        elif isinstance(s, ir.ScopeStmt):
+            _walk(s.body)
+
+    _walk(stmt)
+    return out
+
+
+class TestCommentsSurviveMutator:
+    def test_base_mutator_rebuild_preserves_comments(self):
+        """Comments on compound stmts rebuilt through IRMutator's base
+        VisitStmt_ path (via MakeLikeStmt) must survive transformation.
+
+        Documented v1 limitation: IRMutator *subclasses* that construct stmts
+        directly (bypassing MakeLikeStmt) may drop comments. The ``convert_to_ssa``
+        pass goes through the base path for ``ForStmt`` but not for ``AssignStmt``;
+        this test only asserts the preservation that the base path guarantees.
+        """
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # loop annotation
+                for i in pl.range(4):  # trailing
+                    x = x + 1.0
+                return x
+
+        before = _collect_leading(list(P.functions.values())[0].body)
+        assert ["loop annotation", "trailing"] in before
+
+        P2 = passes.convert_to_ssa()(P)
+
+        after = _collect_leading(list(P2.functions.values())[0].body)
+        assert ["loop annotation", "trailing"] in after
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -798,5 +798,62 @@ class TestTypeSerialization:
         ir.assert_structural_equal(var, restored_var, enable_auto_mapping=True)
 
 
+class TestLeadingCommentsRoundTrip:
+    """Stmt.leading_comments metadata survives serialize/deserialize."""
+
+    def _make_assign_with_comments(self, comments: list[str]) -> ir.Stmt:
+        var = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        value = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        stmt = ir.AssignStmt(var, value, ir.Span.unknown())
+        return ir.attach_leading_comments(stmt, comments)
+
+    def test_single_comment_survives(self):
+        stmt = self._make_assign_with_comments(["note"])
+        restored = cast(ir.Stmt, ir.deserialize(ir.serialize(stmt)))
+        assert list(restored.leading_comments) == ["note"]
+
+    def test_multiple_comments_survive(self):
+        stmt = self._make_assign_with_comments(["first", "second", "third"])
+        restored = cast(ir.Stmt, ir.deserialize(ir.serialize(stmt)))
+        assert list(restored.leading_comments) == ["first", "second", "third"]
+
+    def test_empty_comments(self):
+        var = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        value = ir.ConstInt(1, DataType.INT64, ir.Span.unknown())
+        stmt = ir.AssignStmt(var, value, ir.Span.unknown())
+        restored = cast(ir.Stmt, ir.deserialize(ir.serialize(stmt)))
+        assert list(restored.leading_comments) == []
+
+    def test_comments_on_nested_stmts(self):
+        import pypto.language as pl  # noqa: PLC0415 — local import keeps top-level test deps minimal
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Scalar[pl.FP32]) -> pl.Scalar[pl.FP32]:
+                # outer
+                for _i in pl.range(4):  # header
+                    # body
+                    x = x + 1.0
+                return x
+
+        restored = cast(ir.Program, ir.deserialize(ir.serialize(P)))
+
+        def _collect(stmt: ir.Stmt) -> list[list[str]]:
+            out: list[list[str]] = []
+            if isinstance(stmt, ir.SeqStmts):
+                for s in stmt.stmts:
+                    out.extend(_collect(s))
+            else:
+                out.append(list(stmt.leading_comments))
+                if isinstance(stmt, ir.ForStmt):
+                    out.extend(_collect(stmt.body))
+            return out
+
+        func = list(restored.functions.values())[0]
+        assert ["outer", "header"] in _collect(func.body)
+        assert ["body"] in _collect(func.body)
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

Implements RFC #1009. Adds a `leading_comments_: vector<string>` field on the `Stmt` base class so Python DSL `#` comments and bare-string docstrings survive parsing and appear above their stmts in IR dumps.

- **C++ field**: `Stmt.leading_comments_` — registered as `IgnoreField` so it is excluded from `structural_equal` and `structural_hash`, but IS serialized/deserialized so comments survive `serialize_to_file` round-trips. Passed through the ctor (symmetric with `span_`) — no post-construction mutation except on two narrow late-binding paths (parser builder + unroll_loops merge).
- **Python API**: `stmt.leading_comments` is read-only. Late-binding hook `ir.attach_leading_comments(stmt, comments)` remains for the parser-builder path and comment-merging passes (rejects `SeqStmts`; `SeqStmts` ctor also rejects via `INTERNAL_CHECK`).
- **Printer**: `PrintLeadingComments` hook emits each line as `# <text>` above the stmt via `PrintStmtBlock`, and is also called on the special-cased `YieldStmt` / rewritten `return` paths in `VisitStmtBody` / `VisitFunction` so loop-body yields and function-body returns don't drop their comments.
- **Pass propagation**: same-type stmt rebuilds use `MutableCopy(op)` + field assignment, which auto-preserves `leading_comments_` together with every other unchanged field (no helper needed). Split expansions (e.g. `expand_mixed_kernel` AIC/AIV) use `std::make_shared<NewT>(..., orig->leading_comments_)` to attach the origin's comments to the first emitted stmt. `unroll_loops` merges the erased `ForStmt`'s comments onto the first surviving body stmt.
- **Parser**: new `comment_extractor.py` (stdlib `tokenize` → `{line: [(col, text)]}`) records column so header comments can be distinguished from body-indent comments. Builder-side pending-comments stack (`push_pending_leading_comments` / `pop_pending_leading_comments`) replaces the earlier "attach-to-last" hook so 0-emit lowers (`pl.static_assert`), N-emit lowers (tuple unpack), and compound stmts (`with`/`for`/`while`/`if`) all attribute comments correctly. `@pl.program` filters per-method comment ranges so comments don't leak across methods.
- **Tail-of-block warning**: comments after the last stmt in a block (at block indent) have no attachment target; they're dropped with a `UserWarning` (was silent). Column-based disambiguation keeps outer-scope comments (`# fallback` before `else:`) from being misclassified as tail.
- **Docs**: new "Leading comments on statements" subsection in `docs/en/dev/ir/01-hierarchy.md` + Chinese mirror.

## Testing

- [x] 28 new tests (unit / parser / printer / mutator / serialization round-trip)
- [x] Full suite: 3546 passed, 0 failed
- [x] Round-trip idempotency (`parse(print(parse(src)))`) verified
- [x] Binary serialization round-trip verified
- [x] Bilingual docs updated (en + zh-cn)
- [x] clang-tidy passes on all changed files

## Related Issues

Fixes #1009