### PR TITLE
fix(ir): Compare symbolic shape dims via arithmetic simplifier

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -148,7 +148,9 @@ std::optional<int64_t> GetConstantDimension(const ExprPtr& dim);
  *
  * Handles both constant and symbolic dimensions.
  * For constant dimensions, compares values.
- * For symbolic dimensions, uses structural equality.
+ * For symbolic dimensions, applies expression simplification and proves
+ * equality via the arithmetic analyzer (e.g. (x + 64) - x and
+ * (x + 128) - (x + 64) are both recognised as 64).
  *
  * @param dim1 First dimension
  * @param dim2 Second dimension

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -118,6 +118,13 @@ def _normalize_type_for_syntax_match(type_: ir.Type | None) -> ir.Type | None:
     return type_
 
 
+def _shape_has_symbolic_dim(type_: ir.Type) -> bool:
+    """Return True when *type_* is a shaped type with at least one non-ConstInt dim."""
+    if not isinstance(type_, (ir.TensorType, ir.TileType)):
+        return False
+    return any(not isinstance(d, ir.ConstInt) for d in type_.shape)
+
+
 def _simplify_shape_dims(type_: ir.Type, analyzer: "_arith.Analyzer") -> ir.Type:
     """Rebuild a TensorType/TileType with each outer shape dim passed through
     the arithmetic simplifier.
@@ -129,10 +136,9 @@ def _simplify_shape_dims(type_: ir.Type, analyzer: "_arith.Analyzer") -> ir.Type
     (``valid_shape``, ``stride``, ``start_offset``) and TensorView
     fields retain their original expressions and still compare structurally.
     """
-    if not isinstance(type_, (ir.TensorType, ir.TileType)):
+    if not _shape_has_symbolic_dim(type_):
         return type_
-    if all(isinstance(d, ir.ConstInt) for d in type_.shape):
-        return type_
+    assert isinstance(type_, (ir.TensorType, ir.TileType))
     simplified_shape = [analyzer.simplify(d) if isinstance(d, ir.Expr) else d for d in type_.shape]
     if isinstance(type_, ir.TensorType):
         return ir.TensorType(simplified_shape, type_.dtype, type_.memref, type_.tensor_view)
@@ -149,7 +155,9 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     authoritative memref via ``override_type``.
 
     Outer shape dimensions are simplified via a shared arithmetic analyzer
