### PR TITLE
fix(runtime): resolve simpler root via simpler_setup wheel layout

### DIFF
--- a/python/pypto/runtime/env_manager.py
+++ b/python/pypto/runtime/env_manager.py
@@ -20,8 +20,10 @@ from pathlib import Path
 
 _SIMPLER_SETUP_PROJECT_ROOT: Path | None
 try:
-    _SIMPLER_SETUP_PROJECT_ROOT = Path(importlib.import_module("simpler_setup.environment").PROJECT_ROOT)
-except ImportError:
+    _simpler_env_module = importlib.import_module("simpler_setup.environment")
+    _project_root_attr = getattr(_simpler_env_module, "PROJECT_ROOT", None)
+    _SIMPLER_SETUP_PROJECT_ROOT = Path(_project_root_attr) if _project_root_attr is not None else None
+except (ImportError, TypeError, ValueError):
     _SIMPLER_SETUP_PROJECT_ROOT = None
 
 _cache: dict[str, str | None] = {}

--- a/python/pypto/runtime/env_manager.py
+++ b/python/pypto/runtime/env_manager.py
@@ -14,8 +14,15 @@ Provides :func:`ensure` to validate and cache required environment variables,
 :func:`get_simpler_root` to locate the simpler ``runtime/`` submodule.
 """
 
+import importlib
 import os
 from pathlib import Path
+
+_SIMPLER_SETUP_PROJECT_ROOT: Path | None
+try:
+    _SIMPLER_SETUP_PROJECT_ROOT = Path(importlib.import_module("simpler_setup.environment").PROJECT_ROOT)
+except ImportError:
+    _SIMPLER_SETUP_PROJECT_ROOT = None
 
 _cache: dict[str, str | None] = {}
 
@@ -44,10 +51,14 @@ def get_simpler_root() -> Path:
 
     Resolution order:
 
-    1. Editable / source-tree install: ``<pypto-repo>/simpler/`` relative to
+    1. Editable / source-tree install: ``<pypto-repo>/runtime/`` relative to
        this file (``python/pypto/runtime/env_manager.py`` → 3 parents up).
-    2. Non-editable (pip) install: walk up from ``cwd()`` looking for a git
-       repository that contains a ``simpler/`` submodule.
+    2. Wheel install of ``simpler``: ``simpler_setup.environment.PROJECT_ROOT``,
+       which resolves to ``site-packages/simpler_setup/_assets/`` after a
+       ``pip install <pypto-repo>/runtime`` and contains the runtime ``src/``
+       installed by simpler's CMakeLists.
+    3. Legacy fallback: walk up from ``cwd()`` looking for a git repository
+       that contains a ``runtime/`` submodule (kept for ad-hoc setups).
 
     The result is cached after the first successful lookup.
     """
@@ -60,6 +71,10 @@ def get_simpler_root() -> Path:
         _simpler_root = candidate
         return _simpler_root
 
+    if _SIMPLER_SETUP_PROJECT_ROOT is not None and (_SIMPLER_SETUP_PROJECT_ROOT / "src").is_dir():
+        _simpler_root = _SIMPLER_SETUP_PROJECT_ROOT
+        return _simpler_root
+
     cwd = Path.cwd()
     for parent in [cwd, *cwd.parents]:
         candidate = parent / "runtime"
@@ -69,7 +84,8 @@ def get_simpler_root() -> Path:
 
     raise OSError(
         "Cannot find runtime/ submodule directory.\n"
-        "Ensure you are running from within the pypto repository with "
-        "submodules initialized:\n"
-        "  git submodule update --init"
+        "Either run from within the pypto repository with submodules initialised\n"
+        "  git submodule update --init\n"
+        "or install the runtime wheel so simpler_setup is importable\n"
+        "  pip install <pypto-repo>/runtime"
     )

