### PR TITLE
refactor(ir): Remove unroll_replicated marker; broaden IO reorder scope

### DIFF
--- a/docs/en/dev/passes/20-partial_unroll_tile_loops.md
+++ b/docs/en/dev/passes/20-partial_unroll_tile_loops.md
@@ -36,7 +36,7 @@ for i in pl.range(64, unroll=4):
 
 For `for i in range(start, stop, step)` with `attrs_["unroll_factor"] = F`:
 
-- **Main loop**: stride `F*step`, body is a `SeqStmts` of `F` clones; the outer loop carries `attrs_["unroll_replicated"] = F`.
+- **Main loop**: stride `F*step`, body is a `SeqStmts` of `F` clones.
 - **Cloning**: each clone uses `DeepClone(body, {loop_var → new_var + k * step}, clone_def_vars=true)`. Fresh def-vars per clone keep SSA intact and give `MemoryReuse` distinct tile identities to work with.
 
 Two lowering modes — static vs dynamic — differ only in how the main loop's `stop` and the remainder are computed.
@@ -46,7 +46,8 @@ Two lowering modes — static vs dynamic — differ only in how the main loop's 
 With trip count `T = (stop - start) / step`:
 
 - Main loop stops at `start + (T // F) * F * step`.
-- If `T % F != 0`, a single **tail branch** is emitted: a trip-1 `ForStmt` tagged `unroll_replicated = T % F`, containing `T % F` cloned bodies at offsets `start + (T // F) * F * step + j * step` for `j ∈ [0, T%F)`. No runtime dispatch is needed — the remainder count is known.
+- If `T % F != 0`, a **bare `SeqStmts`** of `T % F` cloned bodies at offsets `start + (T // F) * F * step + j * step` (for `j ∈ [0, T%F)`) is flattened directly into the outer scope. No runtime dispatch and no wrapper are needed — the remainder count is known.
+- When the source loop has `iter_args`, trailing `AssignStmt`s bind the outer loop's `return_vars` to the tail's final yielded expressions so downstream references stay valid.
 
 ### Dynamic bounds — `start` and/or `stop` are runtime Exprs (`step` still static, positive)
 
@@ -56,15 +57,15 @@ With trip count `T = (stop - start) / step`:
 - Materialize `rem_iters = trip_iters - main_iters * factor` as a fresh SSA `AssignStmt` (named `unroll_rem`). When `step == 1` this is equivalent to `stop - main_end`, and the pass emits that shorter form. The remainder is dispatched through a cascaded IfStmt chain:
 
   ```text
-  if rem_iters == 1:    <1 clone>                      # outermost
-  else if rem_iters == 2: <2 clones marked unroll_replicated=2>
-  else if rem_iters == 3: <3 clones marked unroll_replicated=3>
+  if rem_iters == 1:    <1 clone>
+  else if rem_iters == 2: <2 clones>
+  else if rem_iters == 3: <3 clones>
   # ...
   else if rem_iters == F-1: <F-1 clones>
   # rem_iters == 0 falls through — no tail work.
   ```
 
-  Each branch's body is a trip-1 `ForStmt` tagged `unroll_replicated = k`, so `ReorderUnrolledIO` reorders each branch internally the same way it does the main loop. SSA stays clean: each branch is self-contained; no conditionally-defined var escapes its IfStmt.
+  Each branch body is a bare `SeqStmts` of `k` cloned bodies (followed by a `YieldStmt` when the source loop has `iter_args`). The enclosing `IfStmt` carries `return_vars`; at the outermost level these are the original outer loop's `return_vars`, at inner levels they are fresh vars fed upward via successive `YieldStmt`s. SSA stays clean: each branch is self-contained; no conditionally-defined var escapes its IfStmt.
 
 ## Constraints
 
@@ -74,12 +75,6 @@ With trip count `T = (stop - start) / step`:
 | Dynamic bounds require `step > 0` | The dynamic trip-count formula assumes positive step; negative-step ranges must use static bounds |
 | `unroll` and `chunk` are mutually exclusive on `pl.range` | Different optimization axes; combining them adds semantic ambiguity without a clear use case |
 | `unroll=` only on `pl.range()` | Scoped feature; `pl.parallel()` / `pl.unroll()` have different semantics |
-
-### Loop-carried state (`iter_args`)
-
-`iter_args` / `init_values` are supported. Loop-carried state threads sequentially through the `F` replicated clones: clone `k` consumes the previous clone's yielded expressions as its iter-arg substitutes, and only the last clone's `YieldStmt` is kept to feed the next outer iteration. When a tail follows, the main loop's `return_vars` become fresh SSA names that seed the tail's `iter_args`; the tail inherits the original outer loop's `return_vars` so downstream references stay valid.
-
-Under dynamic bounds, every `IfStmt` in the cascade carries `return_vars` matching the iter-arg types and every branch ends with a `YieldStmt`. The innermost `else` yields the main-loop `return_vars` unchanged — that is the `rem == 0` no-op fall-through.
 
 ## Examples
 
@@ -91,38 +86,15 @@ for i in pl.range(0, 10, 1, attrs={"unroll_factor": 4}):
     tile_x = pl.tile.load(input_a, [i * 128], [128])
     pl.tile.store(tile_x, [i * 128], output)
 
-# After: main loop covers [0, 8), single tail branch for the leftover 2 iters
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+# After: main loop covers [0, 8), bare tail clones flattened into the outer scope
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128]); pl.tile.store(tile_x_0, [i * 128], output)
     tile_x_1 = pl.tile.load(input_a, [(i + 1) * 128], [128]); pl.tile.store(tile_x_1, [(i + 1) * 128], output)
     tile_x_2 = pl.tile.load(input_a, [(i + 2) * 128], [128]); pl.tile.store(tile_x_2, [(i + 2) * 128], output)
     tile_x_3 = pl.tile.load(input_a, [(i + 3) * 128], [128]); pl.tile.store(tile_x_3, [(i + 3) * 128], output)
 
-for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-    tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
-    tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
-```
-
-### Static with `iter_args` — loop-carried accumulator (`N=10`, `F=4`)
-
-```python
-# Before
-for i, (a,) in pl.range(0, 10, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
-    b = a + i
-    r = pl.yield_(b)
-
-# After: main loop threads a → b → b_1 → b_2 → b_3, then tail seeds a_tail from r_main
-for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
-    b = a + i
-    b_1 = b + (i + 1)
-    b_2 = b_1 + (i + 2)
-    b_3 = b_2 + (i + 3)
-    r_main = pl.yield_(b_3)
-
-for _tail_iter_2, (a,) in pl.range(0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}):
-    b_4 = a + 8
-    b_5 = b_4 + 9
-    r = pl.yield_(b_5)
+tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
+tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
 ```
 
 ### Dynamic — runtime stop `n`
@@ -135,28 +107,26 @@ for i in pl.range(0, n, 1, attrs={"unroll_factor": 4}):
 
 # After
 unroll_main_end: pl.Scalar[pl.INDEX] = ((n - 0) // 4) * 4 + 0
-for i in pl.range(0, unroll_main_end, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, unroll_main_end, 4):
     <4 clones as above>
 
 unroll_rem: pl.Scalar[pl.INDEX] = n - unroll_main_end
 if unroll_rem == 1:
-    for _tail_iter_1 in pl.range(0, 1, 1, attrs={"unroll_replicated": 1}):
-        tile_x_t0 = pl.tile.load(input_a, [unroll_main_end * 128], [128])
-        pl.tile.store(tile_x_t0, [unroll_main_end * 128], output)
+    tile_x_t0 = pl.tile.load(input_a, [unroll_main_end * 128], [128])
+    pl.tile.store(tile_x_t0, [unroll_main_end * 128], output)
 else:
     if unroll_rem == 2:
-        for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-            <2 clones at offsets unroll_main_end + 0, unroll_main_end + 1>
+        <2 clones at offsets unroll_main_end + 0, unroll_main_end + 1>
     else:
         if unroll_rem == 3:
-            for _tail_iter_3 in pl.range(0, 1, 1, attrs={"unroll_replicated": 3}):
-                <3 clones at offsets unroll_main_end + 0, +1, +2>
+            <3 clones at offsets unroll_main_end + 0, +1, +2>
 ```
 
-Every main-loop iteration AND every tail branch carries the `unroll_replicated` marker, so `ReorderUnrolledIO` uniformly clusters loads at the top, stores at the bottom — making the cloned input tiles co-live so `MemoryReuse` keeps them in distinct buffers. Ping-pong buffering works for both the bulk (main) and the tail.
+After this pass, `ReorderUnrolledIO` runs over every `SeqStmts` in the program and clusters loads at the top and stores at the bottom — making the cloned input tiles co-live so `MemoryReuse` keeps them in distinct buffers. Ping-pong buffering applies to both the bulk main loop and the tail clones.
 
 ## Related
 
-- [`ReorderUnrolledIO`](21-reorder_unrolled_io.md) — consumes the `unroll_replicated` marker
+- [`ReorderUnrolledIO`](21-reorder_unrolled_io.md) — the IO-order canonicalization pass that runs next over every `SeqStmts`
 - [`UnrollLoops`](01-unroll_loops.md) — full-unroll pass at slot #1, kept as the primary `pl.unroll(N)` lowering
 - RFC #1025 — design document
+- RFC #1048 — removal of the `unroll_replicated` marker

--- a/docs/en/dev/passes/21-reorder_unrolled_io.md
+++ b/docs/en/dev/passes/21-reorder_unrolled_io.md
@@ -1,18 +1,18 @@
 # ReorderUnrolledIO Pass
 
-Inside each `unroll_replicated` region, lifts `tile.load` to the top and sinks `tile.store` to the bottom — subject to the SSA dependency graph — to enable symmetric ping-pong buffering.
+Inside every `SeqStmts` in the program, lifts `tile.load` / `tile.read` to the top and sinks `tile.store` / `tile.write` to the bottom — subject to the SSA dependency graph — to canonicalize IO order. Within replicated regions produced by `PartialUnrollTileLoops`, this enables symmetric ping-pong buffering.
 
 ## Overview
 
 After `PartialUnrollTileLoops` produces an outer `ForStmt` whose body is a `SeqStmts` of `F` cloned bodies, the natural emission order is `[load_0, compute_0, store_0, load_1, compute_1, store_1, …]`. With this layout, sibling clones' tile live ranges are sequential — `MemoryReuse` happily coalesces them into a single buffer, defeating ping-pong.
 
-This pass reorders each marked `SeqStmts` so:
+This pass reorders every `SeqStmts` in the program (including function bodies, `ForStmt` bodies, and `IfStmt` branch bodies) so:
 
-- Each `tile.load` floats to the earliest position the dependency graph permits.
-- Each `tile.store` sinks to the latest position the dependency graph permits.
+- Each `tile.load` / `tile.read` floats to the earliest position the dependency graph permits.
+- Each `tile.store` / `tile.write` sinks to the latest position the dependency graph permits.
 - Compute statements settle in the middle.
 