-    before comparison so expressions like ``(k + C) - k`` match ``C``.
+    before comparison so expressions like ``(k + C) - k`` match ``C``.  The
+    analyzer is only constructed when at least one shape actually contains a
+    symbolic dim, keeping the all-static fast path free of arith overhead.
     """
     if lhs is rhs:
         return True
@@ -161,9 +169,10 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     assert rhs is not None
     if type(lhs) is not type(rhs):
         return False
-    analyzer = _arith.Analyzer()
-    lhs = _simplify_shape_dims(lhs, analyzer)
-    rhs = _simplify_shape_dims(rhs, analyzer)
+    if _shape_has_symbolic_dim(lhs) or _shape_has_symbolic_dim(rhs):
+        analyzer = _arith.Analyzer()
+        lhs = _simplify_shape_dims(lhs, analyzer)
+        rhs = _simplify_shape_dims(rhs, analyzer)
     return lhs == rhs
 
 
@@ -311,6 +320,11 @@ class ASTParser:
         # Each entry is (col_offset, text) so the parser can distinguish
         # tail-of-block comments (inside body indent) from outer-scope comments.
         self._pending_comments: dict[int, list[tuple[int, str]]] = pending_comments or {}
+
+        # Cached arithmetic analyzer used to simplify symbolic slice extents at
+        # construction time. One instance per parser amortises the sub-analyzer
+        # setup across the many subscripts found in a typical function body.
+        self._arith_analyzer: _arith.Analyzer | None = None
 
     @contextmanager
     def _yield_tracking_scope(self) -> Iterator[None]:
@@ -3878,6 +3892,12 @@ class ASTParser:
             return list(slc.elts)
         return [slc]
 
+    def _get_arith_analyzer(self) -> "_arith.Analyzer":
+        """Return a parser-scoped, lazily-constructed arithmetic analyzer."""
+        if self._arith_analyzer is None:
+            self._arith_analyzer = _arith.Analyzer()
+        return self._arith_analyzer
+
     def _build_slice_shape_expr(
         self,
         upper_expr: int | ir.Expr,
@@ -3904,7 +3924,7 @@ class ASTParser:
             if isinstance(lower_expr, ir.Expr)
             else ir.ConstInt(lower_expr, DataType.INDEX, ir.Span.unknown())
         )
-        simplified = _arith.Analyzer().simplify(ir.sub(lhs, rhs))
+        simplified = self._get_arith_analyzer().simplify(ir.sub(lhs, rhs))
         const_value = _const_int_value(simplified)
         if const_value is not None:
             return const_value

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -21,6 +21,7 @@ from pypto.ir import IRBuilder
 from pypto.ir import op as ir_op
 from pypto.ir.printer import python_print
 from pypto.pypto_core import DataType, ir
+from pypto.pypto_core import arith as _arith
 
 from .diagnostics import (
     InvalidOperationError,
@@ -117,6 +118,27 @@ def _normalize_type_for_syntax_match(type_: ir.Type | None) -> ir.Type | None:
     return type_
 
 
+def _simplify_shape_dims(type_: ir.Type, analyzer: "_arith.Analyzer") -> ir.Type:
+    """Rebuild a TensorType/TileType with each outer shape dim passed through
+    the arithmetic simplifier.
+
+    Needed so that symbolic dims that reduce to the same value — e.g.
+    ``(k + C) - k`` and ``C`` — compare equal under structural ``==``.
+
+    Scope: only the outer ``shape`` is simplified. TileView fields
+    (``valid_shape``, ``stride``, ``start_offset``) and TensorView
+    fields retain their original expressions and still compare structurally.
+    """
+    if not isinstance(type_, (ir.TensorType, ir.TileType)):
+        return type_
+    if all(isinstance(d, ir.ConstInt) for d in type_.shape):
+        return type_
+    simplified_shape = [analyzer.simplify(d) if isinstance(d, ir.Expr) else d for d in type_.shape]
+    if isinstance(type_, ir.TensorType):
+        return ir.TensorType(simplified_shape, type_.dtype, type_.memref, type_.tensor_view)
+    return ir.TileType(simplified_shape, type_.dtype, type_.memref, type_.tile_view, type_.memory_space)
+
+
 def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     """Return whether two IR types are structurally equal after TileView normalization.
 
@@ -125,6 +147,9 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     field on TileType/TensorType — memref identity is not relevant for
     parser-level type matching because the Var (not the Call) carries the
     authoritative memref via ``override_type``.
