### PR TITLE
fix(codegen): use add_inout for locally allocated Out tensors

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -131,6 +132,43 @@ class VarLineageCollector : public ir::IRVisitor {
   [[nodiscard]] const ir::Var* ResolveExpr(const ir::ExprPtr& expr) const;
 
   ir::ProgramPtr program_;
+};
+
+/**
+ * @brief Compute effective call-site parameter directions for orchestration calls
+ *
+ * Resolves the semantic mismatch between function-level ParamDirection (a property
+ * of the callee: "this function reads/writes this parameter") and orchestration
+ * call-site direction (a property of the task submission: "establish dependencies
+ * and manage memory for this buffer").
+ *
+ * Key rule: when a locally allocated tensor (from tensor.create / alloc_tensors)
+ * is passed as Out to an InCore call, the call-site direction must be InOut so
+ * that the runtime establishes WAW dependencies between tasks sharing the buffer.
+ *
+ * Uses BufferRootCollector results to trace each argument back to its buffer root
+ * and determine whether it originates from a function parameter (external) or a
+ * local tensor.create (pre-allocated).
+ */
+class CallSiteDirectionResolver : public ir::IRVisitor {
+ public:
+  CallSiteDirectionResolver(ir::ProgramPtr program,
+                            const std::unordered_map<const ir::Var*, const ir::Var*>& buffer_roots,
+                            const std::vector<ir::VarPtr>& params);
+
+  /// Per-call effective directions. Only populated for calls that need overrides
+  /// (i.e., at least one Out parameter targets a locally allocated buffer).
+  std::unordered_map<const ir::Call*, std::vector<ir::ParamDirection>> call_site_directions;
+
+ protected:
+  void VisitExpr_(const ir::CallPtr& call) override;
+
+ private:
+  [[nodiscard]] bool IsLocallyAllocated(const ir::Var* var) const;
+
+  ir::ProgramPtr program_;
+  const std::unordered_map<const ir::Var*, const ir::Var*>& buffer_roots_;
+  std::unordered_set<const ir::Var*> param_vars_;
 };
 
 /// Compute effective param directions for a Group function.

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -341,6 +341,63 @@ const Var* VarLineageCollector::ResolveExpr(const ExprPtr& expr) const {
 }
 
 // ---------------------------------------------------------------------------
+// CallSiteDirectionResolver
+// ---------------------------------------------------------------------------
+
+CallSiteDirectionResolver::CallSiteDirectionResolver(
+    ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
+    const std::vector<VarPtr>& params)
+    : program_(std::move(program)), buffer_roots_(buffer_roots) {
+  for (const auto& p : params) {
+    param_vars_.insert(p.get());
+  }
+}
+
+bool CallSiteDirectionResolver::IsLocallyAllocated(const Var* var) const {
+  auto it = buffer_roots_.find(var);
+  if (it == buffer_roots_.end()) return false;
+  const Var* root = it->second;
+  return param_vars_.count(root) == 0;
+}
+
+void CallSiteDirectionResolver::VisitExpr_(const CallPtr& call) {
+  if (IsBuiltinOp(call->op_->name_)) {
+    IRVisitor::VisitExpr_(call);
+    return;
+  }
+
+  auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+  if (!callee) {
+    IRVisitor::VisitExpr_(call);
+    return;
+  }
+
+  std::vector<ParamDirection> effective_dirs = callee->param_directions_;
+  if (callee->func_type_ == FunctionType::Group) {
+    effective_dirs = ComputeGroupEffectiveDirections(callee, program_);
+  }
+
+  bool has_override = false;
+  for (size_t i = 0; i < call->args_.size() && i < effective_dirs.size(); ++i) {
+    if (effective_dirs[i] != ParamDirection::Out) continue;
+
+    auto arg_var = AsVarLike(call->args_[i]);
+    if (!arg_var) continue;
+
+    if (IsLocallyAllocated(arg_var.get())) {
+      effective_dirs[i] = ParamDirection::InOut;
+      has_override = true;
+    }
+  }
+
+  if (has_override) {
+    call_site_directions[call.get()] = std::move(effective_dirs);
+  }
+
+  IRVisitor::VisitExpr_(call);
+}
+
+// ---------------------------------------------------------------------------
 // ComputeGroupEffectiveDirections
 // ---------------------------------------------------------------------------
 

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -373,7 +373,7 @@ void CallSiteDirectionResolver::VisitExpr_(const CallPtr& call) {
   }
 
   std::vector<ParamDirection> effective_dirs = callee->param_directions_;
