### PR TITLE
fix(ir): Propagate parent strides to InCore In params for sliced tensors

### DIFF
--- a/docs/en/dev/passes/10-optimize_orch_tensors.md
+++ b/docs/en/dev/passes/10-optimize_orch_tensors.md
@@ -29,7 +29,7 @@ program_opt = opt_pass(program)
 
 ## Patterns
 
-The pass applies three patterns in sequence. Each pattern sees the results of the previous one.
+The pass applies four patterns in sequence. Each pattern sees the results of the previous one.
 
 ### Pattern 1: Iter-Arg Reuse (IterArgReuseOptimizer)
 
@@ -59,6 +59,12 @@ for i in pl.range(N, init_values=[init_buf]):
 **Problem**: When orchestration scatters InCore results into a larger tensor via `tensor.assemble`, the InCore function's `tile.store` doesn't know the parent tensor's strides, which can lead to suboptimal memory layout.
 
 **Solution**: Analyze `tensor.assemble(parent, incore_result, offset)` patterns in orchestration. Attach the parent tensor's shape as `TensorView` strides on the InCore function's `Out` param type, so `tile.store` can use the correct memory layout.
+
+### Pattern 4: Slice Input Strides (SliceInputStridesOptimizer)
+
+**Problem**: When orchestration passes a sliced tensor (`tensor.slice`) as an `In` argument to an InCore function, the InCore function's parameter has contiguous strides (computed from its own shape), not the parent tensor's strides. This causes incorrect memory access when the slice is a non-contiguous view of the parent.
+
+**Solution**: Analyze `tensor.slice(parent, size, offset)` patterns in orchestration. When a slice result is passed as an `In` argument to an InCore call, attach the parent tensor's shape-derived strides via `TensorView` on the InCore function's `In` param type, so `tile.load` uses the correct memory layout.
 
 ### Pattern 3: Assemble-Loop Rewrite (AssembleLoopRewriter)
 
@@ -136,13 +142,15 @@ The `tensor.create` is eliminated; the iter-arg buffer is reused across iteratio
 | --------- | ---- |
 | `IterArgReuseOptimizer` | Pattern 1 — merges Out params into In params for loop-carried buffers |
 | `AssembleParentStridesOptimizer` | Pattern 2 — attaches parent strides via TensorView |
+| `SliceInputStridesOptimizer` | Pattern 4 — attaches parent strides to In params via TensorView for slice patterns |
 | `AssembleLoopRewriter` | Pattern 3 — rewrites tile.assemble loops to tile.store loops |
 | `BuildOutParamReturnMappings` | Shared helper — maps Out params to return indices via tile.store |
+| `ComputeRowMajorStrides` | Shared helper — computes row-major strides from a shape |
 
 ## Scope
 
 | Function type | Action |
 | ------------- | ------ |
-| InCore | Params/body rewritten (Patterns 1, 3) |
+| InCore | Params/body rewritten (Patterns 1, 3, 4) |
 | Orchestration / Opaque | Call sites rewritten (Patterns 1, 2) |
 | Group | Unchanged |

--- a/docs/zh-cn/dev/passes/10-optimize_orch_tensors.md
+++ b/docs/zh-cn/dev/passes/10-optimize_orch_tensors.md
@@ -29,7 +29,7 @@ program_opt = opt_pass(program)
 
 ## 优化模式
 
-本 pass 按顺序应用三个模式。每个模式可以看到前一个模式的结果。
+本 pass 按顺序应用四个模式。每个模式可以看到前一个模式的结果。
 
 ### 模式 1：迭代参数复用（IterArgReuseOptimizer）
 
@@ -59,6 +59,12 @@ for i in pl.range(N, init_values=[init_buf]):
 **问题**：当编排函数通过 `tensor.assemble` 将 InCore 结果分散到更大的张量时，InCore 函数的 `tile.store` 不知道父张量的步长，可能导致次优的内存布局。
 
 **方案**：分析编排函数中的 `tensor.assemble(parent, incore_result, offset)` 模式，将父张量的形状作为 `TensorView` 步长附加到 InCore 函数的 `Out` 参数类型上，使 `tile.store` 能使用正确的内存布局。
