### PR TITLE
fix(ir): Remap type annotations in DeepClone

### DIFF
--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1464,23 +1464,29 @@ void BindIR(nb::module_& m) {
 
   ir.def(
       "deep_clone",
-      [](const StmtPtr& body) -> nb::tuple {
-        auto result = DeepClone(body);
+      [](const StmtPtr& body, const std::vector<std::pair<VarPtr, ExprPtr>>& var_map_pairs) -> nb::tuple {
+        std::unordered_map<const Var*, ExprPtr> seed_map;
+        for (const auto& [orig, replacement] : var_map_pairs) {
+          seed_map[orig.get()] = replacement;
+        }
+        auto result = DeepClone(body, seed_map);
         // Convert raw-pointer-keyed map to shared_ptr-keyed map for Python
-        std::vector<std::pair<VarPtr, VarPtr>> var_map_pairs;
-        var_map_pairs.reserve(result.var_map.size());
+        std::vector<std::pair<VarPtr, VarPtr>> out_pairs;
+        out_pairs.reserve(result.var_map.size());
         for (const auto& [raw_ptr, new_var] : result.var_map) {
           // Find the original VarPtr from the raw pointer — wrap as non-owning shared_ptr
           // Since Python holds the original IR tree alive, the raw pointer is valid
-          var_map_pairs.emplace_back(std::shared_ptr<const Var>(std::shared_ptr<const Var>{}, raw_ptr),
-                                     new_var);
+          out_pairs.emplace_back(std::shared_ptr<const Var>(std::shared_ptr<const Var>{}, raw_ptr), new_var);
         }
-        return nb::make_tuple(result.cloned_body, var_map_pairs);
+        return nb::make_tuple(result.cloned_body, out_pairs);
       },
-      nb::arg("body"),
+      nb::arg("body"), nb::arg("var_map") = std::vector<std::pair<VarPtr, ExprPtr>>{},
       "Deep-clone a statement subtree, creating fresh Var objects at definition sites.\n\n"
-      "Returns a tuple of (cloned_body, var_map) where var_map is a list of\n"
-      "(original_var, cloned_var) pairs for definition-site clones.");
+      "var_map seeds the substitution: each (original_var, replacement_expr) pair\n"
+      "replaces references to original_var with replacement_expr inside the clone.\n\n"
+      "Returns a tuple of (cloned_body, def_var_map) where def_var_map is a list of\n"
+      "(original_var, cloned_var) pairs for definition-site clones (excludes seeded\n"
+      "substitutions that map to non-Var expressions).");
 
   // Cross-function call return type deduction
   ir.def("deduce_call_return_type", &DeduceCallReturnType, nb::arg("callee_params"), nb::arg("args"),

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1485,8 +1485,9 @@ void BindIR(nb::module_& m) {
       "var_map seeds the substitution: each (original_var, replacement_expr) pair\n"
       "replaces references to original_var with replacement_expr inside the clone.\n\n"
       "Returns a tuple of (cloned_body, def_var_map) where def_var_map is a list of\n"
-      "(original_var, cloned_var) pairs for definition-site clones (excludes seeded\n"
-      "substitutions that map to non-Var expressions).");
+      "(original_var, cloned_var) pairs for the definition sites freshly cloned by\n"
+      "the traversal. Seeded entries from var_map are NOT included — use the\n"
+      "caller's own substitution map for those.");
 
   // Cross-function call return type deduction
   ir.def("deduce_call_return_type", &DeduceCallReturnType, nb::arg("callee_params"), nb::arg("args"),

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3098,7 +3098,10 @@ def substitute_expr(expr: Expr, var_map: list[tuple[Var, Var]]) -> Expr:
 def substitute_stmt(body: Stmt, var_map: list[tuple[Var, Var]]) -> Stmt:
     """Substitute variable references in a statement subtree using (original_var, replacement_var) pairs."""
 
-def deep_clone(body: Stmt) -> tuple[Stmt, list[tuple[Var, Var]]]:
+def deep_clone(
+    body: Stmt,
+    var_map: list[tuple[Var, Expr]] = ...,
+) -> tuple[Stmt, list[tuple[Var, Var]]]:
     """Deep-clone a statement subtree, creating fresh Var objects at definition sites.
 
     All Var, IterArg, and MemRef objects at definition sites inside the statement
@@ -3106,10 +3109,14 @@ def deep_clone(body: Stmt) -> tuple[Stmt, list[tuple[Var, Var]]]:
 
     Args:
         body: The statement subtree to clone
+        var_map: Optional seeded substitutions. Each (original_var, replacement_expr)
+            pair replaces references to original_var with replacement_expr inside
+            the clone (including expressions embedded in type annotations).
 
     Returns:
-        Tuple of (cloned_body, var_map) where var_map is a list of
-        (original_var, cloned_var) pairs for definition-site clones.
+        Tuple of (cloned_body, def_var_map) where def_var_map is a list of
+        (original_var, cloned_var) pairs for definition-site clones. Seeded
+        substitutions that map to non-Var expressions are excluded.
     """
 
 def deduce_call_return_type(

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3115,8 +3115,8 @@ def deep_clone(
 
     Returns:
         Tuple of (cloned_body, def_var_map) where def_var_map is a list of
-        (original_var, cloned_var) pairs for definition-site clones. Seeded
-        substitutions that map to non-Var expressions are excluded.
+        (original_var, cloned_var) pairs for the definition sites freshly
+        cloned by the traversal. Seeded entries from var_map are NOT included.
     """
 
 def deduce_call_return_type(

--- a/src/ir/transforms/utils/deep_clone_utils.cpp
+++ b/src/ir/transforms/utils/deep_clone_utils.cpp
@@ -12,9 +12,11 @@
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -39,12 +41,20 @@ namespace {
 class DeepCloneMutator : public IRMutator {
  public:
   explicit DeepCloneMutator(const std::unordered_map<const Var*, ExprPtr>& var_map, bool clone_def_vars)
-      : expr_map_(var_map), clone_def_vars_(clone_def_vars) {}
+      : expr_map_(var_map), clone_def_vars_(clone_def_vars) {
+    seed_keys_.reserve(var_map.size());
+    for (const auto& [key, _val] : var_map) {
+      seed_keys_.insert(key);
+    }
+  }
 
-  /// Get the accumulated definition-site Var mapping (excludes non-Var substitutions).
+  /// Get the definition-site Var mapping created by the clone traversal —
+  /// excludes caller-seeded entries (whether they pointed at Vars or not) so
+  /// the result matches the "definition-site clones only" contract.
   [[nodiscard]] std::unordered_map<const Var*, VarPtr> GetVarMap() const {
     std::unordered_map<const Var*, VarPtr> result;
     for (const auto& [key, val] : expr_map_) {
+      if (seed_keys_.count(key)) continue;
       auto var = std::dynamic_pointer_cast<const Var>(val);
       if (var) {
         result[key] = var;
@@ -110,10 +120,20 @@ class DeepCloneMutator : public IRMutator {
     if (it != expr_map_.end()) {
       return it->second;
     }
-    // Create fresh MemRef with cloned byte_offset_ and same base_
+    // Remap base_ through the mutator so a substituted Ptr var carries through
+    // into the cloned MemRef (preserves allocation identity across a scope
+    // substitution). If the remapped expr is not a Var, fall back to the
+    // original base_ — the alternative is silently corrupting MemRef invariants.
+    VarPtr new_base = op->base_;
+    if (op->base_) {
+      auto remapped_base = IRMutator::VisitExpr(op->base_);
+      if (auto as_var = std::dynamic_pointer_cast<const Var>(remapped_base)) {
+        new_base = as_var;
+      }
+    }
     auto new_offset = op->byte_offset_ ? IRMutator::VisitExpr(op->byte_offset_) : op->byte_offset_;
-    auto fresh =
-        std::make_shared<MemRef>(op->name_hint_, op->base_, std::move(new_offset), op->size_, op->span_);
+    auto fresh = std::make_shared<MemRef>(op->name_hint_, std::move(new_base), std::move(new_offset),
+                                          op->size_, op->span_);
     expr_map_[op.get()] = fresh;
     return fresh;
   }
@@ -136,9 +156,26 @@ class DeepCloneMutator : public IRMutator {
   }
 
   /// Remap expressions inside a TypePtr (shape, TileView/TensorView fields, MemRef).
-  /// Returns the original pointer unchanged if nothing inside references a remapped var.
+  /// Recurses into TupleType element types so nested shaped types pick up
+  /// substitutions too. Returns the original pointer unchanged if nothing
+  /// inside references a remapped var.
   TypePtr RemapType(const TypePtr& type) {
     if (!type) return type;
+    // TupleType element types may themselves embed remappable expressions.
+    if (auto tuple_type = std::dynamic_pointer_cast<const TupleType>(type)) {
+      std::vector<TypePtr> new_types;
+      new_types.reserve(tuple_type->types_.size());
+      bool changed = false;
+      for (const auto& elem : tuple_type->types_) {
+        auto new_elem = RemapType(elem);
+        if (new_elem.get() != elem.get()) {
+          changed = true;
+        }
+        new_types.push_back(std::move(new_elem));
+      }
+      if (!changed) return type;
+      return std::make_shared<TupleType>(std::move(new_types));
+    }
     // Remap the embedded MemRef (if any) so its byte_offset_ expression picks up
     // substitutions. Dispatches through VisitExpr_(const MemRefPtr&), which creates
     // a fresh MemRef with the mutated offset and caches it in expr_map_.
@@ -181,6 +218,9 @@ class DeepCloneMutator : public IRMutator {
   }
 
   std::unordered_map<const Var*, ExprPtr> expr_map_;
+  /// Keys present in the caller-supplied seed map; filtered out of GetVarMap()
+  /// so only entries created by the clone traversal are returned.
+  std::unordered_set<const Var*> seed_keys_;
   bool clone_def_vars_;
 };
 

--- a/src/ir/transforms/utils/deep_clone_utils.cpp
+++ b/src/ir/transforms/utils/deep_clone_utils.cpp
@@ -25,6 +25,8 @@
 #include "pypto/ir/reflection/field_traits.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
@@ -91,10 +93,14 @@ class DeepCloneMutator : public IRMutator {
     if (it != expr_map_.end()) {
       return it->second;
     }
-    // Create fresh IterArg with cloned initValue_
+    // Create fresh IterArg with cloned initValue_ and a remapped type — the
+    // type may embed expressions (shape dims, TileView/TensorView fields,
+    // MemRef byte_offset) that reference Vars in expr_map_.
     INTERNAL_CHECK_SPAN(op->initValue_, op->span_) << "IterArg has null initValue";
     auto new_init = IRMutator::VisitExpr(op->initValue_);
-    auto fresh = std::make_shared<IterArg>(op->name_hint_, op->GetType(), std::move(new_init), op->span_);
+    auto new_type = RemapType(op->GetType());
+    auto fresh =
+        std::make_shared<IterArg>(op->name_hint_, std::move(new_type), std::move(new_init), op->span_);
     expr_map_[op.get()] = fresh;
     return fresh;
   }
@@ -113,7 +119,10 @@ class DeepCloneMutator : public IRMutator {
   }
 
  private:
-  /// Create a fresh Var with same name and type, register in expr_map_.
+  /// Create a fresh Var with a remapped type, register in expr_map_.
+  /// The type is rewritten so shape dims, TileView/TensorView fields, and any
+  /// embedded MemRef's byte_offset are substituted via expr_map_ — otherwise
+  /// the fresh Var's type would still reference the caller's old Var pointers.
   void CloneVar(const VarPtr& op) {
     if (expr_map_.count(op.get())) return;  // Already mapped (e.g. pre-seeded)
     // Check if the actual runtime type is MemRef — don't create a plain Var for MemRef
@@ -121,8 +130,28 @@ class DeepCloneMutator : public IRMutator {
       // MemRef will be handled by VisitExpr_(MemRefPtr) during traversal
       return;
     }
-    auto fresh = std::make_shared<Var>(op->name_hint_, op->GetType(), op->span_);
+    auto new_type = RemapType(op->GetType());
+    auto fresh = std::make_shared<Var>(op->name_hint_, std::move(new_type), op->span_);
     expr_map_[op.get()] = fresh;
+  }
+
+  /// Remap expressions inside a TypePtr (shape, TileView/TensorView fields, MemRef).
+  /// Returns the original pointer unchanged if nothing inside references a remapped var.
+  TypePtr RemapType(const TypePtr& type) {
+    if (!type) return type;
+    // Remap the embedded MemRef (if any) so its byte_offset_ expression picks up
+    // substitutions. Dispatches through VisitExpr_(const MemRefPtr&), which creates
+    // a fresh MemRef with the mutated offset and caches it in expr_map_.
+    auto original_memref_opt = GetTypeMemRef(type);
+    std::optional<MemRefPtr> new_memref_opt = original_memref_opt;
+    if (original_memref_opt.has_value()) {
+      auto remapped = IRMutator::VisitExpr(*original_memref_opt);
+      if (auto as_memref = std::dynamic_pointer_cast<const MemRef>(remapped)) {
+        new_memref_opt = as_memref;
+      }
+    }
+    return CloneTypeWithMemRefAndRemapExprs(type, new_memref_opt,
+                                            [this](const ExprPtr& e) { return IRMutator::VisitExpr(e); });
   }
 
   /// Use GetFieldDescriptors to find DefField VarPtr/vector<VarPtr> entries

--- a/tests/ut/ir/transforms/test_deep_clone.py
+++ b/tests/ut/ir/transforms/test_deep_clone.py
@@ -15,7 +15,7 @@ while preserving IR structure and SSA consistency.
 
 import pypto.language as pl
 import pytest
-from pypto import backend, ir, passes
+from pypto import DataType, backend, ir, passes
 from pypto.backend import BackendType
 
 
@@ -157,6 +157,74 @@ class TestDeepCloneWithExpandMixedKernel:
 
         # Whole-program structural equality should work now that DeepClone is used
         ir.assert_structural_equal(After, After2)
+
+
+class TestDeepCloneTypeRemap:
+    """Type annotations embed Exprs (shape dims, TileView/TensorView fields,
+    MemRef byte_offset) that may reference scope Vars. DeepClone must rewrite
+    those embedded Exprs through its expr_map_ — otherwise a cloned Var carries
+    a type pointing at out-of-scope originals, which the printer surfaces as
+    `pl.dynamic(...)` forward declarations.
+    """
+
+    @staticmethod
+    def _make_assign_with_tile_var_referencing(loop_var: ir.Var) -> tuple[ir.AssignStmt, ir.Var]:
+        """Build `t = loop_var` where t has TileType whose tile_view.valid_shape[0] is loop_var."""
+        span = ir.Span.unknown()
+        tile_view = ir.TileView(
+            valid_shape=[loop_var],
+            stride=[ir.ConstInt(1, DataType.INDEX, span)],
+            start_offset=ir.ConstInt(0, DataType.INDEX, span),
+        )
+        tile_type = ir.TileType(
+            [ir.ConstInt(4, DataType.INDEX, span)],
+            DataType.FP32,
+            None,  # memref
+            tile_view,
+            None,  # memory_space
+        )
+        t_var = ir.Var("t", tile_type, span)
+        # The assignment value isn't the focus — we only inspect the LHS Var's type.
+        return ir.AssignStmt(t_var, loop_var, span), t_var
+
+    def test_cloned_tile_type_references_substituted_var(self):
+        """valid_shape referencing a scope var gets remapped to the substitute."""
+        span = ir.Span.unknown()
+        i_orig = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        j_sub = ir.Var("j", ir.ScalarType(DataType.INDEX), span)
+
+        assign, t_var = self._make_assign_with_tile_var_referencing(i_orig)
+        cloned, var_map = ir.deep_clone(assign, var_map=[(i_orig, j_sub)])
+
+        assert isinstance(cloned, ir.AssignStmt)
+        cloned_t = cloned.var
+        assert cloned_t is not t_var  # fresh Var at the def site
+        cloned_tile_type = cloned_t.type
+        assert isinstance(cloned_tile_type, ir.TileType)
+        assert cloned_tile_type.tile_view is not None
+
+        # The embedded valid_shape[0] must now reference j_sub, not i_orig.
+        valid_shape_0 = cloned_tile_type.tile_view.valid_shape[0]
+        assert valid_shape_0 is j_sub
+        assert valid_shape_0 is not i_orig
+
+        # Sanity: the def-site var_map contains the t clone.
+        assert any(orig is t_var and clone is cloned_t for orig, clone in var_map)
+
+    def test_cloned_type_unchanged_when_no_substitution(self):
+        """Without substitution, the embedded Expr identity survives intact."""
+        span = ir.Span.unknown()
+        i_orig = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+
+        assign, _ = self._make_assign_with_tile_var_referencing(i_orig)
+        cloned, _ = ir.deep_clone(assign)  # empty var_map
+
+        assert isinstance(cloned, ir.AssignStmt)
+        cloned_tile_type = cloned.var.type
+        assert isinstance(cloned_tile_type, ir.TileType)
+        assert cloned_tile_type.tile_view is not None
+        # External vars pass through VisitExpr_(VarPtr) unchanged (no substitution).
+        assert cloned_tile_type.tile_view.valid_shape[0] is i_orig
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`DeepClone` was reusing the source `Var`'s `TypePtr` verbatim when creating the fresh clone. Types may embed expressions (shape dims, `TileView` `valid_shape`/`stride`/`start_offset`, `MemRef.byte_offset`) that reference scope `Var`s, so after a scope-substituting clone (e.g. `UnrollLoops` replacing `loop_var` with `ConstInt`, or a future `PartialUnrollTileLoops` substituting a loop var), the cloned `Var` carried a type still pointing at out-of-scope source `Var`s. The printer rendered those dangling references as `pl.dynamic(...)` forward declarations inside the transformed body.

The fix walks the embedded expressions through the mutator's `expr_map_` and rebuilds the type via `CloneTypeWithMemRefAndRemapExprs`, so the fresh `Var`/`IterArg` carries a type consistent with the cloned scope.

- `src/ir/transforms/utils/deep_clone_utils.cpp` — new private `RemapType` helper; `CloneVar` and `VisitExpr_(IterArgPtr)` use it instead of reusing `op->GetType()` verbatim.
- `python/bindings/modules/ir.cpp` + `.pyi` — `ir.deep_clone` now accepts an optional `var_map` seed (matching the C++ API), so tests can directly exercise the type-remapping path.
- `tests/ut/ir/transforms/test_deep_clone.py` — regression test verifying that a `TileType.tile_view.valid_shape` expression referencing a scope var is remapped to the substituted var after cloning.

## Test plan

- [x] `python -m pytest tests/ut/ir/transforms/test_deep_clone.py -v` (all 7 pass; the new tests fail without the fix and pass with it)
- [x] `python -m pytest tests/ut/ir/ -n auto` (2706 passed, 13 skipped — no regressions)