### PR TITLE
feat(ir): stmt dependency analysis with InOut-use discipline check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/utils/tpop_chain_normalizer.cpp
     src/ir/transforms/utils/normalize_stmt_structure.cpp
     src/ir/transforms/utils/parent_stmt_analysis.cpp
+    src/ir/transforms/utils/stmt_dependency_analysis.cpp
     src/ir/transforms/utils/transform_utils.cpp
     src/ir/transforms/visitor.cpp
 

--- a/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
+++ b/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
@@ -16,7 +16,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "pypto/core/error.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 
@@ -50,22 +49,6 @@ struct StmtDependencyGraph {
 };
 
 /**
- * @brief Build the statement dependency graph for a region.
- *
- * Pure dataflow analysis over SSA def-use. Does not check the InOut-use
- * discipline; callers that need soundness should call CheckInOutUseDiscipline
- * first and refuse to proceed on any violation.
- *
- * Complexity: O(N * avg_fanout) where N is the number of statements in the
- * region — a single pass with per-stmt use/def collection.
- *
- * @param region The region (typically a SeqStmts) to analyze. If `region` is
- *               not a SeqStmts, the graph has a single node and no edges.
- * @return Dependency graph with nodes and predecessor edges.
- */
-StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region);
-
-/**
  * @brief Check that the InOut-use discipline (RFC #1026) holds over a region.
  *
  * The discipline: for any user-function call that passes variable `v` as an
@@ -80,12 +63,38 @@ StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region);
  * here; their memory mutations are handled separately (Mode B in RFC #1026)
  * and are out of scope for this dataflow analysis.
  *
+ * Aborts compilation on any violation: a violating region breaks the
+ * dataflow-soundness precondition that `BuildStmtDependencyGraph` relies on,
+ * so any downstream analysis would silently return wrong answers. Throwing
+ * is strictly preferable to returning unsound results.
+ *
  * @param region The region to validate (typically a SeqStmts).
  * @param program The program — used to resolve Call::op_ to a Function and
  *                look up param_directions_.
- * @return A list of Diagnostics; empty iff the discipline holds.
+ * @throws pypto::VerificationError if any violation is found; the error
+ *         carries the full set of diagnostics with precise source locations.
  */
-std::vector<Diagnostic> CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program);
+void CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program);
+
+/**
+ * @brief Build the statement dependency graph for a region.
+ *
+ * Dataflow analysis over SSA def-use. Runs `CheckInOutUseDiscipline` first
+ * (when a program is supplied) so callers always receive a sound graph.
+ *
+ * Complexity: O(N * avg_fanout) where N is the number of statements in the
+ * region — a single pass with per-stmt use/def collection, in addition to
+ * the linear discipline walk.
+ *
+ * @param region The region (typically a SeqStmts) to analyze. If `region` is
+ *               not a SeqStmts, the graph has a single node and no edges.
+ * @param program The program used by the discipline check to resolve callees.
+ *                If null, the discipline check is skipped — useful only for
+ *                self-contained analyses where no user-function calls exist.
+ * @return Dependency graph with nodes and predecessor edges.
+ * @throws pypto::VerificationError if the discipline check rejects the region.
+ */
+StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region, const ProgramPtr& program = nullptr);
 
 }  // namespace stmt_dep
 }  // namespace ir

