### PR TITLE
feat(ops): Expose pto.trsqrt high-precision mode in Python frontend

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -24,6 +24,7 @@ Auto-selects between tensor and tile implementation based on input type.
 | `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | Matrix multiply with accumulation: `acc += lhs @ rhs` |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise max (tile path requires `tmp_tile`) |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise sum (tile path requires `tmp_tile`) |
+| `rsqrt` | `(input: T, high_precision: bool = False) -> T` | Reciprocal square root; `high_precision=True` selects the high-precision path (tensor input only — tile callers must use `pl.tile.rsqrt(src, tmp=...)`) |
 | `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | Tile-only (promoted from `pl.tile.create`): create tile at specific memory space |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices (dispatched by source type). Sugar: `A[i, j]` |
 | `write` | `(dst: T, offset: IntLike \| Sequence[IntLike], value: Scalar) -> None` | Write scalar at indices (dispatched by destination type). Sugar: `A[i, j] = v` |
@@ -54,6 +55,7 @@ Operate on `Tensor` objects (DDR memory).
 | `maximum` | `(lhs: Tensor, rhs: Tensor) -> Tensor` | Element-wise maximum |
 | `row_max` | `(input: Tensor) -> Tensor` | Row-wise max reduction |
 | `row_sum` | `(input: Tensor) -> Tensor` | Row-wise sum reduction |
+| `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` | Element-wise reciprocal square root; `high_precision=True` allocates a scratch tile during lowering for the higher-precision PTO path (requires static tile shape, same constraint as `row_max`/`row_sum`) |
 | `exp` | `(input: Tensor) -> Tensor` | Element-wise exponential |
 | `cast` | `(input: Tensor, target_type: DataType, mode="round") -> Tensor` | Type cast |
 | `matmul` | `(lhs: Tensor, rhs: Tensor, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> Tensor` | Matrix multiplication |
@@ -117,7 +119,7 @@ Transfer data between memory hierarchy levels.
 | `neg` | `(tile: Tile) -> Tile` | Negate |
 | `exp` | `(tile: Tile) -> Tile` | Exponential |
 | `sqrt` | `(tile: Tile) -> Tile` | Square root |
-| `rsqrt` | `(tile: Tile) -> Tile` | Reciprocal square root |
+| `rsqrt` | `(tile: Tile, tmp: Tile \| None = None) -> Tile` | Reciprocal square root; passing `tmp` (same shape/dtype as `tile`) selects the high-precision PTO lowering |
 | `recip` | `(tile: Tile) -> Tile` | Reciprocal (1/x) |
 | `log` | `(tile: Tile) -> Tile` | Natural logarithm |
 | `abs` | `(tile: Tile) -> Tile` | Absolute value |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -24,6 +24,7 @@
 | `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | 带累加的矩阵乘法：`acc += lhs @ rhs` |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行最大值（tile 路径需要 `tmp_tile`） |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行求和（tile 路径需要 `tmp_tile`） |
+| `rsqrt` | `(input: T, high_precision: bool = False) -> T` | 倒数平方根；`high_precision=True` 选择高精度路径（仅对 Tensor 输入生效，Tile 路径需要改用 `pl.tile.rsqrt(src, tmp=...)`） |
 | `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | 在指定内存空间创建 tile（tile-only，对应 `pl.tile.create`） |
 
 ## 仅 Tensor（`pl.tensor.*`）
@@ -51,6 +52,7 @@
 | `maximum` | `(lhs: Tensor, rhs: Tensor) -> Tensor` | 逐元素最大值 |
 | `row_max` | `(input: Tensor) -> Tensor` | 行最大值归约 |
 | `row_sum` | `(input: Tensor) -> Tensor` | 行求和归约 |
+| `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` | 逐元素倒数平方根；`high_precision=True` 时编译器在下沉阶段分配临时 tile，启用高精度 PTO 路径（要求 tile 形状是编译期常量，与 `row_max`/`row_sum` 限制一致） |
 | `exp` | `(input: Tensor) -> Tensor` | 逐元素指数 |
 | `cast` | `(input: Tensor, target_type: DataType, mode="round") -> Tensor` | 类型转换 |
 | `matmul` | `(lhs: Tensor, rhs: Tensor, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> Tensor` | 矩阵乘法 |
@@ -112,7 +114,7 @@
 | `neg` | `(tile: Tile) -> Tile` | 取反 |
 | `exp` | `(tile: Tile) -> Tile` | 指数 |
 | `sqrt` | `(tile: Tile) -> Tile` | 平方根 |