-The result is `[loads…, compute…, stores…]` whenever the dataflow allows. Sibling clones' input tiles are co-live near the top, output tiles co-live near the bottom — `MemoryReuse` cannot coalesce them, so each clone keeps its own MemRef and ping-pong buffering becomes possible.
+The result is `[loads…, compute…, stores…]` whenever the dataflow allows. Within replicated regions, sibling clones' input tiles become co-live near the top and output tiles become co-live near the bottom — `MemoryReuse` cannot coalesce them, so each clone keeps its own MemRef and ping-pong buffering becomes possible.
 
 **Requires**: SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure.
 
@@ -31,13 +31,13 @@ result = passes.reorder_unrolled_io()(program)
 
 ## Algorithm
 
-A priority-aware stable topological sort. Each top-level statement of the marked `SeqStmts` is categorized:
+A priority-aware stable topological sort applied to every `SeqStmts` of two or more statements. Each top-level statement is categorized:
 
 | Category | Priority | Examples |
 | -------- | -------- | -------- |
-| `Load` | 0 (emit first) | `AssignStmt(tile, Call("tile.load", …))` |
+| `Load` | 0 (emit first) | `AssignStmt(tile, Call("tile.load", …))`, `AssignStmt(scalar, Call("tile.read", …))` |
 | `Compute` | 1 | Anything else inside the region |
-| `Store` | 2 (emit last) | `AssignStmt(_, Call("tile.store", …))` or `EvalStmt(Call("tile.store", …))` |
+| `Store` | 2 (emit last) | `AssignStmt(_, Call("tile.store", …))` / `EvalStmt(Call("tile.store", …))` / `tile.write` variants |
 
 At each step:
 
@@ -64,15 +64,14 @@ Output: `[load_0, load_1, compute_0, compute_1, store_0, store_1]`.
 
 The reorder is a topological sort over the SSA def-use dependency graph, so it preserves all dataflow. Soundness rests on two utilities from `stmt_dependency_analysis.h`:
 
-1. `CheckInOutUseDiscipline(region, program)` — aborts compilation if any user-function call passes a variable as `InOut`/`Out` and a later statement reads that same variable. The discipline (RFC #1026) guarantees that physical-memory mutations are mirrored by SSA version changes, so SSA def-use captures all real dependencies.
+1. `CheckInOutUseDiscipline(region, program)` — aborts compilation if any user-function call passes a variable as `InOut`/`Out` and a later statement reads that same variable. Since PR #1039 this is a structural IR invariant (RFC #1026): every `SeqStmts` in valid IR satisfies it, so the reorder is sound everywhere.
 2. `BuildStmtDependencyGraph(region, program)` — produces a sound def-use DAG over the region's top-level statements, given the discipline holds.
 
 ## Constraints
 
 | Constraint | Reason |
 | ---------- | ------ |
-| Operates only inside `ForStmt` carrying `attrs_["unroll_replicated"]` | The pass would otherwise reorder unrelated SeqStmts in unintended ways |
-| Region must satisfy the InOut-use discipline | Required for sound dataflow analysis (see RFC #1026) |
+| Region must satisfy the InOut-use discipline | Required for sound dataflow analysis (structural invariant since PR #1039) |
 | Aborts on cyclic dependency graph | Should be impossible for an SSA region; raised as `INTERNAL_CHECK` |
 
 ## Example
@@ -80,7 +79,7 @@ The reorder is a topological sort over the SSA def-use dependency graph, so it p
 **Before** (input from `PartialUnrollTileLoops`):
 
 ```python
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128])
     tile_y_0 = pl.tile.add(tile_x_0, 1.0)
     pl.tile.store(tile_y_0, [i * 128], output)
@@ -93,7 +92,7 @@ for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
 **After**:
 
 ```python
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128])
     tile_x_1 = pl.tile.load(input_a, [(i + 1) * 128], [128])
     tile_x_2 = pl.tile.load(input_a, [(i + 2) * 128], [128])
@@ -112,7 +111,8 @@ All four `tile_x_k` are now co-live up to the last load, and all four `tile_y_k`
 
 ## Related
 
-- [`PartialUnrollTileLoops`](20-partial_unroll_tile_loops.md) — produces the `unroll_replicated` marker this pass consumes
-- [`MemoryReuse`](16-memory_reuse.md) — runs after this pass; benefits from the co-live tiles
-- RFC #1025 — design document
+- [`PartialUnrollTileLoops`](20-partial_unroll_tile_loops.md) — upstream producer of replicated regions that benefit most from this pass
+- [`MemoryReuse`](16-memory_reuse.md) — runs after this pass; benefits from the co-live tiles in replicated regions
+- RFC #1025 — replicated-region design
 - RFC #1026 / PR #1029 — InOut-use discipline + dependency analysis utility
+- RFC #1048 — removal of the `unroll_replicated` marker; broadening of this pass's scope to every `SeqStmts`

--- a/docs/zh-cn/dev/passes/20-partial_unroll_tile_loops.md
+++ b/docs/zh-cn/dev/passes/20-partial_unroll_tile_loops.md
@@ -36,7 +36,7 @@ for i in pl.range(64, unroll=4):
 
 对于 `attrs_["unroll_factor"] = F` 的循环：
 
-- **主循环**：步长为 `F*step`，循环体为 `F` 份副本组成的 `SeqStmts`；外层循环带 `attrs_["unroll_replicated"] = F` 标记。
+- **主循环**：步长为 `F*step`，循环体为 `F` 份副本组成的 `SeqStmts`。
 - **克隆细节**：每份副本通过 `DeepClone(body, {loop_var → new_var + k * step}, clone_def_vars=true)` 生成。每个副本拥有新鲜的定义变量，既保持 SSA，又给 `MemoryReuse` 提供独立的 tile 身份。
 
 根据 `start` / `stop` 是否为编译期常量，分为两种降级模式，区别仅在主循环的 `stop` 与余数处理方式。
@@ -46,7 +46,8 @@ for i in pl.range(64, unroll=4):
 迭代次数 `T = (stop - start) / step`：
 
 - 主循环终点为 `start + (T // F) * F * step`。
-- 若 `T % F != 0`，再发射一个**尾部分支**：trip-1 `ForStmt`（标记 `unroll_replicated = T % F`），内含 `T % F` 份克隆体，偏移为 `start + (T // F) * F * step + j * step`，`j ∈ [0, T%F)`。余数已知，不需要运行时分派。
+- 若 `T % F != 0`，再发射一段**裸 `SeqStmts`**：`T % F` 份克隆体，偏移为 `start + (T // F) * F * step + j * step`（`j ∈ [0, T%F)`），直接扁平化到外层作用域。余数已知，无需运行时分派，也无需任何包装结构。
+- 当源循环存在 `iter_args` 时，尾部克隆后附加 `AssignStmt` 将源循环的 `return_vars` 绑定到尾部最终 yield 表达式，保证下游引用仍然有效。
 
 ### 动态边界 —— `start` / `stop` 为运行时 Expr（`step` 仍为静态且为正）
 
@@ -56,15 +57,15 @@ for i in pl.range(64, unroll=4):
 - 以 SSA 变量 `unroll_rem` 绑定 `rem_iters = trip_iters - main_iters * factor`（`step == 1` 时等价于 `stop - main_end`，Pass 直接发射该简化形式）。通过级联 IfStmt 根据迭代数分派：
 
   ```text
-  if rem_iters == 1:    <1 份克隆>                         # 最外层
-  else if rem_iters == 2: <2 份克隆，unroll_replicated=2>
-  else if rem_iters == 3: <3 份克隆，unroll_replicated=3>
+  if rem_iters == 1:    <1 份克隆>
+  else if rem_iters == 2: <2 份克隆>
+  else if rem_iters == 3: <3 份克隆>
   # ...
   else if rem_iters == F-1: <F-1 份克隆>
   # rem_iters == 0 不匹配任何分支，跳过尾部。
   ```
 
-  每个分支的 body 为一个 trip-1 `ForStmt`，带 `unroll_replicated = k` 标记，因此 `ReorderUnrolledIO` 以与主循环相同的方式对每个分支内部进行重排。SSA 依然干净：每个分支自包含，任何条件定义的变量都不会逃出其 IfStmt。
+  每个分支 body 为 `k` 份克隆体组成的裸 `SeqStmts`（若源循环存在 `iter_args` 则追加一条 `YieldStmt`）。外层 `IfStmt` 携带 `return_vars`：最外层即原循环的 `return_vars`，内层级联分支使用新鲜变量，通过一系列 `YieldStmt` 向上传递。SSA 依然干净：每个分支自包含，任何条件定义的变量都不会逃出其 IfStmt。
 
 ## 约束
 
@@ -74,12 +75,6 @@ for i in pl.range(64, unroll=4):
 | 动态边界要求 `step > 0` | 动态 trip 计算公式假设正步长；负步长需使用静态边界 |
 | `unroll` 与 `chunk` 在 `pl.range` 中互斥 | 二者优化方向不同，组合使用语义模糊且无明显场景 |
 | `unroll=` 仅支持 `pl.range()` | 该特性作用域限定于 `pl.range()`；`pl.parallel()` / `pl.unroll()` 语义不同 |
-
-### 循环携带状态（`iter_args`）
-
-支持 `iter_args` / `init_values`。循环携带状态按顺序穿过 `F` 个副本：第 `k` 个副本以上一副本的 `YieldStmt` 表达式作为其 iter-arg 的替换值，仅最后一个副本保留 `YieldStmt` 以传递给主循环下一次外层迭代。若存在尾部分支，主循环的 `return_vars` 使用新的 SSA 名字，作为尾部分支 `iter_args` 的初值；尾部分支则继承原外层循环的 `return_vars`，确保下游引用有效。
-
-动态边界下，级联中的每个 `IfStmt` 都携带与 iter-arg 类型一致的 `return_vars`，每个分支均以 `YieldStmt` 结尾。最内层 `else` 直接 yield 主循环的 `return_vars` —— 即 `rem == 0` 时的空操作回退。
 
 ## 示例
 
@@ -91,38 +86,15 @@ for i in pl.range(0, 10, 1, attrs={"unroll_factor": 4}):
     tile_x = pl.tile.load(input_a, [i * 128], [128])
     pl.tile.store(tile_x, [i * 128], output)
 
-# 变换后：主循环覆盖 [0, 8)，单个尾部分支处理剩余 2 次迭代
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+# 变换后：主循环覆盖 [0, 8)，尾部克隆直接扁平化到外层作用域
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128]); pl.tile.store(tile_x_0, [i * 128], output)
     tile_x_1 = pl.tile.load(input_a, [(i + 1) * 128], [128]); pl.tile.store(tile_x_1, [(i + 1) * 128], output)
     tile_x_2 = pl.tile.load(input_a, [(i + 2) * 128], [128]); pl.tile.store(tile_x_2, [(i + 2) * 128], output)
     tile_x_3 = pl.tile.load(input_a, [(i + 3) * 128], [128]); pl.tile.store(tile_x_3, [(i + 3) * 128], output)
 