+
+    Outer shape dimensions are simplified via a shared arithmetic analyzer
+    before comparison so expressions like ``(k + C) - k`` match ``C``.
     """
     if lhs is rhs:
         return True
@@ -136,6 +161,9 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
     assert rhs is not None
     if type(lhs) is not type(rhs):
         return False
+    analyzer = _arith.Analyzer()
+    lhs = _simplify_shape_dims(lhs, analyzer)
+    rhs = _simplify_shape_dims(rhs, analyzer)
     return lhs == rhs
 
 
@@ -3855,7 +3883,14 @@ class ASTParser:
         upper_expr: int | ir.Expr,
         lower_expr: int | ir.Expr,
     ) -> int | ir.Expr:
-        """Build a slice extent, folding compile-time constants when possible."""
+        """Build a slice extent, folding compile-time constants when possible.
+
+        Symbolic extents are passed through the arithmetic simplifier so common
+        patterns like ``x * s + s - x * s`` or ``(k + C) - k`` collapse to the
+        scalar extent at construction time. This keeps downstream shape checks
+        and reassignment guards from seeing structurally-distinct-but-equal
+        expressions.
+        """
         folded_extent = _fold_const_slice_extent(upper_expr, lower_expr)
         if folded_extent is not None:
             return folded_extent
@@ -3869,7 +3904,11 @@ class ASTParser:
             if isinstance(lower_expr, ir.Expr)
             else ir.ConstInt(lower_expr, DataType.INDEX, ir.Span.unknown())
         )
-        return ir.sub(lhs, rhs)
+        simplified = _arith.Analyzer().simplify(ir.sub(lhs, rhs))
+        const_value = _const_int_value(simplified)
+        if const_value is not None:
+            return const_value
+        return simplified
 
     def _to_index_expr(self, expr: int | ir.Expr) -> ir.Expr:
         """Convert an integer-like slice bound into an INDEX expression."""

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -24,6 +24,7 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
@@ -223,8 +224,11 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2) {
     return *const1 == *const2;
   }
 
-  // For symbolic dimensions, use pointer equality
-  return false;
+  // For symbolic dimensions, prove equality via expression simplification.
+  // Handles cases like `(x + 64) - x` vs `(x + 128) - (x + 64)` which both
+  // reduce to 64 but are not structurally identical.
+  arith::Analyzer analyzer;
+  return analyzer.CanProveEqual(dim1, dim2);
 }
 
 bool IsBroadcastable(const ExprPtr& source_dim, const ExprPtr& target_dim) {

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -227,7 +227,11 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2) {
   // For symbolic dimensions, prove equality via expression simplification.
   // Handles cases like `(x + 64) - x` vs `(x + 128) - (x + 64)` which both
   // reduce to 64 but are not structurally identical.
-  arith::Analyzer analyzer;
+  //
+  // Uses a thread_local analyzer so repeated calls on the slow path (e.g.
+  // per-dim inside BroadcastShapes) reuse sub-analyzer state instead of
+  // paying full setup per call.
+  thread_local arith::Analyzer analyzer;
   return analyzer.CanProveEqual(dim1, dim2);
 }
 

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -20,14 +20,30 @@ from pypto.pypto_core import ir
 
 
 def _collect_call_args(func: ir.Function, op_name: str) -> list[list]:
-    """Collect argument lists of all Calls matching *op_name* in a function body."""
+    """Collect argument lists of all Calls matching *op_name* anywhere in the
+    function body, recursing into ``ForStmt``/``WhileStmt``/``IfStmt``/``SeqStmts``
+    bodies so loop-local calls are not missed.
+    """
     results: list[list] = []
-    body = func.body
-    assert isinstance(body, ir.SeqStmts)
-    for stmt in body.stmts:
-        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-            if stmt.value.op.name == op_name:
-                results.append(list(stmt.value.args))
+
+    def visit(node: object) -> None:
+        if isinstance(node, ir.AssignStmt) and isinstance(node.value, ir.Call):
+            if node.value.op.name == op_name:
+                results.append(list(node.value.args))
+            return
+        if isinstance(node, ir.SeqStmts):
+            for s in node.stmts:
+                visit(s)
+            return
+        body = getattr(node, "body", None)
+        if body is not None:
+            visit(body)
+        for attr in ("then_body", "else_body"):
+            branch = getattr(node, attr, None)
+            if branch is not None:
+                visit(branch)
+
+    visit(func.body)
     return results
 
 
@@ -322,13 +338,29 @@ class TestScopeShadowingSafety:
         )
 
 
+def _assert_all_slice_extents_are_constint(func: ir.Function, expected_dims: list[int]) -> None:
+    """Verify every ``tensor.slice`` call in *func* has shape_tuple = expected_dims."""
+    slice_calls = _collect_call_args(func, "tensor.slice")
+    assert slice_calls, "expected tensor.slice calls to be emitted"
+    for args in slice_calls:
+        extent = args[1]  # tensor.slice(tensor, shape_tuple, offset_tuple)
+        assert isinstance(extent, ir.MakeTuple)
+        actual = []
+        for dim in extent.elements:
+            assert isinstance(dim, ir.ConstInt), (
+                f"slice extent dim should be folded to ConstInt, got {type(dim).__name__}: {dim}"
+            )
+            actual.append(dim.value)
+        assert actual == expected_dims, f"expected slice shape {expected_dims}, got {actual}"
+
+
 class TestSymbolicShapeEquality:
     """Symbolic dimension expressions that simplify to the same value should
     compare equal. Covers the subscript-slice pattern where extent is built
     as ``upper - lower`` with a loop induction variable on both sides."""
 
     def test_slice_extent_simplifies_to_constant(self):
-        """``x[:, k : k + C]`` produces a literal-C extent, not ``k + C - k``."""
+        """``x[:, k : k + C]`` inside a loop produces a literal-C extent."""
         C = 64
 
         @pl.function
@@ -339,15 +371,7 @@ class TestSymbolicShapeEquality:
             return out
 
         assert isinstance(func, ir.Function)
-        slice_calls = _collect_call_args(func, "tensor.slice")
-        assert slice_calls, "expected tensor.slice calls to be emitted"
-        for args in slice_calls:
-            extent = args[1]  # [tensor, shape_tuple, offset_tuple] -> shape_tuple
-            assert isinstance(extent, ir.MakeTuple)
-            for dim in extent.elements:
-                assert isinstance(dim, ir.ConstInt), (
-                    f"slice extent dim should be folded to ConstInt, got {type(dim).__name__}: {dim}"
-                )
+        _assert_all_slice_extents_are_constint(func, [8, C])
 
     def test_loop_induction_slice_extent_folds(self):
         """``x[:, i * s : (i + 1) * s]`` folds to extent ``s``."""
@@ -361,6 +385,7 @@ class TestSymbolicShapeEquality:
             return out
 
         assert isinstance(func, ir.Function)
+        _assert_all_slice_extents_are_constint(func, [8, S])
 
     def test_reassign_across_loop_with_symbolic_extent(self):
         """Reassignment of a tensor variable inside a loop with a symbolic

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -322,5 +322,81 @@ class TestScopeShadowingSafety:
         )
 
 
