### PR TITLE
refactor(ir): Use structural_equal in MemoryReuse tile compatibility

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -397,12 +397,7 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
 // are structurally identical but allocated fresh (e.g. two `pl.min(x, y)`
 // calls cloned from the same source). structural_equal walks the IR tree and
 // compares op kinds and children so these cases are treated as equal.
-static bool AreTileExprsEqual(const ExprPtr& e1, const ExprPtr& e2) {
-  if (e1.get() == e2.get()) return true;
-  if (!e1 || !e2) return false;
-  return structural_equal(std::static_pointer_cast<const IRNode>(e1),
-                          std::static_pointer_cast<const IRNode>(e2));
-}
+static bool AreTileExprsEqual(const ExprPtr& e1, const ExprPtr& e2) { return structural_equal(e1, e2); }
 
 static bool AreTileExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2) {
   if (v1.size() != v2.size()) return false;
@@ -427,7 +422,7 @@ static bool AreTileViewsEqual(const TileView& a, const TileView& b) {
  * the generated PTO IR, leading to incorrect codegen or hardware behaviour.
  *
  * Checked attributes: shape, dtype, and TileView (all fields compared via the
- * analyzer-backed helpers above).
+ * structural comparison helpers above).
  */
 bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   auto t1 = As<TileType>(var1->GetType());

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
@@ -390,6 +391,33 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
   return {lifetimes, var_sharing_groups};
 }
 
+// Expression equality via full recursive structural comparison. The shared
+// AreExprsEqual/AreExprVectorsEqual helpers fall back to pointer identity for
+// non-ConstInt expressions, which misses DeepClone-produced expressions that
+// are structurally identical but allocated fresh (e.g. two `pl.min(x, y)`
+// calls cloned from the same source). structural_equal walks the IR tree and
+// compares op kinds and children so these cases are treated as equal.
+static bool AreTileExprsEqual(const ExprPtr& e1, const ExprPtr& e2) {
+  if (e1.get() == e2.get()) return true;
+  if (!e1 || !e2) return false;
+  return structural_equal(std::static_pointer_cast<const IRNode>(e1),
+                          std::static_pointer_cast<const IRNode>(e2));
+}
+
+static bool AreTileExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2) {
+  if (v1.size() != v2.size()) return false;
+  for (size_t i = 0; i < v1.size(); ++i) {
+    if (!AreTileExprsEqual(v1[i], v2[i])) return false;
+  }
+  return true;
+}
+
+static bool AreTileViewsEqual(const TileView& a, const TileView& b) {
+  return AreTileExprVectorsEqual(a.valid_shape, b.valid_shape) &&
+         AreTileExprVectorsEqual(a.stride, b.stride) && AreTileExprsEqual(a.start_offset, b.start_offset) &&
+         a.blayout == b.blayout && a.slayout == b.slayout && a.fractal == b.fractal && a.pad == b.pad;
+}
+
 /**
  * @brief Check if two TileType variables have fully compatible tile attributes
  *
@@ -398,7 +426,8 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
  * Reuse between tiles with different attributes would cause attribute mismatches in
  * the generated PTO IR, leading to incorrect codegen or hardware behaviour.
  *
- * Checked attributes: shape, dtype, and TileView (all fields via TileView::operator==).
+ * Checked attributes: shape, dtype, and TileView (all fields compared via the
+ * analyzer-backed helpers above).
  */
 bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   auto t1 = As<TileType>(var1->GetType());
@@ -406,12 +435,12 @@ bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   if (!t1 || !t2) return true;
 
   if (t1->dtype_ != t2->dtype_) return false;
-  if (!AreExprVectorsEqual(t1->shape_, t2->shape_)) return false;
+  if (!AreTileExprVectorsEqual(t1->shape_, t2->shape_)) return false;
 
   bool has_view1 = t1->tile_view_.has_value();
   bool has_view2 = t2->tile_view_.has_value();
   if (has_view1 != has_view2) return false;
-  if (has_view1 && t1->tile_view_.value() != t2->tile_view_.value()) return false;
+  if (has_view1 && !AreTileViewsEqual(t1->tile_view_.value(), t2->tile_view_.value())) return false;
   return true;
 }
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -18,7 +18,8 @@ in ``Expected`` must also share (i.e. use the same ``mem_*`` pointer name).
 
 import pypto.language as pl
 import pytest
-from pypto import ir, passes
+from pypto import DataType, ir, passes
+from pypto.ir.op import tile
 
 
 def _run_pipeline(program: ir.Program) -> ir.Program:
@@ -2117,6 +2118,102 @@ class TestMetadata:
         after_vp = After.get_function("vector_producer")
         assert after_vp is not None
         assert after_vp.split == ir.SplitMode.UP_DOWN