+
+### 模式 4：切片输入步长（SliceInputStridesOptimizer）
+
+**问题**：当编排函数将切片张量（`tensor.slice`）作为 `In` 参数传递给 InCore 函数时，InCore 函数的参数使用连续步长（从自身形状计算），而非父张量的步长。当切片是父张量的非连续视图时，这会导致错误的内存访问。
+
+**方案**：分析编排函数中的 `tensor.slice(parent, size, offset)` 模式。当切片结果作为 `In` 参数传递给 InCore 调用时，将父张量形状推导出的步长通过 `TensorView` 附加到 InCore 函数的 `In` 参数类型上，使 `tile.load` 能使用正确的内存布局。
 
 ### 模式 3：Assemble 循环重写（AssembleLoopRewriter）
 
@@ -136,13 +142,15 @@ class After:
 | ---- | ---- |
 | `IterArgReuseOptimizer` | 模式 1 — 合并 Out 参数到 In 参数以复用循环携带缓冲区 |
 | `AssembleParentStridesOptimizer` | 模式 2 — 通过 TensorView 附加父张量步长 |
+| `SliceInputStridesOptimizer` | 模式 4 — 通过 TensorView 为切片输入的 In 参数附加父张量步长 |
 | `AssembleLoopRewriter` | 模式 3 — 将 tile.assemble 循环重写为 tile.store 循环 |
 | `BuildOutParamReturnMappings` | 共享辅助函数 — 通过 tile.store 映射 Out 参数到返回索引 |
+| `ComputeRowMajorStrides` | 共享辅助函数 — 从形状计算行主序步长 |
 
 ## 作用范围
 
 | 函数类型 | 操作 |
 | -------- | ---- |
-| InCore | 参数/函数体重写（模式 1、3） |
+| InCore | 参数/函数体重写（模式 1、3、4） |
 | Orchestration / Opaque | 调用点重写（模式 1、2） |
 | Group | 不变 |

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -62,6 +62,27 @@ std::string GetCallFuncName(const CallPtr& call) {
   return gvar ? gvar->name_ : "";
 }
 
+/// Compute row-major strides from a shape: [D1*D2*...*Dn, D2*...*Dn, ..., 1].
+/// Returns empty vector if any dimension is not a ConstInt.
+std::vector<ExprPtr> ComputeRowMajorStrides(const std::vector<ExprPtr>& shape) {
+  std::vector<int64_t> dims;
+  dims.reserve(shape.size());
+  for (const auto& dim : shape) {
+    auto ci = As<ConstInt>(dim);
+    if (!ci) return {};
+    dims.push_back(ci->value_);
+  }
+
+  size_t ndim = dims.size();
+  std::vector<ExprPtr> strides(ndim);
+  int64_t product = 1;
+  for (size_t i = ndim; i > 0; --i) {
+    strides[i - 1] = std::make_shared<ConstInt>(product, DataType::INDEX, Span::unknown());
+    product *= dims[i - 1];
+  }
+  return strides;
+}
+
 /// Info about an InCore function's Out params and their return mappings.
 struct OutParamReturnMapping {
   size_t param_index;   ///< Position in param list
@@ -951,24 +972,8 @@ class AssembleParentStridesOptimizer {
     return analyzer.result();
   }
 
-  /// Compute row-major strides from a shape: [D1*D2*...*Dn, D2*...*Dn, ..., 1].
   static std::vector<ExprPtr> ComputeStrides(const std::vector<ExprPtr>& shape) {
-    std::vector<int64_t> dims;
-    dims.reserve(shape.size());
-    for (const auto& dim : shape) {
-      auto ci = As<ConstInt>(dim);
-      if (!ci) return {};
-      dims.push_back(ci->value_);
-    }
-
-    size_t ndim = dims.size();
-    std::vector<ExprPtr> strides(ndim);
-    int64_t product = 1;
-    for (size_t i = ndim; i > 0; --i) {
-      strides[i - 1] = std::make_shared<ConstInt>(product, DataType::INDEX, Span::unknown());
-      product *= dims[i - 1];
-    }
-    return strides;
+    return ComputeRowMajorStrides(shape);
   }
 
   // -- Mutation: IRMutator that propagates updated param types through tile.store --
@@ -1458,6 +1463,191 @@ class AssembleLoopRewriter {
   }
 };
 