-  if (callee->func_type_ == FunctionType::Group) {
+  if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
     effective_dirs = ComputeGroupEffectiveDirections(callee, program_);
   }
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -178,6 +178,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetCallToTupleKey(const std::map<const Call*, std::string>& mapping) { call_to_tuple_key_ = mapping; }
 
+  void SetCallSiteDirections(std::unordered_map<const Call*, std::vector<ParamDirection>> directions) {
+    call_site_directions_ = std::move(directions);
+  }
+
   void SetInitialIndent(int indent) { indent_ = indent; }
 
   std::string GetGeneratedCode() const { return code_.str(); }
@@ -650,6 +654,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
             << ") for callee '" << inner_callee->name_ << "'";
 
         ParamDirection dir = inner_callee->param_directions_[inner_idx];
+
+        // Apply call-site direction override: if the outer call has an override
+        // (e.g., Out→InOut for locally allocated tensors), use it.
+        auto cs_it = call_site_directions_.find(outer_call.get());
+        if (cs_it != call_site_directions_.end() && outer_idx < cs_it->second.size()) {
+          ParamDirection call_site_dir = cs_it->second[outer_idx];
+          if (dir == ParamDirection::Out && call_site_dir == ParamDirection::InOut) {
+            dir = ParamDirection::InOut;
+          }
+        }
+
         switch (dir) {
           case ParamDirection::Out:
             params.push_back({ParamKind::Output, ext_name});
@@ -839,7 +854,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     int func_id = GetOrCreateFuncId(callee_name, func_name_to_id_, next_func_id_);
 
-    auto params = BuildTaskParams(call, callee_func);
+    auto params = BuildTaskParams(call, callee_func, LookupCallSiteDirections(call));
 
     std::string ind = Indent();
     std::string task_var = "params_t" + std::to_string(task_counter_);
@@ -1105,6 +1120,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::map<const Call*, std::string> call_to_tuple_key_;
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
+  std::unordered_map<const Call*, std::vector<ParamDirection>> call_site_directions_;
+
+  const std::vector<ParamDirection>* LookupCallSiteDirections(const CallPtr& call) const {
+    auto it = call_site_directions_.find(call.get());
+    return it != call_site_directions_.end() ? &it->second : nullptr;
+  }
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {
@@ -1123,6 +1144,13 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   VarLineageCollector lineage(program);
   lineage.Initialize(func->params_);
   lineage.VisitStmt(func->body_);
+
+  BufferRootCollector root_collector(program);
+  root_collector.Initialize(func->params_);
+  root_collector.VisitStmt(func->body_);
+
+  CallSiteDirectionResolver direction_resolver(program, root_collector.buffer_roots, func->params_);
+  direction_resolver.VisitStmt(func->body_);
 
   std::unordered_map<const Var*, std::string> emit_name_map;
   std::set<std::string> param_name_set;
@@ -1163,6 +1191,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
                                         std::move(param_name_to_orch_index));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
+  stmt_codegen.SetCallSiteDirections(std::move(direction_resolver.call_site_directions));
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -128,7 +128,7 @@ class TestOrchestration:
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c);
+                    params_t0.add_inout(c);
                     pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add
@@ -380,20 +380,20 @@ class TestOrchestration:
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_output(c);
+                    params_t0.add_inout(c);
                     pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add_scalar
                     Arg params_t1;
                     params_t1.add_input(c);
-                    params_t1.add_output(d);
+                    params_t1.add_inout(d);
                     params_t1.add_scalar(to_u64(1.000000f));
                     pto2_rt_submit_aiv_task(1, params_t1);
 
                     // Task 2: kernel_add_scalar
                     Arg params_t2;
                     params_t2.add_input(c);