-| `rsqrt` | `(tile: Tile) -> Tile` | 倒数平方根 |
+| `rsqrt` | `(tile: Tile, tmp: Tile \| None = None) -> Tile` | 倒数平方根；传入 `tmp`（与 `tile` 同形状同 dtype）时选择高精度 PTO 路径 |
 | `recip` | `(tile: Tile) -> Tile` | 倒数（1/x） |
 | `log` | `(tile: Tile) -> Tile` | 自然对数 |
 | `abs` | `(tile: Tile) -> Tile` | 绝对值 |

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -243,7 +243,9 @@ def _register_ops() -> None:
         m[f"{prefix}.neg"] = _torch_fn("neg")
         m[f"{prefix}.exp"] = _torch_fn("exp")
         m[f"{prefix}.sqrt"] = _torch_fn("sqrt")
-        m[f"{prefix}.rsqrt"] = _torch_fn("rsqrt")
+        # rsqrt in tile form may carry an optional tmp_tile arg for the high-precision
+        # path; torch.rsqrt takes only the input, so ignore any extra operands.
+        m[f"{prefix}.rsqrt"] = lambda a, _kw: f"torch.rsqrt({a[0]})"
         m[f"{prefix}.recip"] = _torch_fn("reciprocal")
         m[f"{prefix}.abs"] = _torch_fn("abs")
 

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -738,18 +738,21 @@ def sqrt(input: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.sqrt", [input], {}, actual_span)
 
 
-def rsqrt(input: Expr, span: Span | None = None) -> Call:
+def rsqrt(input: Expr, high_precision: bool = False, span: Span | None = None) -> Call:
     """Element-wise reciprocal square root operation.
 
     Args:
         input: Input tensor
+        high_precision: If True, lower to the high-precision PTO path that
+            uses a scratch buffer (compiler-allocated during conversion).
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise reciprocal square root
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tensor.rsqrt", [input], {}, actual_span)
+    kwargs: dict = {"high_precision": high_precision} if high_precision else {}
+    return _ir_core.create_op_call("tensor.rsqrt", [input], kwargs, actual_span)
 
 
 def cast(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1150,18 +1150,21 @@ def sqrt(tile: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.sqrt", [tile], {}, actual_span)
 
 
-def rsqrt(tile: Expr, span: Span | None = None) -> Call:
+def rsqrt(tile: Expr, tmp: Expr | None = None, span: Span | None = None) -> Call:
     """Element-wise reciprocal square root (1/sqrt(x)) of a tile.
 
     Args:
         tile: Input tile (TileType)
+        tmp: Optional scratch tile (TileType, same shape/dtype as ``tile``).
+            Passing it selects the high-precision PTO lowering.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise reciprocal square root
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.rsqrt", [tile], {}, actual_span)
+    args: list[Expr] = [tile] if tmp is None else [tile, tmp]
+    return _ir_core.create_op_call("tile.rsqrt", args, {}, actual_span)
 
 
 def cast(

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -684,17 +684,19 @@ def sqrt(input: Tensor) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def rsqrt(input: Tensor) -> Tensor:
+def rsqrt(input: Tensor, high_precision: bool = False) -> Tensor:
     """Element-wise reciprocal square root operation.
 
     Args:
         input: Input tensor
+        high_precision: If True, lower to the higher-precision PTO path. The
+            compiler allocates a scratch buffer during tensor-to-tile conversion.
 
     Returns:
         Tensor wrapping the rsqrt operation
     """
     input_expr = input.unwrap()
-    call_expr = _ir_ops.rsqrt(input_expr)
+    call_expr = _ir_ops.rsqrt(input_expr, high_precision=high_precision)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -640,16 +640,19 @@ def sqrt(tile: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def rsqrt(tile: Tile) -> Tile:
+def rsqrt(tile: Tile, tmp: Tile | None = None) -> Tile:
     """Element-wise reciprocal square root.
 
     Args:
         tile: Input tile
+        tmp: Optional scratch tile (same shape/dtype as ``tile``) that activates
+            the high-precision PTO lowering.
 
     Returns:
         Tile wrapping the rsqrt operation
     """
-    call_expr = _ir_ops.rsqrt(tile.unwrap())
+    tmp_expr = tmp.unwrap() if tmp is not None else None
+    call_expr = _ir_ops.rsqrt(tile.unwrap(), tmp_expr)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -195,10 +195,16 @@ def sqrt(input: T) -> T:
     raise TypeError(f"sqrt: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def rsqrt(input: T) -> T:
-    """Element-wise reciprocal square root, dispatched by input type."""
+def rsqrt(input: T, high_precision: bool = False) -> T:
+    """Element-wise reciprocal square root, dispatched by input type.
+
+    ``high_precision`` applies to the tensor path where the compiler inserts
+    the scratch allocation. At the tile level, callers that need the high-
+    precision path must call ``pl.tile.rsqrt(src, tmp=...)`` directly since
+    buffer lifetimes are user-managed there.
+    """
     if isinstance(input, Tensor):
-        return _tensor.rsqrt(input)
+        return _tensor.rsqrt(input, high_precision=high_precision)
     if isinstance(input, Tile):
         return _tile.rsqrt(input)
     raise TypeError(f"rsqrt: expected Tensor or Tile, got {type(input).__name__}")

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1217,7 +1217,7 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.exp",             "pto.texp",             1},
     {"tile.log",             "pto.tlog",             1},
     {"tile.sqrt",            "pto.tsqrt",            1},
-    {"tile.rsqrt",           "pto.trsqrt",           1},
+    // tile.rsqrt is registered with a custom codegen handler below (supports 1 or 2 args).
     {"tile.recip",           "pto.trecip",           1},
     {"tile.neg",             "pto.tneg",             1},
     {"tile.not",             "pto.tnot",             1},
@@ -1370,6 +1370,13 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.cast", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileCvtCodegenPTO("pto.tcvt", op, codegen);
+  });
+  // tile.rsqrt accepts 1 arg (basic) or 2 args (high-precision with tmp workspace).
+  // Both forms emit pto.trsqrt with the appropriate ins() arity.
+  reg("tile.rsqrt", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    size_t arity = op->args_.size();
+    CHECK(arity == 1 || arity == 2) << "tile.rsqrt requires 1 or 2 arguments, but got " << arity;
+    return MakeNaryCodegenPTO("pto.trsqrt", arity, op, codegen);
   });
   // tile.full (TEXPANDS): output is row_major per ISA
   if (exclude_ops.count("tile.full") == 0) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1372,12 +1372,19 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     return MakeTileCvtCodegenPTO("pto.tcvt", op, codegen);
   });
   // tile.rsqrt accepts 1 arg (basic) or 2 args (high-precision with tmp workspace).