--- a/tests/ut/runtime/test_env_manager.py
+++ b/tests/ut/runtime/test_env_manager.py
@@ -1,0 +1,117 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``pypto.runtime.env_manager.get_simpler_root``.
+
+The function has three resolution strategies and one error path. We exercise
+each branch by monkey-patching ``env_manager.__file__`` and the cached
+``_SIMPLER_SETUP_PROJECT_ROOT`` value, so the tests stay hermetic and never
+need a real ``pip install``.
+"""
+
+import pytest
+from pypto.runtime import env_manager
+
+
+@pytest.fixture
+def fresh_env_manager(monkeypatch):
+    """Return ``env_manager`` with the resolution cache cleared per test."""
+    monkeypatch.setattr(env_manager, "_simpler_root", None)
+    return env_manager
+
+
+class TestGetSimplerRoot:
+    """Verify each resolution branch of ``get_simpler_root``."""
+
+    def test_source_tree_install(self, fresh_env_manager):
+        """Editable install: ``<repo>/runtime`` is found via ``__file__`` anchor."""
+        root = fresh_env_manager.get_simpler_root()
+        assert root.is_dir()
+        assert (root / "src").is_dir(), "expected runtime/src to exist in source tree"
+
+    def test_simpler_setup_fallback(self, fresh_env_manager, tmp_path, monkeypatch):
+        """Pip-installed pypto + pip-installed simpler.
+
+        Simulates the post-install layout that the ``pypto-lib`` CI hits:
+        ``__file__`` lives under ``site-packages/pypto/runtime/`` so the
+        source-tree anchor misses, and ``simpler_setup.environment.PROJECT_ROOT``
+        points into ``site-packages/simpler_setup/_assets/`` where the wheel
+        installer placed ``src/``.
+        """
+        fake_install = tmp_path / "fake_site_packages" / "pypto" / "runtime"
+        fake_install.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_install / "env_manager.py"))
+
+        fake_assets = tmp_path / "simpler_assets"
+        (fake_assets / "src").mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "_SIMPLER_SETUP_PROJECT_ROOT", fake_assets)
+
+        root = fresh_env_manager.get_simpler_root()
+        assert root == fake_assets
+
+    def test_cwd_walk_fallback(self, fresh_env_manager, tmp_path, monkeypatch):
+        """Legacy ad-hoc layout: walk up from cwd to find ``.git`` + ``runtime/``.
+
+        Triggered only when both the source-tree anchor and the simpler wheel
+        are unavailable.
+        """
+        fake_install = tmp_path / "fake_site_packages" / "pypto" / "runtime"
+        fake_install.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_install / "env_manager.py"))
+        monkeypatch.setattr(fresh_env_manager, "_SIMPLER_SETUP_PROJECT_ROOT", None)
+
+        fake_repo = tmp_path / "fake_repo"
+        (fake_repo / ".git").mkdir(parents=True)
+        (fake_repo / "runtime").mkdir(parents=True)
+        monkeypatch.chdir(fake_repo)
+
+        root = fresh_env_manager.get_simpler_root()
+        assert root == fake_repo / "runtime"
+
+    def test_simpler_setup_skipped_when_src_missing(self, fresh_env_manager, tmp_path, monkeypatch):
+        """An importable ``simpler_setup`` whose ``_assets/src`` is absent must not match.
+
+        Guards against partial installs where ``simpler_setup`` is on the path
+        but the wheel's ``src/`` payload was never placed.
+        """
+        fake_install = tmp_path / "fake_site_packages" / "pypto" / "runtime"
+        fake_install.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_install / "env_manager.py"))
+
+        broken_assets = tmp_path / "broken_simpler"
+        broken_assets.mkdir()
+        monkeypatch.setattr(fresh_env_manager, "_SIMPLER_SETUP_PROJECT_ROOT", broken_assets)
+
+        fake_repo = tmp_path / "legacy_repo"
+        (fake_repo / ".git").mkdir(parents=True)
+        (fake_repo / "runtime").mkdir(parents=True)
+        monkeypatch.chdir(fake_repo)
+
+        root = fresh_env_manager.get_simpler_root()
+        assert root == fake_repo / "runtime"
+
+    def test_all_paths_fail_raises(self, fresh_env_manager, tmp_path, monkeypatch):
+        """When no strategy succeeds, raise ``OSError`` with actionable guidance."""
+        fake_install = tmp_path / "fake_site_packages" / "pypto" / "runtime"
+        fake_install.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_install / "env_manager.py"))
+        monkeypatch.setattr(fresh_env_manager, "_SIMPLER_SETUP_PROJECT_ROOT", None)
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.chdir(empty_dir)
+
+        with pytest.raises(OSError, match=r"Cannot find runtime/"):
+            fresh_env_manager.get_simpler_root()
+
+    def test_result_is_cached(self, fresh_env_manager):
+        """Repeated calls return the cached path object without re-resolving."""
+        first = fresh_env_manager.get_simpler_root()
+        second = fresh_env_manager.get_simpler_root()
+        assert first is second

--- a/tests/ut/runtime/test_env_manager.py
+++ b/tests/ut/runtime/test_env_manager.py
@@ -29,11 +29,22 @@ def fresh_env_manager(monkeypatch):
 class TestGetSimplerRoot:
     """Verify each resolution branch of ``get_simpler_root``."""
 
-    def test_source_tree_install(self, fresh_env_manager):
-        """Editable install: ``<repo>/runtime`` is found via ``__file__`` anchor."""
+    def test_source_tree_install(self, fresh_env_manager, tmp_path, monkeypatch):
+        """Editable install: ``<repo>/runtime`` is found via the ``__file__`` anchor.
+
+        Hermetic: build a fake repo with the expected ``python/pypto/runtime/``
+        depth so the ``parents[3] / "runtime"`` lookup hits a controlled dir,
+        and ensure the test passes regardless of how/where pypto is installed.
+        """
+        fake_repo = tmp_path / "fake_repo"
+        fake_runtime = fake_repo / "runtime"
+        fake_runtime.mkdir(parents=True)
+        fake_module_dir = fake_repo / "python" / "pypto" / "runtime"
+        fake_module_dir.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_module_dir / "env_manager.py"))
+
         root = fresh_env_manager.get_simpler_root()
-        assert root.is_dir()
-        assert (root / "src").is_dir(), "expected runtime/src to exist in source tree"
+        assert root == fake_runtime
 
     def test_simpler_setup_fallback(self, fresh_env_manager, tmp_path, monkeypatch):
         """Pip-installed pypto + pip-installed simpler.
