### PR TITLE
feat(ir): Add tensor-level sort32, mrgsort, and gather operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(PYPTO_SOURCES
     src/ir/op/tensor_ops/scatter_update.cpp
     src/ir/op/tensor_ops/reduction.cpp
     src/ir/op/tensor_ops/sort.cpp
+    src/ir/op/tensor_ops/gather.cpp
     src/ir/op/tensor_ops/transform.cpp
     src/ir/op/tensor_ops/unary.cpp
     src/ir/op/testing.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(PYPTO_SOURCES
     src/ir/op/tensor_ops/memory.cpp
     src/ir/op/tensor_ops/scatter_update.cpp
     src/ir/op/tensor_ops/reduction.cpp
+    src/ir/op/tensor_ops/sort.cpp
     src/ir/op/tensor_ops/transform.cpp
     src/ir/op/tensor_ops/unary.cpp
     src/ir/op/testing.cpp

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -219,7 +219,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`)
 
 **Example:**
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -219,7 +219,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype`)
 
 **Example:**
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -219,7 +219,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`)
 
 **Example:**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -216,7 +216,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环）
 
 **示例：**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -216,7 +216,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作）
 
 **示例：**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -216,7 +216,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`）
 
 **示例：**
 

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -147,6 +147,7 @@ class OpConversionRegistry {
   void RegisterMemoryOps();
   void RegisterMatmulOps();
   void RegisterReductionOps();
+  void RegisterSortOps();
 
   std::unordered_map<std::string, ConversionEntry> conversions_;
 };

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -148,6 +148,7 @@ class OpConversionRegistry {
   void RegisterMatmulOps();
   void RegisterReductionOps();
   void RegisterSortOps();
+  void RegisterGatherOps();
 
   std::unordered_map<std::string, ConversionEntry> conversions_;
 };

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1101,3 +1101,76 @@ def mrgsort_format2(
     Prefer ``mrgsort(src0, src1, src2, src3, tmp, executed)`` in user code.
     """
     return mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=exhausted, span=span)
+
+
+# ============================================================================
+# Gather Operation
+# ============================================================================
+
+
+def gather(
+    input: Expr,
+    dim: int | None = None,
+    index: Expr | None = None,
+    *,
+    mask_pattern: int | None = None,
+    output_dtype: int | DataType | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Gather elements of ``input`` (tensor-level) — index form or mask-pattern form.
+
+    Index form (``dim`` + ``index``): output[b, k] = input[b, index[b, k]].
+        MVP limitation: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
+        ``index`` must be an INT32 tensor whose shape matches ``input`` on every
+        axis except ``dim``; output shape == ``index.shape``, dtype == ``input.dtype``.
+
+    Mask form (``mask_pattern=<int>``): selects columns of each row by a fixed
+        hardware mask. Last-dim shrinks by 2 (P0101/P1010) or 4 (P0001..P1000),
+        or stays the same for P1111. Optional ``output_dtype`` keyword reinterprets
+        result bits to a same-bit-width dtype (e.g. FP32 → UINT32).
+
+    Args:
+        input: Source tensor (TensorType, FP16/FP32/INT16/INT32).
+        dim: (index form) Axis along which to gather. Only ``-1`` / ``rank - 1`` accepted in MVP.
+        index: (index form) Index tensor (TensorType, INT32) with the same rank as ``input``.
+        mask_pattern: (mask form, keyword-only) Mask pattern selector in [1, 7].
+            1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
+        output_dtype: (mask form, keyword-only) Optional output dtype with the same
+            bit width as ``input.dtype``.
+        span: Optional source span for debugging (auto-captured if not provided).
+
+    Returns:
+        Call expression with the appropriate result type for the chosen form.
+    """
+    actual_span = _get_span_or_capture(span)
+    if mask_pattern is not None:
+        if dim is not None or index is not None:
+            raise ValueError(
+                "gather() mask form (mask_pattern=...) and index form (dim, index) "
+                "are mutually exclusive; do not pass dim or index with mask_pattern"
+            )
+        kwargs: dict[str, Any] = {"mask_pattern": mask_pattern}
+        if output_dtype is not None:
+            kwargs["output_dtype"] = output_dtype
+        return _ir_core.create_op_call("tensor.gather_mask", [input], kwargs, actual_span)
+    if dim is None or index is None:
+        raise ValueError(
+            "gather() requires either (dim, index) for index form, "
+            "or mask_pattern=<int> for mask form"
+        )
+    kwargs = {"dim": dim}
+    return _ir_core.create_op_call("tensor.gather", [input, index], kwargs, actual_span)
+
+
+def gather_mask(
+    input: Expr,
+    mask_pattern: int,
+    output_dtype: int | DataType | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Gather elements of ``input`` (tensor-level) by mask pattern. Used by the parser
+    for roundtrip fidelity.
+
+    Prefer ``gather(input, mask_pattern=...)`` in user code.
+    """
+    return gather(input, mask_pattern=mask_pattern, output_dtype=output_dtype, span=span)

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -994,3 +994,110 @@ def scatter_update(
     op_args: list[Expr] = [input, index, src]
     kwargs: dict[str, Any] = {"dim": dim_val}
     return _ir_core.create_op_call("tensor.scatter_update", op_args, kwargs, actual_span)
+
+
+# ============================================================================
+# Sort Operations
+# ============================================================================
+
+
+def sort32(src: Expr, idx: Expr, span: Span | None = None) -> Call:
+    """Sort fixed 32-element blocks with explicit index tensor (tensor-level).
+
+    Tensor-level counterpart of ``tile.sort32``. Sorts 32-element blocks in src
+    and permutes idx accordingly. Output tensor stores sorted value-index pairs
+    with the last dimension doubled.
+
+    Args:
+        src: Input value tensor (TensorType, FP16 or FP32)
+        idx: Input index tensor (TensorType) with sequential offsets
+        span: Optional source span for debugging
+
+    Returns:
+        Call expression returning sorted tensor with doubled last dimension
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tensor.sort32", [src, idx], {}, actual_span)
+
+
+def mrgsort(
+    src0: Expr,
+    src1: Expr | None = None,
+    src2: Expr | None = None,
+    src3: Expr | None = None,
+    tmp: Expr | None = None,
+    executed: Expr | None = None,
+    exhausted: bool = False,
+    *,
+    block_len: int | Expr | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Merge sort — format1 (single-list) or format2 (4-way merge), tensor-level.
+
+    Tensor-level counterpart of ``tile.mrgsort``. Format1 sorts a tensor
+    containing multiple pre-sorted runs of length ``block_len``. Format2 merges
+    4 pre-sorted input tensors into one sorted output.
+
+    Args:
+        src0: For format1: input tensor with pre-sorted runs (FP16 or FP32).
+              For format2: first sorted input tensor.
+        src1: (format2) Second sorted input tensor.
+        src2: (format2) Third sorted input tensor.
+        src3: (format2) Fourth sorted input tensor.
+        tmp: (format2) Temporary workspace tensor.
+        executed: (format2) Exhaustion status tensor (written by hardware).
+        exhausted: (format2) If True, marks inputs as exhausted (default: False).
+        block_len: (format1, keyword-only) Run length, must be multiple of 64.
+        span: Optional source span for debugging.
+
+    Returns:
+        Call expression returning merged sorted tensor.
+    """
+    actual_span = _get_span_or_capture(span)
+    if block_len is not None:
+        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+            raise ValueError(
+                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "are mutually exclusive; do not pass format2 arguments with block_len"
+            )
+        if isinstance(block_len, _ir_core.ConstInt):
+            block_len_expr = _ir_core.ConstInt(block_len.value, DataType.INT32, actual_span)
+        elif isinstance(block_len, Expr):
+            block_len_expr = block_len
+        else:
+            block_len_expr = _ir_core.ConstInt(block_len, DataType.INT32, actual_span)
+        return _ir_core.create_op_call("tensor.mrgsort_format1", [src0, block_len_expr], {}, actual_span)
+    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+        raise ValueError(
+            "mrgsort() requires either block_len=<int> for format1, "
+            "or (src0, src1, src2, src3, tmp, executed) for format2"
+        )
+    kwargs: dict[str, Any] = {"exhausted": exhausted}
+    return _ir_core.create_op_call(
+        "tensor.mrgsort_format2", [src0, src1, src2, src3, tmp, executed], kwargs, actual_span
+    )
+
+
+def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None) -> Call:
+    """Single-list merge sort (format1). Used by the parser for roundtrip fidelity.
+
+    Prefer ``mrgsort(src, block_len=...)`` in user code.
+    """
+    return mrgsort(src0, block_len=block_len, span=span)
+
+
+def mrgsort_format2(
+    src0: Expr,
+    src1: Expr,
+    src2: Expr,
+    src3: Expr,
+    tmp: Expr,
+    executed: Expr,
+    exhausted: bool = False,
+    span: Span | None = None,
+) -> Call:
+    """4-way merge sort (format2). Used by the parser for roundtrip fidelity.
+
+    Prefer ``mrgsort(src0, src1, src2, src3, tmp, executed)`` in user code.
+    """
+    return mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=exhausted, span=span)

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1055,10 +1055,10 @@ def mrgsort(
     """
     actual_span = _get_span_or_capture(span)
     if block_len is not None:
-        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if exhausted or any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
             raise ValueError(
                 "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
-                "are mutually exclusive; do not pass format2 arguments with block_len"
+                "are mutually exclusive; do not pass format2 arguments or exhausted=True with block_len"
             )
         if isinstance(block_len, _ir_core.ConstInt):
             block_len_expr = _ir_core.ConstInt(block_len.value, DataType.INT32, actual_span)
@@ -1155,9 +1155,10 @@ def gather(
         return _ir_core.create_op_call("tensor.gather_mask", [input], kwargs, actual_span)
     if dim is None or index is None:
         raise ValueError(
-            "gather() requires either (dim, index) for index form, "
-            "or mask_pattern=<int> for mask form"
+            "gather() requires either (dim, index) for index form, or mask_pattern=<int> for mask form"
         )
+    if output_dtype is not None:
+        raise ValueError("gather() output_dtype is only valid for the mask form; use mask_pattern=<int>")
     kwargs = {"dim": dim}
     return _ir_core.create_op_call("tensor.gather", [input, index], kwargs, actual_span)
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -64,6 +64,7 @@ __all__ = [
     "set_validshape",
     "sort32",
     "mrgsort",
+    "gather",
     "alloc",
 ]
 
@@ -926,6 +927,74 @@ def mrgsort(
         executed.unwrap(),
         exhausted,
     )
+    return Tensor(expr=call_expr)
+
+
+@overload
+def gather(input: Tensor, dim: int, index: Tensor) -> Tensor: ...
+
+
+@overload
+def gather(input: Tensor, *, mask_pattern: int, output_dtype: int | DataType | None = None) -> Tensor: ...
+
+
+def gather(
+    input: Tensor,
+    dim: int | None = None,
+    index: Tensor | None = None,
+    *,
+    mask_pattern: int | None = None,
+    output_dtype: int | DataType | None = None,
+) -> Tensor:
+    """Gather elements of ``input`` (tensor-level) — index form or mask-pattern form.
+
+    Index form (``dim`` + ``index``):
+        ``output[b, k] = input[b, index[b, k]]``
+        MVP: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
+        ``index`` must be an INT32 tensor whose shape matches ``input`` on every
+        axis except ``dim``.
+
+    Mask form (``mask_pattern=<int>``):
+        Selects columns of each row by a fixed hardware mask pattern (lowered
+        directly to ``tile.gather_mask``). Last-dim shrinks by 2 (P0101/P1010)
+        or 4 (P0001..P1000), or stays the same for P1111.
+
+    Args:
+        input: Source tensor (FP16/FP32/INT16/INT32).
+        dim: (index form) Axis to gather along; only ``-1`` / ``rank - 1`` accepted in MVP.
+        index: (index form) Index tensor (INT32) with same rank as input.
+        mask_pattern: (mask form, keyword-only) Mask pattern selector (1-7).
+            1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111.
+        output_dtype: (mask form, keyword-only) Optional output dtype with the same
+            bit width as ``input.dtype`` (e.g. FP32 → UINT32 for sort32 index bits).
+
+    Returns:
+        Tensor of shape ``index.shape`` (index form) or shape with shrunk last dim
+        (mask form), and dtype ``input.dtype`` (or ``output_dtype`` if provided).
+
+    Examples:
+        out = gather(input, dim=-1, index=idx)
+        out = gather(input, mask_pattern=1)
+        out = gather(input, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32)
+    """
+    if mask_pattern is not None:
+        if dim is not None or index is not None:
+            raise ValueError(
+                "gather() mask form (mask_pattern=...) and index form (dim, index) "
+                "are mutually exclusive; do not pass dim or index with mask_pattern"
+            )
+        call_expr = _ir_ops.gather(input.unwrap(), mask_pattern=mask_pattern, output_dtype=output_dtype)
+        return Tensor(expr=call_expr)
+    if output_dtype is not None:
+        raise ValueError(
+            "output_dtype is only valid for the mask form of gather(); use mask_pattern=<int>"
+        )
+    if dim is None or index is None:
+        raise ValueError(
+            "gather() requires either (dim, index) for index form, "
+            "or mask_pattern=<int> for mask form"
+        )
+    call_expr = _ir_ops.gather(input.unwrap(), dim, index.unwrap())
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -14,6 +14,7 @@ that accept and return Tensor types instead of raw Expr/Call objects.
 """
 
 from collections.abc import Sequence
+from typing import overload
 
 __all__ = [
     "create_tensor",
@@ -61,6 +62,8 @@ __all__ = [
     "transpose",
     "scatter_update",
     "set_validshape",
+    "sort32",
+    "mrgsort",
     "alloc",
 ]
 
@@ -824,6 +827,105 @@ def scatter_update(
         Tensor wrapping the scatter_update operation
     """
     call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
+    return Tensor(expr=call_expr)
+
+
+def sort32(src: Tensor, idx: Tensor) -> Tensor:
+    """Sort fixed 32-element blocks with explicit index tensor (tensor-level).
+
+    Tensor-level counterpart of ``pl.tile.sort32``. Sorts 32-element blocks in
+    src, permuting idx alongside. Returns sorted value-index pairs tensor with
+    doubled last dimension.
+
+    For FP16 src: initialize idx with [0, 1, 2, ..., 31] per block.
+    For FP32 src: initialize idx with [0, 2, 4, ..., 62] per block.
+
+    Args:
+        src: Input value tensor (FP16 or FP32)
+        idx: Input index tensor with sequential offsets
+
+    Returns:
+        Tensor wrapping the sort32 operation (last dim doubled)
+    """
+    call_expr = _ir_ops.sort32(src.unwrap(), idx.unwrap())
+    return Tensor(expr=call_expr)
+
+
+@overload
+def mrgsort(src0: Tensor, *, block_len: int | Scalar) -> Tensor: ...
+
+
+@overload
+def mrgsort(
+    src0: Tensor,
+    src1: Tensor,
+    src2: Tensor,
+    src3: Tensor,
+    tmp: Tensor,
+    executed: Tensor,
+    exhausted: bool = ...,
+) -> Tensor: ...
+
+
+def mrgsort(
+    src0: Tensor,
+    src1: Tensor | None = None,
+    src2: Tensor | None = None,
+    src3: Tensor | None = None,
+    tmp: Tensor | None = None,
+    executed: Tensor | None = None,
+    exhausted: bool = False,
+    *,
+    block_len: int | Scalar | None = None,
+) -> Tensor:
+    """Merge sort — format1 (single-list) or format2 (4-way merge), tensor-level.
+
+    Tensor-level counterpart of ``pl.tile.mrgsort``.
+
+    Format1 usage (keyword block_len):
+        out = mrgsort(src, block_len=64)
+
+    Format2 usage (6 positional args):
+        out = mrgsort(src0, src1, src2, src3, tmp, executed)
+        out = mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=True)
+
+    Args:
+        src0: For format1: input tensor with pre-sorted runs (FP16 or FP32).
+              For format2: first sorted input tensor.
+        src1: (format2) Second sorted input tensor.
+        src2: (format2) Third sorted input tensor.
+        src3: (format2) Fourth sorted input tensor.
+        tmp: (format2) Temporary workspace tensor.
+        executed: (format2) Exhaustion status tensor (written by hardware).
+        exhausted: (format2) If True, marks inputs as exhausted (default: False).
+        block_len: (format1, keyword-only) Run length, must be multiple of 64.
+
+    Returns:
+        Tensor with merged sorted elements
+    """
+    if block_len is not None:
+        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+            raise ValueError(
+                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "are mutually exclusive; do not pass format2 arguments with block_len"
+            )
+        block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
+        call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
+        return Tensor(expr=call_expr)
+    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+        raise ValueError(
+            "mrgsort() requires either block_len=<int> for format1, "
+            "or (src0, src1, src2, src3, tmp, executed) for format2"
+        )
+    call_expr = _ir_ops.mrgsort(
+        src0.unwrap(),
+        src1.unwrap(),
+        src2.unwrap(),
+        src3.unwrap(),
+        tmp.unwrap(),
+        executed.unwrap(),
+        exhausted,
+    )
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -905,10 +905,10 @@ def mrgsort(
         Tensor with merged sorted elements
     """
     if block_len is not None:
-        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if exhausted or any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
             raise ValueError(
                 "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
-                "are mutually exclusive; do not pass format2 arguments with block_len"
+                "are mutually exclusive; do not pass format2 arguments or exhausted=True with block_len"
             )
         block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
         call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
@@ -986,13 +986,10 @@ def gather(
         call_expr = _ir_ops.gather(input.unwrap(), mask_pattern=mask_pattern, output_dtype=output_dtype)
         return Tensor(expr=call_expr)
     if output_dtype is not None:
-        raise ValueError(
-            "output_dtype is only valid for the mask form of gather(); use mask_pattern=<int>"
-        )
+        raise ValueError("output_dtype is only valid for the mask form of gather(); use mask_pattern=<int>")
     if dim is None or index is None:
         raise ValueError(
-            "gather() requires either (dim, index) for index form, "
-            "or mask_pattern=<int> for mask form"
+            "gather() requires either (dim, index) for index form, or mask_pattern=<int> for mask form"
         )
     call_expr = _ir_ops.gather(input.unwrap(), dim, index.unwrap())
     return Tensor(expr=call_expr)

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -40,28 +40,27 @@ namespace ir {
 TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs,
                                const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name
-                          << " requires 2 arguments (input, index), but got " << args.size();
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (input, index), but got "
+                          << args.size();
 
   auto input_type = As<TensorType>(args[0]->GetType());
-  CHECK(input_type) << "The operator " << op_name
-                    << " requires input to be a TensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(input_type) << "The operator " << op_name << " requires input to be a TensorType, but got "
+                    << args[0]->GetType()->TypeName();
   CHECK(input_type->dtype_ == DataType::FP16 || input_type->dtype_ == DataType::FP32 ||
         input_type->dtype_ == DataType::INT16 || input_type->dtype_ == DataType::INT32)
-      << "The operator " << op_name
-      << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
+      << "The operator " << op_name << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
       << input_type->dtype_.ToString();
 
   auto index_type = As<TensorType>(args[1]->GetType());
-  CHECK(index_type) << "The operator " << op_name
-                    << " requires index to be a TensorType, but got " << args[1]->GetType()->TypeName();
+  CHECK(index_type) << "The operator " << op_name << " requires index to be a TensorType, but got "
+                    << args[1]->GetType()->TypeName();
   CHECK(index_type->dtype_ == DataType::INT32)
       << "The operator " << op_name << " requires index dtype to be INT32, but got "
       << index_type->dtype_.ToString();
 
   const int64_t rank = static_cast<int64_t>(input_type->shape_.size());
-  CHECK(rank == 2) << "The operator " << op_name
-                   << " currently supports only 2D input (MVP), but got rank " << rank;
+  CHECK(rank == 2) << "The operator " << op_name << " currently supports only 2D input (MVP), but got rank "
+                   << rank;
   CHECK(static_cast<int64_t>(index_type->shape_.size()) == rank)
       << "The operator " << op_name << " requires index rank (" << index_type->shape_.size()
       << ") to match input rank (" << rank << ")";
@@ -113,17 +112,15 @@ TypePtr DeduceTensorGatherMaskType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   auto input_type = As<TensorType>(args[0]->GetType());
-  CHECK(input_type) << "The operator " << op_name
-                    << " requires input to be a TensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(input_type) << "The operator " << op_name << " requires input to be a TensorType, but got "
+                    << args[0]->GetType()->TypeName();
   CHECK(input_type->dtype_ == DataType::FP16 || input_type->dtype_ == DataType::FP32 ||
         input_type->dtype_ == DataType::INT16 || input_type->dtype_ == DataType::INT32)
-      << "The operator " << op_name
-      << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
+      << "The operator " << op_name << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
       << input_type->dtype_.ToString();
 
   CHECK(input_type->shape_.size() == 2)
-      << "The operator " << op_name << " requires 2D input, but got rank "
-      << input_type->shape_.size();
+      << "The operator " << op_name << " requires 2D input, but got rank " << input_type->shape_.size();
 
   int pattern = -1;
   for (const auto& [key, value] : kwargs) {

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -161,9 +161,11 @@ TypePtr DeduceTensorGatherMaskType(const std::vector<ExprPtr>& args,
   DataType out_dtype;
   for (const auto& [key, value] : kwargs) {
     if (key == "output_dtype") {
+      CHECK(value.type() == typeid(DataType) || value.type() == typeid(int))
+          << "The operator " << op_name << " requires output_dtype to be DataType or int";
       if (value.type() == typeid(DataType)) {
         out_dtype = AnyCast<DataType>(value, "kwarg key: output_dtype");
-      } else if (value.type() == typeid(int)) {
+      } else {
         out_dtype = static_cast<DataType>(AnyCast<int>(value, "kwarg key: output_dtype"));
       }
       has_output_dtype = true;

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file gather.cpp
+ * @brief Tensor-level gather operator.
+ *
+ * MVP scope: rank == 2 and dim == -1 (last axis). Lowered to a per-row
+ * tile.gather loop by ConvertTensorToTileOps.
+ */
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/any_cast.h"
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+
+TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name
+                          << " requires 2 arguments (input, index), but got " << args.size();
+
+  auto input_type = As<TensorType>(args[0]->GetType());
+  CHECK(input_type) << "The operator " << op_name
+                    << " requires input to be a TensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(input_type->dtype_ == DataType::FP16 || input_type->dtype_ == DataType::FP32 ||
+        input_type->dtype_ == DataType::INT16 || input_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name
+      << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
+      << input_type->dtype_.ToString();
+
+  auto index_type = As<TensorType>(args[1]->GetType());
+  CHECK(index_type) << "The operator " << op_name
+                    << " requires index to be a TensorType, but got " << args[1]->GetType()->TypeName();
+  CHECK(index_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name << " requires index dtype to be INT32, but got "
+      << index_type->dtype_.ToString();
+
+  const int64_t rank = static_cast<int64_t>(input_type->shape_.size());
+  CHECK(rank == 2) << "The operator " << op_name
+                   << " currently supports only 2D input (MVP), but got rank " << rank;
+  CHECK(static_cast<int64_t>(index_type->shape_.size()) == rank)
+      << "The operator " << op_name << " requires index rank (" << index_type->shape_.size()
+      << ") to match input rank (" << rank << ")";
+
+  int dim_val = -1;
+  bool dim_seen = false;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "dim") {
+      dim_val = AnyCast<int>(value, "kwarg key: dim");
+      dim_seen = true;
+      break;
+    }
+  }
+  CHECK(dim_seen) << "The operator " << op_name << " requires a 'dim' keyword argument";
+  CHECK(dim_val == -1 || dim_val == rank - 1)
+      << "The operator " << op_name
+      << " currently supports only dim=-1 or dim=rank-1 (MVP), but got dim=" << dim_val;
+
+  // Non-dim axis (axis 0 for 2D) must match between input and index.
+  CHECK(DimensionsEqual(input_type->shape_[0], index_type->shape_[0]))
+      << "The operator " << op_name
+      << " requires index.shape[0] to equal input.shape[0] on the non-gather axis";
+
+  return std::make_shared<TensorType>(index_type->shape_, input_type->dtype_);
+}
+
+REGISTER_OP("tensor.gather")
+    .set_op_category("TensorOp")
+    .set_description(
+        "Gather elements of input along the specified dimension using the index tensor "
+        "(tensor-level). MVP: rank==2 and dim==-1; lowered to a per-row tile.gather loop.")
+    .add_argument("input", "Input tensor (TensorType; FP16, FP32, INT16, or INT32)")
+    .add_argument("index", "Index tensor (TensorType, INT32, same shape as output)")
+    .set_attr<int>("dim")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorGatherType(args, kwargs, "tensor.gather");
+    });
+
+// ============================================================================
+// tensor.gather_mask — mask-pattern element selection (tensor-level).
+// 1:1 maps to tile.gather_mask in ConvertTensorToTileOps.
+// ============================================================================
+
+TypePtr DeduceTensorGatherMaskType(const std::vector<ExprPtr>& args,
+                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                   const std::string& op_name) {
+  CHECK(args.size() == 1) << "The operator " << op_name << " requires 1 argument (input), but got "
+                          << args.size();
+
+  auto input_type = As<TensorType>(args[0]->GetType());
+  CHECK(input_type) << "The operator " << op_name
+                    << " requires input to be a TensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(input_type->dtype_ == DataType::FP16 || input_type->dtype_ == DataType::FP32 ||
+        input_type->dtype_ == DataType::INT16 || input_type->dtype_ == DataType::INT32)
+      << "The operator " << op_name
+      << " requires input dtype to be FP16, FP32, INT16, or INT32, but got "
+      << input_type->dtype_.ToString();
+
+  CHECK(input_type->shape_.size() == 2)
+      << "The operator " << op_name << " requires 2D input, but got rank "
+      << input_type->shape_.size();
+
+  int pattern = -1;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "mask_pattern") {
+      pattern = AnyCast<int>(value, "kwarg key: mask_pattern");
+      break;
+    }
+  }
+  CHECK(pattern >= 1 && pattern <= 7)
+      << "The operator " << op_name << " requires mask_pattern in range [1, 7], but got " << pattern;
+
+  // Output last-dim shrink mirrors tile.gather_mask:
+  //   P0101 (1), P1010 (2)               → divisor 2
+  //   P0001 (3) .. P1000 (6)             → divisor 4
+  //   P1111 (7)                           → no shrink
+  const auto& src_shape = input_type->shape_;
+  const ExprPtr& col_expr = src_shape[1];
+  ExprPtr out_col_expr;
+  if (pattern == 7) {
+    out_col_expr = col_expr;
+  } else {
+    int64_t divisor = (pattern <= 2) ? 2 : 4;
+    if (auto const_col = As<ConstInt>(col_expr)) {
+      CHECK(const_col->value_ % divisor == 0)
+          << "The operator " << op_name << " with mask_pattern=" << pattern
+          << " requires src columns divisible by " << divisor << ", got " << const_col->value_;
+      out_col_expr =
+          std::make_shared<ConstInt>(const_col->value_ / divisor, DataType::INDEX, Span::unknown());
+    } else {
+      auto div_expr = std::make_shared<ConstInt>(divisor, DataType::INDEX, Span::unknown());
+      out_col_expr = std::make_shared<FloorDiv>(col_expr, div_expr, DataType::INDEX, Span::unknown());
+    }
+  }
+  std::vector<ExprPtr> out_shape = {src_shape[0], out_col_expr};
+
+  // Optional output_dtype kwarg — same bit width as input dtype.
+  bool has_output_dtype = false;
+  DataType out_dtype;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "output_dtype") {
+      if (value.type() == typeid(DataType)) {
+        out_dtype = AnyCast<DataType>(value, "kwarg key: output_dtype");
+      } else if (value.type() == typeid(int)) {
+        out_dtype = static_cast<DataType>(AnyCast<int>(value, "kwarg key: output_dtype"));
+      }
+      has_output_dtype = true;
+      break;
+    }
+  }
+  if (!has_output_dtype) {
+    out_dtype = input_type->dtype_;
+  } else {
+    CHECK(out_dtype.GetBit() == input_type->dtype_.GetBit())
+        << "The operator " << op_name << " output_dtype must have the same bit width as input dtype ("
+        << input_type->dtype_.ToString() << " = " << input_type->dtype_.GetBit() << " bits), but got "
+        << out_dtype.ToString() << " = " << out_dtype.GetBit() << " bits";
+  }
+
+  return std::make_shared<TensorType>(out_shape, out_dtype);
+}
+
+REGISTER_OP("tensor.gather_mask")
+    .set_op_category("TensorOp")
+    .set_description(
+        "Gather elements of input by mask pattern (tensor-level, maps to tile.gather_mask). "
+        "Each row of the 2D input is compacted by selecting columns that the mask marks active.")
+    .add_argument("input", "Input tensor (TensorType; FP16, FP32, INT16, or INT32)")
+    .set_attr<int>("mask_pattern")
+    .set_attr<DataType>("output_dtype")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorGatherMaskType(args, kwargs, "tensor.gather_mask");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/tensor_ops/sort.cpp
+++ b/src/ir/op/tensor_ops/sort.cpp
@@ -27,13 +27,13 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
-#include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -45,24 +45,37 @@ namespace ir {
 TypePtr DeduceTensorSort32Type(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs,
                                const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name
-                          << " requires 2 arguments (src, idx), but got " << args.size();
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (src, idx), but got "
+                          << args.size();
 
   auto src_type = As<TensorType>(args[0]->GetType());
-  CHECK(src_type) << "The operator " << op_name
-                  << " requires first argument to be a TensorType, but got "
+  CHECK(src_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                   << args[0]->GetType()->TypeName();
   CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
       << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
       << src_type->dtype_.ToString();
 
-  auto idx_type = As<TensorType>(args[1]->GetType());
-  CHECK(idx_type) << "The operator " << op_name
-                  << " requires second argument to be a TensorType, but got "
-                  << args[1]->GetType()->TypeName();
-
   const auto& input_shape = src_type->shape_;
   CHECK(!input_shape.empty()) << "The operator " << op_name << " requires non-empty input shape";
+  if (auto const_last_dim = As<ConstInt>(input_shape.back())) {
+    CHECK(const_last_dim->value_ > 0 && const_last_dim->value_ % 32 == 0)
+        << "The operator " << op_name
+        << " requires the last dimension to be a positive multiple of 32, but got " << const_last_dim->value_;
+  }
+
+  auto idx_type = As<TensorType>(args[1]->GetType());
+  CHECK(idx_type) << "The operator " << op_name << " requires second argument to be a TensorType, but got "
+                  << args[1]->GetType()->TypeName();
+  CHECK(idx_type->dtype_ == DataType::UINT32)
+      << "The operator " << op_name << " requires idx dtype to be UINT32, but got "
+      << idx_type->dtype_.ToString();
+  CHECK(idx_type->shape_.size() == input_shape.size())
+      << "The operator " << op_name << " requires idx rank (" << idx_type->shape_.size()
+      << ") to match src rank (" << input_shape.size() << ")";
+  for (size_t i = 0; i < input_shape.size(); ++i) {
+    CHECK(DimensionsEqual(input_shape[i], idx_type->shape_[i]))
+        << "The operator " << op_name << " requires idx shape to match src shape at axis " << i;
+  }
 
   std::vector<ExprPtr> output_shape(input_shape.begin(), input_shape.end() - 1);
   auto last_dim = input_shape.back();
@@ -99,8 +112,7 @@ TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
                           << args.size();
 
   auto src0_type = As<TensorType>(args[0]->GetType());
-  CHECK(src0_type) << "The operator " << op_name
-                   << " requires argument 0 to be a TensorType, but got "
+  CHECK(src0_type) << "The operator " << op_name << " requires argument 0 to be a TensorType, but got "
                    << args[0]->GetType()->TypeName();
   CHECK(src0_type->dtype_ == DataType::FP16 || src0_type->dtype_ == DataType::FP32)
       << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
@@ -111,14 +123,13 @@ TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
     CHECK(src_type) << "The operator " << op_name << " requires argument " << i
                     << " to be a TensorType, but got " << args[i]->GetType()->TypeName();
     CHECK(src_type->dtype_ == src0_type->dtype_)
-        << "The operator " << op_name
-        << " requires all src tensors to have matching dtype, but argument " << i << " has "
-        << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString() << ")";
+        << "The operator " << op_name << " requires all src tensors to have matching dtype, but argument "
+        << i << " has " << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString()
+        << ")";
   }
 
   auto tmp_type = As<TensorType>(args[4]->GetType());
-  CHECK(tmp_type) << "The operator " << op_name
-                  << " requires argument 4 (tmp) to be a TensorType, but got "
+  CHECK(tmp_type) << "The operator " << op_name << " requires argument 4 (tmp) to be a TensorType, but got "
                   << args[4]->GetType()->TypeName();
 
   auto exc_type = As<TensorType>(args[5]->GetType());
@@ -151,12 +162,11 @@ REGISTER_OP("tensor.mrgsort_format2")
 TypePtr DeduceTensorMrgSort1Type(const std::vector<ExprPtr>& args,
                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
                                  const std::string& op_name) {
-  CHECK(args.size() == 2) << "The operator " << op_name
-                          << " requires 2 arguments (src, block_len), but got " << args.size();
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (src, block_len), but got "
+                          << args.size();
 
   auto src_type = As<TensorType>(args[0]->GetType());
-  CHECK(src_type) << "The operator " << op_name
-                  << " requires argument 0 to be a TensorType, but got "
+  CHECK(src_type) << "The operator " << op_name << " requires argument 0 to be a TensorType, but got "
                   << args[0]->GetType()->TypeName();
   CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
       << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
@@ -172,8 +182,8 @@ TypePtr DeduceTensorMrgSort1Type(const std::vector<ExprPtr>& args,
 
   if (auto const_val = As<ConstInt>(args[1])) {
     CHECK(const_val->value_ > 0 && const_val->value_ % 64 == 0)
-        << "The operator " << op_name
-        << " requires block_len to be a positive multiple of 64, but got " << const_val->value_;
+        << "The operator " << op_name << " requires block_len to be a positive multiple of 64, but got "
+        << const_val->value_;
   }
 
   return std::make_shared<TensorType>(src_type->shape_, src_type->dtype_);

--- a/src/ir/op/tensor_ops/sort.cpp
+++ b/src/ir/op/tensor_ops/sort.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file sort.cpp
+ * @brief Sorting tensor operations (sort32, mrgsort format1/format2)
+ *
+ * Tensor-level counterparts of the tile-level sort operators in
+ * src/ir/op/tile_ops/sort.cpp. Converted to tile ops by ConvertTensorToTileOps
+ * via a simple 1:1 name mapping registered in op_conversion_registry.cpp.
+ */
+
+#include <any>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+// ============================================================================
+// tensor.sort32 — sorts fixed 32-element blocks, output has last dim doubled.
+// ============================================================================
+
+TypePtr DeduceTensorSort32Type(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name
+                          << " requires 2 arguments (src, idx), but got " << args.size();
+
+  auto src_type = As<TensorType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name
+                  << " requires first argument to be a TensorType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src_type->dtype_.ToString();
+
+  auto idx_type = As<TensorType>(args[1]->GetType());
+  CHECK(idx_type) << "The operator " << op_name
+                  << " requires second argument to be a TensorType, but got "
+                  << args[1]->GetType()->TypeName();
+
+  const auto& input_shape = src_type->shape_;
+  CHECK(!input_shape.empty()) << "The operator " << op_name << " requires non-empty input shape";
+
+  std::vector<ExprPtr> output_shape(input_shape.begin(), input_shape.end() - 1);
+  auto last_dim = input_shape.back();
+  if (auto const_dim = As<ConstInt>(last_dim)) {
+    int64_t doubled = const_dim->value_ * 2;
+    output_shape.push_back(std::make_shared<ConstInt>(doubled, DataType::INDEX, Span::unknown()));
+  } else {
+    auto two = std::make_shared<ConstInt>(2, DataType::INDEX, Span::unknown());
+    output_shape.push_back(std::make_shared<Mul>(last_dim, two, DataType::INDEX, Span::unknown()));
+  }
+
+  return std::make_shared<TensorType>(output_shape, src_type->dtype_);
+}
+
+REGISTER_OP("tensor.sort32")
+    .set_op_category("TensorOp")
+    .set_description("Sort fixed 32-element blocks (tensor-level, maps to tile.sort32)")
+    .add_argument("src", "Input value tensor (TensorType, FP16 or FP32)")
+    .add_argument("idx", "Input index tensor (TensorType)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorSort32Type(args, kwargs, "tensor.sort32");
+    });
+
+// ============================================================================
+// tensor.mrgsort_format2 — 4-way merge sort (tensor-level).
+// ============================================================================
+
+TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
+                                const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                const std::string& op_name) {
+  CHECK(args.size() == 6) << "The operator " << op_name
+                          << " requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
+                          << args.size();
+
+  auto src0_type = As<TensorType>(args[0]->GetType());
+  CHECK(src0_type) << "The operator " << op_name
+                   << " requires argument 0 to be a TensorType, but got "
+                   << args[0]->GetType()->TypeName();
+  CHECK(src0_type->dtype_ == DataType::FP16 || src0_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src0_type->dtype_.ToString();
+
+  for (size_t i = 1; i < 4; ++i) {
+    auto src_type = As<TensorType>(args[i]->GetType());
+    CHECK(src_type) << "The operator " << op_name << " requires argument " << i
+                    << " to be a TensorType, but got " << args[i]->GetType()->TypeName();
+    CHECK(src_type->dtype_ == src0_type->dtype_)
+        << "The operator " << op_name
+        << " requires all src tensors to have matching dtype, but argument " << i << " has "
+        << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString() << ")";
+  }
+
+  auto tmp_type = As<TensorType>(args[4]->GetType());
+  CHECK(tmp_type) << "The operator " << op_name
+                  << " requires argument 4 (tmp) to be a TensorType, but got "
+                  << args[4]->GetType()->TypeName();
+
+  auto exc_type = As<TensorType>(args[5]->GetType());
+  CHECK(exc_type) << "The operator " << op_name
+                  << " requires argument 5 (executed) to be a TensorType, but got "
+                  << args[5]->GetType()->TypeName();
+
+  return std::make_shared<TensorType>(tmp_type->shape_, src0_type->dtype_);
+}
+
+REGISTER_OP("tensor.mrgsort_format2")
+    .set_op_category("TensorOp")
+    .set_description("Merge sort 4 sorted lists, format2 (tensor-level, maps to tile.mrgsort_format2)")
+    .add_argument("src0", "First sorted input tensor (FP16 or FP32)")
+    .add_argument("src1", "Second sorted input tensor")
+    .add_argument("src2", "Third sorted input tensor")
+    .add_argument("src3", "Fourth sorted input tensor")
+    .add_argument("tmp", "Temporary workspace tensor")
+    .add_argument("executed", "Exhaustion status output tensor")
+    .set_attr<bool>("exhausted")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorMrgSortType(args, kwargs, "tensor.mrgsort_format2");
+    });
+
+// ============================================================================
+// tensor.mrgsort_format1 — single-list merge sort (tensor-level).
+// ============================================================================
+
+TypePtr DeduceTensorMrgSort1Type(const std::vector<ExprPtr>& args,
+                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                 const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name
+                          << " requires 2 arguments (src, block_len), but got " << args.size();
+
+  auto src_type = As<TensorType>(args[0]->GetType());
+  CHECK(src_type) << "The operator " << op_name
+                  << " requires argument 0 to be a TensorType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::FP32)
+      << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
+      << src_type->dtype_.ToString();
+
+  auto block_len_type = As<ScalarType>(args[1]->GetType());
+  CHECK(block_len_type) << "The operator " << op_name
+                        << " requires argument 1 (block_len) to be a ScalarType, but got "
+                        << args[1]->GetType()->TypeName();
+  CHECK(block_len_type->dtype_.IsInt())
+      << "The operator " << op_name << " requires block_len to be an integer type, but got "
+      << block_len_type->dtype_.ToString();
+
+  if (auto const_val = As<ConstInt>(args[1])) {
+    CHECK(const_val->value_ > 0 && const_val->value_ % 64 == 0)
+        << "The operator " << op_name
+        << " requires block_len to be a positive multiple of 64, but got " << const_val->value_;
+  }
+
+  return std::make_shared<TensorType>(src_type->shape_, src_type->dtype_);
+}
+
+REGISTER_OP("tensor.mrgsort_format1")
+    .set_op_category("TensorOp")
+    .set_description("Single-list merge sort, format1 (tensor-level, maps to tile.mrgsort_format1)")
+    .add_argument("src", "Input tensor containing pre-sorted runs (FP16 or FP32)")
+    .add_argument("block_len", "Run length for merge sort (integer scalar, multiple of 64)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorMrgSort1Type(args, kwargs, "tensor.mrgsort_format1");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -121,8 +121,8 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // they create loads with specific offsets/spaces, so Phase-1 default Vec loads
       // would be redundant or wrong.
       static const std::unordered_set<std::string> kSelfLoadingOps = {
-          "tensor.slice",  "tensor.assemble",     "tensor.read",
-          "tensor.write",  "tensor.expand_clone", "tensor.gather"};
+          "tensor.slice", "tensor.assemble",     "tensor.read",
+          "tensor.write", "tensor.expand_clone", "tensor.gather"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);
         return;

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -121,7 +121,8 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // they create loads with specific offsets/spaces, so Phase-1 default Vec loads
       // would be redundant or wrong.
       static const std::unordered_set<std::string> kSelfLoadingOps = {
-          "tensor.slice", "tensor.assemble", "tensor.read", "tensor.write", "tensor.expand_clone"};
+          "tensor.slice",  "tensor.assemble",     "tensor.read",
+          "tensor.write",  "tensor.expand_clone", "tensor.gather"};
       if (kSelfLoadingOps.count(call->op_->name_)) {
         IRVisitor::VisitStmt_(op);
         return;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -764,22 +764,26 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& index = args[1];
 
         auto input_tensor_type = As<TensorType>(input->GetType());
-        CHECK(input_tensor_type) << "tensor.gather conversion: input must be TensorType, got "
-                                 << input->GetType()->TypeName();
+        auto input_tile_type = As<TileType>(input->GetType());
+        CHECK(input_tensor_type || input_tile_type)
+            << "tensor.gather conversion: input must be TensorType or TileType, got "
+            << input->GetType()->TypeName();
         auto index_tensor_type = As<TensorType>(index->GetType());
-        CHECK(index_tensor_type) << "tensor.gather conversion: index must be TensorType, got "
-                                 << index->GetType()->TypeName();
-        CHECK(input_tensor_type->shape_.size() == 2 && index_tensor_type->shape_.size() == 2)
+        auto index_tile_type = As<TileType>(index->GetType());
+        CHECK(index_tensor_type || index_tile_type)
+            << "tensor.gather conversion: index must be TensorType or TileType, got "
+            << index->GetType()->TypeName();
+        const auto& input_shape = input_tensor_type ? input_tensor_type->shape_ : input_tile_type->shape_;
+        const auto& index_shape = index_tensor_type ? index_tensor_type->shape_ : index_tile_type->shape_;
+        CHECK(input_shape.size() == 2 && index_shape.size() == 2)
             << "tensor.gather conversion (MVP): only rank-2 inputs supported";
 
         int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
-        const int64_t rank = static_cast<int64_t>(input_tensor_type->shape_.size());
+        const int64_t rank = static_cast<int64_t>(input_shape.size());
         CHECK(dim_val == -1 || dim_val == rank - 1)
             << "tensor.gather conversion (MVP): only dim=-1 supported, got " << dim_val;
 
-        const auto& input_shape = input_tensor_type->shape_;   // [B, N]
-        const auto& index_shape = index_tensor_type->shape_;   // [B, K]
-        DataType input_dtype = input_tensor_type->dtype_;
+        DataType input_dtype = input_tensor_type ? input_tensor_type->dtype_ : input_tile_type->dtype_;
 
         auto make_index_const = [&](int64_t value) -> ExprPtr {
           return std::make_shared<ConstInt>(value, DataType::INDEX, span);
@@ -809,45 +813,50 @@ void OpConversionRegistry::RegisterGatherOps() {
         auto src_shape_tuple = MakeShapeTuple(src_row_shape, span);
         auto idx_shape_tuple = MakeShapeTuple(idx_row_shape, span);
 
-        std::vector<std::pair<std::string, std::any>> load_kwargs = {
-            {"target_memory", MemorySpace::Vec}, {"transpose", false}};
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
+                                                                     {"transpose", false}};
+
+        auto make_row = [&](const ExprPtr& tensor_or_tile, bool is_tensor,
+                            const ExprPtr& row_shape_tuple) -> CallPtr {
+          if (is_tensor) {
+            return op_reg.Create("tile.load", {tensor_or_tile, row_offsets, row_shape_tuple, row_shape_tuple},
+                                 load_kwargs, span);
+          }
+          return op_reg.Create("tile.slice", {tensor_or_tile, row_shape_tuple, row_offsets, row_shape_tuple},
+                               span);
+        };
 
         std::vector<StmtPtr> body_stmts;
-        auto src_load = op_reg.Create("tile.load", {input, row_offsets, src_shape_tuple, src_shape_tuple},
-                                      load_kwargs, span);
+        auto src_load = make_row(input, input_tensor_type != nullptr, src_shape_tuple);
         auto src_tile_var = std::make_shared<Var>("gather_src_row", src_load->GetType(), span);
         body_stmts.push_back(std::make_shared<AssignStmt>(src_tile_var, src_load, span));
 
-        auto idx_load = op_reg.Create("tile.load", {index, row_offsets, idx_shape_tuple, idx_shape_tuple},
-                                      load_kwargs, span);
+        auto idx_load = make_row(index, index_tensor_type != nullptr, idx_shape_tuple);
         auto idx_tile_var = std::make_shared<Var>("gather_idx_row", idx_load->GetType(), span);
         body_stmts.push_back(std::make_shared<AssignStmt>(idx_tile_var, idx_load, span));
 
         // Scratch workspace tile required by tile.gather (same shape as idx row, INT32).
         std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
             {"dtype", DataType(DataType::INT32)}, {"target_memory", MemorySpace::Vec}};
-        auto tmp_create_call =
-            op_reg.Create("tile.create", {idx_shape_tuple}, tmp_create_kwargs, span);
+        auto tmp_create_call = op_reg.Create("tile.create", {idx_shape_tuple}, tmp_create_kwargs, span);
         auto tmp_tile_var = std::make_shared<Var>("gather_tmp", tmp_create_call->GetType(), span);
         body_stmts.push_back(std::make_shared<AssignStmt>(tmp_tile_var, tmp_create_call, span));
 
-        auto gather_call =
-            op_reg.Create("tile.gather", {src_tile_var, idx_tile_var, tmp_tile_var}, span);
+        auto gather_call = op_reg.Create("tile.gather", {src_tile_var, idx_tile_var, tmp_tile_var}, span);
         auto gather_row_var = std::make_shared<Var>("gather_row", gather_call->GetType(), span);
         body_stmts.push_back(std::make_shared<AssignStmt>(gather_row_var, gather_call, span));
 
         // Assemble the per-row result into the accumulator; Phase 3 rewrites
         // this tile.assemble into tile.store once the Out param is added.
-        auto assemble_call =
-            op_reg.Create("tile.assemble", {iter_arg, gather_row_var, row_offsets}, span);
+        auto assemble_call = op_reg.Create("tile.assemble", {iter_arg, gather_row_var, row_offsets}, span);
         auto assemble_var = std::make_shared<Var>("gather_assemble", assemble_call->GetType(), span);
         body_stmts.push_back(std::make_shared<AssignStmt>(assemble_var, assemble_call, span));
         body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{assemble_var}, span));
 
         auto body = SeqStmts::Flatten(std::move(body_stmts), span);
-        auto for_stmt = std::make_shared<ForStmt>(loop_var, zero, input_shape[0], one,
-                                                  std::vector<IterArgPtr>{iter_arg}, body,
-                                                  std::vector<VarPtr>{return_var}, span);
+        auto for_stmt =
+            std::make_shared<ForStmt>(loop_var, zero, input_shape[0], one, std::vector<IterArgPtr>{iter_arg},
+                                      body, std::vector<VarPtr>{return_var}, span);
         prologue.push_back(for_stmt);
         return ConversionResult{std::move(prologue), return_var};
       });

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -87,6 +87,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterMemoryOps();
   RegisterMatmulOps();
   RegisterReductionOps();
+  RegisterSortOps();
 }
 
 // ============================================================================
@@ -721,6 +722,17 @@ void OpConversionRegistry::RegisterReductionOps() {
   RegisterCustom("tensor.row_max", MakeReductionConv("tile.row_max"));
   RegisterCustom("tensor.row_sum", MakeReductionConv("tile.row_sum"));
   RegisterCustom("tensor.row_min", MakeReductionConv("tile.row_min"));
+}
+
+// ============================================================================
+// Sort ops: sort32, mrgsort_format1, mrgsort_format2 — simple 1:1 name mapping.
+// Auto-bridge in the convert pass loads TensorType args to Vec tiles.
+// ============================================================================
+
+void OpConversionRegistry::RegisterSortOps() {
+  RegisterSimple("tensor.sort32", "tile.sort32");
+  RegisterSimple("tensor.mrgsort_format1", "tile.mrgsort_format1");
+  RegisterSimple("tensor.mrgsort_format2", "tile.mrgsort_format2");
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -88,6 +88,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterMatmulOps();
   RegisterReductionOps();
   RegisterSortOps();
+  RegisterGatherOps();
 }
 
 // ============================================================================
@@ -733,6 +734,123 @@ void OpConversionRegistry::RegisterSortOps() {
   RegisterSimple("tensor.sort32", "tile.sort32");
   RegisterSimple("tensor.mrgsort_format1", "tile.mrgsort_format1");
   RegisterSimple("tensor.mrgsort_format2", "tile.mrgsort_format2");
+  RegisterSimple("tensor.gather_mask", "tile.gather_mask");
+}
+
+// ============================================================================
+// Gather op: tensor.gather -> per-row tile.load + tile.gather + tile.assemble
+// loop over the outer (non-gather) dimension.
+//
+// MVP supports 2D input with dim == -1 (last axis). Semantics:
+//     out[b, k] = input[b, index[b, k]]
+//
+// The loop yields a TileType accumulator built via tile.assemble; Phase 3 of
+// ConvertTensorToTileOps then rewrites the loop to write directly into an
+// added Out tensor parameter via tile.store (see RewriteReturnedAssembleLoop-
+// ToStore). Using per-row slicing avoids materialising a `b * N` base offset
+// tile, which would otherwise require an arange/iota op PyPTO currently lacks.
+// ============================================================================
+
+void OpConversionRegistry::RegisterGatherOps() {
+  RegisterCustom(
+      "tensor.gather",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 2) << "tensor.gather conversion expects 2 args (input, index), got "
+                                << args.size();
+        auto& op_reg = OpRegistry::GetInstance();
+
+        const auto& input = args[0];
+        const auto& index = args[1];
+
+        auto input_tensor_type = As<TensorType>(input->GetType());
+        CHECK(input_tensor_type) << "tensor.gather conversion: input must be TensorType, got "
+                                 << input->GetType()->TypeName();
+        auto index_tensor_type = As<TensorType>(index->GetType());
+        CHECK(index_tensor_type) << "tensor.gather conversion: index must be TensorType, got "
+                                 << index->GetType()->TypeName();
+        CHECK(input_tensor_type->shape_.size() == 2 && index_tensor_type->shape_.size() == 2)
+            << "tensor.gather conversion (MVP): only rank-2 inputs supported";
+
+        int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
+        const int64_t rank = static_cast<int64_t>(input_tensor_type->shape_.size());
+        CHECK(dim_val == -1 || dim_val == rank - 1)
+            << "tensor.gather conversion (MVP): only dim=-1 supported, got " << dim_val;
+
+        const auto& input_shape = input_tensor_type->shape_;   // [B, N]
+        const auto& index_shape = index_tensor_type->shape_;   // [B, K]
+        DataType input_dtype = input_tensor_type->dtype_;
+
+        auto make_index_const = [&](int64_t value) -> ExprPtr {
+          return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+        };
+        ExprPtr zero = make_index_const(0);
+        ExprPtr one = make_index_const(1);
+
+        std::vector<StmtPtr> prologue;
+
+        // Accumulator tile, shape equal to the output tensor; Phase 3 later
+        // rewrites this init to the added Out tensor parameter.
+        auto acc_shape_tuple = MakeShapeTuple(index_shape, span);
+        std::vector<std::pair<std::string, std::any>> acc_create_kwargs = {
+            {"dtype", input_dtype}, {"target_memory", MemorySpace::Vec}};
+        auto acc_create_call = op_reg.Create("tile.create", {acc_shape_tuple}, acc_create_kwargs, span);
+        auto acc_init_var = std::make_shared<Var>("gather_out_init", acc_create_call->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(acc_init_var, acc_create_call, span));
+
+        auto acc_tile_type = acc_create_call->GetType();
+        auto loop_var = std::make_shared<Var>("b", std::make_shared<ScalarType>(DataType::INDEX), span);
+        auto iter_arg = std::make_shared<IterArg>("gather_acc", acc_tile_type, acc_init_var, span);
+        auto return_var = std::make_shared<Var>("gather_result", acc_tile_type, span);
+
+        auto row_offsets = std::make_shared<MakeTuple>(std::vector<ExprPtr>{loop_var, zero}, span);
+        std::vector<ExprPtr> src_row_shape = {one, input_shape[1]};
+        std::vector<ExprPtr> idx_row_shape = {one, index_shape[1]};
+        auto src_shape_tuple = MakeShapeTuple(src_row_shape, span);
+        auto idx_shape_tuple = MakeShapeTuple(idx_row_shape, span);
+
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {
+            {"target_memory", MemorySpace::Vec}, {"transpose", false}};
+
+        std::vector<StmtPtr> body_stmts;
+        auto src_load = op_reg.Create("tile.load", {input, row_offsets, src_shape_tuple, src_shape_tuple},
+                                      load_kwargs, span);
+        auto src_tile_var = std::make_shared<Var>("gather_src_row", src_load->GetType(), span);
+        body_stmts.push_back(std::make_shared<AssignStmt>(src_tile_var, src_load, span));
+
+        auto idx_load = op_reg.Create("tile.load", {index, row_offsets, idx_shape_tuple, idx_shape_tuple},
+                                      load_kwargs, span);
+        auto idx_tile_var = std::make_shared<Var>("gather_idx_row", idx_load->GetType(), span);
+        body_stmts.push_back(std::make_shared<AssignStmt>(idx_tile_var, idx_load, span));
+
+        // Scratch workspace tile required by tile.gather (same shape as idx row, INT32).
+        std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
+            {"dtype", DataType(DataType::INT32)}, {"target_memory", MemorySpace::Vec}};
+        auto tmp_create_call =
+            op_reg.Create("tile.create", {idx_shape_tuple}, tmp_create_kwargs, span);
+        auto tmp_tile_var = std::make_shared<Var>("gather_tmp", tmp_create_call->GetType(), span);
+        body_stmts.push_back(std::make_shared<AssignStmt>(tmp_tile_var, tmp_create_call, span));
+
+        auto gather_call =
+            op_reg.Create("tile.gather", {src_tile_var, idx_tile_var, tmp_tile_var}, span);
+        auto gather_row_var = std::make_shared<Var>("gather_row", gather_call->GetType(), span);
+        body_stmts.push_back(std::make_shared<AssignStmt>(gather_row_var, gather_call, span));
+
+        // Assemble the per-row result into the accumulator; Phase 3 rewrites
+        // this tile.assemble into tile.store once the Out param is added.
+        auto assemble_call =
+            op_reg.Create("tile.assemble", {iter_arg, gather_row_var, row_offsets}, span);
+        auto assemble_var = std::make_shared<Var>("gather_assemble", assemble_call->GetType(), span);
+        body_stmts.push_back(std::make_shared<AssignStmt>(assemble_var, assemble_call, span));
+        body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{assemble_var}, span));
+
+        auto body = SeqStmts::Flatten(std::move(body_stmts), span);
+        auto for_stmt = std::make_shared<ForStmt>(loop_var, zero, input_shape[0], one,
+                                                  std::vector<IterArgPtr>{iter_arg}, body,
+                                                  std::vector<VarPtr>{return_var}, span);
+        prologue.push_back(for_stmt);
+        return ConversionResult{std::move(prologue), return_var};
+      });
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -213,6 +213,80 @@ class MrgSort1FP32Program:
 
 
 @pl.program
+class MrgSort1DynFP32TensorProgram:
+    """Tensor-level counterpart of ``MrgSort1DynFP32Program``.
+
+    Same pipeline (sort32 → 3× mrgsort format1 → gather for sorted values) but
+    expressed with the ``pl.tensor.*`` API inside a single ``Opaque`` main
+    wrapped in ``pl.at(CORE_GROUP)`` — following the tensor-level style used in
+    ``test_cross_core.py``. Sorted values are extracted from the interleaved
+    ``[1, 4096]`` mrgsort output via ``pl.tensor.gather(mask_pattern=P0101)``,
+    which lowers directly to ``tile.gather_mask`` (1:1).
+
+    Block_len schedule matches the tile version: 1<<(6+2*i) = 64, 256, 1024.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[1, 2048], pl.FP32],
+        idx: pl.Tensor[[1, 2048], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
+    ) -> pl.Tensor[[1, 2048], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            sorted_t = pl.tensor.sort32(src, idx)
+            for i, (acc,) in pl.range(3, init_values=(sorted_t,)):
+                block_len = 1 << (6 + i * 2)
+                merged = pl.tensor.mrgsort(acc, block_len=block_len)
+                result = pl.yield_(merged)
+            # P0101 selects even positions: [val0, idx0, val1, idx1, ...] → values only.
+            vals = pl.tensor.gather(result, mask_pattern=pl.tile.MaskPattern.P0101)
+            val_output = pl.assemble(val_output, vals, [0, 0])
+        return val_output
+
+
+@pl.program
+class MrgSort1DynFP32TensorValIdxProgram:
+    """Tensor-level sort32 + mrgsort + mask-gather pipeline that returns BOTH
+    sorted values and their original indices.
+
+    Mirrors ``MrgSort1DynFP32Program`` at the tensor level: P0101 extracts
+    value lanes, P1010 with ``output_dtype=UINT32`` bit-reinterprets the
+    odd-position UINT32 index bits stored by sort32 into a UINT32 tensor.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[1, 2048], pl.FP32],
+        idx: pl.Tensor[[1, 2048], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 2048], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            sorted_t = pl.tensor.sort32(src, idx)
+            for i, (acc,) in pl.range(3, init_values=(sorted_t,)):
+                block_len = 1 << (6 + i * 2)
+                merged = pl.tensor.mrgsort(acc, block_len=block_len)
+                result = pl.yield_(merged)
+            # P0101 → sorted values (FP32 at even positions).
+            vals = pl.tensor.gather(result, mask_pattern=pl.tile.MaskPattern.P0101)
+            # P1010 + output_dtype=UINT32 → bit-reinterpret odd-position bits into UINT32.
+            sorted_idx = pl.tensor.gather(
+                result, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
+            )
+            val_output = pl.assemble(val_output, vals, [0, 0])
+            idx_output = pl.assemble(idx_output, sorted_idx, [0, 0])
+        return val_output, idx_output
+
+
+@pl.program
 class MrgSort1DynFP32Program:
     """Sort 64×32-element blocks (2048 values) with sort32, then merge with
     3 iterations of mrgsort format1 using dynamic block_len computed from loop index.
@@ -382,6 +456,77 @@ class MrgSort1DynFP32TestCase(PTOTestCase):
         tensors["val_output"][:] = src[global_order].unsqueeze(0)
 
         # Expected idx: the original index mapping permuted by sort order
+        tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
+
+
+class MrgSort1DynFP32TensorTestCase(PTOTestCase):
+    """Tensor-level counterpart of ``MrgSort1DynFP32TestCase``.
+
+    Uses the ``pl.tensor.*`` API (sort32 / mrgsort / gather mask form) inside
+    an Opaque main wrapped in ``pl.at(CORE_GROUP)``. Only sorted values are
+    checked — the gather P0101 form extracts even-position values and discards
+    the odd-position index bits.
+    """
+
+    def get_name(self) -> str:
+        return "mrgsort1_dyn_fp32_tensor"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [1, 2048], DataType.FP32, init_value=_make_src_1x2048),
+            TensorSpec("idx", [1, 2048], DataType.UINT32, init_value=_make_idx_1x2048),
+            TensorSpec("val_output", [1, 2048], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MrgSort1DynFP32TensorProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Sorted descending values for the 2048-element input."""
+        src = tensors["src"].flatten()
+        sorted_vals, _ = torch.sort(src, descending=True)
+        tensors["val_output"][:] = sorted_vals.unsqueeze(0)
+
+
+class MrgSort1DynFP32TensorValIdxTestCase(PTOTestCase):
+    """Tensor-level sort32 + mrgsort + mask-gather returning both val and idx.
+
+    Tests P0101 (values) and P1010 (+ output_dtype=UINT32 for bit-reinterpret)
+    tensor-level gather masks in a single program.
+    """
+
+    def get_name(self) -> str:
+        return "mrgsort1_dyn_fp32_tensor_val_idx"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [1, 2048], DataType.FP32, init_value=_make_src_1x2048),
+            TensorSpec("idx", [1, 2048], DataType.UINT32, init_value=_make_idx_1x2048),
+            TensorSpec("val_output", [1, 2048], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [1, 2048], DataType.UINT32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MrgSort1DynFP32TensorValIdxProgram
+
+    def compute_expected(self, tensors, params=None):
+        """Sorted values and permuted original indices for the 2048-element input."""
+        src = tensors["src"].flatten()
+        idx = tensors["idx"].flatten()
+        _, global_order = torch.sort(src, descending=True)
+        tensors["val_output"][:] = src[global_order].unsqueeze(0)
         tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
 
 
@@ -556,6 +701,18 @@ class TestSort:
     def test_mrgsort1_dyn_fp32(self, test_runner):
         """Test tmrgsort format1 with dynamic block_len: sort 2048 elements via iterative merge."""
         test_case = MrgSort1DynFP32TestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_mrgsort1_dyn_fp32_tensor(self, test_runner):
+        """Tensor-level sort32 + mrgsort + gather pipeline for 2048-element sort."""
+        test_case = MrgSort1DynFP32TensorTestCase()
+        result = test_runner.run(test_case)
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_mrgsort1_dyn_fp32_tensor_val_idx(self, test_runner):
+        """Tensor-level sort32 + mrgsort + P0101/P1010 mask-gather: returns values and indices."""
+        test_case = MrgSort1DynFP32TensorValIdxTestCase()
         result = test_runner.run(test_case)
         assert result.passed, f"Test failed: {result.error}"
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1848,5 +1848,124 @@ class TestTensorFormatShapeError:
             ir.op.tensor.add(tensor_a, tensor_b)
 
 
+def test_tensor_sort32():
+    """tensor.sort32 doubles the last dim and preserves dtype."""
+    span = ir.Span.unknown()
+    d8 = ir.ConstInt(8, DataType.INT32, span)
+    d32 = ir.ConstInt(32, DataType.INT32, span)
+    src = ir.Var("src", ir.TensorType([d8, d32], DataType.FP32), span)
+    idx = ir.Var("idx", ir.TensorType([d8, d32], DataType.UINT32), span)
+
+    call = ir.op.tensor.sort32(src, idx)
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.sort32"
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 2
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[1].value == 64
+
+
+def test_tensor_sort32_wrong_dtype():
+    """tensor.sort32 rejects non-FP src dtype."""
+    span = ir.Span.unknown()
+    d8 = ir.ConstInt(8, DataType.INT32, span)
+    d32 = ir.ConstInt(32, DataType.INT32, span)
+    src = ir.Var("src", ir.TensorType([d8, d32], DataType.INT32), span)
+    idx = ir.Var("idx", ir.TensorType([d8, d32], DataType.INT32), span)
+
+    with pytest.raises(Exception, match=r"FP16 or FP32"):
+        ir.op.tensor.sort32(src, idx)
+
+
+def test_tensor_mrgsort_format1():
+    """tensor.mrgsort(block_len=...) emits tensor.mrgsort_format1 with src shape."""
+    span = ir.Span.unknown()
+    d1 = ir.ConstInt(1, DataType.INT32, span)
+    d128 = ir.ConstInt(128, DataType.INT32, span)
+    src = ir.Var("src", ir.TensorType([d1, d128], DataType.FP32), span)
+
+    call = ir.op.tensor.mrgsort(src, block_len=64)
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.mrgsort_format1"
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[1].value == 128
+
+
+def test_tensor_mrgsort_format1_invalid_block_len():
+    """tensor.mrgsort_format1 rejects block_len that is not a multiple of 64."""
+    span = ir.Span.unknown()
+    d1 = ir.ConstInt(1, DataType.INT32, span)
+    d128 = ir.ConstInt(128, DataType.INT32, span)
+    src = ir.Var("src", ir.TensorType([d1, d128], DataType.FP32), span)
+
+    with pytest.raises(Exception, match=r"multiple of 64"):
+        ir.op.tensor.mrgsort(src, block_len=63)
+
+
+def test_tensor_mrgsort_format2():
+    """tensor.mrgsort(src0..src3, tmp, executed) emits tensor.mrgsort_format2."""
+    span = ir.Span.unknown()
+    d1 = ir.ConstInt(1, DataType.INT32, span)
+    d128 = ir.ConstInt(128, DataType.INT32, span)
+    d4 = ir.ConstInt(4, DataType.INT32, span)
+    d512 = ir.ConstInt(512, DataType.INT32, span)
+    src_t = ir.TensorType([d1, d128], DataType.FP32)
+    tmp_t = ir.TensorType([d1, d512], DataType.FP32)
+    exe_t = ir.TensorType([d4], DataType.INT32)
+
+    srcs = [ir.Var(f"s{i}", src_t, span) for i in range(4)]
+    tmp = ir.Var("tmp", tmp_t, span)
+    exe = ir.Var("exe", exe_t, span)
+
+    call = ir.op.tensor.mrgsort(*srcs, tmp, exe)
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.mrgsort_format2"
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    # Output shape matches tmp tensor's shape
+    assert isinstance(result_type.shape[1], ir.ConstInt)
+    assert result_type.shape[1].value == 512
+
+
+def test_tensor_mrgsort_format2_dtype_mismatch():
+    """tensor.mrgsort_format2 rejects mismatched src dtypes."""
+    span = ir.Span.unknown()
+    d1 = ir.ConstInt(1, DataType.INT32, span)
+    d128 = ir.ConstInt(128, DataType.INT32, span)
+    src_fp32 = ir.TensorType([d1, d128], DataType.FP32)
+    src_fp16 = ir.TensorType([d1, d128], DataType.FP16)
+
+    s0 = ir.Var("s0", src_fp32, span)
+    s1 = ir.Var("s1", src_fp16, span)
+    s2 = ir.Var("s2", src_fp32, span)
+    s3 = ir.Var("s3", src_fp32, span)
+    tmp = ir.Var("tmp", src_fp32, span)
+    exe = ir.Var("exe", src_fp32, span)
+
+    with pytest.raises(Exception, match=r"matching dtype"):
+        ir.op.tensor.mrgsort(s0, s1, s2, s3, tmp, exe)
+
+
+def test_tensor_mrgsort_mixed_args_rejected():
+    """mrgsort cannot mix block_len with format2 positional args."""
+    span = ir.Span.unknown()
+    d1 = ir.ConstInt(1, DataType.INT32, span)
+    d128 = ir.ConstInt(128, DataType.INT32, span)
+    s0 = ir.Var("s0", ir.TensorType([d1, d128], DataType.FP32), span)
+    s1 = ir.Var("s1", ir.TensorType([d1, d128], DataType.FP32), span)
+
+    with pytest.raises(ValueError, match=r"mutually exclusive"):
+        ir.op.tensor.mrgsort(s0, s1, block_len=64)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1967,5 +1967,150 @@ def test_tensor_mrgsort_mixed_args_rejected():
         ir.op.tensor.mrgsort(s0, s1, block_len=64)
 
 
+# Tensor gather tests
+
+
+def _make_gather_inputs(src_dtype=DataType.FP32, idx_dtype=DataType.INT32, b=4, n=16, k=3):
+    span = ir.Span.unknown()
+    B = ir.ConstInt(b, DataType.INT32, span)
+    N = ir.ConstInt(n, DataType.INT32, span)
+    K = ir.ConstInt(k, DataType.INT32, span)
+    inp = ir.Var("inp", ir.TensorType([B, N], src_dtype), span)
+    idx = ir.Var("idx", ir.TensorType([B, K], idx_dtype), span)
+    return inp, idx
+
+
+def test_tensor_gather_basic():
+    """tensor.gather output has index shape and input dtype."""
+    inp, idx = _make_gather_inputs()
+    call = ir.op.tensor.gather(inp, dim=-1, index=idx)
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    assert len(result_type.shape) == 2
+    assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 4
+    assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 3
+
+
+def test_tensor_gather_dim_last_axis_positive():
+    """dim=rank-1 is accepted as an alias for dim=-1."""
+    inp, idx = _make_gather_inputs()
+    call = ir.op.tensor.gather(inp, dim=1, index=idx)
+    assert call.op.name == "tensor.gather"
+
+
+def test_tensor_gather_rejects_bad_dim():
+    inp, idx = _make_gather_inputs()
+    with pytest.raises(Exception, match=r"dim=-1 or dim=rank-1"):
+        ir.op.tensor.gather(inp, dim=0, index=idx)
+
+
+def test_tensor_gather_rejects_non_int32_index():
+    inp, idx = _make_gather_inputs(idx_dtype=DataType.INT16)
+    with pytest.raises(Exception, match=r"index dtype to be INT32"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx)
+
+
+def test_tensor_gather_rejects_unsupported_input_dtype():
+    inp, idx = _make_gather_inputs(src_dtype=DataType.UINT32)
+    with pytest.raises(Exception, match=r"FP16, FP32, INT16, or INT32"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx)
+
+
+def test_tensor_gather_rejects_rank_mismatch():
+    span = ir.Span.unknown()
+    B = ir.ConstInt(4, DataType.INT32, span)
+    N = ir.ConstInt(16, DataType.INT32, span)
+    K = ir.ConstInt(3, DataType.INT32, span)
+    inp = ir.Var("inp", ir.TensorType([B, N], DataType.FP32), span)
+    idx = ir.Var("idx", ir.TensorType([K], DataType.INT32), span)
+    with pytest.raises(Exception, match=r"rank"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx)
+
+
+def test_tensor_gather_rejects_non_matching_outer_dim():
+    span = ir.Span.unknown()
+    B = ir.ConstInt(4, DataType.INT32, span)
+    B2 = ir.ConstInt(5, DataType.INT32, span)
+    N = ir.ConstInt(16, DataType.INT32, span)
+    K = ir.ConstInt(3, DataType.INT32, span)
+    inp = ir.Var("inp", ir.TensorType([B, N], DataType.FP32), span)
+    idx = ir.Var("idx", ir.TensorType([B2, K], DataType.INT32), span)
+    with pytest.raises(Exception, match=r"non-gather axis"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx)
+
+
+# ---- tensor.gather_mask (mask-pattern form) -----------------------------------
+
+
+def _make_gather_mask_input(rows: int = 8, cols: int = 64, dtype: DataType = DataType.FP32):
+    span = ir.Span.unknown()
+    R = ir.ConstInt(rows, DataType.INT32, span)
+    C = ir.ConstInt(cols, DataType.INT32, span)
+    return ir.Var("inp", ir.TensorType([R, C], dtype), span)
+
+
+def test_tensor_gather_mask_p0101_halves_last_dim():
+    """tensor.gather(input, mask_pattern=1) emits tensor.gather_mask, last dim /= 2."""
+    inp = _make_gather_mask_input(rows=8, cols=64)
+    call = ir.op.tensor.gather(inp, mask_pattern=1)
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.gather_mask"
+    rt = call.type
+    assert isinstance(rt, ir.TensorType)
+    assert rt.dtype == DataType.FP32
+    assert isinstance(rt.shape[0], ir.ConstInt) and rt.shape[0].value == 8
+    assert isinstance(rt.shape[1], ir.ConstInt) and rt.shape[1].value == 32
+
+
+def test_tensor_gather_mask_p0001_quarters_last_dim():
+    """Patterns 3..6 produce a /4 shrink."""
+    inp = _make_gather_mask_input(rows=4, cols=64)
+    call = ir.op.tensor.gather(inp, mask_pattern=3)
+    assert isinstance(call.type.shape[1], ir.ConstInt)
+    assert call.type.shape[1].value == 16
+
+
+def test_tensor_gather_mask_p1111_keeps_last_dim():
+    inp = _make_gather_mask_input(rows=4, cols=64)
+    call = ir.op.tensor.gather(inp, mask_pattern=7)
+    assert isinstance(call.type.shape[1], ir.ConstInt)
+    assert call.type.shape[1].value == 64
+
+
+def test_tensor_gather_mask_output_dtype_reinterpret():
+    """output_dtype reinterprets bits to a same-bit-width dtype."""
+    inp = _make_gather_mask_input(rows=2, cols=32, dtype=DataType.FP32)
+    call = ir.op.tensor.gather(inp, mask_pattern=2, output_dtype=DataType.UINT32)
+    assert call.op.name == "tensor.gather_mask"
+    assert call.type.dtype == DataType.UINT32
+
+
+def test_tensor_gather_mask_rejects_bad_pattern():
+    inp = _make_gather_mask_input()
+    with pytest.raises(Exception, match=r"mask_pattern in range"):
+        ir.op.tensor.gather(inp, mask_pattern=0)
+
+
+def test_tensor_gather_mask_rejects_indivisible_cols():
+    inp = _make_gather_mask_input(rows=2, cols=33)
+    with pytest.raises(Exception, match=r"divisible by 2"):
+        ir.op.tensor.gather(inp, mask_pattern=1)
+
+
+def test_tensor_gather_mask_rejects_dtype_width_mismatch():
+    inp = _make_gather_mask_input(rows=2, cols=32, dtype=DataType.FP16)
+    with pytest.raises(Exception, match=r"same bit width"):
+        ir.op.tensor.gather(inp, mask_pattern=1, output_dtype=DataType.FP32)
+
+
+def test_tensor_gather_rejects_mixed_index_and_mask():
+    inp, idx = _make_gather_inputs()
+    with pytest.raises(ValueError, match=r"mutually exclusive"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx, mask_pattern=1)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2069,15 +2069,19 @@ def test_tensor_gather_mask_p0001_quarters_last_dim():
     """Patterns 3..6 produce a /4 shrink."""
     inp = _make_gather_mask_input(rows=4, cols=64)
     call = ir.op.tensor.gather(inp, mask_pattern=3)
-    assert isinstance(call.type.shape[1], ir.ConstInt)
-    assert call.type.shape[1].value == 16
+    rt = call.type
+    assert isinstance(rt, ir.TensorType)
+    assert isinstance(rt.shape[1], ir.ConstInt)
+    assert rt.shape[1].value == 16
 
 
 def test_tensor_gather_mask_p1111_keeps_last_dim():
     inp = _make_gather_mask_input(rows=4, cols=64)
     call = ir.op.tensor.gather(inp, mask_pattern=7)
-    assert isinstance(call.type.shape[1], ir.ConstInt)
-    assert call.type.shape[1].value == 64
+    rt = call.type
+    assert isinstance(rt, ir.TensorType)
+    assert isinstance(rt.shape[1], ir.ConstInt)
+    assert rt.shape[1].value == 64
 
 
 def test_tensor_gather_mask_output_dtype_reinterpret():
@@ -2085,7 +2089,9 @@ def test_tensor_gather_mask_output_dtype_reinterpret():
     inp = _make_gather_mask_input(rows=2, cols=32, dtype=DataType.FP32)
     call = ir.op.tensor.gather(inp, mask_pattern=2, output_dtype=DataType.UINT32)
     assert call.op.name == "tensor.gather_mask"
-    assert call.type.dtype == DataType.UINT32
+    rt = call.type
+    assert isinstance(rt, ir.TensorType)
+    assert rt.dtype == DataType.UINT32
 
 
 def test_tensor_gather_mask_rejects_bad_pattern():

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2608,9 +2608,7 @@ class TestConvertSortOps:
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self, src: pl.Tensor[[1, 128], pl.FP32]
-            ) -> pl.Tensor[[1, 128], pl.FP32]:
+            def main_incore_0(self, src: pl.Tensor[[1, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
                 out: pl.Tensor[[1, 128], pl.FP32] = pl.tensor.mrgsort(src, block_len=64)
                 return out
 
@@ -2762,9 +2760,7 @@ class TestConvertGatherOp:
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self, src: pl.Tensor[[8, 64], pl.FP32]
-            ) -> pl.Tensor[[8, 32], pl.FP32]:
+            def main_incore_0(self, src: pl.Tensor[[8, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
                 out: pl.Tensor[[8, 32], pl.FP32] = pl.tensor.gather(src, mask_pattern=1)
                 return out
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2548,5 +2548,172 @@ class TestAssembleParentStride:
         assert "tensor.create" in after_src, "Orchestration should have tensor.create for Out param"
 
 
+class TestConvertSortOps:
+    """Test conversion of tensor sort ops to tile sort ops."""
+
+    def test_sort32_conversion(self):
+        """tensor.sort32 -> tile.load (src, idx) + tile.sort32 + tile.store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[8, 32], pl.FP32],
+                idx: pl.Tensor[[8, 32], pl.UINT32],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                out: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.sort32(src, idx)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[8, 32], pl.FP32],
+                idx: pl.Tensor[[8, 32], pl.UINT32],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                out: pl.Tensor[[8, 64], pl.FP32] = self.main_incore_0(src, idx)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[8, 32], pl.FP32],
+                idx: pl.Tensor[[8, 32], pl.UINT32],
+                out_0: pl.Out[pl.Tensor[[8, 64], pl.FP32]],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                src_tile: pl.Tile[[8, 32], pl.FP32] = pl.load(src, [0, 0], [8, 32])
+                idx_tile: pl.Tile[[8, 32], pl.UINT32] = pl.load(idx, [0, 0], [8, 32])
+                out_tile: pl.Tile[[8, 64], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
+                out_store: pl.Tensor[[8, 64], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
+                return out_store
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[8, 32], pl.FP32],
+                idx: pl.Tensor[[8, 32], pl.UINT32],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                out_0: pl.Tensor[[8, 64], pl.FP32] = pl.create_tensor([8, 64], dtype=pl.FP32)
+                out: pl.Tensor[[8, 64], pl.FP32] = self.main_incore_0(src, idx, out_0)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_mrgsort_format1_conversion(self):
+        """tensor.mrgsort(block_len=...) -> tile.load + tile.mrgsort_format1 + tile.store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, src: pl.Tensor[[1, 128], pl.FP32]
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                out: pl.Tensor[[1, 128], pl.FP32] = pl.tensor.mrgsort(src, block_len=64)
+                return out
+
+            @pl.function
+            def main(self, src: pl.Tensor[[1, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+                out: pl.Tensor[[1, 128], pl.FP32] = self.main_incore_0(src)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                src_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(src, [0, 0], [1, 128])
+                out_tile: pl.Tile[[1, 128], pl.FP32] = pl.tile.mrgsort(src_tile, block_len=64)
+                out_store: pl.Tensor[[1, 128], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
+                return out_store
+
+            @pl.function
+            def main(self, src: pl.Tensor[[1, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+                out_0: pl.Tensor[[1, 128], pl.FP32] = pl.create_tensor([1, 128], dtype=pl.FP32)
+                out: pl.Tensor[[1, 128], pl.FP32] = self.main_incore_0(src, out_0)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_mrgsort_format2_conversion(self):
+        """tensor.mrgsort(s0..s3, tmp, exe) -> 6 tile.loads + tile.mrgsort_format2 + tile.store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                s0: pl.Tensor[[1, 128], pl.FP32],
+                s1: pl.Tensor[[1, 128], pl.FP32],
+                s2: pl.Tensor[[1, 128], pl.FP32],
+                s3: pl.Tensor[[1, 128], pl.FP32],
+                tmp: pl.Tensor[[1, 512], pl.FP32],
+                exe: pl.Tensor[[4], pl.INT32],
+            ) -> pl.Tensor[[1, 512], pl.FP32]:
+                out: pl.Tensor[[1, 512], pl.FP32] = pl.tensor.mrgsort(s0, s1, s2, s3, tmp, exe)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                s0: pl.Tensor[[1, 128], pl.FP32],
+                s1: pl.Tensor[[1, 128], pl.FP32],
+                s2: pl.Tensor[[1, 128], pl.FP32],
+                s3: pl.Tensor[[1, 128], pl.FP32],
+                tmp: pl.Tensor[[1, 512], pl.FP32],
+                exe: pl.Tensor[[4], pl.INT32],
+            ) -> pl.Tensor[[1, 512], pl.FP32]:
+                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, tmp, exe)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                s0: pl.Tensor[[1, 128], pl.FP32],
+                s1: pl.Tensor[[1, 128], pl.FP32],
+                s2: pl.Tensor[[1, 128], pl.FP32],
+                s3: pl.Tensor[[1, 128], pl.FP32],
+                tmp: pl.Tensor[[1, 512], pl.FP32],
+                exe: pl.Tensor[[4], pl.INT32],
+                out_0: pl.Out[pl.Tensor[[1, 512], pl.FP32]],
+            ) -> pl.Tensor[[1, 512], pl.FP32]:
+                s0_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s0, [0, 0], [1, 128])
+                s1_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s1, [0, 0], [1, 128])
+                s2_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s2, [0, 0], [1, 128])
+                s3_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s3, [0, 0], [1, 128])
+                tmp_tile: pl.Tile[[1, 512], pl.FP32] = pl.load(tmp, [0, 0], [1, 512])
+                exe_tile: pl.Tile[[4], pl.INT32] = pl.load(exe, [0], [4])
+                out_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
+                    s0_tile, s1_tile, s2_tile, s3_tile, tmp_tile, exe_tile
+                )
+                out_store: pl.Tensor[[1, 512], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
+                return out_store
+
+            @pl.function
+            def main(
+                self,
+                s0: pl.Tensor[[1, 128], pl.FP32],
+                s1: pl.Tensor[[1, 128], pl.FP32],
+                s2: pl.Tensor[[1, 128], pl.FP32],
+                s3: pl.Tensor[[1, 128], pl.FP32],
+                tmp: pl.Tensor[[1, 512], pl.FP32],
+                exe: pl.Tensor[[4], pl.INT32],
+            ) -> pl.Tensor[[1, 512], pl.FP32]:
+                out_0: pl.Tensor[[1, 512], pl.FP32] = pl.create_tensor([1, 512], dtype=pl.FP32)
+                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, tmp, exe, out_0)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2715,5 +2715,86 @@ class TestConvertSortOps:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestConvertGatherOp:
+    """Test conversion of tensor.gather (MVP: 2D + dim=-1)."""
+
+    def test_gather_conversion(self):
+        """tensor.gather -> per-row loop of tile.load + tile.gather + tile.store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                out: pl.Tensor[[4, 3], pl.FP32] = pl.tensor.gather(inp, dim=-1, index=idx)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_src = After.as_python()
+
+        # Sanity: tensor.gather is fully lowered; tile.gather appears inside a per-row loop.
+        assert "tensor.gather" not in after_src
+        assert "tile.gather" in after_src
+        assert "pl.range(4" in after_src or "range(4" in after_src
+        # The index-form tile.gather needs a [1, 3] INT32 scratch tile.
+        assert "dtype=pl.INT32" in after_src
+        # Per-row slices: [1, 16] from inp, [1, 3] from idx.
+        assert "[1, 16]" in after_src
+        assert "[1, 3]" in after_src
+        # Phase 3 adds an Out tensor param for the result.
+        assert "pl.Out[pl.Tensor[[4, 3]" in after_src
+
+    def test_gather_mask_conversion(self):
+        """tensor.gather(mask_pattern=...) -> tile.load + tile.gather_mask + tile.store."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, src: pl.Tensor[[8, 64], pl.FP32]
+            ) -> pl.Tensor[[8, 32], pl.FP32]:
+                out: pl.Tensor[[8, 32], pl.FP32] = pl.tensor.gather(src, mask_pattern=1)
+                return out
+
+            @pl.function
+            def main(self, src: pl.Tensor[[8, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(src)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[8, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+            ) -> pl.Tensor[[8, 32], pl.FP32]:
+                src_tile: pl.Tile[[8, 64], pl.FP32] = pl.load(src, [0, 0], [8, 64])
+                out_tile: pl.Tile[[8, 32], pl.FP32] = pl.tile.gather(src_tile, mask_pattern=1)
+                out_store: pl.Tensor[[8, 32], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
+                return out_store
+
+            @pl.function
+            def main(self, src: pl.Tensor[[8, 64], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out_0: pl.Tensor[[8, 32], pl.FP32] = pl.create_tensor([8, 32], dtype=pl.FP32)
+                out: pl.Tensor[[8, 32], pl.FP32] = self.main_incore_0(src, out_0)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add tensor-level counterparts to the existing tile-level sort/gather ops so users can write sort/gather pipelines over tensors and let `ConvertTensorToTileOps` handle the tile.load / tile.store bridging.

### New tensor ops

- **`tensor.sort32`** — 1:1 mapping to `tile.sort32`.
- **`tensor.mrgsort_format1` / `tensor.mrgsort_format2`** — 1:1 mapping to tile variants. Python DSL exposes a single `mrgsort()` dispatcher that selects format by argument count.
- **`tensor.gather`** (index form, MVP: rank-2, `dim=-1`) — lowered to a per-row `tile.load` + `tile.gather` + `tile.assemble` loop; Phase-3 rewrites the loop to write directly into an added `Out` tensor param via `tile.store`.
- **`tensor.gather_mask`** — 1:1 mapping to `tile.gather_mask` with `mask_pattern` (P0101..P1111) and optional same-bit-width `output_dtype`.

### Changes span

- **C++ op defs** — `src/ir/op/tensor_ops/sort.cpp`, `src/ir/op/tensor_ops/gather.cpp`
- **Conversion** — `OpConversionRegistry::RegisterSortOps`, `RegisterGatherOps`
- **Python IR/DSL** — `tensor_ops.py` wrappers with `@overload`-based index/mask-form dispatch; mutual-exclusion validation
- **Docs** — `docs/{en,zh-cn}/dev/ir/05-operators.md`
- **Tests** — op unit tests, conversion unit tests (Before/Expected with `ir.assert_structural_equal`), ST runtime tests

## Test plan

- [x] Build passes (`cmake --build build --parallel`)
- [x] Full unit test suite passes (3758 passed / 16 skipped / 0 failed)
- [x] New `TestConvertSortOps` and `TestConvertGatherOp` UT classes pass
- [x] `clang-tidy` clean on newly added/changed code (pre-existing warnings in untouched code only)
- [x] English + Chinese docs synced