### PR TITLE
chore(runtime): add simpler as git submodule and remove SIMPLER_ROOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
     runs-on: [self-hosted, linux, arm64, npu]
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: v0.24
       PTOAS_SHA256: 31a1f14767f23f0e530faeea0b0dea481ec22c09f9bee5045287b444df00b5bd
@@ -134,11 +133,8 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "/usr/local/Ascend/cann-8.5.0/bin" >> $GITHUB_PATH
 
-      - name: Clone and install simpler repository (pinned)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
+      - name: Install simpler
+        run: pip install -v ./runtime
 
       - name: Test system tests
         run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=d96c8784
@@ -151,7 +147,6 @@ jobs:
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: v0.16
       PTOAS_SHA256: 37bae58a015fe64be1cc105898317fb38f422992e87963ac90fcef5d595d00ec
@@ -186,11 +181,8 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
-      - name: Clone and install simpler repository (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
+      - name: Install simpler
+        run: pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
         run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=d96c8784 -m a5
@@ -210,18 +202,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -v .[dev]
 
-      - name: Clone and install simpler repository (pinned)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
+      - name: Install simpler
+        run: pip install -v ./runtime
 
       - name: Run fuzz tests (sim mode)
         id: run_fuzz
         continue-on-error: true
         run: |
-          export SIMPLER_ROOT="${GITHUB_WORKSPACE}/simpler"
-          export PYTHONPATH="${SIMPLER_ROOT}/python:${SIMPLER_ROOT}/examples/scripts:${PYTHONPATH:-}"
           mkdir -p build/fuzz-artifacts/sim
           cd tests/st/fuzz
           python generate_test.py --num-cases 10 --seed ${{ github.run_number }}

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTOAS_VERSION: v0.25
       PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
@@ -63,11 +62,8 @@ jobs:
       - name: Clone pto-isa repository
         run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
 
-      - name: Install simpler (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
+      - name: Install simpler
+        run: pip install -v ./runtime
 
       - name: Clone pypto-lib
         run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
@@ -94,7 +90,6 @@ jobs:
     runs-on: [self-hosted, a5]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTOAS_VERSION: v0.25
       PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
@@ -129,11 +124,8 @@ jobs:
       - name: Clone pto-isa repository
         run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
 
-      - name: Install simpler (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
+      - name: Install simpler
+        run: pip install -v ./runtime
 
       - name: Run A5 system tests
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "3rdparty/msgpack-c"]
 	path = 3rdparty/msgpack-c
 	url = https://github.com/msgpack/msgpack-c.git
+[submodule "simpler"]
+	path = runtime
+	url = https://github.com/hw-native-sys/simpler

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -618,7 +618,6 @@ def main():
         max_num_blocks_per_req=max_num_blocks_per_req,
     )
 
-    # Run on device (requires Simpler's CodeRunner in SIMPLER_ROOT)
     tensor_specs = build_tensor_specs(
         batch=batch,
         num_heads=num_heads,

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -22,7 +22,8 @@ These functions eliminate all Python-level imports from Simpler. The only
 Simpler dependency remaining is:
 
 - ``pip install simpler`` → provides the ``_task_interface`` nanobind C++ module.
-- ``SIMPLER_ROOT`` → provides C++ headers and pre-built runtime binaries.
+- The ``runtime/`` git submodule at the repository root provides C++ headers and
+  pre-built runtime binaries.
 """
 
 from __future__ import annotations

--- a/python/pypto/runtime/env_manager.py
+++ b/python/pypto/runtime/env_manager.py
@@ -9,13 +9,17 @@
 
 """Environment variable caching utility.
 
-Provides :func:`ensure` to validate and cache required environment variables
-and :func:`get` to retrieve previously validated values.
+Provides :func:`ensure` to validate and cache required environment variables,
+:func:`get` to retrieve previously validated values, and
+:func:`get_simpler_root` to locate the simpler ``runtime/`` submodule.
 """
 
 import os
+from pathlib import Path
 
 _cache: dict[str, str | None] = {}
+
+_simpler_root: Path | None = None
 
 
 def get(name: str) -> str | None:
@@ -33,3 +37,39 @@ def ensure(name: str) -> str:
         raise OSError(f"Environment variable '{name}' is not set.")
     _cache[name] = value
     return value
+
+
+def get_simpler_root() -> Path:
+    """Return the ``simpler`` submodule root directory.
+
+    Resolution order:
+
+    1. Editable / source-tree install: ``<pypto-repo>/simpler/`` relative to
+       this file (``python/pypto/runtime/env_manager.py`` → 3 parents up).
+    2. Non-editable (pip) install: walk up from ``cwd()`` looking for a git
+       repository that contains a ``simpler/`` submodule.
+
+    The result is cached after the first successful lookup.
+    """
+    global _simpler_root  # noqa: PLW0603
+    if _simpler_root is not None:
+        return _simpler_root
+
+    candidate = Path(__file__).resolve().parents[3] / "runtime"
+    if candidate.is_dir():
+        _simpler_root = candidate
+        return _simpler_root
+
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        candidate = parent / "runtime"
+        if (parent / ".git").exists() and candidate.is_dir():
+            _simpler_root = candidate
+            return _simpler_root
+
+    raise OSError(
+        "Cannot find runtime/ submodule directory.\n"
+        "Ensure you are running from within the pypto repository with "
+        "submodules initialized:\n"
+        "  git submodule update --init"
+    )

--- a/python/pypto/runtime/kernel_compiler.py
+++ b/python/pypto/runtime/kernel_compiler.py
@@ -17,8 +17,8 @@ Toolchain selection is determined by platform:
 - Hardware (a2a3/a5): CCEC for kernels, aarch64-g++ for orchestration
 - Simulation (a2a3sim/a5sim): g++-15 for kernels, g++ for orchestration
 
-Requires ``SIMPLER_ROOT`` environment variable pointing to the Simpler repository
-for C++ header paths (runtime headers, task_interface, platform includes).
+C++ header paths (runtime headers, task_interface, platform includes) are resolved
+from the ``simpler`` git submodule at the repository root.
 """
 
 import importlib.util
@@ -27,7 +27,6 @@ import os
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 from . import env_manager
 from .toolchain import (
@@ -39,23 +38,6 @@ from .toolchain import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _get_simpler_root() -> Path:
-    """Return the Simpler project root from ``SIMPLER_ROOT`` environment variable.
-
-    Raises:
-        EnvironmentError: If ``SIMPLER_ROOT`` is not set.
-    """
-    root = os.environ.get("SIMPLER_ROOT")
-    if not root:
-        raise OSError(
-            "SIMPLER_ROOT environment variable is not set.\n"
-            "Kernel and orchestration compilation requires C++ headers from the Simpler repository.\n"
-            "Set it to the root of your Simpler checkout:\n"
-            "  export SIMPLER_ROOT=/path/to/simpler"
-        )
-    return Path(root)
 
 
 class KernelCompiler:
@@ -72,7 +54,7 @@ class KernelCompiler:
 
     def __init__(self, platform: str = "a2a3"):
         self.platform = platform
-        self.runtime_root = _get_simpler_root()
+        self.runtime_root = env_manager.get_simpler_root()
 
         # Map platform to architecture directory
         if platform in ("a2a3", "a2a3sim"):

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -56,6 +56,7 @@ from pypto.compile_profiling import CompileProfiler, get_active_profiler
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.pypto_core.passes import WarningCheckSet, WarningLevel
 
+from .env_manager import get_simpler_root as _get_simpler_root
 from .golden_writer import write_golden
 from .tensor_spec import ScalarSpec, TensorSpec
 
@@ -498,7 +499,7 @@ def _collect_swimlane_data(
     Moves ``perf_swimlane_*.json`` into ``work_dir/swimlane_data/`` and runs
     Simpler's ``swimlane_converter.py`` (if available) to produce merged JSON.
     """
-    simpler_root = os.environ.get("SIMPLER_ROOT")
+    simpler_root = _get_simpler_root()
     swimlane_dir = work_dir / "swimlane_data"
     swimlane_dir.mkdir(parents=True, exist_ok=True)
 
@@ -559,7 +560,7 @@ def _generate_swimlane(
     device_id: int,
     device_log_dir: Path | None,
     pre_run_logs: set[Path],
-    simpler_root: str | None,
+    simpler_root: Path,
     swimlane_dir: Path,
     perf_file: Path | None,
 ) -> None:
@@ -572,16 +573,13 @@ def _generate_swimlane(
         device_id: Hardware device index (fallback when no device log found).
         device_log_dir: CANN device log directory snapshotted before the run.
         pre_run_logs: Set of log files that existed before the run.
-        simpler_root: Path to the Simpler repository root.
+        simpler_root: Path to the Simpler submodule root.
         swimlane_dir: Directory where swimlane JSON files are written.
         perf_file: Path to the ``perf_swimlane_*.json`` file produced by
             CodeRunner and already moved into *swimlane_dir*.  When ``None``,
             swimlane conversion is skipped.
     """
-    if not simpler_root:
-        return
-
-    swimlane_script = Path(simpler_root) / "tools" / "swimlane_converter.py"
+    swimlane_script = simpler_root / "tools" / "swimlane_converter.py"
     if not swimlane_script.exists():
         return
 

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -34,7 +34,7 @@ Test Case Definition → Build IR → Generate Kernels → Compile → Execute �
 
 - **Python**: Version 3.9 or higher
 - **PyPTO**: Installed (`pip install -e .` from project root)
-- **Simpler Runtime**: Set `SIMPLER_ROOT` environment variable
+- **Simpler Runtime**: Bundled as a git submodule (`git submodule update --init`)
 
 ### Python Dependencies
 
@@ -471,12 +471,13 @@ The `conftest.py` automatically adds `tests/st/` to the Python path.
 
 #### ModuleNotFoundError: No module named 'code_runner'
 
-**Problem:** Simpler runtime is not available.
+**Problem:** Simpler submodule is not checked out.
 
-**Solution:** Set the SIMPLER_ROOT environment variable:
+**Solution:** Initialize the git submodule:
 
 ```bash
-export SIMPLER_ROOT=/path/to/simpler
+git submodule update --init
+pip install -v ./simpler
 ```
 
 #### Fixtures Not Found
@@ -514,7 +515,7 @@ Before running tests, verify your setup:
 - [ ] In correct directory: `pwd` shows PyPTO project root
 - [ ] conftest.py exists: `ls tests/st/conftest.py`
 - [ ] harness package exists: `ls tests/st/harness/`
-- [ ] Simpler is set up: `echo $SIMPLER_ROOT`
+- [ ] Simpler submodule checked out: `ls runtime/`
 
 ---
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -15,7 +15,6 @@ harness package (migrated from pto-testing-framework).
 """
 
 import inspect
-import os
 import random
 import re
 import shutil
@@ -37,7 +36,6 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 import pytest  # noqa: E402
 from harness.core.environment import (  # noqa: E402
-    ensure_simpler_available,
     get_simpler_python_path,
     get_simpler_scripts_path,
 )
@@ -57,41 +55,17 @@ from pypto.runtime.runner import RunConfig  # noqa: E402
 _temp_precompile_dirs: list[Path] = []
 
 
-def _init_simpler_root_if_needed() -> None:
-    """Populate SIMPLER_ROOT if not already set.
-
-    pytest_collection_finish runs before session fixtures, so
-    setup_simpler_dependency may not have set SIMPLER_ROOT yet when
-    prebuild_binaries is called.  This function bridges that gap.
-    """
-    if os.environ.get("SIMPLER_ROOT"):
-        return
-    try:
-        os.environ["SIMPLER_ROOT"] = str(ensure_simpler_available())
-    except Exception:
-        pass  # SIMPLER_ROOT unavailable; prebuild_binaries will bail out early
-
-
 @pytest.fixture(scope="session", autouse=True)
 def setup_simpler_dependency(request):
-    """Ensure Simpler dependency is available.
-
-    This fixture runs once per session before any tests. It:
-    1. Checks if Simpler is available (raises error if not)
-    2. Sets SIMPLER_ROOT environment variable for test runner
-    3. Adds simpler's Python paths to sys.path
+    """Add Simpler submodule Python paths to sys.path.
 
     Skipped when --codegen-only is specified (Simpler not needed).
     """
     if request.config.getoption("--codegen-only"):
-        return  # Code generation only, Simpler not needed
+        return
 
-    simpler_root = ensure_simpler_available()
-    os.environ["SIMPLER_ROOT"] = str(simpler_root)
-
-    # Add simpler to sys.path after ensuring it's available
     for path in [get_simpler_python_path(), get_simpler_scripts_path()]:
-        if path is not None and path.exists() and str(path) not in sys.path:
+        if path.exists() and str(path) not in sys.path:
             sys.path.insert(0, str(path))
 
 
@@ -402,10 +376,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         ]
         platform: str = session.config.getoption("--platform")
         pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
-        # Ensure SIMPLER_ROOT is available before prebuild_binaries checks it.
-        # This hook runs before session fixtures, so setup_simpler_dependency
-        # may not have set it yet.
-        _init_simpler_root_if_needed()
         print(
             f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
             f" in parallel (workers={workers_str})…"

--- a/tests/st/fuzz/conftest.py
+++ b/tests/st/fuzz/conftest.py
@@ -9,8 +9,10 @@
 
 """Fuzz-specific conftest ensuring simpler paths survive pytest-forked forks."""
 
-import os
 import sys
+from pathlib import Path
+
+_SIMPLER_ROOT = Path(__file__).resolve().parents[3] / "runtime"
 
 
 def pytest_configure(config):
@@ -21,11 +23,7 @@ def pytest_configure(config):
     rather than in a session fixture, we guarantee that forked children
     see the correct paths for ``code_runner``, ``runtime_builder``, etc.
     """
-    simpler_root = os.environ.get("SIMPLER_ROOT")
-    if not simpler_root:
-        return
-
     for sub in ("examples/scripts", "python"):
-        p = os.path.join(simpler_root, sub)
-        if os.path.isdir(p) and p not in sys.path:
+        p = str(_SIMPLER_ROOT / sub)
+        if Path(p).is_dir() and p not in sys.path:
             sys.path.insert(0, p)

--- a/tests/st/harness/core/__init__.py
+++ b/tests/st/harness/core/__init__.py
@@ -11,7 +11,6 @@
 
 from pypto.runtime.runner import RunConfig, RunResult
 
-from harness.core.environment import ensure_simpler_available
 from harness.core.harness import (
     A2A3_ONLY,
     A5_ONLY,
@@ -34,5 +33,4 @@ __all__ = [
     "RunConfig",
     "RunResult",
     "TestRunner",
-    "ensure_simpler_available",
 ]

--- a/tests/st/harness/core/environment.py
+++ b/tests/st/harness/core/environment.py
@@ -9,65 +9,27 @@
 
 """Environment configuration for Simpler dependency.
 
-This module manages the Simpler runtime dependency, which is external
-to the PyPTO project and required for test execution.
+Simpler is bundled as a git submodule at the repository root (``runtime/``).
 """
 
-import os
 from pathlib import Path
 
-
-class PtoEnvironmentError(Exception):
-    """Environment configuration error exception"""
-
-    pass
+_SIMPLER_ROOT = Path(__file__).resolve().parents[4] / "runtime"
 
 
-def get_simpler_root() -> Path | None:
-    """Get Simpler root directory from SIMPLER_ROOT environment variable.
-
-    Returns:
-        Simpler root directory, or None if not set.
-    """
-    if "SIMPLER_ROOT" in os.environ:
-        return Path(os.environ["SIMPLER_ROOT"])
-    return None
+def get_simpler_root() -> Path:
+    """Return the Simpler submodule root directory."""
+    return _SIMPLER_ROOT
 
 
-def get_simpler_python_path() -> Path | None:
+def get_simpler_python_path() -> Path:
     """Get Simpler Python package path (simpler/python directory)."""
-    root = get_simpler_root()
-    if root is None:
-        return None
-    return root / "python"
+    return _SIMPLER_ROOT / "python"
 
 
-def get_simpler_scripts_path() -> Path | None:
+def get_simpler_scripts_path() -> Path:
     """Get Simpler scripts path (simpler/examples/scripts directory)."""
-    root = get_simpler_root()
-    if root is None:
-        return None
-    return root / "examples" / "scripts"
-
-
-def ensure_simpler_available() -> Path:
-    """Ensure Simpler is available, raise error if SIMPLER_ROOT is not set.
-
-    Returns:
-        Simpler root directory
-
-    Raises:
-        PtoEnvironmentError: When SIMPLER_ROOT is not set
-    """
-    root = get_simpler_root()
-    if root is not None:
-        return root
-
-    raise PtoEnvironmentError(
-        "Simpler runtime is not available.\n\n"
-        "Please set the SIMPLER_ROOT environment variable:\n"
-        "  export SIMPLER_ROOT=/path/to/your/simpler"
-    )
+    return _SIMPLER_ROOT / "examples" / "scripts"
 
 
 def is_hardware_available() -> bool:

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -21,7 +21,6 @@ Orchestrates the full test execution pipeline:
 import concurrent.futures
 import importlib.util
 import logging
-import os
 import shutil
 import tempfile
 import threading
@@ -299,10 +298,6 @@ def prebuild_binaries(
         Number of test cases whose kernels and orchestration were successfully
         pre-built.
     """
-    simpler_root = os.environ.get("SIMPLER_ROOT", "")
-    if not simpler_root:
-        return 0
-
     from pypto.runtime.device_runner import (  # noqa: PLC0415
         compile_single_kernel,
         compile_single_orchestration,


### PR DESCRIPTION
Bundle hw-native-sys/simpler (stable branch) as a git submodule at the repository root. All code now resolves simpler paths directly from the submodule location, eliminating the need for the SIMPLER_ROOT environment variable.
- Add simpler submodule tracking stable branch
- Replace os.environ["SIMPLER_ROOT"] with Path-based submodule resolution in kernel_compiler, runner, environment, conftest, and test_runner
- Remove ensure_simpler_available() and PtoEnvironmentError (submodule is always present)
- Simplify CI workflows: use submodules checkout instead of git clone
- Update docs and comments