### PR TITLE
feat(ir): add scalar parameter support to CompiledProgram callable API

### DIFF
--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -69,8 +69,10 @@ del _name, _torch_dtype
 # Used to wrap Python int/float/bool values into the correct ctypes scalar
 # when calling a compiled program with scalar parameters.
 _DATATYPE_TO_CTYPE: dict[str, type[ctypes._SimpleCData]] = {
+    "fp16": ctypes.c_float,  # no native half; promote to float
     "fp32": ctypes.c_float,
     "fp64": ctypes.c_double,
+    "bfloat16": ctypes.c_float,  # no native bfloat16; promote to float
     "int8": ctypes.c_int8,
     "int16": ctypes.c_int16,
     "int32": ctypes.c_int32,
@@ -337,6 +339,12 @@ class CompiledProgram:
                 if isinstance(arg, torch.Tensor):
                     raise TypeError(f"Parameter {info.name!r} is a scalar ({info.dtype}); got torch.Tensor")
                 if isinstance(arg, ctypes._SimpleCData):
+                    expected_ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
+                    if expected_ctype is not None and not isinstance(arg, expected_ctype):
+                        raise TypeError(
+                            f"Parameter {info.name!r} expects {expected_ctype.__name__} "
+                            f"for dtype {info.dtype}; got {type(arg).__name__}"
+                        )
                     coerced.append(arg)
                 else:
                     ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -18,6 +18,7 @@ torch tensors::
     compiled(a, b, c, device=1)          # specify device at call time
 """
 
+import ctypes
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,6 +36,11 @@ from pypto.pypto_core.ir import (
     ScalarType,
     ShapedType,
 )
+
+# Type alias for arguments accepted by CompiledProgram.__call__().
+# Tensor params expect torch.Tensor; scalar params accept Python primitives
+# or ctypes scalars (which are coerced to the correct ctypes type internally).
+CallArg = torch.Tensor | int | float | bool | ctypes._SimpleCData
 
 # IR DataType -> torch.dtype mapping.
 # Keyed by string because nanobind DataType instances are not singletons,
@@ -58,6 +64,24 @@ for _name in ("uint16", "uint32", "uint64"):
     if _torch_dtype is not None:
         _DATATYPE_TO_TORCH[_name] = _torch_dtype
 del _name, _torch_dtype
+
+# IR DataType -> ctypes scalar constructor mapping.
+# Used to wrap Python int/float/bool values into the correct ctypes scalar
+# when calling a compiled program with scalar parameters.
+_DATATYPE_TO_CTYPE: dict[str, type[ctypes._SimpleCData]] = {
+    "fp32": ctypes.c_float,
+    "fp64": ctypes.c_double,
+    "int8": ctypes.c_int8,
+    "int16": ctypes.c_int16,
+    "int32": ctypes.c_int32,
+    "int64": ctypes.c_int64,
+    "uint8": ctypes.c_uint8,
+    "uint16": ctypes.c_uint16,
+    "uint32": ctypes.c_uint32,
+    "uint64": ctypes.c_uint64,
+    "bool": ctypes.c_bool,
+    "index": ctypes.c_int64,
+}
 
 
 def _to_torch_dtype(dtype: DataType) -> torch.dtype | None:
@@ -258,18 +282,23 @@ class CompiledProgram:
 
     def __call__(
         self,
-        *args: torch.Tensor,
+        *args: CallArg,
         config: Any = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...] | None:
-        """Execute the compiled program with torch tensors.
+        """Execute the compiled program with torch tensors and/or scalars.
 
         Args match the orchestration function's parameter order.  For
         **in-place** style, pass all tensors (including outputs) and the
         output tensors are modified on device.  For **return** style,
         pass only input tensors and the outputs are allocated and returned.
 
+        Scalar parameters (``pl.Scalar[...]``) accept Python ``int``,
+        ``float``, ``bool``, or ``ctypes`` scalar values.
+
         Args:
-            *args: Positional ``torch.Tensor`` arguments.
+            *args: Positional arguments — ``torch.Tensor`` for tensor
+                params, ``int | float | bool | ctypes._SimpleCData`` for
+                scalar params.
             config: Optional :class:`~pypto.runtime.runner.RunConfig` for
                 device index, profiling, etc.  Defaults to ``RunConfig()``.
 
@@ -278,7 +307,7 @@ class CompiledProgram:
             ``tuple`` for return-style calls.
 
         Raises:
-            TypeError: If argument count does not match.
+            TypeError: If argument count or types do not match.
         """
         param_infos, output_indices, return_types = self._get_metadata()
         n_params = len(param_infos)
@@ -288,9 +317,9 @@ class CompiledProgram:
 
         # Determine calling convention
         if len(args) == n_params:
-            all_tensors = list(args)
+            all_args: list[CallArg] = list(args)
         elif return_style:
-            all_tensors = self._build_full_args(args, param_infos, output_indices)
+            all_args = self._build_full_args(args, param_infos, output_indices)
         else:
             expected = f"{n_params} (in-place)"
             if has_return:
@@ -300,6 +329,26 @@ class CompiledProgram:
                 f"Parameters: {[p.name for p in param_infos]}"
             )
 
