### PR TITLE
fix(ir): align row_expand(target, row_vec) with col_expand

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -148,7 +148,7 @@ Transfer data between memory hierarchy levels.
 
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
-| `row_expand` | `(src: Tile) -> Tile` | Broadcast `src[i,0]` across each row |
+| `row_expand` | `(target: Tile, row_vec: Tile) -> Tile` | Expand `row_vec[M,1]` to `target[M,N]` |
 | `row_expand_add` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile + row_vec[M,1]` broadcast |
 | `row_expand_sub` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile - row_vec` broadcast |
 | `row_expand_mul` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile * row_vec` broadcast |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -143,7 +143,7 @@
 
 | 名称 | 签名 | 说明 |
 | ---- | ---- | ---- |
-| `row_expand` | `(src: Tile) -> Tile` | 将 `src[i,0]` 广播到每行 |
+| `row_expand` | `(target: Tile, row_vec: Tile) -> Tile` | 将 `row_vec[M,1]` 扩展到 `target[M,N]` |
 | `row_expand_add` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile + row_vec[M,1]` 广播 |
 | `row_expand_sub` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile - row_vec` 广播 |
 | `row_expand_mul` | `(tile: Tile, row_vec: Tile) -> Tile` | `tile * row_vec` 广播 |

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -129,6 +129,14 @@ def _identity() -> OpHandler:
     return lambda a, _kw: a[0]
 
 
+def _expand_as_target() -> OpHandler:
+    # row_expand/col_expand in IR deduce promoted dtype from both operands.
+    # Materialize expanded view to avoid aliasing issues with zero-stride expands.
+    return lambda a, _kw: (
+        f"{a[1]}.expand_as({a[0]}).clone().to(torch.promote_types({a[0]}.dtype, {a[1]}.dtype))"
+    )
+
+
 def _noop(comment: str = "") -> OpHandler:
     return lambda _a, _kw: f"None  # {comment}" if comment else "None"
 
@@ -269,8 +277,8 @@ def _register_ops() -> None:
         m[f"{prefix}.col_expand_mul"] = _binop("*")
         m[f"{prefix}.col_expand_sub"] = _binop("-")
         m[f"{prefix}.col_expand_div"] = _binop("/")
-        m[f"{prefix}.col_expand"] = _identity()
-        m[f"{prefix}.row_expand"] = _identity()
+        m[f"{prefix}.col_expand"] = _expand_as_target()
+        m[f"{prefix}.row_expand"] = _expand_as_target()
         m[f"{prefix}.expands"] = lambda a, _kw: f"torch.full_like({a[0]}, {a[1]})"
 
     # --- Tensor-only ops ---

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -506,18 +506,19 @@ def row_min(input: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.row_min", [input], {}, actual_span)
 
 
-def row_expand(input: Expr, span: Span | None = None) -> Call:
-    """Row-wise broadcast: dst[i, j] = src[i, 0].
+def row_expand(target: Expr, row_vec: Expr, span: Span | None = None) -> Call:
+    """Row-wise expansion: expand row_vec [M, 1] to target shape [M, N].
 
     Args:
-        input: Input tensor (TensorType [M, N])
+        target: Target tensor defining output shape (TensorType [M, N])
+        row_vec: Row vector to expand (TensorType [M, 1])
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression for row-wise first-element broadcast
+        Call expression for row-wise expansion
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tensor.row_expand", [input], {}, actual_span)
+    return _ir_core.create_op_call("tensor.row_expand", [target, row_vec], {}, actual_span)
 
 
 def row_expand_mul(tensor: Expr, row_vec: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1359,20 +1359,19 @@ def gemv_bias(lhs: Expr, rhs: Expr, bias: Expr, span: Span | None = None) -> Cal
 # ============================================================================
 
 
-def row_expand(src: Expr, span: Span | None = None) -> Call:
-    """Broadcast the first element of each source row across the destination row.
-
-    For each element (i, j) in the valid region: dst[i, j] = src[i, 0].
+def row_expand(target: Expr, row_vec: Expr, span: Span | None = None) -> Call:
+    """Expand row vector [rows, 1] to target shape [rows, cols].
 
     Args:
-        src: Input tile (TileType [M, N])
+        target: Target tile defining output shape (TileType [M, N])
+        row_vec: Row vector to expand (TileType [M, 1])
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression for row-wise first-element broadcast
+        Call expression for row-wise expansion
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.row_expand", [src], {}, actual_span)
+    return _ir_core.create_op_call("tile.row_expand", [target, row_vec], {}, actual_span)
 
 
 def row_expand_sub(tile: Expr, row_vec: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -468,17 +468,19 @@ def row_min(input: Tensor) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def row_expand(input: Tensor) -> Tensor:
-    """Row-wise broadcast: dst[i, j] = src[i, 0].
+def row_expand(target: Tensor, row_vec: Tensor) -> Tensor:
+    """Row-wise expansion: expand row_vec [M, 1] to target shape [M, N].
 
     Args:
-        input: Input tensor (TensorType [M, N])
+        target: Target tensor defining output shape (TensorType [M, N])
+        row_vec: Row vector to expand (TensorType [M, 1])
 
     Returns:
         Tensor wrapping the row_expand operation
     """
-    input_expr = input.unwrap()
-    call_expr = _ir_ops.row_expand(input_expr)
+    target_expr = target.unwrap()
+    row_vec_expr = row_vec.unwrap()
+    call_expr = _ir_ops.row_expand(target_expr, row_vec_expr)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -869,18 +869,17 @@ def maximum(lhs: Tile, rhs: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def row_expand(src: Tile) -> Tile:
-    """Broadcast the first element of each source row across the destination row.
-
-    For each element (i, j): dst[i, j] = src[i, 0].
+def row_expand(target: Tile, row_vec: Tile) -> Tile:
+    """Expand row vector to target shape.
 
     Args:
-        src: Input tile [M, N]
+        target: Target tile defining output shape [M, N]
+        row_vec: Row vector to expand [M, 1]
 
     Returns:
         Tile wrapping the row_expand operation
     """
-    call_expr = _ir_ops.row_expand(src.unwrap())
+    call_expr = _ir_ops.row_expand(target.unwrap(), row_vec.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -231,13 +231,13 @@ def col_expand_mul(lhs: T, rhs: T) -> T:
     _raise_type_dispatch_error("col_expand_mul", lhs, rhs)
 
 
-def row_expand(input: T) -> T:
-    """Row-wise broadcast: dst[i, j] = src[i, 0], dispatched by input type."""
-    if isinstance(input, Tensor):
-        return _tensor.row_expand(input)
-    if isinstance(input, Tile):
-        return _tile.row_expand(input)
-    raise TypeError(f"row_expand: expected Tensor or Tile, got {type(input).__name__}")
+def row_expand(lhs: T, rhs: T) -> T:
+    """Row-wise expansion, dispatched by input type."""
+    if isinstance(lhs, Tensor) and isinstance(rhs, Tensor):
+        return _tensor.row_expand(lhs, rhs)
+    if isinstance(lhs, Tile) and isinstance(rhs, Tile):
+        return _tile.row_expand(lhs, rhs)
+    _raise_type_dispatch_error("row_expand", lhs, rhs)
 
 
 def row_expand_add(lhs: T, rhs: T) -> T:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -190,6 +190,30 @@ static std::string MakeColExpandCodegenPTO(const CallPtr& op, codegen::CodegenBa
   return "";
 }
 
+// pto.trowexpand takes only the row vector in ins(); output shape comes from outs().
+// IR tile.row_expand(target, row_vec) keeps target for shape/type inference only.
+static std::string MakeRowExpandCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 2) << "tile.row_expand requires 2 arguments, got " << op->args_.size();
+  const ir::ExprPtr& row_vec = op->args_[1];
+  std::string operand = codegen.GetExprAsCode(row_vec);
+  std::string in_type = codegen.GetExprTypeAnnotation(row_vec);
+  std::string result_target = codegen.GetCurrentResultTarget();
+  std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+  std::ostringstream oss;
+  oss << "pto.trowexpand ins(" << operand;
+  if (!in_type.empty()) {
+    oss << " : " << in_type;
+  }
+  oss << ") outs(" << result_target;
+  if (!result_type.empty()) {
+    oss << " : " << result_type;
+  }
+  oss << ")";
+  codegen.Emit(oss.str());
+  return "";
+}
+
 // Helper function for StoreFP
 static std::string MakeStoreFPCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
@@ -1224,7 +1248,6 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.row_sum",         "pto.trowsum",          2},
     {"tile.row_max",         "pto.trowmax",          2},
     {"tile.row_min",         "pto.trowmin",          2},
-    {"tile.row_expand",      "pto.trowexpand",       1},
     {"tile.col_sum",         "pto.tcolsum",          1},
     {"tile.col_max",         "pto.tcolmax",          1},
     {"tile.col_min",         "pto.tcolmin",          1},
@@ -1335,6 +1358,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.col_expand", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeColExpandCodegenPTO(op, codegen);
+  });
+  reg("tile.row_expand", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeRowExpandCodegenPTO(op, codegen);
   });
   reg("tile.store_fp", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeStoreFPCodegenPTO("pto.tstore.fp", op, codegen);

--- a/src/ir/op/tensor_ops/broadcast.cpp
+++ b/src/ir/op/tensor_ops/broadcast.cpp
@@ -143,19 +143,6 @@ TypePtr DeduceTensorColExpandType(const std::vector<ExprPtr>& args,
   return std::make_shared<TensorType>(tensor_shape, *result_dtype);
 }
 
-TypePtr DeduceTensorRowExpandSingleType(const std::vector<ExprPtr>& args,
-                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                        const std::string& op_name) {
-  CHECK(args.size() == 1) << "The operator " << op_name << " requires exactly 1 argument, but got "
-                          << args.size();
-
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
-
-  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
-}
-
 TypePtr DeduceTensorExpandScalarType(const std::vector<ExprPtr>& args,
                                      const std::vector<std::pair<std::string, std::any>>& kwargs,
                                      const std::string& op_name) {
@@ -209,11 +196,12 @@ REGISTER_OP("tensor.col_expand_mul")
 
 REGISTER_OP("tensor.row_expand")
     .set_op_category("TensorOp")
-    .set_description("Row-wise broadcast: dst[i,j] = src[i,0]")
-    .add_argument("src", "Input tensor (TensorType [M, N])")
+    .set_description("Row-wise expansion: expand row_vec [M,1] to target shape [M,N]")
+    .add_argument("target", "Target tensor defining output shape (TensorType [M, N])")
+    .add_argument("row_vec", "Row vector (TensorType [M, 1])")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorRowExpandSingleType(args, kwargs, "tensor.row_expand");
+      return DeduceTensorRowExpandType(args, kwargs, "tensor.row_expand");
     });
 
 REGISTER_OP("tensor.row_expand_add")

--- a/src/ir/op/tile_ops/broadcast.cpp
+++ b/src/ir/op/tile_ops/broadcast.cpp
@@ -152,25 +152,15 @@ TypePtr DeduceTileExpandScalarType(const std::vector<ExprPtr>& args,
 
 REGISTER_OP("tile.row_expand")
     .set_op_category("TileOp")
-    .set_description(
-        "Broadcast first element of each source row across the destination row: dst[i,j] = src[i,0]")
-    .add_argument("src", "Input tile (TileType, 2D [M, N])")
+    .set_description("Expand row tile [rows, 1] to target shape [rows, cols]")
+    .add_argument("target", "Target tile defining output shape (TileType)")
+    .add_argument("row_vec", "Row vector to expand (TileType, shape [rows, 1])")
     .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      CHECK(args.size() == 1) << "The operator tile.row_expand requires exactly 1 argument, but got "
-                              << args.size();
-      auto tile_type = As<TileType>(args[0]->GetType());
-      CHECK(tile_type) << "The operator tile.row_expand requires argument to be a TileType, but got "
-                       << args[0]->GetType()->TypeName();
-      CHECK(tile_type->shape_.size() >= 2)
-          << "The operator tile.row_expand requires input tile"
-          << " to have at least 2 dimensions, but got " << tile_type->shape_.size() << " dimensions";
-      TileView tile_view;
-      tile_view.valid_shape = tile_type->shape_;
-      InheritTileViewLayout(tile_view, tile_type);
-      return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
+      return DeduceTileRowExpandType(args, kwargs, "tile.row_expand");
     });
 
 REGISTER_OP("tile.row_expand_sub")

--- a/tests/st/runtime/test_broadcast.py
+++ b/tests/st/runtime/test_broadcast.py
@@ -19,6 +19,8 @@ import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 
+MN_CASES: list[tuple[int, int]] = [(8, 16), (16, 16), (16, 8)]
+
 
 class TestTileRowExpand(PTOTestCase):
     """Test case for tile.row_expand."""
@@ -35,7 +37,7 @@ class TestTileRowExpand(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("x", [self.M, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("row_vec", [self.M, 1], DataType.FP32, init_value=torch.randn),
             TensorSpec("y", [self.M, self.N], DataType.FP32, is_output=True),
         ]
 
@@ -47,27 +49,28 @@ class TestTileRowExpand(PTOTestCase):
             @pl.function(type=pl.FunctionType.InCore)
             def row_expand_kernel(
                 self,
-                x: pl.Tensor[[M, N], pl.FP32],
+                row_vec: pl.Tensor[[M, 1], pl.FP32],
                 y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile: pl.Tile[[M, N], pl.FP32] = pl.load(x, [0, 0], [M, N])
-                expanded: pl.Tile[[M, N], pl.FP32] = pl.tile.row_expand(tile)
+                row_tile: pl.Tile[[M, 1], pl.FP32] = pl.load(row_vec, [0, 0], [M, 1])
+                target_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.create([M, N], dtype=pl.FP32)
+                expanded: pl.Tile[[M, N], pl.FP32] = pl.tile.row_expand(target_tile, row_tile)
                 out: pl.Tensor[[M, N], pl.FP32] = pl.store(expanded, [0, 0], y)
                 return out
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
                 self,
-                x: pl.Tensor[[M, N], pl.FP32],
+                row_vec: pl.Tensor[[M, 1], pl.FP32],
                 y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                y = self.row_expand_kernel(x, y)
+                y = self.row_expand_kernel(row_vec, y)
                 return y
 
         return TileRowExpandProgram
 
     def compute_expected(self, tensors, params=None):
-        tensors["y"][:] = tensors["x"][:, :1].repeat(1, self.N)
+        tensors["y"][:] = tensors["row_vec"].repeat(1, self.N)
 
 
 class TestTileColExpand(PTOTestCase):
@@ -85,7 +88,6 @@ class TestTileColExpand(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("target", [self.M, self.N], DataType.FP32, init_value=torch.randn),
             TensorSpec("col_vec", [1, self.N], DataType.FP32, init_value=torch.randn),
             TensorSpec("y", [self.M, self.N], DataType.FP32, is_output=True),
         ]
@@ -98,12 +100,11 @@ class TestTileColExpand(PTOTestCase):
             @pl.function(type=pl.FunctionType.InCore)
             def col_expand_kernel(
                 self,
-                target: pl.Tensor[[M, N], pl.FP32],
                 col_vec: pl.Tensor[[1, N], pl.FP32],
                 y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                target_tile: pl.Tile[[M, N], pl.FP32] = pl.load(target, [0, 0], [M, N])
                 col_tile: pl.Tile[[1, N], pl.FP32] = pl.load(col_vec, [0, 0], [1, N])
+                target_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.create([M, N], dtype=pl.FP32)
                 expanded: pl.Tile[[M, N], pl.FP32] = pl.tile.col_expand(target_tile, col_tile)
                 out: pl.Tensor[[M, N], pl.FP32] = pl.store(expanded, [0, 0], y)
                 return out
@@ -111,11 +112,10 @@ class TestTileColExpand(PTOTestCase):
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
                 self,
-                target: pl.Tensor[[M, N], pl.FP32],
                 col_vec: pl.Tensor[[1, N], pl.FP32],
                 y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                y = self.col_expand_kernel(target, col_vec, y)
+                y = self.col_expand_kernel(col_vec, y)
                 return y
 
         return TileColExpandProgram
@@ -127,16 +127,18 @@ class TestTileColExpand(PTOTestCase):
 class TestBroadcastOperations:
     """Test suite for tile broadcast operations."""
 
+    @pytest.mark.parametrize("m, n", MN_CASES)
     @pytest.mark.parametrize("backend", PLATFORMS)
-    def test_tile_row_expand(self, test_runner, backend):
+    def test_tile_row_expand(self, test_runner, backend, m, n):
         """Test tile.row_expand across platforms."""
-        result = test_runner.run(TestTileRowExpand(backend_type=backend))
+        result = test_runner.run(TestTileRowExpand(m=m, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
+    @pytest.mark.parametrize("m, n", MN_CASES)
     @pytest.mark.parametrize("backend", PLATFORMS)
-    def test_tile_col_expand(self, test_runner, backend):
+    def test_tile_col_expand(self, test_runner, backend, m, n):
         """Test tile.col_expand across platforms."""
-        result = test_runner.run(TestTileColExpand(backend_type=backend))
+        result = test_runner.run(TestTileColExpand(m=m, n=n, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -683,6 +683,35 @@ class TestBroadcastOpsCodegen:
         else:
             raise AssertionError("no pto.tcolexpand ins(...) line in MLIR")
 
+    def test_row_expand_codegen(self):
+        """tile.row_expand(target, row_vec) should emit pto.trowexpand with only row_vec in ins()."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP32],
+                row_vec_tensor: pl.Tensor[[16, 1], pl.FP32],
+                dst: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(src, [0, 0], [16, 16])
+                row_tile: pl.Tile[[16, 1], pl.FP32] = pl.load(row_vec_tensor, [0, 0], [16, 1])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.tile.row_expand(src_tile, row_tile)
+                return pl.store(result, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.trowexpand" in mlir, f"row_expand should generate pto.trowexpand, got:\n{mlir}"
+        # ptoas expects unary ins; two SSA values look like "ins(%a, %b : ...)".
+        for line in mlir.splitlines():
+            if "pto.trowexpand" in line and "ins(" in line:
+                after_ins = line.split("ins(", 1)[1]
+                value_list = after_ins.split(" : ", 1)[0]
+                assert "," not in value_list, f"trowexpand ins should be single SSA operand, got: {line!r}"
+                break
+        else:
+            raise AssertionError("no pto.trowexpand ins(...) line in MLIR")
+
 
 class TestTileSliceCodegen:
     """Tests for tile.slice PTO code generation (pto.textract)."""

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1240,10 +1240,13 @@ def test_tensor_row_expand():
     span = ir.Span.unknown()
     dim64 = ir.ConstInt(64, DataType.INT32, span)
     dim128 = ir.ConstInt(128, DataType.INT32, span)
+    dim1 = ir.ConstInt(1, DataType.INT32, span)
     tensor_type = ir.TensorType([dim64, dim128], DataType.FP16)
+    row_type = ir.TensorType([dim64, dim1], DataType.FP16)
     tensor_var = ir.Var("t", tensor_type, span)
+    row_var = ir.Var("rv", row_type, span)
 
-    call = ir.op.tensor.row_expand(tensor_var)
+    call = ir.op.tensor.row_expand(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
     assert call.op.name == "tensor.row_expand"

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -673,7 +673,7 @@ class TestTileBroadcastOps:
         assert "tile.row_expand_mul" in ir_str
 
     def test_tile_row_expand(self):
-        """Test tile.row_expand operator - broadcast first element of each row across the row."""
+        """Test tile.row_expand operator - expand row vector to target tile shape."""
 
         @pl.program
         class Program:
@@ -681,10 +681,12 @@ class TestTileBroadcastOps:
             def main(
                 self,
                 tile: pl.Tensor[[128, 128], pl.FP32],
+                row: pl.Tensor[[128, 128], pl.FP32],
                 output: pl.Tensor[[128, 128], pl.FP32],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(tile, [0, 0], [32, 32])
-                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.row_expand(tile_a)
+                tile_row: pl.Tile[[32, 1], pl.FP32] = pl.load(row, [0, 0], [32, 1])
+                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.row_expand(tile_a, tile_row)
                 result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
                 return result
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1155,16 +1155,18 @@ class TestConvertTensorToTileOps:
             def main_incore_0(
                 self,
                 x: pl.Tensor[[32, 64], pl.FP16],
+                rv: pl.Tensor[[32, 1], pl.FP16],
             ) -> pl.Tensor[[32, 64], pl.FP16]:
-                y: pl.Tensor[[32, 64], pl.FP16] = pl.row_expand(x)
+                y: pl.Tensor[[32, 64], pl.FP16] = pl.row_expand(x, rv)
                 return y
 
             @pl.function
             def main(
                 self,
                 x: pl.Tensor[[32, 64], pl.FP16],
+                rv: pl.Tensor[[32, 1], pl.FP16],
             ) -> pl.Tensor[[32, 64], pl.FP16]:
-                y: pl.Tensor[[32, 64], pl.FP16] = self.main_incore_0(x)
+                y: pl.Tensor[[32, 64], pl.FP16] = self.main_incore_0(x, rv)
                 return y
 
         @pl.program
@@ -1173,10 +1175,12 @@ class TestConvertTensorToTileOps:
             def main_incore_0(
                 self,
                 x: pl.Tensor[[32, 64], pl.FP16],
+                rv: pl.Tensor[[32, 1], pl.FP16],
                 out_0: pl.Out[pl.Tensor[[32, 64], pl.FP16]],
             ) -> pl.Tensor[[32, 64], pl.FP16]:
                 x_tile: pl.Tile[[32, 64], pl.FP16] = pl.load(x, [0, 0], [32, 64])
-                y_tile: pl.Tile[[32, 64], pl.FP16] = pl.tile.row_expand(x_tile)
+                rv_tile: pl.Tile[[32, 1], pl.FP16] = pl.load(rv, [0, 0], [32, 1])
+                y_tile: pl.Tile[[32, 64], pl.FP16] = pl.tile.row_expand(x_tile, rv_tile)
                 out_0_store: pl.Tensor[[32, 64], pl.FP16] = pl.store(y_tile, [0, 0], out_0)
                 return out_0_store
 
@@ -1184,9 +1188,10 @@ class TestConvertTensorToTileOps:
             def main(
                 self,
                 x: pl.Tensor[[32, 64], pl.FP16],
+                rv: pl.Tensor[[32, 1], pl.FP16],
             ) -> pl.Tensor[[32, 64], pl.FP16]:
                 out_0: pl.Tensor[[32, 64], pl.FP16] = pl.create_tensor([32, 64], dtype=pl.FP16)
-                y: pl.Tensor[[32, 64], pl.FP16] = self.main_incore_0(x, out_0)
+                y: pl.Tensor[[32, 64], pl.FP16] = self.main_incore_0(x, rv, out_0)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -271,13 +271,17 @@ class TestUnifiedTensorDispatch:
 
     def test_row_expand(self):
         @pl.function
-        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 128], pl.FP32]:
-            c: pl.Tensor[[64, 128], pl.FP32] = pl.row_expand(a)
+        def unified(
+            a: pl.Tensor[[64, 128], pl.FP32], rv: pl.Tensor[[64, 1], pl.FP32]
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            c: pl.Tensor[[64, 128], pl.FP32] = pl.row_expand(a, rv)
             return c
 
         @pl.function
-        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[64, 128], pl.FP32]:
-            c: pl.Tensor[[64, 128], pl.FP32] = pl.tensor.row_expand(a)
+        def explicit(
+            a: pl.Tensor[[64, 128], pl.FP32], rv: pl.Tensor[[64, 1], pl.FP32]
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            c: pl.Tensor[[64, 128], pl.FP32] = pl.tensor.row_expand(a, rv)
             return c
 
         ir.assert_structural_equal(unified, explicit)
@@ -577,19 +581,25 @@ class TestUnifiedBlockDispatch:
     def test_row_expand(self):
         @pl.function
         def unified(
-            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            t: pl.Tensor[[64, 64], pl.FP32],
+            row_t: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Tensor[[64, 64], pl.FP32],
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
-            b: pl.Tile[[64, 64], pl.FP32] = pl.row_expand(a)
+            rv: pl.Tile[[64, 1], pl.FP32] = pl.tile.load(row_t, offsets=[0, 0], shapes=[64, 1])
+            b: pl.Tile[[64, 64], pl.FP32] = pl.row_expand(a, rv)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
             return result
 
         @pl.function
         def explicit(
-            t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
+            t: pl.Tensor[[64, 64], pl.FP32],
+            row_t: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Tensor[[64, 64], pl.FP32],
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
-            b: pl.Tile[[64, 64], pl.FP32] = pl.tile.row_expand(a)
+            rv: pl.Tile[[64, 1], pl.FP32] = pl.tile.load(row_t, offsets=[0, 0], shapes=[64, 1])
+            b: pl.Tile[[64, 64], pl.FP32] = pl.tile.row_expand(a, rv)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
             return result
 


### PR DESCRIPTION
## Summary
- Align row_expand signature to (target, row_vec) for both tensor and tile APIs.
- Update C++ op registration/type deduction, Python IR/language/unified wrappers, backend PTO codegen, and torch debug codegen to match col_expand style.
- Update UT/ST/codegen/transform tests and EN/ZH user operation reference docs.

## Testing
- Not run in this environment (local build/test toolchain was not in a runnable state).

## Related Issues
Fixes #883