### PR TITLE
fix(codegen): eliminate unused const Tensor& alias in orchestration output

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -40,6 +40,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -148,6 +149,11 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
   return oss.str();
 }
 
+class CodegenEffectiveUseCollector : public var_collectors::VarDefUseCollector {
+ protected:
+  void VisitStmt_(const ReturnStmtPtr&) override {}
+};
+
 }  // namespace
 
 // Statement code generator for orchestration
@@ -183,6 +189,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void SetInitialIndent(int indent) { indent_ = indent; }
+
+  void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
 
   std::string GetGeneratedCode() const { return code_.str(); }
   // --- CodegenBase pure virtual implementations ---
@@ -305,7 +313,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         GenerateFunctionCallCode(call, result_key);
 
         if (!As<TupleType>(call->GetType())) {
-          GenerateSingleReturnAlias(call, var_name);
+          if (effective_uses_.count(assign->var_.get())) {
+            GenerateSingleReturnAlias(call, var_name);
+          }
         } else {
           GenerateTupleReturnAliases(call);
         }
@@ -1051,6 +1061,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (effective_dirs[param_idx] == ParamDirection::InOut) {
         continue;
       }
+      if (!effective_uses_.count(elem.var)) {
+        continue;
+      }
       std::string elem_name = ReserveVarEmitName(elem.var);
       EmitTensorAlias(elem_name, call, param_idx);
     }
@@ -1121,6 +1134,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
   std::unordered_map<const Call*, std::vector<ParamDirection>> call_site_directions_;
+  std::unordered_set<const Var*> effective_uses_;
 
   const std::vector<ParamDirection>* LookupCallSiteDirections(const CallPtr& call) const {
     auto it = call_site_directions_.find(call.get());
@@ -1151,6 +1165,9 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   CallSiteDirectionResolver direction_resolver(program, root_collector.buffer_roots, func->params_);
   direction_resolver.VisitStmt(func->body_);
+
+  CodegenEffectiveUseCollector use_collector;
+  use_collector.VisitStmt(func->body_);
 
   std::unordered_map<const Var*, std::string> emit_name_map;
   std::set<std::string> param_name_set;
@@ -1192,6 +1209,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
   stmt_codegen.SetCallSiteDirections(std::move(direction_resolver.call_site_directions));
+  stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1405,7 +1405,41 @@ class TestOrchestration:
         assert "params_t0.add_inout(ret0__out)" in code
         assert "params_t1.add_inout(ret0__out_1)" in code
         assert "const Tensor& first = ret0__out;" in code
-        assert "const Tensor& second = ret0__out_1;" in code
+        assert "const Tensor& second" not in code
+
+    def test_unused_alias_not_emitted(self):
+        """Alias for a kernel result that is never consumed downstream should be omitted."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class UnusedAliasProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_op(
+                self,
+                a: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], a)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_unused(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result: pl.Tensor[[16, 16], pl.FP32] = self.kernel_op(a, b)
+                return result
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(UnusedAliasProgram)
+        code = _generate_orch_code(transformed)
+
+        assert "pto2_rt_submit_" in code
+        assert "const Tensor& result" not in code
 
     def test_multi_scope_alloc_tensors_batching(self):
         """Each scope (function body, for body) batches its own alloc_tensors independently."""


### PR DESCRIPTION
## Summary

- Pre-scan the orchestration function body with a `CodegenEffectiveUseCollector` (extends `VarDefUseCollector`, skips `ReturnStmt` since codegen treats it as a no-op) to identify variables that are actually consumed in the generated C++ code.
- Skip emitting `const Tensor&` alias variables for kernel call results that have no downstream consumers, eliminating dead code and `-Wunused-variable` compiler warnings.

Fixes #844

## Test plan

- [x] New test `test_unused_alias_not_emitted` verifies aliases for return-only variables are suppressed
- [x] Updated `test_repeated_auto_output_buffers_get_unique_names` to reflect that `second` (only used in return) is no longer emitted
- [x] All 3632 unit tests pass
- [x] All pre-commit checks pass (clang-format, cpplint, ruff, pyright)

Made with [Cursor](https://cursor.com)