--- a/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
+++ b/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
@@ -36,8 +36,9 @@ namespace stmt_dep {
  *
  * The graph is sound under the InOut-use discipline (RFC #1026): physical
  * memory mutation is mirrored by SSA version changes, so SSA def-use captures
- * all real dependencies. Callers needing soundness must first run
- * CheckInOutUseDiscipline and refuse to proceed on any violation.
+ * all real dependencies. `BuildStmtDependencyGraph` enforces this
+ * precondition when a program is supplied; callers that bypass that path
+ * must ensure the discipline holds before relying on the graph for soundness.
  */
 struct StmtDependencyGraph {
   /// Top-level stmts in region order.

--- a/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
+++ b/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_STMT_DEPENDENCY_ANALYSIS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_STMT_DEPENDENCY_ANALYSIS_H_
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/stmt.h"
+
+namespace pypto {
+namespace ir {
+namespace stmt_dep {
+
+/**
+ * @brief Dataflow dependency graph over the top-level statements of a region.
+ *
+ * Nodes are the region's top-level statements:
+ *   - If the region is a SeqStmts, each child of `stmts_` becomes a node.
+ *   - Otherwise the region itself is the single node.
+ *
+ * Edges are predecessor relationships at block granularity: a compound child
+ * (IfStmt/ForStmt/...) aggregates all the variable uses and defs from its
+ * subtree. `predecessors[X]` is the set of nodes whose defs X directly reads.
+ *
+ * The graph is sound under the InOut-use discipline (RFC #1026): physical
+ * memory mutation is mirrored by SSA version changes, so SSA def-use captures
+ * all real dependencies. Callers needing soundness must first run
+ * CheckInOutUseDiscipline and refuse to proceed on any violation.
+ */
+struct StmtDependencyGraph {
+  /// Top-level stmts in region order.
+  std::vector<StmtPtr> stmts;
+
+  /// predecessors[X] = set of stmts in `stmts` that X directly depends on.
+  /// Keyed by raw pointer; the StmtPtr ownership is held in `stmts`.
+  std::unordered_map<const Stmt*, std::unordered_set<const Stmt*>> predecessors;
+};
+
+/**
+ * @brief Build the statement dependency graph for a region.
+ *
+ * Pure dataflow analysis over SSA def-use. Does not check the InOut-use
+ * discipline; callers that need soundness should call CheckInOutUseDiscipline
+ * first and refuse to proceed on any violation.
+ *
+ * Complexity: O(N * avg_fanout) where N is the number of statements in the
+ * region — a single pass with per-stmt use/def collection.
+ *
+ * @param region The region (typically a SeqStmts) to analyze. If `region` is
+ *               not a SeqStmts, the graph has a single node and no edges.
+ * @return Dependency graph with nodes and predecessor edges.
+ */
+StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region);
+
+/**
+ * @brief Check that the InOut-use discipline (RFC #1026) holds over a region.
+ *
+ * The discipline: for any user-function call that passes variable `v` as an
+ * InOut or Out parameter, `v` must not be read by any statement reachable
+ * from the call in CFG order. Post-mutation values flow exclusively through
+ * the call's return slots.
+ *
+ * InOut and Out are treated identically — both cause `v` to be "dead for read"
+ * after the call.
+ *
+ * Built-in ops (tile.*, tensor.*, system.*) do not contribute to the dead set
+ * here; their memory mutations are handled separately (Mode B in RFC #1026)
+ * and are out of scope for this dataflow analysis.
+ *
+ * @param region The region to validate (typically a SeqStmts).
+ * @param program The program — used to resolve Call::op_ to a Function and
+ *                look up param_directions_.
+ * @return A list of Diagnostics; empty iff the discipline holds.
+ */
+std::vector<Diagnostic> CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program);
+
+}  // namespace stmt_dep
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_STMT_DEPENDENCY_ANALYSIS_H_

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/reporter/report.h"
 #include "pypto/ir/transforms/ir_property.h"
 #include "pypto/ir/transforms/pass_context.h"
+#include "pypto/ir/transforms/utils/stmt_dependency_analysis.h"
 #include "pypto/ir/verifier/property_verifier_registry.h"
 #include "pypto/ir/verifier/verification_error.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -429,6 +430,34 @@ void BindPass(nb::module_& m) {
              nb::arg("properties") = PassProperties{},
              "Create a pass from a Python program-level transform.\n\n"
              "The transform receives a Program and returns a (possibly new) Program.");
+
+  // Statement dependency analysis submodule (RFC #1026 Phase 1 — issue #1027).
+  nb::module_ dep_analysis = passes.def_submodule(
+      "stmt_dependency_analysis", "Statement dependency analysis and InOut-use discipline check");
+
+  nb::class_<stmt_dep::StmtDependencyGraph>(dep_analysis, "StmtDependencyGraph",
+                                            "Dataflow dependency graph over a region's top-level statements")
+      .def_ro("stmts", &stmt_dep::StmtDependencyGraph::stmts, "Top-level stmts of the region in order")
+      .def(
+          "get_predecessors",
+          [](const stmt_dep::StmtDependencyGraph& self, const StmtPtr& stmt) {
+            std::vector<StmtPtr> result;
+            if (!stmt) return result;
+            auto it = self.predecessors.find(stmt.get());
+            if (it == self.predecessors.end()) return result;
+            // Preserve region order for determinism.
+            for (const auto& s : self.stmts) {
+              if (it->second.count(s.get())) result.push_back(s);
+            }
+            return result;
+          },
+          nb::arg("stmt"), "Return the predecessor stmts of the given stmt in region order");
+
+  dep_analysis.def("build_stmt_dependency_graph", &stmt_dep::BuildStmtDependencyGraph, nb::arg("region"),
+                   "Build a dataflow dependency graph over a region's top-level stmts");
+
+  dep_analysis.def("check_inout_use_discipline", &stmt_dep::CheckInOutUseDiscipline, nb::arg("region"),
+                   nb::arg("program"), "Check that no InOut/Out-passed var is read after its mutating call");
 }
 
 }  // namespace python

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -454,10 +454,15 @@ void BindPass(nb::module_& m) {
           nb::arg("stmt"), "Return the predecessor stmts of the given stmt in region order");
 
   dep_analysis.def("build_stmt_dependency_graph", &stmt_dep::BuildStmtDependencyGraph, nb::arg("region"),
-                   "Build a dataflow dependency graph over a region's top-level stmts");
+                   nb::arg("program").none() = nb::none(),
+                   "Build a dataflow dependency graph over a region's top-level stmts. "
+                   "When `program` is provided, the InOut-use discipline is checked first "
+                   "and any violation raises pypto.Error (VerificationError).");
 
   dep_analysis.def("check_inout_use_discipline", &stmt_dep::CheckInOutUseDiscipline, nb::arg("region"),
-                   nb::arg("program"), "Check that no InOut/Out-passed var is read after its mutating call");
+                   nb::arg("program"),
+                   "Enforce the InOut-use discipline; raises pypto.Error (VerificationError) "
+                   "on any violation so compilation halts rather than proceeding with unsound IR.");
 }
 
 }  // namespace python

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -13,7 +13,7 @@ from enum import Enum
 from types import TracebackType
 from typing import overload
 
-from pypto.pypto_core.ir import Function, Program, Span
+from pypto.pypto_core.ir import Function, Program, Span, Stmt
 
 class IRProperty(Enum):
     """Verifiable IR properties."""
@@ -416,6 +416,24 @@ class PropertyVerifierRegistry:
 def run_verifier(properties: IRPropertySet | None = None) -> Pass:
     """Create a verifier pass. Defaults to get_default_verify_properties() if None."""
 
