### PR TITLE
fix(pass): update variable type after shape padding in RewriteCreateToSlice

### DIFF
--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -315,6 +315,12 @@ class FuseCreateAssembleMutator : public IRMutator {
 
     auto slice_call = op_registry.Create("tensor.slice", {target, shape_tuple, offset_tuple}, assign->span_);
 
+    if (offset_ndim > ndim) {
+      auto new_var =
+          std::make_shared<Var>(assign->var_->name_hint_, slice_call->GetType(), assign->var_->span_);
+      var_remap_[assign->var_.get()] = new_var;
+      return std::make_shared<AssignStmt>(new_var, slice_call, assign->span_);
+    }
     return std::make_shared<AssignStmt>(assign->var_, slice_call, assign->span_);
   }
 

--- a/tests/st/runtime/test_elementwise_nd.py
+++ b/tests/st/runtime/test_elementwise_nd.py
@@ -162,6 +162,39 @@ class Tile2DStoreTo3DProgram:
         return out
 
 
+@pl.program
+class TensorAssemble2DTo3DProgram:
+    """2D tensor.create assembled into 3D target with shape padding.
+
+    Exercises FuseCreateAssembleToSlice: the pass fuses tensor.create([4, 16])
+    + tensor.assemble(out[2, 4, 16], ..., [b, 0, 0]) into tensor.slice with
+    shape [1, 4, 16] (padded with leading 1 to match target rank).
+    Regression test for #1006.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def compute(
+        self,
+        x: pl.Tensor[[4, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[4, 16], pl.FP32]],
+    ) -> pl.Tensor[[4, 16], pl.FP32]:
+        t: pl.Tile[[4, 16], pl.FP32] = pl.load(x, [0, 0], [4, 16])
+        out = pl.store(t, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orch(
+        self,
+        x: pl.Tensor[[4, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[2, 4, 16], pl.FP32]],
+    ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
+        for b in pl.range(2):
+            chunk: pl.Tensor[[4, 16], pl.FP32] = pl.create_tensor([4, 16], dtype=pl.FP32)
+            chunk = self.compute(x, chunk)
+            out = pl.assemble(out, chunk, [b, 0, 0])
+        return out
+
+
 # --- Test Cases ---
 
 
@@ -269,6 +302,31 @@ class Tile2DStoreTo3DTestCase(PTOTestCase):
         tensors["out"][1, 2, :] = tensors["a"][0, :] * tensors["b"][0, :]
 
 
+class TensorAssemble2DTo3DTestCase(PTOTestCase):
+    """2D create assembled into 3D target → fused to slice with leading-1 padding (#1006)."""
+
+    __test__ = False
+
+    def __init__(self, *, backend_type: BackendType | None = None, config=None):
+        super().__init__(config, backend_type=backend_type)
+
+    def get_name(self) -> str:
+        return "tensor_assemble_2d_to_3d"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [4, 16], DataType.FP32, init_value=torch.rand),
+            TensorSpec("out", [2, 4, 16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorAssemble2DTo3DProgram
+
+    def compute_expected(self, tensors, params=None):
+        for b in range(2):
+            tensors["out"][b, :, :] = tensors["x"]
+
+
 # --- Tests ---
 
 
@@ -297,6 +355,12 @@ class TestElementwise4D:
     def test_tile_2d_store_to_3d(self, test_runner, backend):
         """2D tile [1, 16] stored into a 3D tensor [2, 4, 16]."""
         result = test_runner.run(Tile2DStoreTo3DTestCase(backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tensor_assemble_2d_to_3d(self, test_runner, backend):
+        """2D create assembled into 3D target, fused to slice with padding (#1006)."""
+        result = test_runner.run(TensorAssemble2DTo3DTestCase(backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -336,38 +336,38 @@ class TestFuseCreateAssembleToSlice:
                         out = pl.assemble(out, chunk, [b, 0, col])
                 return out
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 4], pl.FP32]:
+                t: pl.Tile[[2, 4], pl.FP32] = pl.load(x, [0, 0], [2, 4])
+                out_1: pl.Tensor[[2, 4], pl.FP32] = pl.store(t, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[2, 4, 8], pl.FP32]],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP32]:
+                for b in pl.range(2):
+                    for c in pl.range(2):
+                        col = c * 4
+                        chunk: pl.Tensor[[1, 2, 4], pl.FP32] = pl.slice(out, [1, 2, 4], [b, 0, col])
+                        # Use a different name because the DSL rejects reassigning
+                        # chunk (type [1,2,4]) with compute's return (type [2,4]).
+                        # After SSA both programs produce distinct vars anyway, and
+                        # name_hint_ is IgnoreField in structural equality.
+                        _chunk_ret: pl.Tensor[[2, 4], pl.FP32] = self.compute(x, chunk)
+                return out
+
         after = _run_prereqs_and_fuse(Before)
-
-        # After fusion: tensor.create + tensor.assemble should become tensor.slice.
-        ops = _collect_tensor_ops_in_orch(after)
-        assert "tensor.slice" in ops, f"Expected tensor.slice after fusion, got {ops}"
-        assert "tensor.create" not in ops, f"tensor.create should be fused away, got {ops}"
-        assert "tensor.assemble" not in ops, f"tensor.assemble should be fused away, got {ops}"
-
-        # Verify the generated tensor.slice has matching shape/offset ranks (both 3D).
-        class SliceRankChecker(ir_core.IRVisitor):
-            def __init__(self):
-                super().__init__()
-                self.checked = False
-
-            def visit_assign_stmt(self, stmt):
-                if hasattr(stmt.value, "op") and stmt.value.op.name == "tensor.slice":
-                    args = stmt.value.args
-                    shape_rank = len(args[1].elements)
-                    offset_rank = len(args[2].elements)
-                    assert shape_rank == offset_rank, (
-                        f"tensor.slice shape rank ({shape_rank}) != offset rank ({offset_rank})"
-                    )
-                    # shape should be [1, 2, 4] (padded with leading 1)
-                    assert shape_rank == 3, f"Expected rank 3 after padding, got {shape_rank}"
-                    self.checked = True
-                super().visit_assign_stmt(stmt)
-
-        for func in after.functions.values():
-            if func.func_type == ir_core.FunctionType.Orchestration:
-                checker = SliceRankChecker()
-                checker.visit_stmt(func.body)
-                assert checker.checked, "No tensor.slice found in orch function"
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
 
     def test_no_orchestration_function_noop(self):
         """Pass should be a no-op when there are no Orchestration functions."""


### PR DESCRIPTION
## Summary
- When a 2D `tensor.create` is assembled into a 3D target, `RewriteCreateToSlice` pads the slice shape with leading 1s but reused the original `Var` with its stale 2D type. This creates a new `Var` with the padded type and registers it in `var_remap_` so downstream references see the correct type.
- Refactored `test_3d_target_2d_tile_offset_padded` to use the standard `Before`/`Expected` + `assert_structural_equal` pattern.
- Added an ST test for the 2D-create-into-3D-target fusion path.

## Testing
- [x] Unit test refactored to Before/Expected pattern
- [x] ST test added for 2D-create-into-3D-target fusion
- [x] Existing tests pass

## Related Issues
Fixes #1006