### PR TITLE
feat(language): add pl.at(optimizations=[...]) with pl.split / pl.auto_chunk

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -256,19 +256,22 @@ for i in pl.unroll(12, chunk=4):
     body_statements
 ```
 
-**Key points:** `chunk=C` splits the loop into an outer sequential loop and an inner loop of `C` iterations. The inner loop preserves the original kind (Sequential/Parallel/Unroll). `chunk` cannot be combined with `init_values`, and `chunk=` loops are only valid inside a `with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):` (or the deprecated `with pl.auto_incore():`) — outside that scope the parser rejects them with an error. See [SplitChunkedLoops Pass](../passes/05-split_chunked_loops.md).
+**Key points:** `chunk=C` splits the loop into an outer sequential loop and an inner loop of `C` iterations. The inner loop preserves the original kind (Sequential/Parallel/Unroll). `chunk` cannot be combined with `init_values`, and `chunk=` loops are only valid inside a `with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):` — outside that scope the parser rejects them with an error. See [SplitChunkedLoops Pass](../passes/05-split_chunked_loops.md).
 
 ### Scope Context Managers
 
 | Form | Scope Kind | Notes |
 | ---- | ---------- | ----- |
 | `pl.at(level=pl.Level.CORE_GROUP)` | `InCore` | Fixed-boundary outline at CORE_GROUP |
-| `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer)` | `AutoInCore` | Compiler-driven chunked loop split (default `SplitMode.UP_DOWN`) |
-| `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=...))` | `AutoInCore` | Explicit split mode |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(MODE)])` | `InCore` | InCore + cross-core split hint |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])` | `AutoInCore` | Compiler-driven chunked loop split |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(MODE)])` | `AutoInCore` | AutoInCore + split hint (independent entries) |
 | `pl.at(level=pl.Level.HOST)` *(or any non-`CORE_GROUP` level)* | `Hierarchy` | Distributed hierarchy scope |
 | `pl.cluster()` | `Cluster` | Co-scheduled AIC+AIV group |
 | `pl.incore()` *(deprecated)* | `InCore` | Use `pl.at(level=pl.Level.CORE_GROUP)` instead |
-| `pl.auto_incore(split=...)` *(deprecated)* | `AutoInCore` | Use `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(...))` |
+| `pl.auto_incore(split=...)` *(deprecated)* | `AutoInCore` | Use `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
+| `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(deprecated)* | `AutoInCore` | Use `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |
+| `pl.at(..., split=...)` *(deprecated)* | `InCore` | Use `pl.at(..., optimizations=[pl.split(...)])` |
 
 See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples.
 

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -419,18 +419,41 @@ with pl.incore():
     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
 ```
 
-For compiler-driven chunked loop outlining (AutoInCore), use `pl.chunked_loop_optimizer`:
+For compiler-driven chunked loop outlining (AutoInCore), pass `pl.auto_chunk` in
+the `optimizations` list:
 
 ```python
 # Preferred (new API):
-with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
 
-# Deprecated (use pl.at instead):
+# Deprecated (still works, emits DeprecationWarning):
+with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+    ...
+
 with pl.auto_incore():
+    ...
+```
+
+To set a cross-core split mode (consumed by the `ExpandMixedKernel` pass), use
+`pl.split(...)` — independent from `pl.auto_chunk`, so the two can be combined:
+
+```python
+# Plain InCore + split hint:
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+
+# AutoInCore + split hint (independent entries, combined freely):
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
+
+# Deprecated single-kwarg form (still works, emits DeprecationWarning):
+with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
+    ...
 ```
 
 ## Memory and Data Movement

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -255,19 +255,22 @@ for i in pl.unroll(12, chunk=4):
     body_statements
 ```
 
-**要点:** `chunk=C` 将循环拆分为外层顺序循环和 `C` 次迭代的内层循环。内层循环保留原始类型 (Sequential/Parallel/Unroll)。`chunk` 不能与 `init_values` 一起使用，且 `chunk=` 循环只能出现在 `with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):` 内（或已弃用的 `with pl.auto_incore():`）；在该作用域外，parser 会直接报错。参见 [SplitChunkedLoops Pass](../passes/05-split_chunked_loops.md)。
+**要点:** `chunk=C` 将循环拆分为外层顺序循环和 `C` 次迭代的内层循环。内层循环保留原始类型 (Sequential/Parallel/Unroll)。`chunk` 不能与 `init_values` 一起使用，且 `chunk=` 循环只能出现在 `with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):` 内；在该作用域外，parser 会直接报错。参见 [SplitChunkedLoops Pass](../passes/05-split_chunked_loops.md)。
 
 ### 作用域上下文管理器 (Scope Context Managers)
 
 | 形式 | Scope 类型 | 说明 |
 | ---- | ---------- | ---- |
 | `pl.at(level=pl.Level.CORE_GROUP)` | `InCore` | CORE_GROUP 级固定边界 outline |
-| `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer)` | `AutoInCore` | 编译器驱动的 chunked 循环 split（默认 `SplitMode.UP_DOWN`） |
-| `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=...))` | `AutoInCore` | 显式指定 split 模式 |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(MODE)])` | `InCore` | InCore + 跨核 split 提示 |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])` | `AutoInCore` | 编译器驱动的 chunked 循环 split |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(MODE)])` | `AutoInCore` | AutoInCore + split 提示（条目独立） |
 | `pl.at(level=pl.Level.HOST)`（或任意非 `CORE_GROUP` 级别） | `Hierarchy` | 分布式层级作用域 |
 | `pl.cluster()` | `Cluster` | AIC+AIV 协同调度组 |
 | `pl.incore()` *(已弃用)* | `InCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP)` |