+class TestSymbolicShapeEquality:
+    """Symbolic dimension expressions that simplify to the same value should
+    compare equal. Covers the subscript-slice pattern where extent is built
+    as ``upper - lower`` with a loop induction variable on both sides."""
+
+    def test_slice_extent_simplifies_to_constant(self):
+        """``x[:, k : k + C]`` produces a literal-C extent, not ``k + C - k``."""
+        C = 64
+
+        @pl.function
+        def func(a: pl.Tensor[[8, 256], pl.BF16]) -> pl.Tensor[[8, 64], pl.BF16]:
+            out = a[:, 0:C]
+            for k in pl.range(C, 256, C):
+                out = a[:, k : k + C]
+            return out
+
+        assert isinstance(func, ir.Function)
+        slice_calls = _collect_call_args(func, "tensor.slice")
+        assert slice_calls, "expected tensor.slice calls to be emitted"
+        for args in slice_calls:
+            extent = args[1]  # [tensor, shape_tuple, offset_tuple] -> shape_tuple
+            assert isinstance(extent, ir.MakeTuple)
+            for dim in extent.elements:
+                assert isinstance(dim, ir.ConstInt), (
+                    f"slice extent dim should be folded to ConstInt, got {type(dim).__name__}: {dim}"
+                )
+
+    def test_loop_induction_slice_extent_folds(self):
+        """``x[:, i * s : (i + 1) * s]`` folds to extent ``s``."""
+        S = 32
+
+        @pl.function
+        def func(a: pl.Tensor[[8, 256], pl.BF16]) -> pl.Tensor[[8, 32], pl.BF16]:
+            out = a[:, 0:S]
+            for i in pl.range(8):
+                out = a[:, i * S : (i + 1) * S]
+            return out
+
+        assert isinstance(func, ir.Function)
+
+    def test_reassign_across_loop_with_symbolic_extent(self):
+        """Reassignment of a tensor variable inside a loop with a symbolic
+        slice extent should succeed — the pre-fix parser rejected this with
+        'Cannot reassign with a different type' because the slice shape built
+        as ``k + C - k`` did not match the initial ``C`` shape."""
+        C = 64
+
+        @pl.function
+        def func(a: pl.Tensor[[8, 256], pl.BF16]) -> pl.Tensor[[8, 64], pl.BF16]:
+            chunk = a[:, 0:C]
+            for k in pl.range(C, 256, C):
+                chunk = a[:, k : k + C]
+            return chunk
+
+        assert isinstance(func, ir.Function)
+
+    def test_symbolic_cancellation_in_broadcast_sub(self):
+        """``pl.sub`` of two slices whose extents simplify to the same constant
+        but differ structurally should pass shape broadcasting.  Pre-fix this
+        raised 'requires compatible shapes'."""
+        HALF = 32
+
+        @pl.function
+        def func(
+            src: pl.Tensor[[1, 128], pl.FP32],
+            out: pl.Tensor[[1, 32], pl.FP32],
+        ) -> pl.Tensor[[1, 32], pl.FP32]:
+            for k in pl.range(0, 64, HALF):
+                lo = src[:, k : k + HALF]
+                hi = src[:, k + HALF : k + HALF + HALF]
+                out = pl.sub(lo, hi)
+            return out
+
+        assert isinstance(func, ir.Function)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Route symbolic shape dimensions through the arithmetic analyzer so semantically equal expressions (e.g. `(x + C) - x` vs `C`, `x * s + s - x * s` vs `s`) compare equal during shape checks and variable reassignment.
- Fixes spurious \"shape mismatch\" from `BroadcastShapes` and \"Cannot reassign with a different type\" from the parser on common subscript patterns like `a[:, k : k + CHUNK]` used inside a loop.

