### PR TITLE
fix(ir): Classify tile.create as SHARED and promote accumulator memory

### DIFF
--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -132,8 +132,12 @@ class TileMemorySpaceAnalyzer : public IRVisitor {
       // the kernel as mixed, producing broken AIC/AIV IR.
       if (i < op->iter_args_.size()) {
         var_memory_[op->iter_args_[i]] = *yield_memory;
+        // Any TileType init carrier needs to agree with the promoted iter_arg,
+        // whether or not the analyzer has already recorded it — e.g. an IfStmt
+        // return_var used as the loop init is never visited by the AssignStmt
+        // path, so it would otherwise keep its old memory space.
         if (auto init_var = As<Var>(op->iter_args_[i]->initValue_);
-            init_var && var_memory_.count(init_var) > 0) {
+            init_var && As<TileType>(init_var->GetType())) {
           var_memory_[init_var] = *yield_memory;
         }
       }
@@ -347,15 +351,24 @@ class TileMemorySpaceMutator : public IRMutator {
               break;
             }
           }
-          if (kwarg_target.has_value() && *kwarg_target != promoted) {
+          // tile.create defaults target_memory to Vec, so an explicit Vec call
+          // may omit the kwarg entirely. Rewrite when the kwarg is missing or
+          // differs from the promoted space: preserve other kwargs, overwrite
+          // target_memory if present, and inject it otherwise.
+          if (!kwarg_target.has_value() || *kwarg_target != promoted) {
             std::vector<std::pair<std::string, std::any>> new_kwargs;
-            new_kwargs.reserve(call->kwargs_.size());
+            new_kwargs.reserve(call->kwargs_.size() + 1);
+            bool saw_target_memory = false;
             for (const auto& [key, value] : call->kwargs_) {
               if (key == "target_memory") {
+                saw_target_memory = true;
                 new_kwargs.emplace_back(key, std::any(promoted));
               } else {
                 new_kwargs.emplace_back(key, value);
               }
+            }
+            if (!saw_target_memory) {
+              new_kwargs.emplace_back("target_memory", std::any(promoted));
             }
             auto promoted_view = tile_view_semantics::GetImplicitTileView(old_call_type->shape_, promoted);
             auto promoted_type = std::make_shared<TileType>(old_call_type->shape_, old_call_type->dtype_,
@@ -403,6 +416,10 @@ class TileMemorySpaceMutator : public IRMutator {
   const std::set<MoveKey, MoveKeyLess>& needed_moves_;
   std::map<VarPtr, ExprPtr> var_cache_;
   std::map<MoveKey, ExprPtr, MoveKeyLess> created_moves_;
+  // One entry per active SeqStmts scope holding the keys inserted into
+  // created_moves_ within that scope. Popping a scope erases only those keys,
+  // avoiding a full-map copy on every SeqStmts visit (O(N^2) on nested IR).
+  std::vector<std::vector<MoveKey>> scope_inserted_stack_;
 
   std::vector<StmtPtr> VisitAndInsertMoves(const std::vector<StmtPtr>& stmts, bool& changed) {
     // Scope created_moves_ to this SeqStmts so moves emitted in one branch
@@ -410,7 +427,7 @@ class TileMemorySpaceMutator : public IRMutator {
     // later sibling blocks. Otherwise the cache would skip re-emitting a
     // required tile.move in the else branch while the target var is defined
     // only in the then branch, leaving a dangling SSA reference.
-    auto saved_moves = created_moves_;
+    scope_inserted_stack_.emplace_back();
     std::vector<StmtPtr> new_stmts;
     for (const auto& stmt : stmts) {
       InsertMovesForConsumer(new_stmts, stmt, changed);
@@ -418,7 +435,10 @@ class TileMemorySpaceMutator : public IRMutator {
       if (new_stmt.get() != stmt.get()) changed = true;
       new_stmts.push_back(new_stmt);
     }
-    created_moves_ = std::move(saved_moves);
+    for (const auto& key : scope_inserted_stack_.back()) {
+      created_moves_.erase(key);
+    }
+    scope_inserted_stack_.pop_back();
     return new_stmts;
   }
 
@@ -497,9 +517,13 @@ class TileMemorySpaceMutator : public IRMutator {
     auto moved_var = std::make_shared<Var>(
         mutated_producer_var->name_hint_ + "_" + MemorySpaceToString(target), std::move(moved_type), span);
 
-    // Register for substitution and in var_cache_ so VisitExpr_(VarPtr) returns it as-is
+    // Register for substitution and in var_cache_ so VisitExpr_(VarPtr) returns it as-is.
+    // Record the key in the current scope so it is erased when the SeqStmts exits.
     MoveKey key = {original_var, target};
     created_moves_[key] = moved_var;
+    if (!scope_inserted_stack_.empty()) {
+      scope_inserted_stack_.back().push_back(key);
+    }
     var_cache_[moved_var] = moved_var;
 
     stmts.push_back(std::make_shared<AssignStmt>(moved_var, move_call, span));

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -23,6 +23,7 @@
 
 #include "pypto/backend/common/backend.h"
 #include "pypto/backend/common/backend_config.h"
+#include "pypto/core/any_cast.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
@@ -38,6 +39,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -106,12 +108,33 @@ class TileMemorySpaceAnalyzer : public IRVisitor {
 
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
       if (!As<TileType>(op->return_vars_[i]->GetType())) continue;
-      if (i < yield_stmt->value_.size()) {
-        if (auto yield_var = As<Var>(yield_stmt->value_[i])) {
-          auto it = var_memory_.find(yield_var);
-          if (it != var_memory_.end()) {
-            var_memory_[op->return_vars_[i]] = it->second;
-          }
+      if (i >= yield_stmt->value_.size()) continue;
+      auto yield_var = As<Var>(yield_stmt->value_[i]);
+      if (!yield_var) continue;
+
+      // Fallback to the TileType annotation handles IfStmt return_vars — they
+      // carry a memory_space_ set by earlier passes but never get re-tracked
+      // in var_memory_ since this analyzer only visits AssignStmts.
+      std::optional<MemorySpace> yield_memory;
+      if (auto it = var_memory_.find(yield_var); it != var_memory_.end()) {
+        yield_memory = it->second;
+      } else if (auto yt = As<TileType>(yield_var->GetType()); yt) {
+        yield_memory = yt->memory_space_;
+      }
+      if (!yield_memory.has_value()) continue;
+
+      var_memory_[op->return_vars_[i]] = *yield_memory;
+
+      // Back-propagation handles the accumulator pattern: a tile.create
+      // conservatively defaults to Mem.Vec but the loop body writes a
+      // different space (e.g. Acc from matmul_acc). Without this override the
+      // final tile.store reads a Vec tile and ExpandMixedKernel misclassifies
+      // the kernel as mixed, producing broken AIC/AIV IR.
+      if (i < op->iter_args_.size()) {
+        var_memory_[op->iter_args_[i]] = *yield_memory;
+        if (auto init_var = As<Var>(op->iter_args_[i]->initValue_);
+            init_var && var_memory_.count(init_var) > 0) {
+          var_memory_[init_var] = *yield_memory;
         }
       }
     }
@@ -241,8 +264,17 @@ class TileMemorySpaceMutator : public IRMutator {
     auto mem_it = var_memory_.find(op);
 
     if (tile_type && mem_it != var_memory_.end()) {
+      // When promoting to a new memory space, refresh the TileView to the
+      // implicit view for the target — the old view (e.g. Vec-style defaults
+      // from a tile.create) becomes a layout mismatch once the memory space
+      // changes (e.g. Acc expects col_major/row_major/fractal=1024 rather
+      // than the Vec-style row_major/none_box/fractal=512).
+      std::optional<TileView> new_view = tile_type->tile_view_;
+      if (tile_type->memory_space_ != mem_it->second) {
+        new_view = tile_view_semantics::GetImplicitTileView(tile_type->shape_, mem_it->second);
+      }
       auto new_type = std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, tile_type->memref_,
-                                                 tile_type->tile_view_, mem_it->second);
+                                                 std::move(new_view), mem_it->second);
       auto new_var = std::make_shared<Var>(op->name_hint_, std::move(new_type), op->span_);
       var_cache_[op] = new_var;
       return new_var;
@@ -297,6 +329,44 @@ class TileMemorySpaceMutator : public IRMutator {
       return std::make_shared<AssignStmt>(As<Var>(new_var_expr), new_value, op->span_);
     }
 
+    // Rewrite tile.create's target_memory kwarg when the LHS var was promoted
+    // (e.g. the for-loop accumulator back-propagation in Phase 1 moved the
+    // init from Vec to Acc). The new result type uses the implicit TileView
+    // for the promoted memory so later passes see a consistent layout.
+    // OpRegistry deduction would otherwise keep Vec-style layout defaults.
+    if (auto call = As<Call>(new_value); call) {
+      if (auto op_name_node = As<Op>(call->op_); op_name_node && op_name_node->name_ == "tile.create") {
+        auto mem_it = var_memory_.find(op->var_);
+        auto old_call_type = As<TileType>(call->GetType());
+        if (mem_it != var_memory_.end() && old_call_type) {
+          MemorySpace promoted = mem_it->second;
+          std::optional<MemorySpace> kwarg_target;
+          for (const auto& [key, value] : call->kwargs_) {
+            if (key == "target_memory") {
+              kwarg_target = AnyCast<MemorySpace>(value, "target_memory");
+              break;
+            }
+          }
+          if (kwarg_target.has_value() && *kwarg_target != promoted) {
+            std::vector<std::pair<std::string, std::any>> new_kwargs;
+            new_kwargs.reserve(call->kwargs_.size());
+            for (const auto& [key, value] : call->kwargs_) {
+              if (key == "target_memory") {
+                new_kwargs.emplace_back(key, std::any(promoted));
+              } else {
+                new_kwargs.emplace_back(key, value);
+              }
+            }
+            auto promoted_view = tile_view_semantics::GetImplicitTileView(old_call_type->shape_, promoted);
+            auto promoted_type = std::make_shared<TileType>(old_call_type->shape_, old_call_type->dtype_,
+                                                            old_call_type->memref_, promoted_view, promoted);
+            new_value = std::make_shared<Call>(call->op_, call->args_, std::move(new_kwargs),
+                                               std::move(promoted_type), call->span_);
+          }
+        }
+      }
+    }
+
     // Sync LHS Var type with the rebuilt Call's result type.  When VisitExpr_(CallPtr)
     // rebuilds the Call via OpRegistry after substituting moved arguments, the deduced
     // result type may differ from the LHS Var's original type (e.g. tile_view changes
@@ -335,6 +405,12 @@ class TileMemorySpaceMutator : public IRMutator {
   std::map<MoveKey, ExprPtr, MoveKeyLess> created_moves_;
 
   std::vector<StmtPtr> VisitAndInsertMoves(const std::vector<StmtPtr>& stmts, bool& changed) {
+    // Scope created_moves_ to this SeqStmts so moves emitted in one branch
+    // of an IfStmt (or other sibling scope) are not treated as available in
+    // later sibling blocks. Otherwise the cache would skip re-emitting a
+    // required tile.move in the else branch while the target var is defined
+    // only in the then branch, leaving a dangling SSA reference.
+    auto saved_moves = created_moves_;
     std::vector<StmtPtr> new_stmts;
     for (const auto& stmt : stmts) {
       InsertMovesForConsumer(new_stmts, stmt, changed);
@@ -342,6 +418,7 @@ class TileMemorySpaceMutator : public IRMutator {
       if (new_stmt.get() != stmt.get()) changed = true;
       new_stmts.push_back(new_stmt);
     }
+    created_moves_ = std::move(saved_moves);
     return new_stmts;
   }
 

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -123,10 +123,16 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
       "system.aic_initialize_pipe", "system.tfree_to_aiv", "system.tpush_to_aiv", "tile.tpush_to_aiv",
       "tile.tpop_from_aiv"};
   if (cube_cross_core_ops.count(name)) return CoreAffinity::CUBE;
-  // SPMD block-index ops: needed on both AIC and AIV under SPMD dispatch
+  // Ops with no execution side. SPMD block-index ops are needed on both AIC
+  // and AIV under SPMD dispatch. tile.create is a pure declaration (no
+  // compute, no data motion); letting the catch-all below classify it as
+  // VECTOR caused pure-cube scopes whose only "vector" signal was an
+  // accumulator declaration to be routed through the mixed-kernel split
+  // path, which then produced broken AIC/AIV IR.
   static const std::unordered_set<std::string> shared_tile_ops = {
       "tile.get_block_idx",
       "tile.get_block_num",
+      "tile.create",
   };
   if (shared_tile_ops.count(name)) return CoreAffinity::SHARED;
   if (name.substr(0, 5) == "tile.") return CoreAffinity::VECTOR;

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -32,6 +32,16 @@ def _run_pipeline(program: ir.Program) -> ir.Program:
         )
 
 
+def _run_pipeline_from_tensor(program: ir.Program) -> ir.Program:
+    """Run the tensor-to-tile conversion on top of _run_pipeline."""
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        return passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(
+                passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(program))
+            )
+        )
+
+
 def _patch_tensor_create_manual_dep(program: ir.Program, func_name: str) -> ir.Program:
     """Add manual_dep=True kwarg to tensor.create calls in the named function.
 
@@ -857,6 +867,47 @@ def test_gm_pipe_buffer_param_direction_is_out():
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
     ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
+
+def test_accumulator_with_tile_create_classifies_as_pure_aic():
+    """Regression for issue #1083.
+
+    A CORE_GROUP scope whose only "vector" signal is a declaration-only
+    ``tile.create`` feeding a matmul/matmul_acc loop used to be misclassified
+    as mixed — routed through the split path and emitting broken AIC/AIV IR.
+    After the fix, ``tile.create`` is SHARED in the core-affinity classifier,
+    and ``InferTileMemorySpace`` back-propagates the body's Acc memory to the
+    iter_arg and init, so the kernel classifies as pure AIC.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def matmul_accumulator(
+            self,
+            a: pl.Tensor[[16, 256], pl.BF16],
+            b: pl.Tensor[[256, 128], pl.BF16],
+            out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            acc = pl.create_tensor([16, 128], dtype=pl.FP32)
+            for k in pl.range(0, 256, 64):
+                a_slice = pl.slice(a, [16, 64], [0, k])
+                b_slice = pl.slice(b, [64, 128], [k, 0])
+                acc = pl.matmul_acc(acc, a_slice, b_slice)
+            out = pl.assemble(out, acc, [0, 0])
+            return out
+
+    After = _run_pipeline_from_tensor(Before)
+
+    # Exactly one non-orchestration function, typed as AIC (no AIC/AIV split,
+    # no Group wrapper), since the scope is semantically pure cube.
+    compute_funcs = [fn for _, fn in After.functions.items() if fn.func_type != ir.FunctionType.Orchestration]
+    assert len(compute_funcs) == 1, (
+        f"expected a single pure-AIC function, got {[(fn.name, fn.func_type) for fn in compute_funcs]}"
+    )
+    assert compute_funcs[0].func_type == ir.FunctionType.AIC, (
+        f"expected FunctionType.AIC, got {compute_funcs[0].func_type}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -33,7 +33,11 @@ def _run_pipeline(program: ir.Program) -> ir.Program:
 
 
 def _run_pipeline_from_tensor(program: ir.Program) -> ir.Program:
-    """Run the tensor-to-tile conversion on top of _run_pipeline."""
+    """Run SSA -> tensor-to-tile -> infer-memory -> expand-mixed-kernel.
+
+    Mirrors _run_pipeline but inserts convert_tensor_to_tile_ops between SSA
+    and InferTileMemorySpace, for cases that start from tensor-level IR.
+    """
     with passes.PassContext([], ir.VerificationLevel.NONE):
         return passes.expand_mixed_kernel()(
             passes.infer_tile_memory_space()(


### PR DESCRIPTION
## Summary

Fixes #1083. A CORE_GROUP scope holding a `tile.create` accumulator that feeds `matmul_acc` was being mis-classified as MIXED, which routed it through ExpandMixedKernel's split path and produced broken AIC/AIV IR that crashed codegen with `no MLIR mapping for MemRef base`.

This PR fixes the issue end-to-end across the classifier and the `InferTileMemorySpace` pass.

### 1. Classifier fix (`src/ir/transforms/utils/core_affinity.cpp`)

`tile.create` is a declaration-only op (no compute, no data motion), but `ClassifyCallAffinity`'s catch-all was routing it to `VECTOR`. A CORE_GROUP scope with a `tile.create` accumulator + a `matmul_acc` body therefore combined to `MIXED` and entered the split path. Classify `tile.create` as `SHARED` so it no longer forces scope affinity.

### 2. Back-propagate yielded memory space onto accumulator chain (`infer_tile_memory_space_pass.cpp`)

Extend the `ForStmt` visitor to propagate the body's yielded memory space back onto the `iter_arg` and its init value. Fall back to reading `memory_space_` from the yield var's `TileType` so that `IfStmt` return_vars, which this analyzer does not otherwise track, are still picked up.

### 3. Three follow-ups surfaced while running the user's repro end-to-end

- **Scope `created_moves_` per `SeqStmts` visit.** The cache was an instance member shared across sibling blocks. When Phase 3 emitted a `tile.move` inside an `if` branch and then processed the `else` branch of the same `IfStmt`, the consumer lookup hit the cached key and skipped the move — leaving the `else` branch with a dangling SSA reference to a `Var` defined only in the `then` branch.
- **Rewrite `tile.create` when the LHS `Var` is promoted.** After Phase 1 back-propagates `Acc` memory onto the `tile.create` init `Var`, the init `Call` still carried `target_memory=Vec` in its kwargs and a `Vec`-style result type. Rebuild the `Call` with the promoted kwarg and a `TileType` whose `TileView` matches the implicit view for the new memory space.
- **Refresh the `TileView` of any promoted `Var`, not only the `tile.create` output.** `IterArg` and `ForStmt` return_var types were carrying the old `Vec`-style view forward into memory spaces where those values are nonsense (`Acc` expects `col_major`/`row_major`/`fractal=1024`, not the `Vec` defaults). Later `tmov` lowering then produced invalid ops.

## Test plan

- [x] Build in worktree with nanobind cmake path
- [x] New end-to-end case: `tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py::test_accumulator_with_tile_create_classifies_as_pure_aic` passes
- [x] Full transforms suite: `python -m pytest tests/ut/ir/transforms/ -n auto` — 1066 passed, 12 skipped, no regressions

Fixes #1083
