### PR TITLE
fix(ir): Propagate Mat requirement backward through tensor.reshape

### DIFF
--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -79,6 +79,10 @@ struct InputSpaceReq {
 struct ConversionEntry {
   ConversionFunc func;
   std::unordered_map<size_t, InputSpaceReq> input_reqs;  ///< Per-input space requirements (key = arg index)
+  /// If set, consumer memory-space requirements on the op's result propagate
+  /// backward to this positional arg (e.g. tensor.reshape preserves the
+  /// input's memory space, so a Mat requirement on its output flows to arg 0).
+  std::optional<size_t> pass_through_arg;
 };
 
 /**
@@ -109,9 +113,12 @@ class OpConversionRegistry {
    * @param from_op Source op name (e.g., "tensor.add")
    * @param to_op Target op name (e.g., "tile.add")
    * @param input_reqs Per-input memory space requirements (default: none)
+   * @param pass_through_arg If set, downstream memory-space requirements on the
+   *        result flow backward to this positional arg (default: none)
    */
   void RegisterSimple(const std::string& from_op, const std::string& to_op,
-                      std::unordered_map<size_t, InputSpaceReq> input_reqs = {});
+                      std::unordered_map<size_t, InputSpaceReq> input_reqs = {},
+                      std::optional<size_t> pass_through_arg = std::nullopt);
 
   /**
    * @brief Register a custom conversion function
@@ -121,9 +128,12 @@ class OpConversionRegistry {
    * @param from_op Source op name (e.g., "tensor.matmul")
    * @param func Custom conversion function
    * @param input_reqs Per-input memory space requirements (default: none)
+   * @param pass_through_arg If set, downstream memory-space requirements on the
+   *        result flow backward to this positional arg (default: none)
    */
   void RegisterCustom(const std::string& from_op, ConversionFunc func,
-                      std::unordered_map<size_t, InputSpaceReq> input_reqs = {});
+                      std::unordered_map<size_t, InputSpaceReq> input_reqs = {},
+                      std::optional<size_t> pass_through_arg = std::nullopt);
 
   /**
    * @brief Look up a conversion entry for an op

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -226,6 +226,22 @@ class ConsumerSpaceCollector : public IRVisitor {
     return it != consumer_reqs_.end() ? std::optional{it->second} : std::nullopt;
   }
 
+  /// Propagate non-Vec consumer requirements backward through pass-through ops
+  /// (e.g., tensor.reshape).  Walks recorded edges in reverse program order so
+  /// that a chain of pass-through ops between a producer (e.g. tensor.slice)
+  /// and a consumer (e.g. tensor.matmul) correctly forwards the required
+  /// memory space to the producer.  Call after VisitStmt() on the function.
+  void PropagatePassThrough() {
+    for (auto it = pass_through_edges_.rbegin(); it != pass_through_edges_.rend(); ++it) {
+      auto out_req = GetConsumerReq(it->output_var);
+      if (!out_req || out_req->space == MemorySpace::Vec) continue;
+      auto [entry_it, inserted] = consumer_reqs_.try_emplace(it->input_var.get(), *out_req);
+      if (!inserted && entry_it->second.space == MemorySpace::Vec) {
+        entry_it->second = *out_req;
+      }
+    }
+  }
+
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
     if (!op) return;
@@ -236,7 +252,7 @@ class ConsumerSpaceCollector : public IRVisitor {
     }
 
     const auto* entry = registry_.Lookup(call->op_->name_);
-    if (!entry || entry->input_reqs.empty()) {
+    if (!entry) {
       IRVisitor::VisitStmt_(op);
       return;
     }
@@ -254,12 +270,32 @@ class ConsumerSpaceCollector : public IRVisitor {
         }
       }
     }
+
+    // Record a pass-through edge so non-Vec requirements on this op's result
+    // can later be propagated backward to the designated input arg.
+    if (entry->pass_through_arg && op->var_) {
+      size_t idx = *entry->pass_through_arg;
+      if (idx < call->args_.size()) {
+        if (auto in_var = As<Var>(call->args_[idx])) {
+          pass_through_edges_.push_back({op->var_.get(), in_var});
+        }
+      }
+    }
+
     IRVisitor::VisitStmt_(op);
   }
 
  private:
+  struct PassThroughEdge {
+    /// Transient key for consumer_reqs_ lookup; never dereferenced.
+    const Var* output_var;
+    /// Held as shared_ptr so the Var stays alive until PropagatePassThrough runs.
+    VarPtr input_var;
+  };
+
   const OpConversionRegistry& registry_;
   std::unordered_map<const Var*, ConsumerSpaceReq> consumer_reqs_;
+  std::vector<PassThroughEdge> pass_through_edges_;
 };
 
 // ============================================================================
@@ -1185,8 +1221,11 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
 
   // Pre-scan: collect consumer memory space requirements (e.g. tensor.slice → tensor.matmul
   // needs Mat-space loads).  Driven by InputSpaceReq metadata in OpConversionRegistry.
+  // Then propagate non-Vec requirements backward through pass-through ops (e.g. reshape)
+  // so that patterns like slice → reshape → matmul still load directly into Mat.
   ConsumerSpaceCollector consumer_collector(conv_registry);
   consumer_collector.VisitStmt(func->body_);
+  consumer_collector.PropagatePassThrough();
 
   // Create the body mutator
   TensorToTileMutator mutator(conv_registry, op_registry, consumer_collector);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -231,13 +231,21 @@ class ConsumerSpaceCollector : public IRVisitor {
   /// that a chain of pass-through ops between a producer (e.g. tensor.slice)
   /// and a consumer (e.g. tensor.matmul) correctly forwards the required
   /// memory space to the producer.  Call after VisitStmt() on the function.
+  ///
+  /// Only the memory space is propagated; the transpose flag is forced to
+  /// false.  Pass-through ops such as reshape may change rank/shape, so a
+  /// downstream transpose requirement is not generally valid for the upstream
+  /// producer — e.g. propagating transpose=true onto an ND tensor.slice would
+  /// later emit an invalid tile.load (transpose is only supported for 2D loads
+  /// to Mat).  The downstream consumer's auto-bridge still handles transposes.
   void PropagatePassThrough() {
     for (auto it = pass_through_edges_.rbegin(); it != pass_through_edges_.rend(); ++it) {
       auto out_req = GetConsumerReq(it->output_var);
       if (!out_req || out_req->space == MemorySpace::Vec) continue;
-      auto [entry_it, inserted] = consumer_reqs_.try_emplace(it->input_var.get(), *out_req);
+      ConsumerSpaceReq in_req{out_req->space, /*transpose=*/false};
+      auto [entry_it, inserted] = consumer_reqs_.try_emplace(it->input_var, in_req);
       if (!inserted && entry_it->second.space == MemorySpace::Vec) {
-        entry_it->second = *out_req;
+        entry_it->second = in_req;
       }
     }
   }
