### PR TITLE
feat(ir): add tensor.expand_clone lowering and broadcast coverage

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -682,6 +682,25 @@ def expands(target: Expr, scalar: int | float | Expr, span: Span | None = None) 
     return _ir_core.create_op_call("tensor.expands", [target, scalar_expr], {}, actual_span)
 
 
+def expand_clone(
+    src: Expr,
+    target: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Expand tensor to new shape.
+
+    Args:
+        src: Source tensor expression
+        target: Target tensor defining output shape
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for tensor expand_clone
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tensor.expand_clone", [src, target], {}, actual_span)
+
+
 def exp(input: Expr, span: Span | None = None) -> Call:
     """Element-wise exponential operation.
 

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -90,7 +90,7 @@ from .op.system_ops import (
     tpush_to_aic,
     tpush_to_aiv,
 )
-from .op.tensor_ops import assemble, create_tensor, dim, full, scatter_update
+from .op.tensor_ops import assemble, create_tensor, dim, expand_clone, full, scatter_update
 from .op.tile_ops import (
     MemRefType,
     abs,
@@ -272,6 +272,7 @@ __all__ = [
     "col_expand_mul",
     "col_expand_div",
     "col_expand_sub",
+    "expand_clone",
     "expands",
     "neg",
     "recip",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -27,7 +27,7 @@ from . import tensor_ops as tensor
 from . import tile_ops as tile
 
 # Promoted tensor-only ops (accessible as pl.create_tensor, etc.)
-from .tensor_ops import assemble, dim, scatter_update
+from .tensor_ops import assemble, dim, expand_clone, scatter_update
 from .tensor_ops import create as create_tensor
 
 # Promoted tile-only ops (accessible as pl.load, etc.)
@@ -144,6 +144,7 @@ __all__ = [
     "col_expand_mul",
     "col_expand_div",
     "col_expand_sub",
+    "expand_clone",
     "expands",
     "neg",
     "recip",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -48,6 +48,7 @@ __all__ = [
     "col_expand_div",
     "col_expand_sub",
     "expands",
+    "expand_clone",
     "exp",
     "neg",
     "recip",
@@ -625,6 +626,22 @@ def expands(target: Tensor, scalar: int | float | Scalar) -> Tensor:
     target_expr = target.unwrap()
     scalar_expr = scalar.unwrap() if isinstance(scalar, Scalar) else scalar
     call_expr = _ir_ops.expands(target_expr, scalar_expr)
+    return Tensor(expr=call_expr)
+
+
+def expand_clone(src: Tensor, target: Tensor) -> Tensor:
+    """Clone and expand input to target shape.
+
+    Args:
+        src: Source tensor
+        target: Target tensor defining output shape
+
+    Returns:
+        Tensor wrapping the expand_clone operation
+    """
+    src_expr = src.unwrap()
+    target_expr = target.unwrap()
+    call_expr = _ir_ops.expand_clone(src_expr, target_expr)
     return Tensor(expr=call_expr)
 
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -498,8 +498,8 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       // [M, 1] column vectors: PTOAS always infers DN for shape [M, 1] with
       // degenerate strides, so force DN layout and emit strides [1, M].
       bool is_column_vector = false;
-      if (tensor_type->shape_.size() == 2) {
-        auto last_dim = As<ir::ConstInt>(tensor_type->shape_[1]);
+      if (tensor_type->shape_.size() == 2 || tensor_type->shape_.size() == 3) {
+        auto last_dim = As<ir::ConstInt>(tensor_type->shape_.back());
         if (last_dim && last_dim->value_ == 1) {
           is_column_vector = true;
           layout_DN = true;

--- a/src/ir/op/tensor_ops/broadcast.cpp
+++ b/src/ir/op/tensor_ops/broadcast.cpp
@@ -19,15 +19,19 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -160,6 +164,57 @@ TypePtr DeduceTensorExpandScalarType(const std::vector<ExprPtr>& args,
   return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
 }
 
+TypePtr DeduceTensorExpandCloneType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  CHECK(args.size() == 2) << op_name << " requires 2 arguments (input, target), but got " << args.size();
+
+  // First argument must be TensorType
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << op_name << "requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  // Second argument must be TensorType (target tensor)
+  auto target_type = As<TensorType>(args[1]->GetType());
+  CHECK(target_type) << op_name << "requires second argument to be a TensorType, but got "
+                     << args[1]->GetType()->TypeName();
+
+  // Extract new shape dimensions from target tensor
+  std::vector<ExprPtr> new_shape = target_type->shape_;
+
+  // Validate broadcast rules between input shape and new shape
+  const auto& input_shape = tensor_type->shape_;
+  CHECK(input_shape.size() == 3) << op_name << " requires input rank to be 3, but got " << input_shape.size();
+  CHECK(input_shape.size() == new_shape.size()) << op_name << " requires input rank (" << input_shape.size()
+                                                << ") to match target rank (" << new_shape.size() << ")";
+
+  size_t broadcast_dims = 0;
+  for (size_t i = 0; i < input_shape.size(); ++i) {
+    if (DimensionsEqual(input_shape[i], new_shape[i])) {
+      continue;
+    }
+
+    auto input_const = GetConstantDimension(input_shape[i]);
+    CHECK(input_const && *input_const == 1)
+        << op_name << " only allows broadcasting from dimension 1, but input shape "
+        << FormatShape(input_shape) << " cannot be expanded to " << FormatShape(new_shape) << " at dim " << i
+        << " (got " << PythonPrint(input_shape[i]) << " -> " << PythonPrint(new_shape[i]) << ")";
+
+    ++broadcast_dims;
+  }
+
+  CHECK(broadcast_dims <= 1) << op_name << " allows broadcasting in at most one dimension, but got "
+                             << broadcast_dims << " (input shape " << FormatShape(input_shape)
+                             << ", target shape " << FormatShape(new_shape) << ")";
+
+  // Promote data types
+  auto result_dtype = PromoteDataTypes(tensor_type->dtype_, target_type->dtype_);
+  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
+                      << tensor_type->dtype_.ToString() << " and " << target_type->dtype_.ToString();
+
+  return std::make_shared<TensorType>(new_shape, *result_dtype);
+}
+
 // ============================================================================
 // Registration Function for Tensor Broadcast Operations
 // ============================================================================
@@ -262,6 +317,17 @@ REGISTER_OP("tensor.expands")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorExpandScalarType(args, kwargs, "tensor.expands");
+    });
+
+REGISTER_OP("tensor.expand_clone")
+    .set_op_category("TensorOp")
+    .set_description(
+        "Expand tensor by cloning data (not broadcasting). All dimensions must be 1 or match target shape.")
+    .add_argument("input", "Input tensor to expand (TensorType)")
+    .add_argument("target", "Target tensor defining output shape (TensorType)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorExpandCloneType(args, kwargs, "tensor.expand_clone");
     });
 
 }  // namespace ir

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -120,8 +120,8 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // Skip ops whose inputs are handled by their own converter (self-loading):
       // they create loads with specific offsets/spaces, so Phase-1 default Vec loads
       // would be redundant or wrong.
-      static const std::unordered_set<std::string> kSelfLoadingOps = {"tensor.slice", "tensor.assemble",
-                                                                      "tensor.read", "tensor.write"};
+      static const std::unordered_set<std::string> kSelfLoadingOps = {
+          "tensor.slice", "tensor.assemble", "tensor.read", "tensor.write", "tensor.expand_clone"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);
         return;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -31,8 +31,10 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -452,6 +454,173 @@ void OpConversionRegistry::RegisterMemoryOps() {
 
         CHECK(false) << "tensor.write conversion: unexpected input type: " << dest->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
+      });
+
+  RegisterCustom(
+      "tensor.expand_clone",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 2) << "tensor.expand_clone conversion expects 2 args (input, target)";
+
+        auto& op_reg = OpRegistry::GetInstance();
+        const auto& input = args[0];
+        const auto& target = args[1];
+
+        auto input_tensor_type = As<TensorType>(input->GetType());
+        CHECK(input_tensor_type) << "tensor.expand_clone conversion: input must be TensorType, but got "
+                                 << input->GetType()->TypeName();
+
+        auto target_tensor_type = As<TensorType>(target->GetType());
+        CHECK(target_tensor_type) << "tensor.expand_clone conversion: target must be TensorType, but got "
+                                  << target->GetType()->TypeName();
+
+        const auto& input_shape = input_tensor_type->shape_;
+        const auto& target_shape = target_tensor_type->shape_;
+
+        CHECK(input_shape.size() == 3)
+            << "tensor.expand_clone conversion: input rank must be 3, but got " << input_shape.size();
+        CHECK(target_shape.size() == input_shape.size())
+            << "tensor.expand_clone conversion: input rank (" << input_shape.size()
+            << ") must match target rank (" << target_shape.size() << ")";
+
+        int broadcast_dim = -1;
+        for (size_t i = 0; i < input_shape.size(); ++i) {
+          if (DimensionsEqual(input_shape[i], target_shape[i])) {
+            continue;
+          }
+          auto input_const = GetConstantDimension(input_shape[i]);
+          CHECK(input_const && *input_const == 1)
+              << "tensor.expand_clone conversion requires input dim " << i
+              << " to be 1 for broadcasting, but got " << PythonPrint(input_shape[i]);
+          CHECK(broadcast_dim < 0)
+              << "tensor.expand_clone conversion allows broadcasting in at most one dimension";
+          broadcast_dim = static_cast<int>(i);
+        }
+
+        std::vector<StmtPtr> prologue;
+
+        auto make_index_const = [&](int64_t value) -> ExprPtr {
+          return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+        };
+
+        auto make_tuple = [&](std::vector<ExprPtr> elems) -> ExprPtr {
+          return std::make_shared<MakeTuple>(std::move(elems), span);
+        };
+
+        auto load_tensor_tile = [&](const ExprPtr& tensor, const ExprPtr& offsets,
+                                    const std::vector<ExprPtr>& shape,
+                                    const std::vector<ExprPtr>& valid_shape, const std::string& name_hint,
+                                    std::vector<StmtPtr>& stmts) -> ExprPtr {
+          auto shapes = MakeShapeTuple(shape, span);
+          auto valid_shapes = MakeShapeTuple(valid_shape, span);
+          std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
+                                                                       {"transpose", false}};
+          auto load_call =
+              op_reg.Create("tile.load", {tensor, offsets, shapes, valid_shapes}, load_kwargs, span);
+          auto load_var = std::make_shared<Var>(name_hint, load_call->GetType(), span);
+          stmts.push_back(std::make_shared<AssignStmt>(load_var, load_call, span));
+          return load_var;
+        };
+
+        DataType input_dtype = input_tensor_type->dtype_;
+
+        std::vector<ExprPtr> input_valid_shape = input_shape;
+        if (input_tensor_type && input_tensor_type->tensor_view_.has_value() &&
+            !input_tensor_type->tensor_view_->valid_shape.empty()) {
+          input_valid_shape = input_tensor_type->tensor_view_->valid_shape;
+        }
+
+        ExprPtr zero = make_index_const(0);
+        ExprPtr one = make_index_const(1);
+
+        if (broadcast_dim < 0) {
+          ExprPtr input_tile = input;
+          auto offsets = MakeZeroOffsets(input_shape.size(), span);
+          input_tile = load_tensor_tile(input, offsets, input_shape, input_valid_shape, "expand_clone_input",
+                                        prologue);
+          auto store_call = op_reg.Create("tile.store", {input_tile, offsets, target}, span);
+          return ConversionResult{std::move(prologue), store_call};
+        }
+
+        if (broadcast_dim == 0) {
+          ExprPtr input_tile = input;
+          auto offsets = MakeZeroOffsets(input_tensor_type->shape_.size(), span);
+          input_tile = load_tensor_tile(input, offsets, input_shape, input_valid_shape, "expand_clone_input",
+                                        prologue);
+
+          auto loop_var = std::make_shared<Var>("i", std::make_shared<ScalarType>(DataType::INDEX), span);
+          auto iter_arg = std::make_shared<IterArg>("expand_clone_acc", target_tensor_type, target, span);
+          auto return_var = std::make_shared<Var>("expand_clone_d0_result", target_tensor_type, span);
+
+          auto loop_offsets = make_tuple({loop_var, zero, zero});
+          auto store_call = op_reg.Create("tile.store", {input_tile, loop_offsets, iter_arg}, span);
+          auto store_var = std::make_shared<Var>("expand_clone_d0_store", store_call->GetType(), span);
+
+          std::vector<StmtPtr> body_stmts;
+          body_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
+          body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{store_var}, span));
+
+          auto body = SeqStmts::Flatten(std::move(body_stmts), span);
+          auto for_stmt = std::make_shared<ForStmt>(loop_var, zero, target_shape[0], one,
+                                                    std::vector<IterArgPtr>{iter_arg}, body,
+                                                    std::vector<VarPtr>{return_var}, span);
+          prologue.push_back(for_stmt);
+          return ConversionResult{std::move(prologue), return_var};
+        }
+
+        if (broadcast_dim == 1) {
+          auto loop_var = std::make_shared<Var>("i", std::make_shared<ScalarType>(DataType::INDEX), span);
+          auto iter_arg = std::make_shared<IterArg>("expand_clone_acc", target_tensor_type, target, span);
+          auto return_var = std::make_shared<Var>("expand_clone_d1_result", target_tensor_type, span);
+
+          auto loop_offsets = make_tuple({loop_var, zero, zero});
+          std::vector<ExprPtr> slice_shape = {one, one, input_valid_shape[2]};
+
+          std::vector<StmtPtr> body_stmts;
+          auto input_tile = load_tensor_tile(input, loop_offsets, slice_shape, slice_shape,
+                                             "expand_clone_d1_input", body_stmts);
+
+          std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", input_dtype},
+                                                                         {"target_memory", MemorySpace::Vec}};
+          auto create_shape = MakeShapeTuple({one, target_shape[1], target_shape[2]}, span);
+          auto create_call = op_reg.Create("tile.create", {create_shape}, create_kwargs, span);
+          auto create_var = std::make_shared<Var>("expand_clone_d1_target", create_call->GetType(), span);
+          body_stmts.push_back(std::make_shared<AssignStmt>(create_var, create_call, span));
+
+          auto col_expand_call = op_reg.Create("tile.col_expand", {create_var, input_tile}, span);
+          auto col_expand_var =
+              std::make_shared<Var>("expand_clone_d1_col", col_expand_call->GetType(), span);
+          body_stmts.push_back(std::make_shared<AssignStmt>(col_expand_var, col_expand_call, span));
+
+          auto store_call = op_reg.Create("tile.store", {col_expand_var, loop_offsets, iter_arg}, span);
+          auto store_var = std::make_shared<Var>("expand_clone_d1_store", store_call->GetType(), span);
+          body_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
+          body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{store_var}, span));
+
+          auto body = SeqStmts::Flatten(std::move(body_stmts), span);
+          auto for_stmt = std::make_shared<ForStmt>(loop_var, zero, target_shape[0], one,
+                                                    std::vector<IterArgPtr>{iter_arg}, body,
+                                                    std::vector<VarPtr>{return_var}, span);
+          prologue.push_back(for_stmt);
+          return ConversionResult{std::move(prologue), return_var};
+        }
+
+        auto offsets = MakeZeroOffsets(target_shape.size(), span);
+        auto input_tile =
+            load_tensor_tile(input, offsets, input_shape, input_valid_shape, "expand_clone_input", prologue);
+
+        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", input_dtype},
+                                                                       {"target_memory", MemorySpace::Vec}};
+        auto create_shape = MakeShapeTuple(target_shape, span);
+        auto create_call = op_reg.Create("tile.create", {create_shape}, create_kwargs, span);
+        auto create_var = std::make_shared<Var>("expand_clone_d2_target", create_call->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(create_var, create_call, span));
+
+        auto row_expand_call = op_reg.Create("tile.row_expand", {create_var, input_tile}, span);
+        auto row_expand_var = std::make_shared<Var>("expand_clone_d2_row", row_expand_call->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(row_expand_var, row_expand_call, span));
+        auto store_call = op_reg.Create("tile.store", {row_expand_var, offsets, target}, span);
+        return ConversionResult{std::move(prologue), store_call};
       });
 }
 

--- a/tests/st/runtime/test_broadcast.py
+++ b/tests/st/runtime/test_broadcast.py
@@ -124,6 +124,87 @@ class TestTileColExpand(PTOTestCase):
         tensors["y"][:] = tensors["col_vec"].repeat(self.M, 1)
 
 
+class TestTensorExpandClone(PTOTestCase):
+    """Test case for tensor.expand_clone."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        b: int = 8,
+        n: int = 8,
+        k: int = 8,
+        broadcast_dim: int = 0,
+        *,
+        backend_type: BackendType | None = None,
+        config=None,
+    ):
+        super().__init__(config, backend_type=backend_type)
+        self.B = b
+        self.N = n
+        self.K = k
+        self.broadcast_dim = broadcast_dim
+
+    def get_name(self) -> str:
+        return f"tensor_expand_clone_d{self.broadcast_dim}_{self.B}x{self.N}x{self.K}"
+
+    def _input_shape(self) -> list[int]:
+        if self.broadcast_dim == -1:
+            return [self.B, self.N, self.K]
+        if self.broadcast_dim == 0:
+            return [1, self.N, self.K]
+        if self.broadcast_dim == 1:
+            return [self.B, 1, self.K]
+        if self.broadcast_dim == 2:
+            return [self.B, self.N, 1]
+        raise ValueError(f"Unsupported broadcast_dim: {self.broadcast_dim}")
+
+    def define_tensors(self) -> list[TensorSpec]:
+        input_shape = self._input_shape()
+        return [
+            TensorSpec("x", input_shape, DataType.FP32, init_value=torch.randn),
+            TensorSpec("y", [self.B, self.N, self.K], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, N, K = self.B, self.N, self.K
+        input_shape = self._input_shape()
+
+        @pl.program
+        class ExpandCloneProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def expand_clone_kernel(
+                self,
+                x: pl.Tensor[input_shape, pl.FP32],
+                y: pl.Out[pl.Tensor[[B, N, K], pl.FP32]],
+            ) -> pl.Tensor[[B, N, K], pl.FP32]:
+                out: pl.Tensor[[B, N, K], pl.FP32] = pl.expand_clone(x, y)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[input_shape, pl.FP32],
+                y: pl.Out[pl.Tensor[[B, N, K], pl.FP32]],
+            ) -> pl.Tensor[[B, N, K], pl.FP32]:
+                y = self.expand_clone_kernel(x, y)
+                return y
+
+        return ExpandCloneProgram
+
+    def compute_expected(self, tensors, params=None):
+        if self.broadcast_dim == -1:
+            tensors["y"][:] = tensors["x"]
+        elif self.broadcast_dim == 0:
+            tensors["y"][:] = tensors["x"].repeat(self.B, 1, 1)
+        elif self.broadcast_dim == 1:
+            tensors["y"][:] = tensors["x"].repeat(1, self.N, 1)
+        elif self.broadcast_dim == 2:
+            tensors["y"][:] = tensors["x"].repeat(1, 1, self.K)
+        else:
+            raise ValueError(f"Unsupported broadcast_dim: {self.broadcast_dim}")
+
+
 class TestBroadcastOperations:
     """Test suite for tile broadcast operations."""
 
@@ -139,6 +220,15 @@ class TestBroadcastOperations:
     def test_tile_col_expand(self, test_runner, backend, m, n):
         """Test tile.col_expand across platforms."""
         result = test_runner.run(TestTileColExpand(m=m, n=n, backend_type=backend))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("broadcast_dim", [-1, 0, 1, 2])
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    def test_tensor_expand_clone(self, test_runner, backend, broadcast_dim):
+        """Test tensor.expand_clone across platforms."""
+        if backend == BackendType.Ascend950 and broadcast_dim == 2:
+            pytest.skip("Skip broadcast_dim=2 for a5 backend due to pto-isa bug.")
+        result = test_runner.run(TestTensorExpandClone(broadcast_dim=broadcast_dim, backend_type=backend))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1557,6 +1557,92 @@ def test_tensor_expands():
     assert len(result_type.shape) == 2
 
 
+# =============================================================================
+# Tensor expand_clone tests
+# =============================================================================
+
+
+def test_tensor_expand_clone_dim0():
+    """Test tensor.expand_clone broadcasts dim0."""
+    span = ir.Span.unknown()
+
+    dim1 = ir.ConstInt(1, DataType.INT32, span)
+    dim2 = ir.ConstInt(2, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+
+    input_type = ir.TensorType([dim1, dim4, dim8], DataType.FP32)
+    target_type = ir.TensorType([dim2, dim4, dim8], DataType.FP32)
+    input_var = ir.Var("src", input_type, span)
+    target_var = ir.Var("dst", target_type, span)
+
+    call = ir.op.tensor.expand_clone(input_var, target_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.expand_clone"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+    for dim, expected in zip(result_type.shape, [2, 4, 8]):
+        assert isinstance(dim, ir.ConstInt)
+        assert dim.value == expected
+
+
+def test_tensor_expand_clone_dim1():
+    """Test tensor.expand_clone broadcasts dim1."""
+    span = ir.Span.unknown()
+
+    dim1 = ir.ConstInt(1, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    input_type = ir.TensorType([dim4, dim1, dim8], DataType.FP32)
+    target_type = ir.TensorType([dim4, dim16, dim8], DataType.FP32)
+    input_var = ir.Var("src", input_type, span)
+    target_var = ir.Var("dst", target_type, span)
+
+    call = ir.op.tensor.expand_clone(input_var, target_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.expand_clone"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+    for dim, expected in zip(result_type.shape, [4, 16, 8]):
+        assert isinstance(dim, ir.ConstInt)
+        assert dim.value == expected
+
+
+def test_tensor_expand_clone_dim2():
+    """Test tensor.expand_clone broadcasts dim2."""
+    span = ir.Span.unknown()
+
+    dim1 = ir.ConstInt(1, DataType.INT32, span)
+    dim4 = ir.ConstInt(4, DataType.INT32, span)
+    dim8 = ir.ConstInt(8, DataType.INT32, span)
+    dim16 = ir.ConstInt(16, DataType.INT32, span)
+
+    input_type = ir.TensorType([dim4, dim8, dim1], DataType.FP32)
+    target_type = ir.TensorType([dim4, dim8, dim16], DataType.FP32)
+    input_var = ir.Var("src", input_type, span)
+    target_var = ir.Var("dst", target_type, span)
+
+    call = ir.op.tensor.expand_clone(input_var, target_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.expand_clone"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 3
+    for dim, expected in zip(result_type.shape, [4, 8, 16]):
+        assert isinstance(dim, ir.ConstInt)
+        assert dim.value == expected
+
+
 def test_tensor_concat():
     """Test tensor.concat - column-wise concatenation."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1197,6 +1197,167 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_expand_clone_dim0_conversion(self):
+        """tensor.expand_clone (dim0 broadcast) -> looped tile.store into target."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[1, 4, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = pl.expand_clone(src, target)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[1, 4, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[1, 4, 8], pl.FP16],
+                target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                expand_clone_input: pl.Tile[[1, 4, 8], pl.FP16] = pl.load(src, [0, 0, 0], [1, 4, 8])
+                for i, (expand_clone_acc,) in pl.range(2, init_values=(target,)):
+                    expand_clone_d0_store: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(
+                        expand_clone_input, [i, 0, 0], expand_clone_acc
+                    )
+                    expand_clone_d0_result = pl.yield_(expand_clone_d0_store)
+                y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = expand_clone_d0_result
+                return y_tile
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[1, 4, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_expand_clone_dim1_conversion(self):
+        """tensor.expand_clone (dim1 broadcast) -> per-row load + col_expand + store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[2, 1, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = pl.expand_clone(src, target)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[2, 1, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[2, 1, 8], pl.FP16],
+                target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                for i, (expand_clone_acc,) in pl.range(2, init_values=(target,)):
+                    expand_clone_d1_input: pl.Tile[[1, 1, 8], pl.FP16] = pl.load(src, [i, 0, 0], [1, 1, 8])
+                    expand_clone_d1_target: pl.Tile[[1, 4, 8], pl.FP16] = pl.tile.create(
+                        [1, 4, 8], dtype=pl.FP16
+                    )
+                    expand_clone_d1_col: pl.Tile[[1, 4, 8], pl.FP16] = pl.tile.col_expand(
+                        expand_clone_d1_target, expand_clone_d1_input
+                    )
+                    expand_clone_d1_store: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(
+                        expand_clone_d1_col, [i, 0, 0], expand_clone_acc
+                    )
+                    expand_clone_d1_result = pl.yield_(expand_clone_d1_store)
+                y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = expand_clone_d1_result
+                return y_tile
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[2, 1, 8], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_expand_clone_dim2_conversion(self):
+        """tensor.expand_clone (dim2 broadcast) -> row_expand + store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[2, 4, 1], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = pl.expand_clone(src, target)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[2, 4, 1], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[2, 4, 1], pl.FP16],
+                target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                expand_clone_input: pl.Tile[[2, 4, 1], pl.FP16] = pl.load(src, [0, 0, 0], [2, 4, 1])
+                expand_clone_d2_target: pl.Tile[[2, 4, 8], pl.FP16] = pl.tile.create([2, 4, 8], dtype=pl.FP16)
+                expand_clone_d2_row: pl.Tile[[2, 4, 8], pl.FP16] = pl.tile.row_expand(
+                    expand_clone_d2_target, expand_clone_input
+                )
+                y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(expand_clone_d2_row, [0, 0, 0], target)
+                return y_tile
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[2, 4, 1], pl.FP16],
+                target: pl.Tensor[[2, 4, 8], pl.FP16],
+            ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
+                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestNestedControlFlow:
     """Test ConvertTensorToTileOps with nested control flow."""


### PR DESCRIPTION
Add tensor.expand_clone through IR/language APIs and lower it in ConvertTensorToTileOps with explicit handling for no-broadcast, dim0, dim1, and dim2 cases.

Update tensor op registration/type deduction to enforce rank-3 input, target-rank alignment, and at-most-one broadcast dimension.

Extend conversion pass self-loading op set for tensor.expand_clone and add custom lowering that emits tile.load/tile.store plus tile.col_expand/tile.row_expand as appropriate.

Adjust PTO tensor-view emission to treat trailing singleton shapes (including [B, M, 1]) as DN during make_tensor_view layout selection.

Add UT/ST coverage for tensor.expand_clone in operator type deduction, tensor-to-tile conversion, and runtime broadcast behavior across broadcast_dim in {-1,0,1,2}.