-                    params_t2.add_output(e);
+                    params_t2.add_inout(e);
                     params_t2.add_scalar(to_u64(2.000000f));
                     pto2_rt_submit_aiv_task(1, params_t2);
 
@@ -401,7 +401,7 @@ class TestOrchestration:
                     Arg params_t3;
                     params_t3.add_input(d);
                     params_t3.add_input(e);
-                    params_t3.add_output(g);
+                    params_t3.add_inout(g);
                     pto2_rt_submit_aiv_task(2, params_t3);
 
                     // Task 4: kernel_add
@@ -1235,7 +1235,7 @@ class TestOrchestration:
         code = _generate_orch_code(transformed)
 
         assert "Tensor row = ext_out.view(row_shapes, row_offsets);" in code
-        assert "params_t0.add_output(row)" in code
+        assert "params_t0.add_inout(row)" in code
         assert "Tensor row = make_tensor(" not in code
         assert "memcpy(" not in code
         assert "ext_out = out;" not in code
@@ -1402,8 +1402,8 @@ class TestOrchestration:
         assert code.count("TensorCreateInfo ret0__out_ci(") == 1
         assert code.count("TensorCreateInfo ret0__out_1_ci(") == 1
         assert "alloc_tensors(ret0__out_ci, ret0__out_1_ci)" in code
-        assert "params_t0.add_output(ret0__out)" in code
-        assert "params_t1.add_output(ret0__out_1)" in code
+        assert "params_t0.add_inout(ret0__out)" in code
+        assert "params_t1.add_inout(ret0__out_1)" in code
         assert "const Tensor& first = ret0__out;" in code
         assert "const Tensor& second = ret0__out_1;" in code
 
@@ -2048,6 +2048,109 @@ class TestUnregisteredOpError:
 
         with pytest.raises(RuntimeError, match="Misplaced tensor op.*tensor.full"):
             codegen.generate_orchestration(program, orch_func)
+
+
+class TestCallSiteDirectionResolver:
+    """Test that locally allocated tensors get add_inout instead of add_output.
+
+    Issue #1022: when a tensor is pre-allocated via alloc_tensors and then
+    passed as Out to multiple InCore tasks in separate loops, the codegen
+    must use add_inout (not add_output) to establish WAW dependencies.
+    """
+
+    def test_alloc_tensor_two_loops_gets_inout(self):
+        """Two loops writing to the same alloc_tensors buffer must use add_inout."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class TwoLoopAllocProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def task_init(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                buf: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], buf)
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def task_compute(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                buf: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], buf)
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def task_read(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                buf: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                for _i in pl.range(4):
+                    buf = self.task_init(x, buf)
+                for _i in pl.range(4):
+                    buf = self.task_compute(x, buf)
+                out = self.task_read(buf, out)
+                return out
+
+        code = _generate_orch_code(TwoLoopAllocProgram)
+
+        assert "add_inout(buf)" in code, (
+            "Locally allocated tensor 'buf' passed as Out must generate "
+            "add_inout (not add_output) to establish WAW dependencies. "
+            f"Generated code:\n{code}"
+        )
+        assert "add_output(buf)" not in code, (
+            f"Locally allocated tensor 'buf' must NOT use add_output. Generated code:\n{code}"
+        )
+
+    def test_external_tensor_keeps_add_output(self):
+        """Function parameter tensors with Out direction keep add_output."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ExternalOutProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                out = self.kernel(a, out)
+                return out
+
+        code = _generate_orch_code(ExternalOutProgram)
+
+        assert "add_output(ext_out)" in code, (
+            f"External (parameter) tensor should keep add_output. Generated code:\n{code}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Locally allocated tensors (from tensor.create / alloc_tensors) passed as Out to InCore tasks were emitted as add_output, which does not establish WAW dependencies between tasks sharing the same buffer. Introduce CallSiteDirectionResolver analysis that traces buffer roots via BufferRootCollector and promotes Out→InOut at the call site when the argument's buffer root is a local allocation rather than a function parameter. Integrates with the existing directions_override mechanism in BuildTaskParams.