### PR TITLE
feat(verifier): Promote InOut-use discipline to structural property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ set(PYPTO_SOURCES
     src/ir/verifier/type_check_pass.cpp
     src/ir/verifier/verify_structured_ctrl_flow_pass.cpp
     src/ir/verifier/verify_out_param_pass.cpp
+    src/ir/verifier/verify_inout_use.cpp
     src/ir/verifier/warning_verifier_registry.cpp
     src/ir/verifier/warning_unused_var.cpp
 

--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -15,7 +15,7 @@ Extensible verification system for validating PyPTO IR correctness through plugg
 
 - **Pluggable Rule System**: Extend with custom verification rules
 - **Property-Based Verification**: Opt-in property sets — verify exactly what you need
-- **Structural Properties**: TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, and NoNestedInCore are verified at pipeline start by `PassPipeline` and before/after each pass by `VerificationInstrument`
+- **Structural Properties**: TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, and InOutUseValid are verified at pipeline start by `PassPipeline` and before/after each pass by `VerificationInstrument`
 - **Dual Verification Modes**: Collect diagnostics or throw on first error
 - **Pass Integration**: Use as a Pass in optimization pipelines
 - **Comprehensive Diagnostics**: Collect all issues with source locations
@@ -26,10 +26,10 @@ Extensible verification system for validating PyPTO IR correctness through plugg
 
 | Category | Examples | Behavior |
 | -------- | -------- | -------- |
-| **Structural** | TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore | Always true. Verified at pipeline start and before/after each pass by `VerificationInstrument`. Never in PassProperties. |
+| **Structural** | TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid | Always true. Verified at pipeline start and before/after each pass by `VerificationInstrument`. Never in PassProperties. |
 | **Pipeline** | SSAForm, NoNestedCalls, HasMemRefs, ... | Produced/invalidated by passes. Verified per pass-declared contracts. |
 
-`GetStructuralProperties()` returns `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}`. These are verified **at pipeline start** by `PassPipeline::Run()` and **before/after each pass** by `VerificationInstrument`. Since no pass declares them in `required`/`produced`/`invalidated`, `VerificationInstrument` unions them with the pass's declared properties to ensure no pass breaks these fundamental invariants.
+`GetStructuralProperties()` returns `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid}`. These are verified **at pipeline start** by `PassPipeline::Run()` and **before/after each pass** by `VerificationInstrument`. Since no pass declares them in `required`/`produced`/`invalidated`, `VerificationInstrument` unions them with the pass's declared properties to ensure no pass breaks these fundamental invariants.
 
 ### Verification Rule System
 
@@ -74,6 +74,7 @@ The `run_verifier()` utility creates a standalone `Pass` for ad-hoc use in custo
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | All MemRefs have valid addresses within buffer limits |
 | **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut params not reassigned with tensor-creating ops |
 | **NoNestedInCore** | NoNestedInCore | No nested InCore scopes (ScopeStmt inside ScopeStmt) |
+| **InOutUseValid** | InOutUseValid | Variables passed as InOut/Out to user-function calls are not read after the call (RFC #1026). Group-typed function bodies are skipped pending follow-up. |
 
 ### SSAVerify
 
@@ -160,9 +161,9 @@ Singleton registry mapping `IRProperty` values to `PropertyVerifier` factories. 
 
 | Function | Returns | Description |
 | -------- | ------- | ----------- |
-| `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}` | Invariants verified at pipeline start and before/after each pass |
+| `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid}` | Invariants verified at pipeline start and before/after each pass |
 | `GetDefaultVerifyProperties()` | `{SSAForm, TypeChecked, NoNestedCalls, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}` | Default set for `run_verifier()` |
-| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks}` | Lightweight set for `PassPipeline` auto-verify |
+| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid}` | Lightweight set for `PassPipeline` auto-verify |
 
 ### RunVerifier Pass Factory
 

--- a/docs/zh-cn/dev/passes/99-verifier.md
+++ b/docs/zh-cn/dev/passes/99-verifier.md
@@ -15,7 +15,7 @@
 
 - **可插拔规则系统**：可通过自定义验证规则进行扩展
 - **基于属性的验证**：选择性属性集——精确验证所需内容
-- **结构性属性 (Structural Properties)**：TypeChecked、BreakContinueValid、NoRedundantBlocks、UseAfterDef、OutParamNotShadowed 和 NoNestedInCore 在流水线启动时由 `PassPipeline` 验证，并由 `VerificationInstrument` 在每个 Pass 执行前后验证
+- **结构性属性 (Structural Properties)**：TypeChecked、BreakContinueValid、NoRedundantBlocks、UseAfterDef、OutParamNotShadowed、NoNestedInCore 和 InOutUseValid 在流水线启动时由 `PassPipeline` 验证，并由 `VerificationInstrument` 在每个 Pass 执行前后验证
 - **双重验证模式**：收集诊断信息或在首个错误时抛出异常
 - **Pass 集成**：可作为优化流水线中的 Pass 使用
 - **全面的诊断信息**：收集所有问题及源码位置
@@ -26,10 +26,10 @@
 
 | 类别 | 示例 | 行为 |
 | ---- | ---- | ---- |
-| **结构性** | TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore | 始终为真。在流水线启动时验证，并由 `VerificationInstrument` 在每个 Pass 执行前后验证。不在 PassProperties 中声明。 |
+| **结构性** | TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid | 始终为真。在流水线启动时验证，并由 `VerificationInstrument` 在每个 Pass 执行前后验证。不在 PassProperties 中声明。 |
 | **流水线** | SSAForm, NoNestedCalls, HasMemRefs, ... | 由 Pass 产生/失效。按 Pass 声明的契约验证。 |
 
-`GetStructuralProperties()` 返回 `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}`。这些在 `PassPipeline::Run()` 中**于流水线启动时验证**，并由 `VerificationInstrument` **在每个 Pass 执行前后验证**。由于没有 Pass 在 `required`/`produced`/`invalidated` 中声明它们，`VerificationInstrument` 将它们与 Pass 声明的属性合并，确保没有 Pass 破坏这些基本不变量。
+`GetStructuralProperties()` 返回 `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid}`。这些在 `PassPipeline::Run()` 中**于流水线启动时验证**，并由 `VerificationInstrument` **在每个 Pass 执行前后验证**。由于没有 Pass 在 `required`/`produced`/`invalidated` 中声明它们，`VerificationInstrument` 将它们与 Pass 声明的属性合并，确保没有 Pass 破坏这些基本不变量。
 
 ### 验证规则系统
 
@@ -74,6 +74,7 @@
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | 所有 MemRef 在缓冲区限制内具有有效地址 |
 | **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut 参数未被张量创建操作重新赋值 |
 | **NoNestedInCore** | NoNestedInCore | 无嵌套 InCore 作用域（ScopeStmt 内含 ScopeStmt） |
+| **InOutUseValid** | InOutUseValid | 作为 InOut/Out 传入用户函数调用的变量，在调用之后不得再被读取（RFC #1026）。Group 类型函数体目前跳过，待后续完善。 |
 
 ### SSAVerify
 
@@ -160,9 +161,9 @@
 
 | 函数 | 返回值 | 描述 |
 | ---- | ------ | ---- |
-| `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}` | 在流水线启动时及每个 Pass 执行前后验证的不变量 |
+| `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid}` | 在流水线启动时及每个 Pass 执行前后验证的不变量 |
 | `GetDefaultVerifyProperties()` | `{SSAForm, TypeChecked, NoNestedCalls, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore}` | `run_verifier()` 的默认属性集 |
-| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks}` | `PassPipeline` 自动验证的轻量级属性集 |
+| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid}` | `PassPipeline` 自动验证的轻量级属性集 |
 
 ### RunVerifier Pass 工厂
 

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -46,8 +46,8 @@ class HelloWorldProgram:
         b: pl.Tensor[[128, 128], pl.FP32],
         out_c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