-for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-    tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
-    tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
-```
-
-### 静态带 `iter_args` —— 循环累加（`N=10`、`F=4`）
-
-```python
-# 变换前
-for i, (a,) in pl.range(0, 10, 1, init_values=(s0,), attrs={"unroll_factor": 4}):
-    b = a + i
-    r = pl.yield_(b)
-
-# 变换后：主循环按 a → b → b_1 → b_2 → b_3 串接，尾部分支以 r_main 作为 a_tail 的初值
-for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
-    b = a + i
-    b_1 = b + (i + 1)
-    b_2 = b_1 + (i + 2)
-    b_3 = b_2 + (i + 3)
-    r_main = pl.yield_(b_3)
-
-for _tail_iter_2, (a,) in pl.range(0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}):
-    b_4 = a + 8
-    b_5 = b_4 + 9
-    r = pl.yield_(b_5)
+tile_x_4 = pl.tile.load(input_a, [8 * 128], [128]); pl.tile.store(tile_x_4, [8 * 128], output)
+tile_x_5 = pl.tile.load(input_a, [9 * 128], [128]); pl.tile.store(tile_x_5, [9 * 128], output)
 ```
 
 ### 动态 —— 运行时 `n`
@@ -135,28 +107,26 @@ for i in pl.range(0, n, 1, attrs={"unroll_factor": 4}):
 
 # 变换后
 unroll_main_end: pl.Scalar[pl.INDEX] = ((n - 0) // 4) * 4 + 0
-for i in pl.range(0, unroll_main_end, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, unroll_main_end, 4):
     <4 份克隆体，与静态示例相同>
 
 unroll_rem: pl.Scalar[pl.INDEX] = n - unroll_main_end
 if unroll_rem == 1:
-    for _tail_iter_1 in pl.range(0, 1, 1, attrs={"unroll_replicated": 1}):
-        tile_x_t0 = pl.tile.load(input_a, [unroll_main_end * 128], [128])
-        pl.tile.store(tile_x_t0, [unroll_main_end * 128], output)
+    tile_x_t0 = pl.tile.load(input_a, [unroll_main_end * 128], [128])
+    pl.tile.store(tile_x_t0, [unroll_main_end * 128], output)
 else:
     if unroll_rem == 2:
-        for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-            <偏移 unroll_main_end + 0、+1 的 2 份克隆体>
+        <偏移 unroll_main_end + 0、+1 的 2 份克隆体>
     else:
         if unroll_rem == 3:
-            for _tail_iter_3 in pl.range(0, 1, 1, attrs={"unroll_replicated": 3}):
-                <偏移 unroll_main_end + 0、+1、+2 的 3 份克隆体>
+            <偏移 unroll_main_end + 0、+1、+2 的 3 份克隆体>
 ```
 
-主循环与每个尾部分支都带 `unroll_replicated` 标记，`ReorderUnrolledIO` 以一致方式将 load 上拉、store 下沉，使各副本的输入 tile 同时活跃，从而 `MemoryReuse` 不能合并它们。主干与尾部都能从 ping-pong 缓冲中受益。
+本 Pass 之后，`ReorderUnrolledIO` 作用于全程序的每一个 `SeqStmts`，将 load 上拉、store 下沉，使各副本的输入 tile 同时活跃，从而 `MemoryReuse` 不能合并它们。主循环与尾部克隆都能从 ping-pong 缓冲中受益。
 
 ## 相关
 
-- [`ReorderUnrolledIO`](21-reorder_unrolled_io.md) —— 消费 `unroll_replicated` 标记
+- [`ReorderUnrolledIO`](21-reorder_unrolled_io.md) —— 下一个 Pass，对全程序每一个 `SeqStmts` 做 IO 顺序规范化
 - [`UnrollLoops`](01-unroll_loops.md) —— slot #1 的全展开 Pass，仍是 `pl.unroll(N)` 的主要降级路径
 - RFC #1025 —— 设计文档
+- RFC #1048 —— 移除 `unroll_replicated` 标记

--- a/docs/zh-cn/dev/passes/21-reorder_unrolled_io.md
+++ b/docs/zh-cn/dev/passes/21-reorder_unrolled_io.md
@@ -1,18 +1,18 @@
 # ReorderUnrolledIO Pass
 
-在每个 `unroll_replicated` 区域内，把 `tile.load` 上拉到顶部、`tile.store` 下沉到底部 —— 受 SSA 依赖图约束 —— 从而启用对称的 ping-pong 缓冲。
+在全程序的每一个 `SeqStmts` 内部，把 `tile.load` / `tile.read` 上拉到顶部、`tile.store` / `tile.write` 下沉到底部 —— 受 SSA 依赖图约束 —— 从而规范化 IO 顺序。对于 `PartialUnrollTileLoops` 产生的复制区域，该规范化直接启用对称的 ping-pong 缓冲。
 
 ## 概述
 
 `PartialUnrollTileLoops` 生成的外层 `ForStmt` 体是 `F` 份克隆体的 `SeqStmts`，自然顺序为 `[load_0, compute_0, store_0, load_1, compute_1, store_1, …]`。这种布局下，相邻克隆的 tile 生命周期不重叠，`MemoryReuse` 会把它们合并为同一缓冲区，ping-pong 失效。
 
-本 Pass 重排每个标记的 `SeqStmts`：
+本 Pass 对全程序的每一个 `SeqStmts`（包括函数体、`ForStmt` body、`IfStmt` 分支 body 等）做重排：
 
-- 每个 `tile.load` 上拉到依赖图允许的最早位置。
-- 每个 `tile.store` 下沉到依赖图允许的最晚位置。
+- 每个 `tile.load` / `tile.read` 上拉到依赖图允许的最早位置。
+- 每个 `tile.store` / `tile.write` 下沉到依赖图允许的最晚位置。
 - 计算语句留在中间。
 
-只要数据流允许，结果即为 `[loads…, compute…, stores…]`。各克隆的输入 tile 在顶部同时活跃，输出 tile 在底部同时活跃 —— `MemoryReuse` 无法合并它们，每个克隆保留独立的 MemRef，从而 ping-pong 缓冲成为可能。
+只要数据流允许，结果即为 `[loads…, compute…, stores…]`。对于复制区域，各克隆的输入 tile 在顶部同时活跃，输出 tile 在底部同时活跃 —— `MemoryReuse` 无法合并它们，每个克隆保留独立的 MemRef，从而 ping-pong 缓冲成为可能。
 
 **前置条件**: SSAForm、SplitIncoreOrch、IncoreTileOps、TileOps2D、TileMemoryInferred、NormalizedStmtStructure。
 
@@ -31,13 +31,13 @@ result = passes.reorder_unrolled_io()(program)
 
 ## 算法
 
-优先级感知的稳定拓扑排序。把标记 `SeqStmts` 内的每条语句分类：
+对所有两条及以上语句的 `SeqStmts` 做优先级感知的稳定拓扑排序。每条语句分类：
 
 | 类别 | 优先级 | 示例 |
 | ---- | ------ | ---- |
-| `Load` | 0（最先发射） | `AssignStmt(tile, Call("tile.load", …))` |
+| `Load` | 0（最先发射） | `AssignStmt(tile, Call("tile.load", …))`、`AssignStmt(scalar, Call("tile.read", …))` |
 | `Compute` | 1 | 区域内其余语句 |
-| `Store` | 2（最后发射） | `AssignStmt(_, Call("tile.store", …))` 或 `EvalStmt(Call("tile.store", …))` |
+| `Store` | 2（最后发射） | `AssignStmt(_, Call("tile.store", …))` / `EvalStmt(Call("tile.store", …))` / `tile.write` 变体 |
 
 每一步：
 
@@ -64,15 +64,14 @@ ready={store_1}               仅 store 就绪 → 发射 store_1
 
 重排是对 SSA def-use 依赖图的拓扑排序，因此保留所有数据流。可靠性依赖于 `stmt_dependency_analysis.h` 中的两个工具：
 
-1. `CheckInOutUseDiscipline(region, program)` —— 若某个用户函数调用以 `InOut`/`Out` 方式传入变量，且后续语句读取该变量，则中止编译。该规约（RFC #1026）保证物理内存变更对应 SSA 版本变化，因此 SSA def-use 即捕获所有真实依赖。
+1. `CheckInOutUseDiscipline(region, program)` —— 若某个用户函数调用以 `InOut`/`Out` 方式传入变量，且后续语句读取该变量，则中止编译。自 PR #1039 起该规约已是结构化 IR 不变式（RFC #1026）：所有合法 IR 的每个 `SeqStmts` 都满足它，重排在任何位置都是安全的。
 2. `BuildStmtDependencyGraph(region, program)` —— 在规约成立时，构造区域顶层语句的可靠 def-use DAG。
 
 ## 约束
 
 | 约束 | 原因 |
 | ---- | ---- |
-| 仅在带 `attrs_["unroll_replicated"]` 的 `ForStmt` 内部生效 | 否则会无意中重排无关 SeqStmts |
-| 区域必须满足 InOut-use 规约 | 数据流分析的可靠性前提（RFC #1026） |
+| 区域必须满足 InOut-use 规约 | 数据流分析的可靠性前提（自 PR #1039 起为结构化不变式） |
 | 依赖图存在环时中止 | SSA 区域不应出现环；以 `INTERNAL_CHECK` 抛出 |
 
 ## 示例
@@ -80,7 +79,7 @@ ready={store_1}               仅 store 就绪 → 发射 store_1
 **变换前**（来自 `PartialUnrollTileLoops` 的输入）:
 
 ```python
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128])
     tile_y_0 = pl.tile.add(tile_x_0, 1.0)
     pl.tile.store(tile_y_0, [i * 128], output)
@@ -93,7 +92,7 @@ for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
 **变换后**:
 
 ```python
-for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
+for i in pl.range(0, 8, 4):
     tile_x_0 = pl.tile.load(input_a, [i * 128], [128])
     tile_x_1 = pl.tile.load(input_a, [(i + 1) * 128], [128])
     tile_x_2 = pl.tile.load(input_a, [(i + 2) * 128], [128])
@@ -112,7 +111,8 @@ for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
 
 ## 相关
 
