### PR TITLE
feat(codegen): support tensor.reshape in Orchestration

### DIFF
--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -252,6 +252,46 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   return oss.str();
 }
 
+REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
+  // tensor.reshape(input, shape_tuple[, valid_shape_tuple]) -> Generate shape array variable and call
+  // .reshape() on the runtime Tensor (see runtime/.../tensor.h: Tensor::reshape).
+  CHECK(op->args_.size() == 2 || op->args_.size() == 3)
+      << "tensor.reshape requires 2 or 3 arguments (input, shape[, valid_shape])";
+
+  std::string input_name = codegen.TryGetVarName(op->args_[0]);
+  CHECK(!input_name.empty()) << "tensor.reshape input must be a variable";
+
+  std::string ext_input_name = codegen.GetExternalTensorName(input_name);
+  std::string result_var = codegen.GetCurrentResultTarget();
+
+  // Extract shape elements from MakeTuple
+  auto shape_tuple = As<MakeTuple>(op->args_[1]);
+  CHECK(shape_tuple) << "tensor.reshape shape must be MakeTuple";
+  size_t ndim = shape_tuple->elements_.size();
+
+  std::ostringstream oss;
+
+  // Generate shape array
+  oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
+  for (size_t i = 0; i < ndim; ++i) {
+    if (i > 0) oss << ", ";
+    oss << EmitAsUint32(shape_tuple->elements_[i], codegen);
+  }
+  oss << "};\n";
+
+  if (op->args_.size() == 3) {
+    auto valid_shape_tuple = As<MakeTuple>(op->args_[2]);
+    CHECK(valid_shape_tuple) << "tensor.reshape valid_shape must be MakeTuple";
+    CHECK(valid_shape_tuple->elements_.size() == ndim)
+        << "tensor.reshape valid_shape must have same rank as shape";
+  }
+
+  // Runtime Tensor::reshape requires the source to be contiguous; valid_shape only affects IR metadata.
+  oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+      << ndim << ");";
+  return oss.str();
+}
+
 REGISTER_ORCHESTRATION_OP(tensor_dim, ("tensor.dim")) {
   // tensor.dim(tensor, axis) -> extract shape dimension as scalar
   // Validation already performed by DeduceTensorDimType during type deduction.

--- a/tests/st/runtime/test_dyn_orch_shape.py
+++ b/tests/st/runtime/test_dyn_orch_shape.py
@@ -142,6 +142,78 @@ class DynOrchAddTestCase(PTOTestCase):
         tensors["c"][:] = tensors["a"] + tensors["b"]
 
 
+class DynOrchReshapeAddTestCase(PTOTestCase):
+    """Test add kernel where the orchestration uses ``pl.reshape`` on dynamic 1D inputs.
+
+    Validates that ``tensor.reshape`` is supported in Orchestration functions and lowers
+    to the runtime ``Tensor::reshape`` interface (issue #1068).  The orchestration takes
+    flat 1D tensors of length ``rows*cols`` and reshapes them to ``[rows, cols]`` before
+    forwarding them to a 2D InCore add kernel.
+    Expected result: c = a + b over the full rows×cols tile.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        shape: tuple[int, int],
+        *,
+        backend_type: BackendType | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, backend_type=backend_type)
+        self._rows, self._cols = shape
+
+    def get_name(self) -> str:
+        return f"dyn_orch_reshape_add_{self._rows}x{self._cols}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        flat = self._rows * self._cols
+        return [
+            TensorSpec("a_flat", [flat], DataType.FP32, init_value=2.0),
+            TensorSpec("b_flat", [flat], DataType.FP32, init_value=3.0),
+            TensorSpec("c", [self._rows, self._cols], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        rows = self._rows
+        cols = self._cols
+
+        @pl.program
+        class DynOrchReshapeAddProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def add_kernel(
+                self,
+                a: pl.Tensor[[M, N], pl.FP32],
+                b: pl.Tensor[[M, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                """Add two dynamic-shape 2D tiles element-wise."""
+                a_tile = pl.load(a, [0, 0], [rows, cols], target_memory=pl.MemorySpace.Vec)
+                b_tile = pl.load(b, [0, 0], [rows, cols])
+                result = pl.add(a_tile, b_tile)
+                out = pl.store(result, [0, 0], c)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a_flat: pl.Tensor[[M], pl.FP32],
+                b_flat: pl.Tensor[[M], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                a2d: pl.Tensor[[rows, cols], pl.FP32] = pl.reshape(a_flat, [rows, cols])
+                b2d: pl.Tensor[[rows, cols], pl.FP32] = pl.reshape(b_flat, [rows, cols])
+                c_out = self.add_kernel(a2d, b2d, c)
+                return c_out
+
+        return DynOrchReshapeAddProgram
+
+    def compute_expected(self, tensors, params=None):
+        rows, cols = self._rows, self._cols
+        tensors["c"][:] = (tensors["a_flat"] + tensors["b_flat"]).reshape(rows, cols)
+
+
 class DynOrchValidShapeAddTestCase(PTOTestCase):
     """Test add with dynamic M×N orchestration and valid_shapes from a scalar tensor.
 
@@ -603,6 +675,16 @@ class TestDynOrchShapeOperations:
     def test_dyn_orch_add(self, test_runner, shape, backend):
         """Test add where both InCore and orchestration use dynamic M×N dims."""
         result = test_runner.run(DynOrchAddTestCase(shape, backend_type=backend))
+        assert result.passed, f"Test failed for shape {shape}: {result.error}"
+
+    @pytest.mark.parametrize("backend", PLATFORMS)
+    @pytest.mark.parametrize("shape", _DYN_SHAPES)
+    def test_dyn_orch_reshape_add(self, test_runner, shape, backend):
+        """Test add where the orchestration reshapes dynamic 1D inputs to 2D before dispatch.
+
+        Validates ``pl.reshape`` (issue #1068) inside an Orchestration function.
+        """
+        result = test_runner.run(DynOrchReshapeAddTestCase(shape, backend_type=backend))
         assert result.passed, f"Test failed for shape {shape}: {result.error}"
 
     @pytest.mark.parametrize("backend", PLATFORMS)

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -881,6 +881,53 @@ class TestOrchestration:
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
+    def test_tensor_reshape_external_input(self):
+        """tensor.reshape on an external orchestration input emits Tensor::reshape on ext_<name>."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ReshapeExternalProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_reshape(
+                self,
+                data: pl.Tensor[[256], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                r: pl.Tensor[[16, 16], pl.FP32] = pl.reshape(data, [16, 16])
+                return r
+
+        code = _generate_orch_code(ReshapeExternalProgram)
+
+        # Shape array emitted with the result variable name as prefix.
+        assert "uint32_t r_shapes[2] = {16, 16};" in code
+        # Reshape lowers to runtime Tensor::reshape on the external tensor handle.
+        assert "Tensor r = ext_data.reshape(r_shapes, 2);" in code
+
+    def test_tensor_reshape_after_slice(self):
+        """slice -> reshape chain: reshape input is a local Tensor (no ext_ prefix)."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ReshapeAfterSliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_slice_reshape(
+                self,
+                data: pl.Tensor[[4, 16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                chunk: pl.Tensor[[1, 16, 16], pl.FP32] = pl.slice(data, [1, 16, 16], [0, 0, 0])
+                r: pl.Tensor[[16, 16], pl.FP32] = pl.reshape(chunk, [16, 16])
+                return r
+
+        code = _generate_orch_code(ReshapeAfterSliceProgram)
+
+        # slice still emits view on the external tensor.
+        assert "uint32_t chunk_shapes[3] = {1, 16, 16};" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).
+        assert "uint32_t r_shapes[2] = {16, 16};" in code
+        assert "Tensor r = chunk.reshape(r_shapes, 2);" in code
+
     def test_if_statement(self):
         """Test if/else codegen with conditional scalar values."""
         backend.reset_for_testing()


### PR DESCRIPTION
## Summary

- Register a `tensor.reshape` orchestration codegen handler that emits a runtime `Tensor::reshape(uint32_t shapes[], uint32_t ndims)` call, mirroring the existing `tensor.slice -> Tensor::view` lowering.
- Previously `pl.reshape` inside a `pl.function(type=Orchestration)` failed with `Misplaced tensor op `tensor.reshape` in Orchestration function (should be inside InCore block)` because the op had no registered orchestration emitter. The runtime side already exposes a `Tensor::reshape` view-style API at `runtime/.../tensor.h:358`, so the codegen simply forwards to it and lets the runtime contiguity assertion gate misuse.
- Shape array uses the result-variable name as a prefix to avoid collisions, identical to the slice handler. The optional 3rd `valid_shape` arg is asserted shape-consistent but not consumed at runtime (consistent with `tensor.slice`).
- Adds UT codegen coverage for both the `external -> reshape` path and the `slice -> reshape` chain from the issue example, plus an ST runtime case that reshapes dynamic 1D inputs to 2D before dispatching to an InCore add kernel.

## Out of Scope

The secondary issue body about `ConvertTensorToTileOps` not propagating `Mat` consumer space through `tensor.reshape` for the `slice -> reshape -> matmul` lhs path is intentionally not addressed here; tracked separately.

## Testing

- [x] `cmake --build build --parallel` succeeds
- [x] `pytest tests/ut/codegen/test_orchestration_codegen.py` -> 43 passed (2 new + 41 existing, including `TestUnregisteredOpError.test_unregistered_tensor_op_raises_error`)
- [x] `pytest tests/ut/codegen/` -> 180 passed, 3 skipped
- [x] `pytest tests/ut/ -k reshape` -> 31 passed
- [x] `pre-commit run --files <modified files>` -> all hooks pass (clang-format, cpplint, ruff, pyright, etc.)
- [ ] ST runtime test (`tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_reshape_add`) — requires Ascend hardware, to be validated by reviewer/CI

## Related Issues

Fixes #1068

Made with [Cursor](https://cursor.com)