### PR TITLE
feat(ir): Support iter_args in PartialUnrollTileLoops

### DIFF
--- a/docs/en/dev/passes/20-partial_unroll_tile_loops.md
+++ b/docs/en/dev/passes/20-partial_unroll_tile_loops.md
@@ -72,9 +72,14 @@ With trip count `T = (stop - start) / step`:
 | ---------- | ------ |
 | `step` must be a compile-time integer constant | Main loop's stride and per-clone offsets both require `factor * step` as an integer |
 | Dynamic bounds require `step > 0` | The dynamic trip-count formula assumes positive step; negative-step ranges must use static bounds |
-| `iter_args` / `init_values` not allowed | Loop-carried state across replicated copies needs SSA-aware renaming not yet implemented |
 | `unroll` and `chunk` are mutually exclusive on `pl.range` | Different optimization axes; combining them adds semantic ambiguity without a clear use case |
 | `unroll=` only on `pl.range()` | Scoped feature; `pl.parallel()` / `pl.unroll()` have different semantics |
+
+### Loop-carried state (`iter_args`)
+
+`iter_args` / `init_values` are supported. Loop-carried state threads sequentially through the `F` replicated clones: clone `k` consumes the previous clone's yielded expressions as its iter-arg substitutes, and only the last clone's `YieldStmt` is kept to feed the next outer iteration. When a tail follows, the main loop's `return_vars` become fresh SSA names that seed the tail's `iter_args`; the tail inherits the original outer loop's `return_vars` so downstream references stay valid.
+
+Under dynamic bounds, every `IfStmt` in the cascade carries `return_vars` matching the iter-arg types and every branch ends with a `YieldStmt`. The innermost `else` yields the main-loop `return_vars` unchanged — that is the `rem == 0` no-op fall-through.
 
 ## Examples
 
@@ -96,6 +101,28 @@ for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
 for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
     tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
     tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