@@ -110,8 +121,22 @@ class TestGetSimplerRoot:
         with pytest.raises(OSError, match=r"Cannot find runtime/"):
             fresh_env_manager.get_simpler_root()
 
-    def test_result_is_cached(self, fresh_env_manager):
-        """Repeated calls return the cached path object without re-resolving."""
+    def test_result_is_cached(self, fresh_env_manager, tmp_path, monkeypatch):
+        """Repeated calls return the cached path object without re-resolving.
+
+        Hermetic: seed a guaranteed-success resolution path via the
+        ``simpler_setup`` fallback so the cache check does not depend on the
+        ambient environment having a real source tree or git checkout.
+        """
+        fake_install = tmp_path / "fake_site_packages" / "pypto" / "runtime"
+        fake_install.mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "__file__", str(fake_install / "env_manager.py"))
+
+        fake_assets = tmp_path / "simpler_assets"
+        (fake_assets / "src").mkdir(parents=True)
+        monkeypatch.setattr(fresh_env_manager, "_SIMPLER_SETUP_PROJECT_ROOT", fake_assets)
+
         first = fresh_env_manager.get_simpler_root()
         second = fresh_env_manager.get_simpler_root()
         assert first is second
+        assert first == fake_assets


### PR DESCRIPTION
## Summary

After `pip install pypto` and `pip install pypto/runtime`, the downstream `pypto-lib` CI still had to run

```bash
ln -s pypto/runtime $GITHUB_WORKSPACE/runtime
```

to make `KernelCompiler` find runtime headers. Root cause: `pypto.runtime.env_manager.get_simpler_root()` only had two resolution paths — a source-tree anchor (relative to `__file__`, fails after wheel install) and a `cwd()` walk that requires a `.git` checkout. Neither matches the post-`pip install` layout.

This PR inserts a third strategy between the two existing ones: read `simpler_setup.environment.PROJECT_ROOT`, which the simpler wheel populates to `site-packages/simpler_setup/_assets/` and which contains the runtime `src/` headers installed by `runtime/CMakeLists.txt`. With this in place the symlink workaround is no longer needed.

Resolution order is now:

1. Source-tree / editable install (`<repo>/runtime/`)
2. Wheel install of simpler (`simpler_setup.environment.PROJECT_ROOT`) — **new**
3. Legacy `cwd()` walk (kept for ad-hoc setups)

`importlib.import_module` is used so pyright does not flag a missing import in dev environments where simpler is not yet installed.

## Changes

- `python/pypto/runtime/env_manager.py`: add wheel-install resolution path and update error message.
- `tests/ut/runtime/test_env_manager.py`: new file — 6 hermetic unit tests covering source-tree, wheel-install fallback (simulates pypto-lib CI layout), cwd walk, partial wheel (`src/` missing), all-paths-fail error, and result caching.

## Testing

- [x] `pytest tests/ut/runtime/test_env_manager.py -v` — 6/6 pass
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pyright` (via pre-commit) — clean
- [x] pre-commit hooks all pass

## Related

Tracking issue: hw-native-sys/pypto#1064

Made with [Cursor](https://cursor.com)