+// ============================================================================
+// Pattern 4: SliceInputStridesOptimizer
+//
+// Cross-function analysis: scans orchestration for
+//   tensor.slice(parent, size, offset)
+// where the slice result is passed as an In argument to an InCore call.
+// Records the parent tensor's shape. Then updates the InCore function's
+// In param TensorType to carry parent-derived strides via TensorView.
+// ============================================================================
+
+class SliceInputStridesOptimizer {
+ public:
+  ProgramPtr Run(const ProgramPtr& program, const std::unordered_set<std::string>& incore_names) {
+    auto input_shapes = Analyze(program, incore_names);
+    if (input_shapes.empty()) return program;
+
+    std::vector<FunctionPtr> new_functions;
+    for (const auto& [gvar, func] : program->functions_) {
+      new_functions.push_back(func);
+    }
+
+    Apply(new_functions, incore_names, input_shapes);
+
+    return std::make_shared<Program>(new_functions, program->name_, program->span_);
+  }
+
+ private:
+  // func_name -> { param_index -> parent_shape }
+  using InputShapeMap = std::unordered_map<std::string, std::unordered_map<size_t, std::vector<ExprPtr>>>;
+
+  // Sentinel: when a param_index maps to this, the parent shapes from
+  // different call sites disagree and the optimization must be skipped.
+  static const std::vector<ExprPtr>& ConflictMarker() {
+    static const std::vector<ExprPtr> marker;
+    return marker;
+  }
+
+  static bool ShapesMatch(const std::vector<ExprPtr>& a, const std::vector<ExprPtr>& b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+      auto ca = As<ConstInt>(a[i]);
+      auto cb = As<ConstInt>(b[i]);
+      if (!ca || !cb || ca->value_ != cb->value_) return false;
+    }
+    return true;
+  }
+
+  class SliceAnalyzer : public IRVisitor {
+   public:
+    SliceAnalyzer(const ProgramPtr& program, const std::unordered_set<std::string>& incore_names)
+        : program_(program), incore_names_(incore_names) {}
+
+    const InputShapeMap& result() const { return result_; }
+
+   protected:
+    void VisitStmt_(const AssignStmtPtr& op) override {
+      auto call = As<Call>(op->value_);
+      if (!call) return;
+
+      // Track tensor.slice(parent, size, offset) results
+      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && call->op_->name_ == "tensor.slice" &&
+          call->args_.size() >= 3) {
+        auto parent_var = AsVarLike(call->args_[0]);
+        if (parent_var) {
+          auto parent_tensor_type = As<TensorType>(parent_var->GetType());
+          if (parent_tensor_type) {
+            var_to_parent_shape_[op->var_.get()] = parent_tensor_type->shape_;
+          }
+        }
+        return;
+      }
+
+      // Check InCore calls: map sliced In arguments to parent shapes
+      auto fname = GetCallFuncName(call);
+      if (!incore_names_.count(fname)) return;
+
+      auto incore_func = FindFunction(program_, fname);
+      if (!incore_func) return;
+
+      for (size_t i = 0; i < call->args_.size() && i < incore_func->param_directions_.size(); ++i) {
+        if (incore_func->param_directions_[i] != ParamDirection::In) continue;
+
+        auto arg_var = AsVarLike(call->args_[i]);
+        if (!arg_var) continue;
+
+        auto it = var_to_parent_shape_.find(arg_var.get());
+        if (it == var_to_parent_shape_.end()) continue;
+
+        auto& entry = result_[fname][i];
+        if (entry.empty() && &entry != &ConflictMarker()) {
+          entry = it->second;
+        } else if (!entry.empty() && !ShapesMatch(entry, it->second)) {
+          entry.clear();  // conflict — different parent shapes at different call sites
+        }
+      }
+    }
+
+   private:
+    const ProgramPtr& program_;
+    const std::unordered_set<std::string>& incore_names_;
+    std::unordered_map<const Var*, std::vector<ExprPtr>> var_to_parent_shape_;
+    InputShapeMap result_;
+  };
+
+  InputShapeMap Analyze(const ProgramPtr& program, const std::unordered_set<std::string>& incore_names) {
+    SliceAnalyzer analyzer(program, incore_names);
+    for (const auto& [gvar, func] : program->functions_) {
+      if (incore_names.count(func->name_)) continue;
+      analyzer.VisitStmt(func->body_);
+    }
+    return analyzer.result();
+  }
+
+  class InParamSubstitutionMutator : public IRMutator {
+   public:
+    void AddSubstitution(const Var* old_ptr, const VarPtr& new_var) { subs_[old_ptr] = new_var; }
+
+   protected:
+    ExprPtr VisitExpr_(const VarPtr& op) override {
+      auto it = subs_.find(op.get());
+      if (it != subs_.end()) return it->second;
+      return op;
+    }
+
+   private:
+    std::unordered_map<const Var*, VarPtr> subs_;
+  };
+
+  void Apply(std::vector<FunctionPtr>& functions, const std::unordered_set<std::string>& incore_names,
+             const InputShapeMap& input_shapes) {
+    for (auto& func : functions) {
+      if (!incore_names.count(func->name_)) continue;
+
+      auto is_it = input_shapes.find(func->name_);
+      if (is_it == input_shapes.end()) continue;
+      const auto& param_idx_to_shape = is_it->second;
+
+      bool changed = false;
+      std::vector<VarPtr> new_params = func->params_;
+
+      for (const auto& [param_idx, parent_shape] : param_idx_to_shape) {
+        if (parent_shape.empty()) continue;  // conflict marker
+        if (param_idx >= func->params_.size()) continue;
+
+        auto full_strides = ComputeRowMajorStrides(parent_shape);
+        if (full_strides.empty()) continue;
+
+        auto tensor_type = As<TensorType>(func->params_[param_idx]->GetType());
+        if (!tensor_type) continue;
+
+        // Skip params that already have explicit strides
+        if (tensor_type->tensor_view_.has_value() && !tensor_type->tensor_view_->stride.empty()) continue;
+
+        size_t in_rank = tensor_type->shape_.size();
+        if (in_rank > full_strides.size()) continue;
+        std::vector<ExprPtr> strides(full_strides.end() - static_cast<std::ptrdiff_t>(in_rank),
+                                     full_strides.end());
+
+        TensorView view(std::move(strides), TensorLayout::ND);
+        auto new_type = std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_,
+                                                     tensor_type->memref_, std::move(view));
+        auto new_param = std::make_shared<Var>(func->params_[param_idx]->name_hint_, new_type,
+                                               func->params_[param_idx]->span_);
+
+        changed = true;
+        new_params[param_idx] = new_param;
+      }
+
+      if (!changed) continue;
+
+      InParamSubstitutionMutator mutator;
+      for (size_t i = 0; i < func->params_.size(); ++i) {
+        if (new_params[i].get() != func->params_[i].get()) {
+          mutator.AddSubstitution(func->params_[i].get(), new_params[i]);
+        }
+      }
+      auto new_body = mutator.VisitStmt(func->body_);
+
+      func = std::make_shared<Function>(func->name_, new_params, func->param_directions_, func->return_types_,
+                                        new_body, func->span_, func->func_type_, func->level_, func->role_,
+                                        func->attrs_);
+    }
+  }
+};
+
 }  // namespace
 
 // ============================================================================