-- [`PartialUnrollTileLoops`](20-partial_unroll_tile_loops.md) —— 生成本 Pass 消费的 `unroll_replicated` 标记
-- [`MemoryReuse`](16-memory_reuse.md) —— 在本 Pass 之后运行；受益于同时活跃的 tile
-- RFC #1025 —— 设计文档
+- [`PartialUnrollTileLoops`](20-partial_unroll_tile_loops.md) —— 上游复制区域生成者，本 Pass 在此区域上效果最显著
+- [`MemoryReuse`](16-memory_reuse.md) —— 在本 Pass 之后运行；受益于复制区域中同时活跃的 tile
+- RFC #1025 —— 复制区域设计
 - RFC #1026 / PR #1029 —— InOut-use 规约 + 依赖分析工具
+- RFC #1048 —— 移除 `unroll_replicated` 标记；将本 Pass 作用域扩展到每一个 `SeqStmts`

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -216,11 +216,9 @@ Pass UnrollLoops();
  * Lowers ``for i in pl.range(N, unroll=F)`` into an outer loop of ``N/F``
  * iterations whose body is a ``SeqStmts`` of ``F`` deep-cloned copies of the
  * original body, each with the loop variable substituted as
- * ``new_var + k * step``. A trailing remainder loop covers ``N % F`` if non-zero.
- * The new outer loop carries ``attrs_["unroll_replicated"] = F`` so the
- * downstream ``ReorderUnrolledIO`` pass can identify the replicated region.
- *
- * First-cut restrictions: static bounds only, no iter_args/init_values.
+ * ``new_var + k * step``. A trailing remainder covers ``N % F`` if non-zero —
+ * a bare ``SeqStmts`` flattened into the outer scope for static bounds, or a
+ * cascaded ``IfStmt`` dispatch on ``rem`` for dynamic bounds.
  *
  * Runs at the tile level (after NormalizeReturnOrder, before InitMemRef) so
  * each clone's tile variables become candidates for distinct MemRef allocations
@@ -229,18 +227,21 @@ Pass UnrollLoops();
 Pass PartialUnrollTileLoops();
 
 /**
- * @brief Cluster tile.load and tile.store calls within unroll-replicated regions
+ * @brief Canonicalize IO order inside every ``SeqStmts`` in the program
  *
- * For every ForStmt carrying ``attrs_["unroll_replicated"]``, performs a
- * priority-aware stable topological sort over the body's top-level statements:
- *   - tile.load assignments are pulled as far up as the dependency graph permits
- *   - tile.store calls are pushed as far down as the dependency graph permits
+ * For every ``SeqStmts`` with two or more statements, performs a priority-aware
+ * stable topological sort over its members:
+ *   - ``tile.load`` / ``tile.read`` assignments are pulled as far up as the
+ *     dependency graph permits
+ *   - ``tile.store`` / ``tile.write`` calls are pushed as far down as the
+ *     dependency graph permits
  *   - compute statements settle in the middle
  *
  * The result is `[loads…, compute…, stores…]` whenever the dataflow allows.
- * Input tiles for sibling clones become co-live near the top, output tiles
- * become co-live near the bottom — preventing MemoryReuse from coalescing them
- * and enabling symmetric ping-pong execution.
+ * Within replicated regions produced by ``PartialUnrollTileLoops``, sibling
+ * clones' input tiles become co-live near the top and output tiles co-live
+ * near the bottom — preventing ``MemoryReuse`` from coalescing them and
+ * enabling symmetric ping-pong execution.
  *
  * Uses ``stmt_dep::BuildStmtDependencyGraph`` and
  * ``stmt_dep::CheckInOutUseDiscipline`` for soundness.

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -325,12 +325,13 @@ void BindPass(nb::module_& m) {
   passes.def("unroll_loops", &pass::UnrollLoops, "Create a loop unrolling pass");
   passes.def("partial_unroll_tile_loops", &pass::PartialUnrollTileLoops,
              "Lower ``pl.range(N, unroll=F)`` loops at the tile level: replicate the body F\n"
-             "times per outer iteration with a remainder loop covering N % F when needed.\n"
-             "Produces a marker attr ``unroll_replicated`` that ReorderUnrolledIO consumes.");
+             "times per outer iteration with a bare-SeqStmts remainder (or a cascaded IfStmt\n"
+             "dispatch for dynamic bounds) covering N % F when needed.");
   passes.def("reorder_unrolled_io", &pass::ReorderUnrolledIO,
-             "Within unroll-replicated regions, lift tile.load to the top and sink tile.store\n"
-             "to the bottom, subject to the SSA dependency graph. Enables symmetric ping-pong\n"
-             "buffering by making sibling clones' input and output tiles co-live.");
+             "Canonicalize IO order inside every SeqStmts in the program: lift tile.load to\n"
+             "the top and sink tile.store to the bottom, subject to the SSA dependency graph.\n"
+             "Enables symmetric ping-pong buffering by making replicated clones' input and\n"
+             "output tiles co-live.");
   passes.def("ctrl_flow_transform", &pass::CtrlFlowTransform,
              "Create a control flow structuring pass (eliminate break/continue)");
   passes.def("convert_to_ssa", &pass::ConvertToSSA, "Create an SSA conversion pass");

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -328,18 +328,21 @@ def unroll_loops() -> Pass:
 def partial_unroll_tile_loops() -> Pass:
     """Create a tile-level partial-unroll pass for ``pl.range(N, unroll=F)`` loops.
 
-    Replicates each loop body F times per outer iteration, optionally appending a
-    remainder loop. Produces an ``unroll_replicated`` marker attr consumed by
-    ``reorder_unrolled_io``.
+    Replicates each loop body F times per outer iteration. Static bounds emit a
+    bare ``SeqStmts`` tail flattened into the outer scope; dynamic bounds emit a
+    cascaded ``IfStmt`` dispatch on ``rem`` whose branch bodies are bare
+    ``SeqStmts``.
     """
 
 def reorder_unrolled_io() -> Pass:
-    """Create a pass that clusters tile.load to the top and tile.store to the bottom
-    within unroll-replicated regions.
+    """Create an IO-order canonicalization pass.
 
-    Performs a priority-aware stable topological sort over each marked SeqStmts so
-    sibling clones' input and output tiles become co-live, enabling ping-pong
-    buffering once MemoryReuse runs.
+    Performs a priority-aware stable topological sort over every ``SeqStmts`` in
+    the program: ``tile.load`` floats to the top, ``tile.store`` sinks to the
+    bottom, compute settles in the middle — subject to the SSA dependency graph.
+    Within replicated regions from ``partial_unroll_tile_loops``, sibling clones'
+    input and output tiles become co-live, enabling ping-pong buffering once
+    ``MemoryReuse`` runs.
     """
 
 def ctrl_flow_transform() -> Pass:

--- a/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
+++ b/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
@@ -42,7 +42,6 @@ using Attrs = std::vector<std::pair<std::string, std::any>>;
 namespace {
 
 constexpr const char* kUnrollFactorAttr = "unroll_factor";
-constexpr const char* kUnrollReplicatedAttr = "unroll_replicated";
 
 /// Extract a compile-time integer from a ConstInt or Neg(ConstInt) expression.
 int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
@@ -93,18 +92,13 @@ ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span) {
   return MakeAdd(base, MakeConstIndex(offset_val, span), span);
 }
 
-/// Copy `original` while removing `kUnrollFactorAttr` and (optionally) adding
-/// `kUnrollReplicatedAttr` with `factor` as an int.
-Attrs RewriteAttrs(const Attrs& original, std::optional<int64_t> replicated_factor) {
+/// Copy `original` while stripping `kUnrollFactorAttr`.
+Attrs StripUnrollFactorAttr(const Attrs& original) {
   Attrs out;
-  out.reserve(original.size() + 1);
+  out.reserve(original.size());
   for (const auto& [k, v] : original) {
     if (k == kUnrollFactorAttr) continue;
-    if (k == kUnrollReplicatedAttr) continue;  // never preserve a stale marker
     out.emplace_back(k, v);
-  }
-  if (replicated_factor.has_value()) {
-    out.emplace_back(kUnrollReplicatedAttr, static_cast<int>(*replicated_factor));
   }
   return out;
 }
@@ -149,11 +143,13 @@ std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
  * @brief Mutator that lowers ForStmt nodes carrying `attrs_["unroll_factor"]`
  *        into a replicated main loop plus a modulo-dispatch remainder.
  *
- * Static bounds → single-branch tail with exactly rem_iters clones.
+ * Static bounds → bare `SeqStmts` tail with exactly rem_iters clones flattened
+ *   into the outer scope (plus trailing `AssignStmt`s to bind the outer loop's
+ *   `return_vars` when iter_args exist).
  * Dynamic bounds (start and/or stop are runtime Exprs) → a cascaded
- *   `if rem == k` dispatch for k in [1, factor), each branch containing
- *   k cloned bodies tagged `unroll_replicated = k`. Step must always be a
- *   compile-time constant.
+ *   `if rem == k` dispatch for k in [1, factor); each branch body is a bare
+ *   `SeqStmts` of k cloned bodies (followed by a `YieldStmt` when iter_args
+ *   exist). Step must always be a compile-time constant.
  *
  * `iter_args` are supported: loop-carried state threads sequentially through the
  * F replicated clones in the main loop (each clone consumes the previous clone's
@@ -197,7 +193,7 @@ class PartialUnrollMutator : public IRMutator {
   StmtPtr CleanupUnrollAttr(const ForStmtPtr& op, const StmtPtr& inner_body) {
     auto cleaned = MutableCopy(op);
     cleaned->body_ = inner_body;
-    cleaned->attrs_ = RewriteAttrs(op->attrs_, std::nullopt);
+    cleaned->attrs_ = StripUnrollFactorAttr(op->attrs_);
     return cleaned;
   }
 
@@ -266,19 +262,6 @@ class PartialUnrollMutator : public IRMutator {
     return result;
   }
 
-  /// Fresh iter_args for a wrapper ForStmt, taking initial values from `init_values`.
-  std::vector<IterArgPtr> MakeFreshIterArgs(const std::vector<IterArgPtr>& originals,
-                                            const std::vector<ExprPtr>& init_values) {
-    INTERNAL_CHECK(originals.size() == init_values.size())
-        << "Internal error: iter_arg/init_value count mismatch";
-    std::vector<IterArgPtr> result;
-    result.reserve(originals.size());
-    for (size_t j = 0; j < originals.size(); ++j) {
-      result.push_back(MakeFreshIterArg(originals[j], init_values[j]));
-    }
-    return result;
-  }
-
   /// Fresh return_vars matching the originals' types, with a suffix applied to names.
   std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix) {
     std::vector<VarPtr> result;
@@ -325,58 +308,37 @@ class PartialUnrollMutator : public IRMutator {
     auto new_body = SeqStmts::Flatten(std::move(body_parts), sp);
 
     ExprPtr new_step = MakeConstIndex(factor * step, sp);
-    Attrs new_attrs = RewriteAttrs(op->attrs_, factor);
+    Attrs new_attrs = StripUnrollFactorAttr(op->attrs_);
     return std::make_shared<ForStmt>(new_loop_var, main_start, main_stop, new_step, new_iter_args, new_body,
                                      main_return_vars, sp, op->kind_,
                                      /*chunk_config=*/std::nullopt, new_attrs, op->leading_comments_);
   }
 
   /**
-   * @brief Build a trip-1 ForStmt wrapping `k_clones` cloned bodies at offsets
-   *        `base_index + j*step` (j in [0, k_clones)), tagged with
-   *        `unroll_replicated = k_clones` so ReorderUnrolledIO processes it.
+   * @brief Build the tail as a bare `SeqStmts` of `k_clones` cloned bodies at
+   *        offsets `base_index + j*step` (j in [0, k_clones)).
    *
-   * SeqStmts has no attrs_, so the wrapper exists purely to carry the marker.
-   * When the source loop has iter_args, the wrapper also threads loop-carried
-   * state: its fresh iter_args are seeded from `iter_init_values`, its clones
-   * are chained via the previous clone's yields, and a trailing YieldStmt feeds
-   * the wrapper's `return_vars`.
+   * Iter-args of the source loop are substituted directly with `iter_init_values`
+   * for the first clone and with the previous clone's yields for subsequent
+   * clones. Callers thread loop-carried state explicitly — either by wiring
+   * `final_yields` into the enclosing IfStmt's `YieldStmt` (dynamic cascade) or
+   * by emitting `AssignStmt`s that bind the outer loop's `return_vars` to the
+   * final yields (static tail after a main loop).
    */
