### PR TITLE
chore(ci): Bump pto-isa-commit and merge A2A3 cross-core job into a5sim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,12 @@ jobs:
         run: pip install -v ./runtime
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=ed0b4643
+        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=6eecebc5
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device=$DEVICE_ID --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=ed0b4643
+            -v --device=$DEVICE_ID --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=6eecebc5
 
   system-tests-a5sim:
     runs-on: ubuntu-latest
@@ -185,7 +185,13 @@ jobs:
         run: pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=ed0b4643 -m a5
+        run: pytest tests/st -v --platform a5sim --forked --pto-isa-commit=6eecebc5 -m a5
+
+      - name: Test A5 cross-core system tests (simulator)
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=6eecebc5
+
+      - name: Test A2A3 cross-core system tests (simulator)
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=6eecebc5
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Update --pto-isa-commit from ed0b4643 to 6eecebc5 in system tests and
  swimlane output steps
- Remove redundant system-tests-a2a3sim-cross-core job; move its A2A3
  cross-core test step into the existing system-tests-a5sim job to reduce
  CI duplication and runtime

## Testing
- [x] All CI jobs pass on GitHub Actions
- [x] Cross-core tests pass on both A5 and A2A3 simulators
- [x] Pre-commit hooks pass (ruff, pyright, markdownlint)