@@ -1484,7 +1674,10 @@ Pass OptimizeOrchTensors() {
     auto p2 = AssembleParentStridesOptimizer().Run(p1, incore_names);
 
     // Pattern 3: Assemble-loop rewrite (sees Pattern 2 results)
-    return AssembleLoopRewriter().Run(p2, incore_names);
+    auto p3 = AssembleLoopRewriter().Run(p2, incore_names);
+
+    // Pattern 4: Slice input strides (propagate parent strides to In params)
+    return SliceInputStridesOptimizer().Run(p3, incore_names);
   };
 
   return CreateProgramPass(pass_func, "OptimizeOrchTensors", kOptimizeOrchTensorsProperties);

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -1493,13 +1493,6 @@ class SliceInputStridesOptimizer {
   // func_name -> { param_index -> parent_shape }
   using InputShapeMap = std::unordered_map<std::string, std::unordered_map<size_t, std::vector<ExprPtr>>>;
 
-  // Sentinel: when a param_index maps to this, the parent shapes from
-  // different call sites disagree and the optimization must be skipped.
-  static const std::vector<ExprPtr>& ConflictMarker() {
-    static const std::vector<ExprPtr> marker;
-    return marker;
-  }
-
   static bool ShapesMatch(const std::vector<ExprPtr>& a, const std::vector<ExprPtr>& b) {
     if (a.size() != b.size()) return false;
     for (size_t i = 0; i < a.size(); ++i) {
@@ -1551,11 +1544,15 @@ class SliceInputStridesOptimizer {
         auto it = var_to_parent_shape_.find(arg_var.get());
         if (it == var_to_parent_shape_.end()) continue;
 
+        auto conflict_key = fname + ":" + std::to_string(i);
+        if (conflicted_.count(conflict_key)) continue;
+
         auto& entry = result_[fname][i];
-        if (entry.empty() && &entry != &ConflictMarker()) {
+        if (entry.empty()) {
           entry = it->second;
-        } else if (!entry.empty() && !ShapesMatch(entry, it->second)) {
-          entry.clear();  // conflict — different parent shapes at different call sites
+        } else if (!ShapesMatch(entry, it->second)) {
+          conflicted_.insert(conflict_key);
+          entry.clear();
         }
       }
     }
@@ -1564,6 +1561,7 @@ class SliceInputStridesOptimizer {
     const ProgramPtr& program_;
     const std::unordered_set<std::string>& incore_names_;
     std::unordered_map<const Var*, std::vector<ExprPtr>> var_to_parent_shape_;
+    std::unordered_set<std::string> conflicted_;
     InputShapeMap result_;
   };
 
@@ -1604,7 +1602,7 @@ class SliceInputStridesOptimizer {
       std::vector<VarPtr> new_params = func->params_;
 
       for (const auto& [param_idx, parent_shape] : param_idx_to_shape) {
-        if (parent_shape.empty()) continue;  // conflict marker
+        if (parent_shape.empty()) continue;  // conflicted or not from slice
         if (param_idx >= func->params_.size()) continue;
 
         auto full_strides = ComputeRowMajorStrides(parent_shape);

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -693,6 +693,247 @@ class TestAssembleLoopRewrite:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestSliceInputStrides:
+    """Pattern 4: Attach parent-derived strides to In params for slice patterns."""
+
+    def test_in_param_gets_parent_stride_from_slice(self):
+        """When orch slices a 2D parent and passes result to InCore In param, param gets parent strides."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[32, 32], pl.FP32],
+                mb: pl.Scalar[pl.INDEX],
+                nb: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                a__tile: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                ret0__store: pl.Tensor[[32, 32], pl.FP32] = pl.store(a__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for mb in pl.range(0, 128, 32):
+                    for nb, (c_iter,) in pl.range(0, 128, 32, init_values=(c,)):
+                        chunk: pl.Tensor[[32, 32], pl.FP32] = pl.slice(data, [32, 32], [mb, nb])
+                        ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor([32, 32], dtype=pl.FP32)
+                        result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(chunk, mb, nb, ret0__out)
+                        c_next: pl.Tensor[[128, 128], pl.FP32] = pl.assemble(c_iter, result, [mb, nb])
+                        c_rv = pl.yield_(c_next)
+                return c_rv
+
+        # fmt: off
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[  # noqa: E501
+                    [32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
+                ],
+                mb: pl.Scalar[pl.INDEX],
+                nb: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[  # noqa: E501
+                    pl.Tensor[[32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
+                ],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                a__tile: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                ret0__store: pl.Tensor[  # noqa: E501
+                    [32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
+                ] = pl.store(a__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for mb in pl.range(0, 128, 32):
+                    for nb, (c_iter,) in pl.range(0, 128, 32, init_values=(c,)):
+                        chunk: pl.Tensor[[32, 32], pl.FP32] = pl.slice(data, [32, 32], [mb, nb])
+                        ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor(
+                            [32, 32], dtype=pl.FP32
+                        )
+                        result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(
+                            chunk, mb, nb, ret0__out
+                        )
+                        c_next: pl.Tensor[[128, 128], pl.FP32] = pl.assemble(
+                            c_iter, result, [mb, nb]
+                        )
+                        c_rv = pl.yield_(c_next)
+                return c_rv
+        # fmt: on
+
+        After = passes.optimize_orch_tensors()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_3d_parent_in_param_gets_trailing_stride(self):
+        """When parent tensor is 3D and input slice is 2D, only trailing strides are applied."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def proj_incore_0(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, 0], [16, 64])
+                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(x__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def proj(
+                self,
+                data: pl.Tensor[[4, 128, 5120], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                chunk: pl.Tensor[[16, 64], pl.FP32] = pl.slice(data, [16, 64], [0, 0, 0])
+                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(chunk, ret0__out)
+                return result
+
+        # fmt: off
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def proj_incore_0(
+                self,
+                x: pl.Tensor[  # noqa: E501
+                    [16, 64], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                ],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, 0], [16, 64])
+                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(
+                    x__tile, [0, 0], ret0__out
+                )
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def proj(
+                self,
+                data: pl.Tensor[[4, 128, 5120], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                chunk: pl.Tensor[[16, 64], pl.FP32] = pl.slice(data, [16, 64], [0, 0, 0])
+                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                    [16, 64], dtype=pl.FP32
+                )
+                result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(chunk, ret0__out)
+                return result
+        # fmt: on
+
+        After = passes.optimize_orch_tensors()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_multiple_sliced_in_params(self):
+        """Multiple In params from different parents each get correct strides."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def gemm_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.FP32],
+                b: pl.Tensor[[128, 64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                a__tile: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [0, 0], [16, 128])
+                b__tile: pl.Tile[[128, 64], pl.FP32] = pl.load(b, [0, 0], [128, 64])
+                c__tile: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(a__tile, b__tile)
+                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(c__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def gemm(
+                self,
+                attn_out: pl.Tensor[[16, 8192], pl.FP32],
+                wo: pl.Tensor[[8192, 8192], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                a_chunk: pl.Tensor[[16, 128], pl.FP32] = pl.slice(attn_out, [16, 128], [0, 0])
+                w_chunk: pl.Tensor[[128, 64], pl.FP32] = pl.slice(wo, [128, 64], [0, 0])
+                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                result: pl.Tensor[[16, 64], pl.FP32] = self.gemm_incore_0(a_chunk, w_chunk, ret0__out)
+                return result
+
+        # fmt: off
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def gemm_incore_0(
+                self,
+                a: pl.Tensor[  # noqa: E501
+                    [16, 128], pl.FP32, pl.TensorView(stride=[8192, 1], layout=pl.TensorLayout.ND)
+                ],
+                b: pl.Tensor[  # noqa: E501
+                    [128, 64], pl.FP32, pl.TensorView(stride=[8192, 1], layout=pl.TensorLayout.ND)
+                ],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                a__tile: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [0, 0], [16, 128])
+                b__tile: pl.Tile[[128, 64], pl.FP32] = pl.load(b, [0, 0], [128, 64])
+                c__tile: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(a__tile, b__tile)
+                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(
+                    c__tile, [0, 0], ret0__out
+                )
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def gemm(
+                self,
+                attn_out: pl.Tensor[[16, 8192], pl.FP32],
+                wo: pl.Tensor[[8192, 8192], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                a_chunk: pl.Tensor[[16, 128], pl.FP32] = pl.slice(
+                    attn_out, [16, 128], [0, 0]
+                )
+                w_chunk: pl.Tensor[[128, 64], pl.FP32] = pl.slice(wo, [128, 64], [0, 0])
+                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                    [16, 64], dtype=pl.FP32
+                )
+                result: pl.Tensor[[16, 64], pl.FP32] = self.gemm_incore_0(
+                    a_chunk, w_chunk, ret0__out
+                )
+                return result
+        # fmt: on
+
+        After = passes.optimize_orch_tensors()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_non_sliced_in_param_unchanged(self):
+        """In params that are not from tensor.slice remain unchanged."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[32, 32], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                x__tile: pl.Tile[[32, 32], pl.FP32] = pl.load(x, [0, 0], [32, 32])
+                ret0__store: pl.Tensor[[32, 32], pl.FP32] = pl.store(x__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor([32, 32], dtype=pl.FP32)
+                result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(data, ret0__out)
+                return result
+
+        After = passes.optimize_orch_tensors()(Before)
+        ir.assert_structural_equal(After, Before)
+
+
 class TestEdgeCases:
     """Edge cases: pass should not modify programs that don't match any pattern."""
 


### PR DESCRIPTION
Fixes #1037
When OutlineIncoreScopes promotes tensor.slice to orchestration level, InCore In params receive contiguous strides instead of parent-derived strides. Add Pattern 4 (SliceInputStridesOptimizer) to OptimizeOrchTensors pass that:
- Scans orchestration for tensor.slice(parent, ...) patterns
- Propagates parent-derived TensorView strides to InCore In params
- Validates consistent parent shapes across multiple call sites