### PR TITLE
feat(ir): Top-down retargeter for MemoryReuse accumulator chains

### DIFF
--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -395,17 +395,20 @@ class InitMemRefMutator : public IRMutator {
     new_for->return_vars_ = new_return_vars;
     new_for->chunk_config_ = new_chunk_config;
 
-    // Patch return_vars so each shares its yield value's MemRef.
-    auto yield_stmt = FindYieldStmt(new_body);
-    if (!yield_stmt || new_for->iter_args_.empty() || new_for->return_vars_.empty()) {
+    // Patch return_vars so each shares its iter_arg's MemRef (inherited from initValue).
+    // This establishes the invariant that initValue/iter_arg/return_var all share the
+    // same MemRef buffer — the loop accumulator lives in one place for the whole loop.
+    // Any yield-vs-buffer mismatch is the concern of downstream passes.
+    if (new_for->iter_args_.empty() || new_for->return_vars_.empty()) {
       return new_for;
     }
 
-    auto get_yield_var = [&](size_t i) -> VarPtr {
-      return (i < yield_stmt->value_.size()) ? As<Var>(yield_stmt->value_[i]) : nullptr;
+    auto get_iter_arg_var = [&](size_t i) -> VarPtr {
+      if (i >= new_for->iter_args_.size()) return nullptr;
+      return std::static_pointer_cast<const Var>(new_for->iter_args_[i]);
     };
     auto [patched, changed] =
-        PatchReturnVarsFromYield(new_for->return_vars_, op->return_vars_, get_yield_var);
+        PatchReturnVarsFromYield(new_for->return_vars_, op->return_vars_, get_iter_arg_var);
 
     if (!changed) return new_for;
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -201,7 +201,25 @@ class DefMapVisitor : public IRVisitor {
     ancestor_stack_.pop_back();
   }
 
+  // Scope statements (InCore/AutoInCore/Cluster/Hierarchy/Spmd) must also
+  // participate in the ancestor chain.  Without them, the liveness walk
+  // would jump straight from a scope body's SeqStmts to the enclosing
+  // loop body SeqStmts without finding its path-child, and reads after
+  // the scope in the enclosing body would be missed.
+  void VisitStmt_(const InCoreScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+  void VisitStmt_(const AutoInCoreScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+  void VisitStmt_(const ClusterScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+  void VisitStmt_(const HierarchyScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+  void VisitStmt_(const SpmdScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+
  private:
+  template <typename ScopeStmtPtrT>
+  void VisitScope(const ScopeStmtPtrT& op, const StmtPtr& body) {
+    ancestor_stack_.push_back(op);
+    VisitStmt(body);
+    ancestor_stack_.pop_back();
+  }
+
   // Outermost-first stack of enclosing stmts during the walk.
   std::vector<StmtPtr> ancestor_stack_;
 };
@@ -329,8 +347,9 @@ class TopDownRetargeter {
     if (!call) return false;
     const auto& reg = OpRegistry::GetInstance();
     if (!reg.IsRegistered(call->op_->name_)) return false;
+    const auto& entry = reg.GetEntry(call->op_->name_);
 
-    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+    auto reuse_idx = entry.GetOutputReusesInputArg();
     if (reuse_idx.has_value()) {
       // Pinned output: can't change this stmt's LHS MemRef; recurse onto pinned input.
       if (*reuse_idx >= call->args_.size()) return false;
@@ -342,10 +361,40 @@ class TopDownRetargeter {
       return true;
     }
 
+    // Decline retargeting for ops whose output memory is not fully captured
+    // by the LHS type alone:
+    //   1. View ops (set_output_memory_inherit_input) — output MemRef
+    //      inherits the input's view byte_offset_ / size_, which rewriting
+    //      with target's full MemRef would silently drop.
+    //   2. Ops that encode output memory in a `target_memory` kwarg (e.g.
+    //      tile.move / tile.load) — retyping the LHS without also rewriting
+    //      the kwarg leaves the call self-inconsistent.
+    if (IsOutputMemoryInheritInput(entry)) return false;
+    if (HasKwarg(*call, "target_memory")) return false;
+
     // Unconstrained: check liveness, then plan retype.
     if (!IsTargetDeadAtAssign(def, target->base_.get())) return false;
     PlanRewrite(var, target, target_memory);
     return true;
+  }
+
+  /// True when the op is registered with set_output_memory_inherit_input:
+  /// the memory spec exists, has no output_reuses_input_arg, and its
+  /// deduce_output_memory lambda returns nullopt for empty kwargs (the
+  /// signature the inherit-input registration leaves behind).
+  static bool IsOutputMemoryInheritInput(const OpRegistryEntry& entry) {
+    const auto& spec = entry.GetMemorySpec();
+    if (!spec.has_value()) return false;
+    if (spec->output_reuses_input_arg.has_value()) return false;
+    if (!spec->deduce_output_memory) return false;
+    return !spec->deduce_output_memory({}).has_value();
+  }
+
+  static bool HasKwarg(const Call& call, const std::string& key) {
+    for (const auto& [k, _] : call.kwargs_) {
+      if (k == key) return true;
+    }
+    return false;
   }
 
   /// Retype an IfStmt return_var: recurse into both branches' yield values.

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -76,6 +76,380 @@ class VarUseCollector : public IRVisitor {
   }
 };
 
+// ============================================================================
+// Top-down target retargeting
+//
+// Walks nested control flow (ForStmt -> IfStmt -> branches) and, for each
+// ForStmt's iter_arg / return_var chain, pushes the canonical target MemRef
+// (= initValue's MemRef, established by InitMemRef) down through the yield
+// graph. Producers along the chain are rewritten to land on the target:
+//
+//   - Unconstrained producers (plain matmul, move, etc.): retyped to write
+//     directly to the target MemRef.
+//   - Pinned producers (set_output_reuses_input, e.g. matmul_acc): we cannot
+//     change their output MemRef, so we recurse onto the pinned-input var
+//     and try to place that upstream.
+//   - IfStmt return_vars: recurse into both branches' yield values with the
+//     same target, and retype the return_var itself.
+//
+// Liveness check: a retype at AssignStmt S is only safe if target's base Ptr
+// is not read between S and the consuming yield, within the same branch body.
+//
+// Complexity: the retargeter runs a single IR walk to build the def map
+// (O(N)), then one TryRetargetVar per ForStmt iter_arg plus recursion into
+// IfStmt branches.  The liveness check (IsTargetDeadAtAssign / BodyReadsBase)
+// scans the tail of the AssignStmt's containing body; in the worst case of
+// a deep linear chain this is O(N^2).  In practice body tails are short
+// (matmul/accumulator loops have a handful of producers each), so the
+// realised cost is well below that bound; we accept the super-linear worst
+// case rather than threading a precomputed "bases read at-or-after" index
+// that would complicate the pass for no measurable win on typical IR.
+// ============================================================================
+
+/// Collects all base Ptrs referenced by MemRefs in an expression.
+class BasePtrCollector : public IRVisitor {
+ public:
+  std::set<const Var*> bases;
+
+  void VisitExpr_(const VarPtr& var) override {
+    if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
+      bases.insert(GetDefinedMemRef(tile)->base_.get());
+    }
+    IRVisitor::VisitExpr_(var);
+  }
+};
+
+inline std::set<const Var*> CollectBasesUsed(const ExprPtr& expr) {
+  BasePtrCollector c;
+  c.VisitExpr(expr);
+  return c.bases;
+}
+
+inline std::set<const Var*> CollectBasesUsed(const std::vector<ExprPtr>& exprs) {
+  BasePtrCollector c;
+  for (const auto& e : exprs) c.VisitExpr(e);
+  return c.bases;
+}
+
+/// Describes where a TileType Var is defined.
+struct VarDef {
+  enum Kind { kAssign, kIfReturn, kForReturn, kIterArg, kUnknown };
+  Kind kind = kUnknown;
+  StmtPtr assign_stmt;      // AssignStmt (for kAssign)
+  StmtPtr control_stmt;     // IfStmt/ForStmt (for kIfReturn/kForReturn)
+  size_t return_idx = 0;    // index into return_vars_ (for kIfReturn/kForReturn)
+  IterArgPtr iter_arg;      // for kIterArg
+  StmtPtr containing_body;  // the SeqStmts or body stmt that holds assign_stmt
+};
+
+/// Walks the IR once to build def map + seq-containment map.
+class DefMapVisitor : public IRVisitor {
+ public:
+  std::map<VarPtr, VarDef> defs;
+
+  void Run(const StmtPtr& body) { VisitStmt(body); }
+
+ protected:
+  void VisitStmt_(const SeqStmtsPtr& op) override {
+    current_body_stack_.push_back(op);
+    for (const auto& s : op->stmts_) VisitStmt(s);
+    current_body_stack_.pop_back();
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (As<TileType>(op->var_->GetType())) {
+      VarDef d;
+      d.kind = VarDef::kAssign;
+      d.assign_stmt = op;
+      d.containing_body = current_body_stack_.empty() ? nullptr : current_body_stack_.back();
+      defs[op->var_] = d;
+    }
+    if (op->value_) VisitExpr(op->value_);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      const auto& rv = op->return_vars_[i];
+      if (!As<TileType>(rv->GetType())) continue;
+      VarDef d;
+      d.kind = VarDef::kIfReturn;
+      d.control_stmt = op;
+      d.return_idx = i;
+      defs[rv] = d;
+    }
+    VisitStmt(op->then_body_);
+    if (op->else_body_.has_value()) VisitStmt(op->else_body_.value());
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      auto ia = op->iter_args_[i];
+      if (!As<TileType>(ia->GetType())) continue;
+      VarDef d;
+      d.kind = VarDef::kIterArg;
+      d.control_stmt = op;
+      d.return_idx = i;
+      d.iter_arg = ia;
+      defs[std::static_pointer_cast<const Var>(ia)] = d;
+    }
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      const auto& rv = op->return_vars_[i];
+      if (!As<TileType>(rv->GetType())) continue;
+      VarDef d;
+      d.kind = VarDef::kForReturn;
+      d.control_stmt = op;
+      d.return_idx = i;
+      defs[rv] = d;
+    }
+    VisitStmt(op->body_);
+  }
+
+ private:
+  std::vector<StmtPtr> current_body_stack_;
+};
+
+/// Plans top-down retypes. Produces (old Var -> new Type) map.
+class TopDownRetargeter {
+ public:
+  /// Runs the analysis. Returns map: old VarPtr -> new Type (with target MemRef).
+  std::map<VarPtr, TypePtr> Compute(const StmtPtr& func_body) {
+    DefMapVisitor def_v;
+    def_v.Run(func_body);
+    defs_ = std::move(def_v.defs);
+    VisitForStmts(func_body);
+    return std::move(rewrites_);
+  }
+
+ private:
+  std::map<VarPtr, VarDef> defs_;
+  std::map<VarPtr, TypePtr> rewrites_;
+  std::set<VarPtr> visiting_;  // cycle guard
+
+  // Walk IR, calling Propagate for each ForStmt we encounter.
+  void VisitForStmts(const StmtPtr& stmt) {
+    if (!stmt) return;
+    if (auto seq = As<SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) VisitForStmts(s);
+    } else if (auto for_stmt = As<ForStmt>(stmt)) {
+      PropagateFromForStmt(for_stmt);
+      VisitForStmts(for_stmt->body_);
+    } else if (auto if_stmt = As<IfStmt>(stmt)) {
+      VisitForStmts(if_stmt->then_body_);
+      if (if_stmt->else_body_.has_value()) VisitForStmts(if_stmt->else_body_.value());
+    } else if (auto scope = As<ScopeStmt>(stmt)) {
+      VisitForStmts(scope->body_);
+    }
+  }
+
+  void PropagateFromForStmt(const ForStmtPtr& for_stmt) {
+    if (for_stmt->iter_args_.empty()) return;
+    auto yield = FindYieldStmt(for_stmt->body_);
+    if (!yield) return;
+
+    for (size_t i = 0; i < for_stmt->iter_args_.size() && i < yield->value_.size(); ++i) {
+      auto ia = for_stmt->iter_args_[i];
+      auto ia_tile = GetTileTypeWithMemRef(ia->GetType());
+      if (!ia_tile) continue;
+      auto target_memref = GetDefinedMemRef(ia_tile);
+      auto target_memory = ia_tile->GetMemorySpace();
+
+      auto yield_var = As<Var>(yield->value_[i]);
+      if (!yield_var) continue;
+
+      TryRetargetVar(yield_var, target_memref, target_memory);
+    }
+  }
+
+  /// Current (possibly-rewritten) MemRef base of `var`.
+  const Var* CurrentBase(const VarPtr& var) {
+    auto it = rewrites_.find(var);
+    auto type = (it != rewrites_.end()) ? it->second : var->GetType();
+    auto tile = GetTileTypeWithMemRef(type);
+    if (!tile) return nullptr;
+    return GetDefinedMemRef(tile)->base_.get();
+  }
+
+  /// Attempts to rewrite `var`'s MemRef to `target` by walking its producer chain.
+  /// Returns true if var already has target MemRef or a rewrite was planned.
+  bool TryRetargetVar(const VarPtr& var, const MemRefPtr& target, std::optional<MemorySpace> target_memory) {
+    if (CurrentBase(var) == target->base_.get()) return true;  // already aligned
+    if (!visiting_.insert(var).second) return false;           // cycle
+    struct Guard {
+      std::set<VarPtr>* s;
+      VarPtr v;
+      ~Guard() { s->erase(v); }
+    } g{&visiting_, var};
+
+    auto it = defs_.find(var);
+    if (it == defs_.end()) return false;
+    const auto& def = it->second;
+
+    if (def.kind == VarDef::kAssign) {
+      return RetargetAssign(var, def, target, target_memory);
+    }
+    if (def.kind == VarDef::kIfReturn) {
+      return RetargetIfReturn(var, def, target, target_memory);
+    }
+    // kIterArg / kForReturn / kUnknown: can't retarget directly.
+    return false;
+  }
+
+  /// Retype a Var defined by an AssignStmt.
+  bool RetargetAssign(const VarPtr& var, const VarDef& def, const MemRefPtr& target,
+                      std::optional<MemorySpace> target_memory) {
+    auto assign = As<AssignStmt>(def.assign_stmt);
+    INTERNAL_CHECK(assign) << "Internal error: kAssign VarDef must carry an AssignStmt";
+    auto call = As<Call>(assign->value_);
+    if (!call) return false;
+    const auto& reg = OpRegistry::GetInstance();
+    if (!reg.IsRegistered(call->op_->name_)) return false;
+
+    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+    if (reuse_idx.has_value()) {
+      // Pinned output: can't change this stmt's LHS MemRef; recurse onto pinned input.
+      if (*reuse_idx >= call->args_.size()) return false;
+      auto input_var = As<Var>(call->args_[*reuse_idx]);
+      if (!input_var) return false;
+      if (!TryRetargetVar(input_var, target, target_memory)) return false;
+      // Also record that `var`'s MemRef should follow the pinned input to target.
+      PlanRewrite(var, target, target_memory);
+      return true;
+    }
+
+    // Unconstrained: check liveness, then plan retype.
+    if (!IsTargetDeadAtAssign(def, target->base_.get())) return false;
+    PlanRewrite(var, target, target_memory);
+    return true;
+  }
+
+  /// Retype an IfStmt return_var: recurse into both branches' yield values.
+  bool RetargetIfReturn(const VarPtr& var, const VarDef& def, const MemRefPtr& target,
+                        std::optional<MemorySpace> target_memory) {
+    auto if_stmt = As<IfStmt>(def.control_stmt);
+    if (!if_stmt) return false;
+    size_t idx = def.return_idx;
+
+    auto visit_branch = [&](const StmtPtr& body) -> bool {
+      auto y = FindYieldStmt(body);
+      if (!y || idx >= y->value_.size()) return false;
+      auto yv = As<Var>(y->value_[idx]);
+      if (!yv) return false;
+      return TryRetargetVar(yv, target, target_memory);
+    };
+
+    bool then_ok = visit_branch(if_stmt->then_body_);
+    bool else_ok = if_stmt->else_body_.has_value() ? visit_branch(if_stmt->else_body_.value()) : true;
+    if (!then_ok || !else_ok) return false;
+
+    PlanRewrite(var, target, target_memory);
+    return true;
+  }
+
+  void PlanRewrite(const VarPtr& var, const MemRefPtr& target, std::optional<MemorySpace> target_memory) {
+    auto new_type = CloneTypeWithMemRef(var->GetType(), target, target_memory);
+    rewrites_[var] = new_type;
+  }
+
+  /// Is target's base Ptr unread between the AssignStmt and the end of its containing body?
+  /// Also walks into nested control flow to check for reads there.
+  bool IsTargetDeadAtAssign(const VarDef& def, const Var* target_base) {
+    auto seq = As<SeqStmts>(def.containing_body);
+    // Non-SeqStmts containing body means the AssignStmt is the *entire* body
+    // of its enclosing scope (IfStmt/ForStmt/ScopeStmt branch with a single
+    // child after NormalizeStmtStructure).  Nothing follows it in that scope,
+    // so target is trivially dead by the end of the body.  Retargetable yield
+    // producers always have a sibling YieldStmt, so this branch only fires
+    // for AssignStmts the retargeter would never plan to rewrite in the
+    // first place; treating it as "dead" is both safe and unreachable-in-
+    // practice for the rewrite path.
+    if (!seq) return true;
+    auto it = std::find(seq->stmts_.begin(), seq->stmts_.end(), def.assign_stmt);
+    if (it == seq->stmts_.end()) return true;
+    for (++it; it != seq->stmts_.end(); ++it) {
+      if (BodyReadsBase(*it, target_base)) return false;
+    }
+    return true;
+  }
+
+  /// Whether any stmt in the given subtree reads a tile with `target_base`.
+  /// Reads = any Var reference in expressions. Writes (LHS of AssignStmt) don't count.
+  bool BodyReadsBase(const StmtPtr& stmt, const Var* target_base) {
+    if (!stmt) return false;
+    if (auto seq = As<SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) {
+        if (BodyReadsBase(s, target_base)) return true;
+      }
+      return false;
+    }
+    if (auto a = As<AssignStmt>(stmt)) {
+      if (!a->value_) return false;
+      auto bases = CollectBasesUsed(a->value_);
+      return bases.count(target_base) > 0;
+    }
+    if (auto y = As<YieldStmt>(stmt)) {
+      auto bases = CollectBasesUsed(y->value_);
+      return bases.count(target_base) > 0;
+    }
+    if (auto r = As<ReturnStmt>(stmt)) {
+      auto bases = CollectBasesUsed(r->value_);
+      return bases.count(target_base) > 0;
+    }
+    if (auto i = As<IfStmt>(stmt)) {
+      if (CollectBasesUsed(i->condition_).count(target_base) > 0) return true;
+      if (BodyReadsBase(i->then_body_, target_base)) return true;
+      if (i->else_body_.has_value() && BodyReadsBase(i->else_body_.value(), target_base)) return true;
+      return false;
+    }
+    if (auto f = As<ForStmt>(stmt)) {
+      // Reading iter_arg init = reading some outer var; count as read only if base matches.
+      for (const auto& ia : f->iter_args_) {
+        if (ia->initValue_ && CollectBasesUsed(ia->initValue_).count(target_base) > 0) return true;
+      }
+      if (BodyReadsBase(f->body_, target_base)) return true;
+      return false;
+    }
+    if (auto s = As<ScopeStmt>(stmt)) return BodyReadsBase(s->body_, target_base);
+    return false;
+  }
+};
+
+/// Applies planned retypes to the IR.
+class RetypeApplier : public IRMutator {
+ public:
+  explicit RetypeApplier(std::map<VarPtr, TypePtr> rewrites) : rewrites_(std::move(rewrites)) {}
+
+  ExprPtr VisitExpr_(const VarPtr& op) override {
+    auto it = var_substitution_.find(op);
+    if (it != var_substitution_.end()) return it->second;
+    return op;
+  }
+
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto rit = rewrites_.find(op->var_);
+    if (rit != rewrites_.end()) {
+      auto new_var = std::make_shared<Var>(op->var_->name_hint_, rit->second, op->var_->span_);
+      var_substitution_[op->var_] = new_var;
+    }
+    return IRMutator::VisitStmt_(op);
+  }
+
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
+    // Pre-register substitutions for any retargeted return_var; the default
+    // IRMutator IfStmt handler will then pick them up through VisitExpr_(Var).
+    for (const auto& rv : op->return_vars_) {
+      auto rit = rewrites_.find(rv);
+      if (rit != rewrites_.end()) {
+        var_substitution_[rv] = std::make_shared<Var>(rv->name_hint_, rit->second, rv->span_);
+      }
+    }
+    return IRMutator::VisitStmt_(op);
+  }
+
+ private:
+  std::map<VarPtr, TypePtr> rewrites_;
+  std::map<VarPtr, VarPtr> var_substitution_;
+};
+
 /**
  * @brief Full IR tree walker for lifetime analysis.
  *
@@ -993,8 +1367,21 @@ StmtPtr RemoveUnusedAllocStatements(const StmtPtr& body, const std::set<const Va
 FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   INTERNAL_CHECK(func) << "MemoryReusePass cannot run on null function";
 
+  // Step 0: Top-down retarget — propagate iter_arg/initValue MemRefs down the
+  // yield chain so accumulator producers land directly in the canonical buffer.
+  // This eliminates most accumulator-related move insertions downstream.
+  StmtPtr new_body = func->body_;
+  {
+    TopDownRetargeter retargeter;
+    auto rewrites = retargeter.Compute(new_body);
+    if (!rewrites.empty()) {
+      RetypeApplier applier(std::move(rewrites));
+      new_body = applier.VisitStmt(new_body);
+    }
+  }
+
   // Step 1: Compute lifetimes by walking full IR tree
-  auto analysis_result = ComputeLifetimes(func->body_);
+  auto analysis_result = ComputeLifetimes(new_body);
 
   if (analysis_result.lifetimes.empty()) {
     LOG_WARN << "No TileType variables found, skipping memory reuse";
@@ -1005,9 +1392,8 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   auto reuse_map = IdentifyReuseOpportunities(analysis_result.lifetimes);
 
   // Step 3: Apply MemRef sharing (skip if no reuse candidates)
-  StmtPtr new_body = func->body_;
   if (!reuse_map.empty()) {
-    new_body = ApplyMemRefSharing(func->body_, reuse_map, analysis_result.var_sharing_groups);
+    new_body = ApplyMemRefSharing(new_body, reuse_map, analysis_result.var_sharing_groups);
   }
 
   // Step 4: Fix ForStmt/IfStmt yield/return_var MemRef mismatches

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -93,56 +93,42 @@ class VarUseCollector : public IRVisitor {
 //     same target, and retype the return_var itself.
 //
 // Liveness check: a retype at AssignStmt S is only safe if target's base Ptr
-// is not read between S and the consuming yield, within the same branch body.
+// is not read between S and the enclosing ForStmt's yield.  The check walks
+// S's full ancestor chain (innermost out), and at each enclosing SeqStmts
+// scans the siblings that execute after the current walk node.  That covers
+// reads inside the same branch, reads after a nested IfStmt in the parent
+// body, and so on up to the enclosing ForStmt — where the retyped value is
+// consumed.
 //
 // Complexity: the retargeter runs a single IR walk to build the def map
 // (O(N)), then one TryRetargetVar per ForStmt iter_arg plus recursion into
-// IfStmt branches.  The liveness check (IsTargetDeadAtAssign / BodyReadsBase)
-// scans the tail of the AssignStmt's containing body; in the worst case of
-// a deep linear chain this is O(N^2).  In practice body tails are short
-// (matmul/accumulator loops have a handful of producers each), so the
-// realised cost is well below that bound; we accept the super-linear worst
-// case rather than threading a precomputed "bases read at-or-after" index
-// that would complicate the pass for no measurable win on typical IR.
+// IfStmt branches.  The liveness check scans the tail of each enclosing
+// SeqStmts up to the owning ForStmt; in the worst case of a deep linear
+// chain this is O(N^2).  In practice body tails are short (matmul/
+// accumulator loops have a handful of producers each), so the realised
+// cost is well below that bound; we accept the super-linear worst case
+// rather than threading a precomputed "bases read at-or-after" index that
+// would complicate the pass for no measurable win on typical IR.
 // ============================================================================
-
-/// Collects all base Ptrs referenced by MemRefs in an expression.
-class BasePtrCollector : public IRVisitor {
- public:
-  std::set<const Var*> bases;
-
-  void VisitExpr_(const VarPtr& var) override {
-    if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
-      bases.insert(GetDefinedMemRef(tile)->base_.get());
-    }
-    IRVisitor::VisitExpr_(var);
-  }
-};
-
-inline std::set<const Var*> CollectBasesUsed(const ExprPtr& expr) {
-  BasePtrCollector c;
-  c.VisitExpr(expr);
-  return c.bases;
-}
-
-inline std::set<const Var*> CollectBasesUsed(const std::vector<ExprPtr>& exprs) {
-  BasePtrCollector c;
-  for (const auto& e : exprs) c.VisitExpr(e);
-  return c.bases;
-}
 
 /// Describes where a TileType Var is defined.
 struct VarDef {
   enum Kind { kAssign, kIfReturn, kForReturn, kIterArg, kUnknown };
   Kind kind = kUnknown;
-  StmtPtr assign_stmt;      // AssignStmt (for kAssign)
-  StmtPtr control_stmt;     // IfStmt/ForStmt (for kIfReturn/kForReturn)
-  size_t return_idx = 0;    // index into return_vars_ (for kIfReturn/kForReturn)
-  IterArgPtr iter_arg;      // for kIterArg
-  StmtPtr containing_body;  // the SeqStmts or body stmt that holds assign_stmt
+  StmtPtr assign_stmt;    // AssignStmt (for kAssign)
+  StmtPtr control_stmt;   // IfStmt/ForStmt (for kIfReturn/kForReturn)
+  size_t return_idx = 0;  // index into return_vars_ (for kIfReturn/kForReturn)
+  IterArgPtr iter_arg;    // for kIterArg
+  // Full chain of enclosing stmts from outermost to innermost (does *not*
+  // include the assign_stmt itself).  Populated for kAssign defs and used
+  // by the liveness check to walk up through nested IfStmt branches to the
+  // enclosing ForStmt's body.
+  std::vector<StmtPtr> ancestors;
 };
 
-/// Walks the IR once to build def map + seq-containment map.
+/// Walks the IR once to build the def map, recording every AssignStmt's full
+/// enclosing-stmt chain so the liveness check can walk up past IfStmt /
+/// ScopeStmt branches into the enclosing loop body.
 class DefMapVisitor : public IRVisitor {
  public:
   std::map<VarPtr, VarDef> defs;
@@ -150,10 +136,17 @@ class DefMapVisitor : public IRVisitor {
   void Run(const StmtPtr& body) { VisitStmt(body); }
 
  protected:
+  // Generic: every stmt becomes an ancestor of its children.  We push on
+  // enter and pop on exit so per-def ancestor snapshots are correct.
+  void VisitStmt(const StmtPtr& stmt) override {
+    if (!stmt) return;
+    IRVisitor::VisitStmt(stmt);
+  }
+
   void VisitStmt_(const SeqStmtsPtr& op) override {
-    current_body_stack_.push_back(op);
+    ancestor_stack_.push_back(op);
     for (const auto& s : op->stmts_) VisitStmt(s);
-    current_body_stack_.pop_back();
+    ancestor_stack_.pop_back();
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -161,7 +154,7 @@ class DefMapVisitor : public IRVisitor {
       VarDef d;
       d.kind = VarDef::kAssign;
       d.assign_stmt = op;
-      d.containing_body = current_body_stack_.empty() ? nullptr : current_body_stack_.back();
+      d.ancestors = ancestor_stack_;
       defs[op->var_] = d;
     }
     if (op->value_) VisitExpr(op->value_);
@@ -177,8 +170,10 @@ class DefMapVisitor : public IRVisitor {
       d.return_idx = i;
       defs[rv] = d;
     }
+    ancestor_stack_.push_back(op);
     VisitStmt(op->then_body_);
     if (op->else_body_.has_value()) VisitStmt(op->else_body_.value());
+    ancestor_stack_.pop_back();
   }
 
   void VisitStmt_(const ForStmtPtr& op) override {
@@ -201,12 +196,43 @@ class DefMapVisitor : public IRVisitor {
       d.return_idx = i;
       defs[rv] = d;
     }
+    ancestor_stack_.push_back(op);
     VisitStmt(op->body_);
+    ancestor_stack_.pop_back();
   }
 
  private:
-  std::vector<StmtPtr> current_body_stack_;
+  // Outermost-first stack of enclosing stmts during the walk.
+  std::vector<StmtPtr> ancestor_stack_;
 };
+
+/// Visits a stmt subtree and collects the MemRef base Ptrs of every *read*
+/// of a TileType Var.  Writes (the LHS of an AssignStmt) are intentionally
+/// excluded; every other stmt/expression kind dispatches through the default
+/// IRVisitor traversal, so new stmt types are covered automatically.
+class SubtreeReadBaseCollector : public IRVisitor {
+ public:
+  std::set<const Var*> bases;
+
+  void VisitExpr_(const VarPtr& var) override {
+    if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
+      bases.insert(GetDefinedMemRef(tile)->base_.get());
+    }
+    IRVisitor::VisitExpr_(var);
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // Skip op->var_ — the LHS is a definition, not a read.
+    if (op->value_) VisitExpr(op->value_);
+  }
+};
+
+inline bool SubtreeReadsBase(const StmtPtr& stmt, const Var* target_base) {
+  if (!stmt) return false;
+  SubtreeReadBaseCollector c;
+  c.VisitStmt(stmt);
+  return c.bases.count(target_base) > 0;
+}
 
 /// Plans top-down retypes. Produces (old Var -> new Type) map.
 class TopDownRetargeter {
@@ -352,64 +378,41 @@ class TopDownRetargeter {
 
   /// Is target's base Ptr unread between the AssignStmt and the end of its containing body?
   /// Also walks into nested control flow to check for reads there.
+  /// Liveness check: walks the AssignStmt's full ancestor chain from innermost
+  /// outward and, at every enclosing SeqStmts, scans the siblings that execute
+  /// after the AssignStmt for reads of `target_base`.  Walking continues past
+  /// IfStmt branches into the parent body so reads that appear after a nested
+  /// IfStmt (but still within the enclosing ForStmt's body) are detected.  The
+  /// walk stops at the first enclosing ForStmt — reads outside the loop body
+  /// cannot observe the retyped value, which is consumed at the loop yield.
   bool IsTargetDeadAtAssign(const VarDef& def, const Var* target_base) {
-    auto seq = As<SeqStmts>(def.containing_body);
-    // Non-SeqStmts containing body means the AssignStmt is the *entire* body
-    // of its enclosing scope (IfStmt/ForStmt/ScopeStmt branch with a single
-    // child after NormalizeStmtStructure).  Nothing follows it in that scope,
-    // so target is trivially dead by the end of the body.  Retargetable yield
-    // producers always have a sibling YieldStmt, so this branch only fires
-    // for AssignStmts the retargeter would never plan to rewrite in the
-    // first place; treating it as "dead" is both safe and unreachable-in-
-    // practice for the rewrite path.
-    if (!seq) return true;
-    auto it = std::find(seq->stmts_.begin(), seq->stmts_.end(), def.assign_stmt);
-    if (it == seq->stmts_.end()) return true;
-    for (++it; it != seq->stmts_.end(); ++it) {
-      if (BodyReadsBase(*it, target_base)) return false;
+    if (def.ancestors.empty()) return true;
+
+    // `child_on_path` is the direct descendant of the current ancestor that
+    // lies on the walk path toward the AssignStmt.  We update it as we step
+    // outward so that, at each SeqStmts level, we can locate it in stmts_.
+    StmtPtr child_on_path = def.assign_stmt;
+
+    for (auto it = def.ancestors.rbegin(); it != def.ancestors.rend(); ++it) {
+      const auto& anc = *it;
+
+      if (auto seq = As<SeqStmts>(anc)) {
+        auto pos = std::find(seq->stmts_.begin(), seq->stmts_.end(), child_on_path);
+        if (pos != seq->stmts_.end()) {
+          for (++pos; pos != seq->stmts_.end(); ++pos) {
+            if (SubtreeReadsBase(*pos, target_base)) return false;
+          }
+        }
+      }
+
+      // Stop once we've scanned the body of the enclosing ForStmt: the
+      // retyped value is consumed by that loop's yield, so anything outside
+      // the loop cannot observe it.
+      if (As<ForStmt>(anc)) return true;
+
+      child_on_path = anc;
     }
     return true;
-  }
-
-  /// Whether any stmt in the given subtree reads a tile with `target_base`.
-  /// Reads = any Var reference in expressions. Writes (LHS of AssignStmt) don't count.
-  bool BodyReadsBase(const StmtPtr& stmt, const Var* target_base) {
-    if (!stmt) return false;
-    if (auto seq = As<SeqStmts>(stmt)) {
-      for (const auto& s : seq->stmts_) {
-        if (BodyReadsBase(s, target_base)) return true;
-      }
-      return false;
-    }
-    if (auto a = As<AssignStmt>(stmt)) {
-      if (!a->value_) return false;
-      auto bases = CollectBasesUsed(a->value_);
-      return bases.count(target_base) > 0;
-    }
-    if (auto y = As<YieldStmt>(stmt)) {
-      auto bases = CollectBasesUsed(y->value_);
-      return bases.count(target_base) > 0;
-    }
-    if (auto r = As<ReturnStmt>(stmt)) {
-      auto bases = CollectBasesUsed(r->value_);
-      return bases.count(target_base) > 0;
-    }
-    if (auto i = As<IfStmt>(stmt)) {
-      if (CollectBasesUsed(i->condition_).count(target_base) > 0) return true;
-      if (BodyReadsBase(i->then_body_, target_base)) return true;
-      if (i->else_body_.has_value() && BodyReadsBase(i->else_body_.value(), target_base)) return true;
-      return false;
-    }
-    if (auto f = As<ForStmt>(stmt)) {
-      // Reading iter_arg init = reading some outer var; count as read only if base matches.
-      for (const auto& ia : f->iter_args_) {
-        if (ia->initValue_ && CollectBasesUsed(ia->initValue_).count(target_base) > 0) return true;
-      }
-      if (BodyReadsBase(f->body_, target_base)) return true;
-      return false;
-    }
-    if (auto s = As<ScopeStmt>(stmt)) return BodyReadsBase(s->body_, target_base);
-    return false;
   }
 };
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -369,13 +369,28 @@ class TopDownRetargeter {
     //   2. Ops that encode output memory in a `target_memory` kwarg (e.g.
     //      tile.move / tile.load) — retyping the LHS without also rewriting
     //      the kwarg leaves the call self-inconsistent.
+    //   3. Ops registered `not_inplace_safe()` (e.g. tile.mrgsort_format1)
+    //      whose implementation requires src buffer != dst buffer.  If any
+    //      input of the call already lives on `target_base`, retyping the
+    //      output onto the same buffer creates an in-place execution that
+    //      the op cannot handle and fails at runtime.
     if (IsOutputMemoryInheritInput(entry)) return false;
     if (HasKwarg(*call, "target_memory")) return false;
+    if (!entry.IsInplaceSafe() && CallReadsBase(*call, target->base_.get())) return false;
 
     // Unconstrained: check liveness, then plan retype.
     if (!IsTargetDeadAtAssign(def, target->base_.get())) return false;
     PlanRewrite(var, target, target_memory);
     return true;
+  }
+
+  /// True if any argument of the call is a TileType Var whose MemRef base
+  /// is `target_base`.  Used to detect would-be in-place execution before
+  /// we retype the output onto the same buffer.
+  static bool CallReadsBase(const Call& call, const Var* target_base) {
+    SubtreeReadBaseCollector c;
+    for (const auto& arg : call.args_) c.VisitExpr(arg);
+    return c.bases.count(target_base) > 0;
   }
 
   /// True when the op is registered with set_output_memory_inherit_input:

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1137,9 +1137,9 @@ class TestInplaceOps:
 class TestYieldFixup:
     """Yield fixup for ForStmt and IfStmt -- ensuring loop-carry and return variables share correct MemRef."""
 
-    def test_tile_move_inserted_when_memrefs_diverge(self):
-        """When initValue and yield value start with different MemRefs,
-        a tile.move is inserted to unify all loop-carry vars to one MemRef.
+    def test_producer_retyped_to_iter_arg_buffer(self):
+        """The yield producer is retyped directly to the iter_arg's MemRef
+        (no tile.move inserted). Intermediate 'extra_0' keeps its own buffer.
         """
 
         @pl.program
@@ -1160,9 +1160,9 @@ class TestYieldFixup:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(out_0, [0, 0], output)
                 return result
 
-        # init_0 uses mem_vec_2; loop body uses mem_vec_3 for extra_0/next_0;
-        # tile.move converts next_0 -> next_0_mv with mem_vec_2 so the yield
-        # value matches the iter_arg's MemRef.
+        # init_0/acc_0/next_0/out_0 all share mem_vec_2 (the iter_arg buffer).
+        # The retargeter places next_0 directly on mem_vec_2; extra_0 (not the
+        # yield value) keeps its own buffer mem_vec_3. No tile.move is needed.
         @pl.program
         class Expected:
             @pl.function
@@ -1180,14 +1180,11 @@ class TestYieldFixup:
                     extra_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc_0, acc_0)
                     )
-                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(extra_0, acc_0)
                     )
-                    next_0_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(next_0, target_memory=pl.Mem.Vec)
-                    )
                     out_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.yield_(
-                        next_0_mv
+                        next_0
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     out_0, [0, 0], output
@@ -1198,11 +1195,9 @@ class TestYieldFixup:
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
     def test_simple_loop_memrefs_unified(self):
-        """Simple loop: after reuse, iter_arg/initValue/return_var share MemRef.
-
-        Even with no extra ops, tile.move is still inserted because the
-        MemoryReuse pass first allocates a separate buffer for next_0 and
-        then unifies via move.
+        """Simple loop: iter_arg/initValue/return_var/next_0 all land in a
+        single MemRef. The retargeter retypes next_0 directly, so no
+        intermediate buffer or tile.move is needed.
         """
 
         @pl.program
@@ -1231,19 +1226,15 @@ class TestYieldFixup:
                 output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 init_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
                 for _i, (acc_0,) in pl.range(4, init_values=(init_0,)):
-                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc_0, acc_0)
                     )
-                    next_0_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(next_0, target_memory=pl.Mem.Vec)
-                    )
                     out_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.yield_(
-                        next_0_mv
+                        next_0
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     out_0, [0, 0], output
@@ -1253,8 +1244,11 @@ class TestYieldFixup:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
-    def test_multiple_iter_args_partial_mismatch(self):
-        """With 2 iter_args, tile.move is inserted for each mismatched pair."""
+    def test_multiple_iter_args_producers_retyped_independently(self):
+        """With 2 iter_args, the retargeter retypes each yield producer
+        directly to its own iter_arg buffer. Intermediate chains share a
+        single scratch buffer.
+        """
 
         @pl.program
         class Before:
@@ -1279,9 +1273,9 @@ class TestYieldFixup:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(out_0, [0, 0], output)
                 return result
 
-        # init_0/init_1 each get their own buffer (mem_vec_2, mem_vec_3).
-        # Loop body uses mem_vec_4/mem_vec_6 for the two intermediate chains.
-        # Two tile.move ops unify next_0/next_1 to init buffers.
+        # init_0 -> mem_vec_2 and init_1 -> mem_vec_3 (loop-carry buffers).
+        # next_0/next_1 retyped directly to mem_vec_2/mem_vec_3; extra_0 and
+        # extra_1 share a single scratch buffer mem_vec_4. No tile.move ops.
         @pl.program
         class Expected:
             @pl.function
@@ -1293,7 +1287,6 @@ class TestYieldFixup:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_6: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 init_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
@@ -1304,22 +1297,16 @@ class TestYieldFixup:
                     extra_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc_0, acc_0)
                     )
-                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
+                    next_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(extra_0, acc_0)
                     )
-                    extra_1: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_6, 0, 16384), pl.Mem.Vec] = (
+                    extra_1: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc_1, acc_1)
                     )
-                    next_1: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_6, 0, 16384), pl.Mem.Vec] = (
+                    next_1: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(extra_1, acc_1)
                     )
-                    next_0_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(next_0, target_memory=pl.Mem.Vec)
-                    )
-                    next_1_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(next_1, target_memory=pl.Mem.Vec)
-                    )
-                    out_0, out_1 = pl.yield_(next_0_mv, next_1_mv)
+                    out_0, out_1 = pl.yield_(next_0, next_1)
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     out_0, [0, 0], output
                 )
@@ -1489,9 +1476,12 @@ class TestYieldFixup:
 class TestControlFlow:
     """Tests for correct lifetime analysis across control flow boundaries."""
 
-    def test_var_used_in_nested_if_not_reused_in_loop(self):
-        """tile_a is used inside loop body so it stays live across the loop;
-        tile_c gets a separate buffer; tile.move unifies the loop-carry."""
+    def test_var_used_in_nested_if_shares_iter_arg_buffer(self):
+        """The iter_arg `acc` and its initValue `tile_a` share MemRef via
+        InitMemRef. The retargeter further propagates that MemRef through
+        the IfStmt's return_var and both branches' yield values, so every
+        tile in the yield chain lands on the iter_arg buffer.
+        """
 
         @pl.program
         class Before:
@@ -1514,6 +1504,10 @@ class TestControlFlow:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
                 return result
 
+        # tile_a/acc/tile_c/if_result/loop_out all share mem_vec_2. The else
+        # branch already yields `acc` (already on mem_vec_2), and the then
+        # branch's tile_c is retargeted onto mem_vec_2 since mem_vec_2 is
+        # not read after tile_c's write inside the branch body.
         @pl.program
         class Expected:
             @pl.function
@@ -1523,27 +1517,23 @@ class TestControlFlow:
                 output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
                 for i, (acc,) in pl.range(4, init_values=(tile_a,)):
                     if i < 2:
-                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                             pl.tile.add(acc, tile_a)
                         )
-                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                             pl.yield_(tile_c)
                         )
                     else:
-                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                             pl.yield_(acc)
                         )
-                    if_result_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(if_result, target_memory=pl.Mem.Vec)
-                    )
                     loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.yield_(if_result_mv)
+                        pl.yield_(if_result)
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     loop_out, [0, 0], output
@@ -1626,8 +1616,10 @@ class TestControlFlow:
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
     def test_loop_local_var_can_be_reused(self):
-        """Variables defined AND used entirely within a single loop iteration
-        can still be reused with other loop-local variables."""
+        """Loop-local vars share a scratch buffer; the yield producer is
+        retyped directly to the iter_arg buffer. tile_x/tile_y share a
+        scratch, tile_z (the yield value) lands on init_tile's buffer.
+        """
 
         @pl.program
         class Before:
@@ -1650,8 +1642,9 @@ class TestControlFlow:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
                 return result
 
-        # init_tile uses mem_vec_2; loop body uses mem_vec_3 for the chain;
-        # tile.move inserts a copy at the yield to reset to init's MemRef.
+        # init_tile/acc/tile_z/loop_out on mem_vec_2; tile_x/tile_y share
+        # scratch mem_vec_3. The retargeter retypes tile_z directly to
+        # mem_vec_2, so no tile.move is needed at yield.
         @pl.program
         class Expected:
             @pl.function
@@ -1679,14 +1672,11 @@ class TestControlFlow:
                     tile_y: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(tile_x, tile_x)
                     )
-                    tile_z: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                    tile_z: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(tile_y, tile_y)
                     )
-                    tile_z_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(tile_z, target_memory=pl.Mem.Vec)
-                    )
                     loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
-                        pl.yield_(tile_z_mv)
+                        pl.yield_(tile_z)
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     loop_out, [0, 0], output
@@ -1698,7 +1688,10 @@ class TestControlFlow:
 
     def test_nested_for_loops_outer_var_extends_to_outer_end(self):
         """Variable defined before nested loops, used in inner loop body --
-        lifetime extends to the END of the OUTER loop (not just inner)."""
+        lifetime extends to the END of the OUTER loop. With the retargeter,
+        each level's yield producer is retyped directly onto that level's
+        iter_arg buffer; no tile.move ops are inserted.
+        """
 
         @pl.program
         class Before:
@@ -1726,10 +1719,10 @@ class TestControlFlow:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(outer_out, [0, 0], output)
                 return result
 
-        # tile_a (mem_vec_2), init_outer (mem_vec_3), init_inner (mem_vec_4),
-        # tile_b (mem_vec_5) — tile_a stays live across both loops, so it
-        # never gets reused. tile.move pairs unify yields back to outer/inner
-        # iter_arg buffers.
+        # tile_a is live across both loops on mem_vec_2. init_outer/acc_outer
+        # share mem_vec_3; init_inner/acc_inner share mem_vec_4. tile_b
+        # (inner yield) is retyped to mem_vec_4, tile_d (outer yield) to
+        # mem_vec_3. No scratch buffer for tile_b is allocated.
         @pl.program
         class Expected:
             @pl.function
@@ -1741,7 +1734,6 @@ class TestControlFlow:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_5: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
@@ -1753,23 +1745,17 @@ class TestControlFlow:
                         pl.tile.create([64, 64], dtype=pl.FP32, target_memory=pl.Mem.Vec)
                     )
                     for _j, (acc_inner,) in pl.range(4, init_values=(init_inner,)):
-                        tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                             pl.tile.add(acc_inner, tile_a)
                         )
-                        tile_b_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
-                            pl.tile.move(tile_b, target_memory=pl.Mem.Vec)
-                        )
                         inner_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
-                            pl.yield_(tile_b_mv)
+                            pl.yield_(tile_b)
                         )
-                    tile_d: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
+                    tile_d: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc_outer, inner_out)
                     )
-                    tile_d_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(tile_d, target_memory=pl.Mem.Vec)
-                    )
                     outer_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.yield_(tile_d_mv)
+                        pl.yield_(tile_d)
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     outer_out, [0, 0], output
@@ -1839,8 +1825,11 @@ class TestControlFlow:
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
     def test_for_with_if_multiple_vars_competing(self):
-        """ForStmt with IfStmt inside, multiple variables from before the loop
-        used inside the if -- all outer variables stay live across the loop."""
+        """ForStmt with IfStmt inside: `tile_a` and `tile_b` are live across
+        the loop on distinct buffers. The retargeter propagates the
+        iter_arg buffer through the IfStmt's return_var and both branches'
+        yield producers (both unconstrained adds with liveness OK).
+        """
 
         @pl.program
         class Before:
@@ -1870,9 +1859,9 @@ class TestControlFlow:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
                 return result
 
-        # tile_a → mem_vec_2, tile_b → mem_vec_3 (both live across loop).
-        # init_tile → mem_vec_4 (loop-carry buffer).
-        # tile_c/tile_d → mem_vec_5 (different branches share).
+        # tile_a -> mem_vec_2, tile_b -> mem_vec_3 (both live across loop).
+        # init_tile/acc/tile_c/tile_d/if_result/loop_out all share mem_vec_4
+        # via the retargeter.
         @pl.program
         class Expected:
             @pl.function
@@ -1884,7 +1873,6 @@ class TestControlFlow:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_5: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
@@ -1896,24 +1884,21 @@ class TestControlFlow:
                 )
                 for i, (acc,) in pl.range(4, init_values=(init_tile,)):
                     if i < 2:
-                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                             pl.tile.add(tile_a, tile_b)
                         )
-                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                             pl.yield_(tile_c)
                         )
                     else:
-                        tile_d: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        tile_d: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                             pl.tile.add(tile_b, tile_a)
                         )
-                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
                             pl.yield_(tile_d)
                         )
-                    if_result_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(if_result, target_memory=pl.Mem.Vec)
-                    )
                     loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
-                        pl.yield_(if_result_mv)
+                        pl.yield_(if_result)
                     )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     loop_out, [0, 0], output
@@ -1993,9 +1978,13 @@ class TestControlFlow:
         """Return_var used after loop must block reuse of initValue's MemRef.
 
         Regression test for issue #768: MemoryReuse allowed a post-loop
-        variable to reuse the initValue's MemRef, but YieldFixup later
-        placed the loop output in the same buffer, causing the accumulated
-        result to be overwritten before the final add consumed it.
+        variable to reuse the initValue's MemRef, causing the accumulated
+        result to be overwritten before the final add consumed it. The
+        critical invariant — `resid` must NOT take the loop-carry buffer
+        `mem_vec_3` — is still enforced. The retargeter additionally
+        retypes `acc_next` directly to `mem_vec_3`, eliminating the
+        tile.move the old pipeline emitted, but the #768 guard is
+        unchanged.
         """
 
         @pl.program
@@ -2021,9 +2010,10 @@ class TestControlFlow:
                 return result
 
         # o_acc/o_acc_z/loop_out/final all share mem_vec_3 (loop-carry buffer).
-        # chunk/acc_next reuse mem_vec_5 inside the loop, and resid reuses
-        # mem_vec_5 because chunk/acc_next are dead by then. Crucially, resid
-        # does NOT take mem_vec_3 — that would clobber the loop result.
+        # acc_next is retyped directly to mem_vec_3 by the retargeter.
+        # chunk lives on mem_vec_5 inside the loop; resid reuses mem_vec_5
+        # because chunk is dead by then. Crucially, resid does NOT take
+        # mem_vec_3 -- that would clobber the loop result (#768 regression).
         @pl.program
         class Expected:
             @pl.function
@@ -2047,14 +2037,11 @@ class TestControlFlow:
                             input_a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                         )
                     )
-                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(acc, chunk)
                     )
-                    acc_next_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.move(acc_next, target_memory=pl.Mem.Vec)
-                    )
                     loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.yield_(acc_next_mv)
+                        pl.yield_(acc_next)
                     )
                 resid: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_b, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
@@ -2064,6 +2051,182 @@ class TestControlFlow:
                 )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 16384)] = pl.tile.store(
                     final, [0, 0], output
+                )
+                return result
+
+        After = _run_pipeline(Before)
+        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
+
+class TestTopDownRetargeter:
+    """Tests for the Step-0 top-down retargeter inside MemoryReuse.
+
+    The retargeter walks each ForStmt's iter_arg -> yield chain and
+    rewrites the producer's MemRef to the iter_arg's MemRef when the
+    source tile is dead at the producer's write. These tests exercise
+    its happy path (pinned accumulator chain) and its safety check
+    (must decline when target is still live).
+    """
+
+    def test_acc_chain_pinned_producer_shares_iter_arg_buffer(self):
+        """A matmul_acc chain over Acc memory: the retargeter follows the
+        pinned `acc` input up to the iter_arg (already on target) and
+        retypes `acc_next` onto the same single Acc allocation. No
+        tile.move ops are inserted.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP16],
+                input_b: pl.Tensor[[32, 32], pl.FP16],
+                output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_a_l1: pl.Tile[[32, 32], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    input_a, [0, 0], [32, 32], target_memory=pl.MemorySpace.Mat
+                )
+                tile_b_l1: pl.Tile[[32, 32], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    input_b, [0, 0], [32, 32], target_memory=pl.MemorySpace.Mat
+                )
+                tile_a_l0a: pl.Tile[[32, 32], pl.FP16, pl.MemorySpace.Left] = pl.move(
+                    tile_a_l1, target_memory=pl.MemorySpace.Left
+                )
+                tile_b_l0b: pl.Tile[[32, 32], pl.FP16, pl.MemorySpace.Right] = pl.move(
+                    tile_b_l1, target_memory=pl.MemorySpace.Right
+                )
+                # Use matmul (not tile.create) so init_acc's TileView
+                # matches matmul_acc's — keeps the pre-verified IR well-formed.
+                init_acc: pl.Tile[[32, 32], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(tile_a_l0a, tile_b_l0b)
+                for _k, (acc,) in pl.range(0, 4, init_values=(init_acc,)):
+                    acc_next: pl.Tile[[32, 32], pl.FP32, pl.MemorySpace.Acc] = pl.matmul_acc(
+                        acc, tile_a_l0a, tile_b_l0b
+                    )
+                    loop_out = pl.yield_(acc_next)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(loop_out, [0, 0], output)
+                return result
+
+        # init_acc, acc, acc_next, loop_out all share the single Acc
+        # allocation mem_acc_7. No tile.move op appears anywhere in the
+        # loop body — the retargeter collapses the chain. (matmul_acc is
+        # already pinned to its acc input by set_output_reuses_input(0), so
+        # the retargeter recurses through the pin to the iter_arg, which
+        # is already on the target MemRef, then retypes acc_next.)
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP16, pl.MemRef("mem_ddr_0", 0, 2048)],
+                input_b: pl.Tensor[[32, 32], pl.FP16, pl.MemRef("mem_ddr_1", 0, 2048)],
+                output: pl.Out[pl.Tensor[[32, 32], pl.FP32, pl.MemRef("mem_ddr_2", 0, 4096)]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                mem_mat_3: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 2048)
+                mem_mat_4: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 2048)
+                mem_left_5: pl.Ptr = pl.tile.alloc(pl.Mem.Left, 2048)
+                mem_right_6: pl.Ptr = pl.tile.alloc(pl.Mem.Right, 2048)
+                mem_acc_7: pl.Ptr = pl.tile.alloc(pl.Mem.Acc, 4096)
+                tile_a_l1: pl.Tile[[32, 32], pl.FP16, pl.MemRef(mem_mat_3, 0, 2048), pl.Mem.Mat] = (
+                    pl.tile.load(
+                        input_a, [0, 0], [32, 32], [32, 32], target_memory=pl.Mem.Mat, transpose=False
+                    )
+                )
+                tile_b_l1: pl.Tile[[32, 32], pl.FP16, pl.MemRef(mem_mat_4, 0, 2048), pl.Mem.Mat] = (
+                    pl.tile.load(
+                        input_b, [0, 0], [32, 32], [32, 32], target_memory=pl.Mem.Mat, transpose=False
+                    )
+                )
+                tile_a_l0a: pl.Tile[[32, 32], pl.FP16, pl.MemRef(mem_left_5, 0, 2048), pl.Mem.Left] = (
+                    pl.tile.move(tile_a_l1, target_memory=pl.Mem.Left)
+                )
+                tile_b_l0b: pl.Tile[[32, 32], pl.FP16, pl.MemRef(mem_right_6, 0, 2048), pl.Mem.Right] = (
+                    pl.tile.move(tile_b_l1, target_memory=pl.Mem.Right)
+                )
+                init_acc: pl.Tile[[32, 32], pl.FP32, pl.MemRef(mem_acc_7, 0, 4096), pl.Mem.Acc] = (
+                    pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                )
+                for _k, (acc,) in pl.range(4, init_values=(init_acc,)):
+                    acc_next: pl.Tile[[32, 32], pl.FP32, pl.MemRef(mem_acc_7, 0, 4096), pl.Mem.Acc] = (
+                        pl.tile.matmul_acc(acc, tile_a_l0a, tile_b_l0b)
+                    )
+                    loop_out: pl.Tile[[32, 32], pl.FP32, pl.MemRef(mem_acc_7, 0, 4096), pl.Mem.Acc] = (
+                        pl.yield_(acc_next)
+                    )
+                result: pl.Tensor[[32, 32], pl.FP32, pl.MemRef("mem_ddr_2", 0, 4096)] = pl.tile.store(
+                    loop_out, [0, 0], output
+                )
+                return result
+
+        After = _run_pipeline(Before)
+        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
+    def test_retargeter_declines_when_target_still_live(self):
+        """Safety check: if target's base is read after the candidate
+        producer (here, via another op that reads the iter_arg), the
+        retargeter must leave the producer alone so that the iter_arg's
+        value is preserved until its last read. YieldFixup then inserts
+        a tile.move to unify the yield to the iter_arg buffer.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                init_0: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_tensor, [0, 0], [64, 64]
+                )
+                for _i, (acc_0,) in pl.range(0, 4, init_values=(init_0,)):
+                    tmp: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_0, acc_0)
+                    # `other` reads acc_0 AFTER tmp is written. If the
+                    # retargeter retyped tmp onto acc_0's buffer here, the
+                    # subsequent read of acc_0 would see the already-
+                    # clobbered value. So the retargeter must decline.
+                    other: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.mul(tmp, acc_0)
+                    _use: pl.Tensor[[64, 64], pl.FP32] = pl.store(other, [0, 0], output)
+                    loop_out = pl.yield_(tmp)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
+                return result
+
+        # tmp stays on its own buffer mem_vec_3 (retargeter declined).
+        # YieldFixup inserts tmp_mv = tile.move(tmp, ...) onto the iter_arg
+        # buffer mem_vec_2, and loop_out yields tmp_mv.
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_0", 0, 16384)],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                init_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
+                    input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for _i, (acc_0,) in pl.range(4, init_values=(init_0,)):
+                    tmp: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = pl.tile.add(
+                        acc_0, acc_0
+                    )
+                    other: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.mul(tmp, acc_0)
+                    )
+                    _use: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                        other, [0, 0], output
+                    )
+                    tmp_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.move(tmp, target_memory=pl.Mem.Vec)
+                    )
+                    loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
+                        pl.yield_(tmp_mv)
+                    )
+                result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                    loop_out, [0, 0], output
                 )
                 return result
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2233,6 +2233,90 @@ class TestTopDownRetargeter:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
+    def test_retargeter_declines_when_read_after_nested_if(self):
+        """Regression test for ancestor-walking liveness check.
+
+        The yield producer (``tile_c``) sits inside an IfStmt branch, but
+        a subsequent op (``side``) reads ``acc_0`` *after* the IfStmt in
+        the enclosing loop body.  An innermost-branch-only liveness check
+        would miss this read and incorrectly retype ``tile_c`` onto
+        ``acc_0``'s buffer, clobbering the iter_arg before ``side`` runs.
+        The ancestor-walking check sees the post-IfStmt read and declines.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                init_0: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_tensor, [0, 0], [64, 64]
+                )
+                for i, (acc_0,) in pl.range(0, 4, init_values=(init_0,)):
+                    if i < 2:
+                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_0, acc_0)
+                        if_result = pl.yield_(tile_c)
+                    else:
+                        if_result = pl.yield_(acc_0)
+                    # side reads acc_0 (target base) AFTER the IfStmt.
+                    side: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.mul(acc_0, acc_0)
+                    _use: pl.Tensor[[64, 64], pl.FP32] = pl.store(side, [0, 0], output)
+                    loop_out = pl.yield_(if_result)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
+                return result
+
+        # acc_0/init_0 share mem_vec_2.  tile_c stays on mem_vec_3 (NOT
+        # retargeted onto mem_vec_2) because the liveness check detects
+        # ``side``'s read of acc_0 after the IfStmt.  YieldFixup then
+        # inserts a tile.move to unify if_result to the iter_arg buffer.
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_0", 0, 16384)],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                init_0: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
+                    input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for i, (acc_0,) in pl.range(4, init_values=(init_0,)):
+                    if i < 2:
+                        tile_c: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                            pl.tile.add(acc_0, acc_0)
+                        )
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                            pl.yield_(tile_c)
+                        )
+                    else:
+                        if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                            pl.yield_(acc_0)
+                        )
+                    side: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.mul(acc_0, acc_0)
+                    )
+                    _use: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                        side, [0, 0], output
+                    )
+                    if_result_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.move(if_result, target_memory=pl.Mem.Vec)
+                    )
+                    loop_out: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
+                        pl.yield_(if_result_mv)
+                    )
+                result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                    loop_out, [0, 0], output
+                )
+                return result
+
+        After = _run_pipeline(Before)
+        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
 
 class TestMetadata:
     """Function metadata should survive MemoryReuse rewrites."""

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1269,7 +1269,7 @@ class TestYieldFixup:
                     next_0: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(extra_0, acc_0)
                     extra_1: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_1, acc_1)
                     next_1: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(extra_1, acc_1)
-                    out_0, out_1 = pl.yield_(next_0, next_1)
+                    out_0, _out_1 = pl.yield_(next_0, next_1)
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(out_0, [0, 0], output)
                 return result
 
@@ -1306,7 +1306,7 @@ class TestYieldFixup:
                     next_1: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.add(extra_1, acc_1)
                     )
-                    out_0, out_1 = pl.yield_(next_0, next_1)
+                    out_0, _out_1 = pl.yield_(next_0, next_1)
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
                     out_0, [0, 0], output
                 )
@@ -2234,14 +2234,20 @@ class TestTopDownRetargeter:
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
     def test_retargeter_declines_when_read_after_nested_if(self):
-        """Regression test for ancestor-walking liveness check.
+        """Regression test for the ancestor-walking liveness check.
 
         The yield producer (``tile_c``) sits inside an IfStmt branch, but
-        a subsequent op (``side``) reads ``acc_0`` *after* the IfStmt in
-        the enclosing loop body.  An innermost-branch-only liveness check
+        a subsequent op reads ``acc_0`` *after* the IfStmt in the
+        enclosing loop body.  An innermost-branch-only liveness check
         would miss this read and incorrectly retype ``tile_c`` onto
-        ``acc_0``'s buffer, clobbering the iter_arg before ``side`` runs.
-        The ancestor-walking check sees the post-IfStmt read and declines.
+        ``acc_0``'s buffer, clobbering the iter_arg before the post-
+        IfStmt read runs.  The ancestor-walking check sees the read and
+        declines.
+
+        The post-IfStmt read is expressed as ``pl.store(acc_0, ...)``
+        directly rather than via an intermediate ``side = op(acc_0)`` so
+        the assertion is not muddied by any lifetime-coalescing that
+        could place ``side`` and ``if_result`` in the same buffer.
         """
 
         @pl.program
@@ -2261,17 +2267,16 @@ class TestTopDownRetargeter:
                         if_result = pl.yield_(tile_c)
                     else:
                         if_result = pl.yield_(acc_0)
-                    # side reads acc_0 (target base) AFTER the IfStmt.
-                    side: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.mul(acc_0, acc_0)
-                    _use: pl.Tensor[[64, 64], pl.FP32] = pl.store(side, [0, 0], output)
+                    # Reads acc_0 (target base) AFTER the IfStmt.
+                    _use: pl.Tensor[[64, 64], pl.FP32] = pl.store(acc_0, [0, 0], output)
                     loop_out = pl.yield_(if_result)
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(loop_out, [0, 0], output)
                 return result
 
         # acc_0/init_0 share mem_vec_2.  tile_c stays on mem_vec_3 (NOT
         # retargeted onto mem_vec_2) because the liveness check detects
-        # ``side``'s read of acc_0 after the IfStmt.  YieldFixup then
-        # inserts a tile.move to unify if_result to the iter_arg buffer.
+        # the post-IfStmt read of acc_0.  YieldFixup then inserts a
+        # tile.move to unify if_result to the iter_arg buffer at the yield.
         @pl.program
         class Expected:
             @pl.function
@@ -2297,11 +2302,8 @@ class TestTopDownRetargeter:
                         if_result: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
                             pl.yield_(acc_0)
                         )
-                    side: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = (
-                        pl.tile.mul(acc_0, acc_0)
-                    )
                     _use: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
-                        side, [0, 0], output
+                        acc_0, [0, 0], output
                     )
                     if_result_mv: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                         pl.tile.move(if_result, target_memory=pl.Mem.Vec)

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2319,6 +2319,94 @@ class TestTopDownRetargeter:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
+    def test_retargeter_declines_for_not_inplace_safe_op(self):
+        """Regression test for the not_inplace_safe check.
+
+        ``tile.mrgsort_format1`` is registered ``.not_inplace_safe()`` —
+        its implementation requires distinct src/dst buffers.  In a
+        merge-sort accumulator loop the yield producer both reads and
+        (would) write ``tile_iter``'s buffer, so retargeting ``merged``
+        onto that buffer creates an in-place execution the op cannot
+        handle and fails at runtime with NPU error 507017
+        (``rtStreamSynchronize AICPU failed``).  The retargeter must
+        decline, and YieldFixup then inserts a ``tile.move`` to unify
+        the yield with the iter_arg buffer.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                src_tensor: pl.Tensor[[1, 2048], pl.FP32],
+                idx_tensor: pl.Tensor[[1, 2048], pl.UINT32],
+                val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
+            ) -> pl.Tensor[[1, 2048], pl.FP32]:
+                src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(src_tensor, [0, 0], [1, 2048])
+                idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(idx_tensor, [0, 0], [1, 2048])
+                sorted_tile: pl.Tile[[1, 4096], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+                for i, (tile_iter,) in pl.range(3, init_values=(sorted_tile,)):
+                    block_len = 1 << (6 + i * 2)
+                    merged: pl.Tile[[1, 4096], pl.FP32] = pl.tile.mrgsort(tile_iter, block_len=block_len)
+                    result = pl.yield_(merged)
+                vals: pl.Tile[[1, 2048], pl.FP32] = pl.tile.gather(
+                    result, mask_pattern=pl.tile.MaskPattern.P0101
+                )
+                out_val: pl.Tensor[[1, 2048], pl.FP32] = pl.store(vals, [0, 0], val_output)
+                return out_val
+
+        # tile_iter/sorted_tile/result live on mem_vec_5 (loop-carry buffer).
+        # `merged` is allocated on its own buffer mem_vec_6 so src (tile_iter
+        # on mem_vec_5) and dst (merged on mem_vec_6) differ.  YieldFixup
+        # inserts merged_mv on mem_vec_5 so the yield matches the iter_arg.
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                src_tensor: pl.Tensor[[1, 2048], pl.FP32, pl.MemRef("mem_ddr_0", 0, 8192)],
+                idx_tensor: pl.Tensor[[1, 2048], pl.UINT32, pl.MemRef("mem_ddr_1", 0, 8192)],
+                val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32, pl.MemRef("mem_ddr_2", 0, 8192)]],
+            ) -> pl.Tensor[[1, 2048], pl.FP32]:
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
+                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
+                mem_vec_5: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_6: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                src_tile: pl.Tile[[1, 2048], pl.FP32, pl.MemRef(mem_vec_3, 0, 8192), pl.Mem.Vec] = (
+                    pl.tile.load(
+                        src_tensor, [0, 0], [1, 2048], [1, 2048], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                )
+                idx_tile: pl.Tile[[1, 2048], pl.UINT32, pl.MemRef(mem_vec_4, 0, 8192), pl.Mem.Vec] = (
+                    pl.tile.load(
+                        idx_tensor, [0, 0], [1, 2048], [1, 2048], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                )
+                sorted_tile: pl.Tile[[1, 4096], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                    pl.tile.sort32(src_tile, idx_tile)
+                )
+                for i, (tile_iter,) in pl.range(3, init_values=(sorted_tile,)):
+                    block_len = 1 << (6 + i * 2)
+                    merged: pl.Tile[[1, 4096], pl.FP32, pl.MemRef(mem_vec_6, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.mrgsort(tile_iter, block_len=block_len)
+                    )
+                    merged_mv: pl.Tile[[1, 4096], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.move(merged, target_memory=pl.Mem.Vec)
+                    )
+                    result: pl.Tile[[1, 4096], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        pl.yield_(merged_mv)
+                    )
+                vals: pl.Tile[[1, 2048], pl.FP32, pl.MemRef(mem_vec_3, 0, 8192), pl.Mem.Vec] = pl.tile.gather(
+                    result, mask_pattern=pl.tile.MaskPattern.P0101
+                )
+                out_val: pl.Tensor[[1, 2048], pl.FP32, pl.MemRef("mem_ddr_2", 0, 8192)] = pl.tile.store(
+                    vals, [0, 0], val_output
+                )
+                return out_val
+
+        After = _run_pipeline(Before)
+        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
 
 class TestMetadata:
     """Function metadata should survive MemoryReuse rewrites."""


### PR DESCRIPTION
## Summary

- Add a Step-0 **top-down retargeter** to `MemoryReuse` that rewrites each `ForStmt`'s yield-chain producer to land directly in the iter_arg's MemRef (eliminates `tile.move` insertions for accumulator chains).
- Tighten the **InitMemRef** invariant so `return_vars` share the *iter_arg*'s MemRef (not the yield value's), giving the retargeter a consistent `(initValue, iter_arg, return_var)` target.
- Update 8 existing tests whose expectations described the old `tile.move`-insertion pattern; add 2 new tests for the retargeter's positive (Acc `matmul_acc` chain) and negative (target-still-live) paths.

## Motivation

For `Acc` → `Acc` accumulator chains (`matmul → matmul_acc → matmul_acc …`) the old lifetime-coloring step reconciled a yield/iter_arg MemRef mismatch by inserting a `tile.move` at the yield. An `Acc → Acc` `tile.move` lowers to a `pto.tmov` on `Acc` memory that the codegen backend rejects, so otherwise-legal accumulator loops failed to compile end-to-end (follow-up to the work in #1083).

## Algorithm

On entry to `MemoryReuse`, a new Step-0 walks each `ForStmt` top-down. For every `iter_arg → yield-value` pair it takes the iter_arg's MemRef as the canonical "target" and tries to retype the yield producer directly onto that MemRef.

- **Unconstrained producers** (plain `add`, `move`, `matmul`, …): retyped to write directly into the target MemRef, provided the target's base `Ptr` is not read between the producer and the yield in the same branch body (liveness check).
- **Pinned producers** (ops with `set_output_reuses_input`, e.g. `matmul_acc`): the output MemRef cannot be changed, so the retargeter recurses onto the pinned input (typically the iter_arg itself) and only plans the LHS retype once the upstream placement is feasible.
- **IfStmt return_vars**: recurse into both branches' yield values with the same target; retype the return_var when both branches succeed.

When the retargeter succeeds, the producer lands directly in the loop-carry buffer and the downstream `YieldFixup` pass has nothing to reconcile, so no `tile.move` ops are emitted. When it declines (e.g. target still live after the producer), `YieldFixup` handles the mismatch exactly as before.

### InitMemRef invariant the retargeter depends on

The retargeter assumes `initValue`, `iter_arg`, and `return_var` all share a single MemRef for the whole loop. `InitMemRef` previously patched `return_vars` from the *yield value*'s MemRef, which left the iter_arg out of sync whenever the yield producer lived in a different buffer. This PR patches `return_vars` from the *iter_arg*'s MemRef instead, so the retargeter can consume a consistent target.

### Complexity note

The retargeter runs a single O(N) IR walk to build the def map, then one `TryRetargetVar` per iter_arg plus recursion into `IfStmt` branches. The liveness check scans the tail of the `AssignStmt`'s containing body; in the worst case of a deep linear chain this is O(N²). In practice body tails are short (matmul/accumulator loops have a handful of producers each), so the realised cost is well below that bound. This super-linear worst case is documented in a comment at the top of the retargeter section per the project's `pass-complexity.md` rule.

## Test expectation updates — per-test justification

Each of the 8 updated tests had Expected IR describing the *old* `producer-on-fresh-buffer + tile.move-at-yield` pattern. Every update swaps that pattern for the retargeter's direct-retype behaviour. No test's *semantic* intent is relaxed — only the tactical buffer-allocation detail changes.

| Test | Old expected | New expected | Why the new expectation is correct |
| ---- | ------------ | ------------ | ---------------------------------- |
| `TestYieldFixup::test_producer_retyped_to_iter_arg_buffer` (was `test_tile_move_inserted_when_memrefs_diverge`) | `next_0` on fresh `mem_vec_3`; `tile.move(next_0) → mem_vec_2` | `next_0` directly on `mem_vec_2`; `extra_0` keeps `mem_vec_3` | Loop-carry unified with iter_arg — exactly what the test name promised, achieved without the intermediate move |
| `TestYieldFixup::test_simple_loop_memrefs_unified` | `next_0` on `mem_vec_3`; `tile.move` to `mem_vec_2` | `next_0` directly on `mem_vec_2`; `mem_vec_3` dropped | Loop-carry unified — stricter: one buffer total |
| `TestYieldFixup::test_multiple_iter_args_producers_retyped_independently` (was `…_partial_mismatch`) | Two `tile.move`s unifying `next_0/next_1` back to iter buffers | `next_0` on `mem_vec_2`, `next_1` on `mem_vec_3`; `extra_*` share `mem_vec_4` | Each iter_arg gets its own producer placed directly in its buffer |
| `TestControlFlow::test_var_used_in_nested_if_shares_iter_arg_buffer` (was `…_not_reused_in_loop`) | `tile_c` on fresh `mem_vec_3`; `tile.move(if_result) → mem_vec_2` | `tile_c`, `if_result`, `loop_out` all on `mem_vec_2` | `tile_a`/`acc` already share `mem_vec_2` via `InitMemRef`; retargeter collapses the yield chain |
| `TestControlFlow::test_loop_local_var_can_be_reused` | `tile_x/y/z` share `mem_vec_3`; `tile.move(tile_z) → mem_vec_2` | `tile_x/y` share `mem_vec_3`; `tile_z` directly on `mem_vec_2` | Loop-locals can still share their own scratch; the yield producer is retyped |
| `TestControlFlow::test_nested_for_loops_outer_var_extends_to_outer_end` | Moves at both inner and outer yields; 4 allocations | `tile_b` on inner iter buffer `mem_vec_4`; `tile_d` on outer iter buffer `mem_vec_3`; 3 allocations | Nested loop-carry unification at both levels |
| `TestControlFlow::test_for_with_if_multiple_vars_competing` | `tile_c/tile_d` on `mem_vec_5`; `tile.move(if_result) → mem_vec_4` | `tile_c/tile_d/if_result/loop_out` all on `mem_vec_4` | Cross-branch producer sharing via the iter buffer |
| `TestControlFlow::test_loop_return_var_blocks_init_memref_reuse` (#768 regression) | `acc_next` on `mem_vec_5`; move to `mem_vec_3` | `acc_next` directly on `mem_vec_3`; `resid` still on `mem_vec_5` (NOT `mem_vec_3`) | **The critical #768 invariant still holds:** `resid` does not clobber the loop-carry buffer. Only the now-unnecessary move is removed. |

## New tests

- `TestTopDownRetargeter::test_acc_chain_pinned_producer_shares_iter_arg_buffer` — a `matmul_acc` chain over `Acc` memory. Exercises the pinned-producer path: `matmul_acc`'s `set_output_reuses_input(0)` forces the retargeter to recurse through the pin to the iter_arg (already on target), then retype `acc_next`. Verifies that the full chain shares a single `mem_acc_*` allocation and that **no** `tile.move` ops remain in the loop body.
- `TestTopDownRetargeter::test_retargeter_declines_when_target_still_live` — a loop body where an op reads `acc_0` *after* the yield producer writes. Verifies the retargeter correctly declines to retype (leaves the producer on its own buffer), so that `YieldFixup` can insert the `tile.move` safely.

## Test plan

- [x] `cmake --build build --parallel` succeeds in the worktree
- [x] `tests/ut/ir/transforms/test_memory_reuse.py` (36 tests, includes the 8 updated + 2 new) — pass
- [x] `tests/ut/ir/transforms/test_init_memref.py` — pass
- [x] Full IR suite `tests/ut/ir/ -n auto` — 2706 passed, 13 skipped
- [x] `clang-tidy` clean on the diff
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)