+
+
+class TestStructuralShapeEquality:
+    """Structural-equality tile compatibility.
+
+    ``AreTileTypesCompatible`` used to compare shape/TileView expressions via
+    pointer identity (with a ConstInt value-equality fallback). That missed
+    freshly-allocated non-ConstInt expressions that were structurally identical
+    — e.g. tiles produced by DeepClone — and blocked legitimate reuse. The pass
+    now uses ``structural_equal`` so such tiles are recognised as compatible.
+    """
+
+    def test_pointer_distinct_but_structurally_equal_shape_reuses_memref(self):
+        """Two tiles whose shape contains pointer-distinct composite expressions
+        that are structurally identical must share a MemRef after memory_reuse.
+
+        Constructing fresh ``Add(ConstInt(32), ConstInt(32))`` nodes for each
+        tile simulates what DeepClone produces: identical tree shape, but
+        freshly-allocated ``ExprPtr``s. The old pointer-equality check (with a
+        ConstInt value-equality fallback) missed these non-ConstInt composite
+        expressions and blocked reuse; ``structural_equal`` recurses into the
+        tree and correctly recognises them as compatible.
+        """
+        span = ir.Span.unknown()
+        c64 = ir.ConstInt(64, DataType.INT64, span)
+
+        def make_add64() -> ir.Add:
+            # Fresh Add(ConstInt(32), ConstInt(32)) — non-ConstInt expression
+            # that is structurally equal across calls but pointer-distinct.
+            return ir.Add(
+                ir.ConstInt(32, DataType.INT64, span),
+                ir.ConstInt(32, DataType.INT64, span),
+                DataType.INT64,
+                span,
+            )
+
+        add_1 = make_add64()
+        add_2 = make_add64()
+        assert add_1 is not add_2
+
+        memref_a = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 16384, 0)
+        memref_b = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(16384, DataType.INT64, span), 16384, 1)
+
+        input_x = ir.Var("input_x", ir.TensorType([64, 64], DataType.FP32), span)
+        output_x = ir.Var("output_x", ir.TensorType([64, 64], DataType.FP32), span)
+
+        tile_a = ir.Var(
+            "tile_a",
+            ir.TileType([add_1, c64], DataType.FP32, memref_a, memory_space=ir.MemorySpace.Vec),
+            span,
+        )
+        tile_b = ir.Var(
+            "tile_b",
+            ir.TileType([add_2, c64], DataType.FP32, memref_b, memory_space=ir.MemorySpace.Vec),
+            span,
+        )
+        store_a = ir.Var("store_a", ir.TensorType([64, 64], DataType.FP32), span)
+        store_b = ir.Var("store_b", ir.TensorType([64, 64], DataType.FP32), span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(tile_a, tile.load(input_x, offsets=[0, 0], shapes=[64, 64]), span),
+                ir.AssignStmt(
+                    store_a,
+                    tile.store(tile_a, offsets=[0, 0], output_tensor=output_x),
+                    span,
+                ),
+                ir.AssignStmt(tile_b, tile.load(input_x, offsets=[0, 0], shapes=[64, 64]), span),
+                ir.AssignStmt(
+                    store_b,
+                    tile.store(tile_b, offsets=[0, 0], output_tensor=output_x),
+                    span,
+                ),
+                ir.ReturnStmt(span),
+            ],
+            span,
+        )
+        func = ir.Function("main", [input_x, output_x], [], body, span, ir.FunctionType.InCore)
+        Before = ir.Program([func], "test_struct_shape_reuse", span)
+
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            After = passes.memory_reuse()(Before)
+
+        after_func = After.get_function("main")
+        assert after_func is not None
+        after_body = after_func.body
+        assert isinstance(after_body, ir.SeqStmts)
+        assign_a = after_body.stmts[0]
+        assign_b = after_body.stmts[2]
+        assert isinstance(assign_a, ir.AssignStmt)
+        assert isinstance(assign_b, ir.AssignStmt)
+        tile_a_type = assign_a.var.type
+        tile_b_type = assign_b.var.type
+        assert isinstance(tile_a_type, ir.TileType)
+        assert isinstance(tile_b_type, ir.TileType)
+        assert tile_a_type.shares_memref_with(tile_b_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`AreTileTypesCompatible` decides whether two `TileType` variables can share a `MemRef`. It compared shape and `TileView` expressions via `AreExprVectorsEqual` (from `src/ir/expr.cpp`), which uses pointer identity with a ConstInt value-equality fallback:

```cpp
bool AreExprsEqual(const ExprPtr& e1, const ExprPtr& e2) {
  if (e1 == e2) return true;
  if (!e1 || !e2) return false;
  auto c1 = As<ConstInt>(e1);
  auto c2 = As<ConstInt>(e2);
  if (c1 && c2) return c1->value_ == c2->value_;
  return false;
}
```

Composite expressions (`Add`, `Mul`, `Call`, ...) that are structurally identical but freshly allocated — e.g. types produced by `DeepClone` remapping — take the `return false` path, so the pass sees the tiles as incompatible and declines to fuse them.

Introduce `AreTileExprsEqual` / `AreTileExprVectorsEqual` / `AreTileViewsEqual` backed by `structural_equal` (`pypto/ir/transforms/structural_comparison.h`), which walks the IR tree and compares op kinds and children. `AreTileTypesCompatible` now routes both the shape vector and the optional `TileView` fields through these helpers, so structurally-identical-but-pointer-distinct expressions correctly compare equal.

## Test plan

- [x] New unit test `TestStructuralShapeEquality::test_pointer_distinct_but_structurally_equal_shape_reuses_memref` in `tests/ut/ir/transforms/test_memory_reuse.py` constructs two tiles whose shape is a freshly-allocated `Add(ConstInt(32), ConstInt(32))` node (pointer-distinct between the two tiles). Without this change the test fails — the tiles retain their separate `MemRef`s; with this change `memory_reuse` fuses them.
- [x] Full `tests/ut/ir/transforms/test_memory_reuse.py` suite (35 tests) passes.
- [x] Full `tests/ut/ir/` suite (2705 passed, 13 skipped) passes.