## Details

Three touch points, all gated so the fast pointer / ConstInt paths stay unchanged:

- **`DimensionsEqual` (src/ir/op/type_inference.cpp)** — falls back to `arith::Analyzer::CanProveEqual` when pointer-equality and literal-ConstInt comparison miss. Fixes the `tensor.sub` error reported as `requires compatible shapes, but got [1, kv_col + 64 - kv_col] and [1, kv_col + 128 - (kv_col + 64)]`.
- **`_types_match` (parser)** — runs outer shape dims through a shared `arith.Analyzer().simplify(...)` before the structural `==` check. Scoped to outer `shape`; TileView / TensorView sub-fields (`valid_shape`, `stride`, `start_offset`, ...) are unchanged.
- **`_build_slice_shape_expr` (parser)** — simplifies `upper - lower` at slice-op construction and demotes to an `int` when the result is a constant. Downstream checks see literal extents for the common `x[:, k : k + C]` and `x[:, i * s : (i + 1) * s]` forms.

Performance: `DimensionsEqual` allocates one `Analyzer` per symbolic call (only hit on the slow path); `_types_match` now constructs a single shared `Analyzer` and also short-circuits when every shape dim is already a `ConstInt`.

## Testing

- [x] `pytest tests/ut/language tests/ut/ir/operators tests/ut/ir/arith` — 1503 passed
- [x] Full suite via `testing` skill — 3721/3721 passed
- [x] Clang-tidy clean on changed C++
- [x] New regression coverage: `TestSymbolicShapeEquality` in `test_constant_folding.py` exercises slice-extent folding, loop-induction slice extents, reassignment with symbolic extents, and broadcast `sub` with symbolic cancellation.