+```
+
+### Static with `iter_args` — loop-carried accumulator (`N=10`, `F=4`)
+
+```python
+# Before
+for i, (a,) in pl.range(0, 10, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
+    b = a + i
+    r = pl.yield_(b)
+
+# After: main loop threads a → b → b_1 → b_2 → b_3, then tail seeds a_tail from r_main
+for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+    b = a + i
+    b_1 = b + (i + 1)
+    b_2 = b_1 + (i + 2)
+    b_3 = b_2 + (i + 3)
+    r_main = pl.yield_(b_3)
+
+for _tail_iter_2, (a,) in pl.range(0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}):
+    b_4 = a + 8
+    b_5 = b_4 + 9
+    r = pl.yield_(b_5)
 ```
 
 ### Dynamic — runtime stop `n`

--- a/docs/zh-cn/dev/passes/20-partial_unroll_tile_loops.md
+++ b/docs/zh-cn/dev/passes/20-partial_unroll_tile_loops.md
@@ -72,9 +72,14 @@ for i in pl.range(64, unroll=4):
 | ---- | ---- |
 | `step` 必须为编译期整数常量 | 主循环步长及各副本偏移均依赖 `factor * step` 为整数 |
 | 动态边界要求 `step > 0` | 动态 trip 计算公式假设正步长；负步长需使用静态边界 |
-| 不允许 `iter_args` / `init_values` | 跨副本的循环携带状态需要 SSA 重命名，首版未实现 |
 | `unroll` 与 `chunk` 在 `pl.range` 中互斥 | 二者优化方向不同，组合使用语义模糊且无明显场景 |
 | `unroll=` 仅支持 `pl.range()` | 该特性作用域限定于 `pl.range()`；`pl.parallel()` / `pl.unroll()` 语义不同 |
+
+### 循环携带状态（`iter_args`）
+
+支持 `iter_args` / `init_values`。循环携带状态按顺序穿过 `F` 个副本：第 `k` 个副本以上一副本的 `YieldStmt` 表达式作为其 iter-arg 的替换值，仅最后一个副本保留 `YieldStmt` 以传递给主循环下一次外层迭代。若存在尾部分支，主循环的 `return_vars` 使用新的 SSA 名字，作为尾部分支 `iter_args` 的初值；尾部分支则继承原外层循环的 `return_vars`，确保下游引用有效。
+
+动态边界下，级联中的每个 `IfStmt` 都携带与 iter-arg 类型一致的 `return_vars`，每个分支均以 `YieldStmt` 结尾。最内层 `else` 直接 yield 主循环的 `return_vars` —— 即 `rem == 0` 时的空操作回退。
 
 ## 示例
 
@@ -96,6 +101,28 @@ for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
 for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
     tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
     tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
+```
+
+### 静态带 `iter_args` —— 循环累加（`N=10`、`F=4`）
+
+```python
+# 变换前
+for i, (a,) in pl.range(0, 10, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
+    b = a + i
+    r = pl.yield_(b)
+
+# 变换后：主循环按 a → b → b_1 → b_2 → b_3 串接，尾部分支以 r_main 作为 a_tail 的初值
+for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+    b = a + i
+    b_1 = b + (i + 1)
+    b_2 = b_1 + (i + 2)
+    b_3 = b_2 + (i + 3)
+    r_main = pl.yield_(b_3)
+
+for _tail_iter_2, (a,) in pl.range(0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}):
+    b_4 = a + 8
+    b_5 = b_4 + 9
+    r = pl.yield_(b_5)
 ```
 
 ### 动态 —— 运行时 `n`

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -187,11 +187,6 @@ def _make_range_iterator(
             raise ValueError(f"{func_name}() unroll factor must be a positive integer, got {unroll_factor!r}")
         if chunk is not None:
             raise ValueError(f"{func_name}() unroll= and chunk= are mutually exclusive")
-        if init_values is not None:
-            raise ValueError(
-                f"{func_name}() unroll= cannot be combined with init_values= "
-                "(partial unroll does not yet support loop-carried state)"
-            )
     kwargs = {
         "init_values": init_values,
         "chunk": chunk,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1202,15 +1202,6 @@ class ASTParser:
                     span=self.span_tracker.get_span(iter_call),
                     hint="Use unroll= for ping-pong replication or chunk= for chunked iteration, not both.",
                 )
-            if range_args["init_values"]:
-                raise ParserSyntaxError(
-                    "unroll= cannot be combined with init_values=",
-                    span=self.span_tracker.get_span(iter_call),
-                    hint=(
-                        "Partial unroll does not yet support loop-carried state. "
-                        "Drop init_values= or remove unroll=."
-                    ),
-                )
             if not _is_const_int(unroll_expr):
                 raise ParserSyntaxError(
                     "unroll must be a compile-time constant positive integer",

--- a/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
+++ b/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
@@ -238,6 +238,9 @@ class PartialUnrollMutator : public IRMutator {
       }
       auto cloned = DeepClone(body, sub_map, /*clone_def_vars=*/true);
       auto [cloned_stmts, cloned_yields] = SplitBodyYield(cloned.cloned_body);
+      INTERNAL_CHECK(cloned_yields.size() == op->iter_args_.size())
+          << "Internal error: loop body must yield " << op->iter_args_.size() << " values for iter_args, got "
+          << cloned_yields.size();
       clones.push_back(cloned_stmts);
       prev_yields = std::move(cloned_yields);
     }

--- a/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
+++ b/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
@@ -114,6 +114,37 @@ VarPtr CloneLoopVar(const VarPtr& original) {
   return std::make_shared<Var>(original->name_hint_, original->GetType(), original->span_);
 }
 
+/// Fresh IterArg mirroring `original`, with `init_value` as the initial value.
+IterArgPtr MakeFreshIterArg(const IterArgPtr& original, const ExprPtr& init_value) {
+  return std::make_shared<IterArg>(original->name_hint_, original->GetType(), init_value, original->span_);
+}
+
+/// Fresh Var mirroring `original` with a suffixed name (for intermediate return_vars).
+VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix) {
+  return std::make_shared<Var>(original->name_hint_ + suffix, original->GetType(), original->span_);
+}
+
+/// Split a body into (stmts_before_yield, yield_values). If the body ends with a
+/// terminal `YieldStmt` (either standalone or as the final stmt of a top-level
+/// `SeqStmts`), strip it and return its values. Otherwise return the body unchanged
+/// and an empty value list. Always pass through — callers that have no iter_args
+/// simply see an empty yield vector and treat `stmts` as the whole body.
+std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
+  if (auto yield = std::dynamic_pointer_cast<const YieldStmt>(body)) {
+    return {std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, body->span_), yield->value_};
+  }
+  auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
+  if (!seq || seq->stmts_.empty()) {
+    return {body, {}};
+  }
+  auto yield = std::dynamic_pointer_cast<const YieldStmt>(seq->stmts_.back());
+  if (!yield) {
+    return {body, {}};
+  }
+  std::vector<StmtPtr> without(seq->stmts_.begin(), seq->stmts_.end() - 1);
+  return {std::make_shared<SeqStmts>(std::move(without), seq->span_), yield->value_};
+}
+
 /**
  * @brief Mutator that lowers ForStmt nodes carrying `attrs_["unroll_factor"]`
  *        into a replicated main loop plus a modulo-dispatch remainder.
@@ -122,7 +153,14 @@ VarPtr CloneLoopVar(const VarPtr& original) {
  * Dynamic bounds (start and/or stop are runtime Exprs) → a cascaded
  *   `if rem == k` dispatch for k in [1, factor), each branch containing
  *   k cloned bodies tagged `unroll_replicated = k`. Step must always be a
- *   compile-time constant; iter_args are rejected (matches full-unroll).
+ *   compile-time constant.
+ *
+ * `iter_args` are supported: loop-carried state threads sequentially through the
+ * F replicated clones in the main loop (each clone consumes the previous clone's
+ * yielded expressions), and through the tail clones starting from the main
+ * loop's return_vars. In the dynamic case, each IfStmt in the cascade carries
+ * `return_vars` matching the iter_args types; the innermost else yields the
+ * main-loop return_vars so the `rem == 0` fall-through is a no-op.
  */
 class PartialUnrollMutator : public IRMutator {
  public:
@@ -132,9 +170,6 @@ class PartialUnrollMutator : public IRMutator {
     }
     int64_t factor = static_cast<int64_t>(op->GetAttr<int>(kUnrollFactorAttr, 0));
     CHECK(factor >= 1) << "PartialUnrollTileLoops: unroll_factor must be >= 1, got " << factor;
-    CHECK(op->iter_args_.empty())
-        << "PartialUnrollTileLoops: loops with iter_args/init_values are not supported. "
-           "Drop init_values= or remove unroll= from the loop.";
 
     // Recurse into the body first so nested unroll-marked loops are lowered too.
     auto inner_body = VisitStmt(op->body_);
@@ -167,60 +202,166 @@ class PartialUnrollMutator : public IRMutator {
   }
 
   /**
-   * @brief Build the replicated main loop: body is a SeqStmts of `factor` clones,
-   *        each with the original loop var substituted by `(new_var + k * step)`.
+   * @brief Clone `body` `n` times with loop-var / iter-arg substitutions,
+   *        threading loop-carried state through the clones.
+   *
+   * Each clone k:
+   *  - substitutes `loop_var → base + k * step` (via OffsetIndex)
+   *  - substitutes original iter_args with `initial_iter_substitutes` (when k == 0)
+   *    or with the previous clone's yielded expressions (when k > 0)
+   *  - is DeepCloned with `clone_def_vars=true` so nested definitions get fresh SSA vars
+   *  - has its trailing `YieldStmt` (if any) stripped into the next clone's substitution
+   *
+   * Returns the concatenated body (a `SeqStmts` of the stripped clones) paired with
+   * the last clone's yielded expressions. For loops without iter_args, the yield
+   * vector is empty and each cloned body is appended verbatim.
+   */
+  struct ReplicatedRegion {
+    StmtPtr body;                       // SeqStmts of cloned bodies (yields stripped)
+    std::vector<ExprPtr> final_yields;  // last clone's yielded expressions
+  };
+
+  ReplicatedRegion ReplicateBody(const ForStmtPtr& op, const StmtPtr& body, int64_t n_clones, int64_t step,
+                                 const ExprPtr& base, const std::vector<ExprPtr>& initial_iter_substitutes) {
+    Span sp = op->span_;
+    INTERNAL_CHECK(initial_iter_substitutes.size() == op->iter_args_.size())
+        << "Internal error: iter substitute count mismatch";
+
+    std::vector<StmtPtr> clones;
+    clones.reserve(static_cast<size_t>(n_clones));
+    std::vector<ExprPtr> prev_yields;
+    for (int64_t k = 0; k < n_clones; ++k) {
+      std::unordered_map<const Var*, ExprPtr> sub_map;
+      sub_map[op->loop_var_.get()] = OffsetIndex(base, k * step, sp);
+      for (size_t j = 0; j < op->iter_args_.size(); ++j) {
+        sub_map[op->iter_args_[j].get()] = (k == 0) ? initial_iter_substitutes[j] : prev_yields[j];
+      }
+      auto cloned = DeepClone(body, sub_map, /*clone_def_vars=*/true);
+      auto [cloned_stmts, cloned_yields] = SplitBodyYield(cloned.cloned_body);
+      clones.push_back(cloned_stmts);
+      prev_yields = std::move(cloned_yields);
+    }
+    return {SeqStmts::Flatten(std::move(clones), sp), std::move(prev_yields)};
+  }
+
+  /// Convert a vector of return_vars into a vector of ExprPtrs (for YieldStmt values
+  /// or iter_arg init-value forwarding).
+  std::vector<ExprPtr> ReturnVarsAsExprs(const std::vector<VarPtr>& vars) {
+    std::vector<ExprPtr> result;
+    result.reserve(vars.size());
+    for (const auto& v : vars) result.push_back(v);
+    return result;
+  }
+
+  /// Collect `initValue_` expressions from a vector of IterArgs — used when the
+  /// tail runs without a preceding main loop, so its iter_args seed directly
+  /// from the source loop's init values rather than a main-loop return_var.
+  std::vector<ExprPtr> InitValueExprs(const std::vector<IterArgPtr>& iter_args) {
+    std::vector<ExprPtr> result;
+    result.reserve(iter_args.size());
+    for (const auto& ia : iter_args) result.push_back(ia->initValue_);
+    return result;
+  }
+
+  /// Fresh iter_args for a wrapper ForStmt, taking initial values from `init_values`.
+  std::vector<IterArgPtr> MakeFreshIterArgs(const std::vector<IterArgPtr>& originals,
+                                            const std::vector<ExprPtr>& init_values) {
+    INTERNAL_CHECK(originals.size() == init_values.size())
+        << "Internal error: iter_arg/init_value count mismatch";
+    std::vector<IterArgPtr> result;
+    result.reserve(originals.size());
+    for (size_t j = 0; j < originals.size(); ++j) {
+      result.push_back(MakeFreshIterArg(originals[j], init_values[j]));
+    }
+    return result;
+  }
+
+  /// Fresh return_vars matching the originals' types, with a suffix applied to names.
+  std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix) {
+    std::vector<VarPtr> result;
+    result.reserve(originals.size());
+    for (const auto& v : originals) result.push_back(MakeFreshVar(v, suffix));
+    return result;
+  }
+
+  /**
+   * @brief Build the replicated main loop.
+   *
+   * Body is a SeqStmts of `factor` clones threading iter_args sequentially. When
+   * the original loop has iter_args, the main loop gets fresh iter_args seeded
+   * from the originals' init values; each clone consumes the previous clone's
+   * yield, and the body ends with a YieldStmt of the last clone's yields to feed
+   * the next outer iteration. `main_return_vars` controls the ForStmt's
+   * return_vars (may be the original return_vars or fresh ones, depending on
+   * whether a tail follows).
    */
   StmtPtr BuildMainLoop(const ForStmtPtr& op, const StmtPtr& body, int64_t factor, int64_t step,
-                        const ExprPtr& main_start, const ExprPtr& main_stop) {
+                        const ExprPtr& main_start, const ExprPtr& main_stop,
+                        const std::vector<VarPtr>& main_return_vars) {
     Span sp = op->span_;
     VarPtr new_loop_var = CloneLoopVar(op->loop_var_);
 
-    std::vector<StmtPtr> clones;
-    clones.reserve(static_cast<size_t>(factor));
-    for (int64_t k = 0; k < factor; ++k) {
-      ExprPtr substitute = OffsetIndex(new_loop_var, k * step, sp);
-      std::unordered_map<const Var*, ExprPtr> sub_map = {{op->loop_var_.get(), substitute}};
-      auto cloned = DeepClone(body, sub_map, /*clone_def_vars=*/true);
-      clones.push_back(cloned.cloned_body);
+    // Fresh iter_args mirroring the originals (same init values as the source loop).
+    std::vector<IterArgPtr> new_iter_args;
+    new_iter_args.reserve(op->iter_args_.size());
+    std::vector<ExprPtr> initial_substitutes;
+    initial_substitutes.reserve(op->iter_args_.size());
+    for (const auto& orig : op->iter_args_) {
+      auto fresh = MakeFreshIterArg(orig, orig->initValue_);
+      new_iter_args.push_back(fresh);
+      initial_substitutes.push_back(fresh);
     }
-    auto new_body = SeqStmts::Flatten(std::move(clones), sp);
+
+    auto region = ReplicateBody(op, body, factor, step, new_loop_var, initial_substitutes);
+
+    // Body = replicated clones, followed by YieldStmt(last_yields) when iter_args exist.
+    std::vector<StmtPtr> body_parts = {region.body};
+    if (!op->iter_args_.empty()) {
+      body_parts.push_back(std::make_shared<YieldStmt>(region.final_yields, sp));
+    }
+    auto new_body = SeqStmts::Flatten(std::move(body_parts), sp);
 
     ExprPtr new_step = MakeConstIndex(factor * step, sp);
     Attrs new_attrs = RewriteAttrs(op->attrs_, factor);
-    return std::make_shared<ForStmt>(new_loop_var, main_start, main_stop, new_step,
-                                     /*iter_args=*/std::vector<IterArgPtr>{}, new_body,
-                                     /*return_vars=*/std::vector<VarPtr>{}, sp, op->kind_,
+    return std::make_shared<ForStmt>(new_loop_var, main_start, main_stop, new_step, new_iter_args, new_body,
+                                     main_return_vars, sp, op->kind_,
                                      /*chunk_config=*/std::nullopt, new_attrs, op->leading_comments_);
   }
 
   /**
-   * @brief Build a trip-1 ForStmt wrapping `k_clones` cloned bodies at
-   *        offsets `base_index + j*step` (j in [0, k_clones)), tagged with
+   * @brief Build a trip-1 ForStmt wrapping `k_clones` cloned bodies at offsets
+   *        `base_index + j*step` (j in [0, k_clones)), tagged with
    *        `unroll_replicated = k_clones` so ReorderUnrolledIO processes it.
    *
-   * This is the attrs-bearing container for a remainder branch; SeqStmts has
-   * no attrs_, so we wrap in a degenerate ForStmt purely for the marker.
+   * SeqStmts has no attrs_, so the wrapper exists purely to carry the marker.
+   * When the source loop has iter_args, the wrapper also threads loop-carried
+   * state: its fresh iter_args are seeded from `iter_init_values`, its clones
+   * are chained via the previous clone's yields, and a trailing YieldStmt feeds
+   * the wrapper's `return_vars`.
    */
   StmtPtr BuildTailBranch(const ForStmtPtr& op, const StmtPtr& body, int64_t k_clones, int64_t step,
-                          const ExprPtr& base_index) {
+                          const ExprPtr& base_index, const std::vector<ExprPtr>& iter_init_values,
+                          const std::vector<VarPtr>& return_vars) {
     Span sp = op->span_;
-    std::vector<StmtPtr> clones;
-    clones.reserve(static_cast<size_t>(k_clones));
-    for (int64_t j = 0; j < k_clones; ++j) {
-      ExprPtr substitute = OffsetIndex(base_index, j * step, sp);
-      std::unordered_map<const Var*, ExprPtr> sub_map = {{op->loop_var_.get(), substitute}};
-      auto cloned = DeepClone(body, sub_map, /*clone_def_vars=*/true);
-      clones.push_back(cloned.cloned_body);
+    auto fresh_iter_args = MakeFreshIterArgs(op->iter_args_, iter_init_values);
+    std::vector<ExprPtr> initial_substitutes;
+    initial_substitutes.reserve(fresh_iter_args.size());
+    for (const auto& ia : fresh_iter_args) initial_substitutes.push_back(ia);
+
+    auto region = ReplicateBody(op, body, k_clones, step, base_index, initial_substitutes);
+
+    std::vector<StmtPtr> body_parts = {region.body};
+    if (!op->iter_args_.empty()) {
+      body_parts.push_back(std::make_shared<YieldStmt>(region.final_yields, sp));
     }
-    auto seq_body = SeqStmts::Flatten(std::move(clones), sp);
+    auto seq_body = SeqStmts::Flatten(std::move(body_parts), sp);
 
     auto dummy_var = std::make_shared<Var>("_tail_iter_" + std::to_string(k_clones),
                                            std::make_shared<ScalarType>(DataType::INDEX), sp);
     Attrs attrs = {{kUnrollReplicatedAttr, static_cast<int>(k_clones)}};
     return std::make_shared<ForStmt>(dummy_var, MakeConstIndex(0, sp), MakeConstIndex(1, sp),
-                                     MakeConstIndex(1, sp),
-                                     /*iter_args=*/std::vector<IterArgPtr>{}, seq_body,
-                                     /*return_vars=*/std::vector<VarPtr>{}, sp, ForKind::Sequential,
+                                     MakeConstIndex(1, sp), fresh_iter_args, seq_body, return_vars, sp,
+                                     ForKind::Sequential,
                                      /*chunk_config=*/std::nullopt, attrs,
                                      /*leading_comments=*/std::vector<std::string>{});
   }
@@ -229,6 +370,10 @@ class PartialUnrollMutator : public IRMutator {
    * @brief Static lowering: compile-time trip count → main loop + (optional)
    *        single-branch tail with exactly rem_iters clones. No dispatch needed
    *        because the remainder count is known.
+   *
+   * When iter_args are present, the main loop's return_vars forward loop-carried
+   * state to the tail branch's iter_args; the tail branch inherits the original
+   * outer loop's return_vars so downstream references stay valid.
    */
   StmtPtr LowerStatic(const ForStmtPtr& op, const StmtPtr& body, int64_t factor, int64_t start, int64_t stop,
                       int64_t step) {
@@ -238,17 +383,32 @@ class PartialUnrollMutator : public IRMutator {
     }
     int64_t main_iters = trip / factor;
     int64_t rem_iters = trip % factor;
+    bool has_tail = rem_iters > 0;
+
+    // Main loop's return_vars forward to the tail via fresh names when a tail
+    // follows; otherwise they terminate at the original names. When there are
+    // no return_vars, fresh-rename is a no-op (both empty), so guard that.
+    std::vector<VarPtr> main_return_vars = op->return_vars_;
+    if (has_tail && !main_return_vars.empty()) {
+      main_return_vars = MakeFreshReturnVars(op->return_vars_, "_main");
+    }
 
     std::vector<StmtPtr> result;
     if (main_iters > 0) {
       ExprPtr main_start = op->start_;
       ExprPtr main_stop = MakeConstIndex(start + main_iters * factor * step, op->span_);
-      result.push_back(BuildMainLoop(op, body, factor, step, main_start, main_stop));
+      result.push_back(BuildMainLoop(op, body, factor, step, main_start, main_stop, main_return_vars));
     }
-    if (rem_iters > 0) {
+    if (has_tail) {
       int64_t tail_base = start + main_iters * factor * step;
       ExprPtr base_index = MakeConstIndex(tail_base, op->span_);
-      result.push_back(BuildTailBranch(op, body, rem_iters, step, base_index));
+      // Tail iter_args seed from main_return_vars when a main loop precedes
+      // the tail; otherwise (trip < factor) they seed from the original loop's
+      // init_values.
+      std::vector<ExprPtr> tail_init_values =
+          (main_iters > 0) ? ReturnVarsAsExprs(main_return_vars) : InitValueExprs(op->iter_args_);
+      result.push_back(
+          BuildTailBranch(op, body, rem_iters, step, base_index, tail_init_values, op->return_vars_));
     }
     return SeqStmts::Flatten(std::move(result), op->span_);
   }
@@ -300,10 +460,14 @@ class PartialUnrollMutator : public IRMutator {
         std::make_shared<Var>("unroll_main_end", std::make_shared<ScalarType>(DataType::INDEX), sp);
     auto main_end_assign = std::make_shared<AssignStmt>(main_end_var, main_end_value, sp);
 
+    // The cascade always lives after the main loop, so the main loop's
+    // return_vars forward state to the IfStmt cascade and need fresh names.
+    std::vector<VarPtr> main_return_vars =
+        op->return_vars_.empty() ? op->return_vars_ : MakeFreshReturnVars(op->return_vars_, "_main");
+
     // Main loop — stop is the fresh SSA var `main_end_var`.
-    StmtPtr main_loop = BuildMainLoop(op, body, factor, step,
-                                      /*main_start=*/op->start_,
-                                      /*main_stop=*/main_end_var);
+    StmtPtr main_loop = BuildMainLoop(op, body, factor, step, /*main_start=*/op->start_,
+                                      /*main_stop=*/main_end_var, main_return_vars);
 
     // rem_iters = trip_iters - main_iters * factor. For step == 1 this equals
     // stop - main_end (since trip == stop - start and main_iters*factor*step ==
@@ -314,15 +478,61 @@ class PartialUnrollMutator : public IRMutator {
                                     : MakeSub(trip_expr, MakeMul(main_iters_expr, factor_expr, sp), sp);
     auto rem_assign = std::make_shared<AssignStmt>(rem_var, rem_value, sp);
 
-    // Build the cascade from innermost (k = factor-1) outward so that each outer
-    // IfStmt can point at the previously-built IfStmt as its else branch.
+    // Fall-through (rem == 0) state expressions — the main loop's return_vars
+    // passed through unchanged. Used as the innermost else's YieldStmt and as
+    // the seed for each branch's tail iter_args.
+    std::vector<ExprPtr> main_return_exprs = ReturnVarsAsExprs(main_return_vars);
+    bool has_iter_args = !op->iter_args_.empty();
+
+    // Build the cascade from innermost (k = factor-1) outward so each outer
+    // IfStmt's else points at the previously-built IfStmt. With iter_args,
+    // every IfStmt carries return_vars (fresh at inner levels, the original
+    // outer return_vars at the outermost level) and every branch ends with a
+    // YieldStmt — including the innermost else, which yields main_return_exprs
+    // for the rem == 0 case.
     std::optional<StmtPtr> inner;
+    std::vector<VarPtr> inner_return_vars;
     for (int64_t k = factor - 1; k >= 1; --k) {
+      // Each branch's tail seeds its iter_args from the main-loop return_vars:
+      // the cascade is a dispatch on `rem`, so every live branch starts from
+      // the same post-main state.
+      auto tail_branch_return_vars = op->return_vars_.empty()
+                                         ? op->return_vars_
+                                         : MakeFreshReturnVars(op->return_vars_, "_tail" + std::to_string(k));
+      StmtPtr tail =
+          BuildTailBranch(op, body, k, step, main_end_var, main_return_exprs, tail_branch_return_vars);
+
+      std::vector<StmtPtr> then_parts = {tail};
+      if (has_iter_args) {
+        then_parts.push_back(std::make_shared<YieldStmt>(ReturnVarsAsExprs(tail_branch_return_vars), sp));
+      }
+      auto then_body = SeqStmts::Flatten(std::move(then_parts), sp);
+
+      std::optional<StmtPtr> else_body;
+      if (k == factor - 1) {
+        // Innermost: rem == 0 fall-through yields the main-loop state.
+        if (has_iter_args) else_body = std::make_shared<YieldStmt>(main_return_exprs, sp);
+      } else {
+        INTERNAL_CHECK(inner.has_value())
+            << "Internal error: inner IfStmt must be built by the previous iteration";
+        std::vector<StmtPtr> else_parts = {*inner};
+        if (has_iter_args) {
+          else_parts.push_back(std::make_shared<YieldStmt>(ReturnVarsAsExprs(inner_return_vars), sp));
+        }
+        else_body = SeqStmts::Flatten(std::move(else_parts), sp);
+      }
+
+      // return_vars: original names at the outermost level (k == 1); fresh at inner levels.
+      std::vector<VarPtr> my_return_vars;
+      if (has_iter_args) {
+        my_return_vars =
+            (k == 1) ? op->return_vars_ : MakeFreshReturnVars(op->return_vars_, "_rem" + std::to_string(k));
+      }
+
       ExprPtr cond = MakeEq(rem_var, MakeConstIndex(k, sp), sp);
-      StmtPtr branch_body = BuildTailBranch(op, body, k, step, main_end_var);
-      auto if_stmt = std::make_shared<IfStmt>(cond, branch_body, inner,
-                                              /*return_vars=*/std::vector<VarPtr>{}, sp);
+      auto if_stmt = std::make_shared<IfStmt>(cond, then_body, else_body, my_return_vars, sp);
       inner = StmtPtr(if_stmt);
+      inner_return_vars = std::move(my_return_vars);
     }
 
     std::vector<StmtPtr> result;

--- a/tests/ut/ir/transforms/test_partial_unroll_tile_loops.py
+++ b/tests/ut/ir/transforms/test_partial_unroll_tile_loops.py
@@ -219,25 +219,146 @@ class TestPartialUnrollMechanics:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_iter_args_rejected_with_clear_message(self):
-        """Loops with iter_args must be rejected — partial unroll cannot handle loop-carried state.
+    def test_iter_args_clean_divide_threads_state_through_clones(self):
+        """Loop-carried scalar threads sequentially through 4 replicated clones.
 
-        ``x = pl.add(x, 1.0)`` inside the loop produces iter_args only after
-        ``ConvertToSSA`` lifts the reassignment; run that first so the pass
-        actually sees the iter_args it must reject."""
+        Each clone consumes the previous clone's yielded value as its iter_arg
+        substitute; the last clone's yield feeds the outer loop's next iteration."""
 
         @pl.program
         class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(0, 8, 1, attrs={"unroll_factor": 4}):
-                    x = pl.add(x, 1.0)
-                return x
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.range(0, 8, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    r = pl.yield_(b)
+                return r
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            ssa_program = passes.convert_to_ssa()(Before)
-            with pytest.raises(ValueError, match="iter_args"):
-                passes.partial_unroll_tile_loops()(ssa_program)
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
+                    b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
+                    b_3: pl.Scalar[pl.INDEX] = b_2 + (i + 3)
+                    r = pl.yield_(b_3)
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_iter_args_with_remainder_forwards_state_to_tail(self):
+        """Main loop's return_var seeds the tail's iter_arg; tail's return_var replaces
+        the original loop's return_var so downstream uses remain valid."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.range(0, 10, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    r = pl.yield_(b)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
+                    b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
+                    b_3: pl.Scalar[pl.INDEX] = b_2 + (i + 3)
+                    r_main = pl.yield_(b_3)
+                for _tail_iter_2, (a,) in pl.range(
+                    0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}
+                ):
+                    b_4: pl.Scalar[pl.INDEX] = a + 8
+                    b_5: pl.Scalar[pl.INDEX] = b_4 + 9
+                    r = pl.yield_(b_5)
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_iter_args_dynamic_cascade_threads_through_every_level(self):
+        """Dynamic cascade: every IfStmt carries return_vars matching the iter_arg
+        types, every branch ends with a YieldStmt, and the innermost else yields
+        the main-loop return_var so ``rem == 0`` is a no-op fall-through."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.range(0, n, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    r = pl.yield_(b)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                unroll_main_end: pl.Scalar[pl.INDEX] = 0 + (n - 0) // 4 * 4
+                for i, (a,) in pl.range(
+                    0, unroll_main_end, 4, init_values=(s0,), attrs={"unroll_replicated": 4}
+                ):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
+                    b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
+                    b_3: pl.Scalar[pl.INDEX] = b_2 + (i + 3)
+                    r_main = pl.yield_(b_3)
+                unroll_rem: pl.Scalar[pl.INDEX] = n - unroll_main_end
+                # Each IfStmt level carries its own return_vars and yield — the
+                # cascade is nested (not elif/else), because every inner IfStmt
+                # is the enclosing one's else body together with a trailing yield
+                # that feeds the outer return_var.
+                if unroll_rem == 1:
+                    for _tail_iter_1, (a,) in pl.range(
+                        0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 1}
+                    ):
+                        b_4: pl.Scalar[pl.INDEX] = a + unroll_main_end
+                        r_tail1 = pl.yield_(b_4)
+                    r = pl.yield_(r_tail1)
+                else:
+                    if unroll_rem == 2:
+                        for _tail_iter_2, (a,) in pl.range(
+                            0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}
+                        ):
+                            b_5: pl.Scalar[pl.INDEX] = a + unroll_main_end
+                            b_6: pl.Scalar[pl.INDEX] = b_5 + (unroll_main_end + 1)
+                            r_tail2 = pl.yield_(b_6)
+                        r_rem2 = pl.yield_(r_tail2)
+                    else:
+                        if unroll_rem == 3:
+                            for _tail_iter_3, (a,) in pl.range(
+                                0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 3}
+                            ):
+                                b_7: pl.Scalar[pl.INDEX] = a + unroll_main_end
+                                b_8: pl.Scalar[pl.INDEX] = b_7 + (unroll_main_end + 1)
+                                b_9: pl.Scalar[pl.INDEX] = b_8 + (unroll_main_end + 2)
+                                r_tail3 = pl.yield_(b_9)
+                            r_rem3 = pl.yield_(r_tail3)
+                        else:
+                            r_rem3 = pl.yield_(r_main)
+                        r_rem2 = pl.yield_(r_rem3)
+                    r = pl.yield_(r_rem2)
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/test_range_unroll_kwarg.py
+++ b/tests/ut/language/test_range_unroll_kwarg.py
@@ -64,6 +64,22 @@ class TestRangeUnrollKwargParser:
 
         assert "unroll_factor" not in dict(_outer_for(P).attrs)
 
+    def test_unroll_with_init_values_parses(self):
+        """``unroll=`` composes with ``init_values=`` — loop-carried state is supported."""
+
+        @pl.program
+        class P:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i, (acc,) in pl.range(8, init_values=(x,), unroll=2):
+                    acc = pl.add(acc, 1.0)
+                    acc_rv = pl.yield_(acc)
+                return acc_rv
+
+        for_stmt = _outer_for(P)
+        assert dict(for_stmt.attrs).get("unroll_factor") == 2
+        assert len(for_stmt.iter_args) == 1
+
 
 class TestRangeUnrollKwargRejection:
     """The parser must reject invalid combinations with clear errors."""
@@ -101,18 +117,6 @@ class TestRangeUnrollKwargRejection:
                         for i in pl.range(8, chunk=4, unroll=2):
                             x = pl.add(x, 1.0)
                     return x
-
-    def test_unroll_with_init_values_rejected(self):
-        with pytest.raises(Exception, match=r"unroll= cannot be combined with init_values="):
-
-            @pl.program
-            class _P:
-                @pl.function
-                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    for i, (acc,) in pl.range(8, init_values=(x,), unroll=2):
-                        acc = pl.add(acc, 1.0)
-                        pl.yield_(acc)
-                    return acc
 
     def test_unroll_runtime_value_rejected(self):
         """Non-constant ``unroll`` is rejected by the parser (must be a literal int)."""


### PR DESCRIPTION
## Summary

- Extend `PartialUnrollTileLoops` to accept `pl.range(..., unroll=F, init_values=(...))`. The pass was previously rejecting any loop with `iter_args`.
- Loop-carried state now threads sequentially through the `F` replicated clones: clone `k` consumes the previous clone's yielded expressions as its iter-arg inputs; only the last clone retains its `YieldStmt` to feed the next outer iteration.
- Static tails and the dynamic `IfStmt` cascade inherit the main loop's `return_vars` as their `iter_args` seed. In the dynamic case, every `IfStmt` in the cascade carries `return_vars`; the innermost else yields the main-loop `return_vars` so `rem == 0` is a clean no-op.

## Changes

- `src/ir/transforms/partial_unroll_tile_loops_pass.cpp` — rewritten `BuildMainLoop`/`BuildTailBranch`/`LowerStatic`/`LowerDynamic` to thread iter-args; new helpers `SplitBodyYield`, `MakeFreshIterArg`, `MakeFreshVar`, `ReplicateBody`, `MakeFreshIterArgs`, `MakeFreshReturnVars`, `ReturnVarsAsExprs`, `InitValueExprs`.
- `python/pypto/language/dsl_api.py`, `python/pypto/language/parser/ast_parser.py` — drop the runtime + parser rejections of `unroll + init_values`.
- `tests/ut/ir/transforms/test_partial_unroll_tile_loops.py` — three new Before/After tests: clean divide, static tail with iter_args, and dynamic cascade threading.
- `tests/ut/language/test_range_unroll_kwarg.py` — convert the rejection test into a positive `test_unroll_with_init_values_parses`.
- `docs/en/dev/passes/20-partial_unroll_tile_loops.md` + zh-CN mirror — drop the "not allowed" constraint row; add "Loop-carried state (`iter_args`)" section and a static-with-iter_args example.

## Test Plan

- [x] `tests/ut/ir/transforms/test_partial_unroll_tile_loops.py` — 9/9 passed (including 3 new iter_args tests)
- [x] `tests/ut/language/test_range_unroll_kwarg.py` — 8/8 passed
- [x] Full unit test suite — 3626 passed / 16 skipped
- [x] clang-tidy clean on the modified C++ file
- [x] pre-commit hooks (clang-format, ruff, pyright, markdownlint) pass

## Follow-ups

RFC #1048 tracks the orthogonal cleanup of the `unroll_replicated` marker attribute — out of scope for this PR.