-        out_c = self.tile_add(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_add(a, b, out_c)
+        return out_c_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/01_elementwise.py
+++ b/examples/kernels/01_elementwise.py
@@ -47,8 +47,8 @@ class TileAddProgram:
         b: pl.Tensor[[128, 128], pl.FP32],
         out_c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
-        out_c = self.tile_add(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_add(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -73,8 +73,8 @@ class TileMulProgram:
         b: pl.Tensor[[128, 128], pl.FP32],
         out_c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
-        out_c = self.tile_mul(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_mul(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -101,8 +101,8 @@ class TileAdd64Program:
         b: pl.Tensor[[64, 64], pl.FP32],
         out_c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        out_c = self.tile_add(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_add(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -129,8 +129,8 @@ class TileMul64Program:
         b: pl.Tensor[[64, 64], pl.FP32],
         out_c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        out_c = self.tile_mul(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_mul(a, b, out_c)
+        return out_c_ret
 
 
 # Aliases for backward compatibility with tests that use size-suffixed names

--- a/examples/kernels/02_fused_ops.py
+++ b/examples/kernels/02_fused_ops.py
@@ -55,8 +55,8 @@ class FusedAddScaleProgram:
         b: pl.Tensor[[128, 128], pl.FP32],
         out_c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
-        out_c = self.fused_add_scale(a, b, out_c)
-        return out_c
+        out_c_ret = self.fused_add_scale(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -83,8 +83,8 @@ class FusedAddReluProgram:
         b: pl.Tensor[[128, 128], pl.FP32],
         out_c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
-        out_c = self.fused_add_relu(a, b, out_c)
-        return out_c
+        out_c_ret = self.fused_add_relu(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -129,9 +129,9 @@ class FusedMatmulBiasProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         """Orchestrate: c = matmul(a, b) + bias"""
         mm_out = pl.create_tensor([64, 64], dtype=pl.FP32)
-        mm_out = self.matmul_kernel(a, b, mm_out)
-        c = self.add_bias_kernel(mm_out, bias, c)
-        return c
+        mm_done = self.matmul_kernel(a, b, mm_out)
+        c_ret = self.add_bias_kernel(mm_done, bias, c)
+        return c_ret
 
 
 @pl.program
@@ -177,9 +177,9 @@ class FusedLinearReluProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         """Orchestrate: y = relu(matmul(x, w) + bias)"""
         mm_out = pl.create_tensor([64, 64], dtype=pl.FP32)
-        mm_out = self.matmul_kernel(x, w, mm_out)
-        y = self.add_bias_relu_kernel(mm_out, bias, y)
-        return y
+        mm_done = self.matmul_kernel(x, w, mm_out)
+        y_ret = self.add_bias_relu_kernel(mm_done, bias, y)
+        return y_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/03_matmul.py
+++ b/examples/kernels/03_matmul.py
@@ -51,8 +51,8 @@ class MatmulProgram:
         b: pl.Tensor[[64, 64], pl.FP32],
         out_c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        out_c = self.matmul(a, b, out_c)
-        return out_c
+        out_c_ret = self.matmul(a, b, out_c)
+        return out_c_ret
 
 
 @pl.program
@@ -94,8 +94,8 @@ class MatmulaccProgram:
         b: pl.Tensor[[64, 64], pl.FP32],
         out_c: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        out_c = self.matmul_acc(a, b, out_c)
-        return out_c
+        out_c_ret = self.matmul_acc(a, b, out_c)
+        return out_c_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/04_concat.py
+++ b/examples/kernels/04_concat.py
@@ -44,8 +44,8 @@ class TileConcat32x32Program:
         self, a: pl.Tensor[[32, 16], pl.FP32], b: pl.Tensor[[32, 16], pl.FP32]
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         out_c = pl.create_tensor([32, 32], dtype=pl.FP32)
-        out_c = self.tile_concat(a, b, out_c)
-        return out_c
+        out_c_ret = self.tile_concat(a, b, out_c)
+        return out_c_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/05_activation.py
+++ b/examples/kernels/05_activation.py
@@ -52,8 +52,8 @@ class SiluProgram:
         x: pl.Tensor[[32, 128], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
     ) -> pl.Tensor[[32, 128], pl.FP32]:
-        output = self.kernel_silu(x, output)
-        return output
+        output_ret = self.kernel_silu(x, output)
+        return output_ret
 
 
 @pl.program
@@ -81,8 +81,8 @@ class GeluProgram:
         x: pl.Tensor[[32, 128], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
     ) -> pl.Tensor[[32, 128], pl.FP32]:
-        output = self.kernel_gelu(x, output)
-        return output
+        output_ret = self.kernel_gelu(x, output)
+        return output_ret
 
 
 @pl.program
@@ -113,8 +113,8 @@ class SwigluProgram:
         up: pl.Tensor[[32, 128], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
     ) -> pl.Tensor[[32, 128], pl.FP32]:
-        output = self.kernel_swiglu(gate, up, output)
-        return output
+        output_ret = self.kernel_swiglu(gate, up, output)
+        return output_ret
 
 
 @pl.program
@@ -147,8 +147,8 @@ class GegluProgram:
         up: pl.Tensor[[32, 128], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
     ) -> pl.Tensor[[32, 128], pl.FP32]:
-        output = self.kernel_geglu(gate, up, output)
-        return output
+        output_ret = self.kernel_geglu(gate, up, output)
+        return output_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/06_softmax.py
+++ b/examples/kernels/06_softmax.py
@@ -61,8 +61,8 @@ class TileSoftmaxProgram:
         a: pl.Tensor[[64, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        output = self.tile_softmax(a, output)
-        return output
+        output_ret = self.tile_softmax(a, output)
+        return output_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/07_normalization.py
+++ b/examples/kernels/07_normalization.py
@@ -75,8 +75,8 @@ class RMSNormProgram:
         gamma: pl.Tensor[[1, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
     ) -> pl.Tensor[[32, 64], pl.FP32]:
-        output = self.kernel_rms_norm(x, gamma, output)
-        return output
+        output_ret = self.kernel_rms_norm(x, gamma, output)
+        return output_ret
 
 
 @pl.program
@@ -138,8 +138,8 @@ class LayerNormProgram:
         beta: pl.Tensor[[1, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
     ) -> pl.Tensor[[32, 64], pl.FP32]:
-        output = self.kernel_layer_norm(x, gamma, beta, output)
-        return output
+        output_ret = self.kernel_layer_norm(x, gamma, beta, output)
+        return output_ret
 
 
 if __name__ == "__main__":

--- a/examples/kernels/08_assemble.py
+++ b/examples/kernels/08_assemble.py
@@ -87,8 +87,8 @@ class TileAssembleAccMatProgram:
         b: pl.Tensor[[16, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, a, b, y)
-        return y
+        y_ret = self.tile_assemble(x, a, b, y)
+        return y_ret
 
 
 @pl.program
@@ -115,8 +115,8 @@ class TileAssembleVecProgram:
         src: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, src, y)
-        return y
+        y_ret = self.tile_assemble(x, src, y)
+        return y_ret
 
 
 @pl.program
@@ -143,8 +143,8 @@ class TileAssembleRowByRowProgram:
         src: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, src, y)
-        return y
+        y_ret = self.tile_assemble(x, src, y)
+        return y_ret
 
 
 @pl.program
@@ -173,8 +173,8 @@ class TileAssembleDoubleLoopProgram:
         src: pl.Tensor[[32, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, src, y)
-        return y
+        y_ret = self.tile_assemble(x, src, y)
+        return y_ret
 
 
 @pl.program
@@ -200,8 +200,8 @@ class TileAssembleLoopColBroadcastProgram:
         src: pl.Tensor[[32, 8], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, src, y)
-        return y
+        y_ret = self.tile_assemble(x, src, y)
+        return y_ret
 
 
 @pl.program
@@ -228,8 +228,8 @@ class TileAssembleDoubleLoopBroadcastProgram:
         src: pl.Tensor[[16, 16], pl.FP32],
         y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        y = self.tile_assemble(x, src, y)
-        return y
+        y_ret = self.tile_assemble(x, src, y)
+        return y_ret
 
 
 if __name__ == "__main__":

--- a/examples/models/01_ffn.py
+++ b/examples/models/01_ffn.py
@@ -79,13 +79,13 @@ class FFNGeluProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         # gate = hidden_states @ gate_proj_weight
         gate = pl.create_tensor([64, 64], dtype=pl.FP32)
-        gate = matmul_kernel(hidden_states, gate_proj_weight, gate)
+        gate_done = matmul_kernel(hidden_states, gate_proj_weight, gate)
         # activated = GELU(gate)
         activated = pl.create_tensor([64, 64], dtype=pl.FP32)
-        activated = self.gelu_kernel(gate, activated)
+        activated_done = self.gelu_kernel(gate_done, activated)
         # output = activated @ down_proj_weight
-        output = matmul_kernel(activated, down_proj_weight, output)
-        return output
+        output_done = matmul_kernel(activated_done, down_proj_weight, output)
+        return output_done
 
 
 # ── FFN with SwiGLU activation ───────────────────────────────────────────────
@@ -123,16 +123,16 @@ class FFNSwigluProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         # gate = hidden_states @ gate_proj_weight
         gate = pl.create_tensor([64, 64], dtype=pl.FP32)
-        gate = matmul_kernel(hidden_states, gate_proj_weight, gate)
+        gate_done = matmul_kernel(hidden_states, gate_proj_weight, gate)
         # up = hidden_states @ up_proj_weight
         up = pl.create_tensor([64, 64], dtype=pl.FP32)
-        up = matmul_kernel(hidden_states, up_proj_weight, up)
+        up_done = matmul_kernel(hidden_states, up_proj_weight, up)
         # activated = SwiGLU(gate, up)
         activated = pl.create_tensor([64, 64], dtype=pl.FP32)
-        activated = self.swiglu_kernel(gate, up, activated)
+        activated_done = self.swiglu_kernel(gate_done, up_done, activated)
         # output = activated @ down_proj_weight
-        output = matmul_kernel(activated, down_proj_weight, output)
-        return output
+        output_done = matmul_kernel(activated_done, down_proj_weight, output)
+        return output_done
 
 
 # ── FFN with ReLU activation ─────────────────────────────────────────────────
@@ -162,13 +162,13 @@ class FFNReluProgram:
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         # gate = hidden_states @ gate_proj_weight
         gate = pl.create_tensor([64, 64], dtype=pl.FP32)
-        gate = matmul_kernel(hidden_states, gate_proj_weight, gate)
+        gate_done = matmul_kernel(hidden_states, gate_proj_weight, gate)
         # activated = ReLU(gate)
         activated = pl.create_tensor([64, 64], dtype=pl.FP32)
-        activated = self.relu_kernel(gate, activated)
+        activated_done = self.relu_kernel(gate_done, activated)
         # output = activated @ down_proj_weight
-        output = matmul_kernel(activated, down_proj_weight, output)
-        return output
+        output_done = matmul_kernel(activated_done, down_proj_weight, output)
+        return output_done
 
 
 if __name__ == "__main__":

--- a/examples/models/02_vector_dag.py
+++ b/examples/models/02_vector_dag.py
@@ -103,15 +103,15 @@ class VectorDAGProgram:
         t4: f = kernel_add(g, c)
         """
         c = pl.create_tensor([128, 128], dtype=pl.FP32)
-        c = self.kernel_add(a, b, c)
+        c_done = self.kernel_add(a, b, c)
         d = pl.create_tensor([128, 128], dtype=pl.FP32)
-        d = self.kernel_add_scalar(c, 1.0, d)
+        d_done = self.kernel_add_scalar(c_done, 1.0, d)
         e = pl.create_tensor([128, 128], dtype=pl.FP32)
-        e = self.kernel_add_scalar(c, 2.0, e)
+        e_done = self.kernel_add_scalar(c_done, 2.0, e)
         g = pl.create_tensor([128, 128], dtype=pl.FP32)
-        g = self.kernel_mul(d, e, g)
-        f = self.kernel_add(g, c, f)
-        return f
+        g_done = self.kernel_mul(d_done, e_done, g)
+        f_ret = self.kernel_add(g_done, c_done, f)
+        return f_ret
 
 
 @pl.program
@@ -171,13 +171,13 @@ class ExampleOrchProgram:
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         """Orchestration: f = (a + b + 1)(a + b + 2)"""
         c = pl.create_tensor([16, 16], dtype=pl.FP32)
-        c = self.kernel_add(a, b, c)
+        c_done = self.kernel_add(a, b, c)
         d = pl.create_tensor([16, 16], dtype=pl.FP32)
-        d = self.kernel_add_scalar(c, 1.0, d)
+        d_done = self.kernel_add_scalar(c_done, 1.0, d)
         e = pl.create_tensor([16, 16], dtype=pl.FP32)
-        e = self.kernel_add_scalar(c, 2.0, e)
-        f_result = self.kernel_mul(d, e, f_result)
-        return f_result
+        e_done = self.kernel_add_scalar(c_done, 2.0, e)
+        f_result_ret = self.kernel_mul(d_done, e_done, f_result)
+        return f_result_ret
 
 
 def golden(tensors: dict, params: dict | None = None) -> None:

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -50,6 +50,7 @@ enum class IRProperty : uint64_t {
   VectorKernelSplit,        ///< AIV functions with split mode have tpop shapes and store offsets adjusted
   OutParamNotShadowed,      ///< Out/InOut params are not reassigned with tensor-creating ops
   NoNestedInCore,           ///< No nested InCore scopes (ScopeStmt inside ScopeStmt)
+  InOutUseValid,            ///< No reads of InOut/Out-passed variables after the call (RFC #1026)
   kCount                    ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
+++ b/include/pypto/ir/transforms/utils/stmt_dependency_analysis.h
@@ -16,6 +16,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "pypto/core/error.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 
@@ -76,6 +77,23 @@ struct StmtDependencyGraph {
  *         carries the full set of diagnostics with precise source locations.
  */
 void CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program);
+
+/**
+ * @brief Collect (without throwing) all InOut-use discipline violations.
+ *
+ * Same analysis as `CheckInOutUseDiscipline` but returns the diagnostics
+ * instead of throwing. Used by the structural property verifier
+ * (`InOutUseValid`) so the registry can aggregate diagnostics across
+ * multiple verifiers before raising.
+ *
+ * @param region The region (typically a SeqStmts) to scan.
+ * @param program The program — used to resolve callees to their parameter
+ *                directions. May be null; in that case all calls are
+ *                treated as built-ins (no contributions to the dead set).
+ * @return Vector of diagnostics; empty when the region conforms.
+ */
+std::vector<Diagnostic> CollectInOutUseDisciplineDiagnostics(const StmtPtr& region,
+                                                             const ProgramPtr& program);
 
 /**
  * @brief Build the statement dependency graph for a region.

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -221,6 +221,18 @@ PropertyVerifierPtr CreateOutParamNotShadowedPropertyVerifier();
  */
 PropertyVerifierPtr CreateNoNestedIncorePropertyVerifier();
 
+/**
+ * @brief Factory function for creating InOutUseValid property verifier
+ *
+ * Verifies the InOut-use discipline (RFC #1026): no statement reachable in CFG
+ * order from a user-function call that passes variable `v` as InOut or Out may
+ * read `v`. Post-mutation values must flow through the call's return slots.
+ * Built-in ops (tile.*, tensor.*, system.*) are out of scope — their memory
+ * effects are handled separately.
+ * @return Shared pointer to InOutUseValid PropertyVerifier
+ */
+PropertyVerifierPtr CreateInOutUseValidPropertyVerifier();
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -63,6 +63,8 @@ std::string IRPropertyToString(IRProperty prop) {
       return "OutParamNotShadowed";
     case IRProperty::NoNestedInCore:
       return "NoNestedInCore";
+    case IRProperty::InOutUseValid:
+      return "InOutUseValid";
     default:
       return "Unknown";
   }
@@ -103,7 +105,8 @@ const IRPropertySet& GetVerifiedProperties() {
                                    IRProperty::MixedKernelExpanded,
                                    IRProperty::AllocatedMemoryAddr,
                                    IRProperty::BreakContinueValid,
-                                   IRProperty::NoRedundantBlocks};
+                                   IRProperty::NoRedundantBlocks,
+                                   IRProperty::InOutUseValid};
   return props;
 }
 
@@ -129,7 +132,8 @@ VerificationLevel GetDefaultVerificationLevel() {
 const IRPropertySet& GetStructuralProperties() {
   static const IRPropertySet props{IRProperty::TypeChecked,         IRProperty::BreakContinueValid,
                                    IRProperty::NoRedundantBlocks,   IRProperty::UseAfterDef,
-                                   IRProperty::OutParamNotShadowed, IRProperty::NoNestedInCore};
+                                   IRProperty::OutParamNotShadowed, IRProperty::NoNestedInCore,
+                                   IRProperty::InOutUseValid};
   return props;
 }
 

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -157,8 +157,14 @@ class InOutUseDisciplineChecker : public IRVisitor {
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
-    // LHS (`op->var_`) is a definition — skip it. Only the RHS is a read.
+    // RHS is read first (the call's args are evaluated before the assignment
+    // takes effect). Then LHS is a re-definition — clear the var from dead_
+    // so subsequent reads see the (re-)bound value, not the pre-call one.
     VisitExpr(op->value_);
+    if (op->var_) {
+      dead_.erase(op->var_.get());
+      dead_origin_.erase(op->var_.get());
+    }
   }
 
   void VisitStmt_(const IfStmtPtr& op) override {
@@ -196,12 +202,25 @@ class InOutUseDisciplineChecker : public IRVisitor {
     // `loop_var_`, `iter_args_` themselves, and `return_vars_` are definitions
     // at the loop header — skip them.
 
-    // Back-edge modelling: any kill anywhere in the body is reachable from
-    // iteration N's tail to iteration N+1's start, so the var must be dead
-    // at body entry for the subsequent iteration's reads to be flagged.
-    // Pre-populate `dead_` with the body's kills, then walk the body.
-    CollectKillsInto(op->body_, dead_, dead_origin_);
+    // Back-edge modelling: any kill in the body is reachable from iteration N
+    // to iteration N+1's start, so the killed var must be dead at body entry
+    // for subsequent iterations' reads to be flagged. Exclude vars that are
+    // re-bound each iteration: iter_args (back-edge re-defines them) and any
+    // var with an AssignStmt LHS inside the body (the assignment re-defines
+    // before any read could see the dead pre-call value).
+    auto exclude = CollectRebindings(op);
+    CollectKillsInto(op->body_, dead_, dead_origin_, exclude);
     VisitStmt(op->body_);
+    // After the loop completes, iter_args go out of scope. Their dead state
+    // is local to this loop's iterations and must not leak to enclosing
+    // scopes (where they would be falsely flagged on the enclosing loop's
+    // back-edge pre-population walk).
+    for (const auto& ia : op->iter_args_) {
+      if (ia) {
+        dead_.erase(ia.get());
+        dead_origin_.erase(ia.get());
+      }
+    }
   }
 
   void VisitStmt_(const WhileStmtPtr& op) override {
@@ -210,21 +229,67 @@ class InOutUseDisciplineChecker : public IRVisitor {
       if (ia->initValue_) VisitExpr(ia->initValue_);
     }
     // `iter_args_` and `return_vars_` are definitions — skip them.
-    CollectKillsInto(op->body_, dead_, dead_origin_);
+    auto exclude = CollectRebindings(op);
+    CollectKillsInto(op->body_, dead_, dead_origin_, exclude);
     VisitStmt(op->body_);
+    for (const auto& ia : op->iter_args_) {
+      if (ia) {
+        dead_.erase(ia.get());
+        dead_origin_.erase(ia.get());
+      }
+    }
   }
 
  private:
+  /// Collect vars that are re-bound each iteration of the given loop:
+  ///   - iter_args (re-defined via the back-edge)
+  ///   - any var that appears as an AssignStmt LHS in the body
+  /// These vars should NOT be added to the back-edge dead set, because the
+  /// re-binding gives reads in the next iteration a fresh value.
+  template <typename LoopPtr>
+  std::unordered_set<const Var*> CollectRebindings(const LoopPtr& op) const {
+    std::unordered_set<const Var*> result;
+    for (const auto& ia : op->iter_args_) {
+      if (ia) result.insert(ia.get());
+    }
+    if (op->body_) CollectAssignedVars(op->body_, result);
+    return result;
+  }
+
+  /// Walk a subtree and add every AssignStmt's LHS var to `out`.
+  void CollectAssignedVars(const StmtPtr& stmt, std::unordered_set<const Var*>& out) const {
+    class Walker : public IRVisitor {
+     public:
+      explicit Walker(std::unordered_set<const Var*>& out) : out_(out) {}
+      void VisitStmt_(const AssignStmtPtr& op) override {
+        if (op->var_) out_.insert(op->var_.get());
+        IRVisitor::VisitStmt_(op);
+      }
+
+     private:
+      std::unordered_set<const Var*>& out_;
+    };
+    Walker w(out);
+    w.VisitStmt(stmt);
+  }
+
   /// Pre-scan a subtree and merge every var it would mark InOut/Out-dead into
-  /// `dead` (with origin span recorded in `origin`). Uses a fresh sub-checker
+  /// `dead` (with origin span recorded in `origin`). Vars listed in `exclude`
+  /// are skipped — used to drop iter_args vars from the back-edge dead set
+  /// (the back-edge re-defines them each iteration). Uses a fresh sub-checker
   /// so the main walk's state and diagnostics are untouched.
   void CollectKillsInto(const StmtPtr& stmt, std::unordered_set<const Var*>& dead,
-                        std::unordered_map<const Var*, Span>& origin) const {
+                        std::unordered_map<const Var*, Span>& origin,
+                        const std::unordered_set<const Var*>& exclude) const {
     if (!stmt) return;
     InOutUseDisciplineChecker sub(program_);
     sub.VisitStmt(stmt);
-    dead.insert(sub.dead_.begin(), sub.dead_.end());
+    for (const Var* v : sub.dead_) {
+      if (exclude.count(v) != 0) continue;
+      dead.insert(v);
+    }
     for (const auto& [v, span] : sub.dead_origin_) {
+      if (exclude.count(v) != 0) continue;
       origin.emplace(v, span);
     }
     // Sub-diagnostics are intentionally discarded: this is a precondition
@@ -240,11 +305,16 @@ class InOutUseDisciplineChecker : public IRVisitor {
 
 }  // namespace
 
-void CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program) {
-  if (!region) return;
+std::vector<Diagnostic> CollectInOutUseDisciplineDiagnostics(const StmtPtr& region,
+                                                             const ProgramPtr& program) {
+  if (!region) return {};
   InOutUseDisciplineChecker checker(program);
   checker.VisitStmt(region);
-  auto diagnostics = checker.TakeDiagnostics();
+  return checker.TakeDiagnostics();
+}
+
+void CheckInOutUseDiscipline(const StmtPtr& region, const ProgramPtr& program) {
+  auto diagnostics = CollectInOutUseDisciplineDiagnostics(region, program);
   if (diagnostics.empty()) return;
 
   std::string report = PropertyVerifierRegistry::GenerateReport(diagnostics);

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -204,11 +204,14 @@ class InOutUseDisciplineChecker : public IRVisitor {
 
     // Back-edge modelling: any kill in the body is reachable from iteration N
     // to iteration N+1's start, so the killed var must be dead at body entry
-    // for subsequent iterations' reads to be flagged. Exclude vars that are
-    // re-bound each iteration: iter_args (back-edge re-defines them) and any
-    // var with an AssignStmt LHS inside the body (the assignment re-defines
-    // before any read could see the dead pre-call value).
-    auto exclude = CollectRebindings(op);
+    // for subsequent iterations' reads to be flagged. Exclude only iter_args,
+    // which the loop header explicitly re-defines on each back-edge. Do not
+    // exclude arbitrary AssignStmt LHS vars in the body: such a rebind may be
+    // conditional or may occur after a read earlier in the iteration, and
+    // excluding them would hide real dead-use reports. When a rebind does
+    // execute before any read, `VisitStmt_(AssignStmtPtr)` erases the var
+    // from `dead_` at that point, so no false positive results.
+    auto exclude = CollectIterArgs(op);
     CollectKillsInto(op->body_, dead_, dead_origin_, exclude);
     VisitStmt(op->body_);
     // After the loop completes, iter_args go out of scope. Their dead state
@@ -229,7 +232,7 @@ class InOutUseDisciplineChecker : public IRVisitor {
       if (ia->initValue_) VisitExpr(ia->initValue_);
     }
     // `iter_args_` and `return_vars_` are definitions — skip them.
-    auto exclude = CollectRebindings(op);
+    auto exclude = CollectIterArgs(op);
     CollectKillsInto(op->body_, dead_, dead_origin_, exclude);
     VisitStmt(op->body_);
     for (const auto& ia : op->iter_args_) {
@@ -241,36 +244,16 @@ class InOutUseDisciplineChecker : public IRVisitor {
   }
 
  private:
-  /// Collect vars that are re-bound each iteration of the given loop:
-  ///   - iter_args (re-defined via the back-edge)
-  ///   - any var that appears as an AssignStmt LHS in the body
-  /// These vars should NOT be added to the back-edge dead set, because the
-  /// re-binding gives reads in the next iteration a fresh value.
+  /// Collect the loop's iter_args — vars re-defined by the loop header on each
+  /// back-edge. These must be excluded from the back-edge dead set because the
+  /// header re-binds them before any body statement can observe a dead value.
   template <typename LoopPtr>
-  std::unordered_set<const Var*> CollectRebindings(const LoopPtr& op) const {
+  std::unordered_set<const Var*> CollectIterArgs(const LoopPtr& op) const {
     std::unordered_set<const Var*> result;
     for (const auto& ia : op->iter_args_) {
       if (ia) result.insert(ia.get());
     }
-    if (op->body_) CollectAssignedVars(op->body_, result);
     return result;
-  }
-
-  /// Walk a subtree and add every AssignStmt's LHS var to `out`.
-  void CollectAssignedVars(const StmtPtr& stmt, std::unordered_set<const Var*>& out) const {
-    class Walker : public IRVisitor {
-     public:
-      explicit Walker(std::unordered_set<const Var*>& out) : out_(out) {}
-      void VisitStmt_(const AssignStmtPtr& op) override {
-        if (op->var_) out_.insert(op->var_.get());
-        IRVisitor::VisitStmt_(op);
-      }
-
-     private:
-      std::unordered_set<const Var*>& out_;
-    };
-    Walker w(out);
-    w.VisitStmt(stmt);
   }
 
   /// Pre-scan a subtree and merge every var it would mark InOut/Out-dead into

--- a/src/ir/verifier/property_verifier_registry.cpp
+++ b/src/ir/verifier/property_verifier_registry.cpp
@@ -58,6 +58,7 @@ PropertyVerifierRegistry::PropertyVerifierRegistry() {
   Register(IRProperty::StructuredCtrlFlow, CreateStructuredCtrlFlowPropertyVerifier);
   Register(IRProperty::OutParamNotShadowed, CreateOutParamNotShadowedPropertyVerifier);
   Register(IRProperty::NoNestedInCore, CreateNoNestedIncorePropertyVerifier);
+  Register(IRProperty::InOutUseValid, CreateInOutUseValidPropertyVerifier);
 }
 
 void PropertyVerifierRegistry::Register(IRProperty prop, std::function<PropertyVerifierPtr()> factory) {

--- a/src/ir/verifier/verify_inout_use.cpp
+++ b/src/ir/verifier/verify_inout_use.cpp
@@ -50,6 +50,9 @@ class InOutUseValidPropertyVerifierImpl : public PropertyVerifier {
       if (!func || !func->body_) continue;
       if (func->func_type_ == FunctionType::Group) continue;
       auto func_diags = stmt_dep::CollectInOutUseDisciplineDiagnostics(func->body_, program);
+      // NOTE: cannot use vector::insert with make_move_iterator here —
+      // Diagnostic holds a Span with const members, so its move-assignment is
+      // deleted. push_back only requires move-construction, which is fine.
       for (auto& d : func_diags) {
         diagnostics.push_back(std::move(d));
       }

--- a/src/ir/verifier/verify_inout_use.cpp
+++ b/src/ir/verifier/verify_inout_use.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/transforms/utils/stmt_dependency_analysis.h"
+#include "pypto/ir/verifier/verifier.h"
+
+namespace pypto {
+namespace ir {
+
+/**
+ * @brief InOutUseValid property verifier (RFC #1026).
+ *
+ * Walks every function body and applies the InOut-use discipline:
+ * a variable passed as an InOut or Out argument to a user-function call is
+ * dead for reads from the call onward (CFG order, within the same scope).
+ * The walk is shared with `BuildStmtDependencyGraph`'s precondition check —
+ * see `CollectInOutUseDisciplineDiagnostics` in stmt_dependency_analysis.cpp
+ * for the visitor implementation.
+ *
+ * Group-typed functions are skipped: they orchestrate parallel AIC/AIV calls
+ * that intentionally share the same Out tensor, which the discipline (as
+ * stated in RFC #1026) does not yet model. Treating Group bodies as opaque
+ * here keeps the verifier useful for the common case while a follow-up
+ * extends the rule to parallel-call constructs.
+ */
+class InOutUseValidPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "InOutUseValid"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+
+    for (const auto& [global_var, func] : program->functions_) {
+      if (!func || !func->body_) continue;
+      if (func->func_type_ == FunctionType::Group) continue;
+      auto func_diags = stmt_dep::CollectInOutUseDisciplineDiagnostics(func->body_, program);
+      for (auto& d : func_diags) {
+        diagnostics.push_back(std::move(d));
+      }
+    }
+  }
+};
+
+PropertyVerifierPtr CreateInOutUseValidPropertyVerifier() {
+  return std::make_shared<InOutUseValidPropertyVerifierImpl>();
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1225,8 +1225,8 @@ class TestOrchestration:
             ) -> pl.Tensor[[4, 8], pl.FP32]:
                 for r in pl.range(4):
                     row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
-                    row = self.fill_row(x, r, row)
-                    out = pl.assemble(out, row, [r, 0])
+                    row_done = self.fill_row(x, r, row)
+                    out = pl.assemble(out, row_done, [r, 0])
                 return out
 
         pm = PassManager.get_strategy(OptimizationStrategy.Default)


### PR DESCRIPTION
## Summary

- Adds `InOutUseValid` as a structural `IRProperty` and registers a `PropertyVerifier` for it, so the RFC #1026 InOut-use discipline is enforced at pipeline start (`PassPipeline`) and before/after every pass (`VerificationInstrument`).
- Splits `stmt_dep::CheckInOutUseDiscipline` into a non-throwing `CollectInOutUseDisciplineDiagnostics` entry point that the verifier reuses, and refines the back-edge model so legitimate per-iteration rebinding (loop `iter_args` and `AssignStmt` LHSs inside the body) is no longer flagged.
- Scrubs `iter_args` from the dead set after each loop so inner-loop state does not leak to the enclosing scope.
- Migrates affected `examples/` and one orchestration test fixture to the new discipline (renaming post-call rebinds such as `out_c = self.kernel(..., out_c)` -> `out_c_ret = ...`).

## Known limitation

`ExpandMixedKernel` produces `Group`-typed function bodies that share the same Out tensor across the AIC and AIV calls without threading SSA versions. The verifier currently skips `Group` function bodies as a workaround; a follow-up should thread return values through AIC -> Group -> AIV so the discipline covers them.

## Test plan

- [x] `cmake --build build --parallel` (clean build, no warnings)
- [x] `python -m pytest tests/ut/ -n auto --maxprocesses 8` — 3573 passed, 16 skipped (no regressions)
- [x] `python tests/lint/clang_tidy.py --diff-base HEAD` — clean
- [x] Pre-commit hooks (clang-format, ruff, pyright, markdownlint) — all green

## Related Issues

Refs #1028
RFC #1026