+class stmt_dependency_analysis:
+    """Statement dependency analysis and InOut-use discipline check (RFC #1026 Phase 1)."""
+
+    class StmtDependencyGraph:
+        """Dataflow dependency graph over a region's top-level statements."""
+
+        stmts: list[Stmt]
+        def get_predecessors(self, stmt: Stmt) -> list[Stmt]:
+            """Return the predecessor stmts of the given stmt in region order."""
+
+    @staticmethod
+    def build_stmt_dependency_graph(region: Stmt) -> StmtDependencyGraph:
+        """Build a dataflow dependency graph over a region's top-level stmts."""
+
+    @staticmethod
+    def check_inout_use_discipline(region: Stmt, program: Program) -> list[Diagnostic]:
+        """Check that no InOut/Out-passed var is read after its mutating call."""
+
 __all__ = [
     "IRProperty",
     "IRPropertySet",
@@ -478,6 +496,7 @@ __all__ = [
     "PassProperties",
     "create_function_pass",
     "create_program_pass",
+    "stmt_dependency_analysis",
 ]
 
 class PassProperties:

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -427,12 +427,20 @@ class stmt_dependency_analysis:
             """Return the predecessor stmts of the given stmt in region order."""
 
     @staticmethod
-    def build_stmt_dependency_graph(region: Stmt) -> StmtDependencyGraph:
-        """Build a dataflow dependency graph over a region's top-level stmts."""
+    def build_stmt_dependency_graph(region: Stmt, program: Program | None = None) -> StmtDependencyGraph:
+        """Build a dataflow dependency graph over a region's top-level stmts.
+
+        When `program` is provided, the InOut-use discipline is checked first
+        and any violation raises `pypto.Error` (VerificationError).
+        """
 
     @staticmethod
-    def check_inout_use_discipline(region: Stmt, program: Program) -> list[Diagnostic]:
-        """Check that no InOut/Out-passed var is read after its mutating call."""
+    def check_inout_use_discipline(region: Stmt, program: Program) -> None:
+        """Enforce the InOut-use discipline.
+
+        Raises `pypto.Error` (VerificationError) on any violation so
+        compilation halts rather than proceeding with unsound IR.
+        """
 
 __all__ = [
     "IRProperty",

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/utils/stmt_dependency_analysis.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/var_collectors.h"
+
+namespace pypto {
+namespace ir {
+namespace stmt_dep {
+
+// ---------------------------------------------------------------------------
+// BuildStmtDependencyGraph
+// ---------------------------------------------------------------------------
+
+StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region) {
+  StmtDependencyGraph graph;
+  if (!region) return graph;
+
+  // Non-SeqStmts regions are single-node graphs with no edges.
+  auto seq = As<SeqStmts>(region);
+  if (!seq) {
+    graph.stmts.push_back(region);
+    graph.predecessors[region.get()] = {};
+    return graph;
+  }
+
+  graph.stmts = seq->stmts_;
+  // Ensure every stmt has an entry, even if it has no predecessors.
+  for (const auto& stmt : graph.stmts) {
+    graph.predecessors[stmt.get()] = {};
+  }
+
+  // Last stmt in the region that defined each Var (tracked by raw pointer).
+  std::unordered_map<const Var*, const Stmt*> last_def;
+
+  for (const auto& stmt : graph.stmts) {
+    var_collectors::VarDefUseCollector collector;
+    collector.VisitStmt(stmt);
+
+    const Stmt* raw_stmt = stmt.get();
+
+    // Uses → predecessor edges from the last intra-region def of the read var.
+    for (const Var* v : collector.var_uses) {
+      auto it = last_def.find(v);
+      if (it != last_def.end() && it->second != raw_stmt) {
+        graph.predecessors[raw_stmt].insert(it->second);
+      }
+    }
+
+    // Defs → update last_def. A stmt that both defines and uses the same var
+    // shadows any prior definition for subsequent stmts; the guard above
+    // prevents self-loops.
+    for (const Var* v : collector.var_defs) {
+      last_def[v] = raw_stmt;
+    }
+  }
+
+  return graph;
+}
+
+// ---------------------------------------------------------------------------
+// CheckInOutUseDiscipline
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Visitor that walks a region in CFG order and flags post-call reads of
+/// InOut/Out-passed variables.
+class InOutUseDisciplineChecker : public IRVisitor {
+ public:
+  explicit InOutUseDisciplineChecker(ProgramPtr program) : program_(std::move(program)) {}
+
+  std::vector<Diagnostic> TakeDiagnostics() { return std::move(diagnostics_); }
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override {
+    const Var* raw = op.get();
+    if (dead_.count(raw) != 0) {
+      auto origin_it = dead_origin_.find(raw);
+      std::string origin_str =
+          origin_it != dead_origin_.end() ? origin_it->second.to_string() : std::string("<unknown>");
+      std::string msg = "variable '" + op->name_hint_ + "' was passed as InOut/Out at " + origin_str +
+                        "; read the post-call return value instead of the pre-call variable";
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "InOutUseDiscipline", 0, std::move(msg),
+                                op->span_);
+    }
+    // Delegate to base so IterArg::initValue_ is still visited.
+    IRVisitor::VisitVarLike_(op);
+  }
+
+  void VisitExpr_(const CallPtr& op) override {
+    // Visit args first — reads in the args happen logically before the call's
+    // effect, so self-reads like `f(T, inout=T)` remain allowed.
+    for (const auto& arg : op->args_) {
+      VisitExpr(arg);
+    }
+
+    // Resolve callee. Built-in ops (tile.*, tensor.*, system.*) won't resolve;
+    // they do not contribute to the dead set. Their memory mutations are
+    // handled as Mode B in RFC #1026, which is out of scope here.
+    if (!program_) return;
+    FunctionPtr callee = program_->GetFunction(op->op_->name_);
+    if (!callee) return;
+
+    const size_t n = std::min(callee->param_directions_.size(), op->args_.size());
+    for (size_t i = 0; i < n; ++i) {
+      ParamDirection dir = callee->param_directions_[i];
+      if (dir != ParamDirection::InOut && dir != ParamDirection::Out) continue;
+      VarPtr var = AsVarLike(op->args_[i]);
+      if (!var) continue;
+      const Var* raw = var.get();
+      dead_.insert(raw);
+      // Only record the first origin span per var — subsequent InOut/Out
+      // passes of the same var don't change the "dead" status.
+      dead_origin_.emplace(raw, op->span_);
+    }
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    // Then- and else-branches are mutually exclusive at runtime, so a
+    // post-call mark added in one branch must not bleed into the other.
+    // Snapshot `dead_` before each branch, then take the union afterwards —
+    // reads *after* the if-stmt still see the effect of either branch, but
+    // reads *within* the sibling branch don't.
+    VisitExpr(op->condition_);
+
+    auto snapshot = dead_;
+    VisitStmt(op->then_body_);
+    auto dead_after_then = dead_;
+
+    dead_ = std::move(snapshot);
+    if (op->else_body_.has_value()) {
+      VisitStmt(*op->else_body_);
+    }
+
+    // Merge: a var is dead after the if iff it was dead in either branch.
+    // Iteration order doesn't affect the result (insert into unordered_set is
+    // commutative and idempotent), so the range-insert form is deterministic.
+    dead_.insert(dead_after_then.begin(), dead_after_then.end());
+  }
+
+ private:
+  ProgramPtr program_;
+  std::unordered_set<const Var*> dead_;
+  std::unordered_map<const Var*, Span> dead_origin_;
+  std::vector<Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+std::vector<Diagnostic> CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program) {
+  if (!region) return {};
+  InOutUseDisciplineChecker checker(program);
+  checker.VisitStmt(region);
+  return checker.TakeDiagnostics();
+}
+
+}  // namespace stmt_dep
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -93,6 +93,17 @@ namespace {
 
 /// Visitor that walks a region in CFG order and flags post-call reads of
 /// InOut/Out-passed variables.
+///
+/// The visitor distinguishes read contexts from definition contexts by
+/// overriding each stmt visitor: we only descend into RHS / condition / body
+/// fields, never into LHS / loop_var_ / return_vars_ / iter_args themselves.
+/// This prevents definition sites from being falsely reported as reads.
+///
+/// Loop back-edges are modelled conservatively: before entering a loop body,
+/// the visitor pre-populates `dead_` with every var the body would kill. This
+/// captures back-edge reachability: a read in iteration N+1 of a var that
+/// iteration N's call marked InOut/Out is flagged on the first (and only)
+/// pass over the body.
 class InOutUseDisciplineChecker : public IRVisitor {
  public:
   explicit InOutUseDisciplineChecker(ProgramPtr program) : program_(std::move(program)) {}
@@ -101,6 +112,8 @@ class InOutUseDisciplineChecker : public IRVisitor {
 
  protected:
   void VisitVarLike_(const VarPtr& op) override {
+    // Only read contexts reach this hook — the overridden stmt visitors skip
+    // definition fields before recursion lands here.
     const Var* raw = op.get();
     if (dead_.count(raw) != 0) {
       auto origin_it = dead_origin_.find(raw);
@@ -111,7 +124,7 @@ class InOutUseDisciplineChecker : public IRVisitor {
       diagnostics_.emplace_back(DiagnosticSeverity::Error, "InOutUseDiscipline", 0, std::move(msg),
                                 op->span_);
     }
-    // Delegate to base so IterArg::initValue_ is still visited.
+    // Delegate to base so TensorType::shape_ expressions on the var are still visited.
     IRVisitor::VisitVarLike_(op);
   }
 
@@ -143,12 +156,15 @@ class InOutUseDisciplineChecker : public IRVisitor {
     }
   }
 
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // LHS (`op->var_`) is a definition — skip it. Only the RHS is a read.
+    VisitExpr(op->value_);
+  }
+
   void VisitStmt_(const IfStmtPtr& op) override {
     // Then- and else-branches are mutually exclusive at runtime, so a
     // post-call mark added in one branch must not bleed into the other.
-    // Snapshot `dead_` before each branch, then take the union afterwards —
-    // reads *after* the if-stmt still see the effect of either branch, but
-    // reads *within* the sibling branch don't.
+    // `return_vars_` are definitions — skip them.
     VisitExpr(op->condition_);
 
     auto snapshot = dead_;
@@ -166,7 +182,56 @@ class InOutUseDisciplineChecker : public IRVisitor {
     dead_.insert(dead_after_then.begin(), dead_after_then.end());
   }
 
+  void VisitStmt_(const ForStmtPtr& op) override {
+    // Header reads: bounds and iter_args' initial values.
+    VisitExpr(op->start_);
+    VisitExpr(op->stop_);
+    VisitExpr(op->step_);
+    if (op->chunk_config_.has_value() && op->chunk_config_->size) {
+      VisitExpr(op->chunk_config_->size);
+    }
+    for (const auto& ia : op->iter_args_) {
+      if (ia->initValue_) VisitExpr(ia->initValue_);
+    }
+    // `loop_var_`, `iter_args_` themselves, and `return_vars_` are definitions
+    // at the loop header — skip them.
+
+    // Back-edge modelling: any kill anywhere in the body is reachable from
+    // iteration N's tail to iteration N+1's start, so the var must be dead
+    // at body entry for the subsequent iteration's reads to be flagged.
+    // Pre-populate `dead_` with the body's kills, then walk the body.
+    CollectKillsInto(op->body_, dead_, dead_origin_);
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    VisitExpr(op->condition_);
+    for (const auto& ia : op->iter_args_) {
+      if (ia->initValue_) VisitExpr(ia->initValue_);
+    }
+    // `iter_args_` and `return_vars_` are definitions — skip them.
+    CollectKillsInto(op->body_, dead_, dead_origin_);
+    VisitStmt(op->body_);
+  }
+
  private:
+  /// Pre-scan a subtree and merge every var it would mark InOut/Out-dead into
+  /// `dead` (with origin span recorded in `origin`). Uses a fresh sub-checker
+  /// so the main walk's state and diagnostics are untouched.
+  void CollectKillsInto(const StmtPtr& stmt, std::unordered_set<const Var*>& dead,
+                        std::unordered_map<const Var*, Span>& origin) const {
+    if (!stmt) return;
+    InOutUseDisciplineChecker sub(program_);
+    sub.VisitStmt(stmt);
+    dead.insert(sub.dead_.begin(), sub.dead_.end());
+    for (const auto& [v, span] : sub.dead_origin_) {
+      origin.emplace(v, span);
+    }
+    // Sub-diagnostics are intentionally discarded: this is a precondition
+    // walk, not the real check. The main walk over the same body will
+    // surface any violations.
+  }
+
   ProgramPtr program_;
   std::unordered_set<const Var*> dead_;
   std::unordered_map<const Var*, Span> dead_origin_;

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -27,6 +27,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
+#include "pypto/ir/verifier/property_verifier_registry.h"
 
 namespace pypto {
 namespace ir {
@@ -36,7 +37,9 @@ namespace stmt_dep {
 // BuildStmtDependencyGraph
 // ---------------------------------------------------------------------------
 
-StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region) {
+StmtDependencyGraph BuildStmtDependencyGraph(const StmtPtr& region, const ProgramPtr& program) {
+  if (program) CheckInOutUseDiscipline(region, program);
+
   StmtDependencyGraph graph;
   if (!region) return graph;
 
@@ -172,11 +175,15 @@ class InOutUseDisciplineChecker : public IRVisitor {
 
 }  // namespace
 
-std::vector<Diagnostic> CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program) {
-  if (!region) return {};
+void CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program) {
+  if (!region) return;
   InOutUseDisciplineChecker checker(program);
   checker.VisitStmt(region);
-  return checker.TakeDiagnostics();
+  auto diagnostics = checker.TakeDiagnostics();
+  if (diagnostics.empty()) return;
+
+  std::string report = PropertyVerifierRegistry::GenerateReport(diagnostics);
+  throw VerificationError(report, std::move(diagnostics));
 }
 
 }  // namespace stmt_dep

--- a/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
+++ b/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
@@ -345,6 +345,57 @@ class TestInOutUseDiscipline:
 
         assert dep_analysis.check_inout_use_discipline(_seq_body(P, "main"), P) is None
 
+    def test_loop_backedge_is_flagged(self):
+        """A call in a for body kills a var; an earlier read in the same body
+        is reachable via the back-edge and must be flagged."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # On iter 2, the read of x happens AFTER iter 1's mutate(x).
+                # The back-edge reachability must flag this.
+                for i in pl.range(0, 4, 1):  # noqa: F841
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION via back-edge  # noqa: F841
+                    z: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
+                return x
+
+        _assert_violation(_seq_body(P, "main"), P, "x")
+
+    def test_for_loop_var_is_not_flagged(self):
+        """The ForStmt's loop_var is a definition at the loop header, not a read.
+        Even when the loop body mutates a var of the same name, the loop_var
+        definition site itself must not be flagged."""
+
+        # Construct IR where the for-stmt's loop_var shares a Var* with a var
+        # killed earlier is not expressible in the DSL directly, but the fix is
+        # structural (skip def fields in VisitStmt_). Verify the common case: a
+        # clean for-loop over a range doesn't raise even when an outer InOut
+        # call has happened.
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)
+                # Loop header `i` and iter_arg `acc` are definitions — must not
+                # be flagged as reads even though the body runs after an InOut
+                # call has marked `x` dead.
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(T_new,)):  # noqa: F841
+                    acc = pl.yield_(pl.add(acc, T_new))
+                return acc
+
+        assert dep_analysis.check_inout_use_discipline(_seq_body(P, "main"), P) is None
+
     def test_build_graph_raises_on_violation(self):
         """`build_stmt_dependency_graph` must also abort on discipline violations."""
 

--- a/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
+++ b/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
@@ -1,0 +1,363 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the statement dependency analysis utilities.
+
+Covers:
+- `build_stmt_dependency_graph`: dataflow dependency graph over a region's
+  top-level statements.
+- `check_inout_use_discipline`: detection of post-call reads of InOut/Out-passed
+  variables (RFC #1026 Phase 1, issue #1027).
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import ir, passes
+
+dep_analysis = passes.stmt_dependency_analysis
+
+
+def _seq_body(program: ir.Program, name: str) -> ir.SeqStmts:
+    """Return the named function's body as a SeqStmts (narrows types for pyright)."""
+    func = program.get_function(name)
+    assert func is not None, f"function '{name}' not found in program"
+    body = func.body
+    assert isinstance(body, ir.SeqStmts), (
+        f"function '{name}' body is {type(body).__name__}, expected SeqStmts"
+    )
+    return body
+
+
+# =============================================================================
+# Dependency graph
+# =============================================================================
+
+
+class TestStmtDependencyGraph:
+    """Tests for `build_stmt_dependency_graph`."""
+
+    def test_non_seqstmts_region_is_single_node(self):
+        """A region that isn't a SeqStmts becomes a one-node graph."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return result
+
+        # Drill down to a non-SeqStmts child: the first AssignStmt.
+        first_stmt = _seq_body(P, "main").stmts[0]
+        graph = dep_analysis.build_stmt_dependency_graph(first_stmt)
+        assert len(graph.stmts) == 1
+        assert graph.stmts[0] is first_stmt
+        assert graph.get_predecessors(first_stmt) == []
+
+    def test_linear_chain(self):
+        """a → b → c: each stmt depends only on its immediate predecessor."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.add(a, a)
+                c: pl.Tensor[[64], pl.FP32] = pl.add(b, b)
+                return c
+
+        body = _seq_body(P, "main")
+        stmts = body.stmts
+        # stmts: [a_assign, b_assign, c_assign, return]
+        graph = dep_analysis.build_stmt_dependency_graph(body)
+
+        assert graph.get_predecessors(stmts[0]) == []  # a depends on external x only
+        assert graph.get_predecessors(stmts[1]) == [stmts[0]]  # b ← a
+        assert graph.get_predecessors(stmts[2]) == [stmts[1]]  # c ← b
+        # return c depends on c_assign (the defining stmt of c).
+        assert graph.get_predecessors(stmts[3]) == [stmts[2]]
+
+    def test_independent_stmts_have_no_edge(self):
+        """Two stmts reading only external vars have no intra-region edges."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                c: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return c
+
+        body = _seq_body(P, "main")
+        stmts = body.stmts
+        graph = dep_analysis.build_stmt_dependency_graph(body)
+        assert graph.get_predecessors(stmts[0]) == []
+        assert graph.get_predecessors(stmts[1]) == []
+        # c reads a and b → depends on both.
+        preds_c = graph.get_predecessors(stmts[2])
+        assert set(preds_c) == {stmts[0], stmts[1]}
+
+    def test_compound_child_aggregates_subtree_use(self):
+        """A subtree read inside an If counts as a use of the If stmt."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                if cond:
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(a, a)
+                else:
+                    b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
+                return b
+
+        body = _seq_body(P, "main")
+        stmts = body.stmts
+        # stmts: [a_assign, if_stmt, return]
+        graph = dep_analysis.build_stmt_dependency_graph(body)
+        # If-stmt depends on a (both branches read a inside).
+        assert graph.get_predecessors(stmts[1]) == [stmts[0]]
+
+    def test_compound_child_aggregates_subtree_def(self):
+        """A var defined inside a For body is visible on the For stmt."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(a,)):
+                    acc = pl.yield_(pl.add(acc, a))
+                b: pl.Tensor[[64], pl.FP32] = pl.add(acc, x)
+                return b
+
+        body = _seq_body(P, "main")
+        stmts = body.stmts
+        # stmts: [a_assign, for_stmt, b_assign, return]
+        graph = dep_analysis.build_stmt_dependency_graph(body)
+        # for_stmt reads a (init_values + body use).
+        assert stmts[0] in graph.get_predecessors(stmts[1])
+        # b reads acc — acc is defined by the for_stmt's return_vars.
+        assert stmts[1] in graph.get_predecessors(stmts[2])
+
+    def test_uses_outside_region_have_no_edge(self):
+        """Uses of vars defined outside the SeqStmts don't create intra-region edges."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # noqa: F841
+                return y
+
+        body = _seq_body(P, "main")
+        stmts = body.stmts
+        graph = dep_analysis.build_stmt_dependency_graph(body)
+        # Neither assign has a predecessor in the region — both only read external x.
+        assert graph.get_predecessors(stmts[0]) == []
+        assert graph.get_predecessors(stmts[1]) == []
+
+
+# =============================================================================
+# InOut-use discipline
+# =============================================================================
+
+
+class TestInOutUseDiscipline:
+    """Tests for `check_inout_use_discipline`."""
+
+    def test_clean_when_return_value_is_used(self):
+        """Well-formed: reads after the call go through the returned var."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)
+                y: pl.Tensor[[64], pl.FP32] = pl.add(T_new, T_new)
+                return y
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert diags == []
+
+    def test_rejects_post_inout_read(self):
+        """A read of the InOut-passed var after the call is flagged."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION
+                return y
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert len(diags) >= 1
+        assert all(d.severity == passes.DiagnosticSeverity.Error for d in diags)
+        assert all(d.rule_name == "InOutUseDiscipline" for d in diags)
+        assert all("'x'" in d.message for d in diags)
+
+    def test_out_direction_treated_like_inout(self):
+        """Out params cause the same 'dead for read' behavior as InOut."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def produce(self, T: pl.Out[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.produce(x)  # noqa: F841
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION: Out is like InOut
+                return y
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert len(diags) >= 1
+        assert all("'x'" in d.message for d in diags)
+
+    def test_rejects_read_in_nested_if_branch(self):
+        """A read in an `if` body after the call is still reachable → violation."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)
+                if cond:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION
+                else:
+                    y: pl.Tensor[[64], pl.FP32] = pl.mul(T_new, T_new)
+                return y
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert len(diags) >= 1
+        assert all("'x'" in d.message for d in diags)
+
+    def test_rejects_read_in_for_body(self):
+        """A read inside a for body after the call is a violation."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(T_new,)):
+                    acc = pl.yield_(pl.add(acc, x))  # VIOLATION reading x
+                return acc
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert len(diags) >= 1
+        assert all("'x'" in d.message for d in diags)
+
+    def test_sibling_if_branch_does_not_bleed(self):
+        """Call in then-branch; read of same var in else-branch is NOT a violation."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                if cond:
+                    y_then: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
+                else:
+                    # x is only "dead" in the then-branch; reading here is OK.
+                    y_else: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # noqa: F841
+                # At runtime, only one branch executed; this read is not
+                # guaranteed to follow the mutating call.
+                return x
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        # The `return x` after the if is reachable from the mutating call on
+        # the then-path, so it IS a violation. But the read inside the
+        # else-branch must not be flagged: before the if-branch-scoping fix we
+        # saw extra diagnostics for the else-branch read; with scoping, only
+        # the post-if `return x` is flagged.
+        assert len(diags) <= 1
+
+    def test_self_read_in_call_args_is_allowed(self):
+        """`f(T, inout=T)` — reading T as an arg on the same call is legal."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(
+                self,
+                read_only: pl.Tensor[[64], pl.FP32],
+                T: pl.InOut[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(read_only, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # x passed twice: once as read-only, once as InOut. Arg-side read
+                # happens before the call effect, so this is allowed.
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x, x)
+                return T_new
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert diags == []
+
+    def test_builtin_ops_do_not_kill_vars(self):
+        """Built-in ops (tile.*/tensor.*) don't contribute to the dead set."""
+
+        # A program that only uses built-in ops — no user function with InOut
+        # params. The validator must accept it cleanly, even if the same tensor
+        # appears on multiple stmts. Mode B (physical aliasing) is out of scope
+        # for this analysis.
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                c: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return c
+
+        body = _seq_body(P, "main")
+        diags = dep_analysis.check_inout_use_discipline(body, P)
+        assert diags == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
+++ b/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
@@ -170,8 +170,15 @@ class TestStmtDependencyGraph:
 # =============================================================================
 
 
+def _assert_violation(body, program, expected_var: str) -> None:
+    """The discipline check must raise, and the error message must name the var."""
+    with pytest.raises(Exception, match="InOutUseDiscipline") as excinfo:
+        dep_analysis.check_inout_use_discipline(body, program)
+    assert f"'{expected_var}'" in str(excinfo.value)
+
+
 class TestInOutUseDiscipline:
-    """Tests for `check_inout_use_discipline`."""
+    """Tests for `check_inout_use_discipline` — violations raise and halt compilation."""
 
     def test_clean_when_return_value_is_used(self):
         """Well-formed: reads after the call go through the returned var."""
@@ -190,11 +197,11 @@ class TestInOutUseDiscipline:
                 return y
 
         body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert diags == []
+        # No exception → clean. Explicit `is None` for pyright.
+        assert dep_analysis.check_inout_use_discipline(body, P) is None
 
     def test_rejects_post_inout_read(self):
-        """A read of the InOut-passed var after the call is flagged."""
+        """A read of the InOut-passed var after the call halts compilation."""
 
         @pl.program
         class P:
@@ -209,12 +216,7 @@ class TestInOutUseDiscipline:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION
                 return y
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert len(diags) >= 1
-        assert all(d.severity == passes.DiagnosticSeverity.Error for d in diags)
-        assert all(d.rule_name == "InOutUseDiscipline" for d in diags)
-        assert all("'x'" in d.message for d in diags)
+        _assert_violation(_seq_body(P, "main"), P, "x")
 
     def test_out_direction_treated_like_inout(self):
         """Out params cause the same 'dead for read' behavior as InOut."""
@@ -232,13 +234,10 @@ class TestInOutUseDiscipline:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION: Out is like InOut
                 return y
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert len(diags) >= 1
-        assert all("'x'" in d.message for d in diags)
+        _assert_violation(_seq_body(P, "main"), P, "x")
 
     def test_rejects_read_in_nested_if_branch(self):
-        """A read in an `if` body after the call is still reachable → violation."""
+        """A read in an `if` body after the call is still reachable → raises."""
 
         @pl.program
         class P:
@@ -256,13 +255,10 @@ class TestInOutUseDiscipline:
                     y: pl.Tensor[[64], pl.FP32] = pl.mul(T_new, T_new)
                 return y
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert len(diags) >= 1
-        assert all("'x'" in d.message for d in diags)
+        _assert_violation(_seq_body(P, "main"), P, "x")
 
     def test_rejects_read_in_for_body(self):
-        """A read inside a for body after the call is a violation."""
+        """A read inside a for body after the call raises."""
 
         @pl.program
         class P:
@@ -274,17 +270,20 @@ class TestInOutUseDiscipline:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)
-                for i, (acc,) in pl.range(0, 4, 1, init_values=(T_new,)):
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(T_new,)):  # noqa: F841
                     acc = pl.yield_(pl.add(acc, x))  # VIOLATION reading x
                 return acc
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert len(diags) >= 1
-        assert all("'x'" in d.message for d in diags)
+        _assert_violation(_seq_body(P, "main"), P, "x")
 
     def test_sibling_if_branch_does_not_bleed(self):
-        """Call in then-branch; read of same var in else-branch is NOT a violation."""
+        """Call in then-branch; read of same var in else-branch is NOT a violation.
+
+        Without branch-scoping, the then-branch's InOut mark would persist when
+        the visitor enters the else-branch and the pl.add(x, x) in the else
+        would be flagged. With scoping, the else sees a clean dead-set.
+        The return goes through `y`, not `x`, so no post-if read of x occurs.
+        """
 
         @pl.program
         class P:
@@ -294,24 +293,20 @@ class TestInOutUseDiscipline:
                 return r
 
             @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+                cond: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
                 if cond:
-                    y_then: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
+                    a: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
                 else:
-                    # x is only "dead" in the then-branch; reading here is OK.
-                    y_else: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # noqa: F841
-                # At runtime, only one branch executed; this read is not
-                # guaranteed to follow the mutating call.
-                return x
+                    # x was never passed InOut on this CFG path; safe to read.
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # noqa: F841
+                return y
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        # The `return x` after the if is reachable from the mutating call on
-        # the then-path, so it IS a violation. But the read inside the
-        # else-branch must not be flagged: before the if-branch-scoping fix we
-        # saw extra diagnostics for the else-branch read; with scoping, only
-        # the post-if `return x` is flagged.
-        assert len(diags) <= 1
+        assert dep_analysis.check_inout_use_discipline(_seq_body(P, "main"), P) is None
 
     def test_self_read_in_call_args_is_allowed(self):
         """`f(T, inout=T)` — reading T as an arg on the same call is legal."""
@@ -334,17 +329,11 @@ class TestInOutUseDiscipline:
                 T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x, x)
                 return T_new
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert diags == []
+        assert dep_analysis.check_inout_use_discipline(_seq_body(P, "main"), P) is None
 
     def test_builtin_ops_do_not_kill_vars(self):
         """Built-in ops (tile.*/tensor.*) don't contribute to the dead set."""
 
-        # A program that only uses built-in ops — no user function with InOut
-        # params. The validator must accept it cleanly, even if the same tensor
-        # appears on multiple stmts. Mode B (physical aliasing) is out of scope
-        # for this analysis.
         @pl.program
         class P:
             @pl.function
@@ -354,9 +343,26 @@ class TestInOutUseDiscipline:
                 c: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
                 return c
 
-        body = _seq_body(P, "main")
-        diags = dep_analysis.check_inout_use_discipline(body, P)
-        assert diags == []
+        assert dep_analysis.check_inout_use_discipline(_seq_body(P, "main"), P) is None
+
+    def test_build_graph_raises_on_violation(self):
+        """`build_stmt_dependency_graph` must also abort on discipline violations."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                T_new: pl.Tensor[[64], pl.FP32] = self.mutate(x)  # noqa: F841
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION
+                return y
+
+        with pytest.raises(Exception, match="InOutUseDiscipline"):
+            dep_analysis.build_stmt_dependency_graph(_seq_body(P, "main"), P)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 1 of RFC #1026: adds a reusable statement dependency analysis utility plus the InOut-use discipline check that guarantees its soundness. Lands the building blocks that RFC #1025's `LiftUnrolledLoads` pass — and any future dataflow-aware pass — will consume.

- `BuildStmtDependencyGraph(region, program)` — SSA def→use DAG over a region's top-level statements. Compound children (If/For/...) aggregate their subtree's uses and defs so edges land at block granularity.
- `CheckInOutUseDiscipline(region, program)` — raises `VerificationError` when a variable that was passed as `InOut` or `Out` to a user-function call is read afterwards in CFG order. `Out` is treated identically to `InOut`: both mutate the caller's buffer, so post-call values must flow through the call's return slots.
- The graph builder runs the discipline check first (when a program is supplied), so callers cannot accidentally receive an unsound graph — a violating region halts compilation instead of silently returning wrong answers.
- If-branch snapshots prevent a post-call mark in one branch from bleeding into its sibling.
- Built-in ops (`tile.*`, `tensor.*`, `system.*`) do not contribute to the dead set — their memory mutations are Mode B in the RFC, out of scope for this dataflow analysis.
- Exposed via `passes.stmt_dependency_analysis` Python submodule for downstream consumers and tests.

## Test plan

- [x] 15 new unit tests covering graph construction (linear chains, independent stmts, compound children aggregating subtree use/def, non-SeqStmts regions, vars defined outside the region) and discipline enforcement (clean programs pass, post-call reads raise with the expected var name, `Out` parity with `InOut`, reads inside nested `if`/`for` raise, sibling-branch reads don't bleed, self-reads in the same call's args are allowed, built-in ops don't kill vars, `BuildStmtDependencyGraph` raises on violation)
- [x] Full `tests/ut/ir/` regression (`python -m pytest tests/ut/ir/ -n auto --maxprocesses 8` — 2520 passed, 13 skipped)
- [x] clang-tidy clean (`python tests/lint/clang_tidy.py --diff-base HEAD~2`)
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

## Related Issues

Fixes #1027
Related: #1025, #1026