@@ -277,7 +285,7 @@ class ConsumerSpaceCollector : public IRVisitor {
       size_t idx = *entry->pass_through_arg;
       if (idx < call->args_.size()) {
         if (auto in_var = As<Var>(call->args_[idx])) {
-          pass_through_edges_.push_back({op->var_.get(), in_var});
+          pass_through_edges_.push_back({op->var_.get(), in_var.get()});
         }
       }
     }
@@ -289,8 +297,10 @@ class ConsumerSpaceCollector : public IRVisitor {
   struct PassThroughEdge {
     /// Transient key for consumer_reqs_ lookup; never dereferenced.
     const Var* output_var;
-    /// Held as shared_ptr so the Var stays alive until PropagatePassThrough runs.
-    VarPtr input_var;
+    /// Transient key for consumer_reqs_ lookup; never dereferenced.
+    /// Safe as a raw pointer — the function body keeps all Var nodes alive
+    /// for the lifetime of the collector (no mutation until the mutator runs).
+    const Var* input_var;
   };
 
   const OpConversionRegistry& registry_;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -121,7 +122,7 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
   RegisterSimple("tensor.col_expand_div", "tile.col_expand_div");
   RegisterSimple("tensor.expands", "tile.expands");
 
-  RegisterSimple("tensor.reshape", "tile.reshape");
+  RegisterSimple("tensor.reshape", "tile.reshape", /*input_reqs=*/{}, /*pass_through_arg=*/0);
   RegisterSimple("tensor.transpose", "tile.transpose");
   RegisterSimple("tensor.concat", "tile.concat");
   RegisterSimple("tensor.set_validshape", "tile.set_validshape");
@@ -524,7 +525,8 @@ void OpConversionRegistry::RegisterReductionOps() {
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,
-                                          std::unordered_map<size_t, InputSpaceReq> input_reqs) {
+                                          std::unordered_map<size_t, InputSpaceReq> input_reqs,
+                                          std::optional<size_t> pass_through_arg) {
   // Capture to_op by value for the lambda
   ConversionFunc func = [to_op](const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -538,12 +540,13 @@ void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std:
     }
     return ConversionResult{call};
   };
-  conversions_[from_op] = ConversionEntry{std::move(func), std::move(input_reqs)};
+  conversions_[from_op] = ConversionEntry{std::move(func), std::move(input_reqs), pass_through_arg};
 }
 
 void OpConversionRegistry::RegisterCustom(const std::string& from_op, ConversionFunc func,
-                                          std::unordered_map<size_t, InputSpaceReq> input_reqs) {
-  conversions_[from_op] = ConversionEntry{std::move(func), std::move(input_reqs)};
+                                          std::unordered_map<size_t, InputSpaceReq> input_reqs,
+                                          std::optional<size_t> pass_through_arg) {
+  conversions_[from_op] = ConversionEntry{std::move(func), std::move(input_reqs), pass_through_arg};
 }
 
 const ConversionEntry* OpConversionRegistry::Lookup(const std::string& op_name) const {

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2214,6 +2214,76 @@ class TestSliceMatmulConversion:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_slice_reshape_then_matmul(self):
+        """slice -> reshape -> matmul: the Mat requirement on matmul's lhs
+        must propagate backward through reshape to the slice, so the slice
+        emits tile.load(Mat) directly (no redundant Vec->Mat move)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                combine_buf: pl.Tensor[[4, 16, 128], pl.BF16],
+                wo: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                row_3d: pl.Tensor[[1, 16, 128], pl.BF16] = pl.slice(combine_buf, [1, 16, 128], [0, 0, 0])
+                a_chunk: pl.Tensor[[16, 128], pl.BF16] = pl.reshape(row_3d, [16, 128])
+                result: pl.Tensor[[16, 64], pl.BF16] = pl.matmul(a_chunk, wo)
+                return result
+
+            @pl.function
+            def main(
+                self,
+                combine_buf: pl.Tensor[[4, 16, 128], pl.BF16],
+                wo: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(combine_buf, wo)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                combine_buf: pl.Tensor[[4, 16, 128], pl.BF16],
+                wo: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.BF16]],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                row_3d_tile: pl.Tile[[1, 16, 128], pl.BF16] = pl.load(
+                    combine_buf,
+                    [0, 0, 0],
+                    [1, 16, 128],
+                    [1, 16, 128],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=False,
+                )
+                a_chunk_tile: pl.Tile[[16, 128], pl.BF16] = pl.tile.reshape(row_3d_tile, [16, 128])
+                rhs_mat: pl.Tile[[128, 64], pl.BF16] = pl.load(
+                    wo,
+                    [0, 0],
+                    [128, 64],
+                    [128, 64],
+                    target_memory=pl.MemorySpace.Mat,
+                    transpose=False,
+                )
+                result_tile: pl.Tile[[16, 64], pl.FP32] = pl.matmul(a_chunk_tile, rhs_mat)
+                out_0_store: pl.Tensor[[16, 64], pl.BF16] = pl.store(result_tile, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function
+            def main(
+                self,
+                combine_buf: pl.Tensor[[4, 16, 128], pl.BF16],
+                wo: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.BF16]:
+                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.create_tensor([16, 64], dtype=pl.BF16)
+                result: pl.Tensor[[16, 64], pl.BF16] = self.main_incore_0(combine_buf, wo, out_0)
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestScatterUpdateConversion:
     """Tests for tensor.scatter_update → tile.scatter_update conversion."""


### PR DESCRIPTION
## Summary

- `ConvertTensorToTileOps` only recorded **direct** consumer memory-space requirements, so the pattern `tensor.slice → tensor.reshape → tensor.matmul` lowered the slice into `tile.load(target_memory=Vec)`. Matmul's auto-bridge then inserted a redundant `Vec → Mat` move, which some backends (e.g. `a2a3`) reject outright.
- Added a `pass_through_arg` field to `ConversionEntry` and marked `tensor.reshape` as pass-through on arg 0. `ConsumerSpaceCollector` now records pass-through edges during its forward scan and walks them in reverse program order afterward, so non-`Vec` requirements flow from consumers back to producers.
- The slice now emits `tile.load(target_memory=Mat)` directly, and the reshape inherits `Mat` via `tile.reshape`'s existing `set_output_memory_inherit_input` semantics — no extra move.

## Root cause

See issue #1068. `ConsumerSpaceCollector` in `src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp` only scanned direct op consumers. `tensor.reshape` was registered in the conversion registry with no `input_reqs`, so the `Mat` requirement declared by `tensor.matmul` on its lhs never reached the `tensor.slice` producing the reshape's input.

## Test plan

- [x] New unit test `TestSliceMatmulConversion::test_slice_reshape_then_matmul` verifies the canonical `slice → reshape → matmul` pattern lowers to a single `tile.load(Mat)` followed by `tile.reshape` inheriting `Mat`, with no intermediate move.
- [x] `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py` — 53/53 pass
- [x] `tests/ut/ir/transforms/` full suite — 1039 pass, 12 skipped (unrelated)
- [x] `clang-tidy` clean on changed C++ files
- [x] All pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

## Related Issues

Fixes #1068