-  StmtPtr BuildTailBranch(const ForStmtPtr& op, const StmtPtr& body, int64_t k_clones, int64_t step,
-                          const ExprPtr& base_index, const std::vector<ExprPtr>& iter_init_values,
-                          const std::vector<VarPtr>& return_vars) {
-    Span sp = op->span_;
-    auto fresh_iter_args = MakeFreshIterArgs(op->iter_args_, iter_init_values);
-    std::vector<ExprPtr> initial_substitutes;
-    initial_substitutes.reserve(fresh_iter_args.size());
-    for (const auto& ia : fresh_iter_args) initial_substitutes.push_back(ia);
-
-    auto region = ReplicateBody(op, body, k_clones, step, base_index, initial_substitutes);
-
-    std::vector<StmtPtr> body_parts = {region.body};
-    if (!op->iter_args_.empty()) {
-      body_parts.push_back(std::make_shared<YieldStmt>(region.final_yields, sp));
-    }
-    auto seq_body = SeqStmts::Flatten(std::move(body_parts), sp);
-
-    auto dummy_var = std::make_shared<Var>("_tail_iter_" + std::to_string(k_clones),
-                                           std::make_shared<ScalarType>(DataType::INDEX), sp);
-    Attrs attrs = {{kUnrollReplicatedAttr, static_cast<int>(k_clones)}};
-    return std::make_shared<ForStmt>(dummy_var, MakeConstIndex(0, sp), MakeConstIndex(1, sp),
-                                     MakeConstIndex(1, sp), fresh_iter_args, seq_body, return_vars, sp,
-                                     ForKind::Sequential,
-                                     /*chunk_config=*/std::nullopt, attrs,
-                                     /*leading_comments=*/std::vector<std::string>{});
+  ReplicatedRegion BuildTailSeq(const ForStmtPtr& op, const StmtPtr& body, int64_t k_clones, int64_t step,
+                                const ExprPtr& base_index, const std::vector<ExprPtr>& iter_init_values) {
+    return ReplicateBody(op, body, k_clones, step, base_index, iter_init_values);
   }
 
   /**
    * @brief Static lowering: compile-time trip count → main loop + (optional)
-   *        single-branch tail with exactly rem_iters clones. No dispatch needed
-   *        because the remainder count is known.
+   *        bare-SeqStmts tail with exactly rem_iters clones, flattened into the
+   *        outer scope. No dispatch needed because the remainder count is known.
    *
    * When iter_args are present, the main loop's return_vars forward loop-carried
-   * state to the tail branch's iter_args; the tail branch inherits the original
-   * outer loop's return_vars so downstream references stay valid.
+   * state to the tail clones as their iter_arg substitutes; the tail's final
+   * yields bind to the outer loop's `return_vars` via trailing `AssignStmt`s so
+   * downstream references to those vars stay valid.
    */
   StmtPtr LowerStatic(const ForStmtPtr& op, const StmtPtr& body, int64_t factor, int64_t start, int64_t stop,
                       int64_t step) {
@@ -410,8 +372,16 @@ class PartialUnrollMutator : public IRMutator {
       // init_values.
       std::vector<ExprPtr> tail_init_values =
           (main_iters > 0) ? ReturnVarsAsExprs(main_return_vars) : InitValueExprs(op->iter_args_);
-      result.push_back(
-          BuildTailBranch(op, body, rem_iters, step, base_index, tail_init_values, op->return_vars_));
+      auto region = BuildTailSeq(op, body, rem_iters, step, base_index, tail_init_values);
+      // Push the bare SeqStmts of clones — SeqStmts::Flatten will splice them
+      // directly into the outer result sequence.
+      result.push_back(region.body);
+      // Bind the original loop's return_vars to the tail's final yields so
+      // downstream references to op->return_vars_ remain valid.
+      for (size_t j = 0; j < op->return_vars_.size(); ++j) {
+        result.push_back(
+            std::make_shared<AssignStmt>(op->return_vars_[j], region.final_yields[j], op->span_));
+      }
     }
     return SeqStmts::Flatten(std::move(result), op->span_);
   }
@@ -422,7 +392,7 @@ class PartialUnrollMutator : public IRMutator {
    *   trip_iters    = ceil_div(stop - start, step)
    *   main_iters    = trip_iters / factor                       (compile-time: `/ factor`)
    *   main_end      = start + main_iters * (factor * step)      (SSA-bound to `unroll_main_end`)
-   *   for i in range(start, main_end, F*step) [unroll_replicated=F]: <F clones>
+   *   for i in range(start, main_end, F*step): <F clones>
    *   rem_iters     = trip_iters - main_iters * factor          (SSA-bound to `unroll_rem`)
    *   if rem_iters == 1: <1 clone>      # outermost
    *   else if rem_iters == 2: <2 clones>
@@ -492,22 +462,20 @@ class PartialUnrollMutator : public IRMutator {
     // every IfStmt carries return_vars (fresh at inner levels, the original
     // outer return_vars at the outermost level) and every branch ends with a
     // YieldStmt — including the innermost else, which yields main_return_exprs
-    // for the rem == 0 case.
+    // for the rem == 0 case. Each branch body is a bare SeqStmts of k cloned
+    // bodies (the IfStmt provides the enclosing scope that declares its
+    // return_vars; no inner ForStmt wrapper is required).
     std::optional<StmtPtr> inner;
     std::vector<VarPtr> inner_return_vars;
     for (int64_t k = factor - 1; k >= 1; --k) {
-      // Each branch's tail seeds its iter_args from the main-loop return_vars:
-      // the cascade is a dispatch on `rem`, so every live branch starts from
-      // the same post-main state.
-      auto tail_branch_return_vars = op->return_vars_.empty()
-                                         ? op->return_vars_
-                                         : MakeFreshReturnVars(op->return_vars_, "_tail" + std::to_string(k));
-      StmtPtr tail =
-          BuildTailBranch(op, body, k, step, main_end_var, main_return_exprs, tail_branch_return_vars);
+      // Each branch's tail clones seed iter-arg uses with the main-loop's
+      // return_vars directly: the cascade is a dispatch on `rem`, so every
+      // live branch starts from the same post-main state.
+      auto region = BuildTailSeq(op, body, k, step, main_end_var, main_return_exprs);
 
-      std::vector<StmtPtr> then_parts = {tail};
+      std::vector<StmtPtr> then_parts = {region.body};
       if (has_iter_args) {
-        then_parts.push_back(std::make_shared<YieldStmt>(ReturnVarsAsExprs(tail_branch_return_vars), sp));
+        then_parts.push_back(std::make_shared<YieldStmt>(region.final_yields, sp));
       }
       auto then_body = SeqStmts::Flatten(std::move(then_parts), sp);
 

--- a/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
+++ b/src/ir/transforms/partial_unroll_tile_loops_pass.cpp
@@ -43,6 +43,11 @@ namespace {
 
 constexpr const char* kUnrollFactorAttr = "unroll_factor";
 
+/// Legacy attribute name once emitted by this pass (RFC #1048 removed it).
+/// Stripped defensively when seen on input so legacy IR (e.g. deserialized
+/// from an older compiler) doesn't carry the now-meaningless marker forward.
+constexpr const char* kLegacyUnrollReplicatedAttr = "unroll_replicated";
+
 /// Extract a compile-time integer from a ConstInt or Neg(ConstInt) expression.
 int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
   if (auto ci = std::dynamic_pointer_cast<const ConstInt>(expr)) {
@@ -92,12 +97,13 @@ ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span) {
   return MakeAdd(base, MakeConstIndex(offset_val, span), span);
 }
 
-/// Copy `original` while stripping `kUnrollFactorAttr`.
+/// Copy `original` while stripping `kUnrollFactorAttr` and the legacy
+/// `kLegacyUnrollReplicatedAttr` (in case it survived from older serialized IR).
 Attrs StripUnrollFactorAttr(const Attrs& original) {
   Attrs out;
   out.reserve(original.size());
   for (const auto& [k, v] : original) {
-    if (k == kUnrollFactorAttr) continue;
+    if (k == kUnrollFactorAttr || k == kLegacyUnrollReplicatedAttr) continue;
     out.emplace_back(k, v);
   }
   return out;

--- a/src/ir/transforms/reorder_unrolled_io_pass.cpp
+++ b/src/ir/transforms/reorder_unrolled_io_pass.cpp
@@ -10,12 +10,12 @@
  */
 
 #include <cstddef>
+#include <functional>
 #include <map>
 #include <memory>
-#include <optional>
+#include <queue>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -82,6 +82,17 @@ IOCategory CategorizeStmt(const StmtPtr& stmt, const IOCategoryOps& ops) {
   return IOCategory::Compute;
 }
 
+/// Terminators (`YieldStmt`, `ReturnStmt`, `BreakStmt`, `ContinueStmt`) must
+/// stay last in their scope: moving them ahead of a side-effecting `tile.store`
+/// would make the store unreachable. Valid SSA always places a terminator at
+/// the end of the enclosing `SeqStmts`.
+bool IsTerminator(const StmtPtr& stmt) {
+  return std::dynamic_pointer_cast<const YieldStmt>(stmt) ||
+         std::dynamic_pointer_cast<const ReturnStmt>(stmt) ||
+         std::dynamic_pointer_cast<const BreakStmt>(stmt) ||
+         std::dynamic_pointer_cast<const ContinueStmt>(stmt);
+}
+
 /**
  * @brief Mutator that reorders every multi-stmt ``SeqStmts`` in the program:
  *        loads pulled to the top, stores pushed to the bottom, compute in the middle —
@@ -102,7 +113,10 @@ class ReorderUnrolledIOMutator : public IRMutator {
     // Regions that violate the InOut-use discipline are left alone: under
     // strict verification they would be caught earlier, but with
     // VerificationLevel.NONE a pre-existing violation can reach us and we
-    // shouldn't reorder potentially-unsound dataflow.
+    // shouldn't reorder potentially-unsound dataflow. We do the discipline
+    // check ourselves so that the subsequent `BuildStmtDependencyGraph` call
+    // (which would repeat the check when given a non-null program) can skip
+    // it by passing `nullptr` — avoiding an O(N) double traversal.
     if (!stmt_dep::CollectInOutUseDisciplineDiagnostics(seq, program_).empty()) {
       return visited;
     }
@@ -112,64 +126,83 @@ class ReorderUnrolledIOMutator : public IRMutator {
  private:
   /// Stable, priority-aware topological sort. Caller is responsible for
   /// verifying the InOut-use discipline before invoking.
+  ///
+  /// Complexity: O(N + E + N log N) per region — adjacency list built once,
+  /// the ready set maintained as a min-heap keyed by (category, index).
+  /// N = number of top-level stmts, E = number of def-use edges (bounded by N).
+  ///
+  /// A trailing terminator (`YieldStmt` / `ReturnStmt` / `BreakStmt` /
+  /// `ContinueStmt`) is peeled off before sorting and re-appended at the end
+  /// so stores can never be emitted after it (which would make them
+  /// unreachable / semantically dropped).
   StmtPtr ReorderRegion(const SeqStmtsPtr& seq) {
-    auto graph = stmt_dep::BuildStmtDependencyGraph(seq, program_);
+    // Pass `nullptr` for the program — we've already validated the discipline,
+    // and re-running it inside BuildStmtDependencyGraph would be redundant work.
+    auto graph = stmt_dep::BuildStmtDependencyGraph(seq, /*program=*/nullptr);
 
     const auto& stmts = seq->stmts_;
     const size_t N = stmts.size();
 
-    std::vector<IOCategory> cats(N);
-    for (size_t i = 0; i < N; ++i) cats[i] = CategorizeStmt(stmts[i], io_ops_);
+    // Peel off a trailing terminator — it stays last regardless of category.
+    const bool has_terminator = IsTerminator(stmts.back());
+    const size_t sort_count = has_terminator ? N - 1 : N;
+    if (sort_count < 2) return seq;  // nothing to reorder among non-terminators
 
-    // Per-stmt count of unsatisfied predecessors. BuildStmtDependencyGraph
-    // only records within-region edges (last_def is populated from stmts in
-    // this region), so every predecessor counted here is a sibling statement.
-    std::vector<size_t> remaining(N, 0);
-    for (size_t i = 0; i < N; ++i) {
-      auto it = graph.predecessors.find(stmts[i].get());
-      if (it != graph.predecessors.end()) remaining[i] = it->second.size();
+    std::vector<IOCategory> cats(sort_count);
+    std::unordered_map<const Stmt*, size_t> idx_of;
+    idx_of.reserve(sort_count);
+    for (size_t i = 0; i < sort_count; ++i) {
+      cats[i] = CategorizeStmt(stmts[i], io_ops_);
+      idx_of.emplace(stmts[i].get(), i);
     }
 
-    std::vector<bool> emitted(N, false);
+    // Build successors adjacency lists + in-degree counts in one pass over
+    // the region's predecessor map. Predecessor entries for the terminator
+    // (if any) are ignored so it cannot decrement any non-terminator's
+    // remaining count and end up "ready" early.
+    std::vector<std::vector<size_t>> successors(sort_count);
+    std::vector<size_t> remaining(sort_count, 0);
+    for (size_t j = 0; j < sort_count; ++j) {
+      auto it = graph.predecessors.find(stmts[j].get());
+      if (it == graph.predecessors.end()) continue;
+      for (const Stmt* pred : it->second) {
+        auto pit = idx_of.find(pred);
+        if (pit == idx_of.end()) continue;  // predecessor is the terminator — ignore
+        successors[pit->second].push_back(j);
+        ++remaining[j];
+      }
+    }
+
+    // Ready-set as a min-heap keyed by (category_bias, original_index). For
+    // non-store stmts the key is (category, i); stores get a bias of +1 above
+    // the max non-store category so they only surface when nothing else is
+    // ready — preserving the original load-top / compute-middle / store-bottom
+    // behavior. Using index as the tiebreaker keeps the sort stable.
+    constexpr int kStoreDeferBias = static_cast<int>(IOCategory::Store) + 100;
+    using HeapKey = std::pair<int, size_t>;
+    std::priority_queue<HeapKey, std::vector<HeapKey>, std::greater<>> ready;
+    auto key_for = [&](size_t i) -> HeapKey {
+      int bias = (cats[i] == IOCategory::Store) ? kStoreDeferBias : static_cast<int>(cats[i]);
+      return {bias, i};
+    };
+    for (size_t i = 0; i < sort_count; ++i) {
+      if (remaining[i] == 0) ready.push(key_for(i));
+    }
+
     std::vector<StmtPtr> out;
     out.reserve(N);
-
-    auto pick_next = [&]() -> std::optional<size_t> {
-      // Prefer the smallest (cat, idx) among non-store ready stmts; only fall
-      // back to a store when nothing else is ready, so stores defer to the end.
-      std::optional<std::pair<int, size_t>> best_non_store;
-      std::optional<size_t> best_store;
-      for (size_t i = 0; i < N; ++i) {
-        if (emitted[i] || remaining[i] != 0) continue;
-        if (cats[i] == IOCategory::Store) {
-          if (!best_store) best_store = i;
-        } else {
-          std::pair<int, size_t> key{static_cast<int>(cats[i]), i};
-          if (!best_non_store || key < *best_non_store) best_non_store = key;
-        }
-      }
-      if (best_non_store) return best_non_store->second;
-      return best_store;
-    };
-
-    while (out.size() < N) {
-      auto pick = pick_next();
-      INTERNAL_CHECK(pick.has_value())
-          << "ReorderUnrolledIO: dependency graph appears cyclic — should be impossible "
-             "for an SSA region under the InOut-use discipline";
-      size_t i = *pick;
-      emitted[i] = true;
+    while (!ready.empty()) {
+      size_t i = ready.top().second;
+      ready.pop();
       out.push_back(stmts[i]);
-      // Decrement successors' unsatisfied-pred counts.
-      for (size_t j = 0; j < N; ++j) {
-        if (emitted[j] || remaining[j] == 0) continue;
-        auto it = graph.predecessors.find(stmts[j].get());
-        if (it == graph.predecessors.end()) continue;
-        if (it->second.count(stmts[i].get())) {
-          --remaining[j];
-        }
+      for (size_t j : successors[i]) {
+        if (--remaining[j] == 0) ready.push(key_for(j));
       }
     }
+    INTERNAL_CHECK(out.size() == sort_count)
+        << "ReorderUnrolledIO: dependency graph appears cyclic — should be impossible "
+           "for an SSA region under the InOut-use discipline";
+    if (has_terminator) out.push_back(stmts.back());
 
     // No-op detection.
     bool changed = false;

--- a/src/ir/transforms/reorder_unrolled_io_pass.cpp
+++ b/src/ir/transforms/reorder_unrolled_io_pass.cpp
@@ -35,8 +35,6 @@ namespace pypto {
 namespace ir {
 namespace {
 
-constexpr const char* kUnrollReplicatedAttr = "unroll_replicated";
-
 /// IO category used for priority during the topological sort. Lower is emitted first.
 enum class IOCategory : int { Load = 0, Compute = 1, Store = 2 };
 
@@ -85,7 +83,7 @@ IOCategory CategorizeStmt(const StmtPtr& stmt, const IOCategoryOps& ops) {
 }
 
 /**
- * @brief Mutator that reorders statements inside ``unroll_replicated`` SeqStmts:
+ * @brief Mutator that reorders every multi-stmt ``SeqStmts`` in the program:
  *        loads pulled to the top, stores pushed to the bottom, compute in the middle —
  *        all subject to the dependency graph.
  */
@@ -94,31 +92,27 @@ class ReorderUnrolledIOMutator : public IRMutator {
   explicit ReorderUnrolledIOMutator(ProgramPtr program)
       : program_(std::move(program)), io_ops_(IOCategoryOps::Build()) {}
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    // Recurse first so any inner unroll-replicated regions are reordered too.
+  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
+    // Recurse first so any nested SeqStmts are reordered bottom-up.
     auto visited = IRMutator::VisitStmt_(op);
-    auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(visited);
-    if (!for_stmt || !for_stmt->HasAttr(kUnrollReplicatedAttr)) {
-      return visited;
-    }
-    auto seq = std::dynamic_pointer_cast<const SeqStmts>(for_stmt->body_);
+    auto seq = std::dynamic_pointer_cast<const SeqStmts>(visited);
     if (!seq || seq->stmts_.size() < 2) {
       return visited;  // single stmt — nothing to reorder
     }
-    auto reordered = ReorderRegion(seq);
-    if (reordered.get() == seq.get()) {
+    // Regions that violate the InOut-use discipline are left alone: under
+    // strict verification they would be caught earlier, but with
+    // VerificationLevel.NONE a pre-existing violation can reach us and we
+    // shouldn't reorder potentially-unsound dataflow.
+    if (!stmt_dep::CollectInOutUseDisciplineDiagnostics(seq, program_).empty()) {
       return visited;
     }
-    auto new_for = MutableCopy(for_stmt);
-    new_for->body_ = reordered;
-    return new_for;
+    return ReorderRegion(seq);
   }
 
  private:
-  /// Stable, priority-aware topological sort.
+  /// Stable, priority-aware topological sort. Caller is responsible for
+  /// verifying the InOut-use discipline before invoking.
   StmtPtr ReorderRegion(const SeqStmtsPtr& seq) {
-    // Discipline check ensures dataflow soundness — see RFC #1026 / PR #1029.
-    stmt_dep::CheckInOutUseDiscipline(seq, program_);
     auto graph = stmt_dep::BuildStmtDependencyGraph(seq, program_);
 
     const auto& stmts = seq->stmts_;

--- a/tests/ut/ir/transforms/test_partial_unroll_tile_loops.py
+++ b/tests/ut/ir/transforms/test_partial_unroll_tile_loops.py
@@ -38,49 +38,48 @@ class TestPartialUnrollMechanics:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.range(0, 8, 1, attrs={"unroll_factor": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
                 return x
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
-                    y_1: pl.Scalar[pl.INDEX] = i + 1  # noqa: F841
-                    y_2: pl.Scalar[pl.INDEX] = i + 2  # noqa: F841
-                    y_3: pl.Scalar[pl.INDEX] = i + 3  # noqa: F841
+                for i in pl.range(0, 8, 4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                    _y_1: pl.Scalar[pl.INDEX] = i + 1
+                    _y_2: pl.Scalar[pl.INDEX] = i + 2
+                    _y_3: pl.Scalar[pl.INDEX] = i + 3
                 return x
 
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
     def test_with_remainder_appends_tail_branch(self):
-        """trip=10, factor=4 → main range(0, 8, 4) with 4 clones + tail wrapper (2 clones).
+        """trip=10, factor=4 → main range(0, 8, 4) with 4 clones + bare 2-clone tail.
 
-        Static path knows rem_iters=2 at compile time — one tail-branch wrapper
-        tagged ``unroll_replicated=2``, no modulo dispatch."""
+        Static path knows rem_iters=2 at compile time — the tail clones are
+        flattened directly into the outer scope (no wrapper, no marker attr)."""
 
         @pl.program
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.range(0, 10, 1, attrs={"unroll_factor": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
                 return x
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(0, 8, 4, attrs={"unroll_replicated": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
-                    y_1: pl.Scalar[pl.INDEX] = i + 1  # noqa: F841
-                    y_2: pl.Scalar[pl.INDEX] = i + 2  # noqa: F841
-                    y_3: pl.Scalar[pl.INDEX] = i + 3  # noqa: F841
-                for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-                    y_4: pl.Scalar[pl.INDEX] = 8  # noqa: F841
-                    y_5: pl.Scalar[pl.INDEX] = 9  # noqa: F841
+                for i in pl.range(0, 8, 4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                    _y_1: pl.Scalar[pl.INDEX] = i + 1
+                    _y_2: pl.Scalar[pl.INDEX] = i + 2
+                    _y_3: pl.Scalar[pl.INDEX] = i + 3
+                _y_4: pl.Scalar[pl.INDEX] = 8
+                _y_5: pl.Scalar[pl.INDEX] = 9
                 return x
 
         After = _run_pass(Before)
@@ -94,7 +93,7 @@ class TestPartialUnrollMechanics:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.range(0, 8, 1, attrs={"unroll_factor": 1}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
                 return x
 
         @pl.program
@@ -103,7 +102,7 @@ class TestPartialUnrollMechanics:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 # Same range as Before, attr dropped.
                 for i in pl.range(0, 8, 1):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
                 return x
 
         After = _run_pass(Before)
@@ -117,18 +116,18 @@ class TestPartialUnrollMechanics:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.range(0, 4, 1, attrs={"unroll_factor": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
                 return x
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.range(0, 4, 4, attrs={"unroll_replicated": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
-                    y_1: pl.Scalar[pl.INDEX] = i + 1  # noqa: F841
-                    y_2: pl.Scalar[pl.INDEX] = i + 2  # noqa: F841
-                    y_3: pl.Scalar[pl.INDEX] = i + 3  # noqa: F841
+                for i in pl.range(0, 4, 4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                    _y_1: pl.Scalar[pl.INDEX] = i + 1
+                    _y_2: pl.Scalar[pl.INDEX] = i + 2
+                    _y_3: pl.Scalar[pl.INDEX] = i + 3
                 return x
 
         After = _run_pass(Before)
@@ -142,7 +141,7 @@ class TestPartialUnrollMechanics:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]):
                 for i in pl.range(0, n, 1, attrs={"unroll_factor": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
 
         @pl.program
         class Expected:
@@ -151,24 +150,21 @@ class TestPartialUnrollMechanics:
                 # Tree shape must match C++ emission:
                 # Add(start, Mul(FloorDiv(Sub(stop, start), chunk), chunk))
                 unroll_main_end: pl.Scalar[pl.INDEX] = 0 + (n - 0) // 4 * 4
-                for i in pl.range(0, unroll_main_end, 4, attrs={"unroll_replicated": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
-                    y_1: pl.Scalar[pl.INDEX] = i + 1  # noqa: F841
-                    y_2: pl.Scalar[pl.INDEX] = i + 2  # noqa: F841
-                    y_3: pl.Scalar[pl.INDEX] = i + 3  # noqa: F841
+                for i in pl.range(0, unroll_main_end, 4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                    _y_1: pl.Scalar[pl.INDEX] = i + 1
+                    _y_2: pl.Scalar[pl.INDEX] = i + 2
+                    _y_3: pl.Scalar[pl.INDEX] = i + 3
                 unroll_rem: pl.Scalar[pl.INDEX] = n - unroll_main_end
                 if unroll_rem == 1:
-                    for _tail_iter_1 in pl.range(0, 1, 1, attrs={"unroll_replicated": 1}):
-                        y_4: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_4: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
                 elif unroll_rem == 2:
-                    for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-                        y_5: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
-                        y_6: pl.Scalar[pl.INDEX] = unroll_main_end + 1  # noqa: F841
+                    y_5: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_6: pl.Scalar[pl.INDEX] = unroll_main_end + 1  # noqa: F841
                 elif unroll_rem == 3:
-                    for _tail_iter_3 in pl.range(0, 1, 1, attrs={"unroll_replicated": 3}):
-                        y_7: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
-                        y_8: pl.Scalar[pl.INDEX] = unroll_main_end + 1  # noqa: F841
-                        y_9: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
+                    y_7: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_8: pl.Scalar[pl.INDEX] = unroll_main_end + 1  # noqa: F841
+                    y_9: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
 
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
@@ -186,7 +182,7 @@ class TestPartialUnrollMechanics:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]):
                 for i in pl.range(0, n, 2, attrs={"unroll_factor": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
+                    _y: pl.Scalar[pl.INDEX] = i
 
         @pl.program
         class Expected:
@@ -196,25 +192,22 @@ class TestPartialUnrollMechanics:
                 # main_iters = trip_iters // 4
                 # main_end   = 0 + main_iters * (4 * 2) = 0 + main_iters * 8
                 unroll_main_end: pl.Scalar[pl.INDEX] = 0 + (n - 0 + 1) // 2 // 4 * 8
-                for i in pl.range(0, unroll_main_end, 8, attrs={"unroll_replicated": 4}):
-                    y: pl.Scalar[pl.INDEX] = i  # noqa: F841
-                    y_1: pl.Scalar[pl.INDEX] = i + 2  # noqa: F841
-                    y_2: pl.Scalar[pl.INDEX] = i + 4  # noqa: F841
-                    y_3: pl.Scalar[pl.INDEX] = i + 6  # noqa: F841
+                for i in pl.range(0, unroll_main_end, 8):
+                    _y: pl.Scalar[pl.INDEX] = i
+                    _y_1: pl.Scalar[pl.INDEX] = i + 2
+                    _y_2: pl.Scalar[pl.INDEX] = i + 4
+                    _y_3: pl.Scalar[pl.INDEX] = i + 6
                 # rem_iters = trip_iters - main_iters * 4 (iteration units, not index units)
                 unroll_rem: pl.Scalar[pl.INDEX] = (n - 0 + 1) // 2 - (n - 0 + 1) // 2 // 4 * 4
                 if unroll_rem == 1:
-                    for _tail_iter_1 in pl.range(0, 1, 1, attrs={"unroll_replicated": 1}):
-                        y_4: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_4: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
                 elif unroll_rem == 2:
-                    for _tail_iter_2 in pl.range(0, 1, 1, attrs={"unroll_replicated": 2}):
-                        y_5: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
-                        y_6: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
+                    y_5: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_6: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
                 elif unroll_rem == 3:
-                    for _tail_iter_3 in pl.range(0, 1, 1, attrs={"unroll_replicated": 3}):
-                        y_7: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
-                        y_8: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
-                        y_9: pl.Scalar[pl.INDEX] = unroll_main_end + 4  # noqa: F841
+                    y_7: pl.Scalar[pl.INDEX] = unroll_main_end  # noqa: F841
+                    y_8: pl.Scalar[pl.INDEX] = unroll_main_end + 2  # noqa: F841
+                    y_9: pl.Scalar[pl.INDEX] = unroll_main_end + 4  # noqa: F841
 
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
@@ -238,7 +231,7 @@ class TestPartialUnrollMechanics:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
-                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,)):
                     b: pl.Scalar[pl.INDEX] = a + i
                     b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
                     b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
@@ -250,8 +243,9 @@ class TestPartialUnrollMechanics:
         ir.assert_structural_equal(After, Expected)
 
     def test_iter_args_with_remainder_forwards_state_to_tail(self):
-        """Main loop's return_var seeds the tail's iter_arg; tail's return_var replaces
-        the original loop's return_var so downstream uses remain valid."""
+        """Main loop's return_var seeds the tail clones' iter-arg uses; the tail's
+        final yield binds to the original loop's return_var via an ``AssignStmt``
+        so downstream uses remain valid."""
 
         @pl.program
         class Before:
@@ -266,18 +260,17 @@ class TestPartialUnrollMechanics:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
-                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,), attrs={"unroll_replicated": 4}):
+                for i, (a,) in pl.range(0, 8, 4, init_values=(s0,)):
                     b: pl.Scalar[pl.INDEX] = a + i
                     b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
                     b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
                     b_3: pl.Scalar[pl.INDEX] = b_2 + (i + 3)
                     r_main = pl.yield_(b_3)
-                for _tail_iter_2, (a,) in pl.range(
-                    0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}
-                ):
-                    b_4: pl.Scalar[pl.INDEX] = a + 8
-                    b_5: pl.Scalar[pl.INDEX] = b_4 + 9
-                    r = pl.yield_(b_5)
+                # Tail clones — iter-arg `a` is substituted by r_main directly.
+                b_4: pl.Scalar[pl.INDEX] = r_main + 8
+                b_5: pl.Scalar[pl.INDEX] = b_4 + 9
+                # Bind the original return_var to the tail's final yield.
+                r: pl.Scalar[pl.INDEX] = b_5
                 return r
 
         After = _run_pass(Before)
@@ -312,9 +305,7 @@ class TestPartialUnrollMechanics:
                 n: pl.Scalar[pl.INDEX],
             ) -> pl.Scalar[pl.INDEX]:
                 unroll_main_end: pl.Scalar[pl.INDEX] = 0 + (n - 0) // 4 * 4
-                for i, (a,) in pl.range(
-                    0, unroll_main_end, 4, init_values=(s0,), attrs={"unroll_replicated": 4}
-                ):
+                for i, (a,) in pl.range(0, unroll_main_end, 4, init_values=(s0,)):
                     b: pl.Scalar[pl.INDEX] = a + i
                     b_1: pl.Scalar[pl.INDEX] = b + (i + 1)
                     b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 2)
@@ -324,33 +315,23 @@ class TestPartialUnrollMechanics:
                 # Each IfStmt level carries its own return_vars and yield — the
                 # cascade is nested (not elif/else), because every inner IfStmt
                 # is the enclosing one's else body together with a trailing yield
-                # that feeds the outer return_var.
+                # that feeds the outer return_var. Each branch body is a bare
+                # SeqStmts (no trip-1 ForStmt wrapper); iter-arg uses inside the
+                # clones are substituted with r_main directly.
                 if unroll_rem == 1:
-                    for _tail_iter_1, (a,) in pl.range(
-                        0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 1}
-                    ):
-                        b_4: pl.Scalar[pl.INDEX] = a + unroll_main_end
-                        r_tail1 = pl.yield_(b_4)
-                    r = pl.yield_(r_tail1)
+                    b_4: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                    r = pl.yield_(b_4)
                 else:
                     if unroll_rem == 2:
-                        for _tail_iter_2, (a,) in pl.range(
-                            0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 2}
-                        ):
-                            b_5: pl.Scalar[pl.INDEX] = a + unroll_main_end
-                            b_6: pl.Scalar[pl.INDEX] = b_5 + (unroll_main_end + 1)
-                            r_tail2 = pl.yield_(b_6)
-                        r_rem2 = pl.yield_(r_tail2)
+                        b_5: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                        b_6: pl.Scalar[pl.INDEX] = b_5 + (unroll_main_end + 1)
+                        r_rem2 = pl.yield_(b_6)
                     else:
                         if unroll_rem == 3:
-                            for _tail_iter_3, (a,) in pl.range(
-                                0, 1, 1, init_values=(r_main,), attrs={"unroll_replicated": 3}
-                            ):
-                                b_7: pl.Scalar[pl.INDEX] = a + unroll_main_end
-                                b_8: pl.Scalar[pl.INDEX] = b_7 + (unroll_main_end + 1)
-                                b_9: pl.Scalar[pl.INDEX] = b_8 + (unroll_main_end + 2)
-                                r_tail3 = pl.yield_(b_9)
-                            r_rem3 = pl.yield_(r_tail3)
+                            b_7: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                            b_8: pl.Scalar[pl.INDEX] = b_7 + (unroll_main_end + 1)
+                            b_9: pl.Scalar[pl.INDEX] = b_8 + (unroll_main_end + 2)
+                            r_rem3 = pl.yield_(b_9)
                         else:
                             r_rem3 = pl.yield_(r_main)
                         r_rem2 = pl.yield_(r_rem3)

--- a/tests/ut/ir/transforms/test_reorder_unrolled_io.py
+++ b/tests/ut/ir/transforms/test_reorder_unrolled_io.py
@@ -9,10 +9,9 @@
 
 """DSL-style Before/Expected tests for the ReorderUnrolledIO pass.
 
-The pass walks ``ForStmt``s carrying ``attrs_["unroll_replicated"]`` and
-reorders their top-level SeqStmts so tile.load floats to the top, tile.store
-sinks to the bottom, compute settles in the middle — subject to the SSA
-dependency graph.
+The pass walks every ``SeqStmts`` in the program and reorders its top-level
+statements so tile.load floats to the top, tile.store sinks to the bottom, and
+compute settles in the middle — subject to the SSA dependency graph.
 """
 
 import pypto.language as pl
@@ -39,7 +38,7 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta0: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     tc0: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(ta0, ta0)
                     pl.tile.store(tc0, [0, 0], out)
@@ -51,7 +50,7 @@ class TestReorderUnrolledIO:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta0: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     ta1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])
                     tc0: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(ta0, ta0)
@@ -69,7 +68,7 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     off: pl.Scalar[pl.INDEX] = 64
                     ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [off, 0], [64, 64])
@@ -82,7 +81,7 @@ class TestReorderUnrolledIO:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     off: pl.Scalar[pl.INDEX] = 64
                     ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [off, 0], [64, 64])
@@ -92,41 +91,67 @@ class TestReorderUnrolledIO:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_skip_unmarked_for(self):
-        """A ForStmt without ``unroll_replicated`` is left untouched."""
+    def test_already_ordered_region_is_noop(self):
+        """A region already in canonical [load, compute, store] order is unchanged —
+        the reorder preserves IR identity when no swap would help."""
 
         @pl.program
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                # No attrs — pass should ignore.
                 for i in pl.range(0, 2, 1):
                     ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     tc: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(ta, ta)
                     pl.tile.store(tc, [0, 0], out)
 
         After = _run_pass(Before)
-        # IR identity preserved when no marker is present.
+        # IR identity preserved — the reorder detects no change is needed.
         assert After is Before
 
+    def test_reorder_on_function_body_seqstmts(self):
+        """The reorder applies to any ``SeqStmts`` — including the function body
+        itself, which is not inside any ForStmt."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                # Store placed before load in source — the pass should reorder.
+                ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                pl.tile.store(ta, [0, 0], out)
+                tb: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                pl.tile.store(tb, [0, 0], out)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                tb: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                pl.tile.store(ta, [0, 0], out)
+                pl.tile.store(tb, [0, 0], out)
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_no_io_ops_is_noop(self):
-        """A marked region with neither loads nor stores is unchanged."""
+        """A region with neither loads nor stores is unchanged."""
 
         @pl.program
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, a: pl.Tile[[64, 64], pl.FP32], b: pl.Tile[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
-                    x: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(a, a)  # noqa: F841
-                    y: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(b, b)  # noqa: F841
+                for i in pl.range(0, 2, 1):
+                    _x: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(a, a)
+                    _y: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(b, b)
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, a: pl.Tile[[64, 64], pl.FP32], b: pl.Tile[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
-                    x: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(a, a)  # noqa: F841
-                    y: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(b, b)  # noqa: F841
+                for i in pl.range(0, 2, 1):
+                    _x: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(a, a)
+                    _y: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(b, b)
 
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
@@ -139,7 +164,7 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     t1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     pl.tile.store(t1, [0, 0], out)
                     t2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])
@@ -149,7 +174,7 @@ class TestReorderUnrolledIO:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     t1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     t2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])
                     pl.tile.store(t1, [0, 0], out)
@@ -170,20 +195,20 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     # Store placed before read in source — reorder should swap them.
                     pl.tile.store(t, [0, 0], out)
-                    elem: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])  # noqa: F841
+                    _elem: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     # tile.read (Load category) lifts above the store.
-                    elem: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])  # noqa: F841
+                    _elem: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])
                     # tile.store sinks to the bottom.
                     pl.tile.store(t, [0, 0], out)
 
@@ -197,11 +222,11 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[192, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta0: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                     tc: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(ta0, ta0)
-                    ta1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])  # noqa: F841
-                    ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [128, 0], [64, 64])  # noqa: F841
+                    _ta1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])
+                    _ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [128, 0], [64, 64])
                     pl.tile.store(tc, [0, 0], out)
 
         # ta0, ta1, ta2 are independent → all cluster at the top in original
@@ -210,10 +235,10 @@ class TestReorderUnrolledIO:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[192, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                for i in pl.range(0, 2, 1, attrs={"unroll_replicated": 2}):
+                for i in pl.range(0, 2, 1):
                     ta0: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
-                    ta1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])  # noqa: F841
-                    ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [128, 0], [64, 64])  # noqa: F841
+                    _ta1: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [64, 0], [64, 64])
+                    _ta2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [128, 0], [64, 64])
                     tc: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(ta0, ta0)
                     pl.tile.store(tc, [0, 0], out)
 

--- a/tests/ut/ir/transforms/test_reorder_unrolled_io.py
+++ b/tests/ut/ir/transforms/test_reorder_unrolled_io.py
@@ -116,7 +116,9 @@ class TestReorderUnrolledIO:
         class Before:
             @pl.function(strict_ssa=True)
             def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                # Store placed before load in source — the pass should reorder.
+                # Interleaved load/store — the second load (`tb`) appears after
+                # the first store (`ta`), so the pass should pull `tb` up ahead
+                # of that store.
                 ta: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
                 pl.tile.store(ta, [0, 0], out)
                 tb: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])


### PR DESCRIPTION
## Summary

Fixes #1048

`PartialUnrollTileLoops` no longer tags replicated loops with an `unroll_replicated` attribute, and `ReorderUnrolledIO` now canonicalizes IO order in **every** multi-stmt `SeqStmts` instead of only marker-tagged regions. The reorder is sound everywhere given the InOut-use discipline structural invariant from PR #1039; regions that pre-date the invariant (reachable only under `VerificationLevel.NONE`) are left alone.

Tail handling is simpler:

- **Static remainder** → bare `SeqStmts` flattened into the outer scope, plus trailing `AssignStmt`s that bind the outer loop's `return_vars` when `iter_args` exist.
- **Dynamic cascade** → each `IfStmt` branch body is a bare `SeqStmts` ending in `YieldStmt` when `iter_args` exist.
- The trip-1 `ForStmt` wrapper (previously needed only to hang the `unroll_replicated` marker on a `SeqStmts`) is gone.

## Changes

- `src/ir/transforms/partial_unroll_tile_loops_pass.cpp` — drop `kUnrollReplicatedAttr` emission; rewrite `BuildTailBranch` into `BuildTailSeq` (returns the bare region); update `LowerStatic` / `LowerDynamic` to flatten tail clones + emit iter-arg binding statements / YieldStmts at the enclosing scope.
- `src/ir/transforms/reorder_unrolled_io_pass.cpp` — replace the `ForStmt`-gated visitor with a `SeqStmts` visitor; skip regions that don't satisfy the InOut-use discipline.
- `include/pypto/ir/transforms/passes.h`, `python/bindings/modules/passes.cpp`, `python/pypto/pypto_core/passes.pyi` — docstrings refreshed; no API changes.
- `docs/en/dev/passes/20-*.md`, `docs/en/dev/passes/21-*.md` (+ zh-cn mirrors) — remove marker references, describe the broadened reorder scope, link this RFC.
- `tests/ut/ir/transforms/test_partial_unroll_tile_loops.py` — fixtures updated to the new layout; iter-arg test expects `AssignStmt` binding on the static tail and bare `SeqStmts` inside each cascade branch.
- `tests/ut/ir/transforms/test_reorder_unrolled_io.py` — input fixtures drop the marker; replaced `test_skip_unmarked_for` with `test_already_ordered_region_is_noop`; added `test_reorder_on_function_body_seqstmts` that exercises the broadened scope outside any ForStmt.

## Test plan

- [x] `python -m pytest tests/ut/ir/transforms/test_partial_unroll_tile_loops.py tests/ut/ir/transforms/test_reorder_unrolled_io.py -v` — 17/17 pass
- [x] Full unit suite (`python -m pytest tests/ut/ -n auto --maxprocesses 8`) — 3632 passed, 16 skipped
- [x] Clang-tidy on changed files — clean
- [x] Ruff / pyright on changed files — clean
- [x] Cross-layer (C++/bindings/stubs) docstrings synced

## Out of scope

- Renaming `ReorderUnrolledIO` now that it's no longer unroll-specific — left as a follow-up (see RFC #1048 open question).