+        # Coerce args: wrap Python scalars into ctypes, validate tensor vs scalar
+        coerced: list[torch.Tensor | ctypes._SimpleCData] = []
+        for info, arg in zip(param_infos, all_args, strict=True):
+            if info.shape is None:
+                # Scalar parameter
+                if isinstance(arg, torch.Tensor):
+                    raise TypeError(f"Parameter {info.name!r} is a scalar ({info.dtype}); got torch.Tensor")
+                if isinstance(arg, ctypes._SimpleCData):
+                    coerced.append(arg)
+                else:
+                    ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
+                    if ctype is None:
+                        raise TypeError(f"Unsupported scalar dtype {info.dtype} for parameter {info.name!r}")
+                    coerced.append(ctype(arg))
+            else:
+                # Tensor parameter
+                if not isinstance(arg, torch.Tensor):
+                    raise TypeError(f"Parameter {info.name!r} is a tensor; got {type(arg).__name__}")
+                coerced.append(arg)
+
         from pypto.runtime.runner import RunConfig, execute_compiled  # noqa: PLC0415
 
         if config is None:
@@ -307,7 +356,7 @@ class CompiledProgram:
 
         execute_compiled(
             self._output_dir,
-            all_tensors,
+            coerced,
             platform=self._platform,
             device_id=config.device_id,
             pto_isa_commit=config.pto_isa_commit,
@@ -316,18 +365,21 @@ class CompiledProgram:
 
         if not return_style:
             return None
-        outputs = [all_tensors[i] for i in output_indices]
-        return outputs[0] if len(outputs) == 1 else tuple(outputs)
+        # Output indices always correspond to tensor params (scalars cannot be Out
+        # direction), so the elements are guaranteed to be torch.Tensor.
+        outputs = [coerced[i] for i in output_indices]
+        assert all(isinstance(o, torch.Tensor) for o in outputs)
+        return outputs[0] if len(outputs) == 1 else tuple(outputs)  # type: ignore[return-value]
 
     @staticmethod
     def _build_full_args(
-        input_args: tuple[torch.Tensor, ...],
+        input_args: tuple[CallArg, ...],
         param_infos: list[_ParamInfo],
         output_indices: list[int],
-    ) -> list[torch.Tensor]:
+    ) -> list[CallArg]:
         """Allocate output tensors and interleave with input args."""
         output_set = set(output_indices)
-        all_tensors: list[torch.Tensor] = []
+        all_tensors: list[CallArg] = []
         input_idx = 0
 
         for i, info in enumerate(param_infos):

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -29,6 +29,7 @@ import os
 import subprocess
 import sys
 import time
+from ctypes import _SimpleCData
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -579,25 +580,25 @@ def _add_headers_to_file(cpp_file: Path) -> None:
 
 def execute_compiled(
     work_dir: str | Path,
-    tensors: list[torch.Tensor],
+    args: list[torch.Tensor | _SimpleCData],
     *,
     platform: str,
     device_id: int,
     pto_isa_commit: str | None = None,
     runtime_profiling: bool = False,
 ) -> None:
-    """Execute a pre-compiled program with user-provided tensors.
+    """Execute a pre-compiled program with user-provided tensors and scalars.
 
     Reuses :func:`device_runner.compile_and_assemble` for binary compilation
     (with caching and parallel kernel compilation) and
     :func:`device_runner.execute_on_device` for device dispatch.  Output
-    tensors in *tensors* are modified in-place with device results.
+    tensors in *args* are modified in-place with device results.
 
     Args:
         work_dir: Root output directory from :func:`ir.compile`, containing
             ``kernels/``, ``orchestration/``, and ``kernel_config.py``.
-        tensors: Ordered list of torch tensors matching the orchestration
-            function's parameter order.
+        args: Ordered list of ``torch.Tensor`` or ``ctypes._SimpleCData``
+            arguments matching the orchestration function's parameter order.
         platform: Target execution platform.
         device_id: Hardware device index.
         pto_isa_commit: Optional git commit to pin pto-isa clone.