-  // Both forms emit pto.trsqrt with the appropriate ins() arity.
-  reg("tile.rsqrt", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-    size_t arity = op->args_.size();
-    CHECK(arity == 1 || arity == 2) << "tile.rsqrt requires 1 or 2 arguments, but got " << arity;
-    return MakeNaryCodegenPTO("pto.trsqrt", arity, op, codegen);
-  });
+  // Both forms emit pto.trsqrt with the appropriate ins() arity. Per ISA, both
+  // inputs (when present) and the output must be row_major.
+  if (exclude_ops.count("tile.rsqrt") == 0) {
+    backend.RegisterOp("tile.rsqrt")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          size_t arity = op->args_.size();
+          CHECK(arity == 1 || arity == 2) << "tile.rsqrt requires 1 or 2 arguments, but got " << arity;
+          return MakeNaryCodegenPTO("pto.trsqrt", arity, op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_input_layout(1, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
   // tile.full (TEXPANDS): output is row_major per ISA
   if (exclude_ops.count("tile.full") == 0) {
     backend.RegisterOp("tile.full")

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -190,8 +190,11 @@ REGISTER_OP("tensor.sqrt")
 
 REGISTER_OP("tensor.rsqrt")
     .set_op_category("TensorOp")
-    .set_description("Element-wise reciprocal square root operation")
+    .set_description(
+        "Element-wise reciprocal square root operation. "
+        "Passing high_precision=True opts into the higher-precision PTO path that uses a scratch buffer.")
     .add_argument("input", "Input tensor (TensorType)")
+    .set_attr<bool>("high_precision")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorRsqrtType(args, kwargs);

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -77,6 +77,11 @@ TypePtr DeduceTileRsqrtType(const std::vector<ExprPtr>& args,
     CHECK(tmp_type->shape_.size() == tile_type->shape_.size())
         << op_name << ": tmp tile rank (" << tmp_type->shape_.size() << ") must match input rank ("
         << tile_type->shape_.size() << ")";
+    for (size_t i = 0; i < tile_type->shape_.size(); ++i) {
+      CHECK(DimensionsEqual(tmp_type->shape_[i], tile_type->shape_[i]))
+          << op_name << ": tmp tile shape mismatch at dimension " << i << " (tmp: " << tmp_type->shape_[i]
+          << ", input: " << tile_type->shape_[i] << ")";
+    }
   }
 
   TileView tile_view;

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -55,6 +55,36 @@ TypePtr DeduceTileUnaryType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
+// tile.rsqrt accepts 1 arg (basic mode) or 2 args (high-precision mode with tmp workspace).
+// The tmp tile must match the input in shape and dtype.
+TypePtr DeduceTileRsqrtType(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs,
+                            const std::string& op_name) {
+  CHECK(args.size() == 1 || args.size() == 2)
+      << "The operator " << op_name << " requires 1 or 2 arguments, but got " << args.size();
+
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+
+  if (args.size() == 2) {
+    auto tmp_type = As<TileType>(args[1]->GetType());
+    CHECK(tmp_type) << "The operator " << op_name << " requires tmp argument to be a TileType, but got "
+                    << args[1]->GetType()->TypeName();
+    CHECK(tmp_type->dtype_ == tile_type->dtype_)
+        << op_name << ": tmp tile dtype (" << tmp_type->dtype_.ToString() << ") must match input dtype ("
+        << tile_type->dtype_.ToString() << ")";
+    CHECK(tmp_type->shape_.size() == tile_type->shape_.size())
+        << op_name << ": tmp tile rank (" << tmp_type->shape_.size() << ") must match input rank ("
+        << tile_type->shape_.size() << ")";
+  }
+
+  TileView tile_view;
+  tile_view.valid_shape = tile_type->shape_;
+  InheritTileViewLayout(tile_view, tile_type);
+  return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
+}
+
 TypePtr DeduceTileCastType(const std::vector<ExprPtr>& args,
                            const std::vector<std::pair<std::string, std::any>>& kwargs,
                            const std::string& op_name) {
@@ -143,13 +173,17 @@ REGISTER_OP("tile.sqrt")
 
 REGISTER_OP("tile.rsqrt")
     .set_op_category("TileOp")
-    .set_description("Reciprocal square root (1/sqrt(x)) of a tile (element-wise)")
+    .set_description(
+        "Reciprocal square root (1/sqrt(x)) of a tile (element-wise). "
+        "Passing an optional second tmp tile activates the high-precision PTO path.")
     .add_argument("tile", "Input tile (TileType)")
+    .add_argument("tmp", "Optional scratch tile for high-precision path (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileUnaryType(args, kwargs, "tile.rsqrt");
+      return DeduceTileRsqrtType(args, kwargs, "tile.rsqrt");
     });
 
 REGISTER_OP("tile.cast")

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -101,8 +101,39 @@ void OpConversionRegistry::RegisterScalarAndUnaryOps() {
   RegisterSimple("tensor.recip", "tile.recip");
   RegisterSimple("tensor.exp", "tile.exp");
   RegisterSimple("tensor.sqrt", "tile.sqrt");
-  RegisterSimple("tensor.rsqrt", "tile.rsqrt");
   RegisterSimple("tensor.cast", "tile.cast");
+
+  // tensor.rsqrt → tile.rsqrt (basic) or tile.rsqrt(src, tmp) (high-precision).
+  // The tmp scratch tile is allocated via tile.create when high_precision=True.
+  RegisterCustom(
+      "tensor.rsqrt",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 1) << "tensor.rsqrt conversion expects 1 arg, got " << args.size();
+        auto& op_reg = OpRegistry::GetInstance();
+        const auto& input = args[0];
+
+        bool high_precision = GetKwargOr<bool>(kwargs, "high_precision", false);
+        if (!high_precision) {
+          return ConversionResult{op_reg.Create("tile.rsqrt", {input}, span)};
+        }
+
+        auto tile_type = As<TileType>(input->GetType());
+        CHECK(tile_type) << "tensor.rsqrt conversion: input must be TileType after memory promotion, got "
+                         << input->GetType()->TypeName();
+
+        auto shape_tuple = std::make_shared<MakeTuple>(tile_type->shape_, span);
+        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", tile_type->dtype_},
+                                                                       {"target_memory", MemorySpace::Vec}};
+        auto create_call = op_reg.Create("tile.create", {shape_tuple}, create_kwargs, span);
+
+        auto tmp_var = std::make_shared<Var>("rsqrt_tmp", create_call->GetType(), span);
+        std::vector<StmtPtr> prologue;
+        prologue.push_back(std::make_shared<AssignStmt>(tmp_var, create_call, span));
+
+        auto rsqrt_call = op_reg.Create("tile.rsqrt", {input, tmp_var}, span);
+        return ConversionResult{std::move(prologue), rsqrt_call};
+      });
 }
 
 // ============================================================================

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -541,6 +541,81 @@ class Test910BBlockOpsCodegen:
             validate_kernel_codegen(func_name, mlir_code)
 
 
+class TestRsqrtHighPrecisionCodegen:
+    """Tests for the high-precision path of tile.rsqrt (2-arg form)."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_rsqrt_with_tmp_emits_two_operand_trsqrt(self):
+        """pl.tile.rsqrt(src, tmp=...) emits pto.trsqrt with two ins operands."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_rsqrt_hp(
+                self,
+                input_tensor: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                input_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(input_tensor, [0, 0], [16, 16])
+                tmp_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.create(
+                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.rsqrt(input_tile, tmp=tmp_tile)
+                updated_output: pl.Tensor[[16, 16], pl.FP32] = pl.store(result_tile, [0, 0], output)
+                return updated_output
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.trsqrt" in mlir
+        # Two ins operands separated by a comma must appear inside a single ins(...) clause.
+        trsqrt_line = next((line for line in mlir.splitlines() if "pto.trsqrt" in line), "")
+        assert trsqrt_line, f"pto.trsqrt not found in MLIR:\n{mlir}"
+        ins_start = trsqrt_line.find("ins(")
+        assert ins_start != -1, f"ins(...) clause not found in: {trsqrt_line}"
+        ins_end = trsqrt_line.find(")", ins_start)
+        ins_body = trsqrt_line[ins_start + len("ins(") : ins_end]
+        # 2-operand form: "<operand1>, <operand2> : ..." — check for a separator before the ":".
+        operand_str = ins_body.split(":", 1)[0]
+        assert operand_str.count(",") >= 1, (
+            f"Expected 2 ins operands for high-precision pto.trsqrt, got: {trsqrt_line}"
+        )
+
+    def test_tensor_rsqrt_high_precision_end_to_end(self):
+        """pl.rsqrt(x, high_precision=True) at the tensor level also emits the 2-operand form."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_rsqrt_hp_tensor(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                y: pl.Tensor[[16, 16], pl.FP32] = pl.rsqrt(x, high_precision=True)
+                return y
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.trsqrt" in mlir
+        trsqrt_line = next((line for line in mlir.splitlines() if "pto.trsqrt" in line), "")
+        ins_start = trsqrt_line.find("ins(")
+        ins_end = trsqrt_line.find(")", ins_start)
+        ins_body = trsqrt_line[ins_start + len("ins(") : ins_end]
+        operand_str = ins_body.split(":", 1)[0]
+        assert operand_str.count(",") >= 1, (
+            f"Expected 2 ins operands for tensor-level high_precision rsqrt, got: {trsqrt_line}"
+        )
+
+
 class TestTileReadWriteOffsetCodegen:
     """Tests verifying tile.read/write multi-dimensional indices generate correct flat offsets."""
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -388,6 +388,21 @@ def test_tensor_rsqrt_wrong_type():
         ir.op.tensor.rsqrt(tile_var)
 
 
+def test_tensor_rsqrt_high_precision_kwarg():
+    """tensor.rsqrt carries the high_precision kwarg when requested."""
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim128], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.rsqrt(tensor_var, high_precision=True)
+
+    assert call.op.name == "tensor.rsqrt"
+    kwargs = dict(call.kwargs)
+    assert kwargs.get("high_precision") is True
+
+
 def test_tensor_cast():
     """Test tensor.cast operation."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -289,6 +289,17 @@ class TestTileUnaryOps:
         ir_str = str(Program)
         assert "tile.sqrt" in ir_str
 
+    def test_tile_rsqrt_rejects_tmp_shape_mismatch(self):
+        """tile.rsqrt rejects a tmp tile whose per-dim shape differs from the input."""
+        span = ir.Span.unknown()
+        input_type = ir.TileType([16, 64], DataType.FP32)
+        tmp_type = ir.TileType([32, 64], DataType.FP32)  # rank matches, dim 0 differs
+        input_var = ir.Var("src", input_type, span)
+        tmp_var = ir.Var("tmp", tmp_type, span)
+
+        with pytest.raises(ValueError, match="shape mismatch"):
+            tile.rsqrt(input_var, tmp_var)
+
     def test_tile_rsqrt_high_precision(self):
         """tile.rsqrt accepts an optional tmp tile for the high-precision path."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -289,6 +289,28 @@ class TestTileUnaryOps:
         ir_str = str(Program)
         assert "tile.sqrt" in ir_str
 
+    def test_tile_rsqrt_high_precision(self):
+        """tile.rsqrt accepts an optional tmp tile for the high-precision path."""
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                output: pl.Tensor[[128, 128], pl.FP32],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                tmp: pl.Tile[[32, 32], pl.FP32] = pl.tile.create(
+                    [32, 32], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.tile.rsqrt(tile_a, tmp=tmp)
+                result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                return result
+
+        ir_str = str(Program)
+        assert "tile.rsqrt" in ir_str
+
     def test_tile_neg(self):
         """Test tile.neg operator - negate all elements."""
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -342,6 +342,46 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_rsqrt_high_precision_conversion(self):
+        """tensor.rsqrt(high_precision=True) allocates a tmp tile and lowers to 2-arg tile.rsqrt."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.rsqrt(x, high_precision=True)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                rsqrt_tmp: pl.Tile[[64], pl.FP32] = pl.tile.create(
+                    [64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                y_tile: pl.Tile[[64], pl.FP32] = pl.tile.rsqrt(x_tile, rsqrt_tmp)
+                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_sqrt_conversion(self):
         """tensor.sqrt -> tile.sqrt."""
 


### PR DESCRIPTION
## Summary

Exposes the 2-operand form of `pto.trsqrt` (which uses a scratch tile for higher numerical precision) at both the tile and tensor DSL layers. Previously only the 1-operand basic form was reachable from Python.

- **Tile level** — user manages the scratch buffer explicitly:

  ```python
  # basic (unchanged)
  dst = pl.tile.rsqrt(src)

  # high precision — caller pre-allocates tmp with same shape/dtype
  tmp = pl.tile.create([...], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
  dst = pl.tile.rsqrt(src, tmp=tmp)
  ```

- **Tensor level** — compiler allocates the tmp tile during tensor→tile lowering:

  ```python
  out = pl.rsqrt(x)                       # basic
  out = pl.rsqrt(x, high_precision=True)  # high precision
  ```

The conversion mirrors the existing `row_max`/`row_sum` pattern: an extra `tile.create` statement is inserted before `tile.rsqrt(src, tmp_tile)`. Codegen uses a small custom handler so `pto.trsqrt` emits `ins(%src)` or `ins(%src, %tmp)` based on the call arity.

Dynamic shapes share the same static-shape constraint as other tmp-allocating conversions (`row_max`, `row_sum`), documented in the operation reference.

## Changes

- **IR op**: `tile.rsqrt` now accepts 1 or 2 args with dtype/rank validation on the tmp tile; `tensor.rsqrt` declares a `high_precision: bool` kwarg.
- **Conversion**: `tensor.rsqrt` becomes a custom converter that inserts a `tile.create` prologue when `high_precision=True`.
- **Codegen**: `tile.rsqrt` moves out of the simple op table into a custom handler emitting `pto.trsqrt` with the matching arity.
- **Python**: IR + DSL wrappers (`ir.op.tile.rsqrt`, `language.op.tile.rsqrt`, `language.op.tensor.rsqrt`, unified `pl.rsqrt`) forward the new parameter.
- **Torch debug codegen**: ignore the optional tmp operand when emitting `torch.rsqrt`.
- **Docs**: updated `docs/en/user/02-operation_reference.md` and the `zh-cn` mirror.

## Test plan

- [x] `tests/ut/ir/operators/test_tensor_ops.py::test_tensor_rsqrt_high_precision_kwarg`
- [x] `tests/ut/ir/operators/test_tile_ops.py::test_tile_rsqrt_high_precision`
- [x] `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py::TestConvertTensorToTileOps::test_rsqrt_high_precision_conversion`
- [x] `tests/ut/codegen/test_pto_codegen_ops.py::TestRsqrtHighPrecisionCodegen` (tile and tensor end-to-end)
- [x] Full unit suite: `pytest tests/ut/ -n auto --maxprocesses 8` — 3662 passed, 16 skipped
- [x] Clang-tidy on changed C++ files — clean

## Related issues

Fixes #1000