### PR TITLE
fix(st): migrate sys.path setup and imports to simpler_setup package

### DIFF
--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -676,14 +676,14 @@ def _execute_on_device(
     """
     simpler_root = os.environ.get("SIMPLER_ROOT")
     if simpler_root:
-        for sub in ("examples/scripts", "python"):
-            p = str(Path(simpler_root) / sub)
+        # Add simpler root for simpler_setup package and python/ for the simpler package.
+        for p in (str(Path(simpler_root)), str(Path(simpler_root) / "python")):
             if p not in sys.path:
                 sys.path.insert(0, p)
 
-    CodeRunner = importlib.import_module("code_runner").CodeRunner
-    KernelCompiler = importlib.import_module("simpler.kernel_compiler").KernelCompiler
-    RuntimeBuilder = importlib.import_module("runtime_builder").RuntimeBuilder
+    CodeRunner = importlib.import_module("simpler_setup.code_runner").CodeRunner
+    KernelCompiler = importlib.import_module("simpler_setup.kernel_compiler").KernelCompiler
+    RuntimeBuilder = importlib.import_module("simpler_setup.runtime_builder").RuntimeBuilder
 
     _install_golden_inputs_patch(CodeRunner)
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -39,7 +39,7 @@ import pytest  # noqa: E402
 from harness.core.environment import (  # noqa: E402
     ensure_simpler_available,
     get_simpler_python_path,
-    get_simpler_scripts_path,
+    get_simpler_root,
 )
 from harness.core.harness import PTOTestCase  # noqa: E402
 from harness.core.test_runner import (  # noqa: E402
@@ -90,8 +90,9 @@ def setup_simpler_dependency(request):
     simpler_root = ensure_simpler_available()
     os.environ["SIMPLER_ROOT"] = str(simpler_root)
 
-    # Add simpler to sys.path after ensuring it's available
-    for path in [get_simpler_python_path(), get_simpler_scripts_path()]:
+    # Add simpler to sys.path after ensuring it's available.
+    # simpler root is needed for the simpler_setup package; python/ for the simpler package.
+    for path in [get_simpler_root(), get_simpler_python_path()]:
         if path is not None and path.exists() and str(path) not in sys.path:
             sys.path.insert(0, str(path))
 

--- a/tests/st/fuzz/conftest.py
+++ b/tests/st/fuzz/conftest.py
@@ -19,13 +19,13 @@ def pytest_configure(config):
     pytest-forked forks the process after collection but inherits the
     parent's sys.path.  By setting the paths here (before any fork)
     rather than in a session fixture, we guarantee that forked children
-    see the correct paths for ``code_runner``, ``runtime_builder``, etc.
+    see the correct paths for ``simpler_setup``, ``simpler``, etc.
     """
     simpler_root = os.environ.get("SIMPLER_ROOT")
     if not simpler_root:
         return
 
-    for sub in ("examples/scripts", "python"):
-        p = os.path.join(simpler_root, sub)
+    # simpler root for simpler_setup package; python/ for the simpler package.
+    for p in (simpler_root, os.path.join(simpler_root, "python")):
         if os.path.isdir(p) and p not in sys.path:
             sys.path.insert(0, p)

--- a/tests/st/harness/core/environment.py
+++ b/tests/st/harness/core/environment.py
@@ -42,14 +42,6 @@ def get_simpler_python_path() -> Path | None:
     return root / "python"
 
 
-def get_simpler_scripts_path() -> Path | None:
-    """Get Simpler scripts path (simpler/examples/scripts directory)."""
-    root = get_simpler_root()
-    if root is None:
-        return None
-    return root / "examples" / "scripts"
-
-
 def ensure_simpler_available() -> Path:
     """Ensure Simpler is available, raise error if SIMPLER_ROOT is not set.
 

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -401,26 +401,27 @@ def prebuild_binaries(
     simpler_root = os.environ.get("SIMPLER_ROOT", "")
     if not simpler_root:
         return 0
-    for sub in ("examples/scripts", "python"):
-        p = str(Path(simpler_root) / sub)
+    for p in (str(Path(simpler_root)), str(Path(simpler_root) / "python")):
         if p not in sys.path:
             sys.path.insert(0, p)
 
     try:
-        code_runner_mod = importlib.import_module("code_runner")
-        kernel_compiler_mod = importlib.import_module("simpler.kernel_compiler")
-        runtime_builder_mod = importlib.import_module("runtime_builder")
+        kernel_compiler_mod = importlib.import_module("simpler_setup.kernel_compiler")
+        runtime_builder_mod = importlib.import_module("simpler_setup.runtime_builder")
+        pto_isa_mod = importlib.import_module("simpler_setup.pto_isa")
     except ImportError:
         return 0
 
-    _ensure_pto_isa_root = code_runner_mod._ensure_pto_isa_root
     KernelCompiler = kernel_compiler_mod.KernelCompiler
     RuntimeBuilder = runtime_builder_mod.RuntimeBuilder
 
     _install_binary_cache_patch(KernelCompiler, RuntimeBuilder)
 
-    pto_isa_root = _ensure_pto_isa_root(verbose=False, clone_protocol="https", commit=pto_isa_commit)
-    if pto_isa_root is None:
+    try:
+        pto_isa_root = pto_isa_mod.ensure_pto_isa_root(
+            verbose=False, clone_protocol="https", commit=pto_isa_commit
+        )
+    except OSError:
         return 0
 
     def _load_kc(work_dir: Path):


### PR DESCRIPTION
## Summary

- Update `runner._execute_on_device`, `test_runner.prebuild_binaries`, and fuzz/ST conftests to import from `simpler_setup.*` (`simpler_setup.code_runner`, `.kernel_compiler`, `.runtime_builder`, `.pto_isa`) instead of the former flat modules in `examples/scripts`
- Add Simpler root to `sys.path` (for the `simpler_setup` top-level package) and `python/` (for the `simpler` package), replacing the old `examples/scripts` entry
- Remove the now-unused `get_simpler_scripts_path()` function from `tests/st/harness/core/environment.py`; callers now use `get_simpler_root()` directly

## Testing

- [x] All 3518 unit tests pass (`tests/ut/`)
- [x] `ruff check` passes on all changed files
- [x] ST harness changes are consistent across `runner.py`, `test_runner.py`, `conftest.py`, and `fuzz/conftest.py`

Adapt to simpler : 1d4c218456451fa99de3ace9601b01fd210a31dd 