### PR TITLE
chore(runtime): update simpler submodule to a9f3ea9 and adapt Worker.run API

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -47,6 +47,7 @@ from .elf_parser import extract_text_section
 from .kernel_compiler import KernelCompiler
 from .task_interface import (
     ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipCallConfig,  # pyright: ignore[reportAttributeAccessIssue]
     ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
     CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
     Worker,  # pyright: ignore[reportAttributeAccessIssue]
@@ -493,15 +494,14 @@ def execute_on_device(
     worker = Worker(level=2, device_id=device_id, platform=platform, runtime=runtime_name)
     worker.init()
 
+    cfg = ChipCallConfig()
+    cfg.block_dim = block_dim
+    cfg.aicpu_thread_num = aicpu_thread_num
+    cfg.enable_profiling = enable_profiling
+
     env = runtime_env or {}
     with _temporary_env(env):
-        worker.run(
-            chip_callable,
-            orch_args,
-            block_dim=block_dim,
-            aicpu_thread_num=aicpu_thread_num,
-            enable_profiling=enable_profiling,
-        )
+        worker.run(chip_callable, orch_args, cfg)
 
     worker.close()
 

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -16,6 +16,7 @@ torch-aware helpers (make_tensor_arg, scalar_to_uint64) come from the
 
 from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     ChipCallable,
+    ChipCallConfig,
     ChipStorageTaskArgs,
     CoreCallable,
     make_tensor_arg,
@@ -25,6 +26,7 @@ from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
 
 __all__ = [
     "ChipCallable",
+    "ChipCallConfig",
     "ChipStorageTaskArgs",
     "CoreCallable",
     "Worker",


### PR DESCRIPTION
## Summary

- Update `runtime` submodule from `1d4c218` (stable) to `a9f3ea9` (main)
- Adapt `execute_on_device()` to the new `Worker.run(callable, args, config)` API introduced in simpler #578
- Re-export `ChipCallConfig` through `pypto.runtime.task_interface`

## Background

Simpler #578 removed the `Task` dataclass and changed `Worker.run()` from accepting
keyword arguments (`block_dim`, `aicpu_thread_num`, `enable_profiling`) to a single
`ChipCallConfig` object. This PR brings the submodule pointer forward and updates
the one PyPTO call site in `execute_on_device()`.

## Testing

- Full unit test suite passes (3631 tests, 0 failures)
- No functional behavior change — all config fields are forwarded identically