@@ -614,26 +615,32 @@ def execute_compiled(
         compile_and_assemble,
         execute_on_device,
         make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
+        scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
     chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit)
 
-    # Build orch args directly from user tensors.
-    # Tensors must be CPU and contiguous so that device execution writes
-    # results back into the caller's buffers (in-place semantics).
+    # Build orch args from user-provided tensors and scalars.
     orch_args = ChipStorageTaskArgs()
-    for i, tensor in enumerate(tensors):
-        if not tensor.is_contiguous():
-            raise ValueError(
-                f"Tensor at position {i} is not contiguous. "
-                f"Call .contiguous() before passing to execute_compiled()."
+    for i, arg in enumerate(args):
+        if isinstance(arg, torch.Tensor):
+            if not arg.is_contiguous():
+                raise ValueError(
+                    f"Tensor at position {i} is not contiguous. "
+                    f"Call .contiguous() before passing to execute_compiled()."
+                )
+            if arg.device.type != "cpu":
+                raise ValueError(
+                    f"Tensor at position {i} is on {arg.device}, expected CPU. "
+                    f"Call .cpu() before passing to execute_compiled()."
+                )
+            orch_args.add_tensor(make_tensor_arg(arg))
+        elif isinstance(arg, _SimpleCData):
+            orch_args.add_scalar(scalar_to_uint64(arg))
+        else:
+            raise TypeError(
+                f"Argument at position {i} must be torch.Tensor or ctypes scalar, got {type(arg).__name__}"
             )
-        if tensor.device.type != "cpu":
-            raise ValueError(
-                f"Tensor at position {i} is on {tensor.device}, expected CPU. "
-                f"Call .cpu() before passing to execute_compiled()."
-            )
-        orch_args.add_tensor(make_tensor_arg(tensor))
 
     # Snapshot profiling state before execution
     if runtime_profiling:

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -9,7 +9,9 @@
 
 """Tests for CompiledProgram callable API."""
 
+import ctypes
 import os
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -77,6 +79,26 @@ def _make_program_with_inout() -> ir.Program:
     body = ir.SeqStmts([], span)
     orch = ir.Function("orchestrator", params, [], body, span, ir.FunctionType.Orchestration)
     return ir.Program([orch], "InOutProgram", span)
+
+
+def _make_program_with_scalar() -> ir.Program:
+    """Build a Program with tensor and scalar params: a (In), n (Scalar INT64), c (Out)."""
+    span = ir.Span.unknown()
+    tensor_type = ir.TensorType([128, 128], DataType.FP32)
+    scalar_type = ir.ScalarType(DataType.INT64)
+
+    a_var = ir.Var("a", tensor_type, span)
+    n_var = ir.Var("n", scalar_type, span)
+    c_var = ir.Var("c", tensor_type, span)
+
+    params = [
+        (a_var, ir.ParamDirection.In),
+        (n_var, ir.ParamDirection.In),
+        (c_var, ir.ParamDirection.Out),
+    ]
+    body = ir.SeqStmts([], span)
+    orch = ir.Function("orchestrator", params, [tensor_type], body, span, ir.FunctionType.Orchestration)
+    return ir.Program([orch], "ScalarProgram", span)
 
 
 class TestCompiledProgramBackwardCompat:
@@ -244,9 +266,11 @@ class TestBuildFullArgs:
         assert full_args[0] is a
         assert full_args[1] is b
         # Output tensor should be allocated with correct shape/dtype
-        assert full_args[2].shape == (128, 128)
-        assert full_args[2].dtype == torch.float32
-        assert torch.all(full_args[2] == 0)
+        out = full_args[2]
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (128, 128)
+        assert out.dtype == torch.float32
+        assert torch.all(out == 0)
 
 
 class TestCompileReturnsCompiledProgram:
@@ -279,6 +303,96 @@ class TestCompileReturnsCompiledProgram:
         assert result.output_dir.is_dir()
         # Metadata works on the original program
         assert result.param_names == ["a", "b", "c"]
+
+
+class TestExtractParamInfosScalar:
+    """Verify metadata extraction for scalar parameters."""
+
+    def test_scalar_param_shape_is_none(self):
+        prog = _make_program_with_scalar()
+        infos, _, _ = _extract_param_infos(prog)
+        assert infos[1].name == "n"
+        assert infos[1].shape is None
+        assert infos[1].dtype == DataType.INT64
+
+    def test_scalar_param_not_in_output_indices(self):
+        prog = _make_program_with_scalar()
+        _, out_idx, _ = _extract_param_infos(prog)
+        # Only index 2 (c, Out tensor) should be auto-allocatable
+        assert out_idx == [2]
+
+
+class TestCompiledProgramScalarCall:
+    """Verify __call__ handles scalar parameters correctly."""
+
+    def test_scalar_param_wraps_python_int(self, tmp_path):
+        """Passing a Python int to a scalar param should wrap it as ctypes.c_int64."""
+        prog = _make_program_with_scalar()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+        c = torch.zeros(128, 128)
+
+        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            cp(a, 5, c)
+
+        coerced_args = mock_exec.call_args.args[1]  # second positional arg is the args list
+        assert isinstance(coerced_args[0], torch.Tensor)
+        assert isinstance(coerced_args[1], ctypes.c_int64)
+        assert coerced_args[1].value == 5
+        assert isinstance(coerced_args[2], torch.Tensor)
+
+    def test_scalar_param_passes_through_ctypes(self, tmp_path):
+        """Passing a ctypes scalar directly should pass through without re-wrapping."""
+        prog = _make_program_with_scalar()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+        c = torch.zeros(128, 128)
+        scalar = ctypes.c_int64(42)
+
+        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            cp(a, scalar, c)
+
+        coerced_args = mock_exec.call_args.args[1]
+        assert coerced_args[1] is scalar
+
+    def test_scalar_param_rejects_tensor(self, tmp_path):
+        """Passing a torch.Tensor for a scalar param should raise TypeError."""
+        prog = _make_program_with_scalar()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+        c = torch.zeros(128, 128)
+
+        with pytest.raises(TypeError, match="scalar"):
+            cp(a, torch.tensor([5]), c)
+
+    def test_tensor_param_rejects_scalar(self, tmp_path):
+        """Passing a Python int for a tensor param should raise TypeError."""
+        prog = _make_program_with_scalar()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        with pytest.raises(TypeError, match="tensor"):
+            cp(5, 10, torch.zeros(128, 128))
+
+    def test_return_style_with_scalar(self, tmp_path):
+        """Return-style call with scalar: compiled(a, n) should allocate output."""
+        prog = _make_program_with_scalar()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+
+        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            result = cp(a, 7)
+
+        # Should have called execute_compiled with 3 args (a, scalar, allocated c)
+        coerced_args = mock_exec.call_args.args[1]
+        assert len(coerced_args) == 3
+        assert isinstance(coerced_args[1], ctypes.c_int64)
+        assert coerced_args[1].value == 7
+        # Output should be returned
+        assert isinstance(result, torch.Tensor)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -357,6 +357,17 @@ class TestCompiledProgramScalarCall:
         coerced_args = mock_exec.call_args.args[1]
         assert coerced_args[1] is scalar
 
+    def test_scalar_param_rejects_wrong_ctypes(self, tmp_path):
+        """Passing a ctypes scalar with mismatched dtype should raise TypeError."""
+        prog = _make_program_with_scalar()  # n is INT64
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+        c = torch.zeros(128, 128)
+
+        with pytest.raises(TypeError, match="int64"):
+            cp(a, ctypes.c_int32(5), c)  # wrong: c_int32 for INT64 param
+
     def test_scalar_param_rejects_tensor(self, tmp_path):
         """Passing a torch.Tensor for a scalar param should raise TypeError."""
         prog = _make_program_with_scalar()


### PR DESCRIPTION
## Summary

`CompiledProgram.__call__()` previously crashed with `AttributeError` when a program had `pl.Scalar[...]` orchestration parameters, because `execute_compiled()` unconditionally called `.is_contiguous()` and `.device` on every arg.

This PR fixes the callable API to accept mixed tensor/scalar arguments:

- **`compiled_program.py`**: Added `_DATATYPE_TO_CTYPE` mapping and a coercion loop in `__call__` that wraps Python `int`/`float`/`bool` into the correct `ctypes` scalar based on IR `DataType`, validates tensor-vs-scalar type matches, and passes `ctypes` scalars through unchanged.
- **`runner.py`**: `execute_compiled()` now branches per-arg on `isinstance(arg, torch.Tensor)` vs `isinstance(arg, _SimpleCData)`, dispatching to `add_tensor()` or `add_scalar(scalar_to_uint64(...))` respectively.
- **`test_compiled_program.py`**: 7 new unit tests covering scalar wrapping, ctypes passthrough, type rejection (both directions), return-style with scalar, and metadata extraction for scalar params.

## Testing

- [x] All 3663+ unit tests pass (0 failures)
- [x] Code review completed (code-review skill)
- [x] Pre-commit hooks pass (ruff check, ruff format, pyright)

## Related Issues

Addresses the remaining CodeRabbit review comment on #1055 regarding `pl.Scalar` parameter support.