-| `pl.auto_incore(split=...)` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(...))` |
+| `pl.auto_incore(split=...)` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
+| `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |
+| `pl.at(..., split=...)` *(已弃用)* | `InCore` | 请改用 `pl.at(..., optimizations=[pl.split(...)])` |
 
 示例参见 [语言指南](../../user/01-language_guide.md#incore-作用域)。
 

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -419,18 +419,41 @@ with pl.incore():
     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
 ```
 
-如需编译器驱动的 chunked 循环 outline（AutoInCore），使用 `pl.chunked_loop_optimizer`：
+如需编译器驱动的 chunked 循环 outline（AutoInCore），在 `optimizations` 列表中传入
+`pl.auto_chunk`：
 
 ```python
 # 推荐用法（新 API）：
-with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
 
-# 已弃用（请改用 pl.at）：
+# 已弃用（仍可用，会触发 DeprecationWarning）：
+with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+    ...
+
 with pl.auto_incore():
+    ...
+```
+
+如需为 `ExpandMixedKernel` Pass 指定跨核 split 模式，使用 `pl.split(...)` —— 它与
+`pl.auto_chunk` 互相独立，可任意组合：
+
+```python
+# 普通 InCore + split 提示：
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+
+# AutoInCore + split 提示（独立条目，自由组合）：
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
+
+# 已弃用的单关键字形式（仍可用，会触发 DeprecationWarning）：
+with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
+    ...
 ```
 
 ## 内存与数据搬运

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -56,7 +56,7 @@ from pypto.pypto_core.ir import (
     TileLayout,
 )
 
-from . import parser
+from . import optimizations, parser
 from .dsl_api import (
     at,
     auto_incore,
@@ -168,6 +168,7 @@ from .op.unified_ops import (
     transpose,
     write,
 )
+from .optimizations import auto_chunk, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
 from .typing import DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
@@ -238,6 +239,9 @@ __all__ = [
     "auto_incore",
     "cluster",
     "chunked_loop_optimizer",
+    "optimizations",
+    "split",
+    "auto_chunk",
     "tile",
     "system",
     "tensor",

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -787,9 +787,11 @@ def at(
     Args:
         level: Target hierarchy level (e.g. pl.Level.HOST, pl.Level.CORE_GROUP).
         role: Function role (Orchestrator or Worker). Default: None.
-        optimizations: Optional list of optimization entries. Each entry is
-            an instance of :class:`Optimization` (e.g. ``pl.split(mode)`` or
-            ``pl.auto_chunk``). Entries are independent and may be combined.
+        optimizations: Optional list literal of optimization entries. Each
+            entry must be one of ``pl.auto_chunk`` or ``pl.split(mode)`` —
+            written inline at the call site, since the DSL parser inspects
+            the AST and does not accept dynamically built variables here.
+            Entries are independent and may be combined.
         optimization: **Deprecated.** Use ``optimizations=[pl.auto_chunk]`` (or
             ``optimizations=[pl.auto_chunk, pl.split(mode)]``) instead.
         split: **Deprecated.** Use ``optimizations=[pl.split(mode)]`` instead.

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 from pypto.pypto_core.ir import SplitMode
 
+from .optimizations import Optimization
+
 
 class _ChunkedLoopOptimizerCall:
     """Result of calling chunked_loop_optimizer(split=...).
@@ -727,11 +729,11 @@ def cluster(*, name_hint: str = "") -> ClusterContext:
 class AtContext:
     """Context manager for hierarchy-level scope.
 
-    Returned by pl.at(level=..., role=..., optimization=...) and used with the 'with' statement.
-    The parser recognizes this pattern and creates:
-    - ScopeStmt(InCore) when level=CORE_GROUP (no optimization, no split)
-    - ScopeStmt(InCore, split=...) when level=CORE_GROUP with split=...
-    - ScopeStmt(AutoInCore) when level=CORE_GROUP and optimization=pl.chunked_loop_optimizer
+    Returned by pl.at(level=..., role=..., optimizations=[...]) and used with the
+    'with' statement. The parser recognizes this pattern and creates:
+    - ScopeStmt(InCore) when level=CORE_GROUP (no optimizations)
+    - ScopeStmt(InCore, split=...) when level=CORE_GROUP with optimizations=[pl.split(...)]
+    - ScopeStmt(AutoInCore) when level=CORE_GROUP with optimizations=[pl.auto_chunk]
     - ScopeStmt(Hierarchy) for all other levels
     """
 
@@ -740,12 +742,15 @@ class AtContext:
         level: ir.Level,
         role: ir.Role | None = None,
         *,
+        optimizations: list[Optimization] | None = None,
+        # Deprecated kwargs (kept for back-compat; emit DeprecationWarning at parse time):
         optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
         split: SplitMode | None = None,
         name_hint: str = "",
     ) -> None:
         self.level = level
         self.role = role
+        self.optimizations = optimizations
         self.optimization = optimization
         self.split = split
         self.name_hint = name_hint
@@ -761,59 +766,57 @@ def at(
     level: ir.Level,
     role: ir.Role | None = None,
     *,
+    optimizations: list[Optimization] | None = None,
+    # Deprecated kwargs (kept for back-compat; emit DeprecationWarning at parse time):
     optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
     split: SplitMode | None = None,
     name_hint: str = "",
 ) -> AtContext:
     """Mark a region of code for execution at a specific hierarchy level.
 
-    When used with ``level=pl.Level.CORE_GROUP``, this creates an InCore scope
-    (equivalent to the deprecated ``pl.incore()``).
+    With ``level=pl.Level.CORE_GROUP``, the ``optimizations=`` list controls
+    the resulting scope kind:
 
-    When used with ``level=pl.Level.CORE_GROUP`` and
-    ``optimization=pl.chunked_loop_optimizer``, this creates an AutoInCore scope
-    (equivalent to the deprecated ``pl.auto_incore()``).
-
-    When used with ``level=pl.Level.CORE_GROUP`` and ``split=pl.SplitMode.UP_DOWN``,
-    this creates an InCore scope with explicit split mode for cross-core data transfer.
+    - no entries → ``ScopeStmt(InCore)``
+    - ``pl.split(mode)`` → ``ScopeStmt(InCore, split=mode)``
+    - ``pl.auto_chunk`` → ``ScopeStmt(AutoInCore)``
+    - both entries → ``ScopeStmt(AutoInCore, split=mode)``
 
     For all other levels, this creates a Hierarchy scope.
 
     Args:
-        level: Target hierarchy level (e.g. pl.Level.HOST, pl.Level.CORE_GROUP)
+        level: Target hierarchy level (e.g. pl.Level.HOST, pl.Level.CORE_GROUP).
         role: Function role (Orchestrator or Worker). Default: None.
-        optimization: Optional optimization hint. Use pl.chunked_loop_optimizer
-            (or pl.chunked_loop_optimizer(split=...)) with level=CORE_GROUP
-            to enable compiler-driven chunked loop outlining.
-        name_hint: Optional name hint for the outlined function (must be a valid identifier)
-        split: Split mode for cross-core data transfer. Use with level=CORE_GROUP
-            to specify how tile data is split between AIC and AIV cores.
-            Cannot be used together with optimization=.
+        optimizations: Optional list of optimization entries. Each entry is
+            an instance of :class:`Optimization` (e.g. ``pl.split(mode)`` or
+            ``pl.auto_chunk``). Entries are independent and may be combined.
+        optimization: **Deprecated.** Use ``optimizations=[pl.auto_chunk]`` (or
+            ``optimizations=[pl.auto_chunk, pl.split(mode)]``) instead.
+        split: **Deprecated.** Use ``optimizations=[pl.split(mode)]`` instead.
+        name_hint: Optional name hint for the outlined function (must be a
+            valid identifier).
 
     Returns:
-        Context manager for the appropriate scope
+        Context manager for the appropriate scope.
 
     Examples:
         >>> # InCore scope (replaces pl.incore()):
         >>> with pl.at(level=pl.Level.CORE_GROUP):
         ...     y = pl.ops.add(x, x)
 
-        >>> # InCore scope with split mode:
-        >>> with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
-        ...     y = pl.ops.add(x, x)
-
-        >>> # Named InCore scope:
-        >>> with pl.at(level=pl.Level.CORE_GROUP, name_hint="fused_matmul_add"):
+        >>> # InCore scope with split hint:
+        >>> with pl.at(level=pl.Level.CORE_GROUP,
+        ...            optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
         ...     y = pl.ops.add(x, x)
 
         >>> # AutoInCore scope (replaces pl.auto_incore()):
-        >>> with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+        >>> with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
         ...     for i in pl.parallel(0, 8, 1, chunk=4):
         ...         x = pl.add(x, x)
 
-        >>> # AutoInCore with explicit split mode:
+        >>> # AutoInCore + split hint (combined, independent entries):
         >>> with pl.at(level=pl.Level.CORE_GROUP,
-        ...            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)):
+        ...            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
         ...     for i in pl.parallel(0, 8, 1, chunk=4):
         ...         x = pl.add(x, x)
 
@@ -821,7 +824,14 @@ def at(
         >>> with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
         ...     y = pl.add(x, x)
     """
-    return AtContext(level, role, optimization=optimization, split=split, name_hint=name_hint)
+    return AtContext(
+        level,
+        role,
+        optimizations=optimizations,
+        optimization=optimization,
+        split=split,
+        name_hint=name_hint,
+    )
 
 
 __all__ = [

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -43,9 +43,13 @@ class Optimization:
 class Split(Optimization):
     """Cross-core data-transfer split hint.
 
-    Consumed by the ``ExpandMixedKernel`` pass via the outlined function's
-    ``SplitMode`` metadata. Lowers the enclosing ``pl.at`` scope to
-    ``ScopeKind::InCore`` with ``split_=mode``.
+    Sets ``ScopeStmt::split_`` on the enclosing ``pl.at`` scope; that metadata
+    is consumed by the ``ExpandMixedKernel`` pass via the outlined function's
+    ``SplitMode``. The split hint is independent of the resulting scope kind:
+
+    - ``optimizations=[pl.split(mode)]`` → ``ScopeKind::InCore`` (split metadata).
+    - ``optimizations=[pl.auto_chunk, pl.split(mode)]`` → ``ScopeKind::AutoInCore``
+      (split metadata still attached).
 
     Args:
         mode: Split mode (``SplitMode.UP_DOWN`` or ``SplitMode.LEFT_RIGHT``).
@@ -72,11 +76,20 @@ def split(mode: SplitMode) -> Split:
     """Create a ``Split`` optimization entry.
 
     Args:
-        mode: Split mode (``SplitMode.UP_DOWN`` or ``SplitMode.LEFT_RIGHT``).
+        mode: Split mode. Must be ``SplitMode.UP_DOWN`` or
+            ``SplitMode.LEFT_RIGHT``. ``SplitMode.NONE`` is rejected — omit
+            the entry instead to indicate "no split".
 
     Returns:
         ``Split`` instance for use in ``pl.at(..., optimizations=[...])``.
+
+    Raises:
+        ValueError: if ``mode`` is ``SplitMode.NONE``.
     """
+    if mode == SplitMode.NONE:
+        raise ValueError(
+            "pl.split(pl.SplitMode.NONE) is not supported; omit the entry instead to indicate 'no split'."
+        )
     return Split(mode=mode)
 
 

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -1,0 +1,96 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Optimization config entries for ``pl.at(..., optimizations=[...])``.
+
+Each entry is an orthogonal optimization hint applied to the enclosing scope.
+The entries can be combined freely in the ``optimizations=`` list.
+
+Available entries:
+    - ``pl.split(mode)`` — Cross-core data-transfer split hint, consumed by
+      the ``ExpandMixedKernel`` pass. Lowers the scope to ``InCore`` with
+      ``split_=mode``.
+    - ``pl.auto_chunk`` — Request compiler-driven outlining of chunked
+      parallel loops. Lowers the scope to ``AutoInCore`` so that the
+      ``InterchangeChunkLoops`` pass can interchange and outline chunked
+      loops within it.
+
+These two entries are independent and may be combined::
+
+    with pl.at(level=pl.Level.CORE_GROUP,
+               optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
+        ...
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pypto.pypto_core.ir import SplitMode
+
+
+class Optimization:
+    """Base class for ``pl.at(..., optimizations=[...])`` entries."""
+
+
+@dataclass(frozen=True)
+class Split(Optimization):
+    """Cross-core data-transfer split hint.
+
+    Consumed by the ``ExpandMixedKernel`` pass via the outlined function's
+    ``SplitMode`` metadata. Lowers the enclosing ``pl.at`` scope to
+    ``ScopeKind::InCore`` with ``split_=mode``.
+
+    Args:
+        mode: Split mode (``SplitMode.UP_DOWN`` or ``SplitMode.LEFT_RIGHT``).
+            ``SplitMode.NONE`` is rejected — omit the entry instead to
+            indicate "no split".
+    """
+
+    mode: SplitMode
+
+
+@dataclass(frozen=True)
+class AutoChunk(Optimization):
+    """Request compiler-driven outlining of chunked parallel loops.
+
+    Lowers the enclosing ``pl.at`` scope to ``ScopeKind::AutoInCore`` so the
+    ``InterchangeChunkLoops`` pass can interchange chunked parallel loops
+    and outline the inner sequential portion into ``InCore`` scopes.
+
+    Only valid with ``level=pl.Level.CORE_GROUP``.
+    """
+
+
+def split(mode: SplitMode) -> Split:
+    """Create a ``Split`` optimization entry.
+
+    Args:
+        mode: Split mode (``SplitMode.UP_DOWN`` or ``SplitMode.LEFT_RIGHT``).
+
+    Returns:
+        ``Split`` instance for use in ``pl.at(..., optimizations=[...])``.
+    """
+    return Split(mode=mode)
+
+
+auto_chunk: AutoChunk = AutoChunk()
+"""Sentinel for the ``AutoChunk`` optimization.
+
+Use as ``pl.auto_chunk`` in ``pl.at(..., optimizations=[pl.auto_chunk, ...])``.
+"""
+
+
+__all__ = [
+    "Optimization",
+    "Split",
+    "AutoChunk",
+    "split",
+    "auto_chunk",
+]

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -14,6 +14,7 @@ import keyword as _keyword_mod
 import warnings
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from pypto.ir import IRBuilder
@@ -174,6 +175,23 @@ def _normalize_inferred_type_for_annotation(
         inferred_type.tile_view,
         inferred_type.memory_space,
     )
+
+
+@dataclass
+class _AtKwargState:
+    """Mutable accumulator used while parsing pl.at() keyword arguments."""
+
+    level: "ir.Level | None" = None
+    role: "ir.Role | None" = None
+    name_hint: str = ""
+    requests_auto_chunk: bool = False
+    split_mode: "ir.SplitMode | None" = None
+    # Tracks which kwarg produced the AutoChunk / split state so the validation
+    # step can reject mixing the new `optimizations=` list with the deprecated
+    # `optimization=`/`split=` kwargs and emit DeprecationWarning at the end.
+    new_optimizations_kw: "ast.keyword | None" = field(default=None)
+    legacy_optimization_kw: "ast.keyword | None" = field(default=None)
+    legacy_split_kw: "ast.keyword | None" = field(default=None)
 
 
 class ASTParser:
@@ -1578,23 +1596,19 @@ class ASTParser:
 
     def _parse_at_kwargs(
         self, call: ast.Call
-    ) -> tuple[ir.Level, ir.Role | None, ir.SplitMode | None, ir.SplitMode | None, str]:
-        """Extract level, role, optimization, split, and name from pl.at(...) call.
+    ) -> tuple[ir.Level, ir.Role | None, bool, ir.SplitMode | None, str]:
+        """Extract level, role, AutoChunk request, split mode, and name from pl.at(...) call.
 
-        Supports both positional and keyword forms:
-        - pl.at(pl.Level.HOST)
-        - pl.at(pl.Level.HOST, pl.Role.Worker)
-        - pl.at(level=pl.Level.HOST, role=pl.Role.Worker)
-        - pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer)
-        - pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=...))
-        - pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN)
-        - pl.at(level=pl.Level.CORE_GROUP, name_hint="my_kernel")
-
-        Args:
-            call: AST Call node for pl.at(...)
+        Supports both positional and keyword forms. Preferred new API uses the
+        ``optimizations=[...]`` list with ``pl.split(...)`` and ``pl.auto_chunk``
+        entries. The legacy ``optimization=`` and top-level ``split=`` kwargs
+        are still accepted but emit a DeprecationWarning. Mixing the new
+        ``optimizations=`` list with either deprecated kwarg is a hard error.
 
         Returns:
-            Tuple of (level, role, opt_split, direct_split, name_hint).
+            Tuple of (level, role, requests_auto_chunk, split_mode, name_hint).
+            ``requests_auto_chunk`` is True when the resulting scope must be
+            ``AutoInCore`` rather than ``InCore``.
         """
         if len(call.args) > 2:
             raise ParserSyntaxError(
@@ -1602,68 +1616,42 @@ class ASTParser:
                 hint="Use pl.at(level) or pl.at(level, role)",
             )
 
-        level = None
-        role = None
-        opt_split: ir.SplitMode | None = None
-        direct_split: ir.SplitMode | None = None
-        name_hint = ""
-
-        # Parse positional arguments
+        state = _AtKwargState()
         if len(call.args) >= 1:
-            level = extract_enum_value(call.args[0], LEVEL_MAP, "Level", "pl.Level")
+            state.level = extract_enum_value(call.args[0], LEVEL_MAP, "Level", "pl.Level")
         if len(call.args) >= 2:
-            role = extract_enum_value(call.args[1], ROLE_MAP, "Role", "pl.Role")
+            state.role = extract_enum_value(call.args[1], ROLE_MAP, "Role", "pl.Role")
 
-        # Parse keyword arguments
         for kw in call.keywords:
-            level, role, opt_split, direct_split, name_hint = self._parse_at_keyword(
-                kw, level, role, opt_split, direct_split, name_hint
-            )
-        if level is None:
+            self._dispatch_at_keyword(kw, state)
+
+        if state.level is None:
             raise ParserSyntaxError(
                 "pl.at() requires a level argument",
                 hint="Use pl.at(pl.Level.HOST) or pl.at(level=pl.Level.HOST)",
             )
-        return level, role, opt_split, direct_split, name_hint
 
-    def _parse_at_keyword(
-        self,
-        kw: ast.keyword,
-        level: "ir.Level | None",
-        role: "ir.Role | None",
-        opt_split: "ir.SplitMode | None",
-        direct_split: "ir.SplitMode | None",
-        name_hint: str,
-    ) -> tuple["ir.Level | None", "ir.Role | None", "ir.SplitMode | None", "ir.SplitMode | None", str]:
-        """Parse a single keyword argument from pl.at() call."""
+        self._validate_at_kwarg_combinations(state)
+        return state.level, state.role, state.requests_auto_chunk, state.split_mode, state.name_hint
+
+    def _dispatch_at_keyword(self, kw: ast.keyword, state: "_AtKwargState") -> None:
+        """Dispatch a single pl.at() keyword argument and update state."""
         if kw.arg == "level":
-            if level is not None:
-                raise ParserSyntaxError(
-                    "pl.at() got multiple values for argument 'level'",
-                )
-            level = extract_enum_value(kw.value, LEVEL_MAP, "Level", "pl.Level")
+            if state.level is not None:
+                raise ParserSyntaxError("pl.at() got multiple values for argument 'level'")
+            state.level = extract_enum_value(kw.value, LEVEL_MAP, "Level", "pl.Level")
         elif kw.arg == "role":
-            if role is not None:
-                raise ParserSyntaxError(
-                    "pl.at() got multiple values for argument 'role'",
-                )
-            role = extract_enum_value(kw.value, ROLE_MAP, "Role", "pl.Role")
+            if state.role is not None:
+                raise ParserSyntaxError("pl.at() got multiple values for argument 'role'")
+            state.role = extract_enum_value(kw.value, ROLE_MAP, "Role", "pl.Role")
+        elif kw.arg == "optimizations":
+            self._handle_at_optimizations_kw(kw, state)
         elif kw.arg == "optimization":
-            if opt_split is not None:
-                raise ParserSyntaxError(
-                    "pl.at() got multiple values for argument 'optimization'",
-                    span=self.span_tracker.get_span(kw),
-                )
-            opt_split = self._parse_chunked_loop_optimizer(kw.value)
-        elif kw.arg == "name_hint":
-            name_hint = self._parse_scope_name_hint(kw.value, "pl.at()")
+            self._handle_at_legacy_optimization_kw(kw, state)
         elif kw.arg == "split":
-            if direct_split is not None:
-                raise ParserSyntaxError(
-                    "pl.at() got multiple values for argument 'split'",
-                    span=self.span_tracker.get_span(kw),
-                )
-            direct_split = self._eval_split_mode(kw.value)
+            self._handle_at_legacy_split_kw(kw, state)
+        elif kw.arg == "name_hint":
+            state.name_hint = self._parse_scope_name_hint(kw.value, "pl.at()")
         elif kw.arg is None:
             raise ParserSyntaxError(
                 "Unsupported **kwargs in pl.at()",
@@ -1672,9 +1660,195 @@ class ASTParser:
         else:
             raise ParserSyntaxError(
                 f"Unknown keyword argument '{kw.arg}' in pl.at()",
-                hint="Supported arguments: level, role, optimization, split, name_hint",
+                hint="Supported arguments: level, role, optimizations, name_hint",
             )
-        return level, role, opt_split, direct_split, name_hint
+
+    def _handle_at_optimizations_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
+        if state.new_optimizations_kw is not None:
+            raise ParserSyntaxError(
+                "pl.at() got multiple values for argument 'optimizations'",
+                span=self.span_tracker.get_span(kw),
+            )
+        state.new_optimizations_kw = kw
+        state.requests_auto_chunk, state.split_mode = self._parse_optimizations_list(kw.value)
+
+    def _handle_at_legacy_optimization_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
+        if state.legacy_optimization_kw is not None:
+            raise ParserSyntaxError(
+                "pl.at() got multiple values for argument 'optimization'",
+                span=self.span_tracker.get_span(kw),
+            )
+        state.legacy_optimization_kw = kw
+        # Bare or called legacy optimizer always implies AutoChunk.
+        state.requests_auto_chunk = True
+        state.split_mode = self._parse_chunked_loop_optimizer(kw.value)
+
+    def _handle_at_legacy_split_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
+        if state.legacy_split_kw is not None:
+            raise ParserSyntaxError(
+                "pl.at() got multiple values for argument 'split'",
+                span=self.span_tracker.get_span(kw),
+            )
+        state.legacy_split_kw = kw
+        state.split_mode = self._eval_split_mode(kw.value)
+
+    def _validate_at_kwarg_combinations(self, state: "_AtKwargState") -> None:
+        """Reject illegal kwarg combinations and emit DeprecationWarnings."""
+        # Hard error when mixing new optimizations= with deprecated kwargs.
+        if state.new_optimizations_kw is not None and (
+            state.legacy_optimization_kw is not None or state.legacy_split_kw is not None
+        ):
+            offending = state.legacy_optimization_kw or state.legacy_split_kw
+            assert offending is not None
+            raise ParserSyntaxError(
+                "Cannot mix 'optimizations=' with deprecated 'optimization=' or 'split=' kwargs in pl.at()",
+                span=self.span_tracker.get_span(offending),
+                hint="Use only optimizations=[pl.split(...), pl.auto_chunk] — drop the deprecated kwargs.",
+            )
+
+        # Preserve the pre-existing rule that the two deprecated kwargs cannot be
+        # combined: legacy `optimization=` always implied AutoInCore + a baked-in
+        # split, so combining it with legacy top-level `split=` was ambiguous.
+        if state.legacy_optimization_kw is not None and state.legacy_split_kw is not None:
+            raise ParserSyntaxError(
+                "Cannot use both 'optimization' and 'split' in pl.at()",
+                span=self.span_tracker.get_span(state.legacy_split_kw),
+                hint="Use optimizations=[pl.auto_chunk, pl.split(...)] for AutoInCore + "
+                "split, or optimizations=[pl.split(...)] for plain InCore + split.",
+            )
+
+        # Emit deprecation warnings for legacy kwargs (after mixing checks, so the
+        # user sees the structural error first if both apply).
+        if state.legacy_optimization_kw is not None:
+            warnings.warn(
+                "pl.at(optimization=pl.chunked_loop_optimizer[(...)]) is deprecated; "
+                "use pl.at(optimizations=[pl.auto_chunk]) — combine with pl.split(...) "
+                "if a split mode is needed.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if state.legacy_split_kw is not None:
+            warnings.warn(
+                "pl.at(split=...) is deprecated; use pl.at(optimizations=[pl.split(...)]).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    def _parse_optimizations_list(self, value: ast.expr) -> tuple[bool, "ir.SplitMode | None"]:
+        """Parse pl.at(..., optimizations=[...]) AST node.
+
+        Each entry must be one of:
+
+        - ``pl.auto_chunk`` — request AutoInCore semantics.
+        - ``pl.split(MODE)`` — set the cross-core split mode.
+
+        Both fully qualified forms (``pl.optimizations.auto_chunk``,
+        ``pl.optimizations.split(MODE)``) are also accepted.
+
+        Returns:
+            Tuple ``(requests_auto_chunk, split_mode)``.
+        """
+        if not isinstance(value, ast.List):
+            raise ParserSyntaxError(
+                "pl.at(optimizations=...) must be a list literal",
+                span=self.span_tracker.get_span(value),
+                hint="Use optimizations=[pl.split(pl.SplitMode.UP_DOWN)] or optimizations=[pl.auto_chunk].",
+            )
+
+        requests_auto_chunk = False
+        split_mode: ir.SplitMode | None = None
+        seen_auto_chunk = False
+        seen_split = False
+
+        for entry in value.elts:
+            if self._is_pl_auto_chunk(entry):
+                if seen_auto_chunk:
+                    raise ParserSyntaxError(
+                        "Duplicate 'pl.auto_chunk' in optimizations=[...]",
+                        span=self.span_tracker.get_span(entry),
+                    )
+                seen_auto_chunk = True
+                requests_auto_chunk = True
+            elif (mode := self._try_parse_pl_split(entry)) is not None:
+                if seen_split:
+                    raise ParserSyntaxError(
+                        "Duplicate 'pl.split(...)' in optimizations=[...]",
+                        span=self.span_tracker.get_span(entry),
+                    )
+                seen_split = True
+                split_mode = mode
+            else:
+                raise ParserSyntaxError(
+                    "Unsupported entry in pl.at(optimizations=[...])",
+                    span=self.span_tracker.get_span(entry),
+                    hint="Each entry must be pl.auto_chunk or pl.split(pl.SplitMode.X).",
+                )
+
+        return requests_auto_chunk, split_mode
+
+    @staticmethod
+    def _is_pl_auto_chunk(node: ast.expr) -> bool:
+        """Return True if the AST node is ``pl.auto_chunk`` or ``pl.optimizations.auto_chunk``."""
+        if not isinstance(node, ast.Attribute) or node.attr != "auto_chunk":
+            return False
+        # pl.auto_chunk
+        if isinstance(node.value, ast.Name) and node.value.id == "pl":
+            return True
+        # pl.optimizations.auto_chunk
+        if (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr == "optimizations"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "pl"
+        ):
+            return True
+        return False
+
+    def _try_parse_pl_split(self, node: ast.expr) -> "ir.SplitMode | None":
+        """Return the SplitMode if the AST node is ``pl.split(MODE)``; else None.
+
+        Also accepts the fully qualified form ``pl.optimizations.split(MODE)``.
+        """
+        if not isinstance(node, ast.Call):
+            return None
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "split":
+            return None
+        # pl.split(...)
+        if isinstance(func.value, ast.Name) and func.value.id == "pl":
+            pass
+        # pl.optimizations.split(...)
+        elif (
+            isinstance(func.value, ast.Attribute)
+            and func.value.attr == "optimizations"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "pl"
+        ):
+            pass
+        else:
+            return None
+
+        if node.keywords:
+            raise ParserSyntaxError(
+                "pl.split() does not accept keyword arguments",
+                span=self.span_tracker.get_span(node),
+                hint="Use pl.split(pl.SplitMode.UP_DOWN).",
+            )
+        if len(node.args) != 1:
+            raise ParserSyntaxError(
+                f"pl.split() takes exactly 1 positional argument, got {len(node.args)}",
+                span=self.span_tracker.get_span(node),
+                hint="Use pl.split(pl.SplitMode.UP_DOWN).",
+            )
+        mode = extract_enum_value(node.args[0], SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
+        if mode == ir.SplitMode.NONE:
+            raise ParserSyntaxError(
+                "pl.split(pl.SplitMode.NONE) is not supported",
+                span=self.span_tracker.get_span(node.args[0]),
+                hint="Use pl.SplitMode.UP_DOWN or pl.SplitMode.LEFT_RIGHT, or omit the "
+                "pl.split(...) entry entirely.",
+            )
+        return mode
 
     def _parse_chunked_loop_optimizer(self, value: ast.expr) -> "ir.SplitMode":
         """Parse pl.chunked_loop_optimizer or pl.chunked_loop_optimizer(split=...) AST node.
@@ -1849,32 +2023,24 @@ class ASTParser:
 
     def _parse_at_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:
         """Parse pl.at(...) context manager into a ScopeStmt."""
-        level, role, opt_split, direct_split, name_hint = self._parse_at_kwargs(context_expr)
+        level, role, requests_auto_chunk, split_mode, name_hint = self._parse_at_kwargs(context_expr)
         span = self.span_tracker.get_span(stmt)
 
         is_core_group = level == ir.Level.CORE_GROUP
 
-        if opt_split is not None and not is_core_group:
+        if requests_auto_chunk and not is_core_group:
             raise ParserSyntaxError(
-                "optimization=chunked_loop_optimizer is only supported with level=pl.Level.CORE_GROUP",
+                "pl.auto_chunk is only supported with level=pl.Level.CORE_GROUP",
                 span=span,
-                hint="Use pl.at(level=pl.Level.CORE_GROUP, "
-                "optimization=pl.chunked_loop_optimizer) for AutoInCore scope",
+                hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]) "
+                "for an AutoInCore scope.",
             )
 
-        if direct_split is not None and not is_core_group:
+        if split_mode is not None and not is_core_group:
             raise ParserSyntaxError(
-                "split= is only supported with level=pl.Level.CORE_GROUP",
+                "pl.split(...) is only supported with level=pl.Level.CORE_GROUP",
                 span=span,
-                hint="Use pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN)",
-            )
-
-        if opt_split is not None and direct_split is not None:
-            raise ParserSyntaxError(
-                "Cannot use both 'optimization' and 'split' in pl.at()",
-                span=span,
-                hint="Use split= inside optimization=pl.chunked_loop_optimizer(split=...) "
-                "for AutoInCore scope, or use split= directly for InCore scope",
+                hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]).",
             )
 
         if is_core_group and role is not None:
@@ -1889,10 +2055,10 @@ class ASTParser:
             self._parse_scope_body(
                 stmt, ir.ScopeKind.Hierarchy, span, level=level, role=role, name_hint=name_hint
             )
-        elif opt_split is not None:
-            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=opt_split, name_hint=name_hint)
+        elif requests_auto_chunk:
+            self._parse_scope_body(stmt, ir.ScopeKind.AutoInCore, span, split=split_mode, name_hint=name_hint)
         else:
-            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span, split=direct_split, name_hint=name_hint)
+            self._parse_scope_body(stmt, ir.ScopeKind.InCore, span, split=split_mode, name_hint=name_hint)
 
     def parse_with_statement(self, stmt: ast.With) -> None:
         """Parse with statement for scope contexts.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -981,11 +981,11 @@ class ASTParser:
         """Validate chunk arguments for range/parallel/unroll loops."""
         if not self._is_inside_scope(ir.ScopeKind.AutoInCore):
             raise ParserSyntaxError(
-                "chunk=... loops are only valid inside with pl.auto_incore(): or "
-                "with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):",
+                "chunk=... loops are only valid inside "
+                "with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):",
                 span=self.span_tracker.get_span(iter_call),
                 hint="Wrap the loop in 'with pl.at(level=pl.Level.CORE_GROUP, "
-                "optimization=pl.chunked_loop_optimizer):' or remove the chunk= argument.",
+                "optimizations=[pl.auto_chunk]):' or remove the chunk= argument.",
             )
         if not _is_const_int(chunk_expr):
             raise ParserSyntaxError(
@@ -1964,15 +1964,16 @@ class ASTParser:
                     )
             if func_attr == "incore":
                 warnings.warn(
-                    "pl.incore() is deprecated; use 'with pl.at(level=pl.Level.CORE_GROUP):' instead",
+                    "pl.incore() is deprecated; use 'with pl.at(level=pl.Level.CORE_GROUP):' "
+                    "(optionally with optimizations=[pl.split(pl.SplitMode.X)]) instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )
             else:
                 warnings.warn(
                     "pl.auto_incore() is deprecated; use "
-                    "'with pl.at(level=pl.Level.CORE_GROUP, "
-                    "optimization=pl.chunked_loop_optimizer):' instead",
+                    "'with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):' "
+                    "(combine with pl.split(pl.SplitMode.X) if a split mode is needed) instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2031,7 +2031,9 @@ class ASTParser:
 
         if requests_auto_chunk and not is_core_group:
             raise ParserSyntaxError(
-                "pl.auto_chunk is only supported with level=pl.Level.CORE_GROUP",
+                "auto-chunk optimization is only supported with level=pl.Level.CORE_GROUP "
+                "(via optimizations=[pl.auto_chunk] or the deprecated "
+                "optimization=pl.chunked_loop_optimizer)",
                 span=span,
                 hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]) "
                 "for an AutoInCore scope.",
@@ -2039,7 +2041,8 @@ class ASTParser:
 
         if split_mode is not None and not is_core_group:
             raise ParserSyntaxError(
-                "pl.split(...) is only supported with level=pl.Level.CORE_GROUP",
+                "split mode is only supported with level=pl.Level.CORE_GROUP "
+                "(via optimizations=[pl.split(...)] or the deprecated split= kwarg)",
                 span=span,
                 hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]).",
             )

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -1,0 +1,409 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for pl.at(..., optimizations=[...]) parsing.
+
+Covers issue #1030: the optimizations= list lets users express ``pl.split(...)``
+and ``pl.auto_chunk`` independently. The legacy ``optimization=`` and top-level
+``split=`` kwargs remain functional but emit DeprecationWarning, and mixing the
+new ``optimizations=`` with either deprecated kwarg is a hard error.
+"""
+
+import warnings
+
+import pypto.language as pl
+import pytest
+from pypto.language.parser.diagnostics import ParserSyntaxError
+from pypto.pypto_core import ir
+
+
+def _find_scope_stmt(stmt):
+    """Recursively find the first ScopeStmt in an IR tree."""
+    if isinstance(stmt, ir.ScopeStmt):
+        return stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            r = _find_scope_stmt(s)
+            if r is not None:
+                return r
+    return None
+
+
+# ─── New API: optimizations=[pl.split(...)] → InCore with split ──────────────
+
+
+def test_parse_optimizations_split_only_up_down():
+    """optimizations=[pl.split(UP_DOWN)] → InCore with split=UP_DOWN."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert scope.split == ir.SplitMode.UP_DOWN
+
+
+def test_parse_optimizations_split_only_left_right():
+    """optimizations=[pl.split(LEFT_RIGHT)] → InCore with split=LEFT_RIGHT."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert scope.split == ir.SplitMode.LEFT_RIGHT
+
+
+# ─── New API: optimizations=[pl.auto_chunk] → AutoInCore (no split) ──────────
+
+
+def test_parse_optimizations_auto_chunk_only():
+    """optimizations=[pl.auto_chunk] → AutoInCore with no split."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.AutoInCore
+    assert scope.split is None
+
+
+# ─── New API: optimizations=[pl.auto_chunk, pl.split(...)] → AutoInCore + split
+
+
+def test_parse_optimizations_auto_chunk_with_split():
+    """optimizations=[pl.auto_chunk, pl.split(UP_DOWN)] → AutoInCore with split."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
+        ):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.AutoInCore
+    assert scope.split == ir.SplitMode.UP_DOWN
+
+
+def test_parse_optimizations_order_independent():
+    """List order does not affect the produced IR."""
+
+    @pl.function
+    def f1(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)],
+        ):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    @pl.function
+    def f2(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT), pl.auto_chunk],
+        ):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    s1 = _find_scope_stmt(f1.body)
+    s2 = _find_scope_stmt(f2.body)
+    assert s1 is not None and s2 is not None
+    assert s1.scope_kind == s2.scope_kind == ir.ScopeKind.AutoInCore
+    assert s1.split == s2.split == ir.SplitMode.LEFT_RIGHT
+
+
+def test_parse_optimizations_empty_list_is_plain_incore():
+    """optimizations=[] → InCore with no split."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[]):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert scope.split is None
+
+
+# ─── Equivalence with deprecated API ──────────────────────────────────────────
+
+
+def test_legacy_chunked_loop_optimizer_matches_new_form():
+    """Legacy bare optimizer (defaults to UP_DOWN) ≡ new auto_chunk + split(UP_DOWN)."""
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        @pl.function
+        def legacy(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                    x = pl.add(x, x)
+            return x
+
+    @pl.function
+    def new(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
+        ):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    s_legacy = _find_scope_stmt(legacy.body)
+    s_new = _find_scope_stmt(new.body)
+    assert s_legacy is not None and s_new is not None
+    assert s_legacy.scope_kind == s_new.scope_kind == ir.ScopeKind.AutoInCore
+    assert s_legacy.split == s_new.split == ir.SplitMode.UP_DOWN
+
+
+def test_legacy_split_kwarg_matches_new_form():
+    """Legacy top-level split= ≡ new optimizations=[pl.split(...)]."""
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        @pl.function
+        def legacy(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.LEFT_RIGHT):
+                y = pl.add(x, x)
+            return y
+
+    @pl.function
+    def new(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
+            y = pl.add(x, x)
+        return y
+
+    s_legacy = _find_scope_stmt(legacy.body)
+    s_new = _find_scope_stmt(new.body)
+    assert s_legacy is not None and s_new is not None
+    assert s_legacy.scope_kind == s_new.scope_kind == ir.ScopeKind.InCore
+    assert s_legacy.split == s_new.split == ir.SplitMode.LEFT_RIGHT
+
+
+# ─── DeprecationWarning emission ──────────────────────────────────────────────
+
+
+def test_legacy_optimization_kwarg_emits_deprecation_warning():
+    """Using the legacy optimization= kwarg emits DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="optimizations=\\[pl.auto_chunk\\]"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                    x = pl.add(x, x)
+            return x
+
+
+def test_legacy_split_kwarg_emits_deprecation_warning():
+    """Using the legacy top-level split= kwarg emits DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="optimizations=\\[pl.split"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
+                y = pl.add(x, x)
+            return y
+
+
+def test_new_optimizations_kwarg_emits_no_warning():
+    """The new optimizations= API emits no DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+                y = pl.add(x, x)
+            return y
+
+
+# ─── Hard errors when mixing new with deprecated kwargs ──────────────────────
+
+
+def test_mix_optimizations_with_legacy_optimization_errors():
+    """Cannot combine optimizations= with deprecated optimization=."""
+    with pytest.raises(ParserSyntaxError, match="Cannot mix"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+                optimization=pl.chunked_loop_optimizer,
+            ):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                    x = pl.add(x, x)
+            return x
+
+
+def test_mix_optimizations_with_legacy_split_errors():
+    """Cannot combine optimizations= with deprecated split=."""
+    with pytest.raises(ParserSyntaxError, match="Cannot mix"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.auto_chunk],
+                split=pl.SplitMode.UP_DOWN,
+            ):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                    x = pl.add(x, x)
+            return x
+
+
+# ─── Validation errors on optimizations= entries ──────────────────────────────
+
+
+def test_optimizations_must_be_list():
+    """optimizations= must be a list literal."""
+    with pytest.raises(ParserSyntaxError, match="must be a list literal"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=pl.auto_chunk):  # type: ignore[arg-type]
+                y = pl.add(x, x)
+            return y
+
+
+def test_duplicate_auto_chunk_errors():
+    """Two pl.auto_chunk entries in the same list is an error."""
+    with pytest.raises(ParserSyntaxError, match="Duplicate.*auto_chunk"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.auto_chunk]):
+                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                    x = pl.add(x, x)
+            return x
+
+
+def test_duplicate_split_errors():
+    """Two pl.split(...) entries in the same list is an error."""
+    with pytest.raises(ParserSyntaxError, match="Duplicate.*split"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN), pl.split(pl.SplitMode.LEFT_RIGHT)],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_unsupported_entry_errors():
+    """Unknown entries in optimizations=[...] are rejected."""
+    with pytest.raises(ParserSyntaxError, match="Unsupported entry"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[42]):  # type: ignore[list-item]
+                y = pl.add(x, x)
+            return y
+
+
+def test_split_none_in_list_errors():
+    """pl.split(SplitMode.NONE) is rejected."""
+    with pytest.raises(ParserSyntaxError, match=r"SplitMode\.NONE"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
+                y = pl.add(x, x)
+            return y
+
+
+def test_auto_chunk_on_non_core_group_errors():
+    """pl.auto_chunk is only valid at CORE_GROUP."""
+    with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.HOST, optimizations=[pl.auto_chunk]):
+                y = pl.add(x, x)
+            return y
+
+
+def test_split_on_non_core_group_errors():
+    """pl.split(...) is only valid at CORE_GROUP."""
+    with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.HOST, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+                y = pl.add(x, x)
+            return y
+
+
+# ─── Fully qualified pl.optimizations.* forms ────────────────────────────────
+
+
+def test_fully_qualified_auto_chunk():
+    """pl.optimizations.auto_chunk also works."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.optimizations.auto_chunk]):
+            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                x = pl.add(x, x)
+        return x
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.AutoInCore
+
+
+def test_fully_qualified_split():
+    """pl.optimizations.split(...) also works."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.optimizations.split(pl.SplitMode.UP_DOWN)],
+        ):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert scope.split == ir.SplitMode.UP_DOWN
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -347,6 +347,18 @@ def test_split_none_in_list_errors():
             return y
 
 
+def test_split_factory_rejects_none_at_runtime():
+    """pl.split() also rejects SplitMode.NONE at construction time.
+
+    The parser-level check above catches DSL source. This factory-level
+    check guards runtime construction (e.g., in scripts that build Split
+    instances directly), per the project rule that DSL helpers should
+    validate user input rather than relying on backend C++ checks.
+    """
+    with pytest.raises(ValueError, match=r"SplitMode\.NONE"):
+        pl.split(pl.SplitMode.NONE)
+
+
 def test_auto_chunk_on_non_core_group_errors():
     """pl.auto_chunk is only valid at CORE_GROUP."""
     with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -139,7 +139,10 @@ class ChunkedLoopProgram:
             _ctx_len = pl.tensor.read(seq_lens, [b])
         return x
 """
-        with pytest.raises(ParserSyntaxError, match="only valid inside with pl.auto_incore"):
+        with pytest.raises(
+            ParserSyntaxError,
+            match=r"chunk=\.\.\. loops are only valid inside with pl\.at",
+        ):
             pl.parse_program(code)
 
     def test_unknown_tensor_operation(self):


### PR DESCRIPTION
## Summary

- Decouple cross-core split mode from AutoInCore opt-in in `pl.at(...)`. The two are consumed by **different** passes (`ExpandMixedKernel` vs `InterchangeChunkLoops`) and now have **independent** entries in a unified `optimizations=` list.
- New API: `pl.at(level=..., optimizations=[pl.split(MODE), pl.auto_chunk])` — entries are orthogonal `Optimization` objects and may be combined freely.
- Legacy `optimization=` and top-level `split=` kwargs still work but emit `DeprecationWarning`. Mixing the new `optimizations=` list with either deprecated kwarg is a hard error. The pre-existing mutual-exclusion between the two deprecated kwargs is preserved.

Fixes #1030.

## Scope (PR1 of a planned series)

This PR is **API surface only**. Out of scope:

- C++ IR (`ScopeKind`, `ScopeStmt`) — unchanged
- Python bindings / type stubs — unchanged
- Pass logic (`InterchangeChunkLoops`, `ExpandMixedKernel`, ...) — unchanged
- Python printer C++ side — still emits the legacy form; updating it to emit the new form is a follow-up

Old and new API forms produce **byte-identical IR**, verified by parse-equivalence tests.

#1020 (`InterchangeChunkLoops` strips `AutoInCore` even when the body has no `ChunkOuter` loops) is a downstream symptom that will be addressed in a follow-up PR once this API is in place. #1010 and #963 are also tracked as related downstream bugs that this API change unblocks.

## Files changed

- `python/pypto/language/optimizations.py` *(new)* — `Optimization` base, `Split` dataclass, `AutoChunk` dataclass, `split()` factory, `auto_chunk` sentinel
- `python/pypto/language/dsl_api.py` — `at()` / `AtContext` gain `optimizations=` kwarg; legacy `optimization=` / `split=` kept as deprecated parameters with updated docstring
- `python/pypto/language/__init__.py` — export `split`, `auto_chunk`, and the `optimizations` submodule
- `python/pypto/language/parser/ast_parser.py` — parse `optimizations=[...]` AST list; emit `DeprecationWarning` for legacy kwargs; reject mixing new + deprecated
- `tests/ut/ir/parser/test_at_optimizations.py` *(new)* — 22 tests
- `docs/en|zh-cn/user/01-language_guide.md` — document new form as preferred

## Migration

| Old | New |
| --- | --- |
| `pl.at(level=CG, split=UP_DOWN)` | `pl.at(level=CG, optimizations=[pl.split(UP_DOWN)])` |
| `pl.at(level=CG, optimization=pl.chunked_loop_optimizer)` | `pl.at(level=CG, optimizations=[pl.auto_chunk])` |
| `pl.at(level=CG, optimization=pl.chunked_loop_optimizer(split=UP_DOWN))` | `pl.at(level=CG, optimizations=[pl.auto_chunk, pl.split(UP_DOWN)])` |

(`CG` = `pl.Level.CORE_GROUP`)

## Test plan

- [x] `pytest tests/ut/ir/parser/test_at_optimizations.py` — 22/22 pass (new tests)
- [x] `pytest tests/ut/ir/parser/` — 57/57 pass (no regressions; existing tests still validate legacy paths)
- [x] `pytest tests/ut/ir/transforms/test_split_chunked_loops.py tests/ut/ir/transforms/test_interchange_chunk_loops.py tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py tests/ut/ir/transforms/test_outline_incore_scopes.py tests/ut/codegen/test_orchestration_codegen.py` — 141/141 pass (no regressions in transform/codegen tests touching `chunked_loop_optimizer`)
- [x] All pre-commit hooks pass: `check-headers`, `ruff check`, `ruff format`, `pyright`, `markdownlint-cli2`, header/whitespace checks