### PR TITLE
fix(debug): handle nested calls and boundary padding in torch_codegen

### DIFF
--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -63,41 +63,105 @@ from collections import deque
 
 _pipes = {'to_aiv': deque(), 'to_aic': deque()}
 
+def _coerce_shape(shape):
+    return tuple(int(s) for s in shape)
+
+def _pad_scalar(tensor, pad_mode):
+    if pad_mode == "zero":
+        return 0
+    if tensor.dtype.is_floating_point:
+        finfo = torch.finfo(tensor.dtype)
+        return finfo.min if pad_mode == "min" else finfo.max
+    if tensor.dtype == torch.bool:
+        return False if pad_mode == "min" else True
+    iinfo = torch.iinfo(tensor.dtype)
+    return iinfo.min if pad_mode == "min" else iinfo.max
+
 def _mask_valid_region(tensor, shapes, valid_shapes):
-    if valid_shapes is not None and tuple(valid_shapes) != tuple(shapes):
-        masked = tensor.new_zeros(shapes)
-        valid_slices = tuple(slice(0, s) for s in valid_shapes)
-        masked[valid_slices] = tensor[valid_slices]
-        return masked
+    shapes_t = _coerce_shape(shapes)
+    valid_t = _coerce_shape(valid_shapes) if valid_shapes is not None else None
+    if valid_t is not None:
+        if valid_t != shapes_t:
+            masked = tensor.new_zeros(shapes_t)
+            valid_slices = tuple(slice(0, s) for s in valid_t)
+            masked[valid_slices] = tensor[valid_slices]
+            tensor = masked
+        tensor._pypto_valid_shape = valid_t
+        tensor._pypto_full_shape = shapes_t
     return tensor
 
 def _tile_load(tensor, offsets, shapes, valid_shapes=None):
-    slices = tuple(slice(o, o + s) for o, s in zip(offsets, shapes))
+    offsets_t = _coerce_shape(offsets)
+    shapes_t = _coerce_shape(shapes)
+    slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, shapes_t))
     tile = tensor[slices].clone()
+    actual_shape = tuple(tile.shape)
     # Pad to requested shape if source is smaller (boundary case)
-    if tile.shape != tuple(shapes):
-        padded = tile.new_zeros(shapes)
-        pad_slices = tuple(slice(0, s) for s in tile.shape)
+    if actual_shape != shapes_t:
+        padded = tile.new_zeros(shapes_t)
+        pad_slices = tuple(slice(0, s) for s in actual_shape)
         padded[pad_slices] = tile
         tile = padded
-    return _mask_valid_region(tile, shapes, valid_shapes)
+    # Use provided valid_shapes or fall back to the physical boundary; cap by actual data bounds.
+    v_shape = _coerce_shape(valid_shapes) if valid_shapes is not None else actual_shape
+    v_shape = tuple(min(v, a) for v, a in zip(v_shape, actual_shape))
+    return _mask_valid_region(tile, shapes_t, v_shape)
 
 def _tile_store(tile, offsets, output_tensor):
-    slices = tuple(slice(o, o + s) for o, s in zip(offsets, tile.shape))
-    output_tensor[slices] = tile
+    offsets_t = _coerce_shape(offsets)
+    valid_shape = getattr(tile, "_pypto_valid_shape", tuple(tile.shape))
+    slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, valid_shape))
+    valid_slices = tuple(slice(0, s) for s in valid_shape)
+    output_tensor[slices] = tile[valid_slices]
     return output_tensor
 
-def _tensor_slice(tensor, offsets, shapes):
-    slices = tuple(slice(o, o + s) for o, s in zip(offsets, shapes))
-    return tensor[slices]
+def _tensor_slice(tensor, offsets, shapes, valid_shapes=None):
+    offsets_t = _coerce_shape(offsets)
+    shapes_t = _coerce_shape(shapes)
+    slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, shapes_t))
+    sliced = tensor[slices]
+    # Out-of-bounds tensor.slice in kernels should still materialize the
+    # requested shape for downstream matmul/fillpad paths.
+    if tuple(sliced.shape) != shapes_t:
+        padded = sliced.new_zeros(shapes_t)
+        pad_slices = tuple(slice(0, s) for s in sliced.shape)
+        padded[pad_slices] = sliced
+        sliced = padded
+    if valid_shapes is not None:
+        sliced._pypto_valid_shape = _coerce_shape(valid_shapes)
+        sliced._pypto_full_shape = shapes_t
+    return sliced
+
+def _fillpad(tensor, pad_mode="zero"):
+    valid_shape = getattr(tensor, "_pypto_valid_shape", None)
+    full_shape = getattr(tensor, "_pypto_full_shape", tuple(tensor.shape))
+    full_shape = _coerce_shape(full_shape)
+    if tuple(tensor.shape) != full_shape:
+        padded = tensor.new_zeros(full_shape)
+        pad_slices = tuple(slice(0, s) for s in tensor.shape)
+        padded[pad_slices] = tensor
+        tensor = padded
+    if valid_shape is None:
+        return tensor
+    valid_shape = _coerce_shape(valid_shape)
+    if valid_shape == full_shape:
+        return tensor
+    fill_value = _pad_scalar(tensor, pad_mode)
+    padded = tensor.new_full(full_shape, fill_value)
+    valid_slices = tuple(slice(0, s) for s in valid_shape)
+    padded[valid_slices] = tensor[valid_slices]
+    return padded
 
 def _write_and_return(container, index, value):
     container[index] = value
     return container
 
 def _assemble(target, source, offsets):
-    slices = tuple(slice(o, o + s) for o, s in zip(offsets, source.shape))
-    target[slices] = source
+    offsets_t = _coerce_shape(offsets)
+    valid_shape = getattr(source, "_pypto_valid_shape", tuple(source.shape))
+    slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, valid_shape))
+    valid_slices = tuple(slice(0, s) for s in valid_shape)
+    target[slices] = source[valid_slices]
     return target
 """
 
@@ -147,7 +211,11 @@ def _handle_tensor_matmul(a: list[str], kw: dict[str, Any]) -> str:
         lhs = f"{lhs}.mT"
     if kw.get("b_trans"):
         rhs = f"{rhs}.mT"
-    return f"torch.matmul({lhs}, {rhs})"
+    expr = f"torch.matmul({lhs}, {rhs})"
+    out_dtype = kw.get("out_dtype")
+    if isinstance(out_dtype, DataType):
+        expr = f"{expr}.to({_torch_dtype(out_dtype)})"
+    return expr
 
 
 def _handle_tensor_matmul_acc(a: list[str], kw: dict[str, Any]) -> str:
@@ -156,7 +224,11 @@ def _handle_tensor_matmul_acc(a: list[str], kw: dict[str, Any]) -> str:
         lhs = f"{lhs}.mT"
     if kw.get("b_trans"):
         rhs = f"{rhs}.mT"
-    return f"({acc} + torch.matmul({lhs}, {rhs}))"
+    expr = f"({acc} + torch.matmul({lhs}, {rhs}))"
+    out_dtype = kw.get("out_dtype")
+    if isinstance(out_dtype, DataType):
+        expr = f"{expr}.to({_torch_dtype(out_dtype)})"
+    return expr
 
 
 def _handle_cast(a: list[str], kw: dict[str, Any]) -> str:
@@ -209,9 +281,26 @@ def _handle_reduction(torch_fn: str) -> OpHandler:
 
 
 def _handle_slice(a: list[str], _kw: dict[str, Any]) -> str:
-    # Slice returns a view — valid_shapes is metadata only and must not
-    # trigger masking, otherwise in-place writes won't propagate back.
+    # args: [tensor, shapes, offsets] or [tensor, shapes, offsets, valid_shapes]
+    if len(a) >= 4:
+        return f"_tensor_slice({a[0]}, {a[2]}, {a[1]}, {a[3]})"
     return f"_tensor_slice({a[0]}, {a[2]}, {a[1]})"
+
+
+def _pad_mode_literal(kw: dict[str, Any]) -> str:
+    pad_value = kw.get("pad_value")
+    if pad_value is None:
+        return '"zero"'
+    s = getattr(pad_value, "name", str(pad_value)).lower()
+    if "min" in s:
+        return '"min"'
+    if "max" in s:
+        return '"max"'
+    return '"zero"'
+
+
+def _handle_fillpad(a: list[str], kw: dict[str, Any]) -> str:
+    return f"_fillpad({a[0]}, {_pad_mode_literal(kw)})"
 
 
 # Build the dispatch table
@@ -262,8 +351,8 @@ def _register_ops() -> None:
         m[f"{prefix}.transpose"] = lambda a, _kw: f"{a[0]}.transpose({a[1]}, {a[2]})"
         m[f"{prefix}.concat"] = lambda a, _kw: f"torch.cat([{a[0]}, {a[1]}], dim=-1)"
 
-        # fillpad -> identity
-        m[f"{prefix}.fillpad"] = _identity()
+        # fillpad
+        m[f"{prefix}.fillpad"] = _handle_fillpad
 
         # assemble -> write source into target at offset
         m[f"{prefix}.assemble"] = lambda a, _kw: f"_assemble({a[0]}, {a[1]}, {a[2]})"
@@ -460,7 +549,13 @@ class TorchCodegen(_ir.IRVisitor):
         return self._var_names[vid]
 
     def _visit_expr_str(self, expr: _ir.Expr) -> str:
-        self.visit_expr(expr)
+        # Force nested Call nodes through our Python visit_call implementation.
+        # Some C++ visitor dispatch paths can bypass visit_call for nested calls
+        # and leave only the last-visited argument string in _expr_result.
+        if isinstance(expr, _ir.Call):
+            self.visit_call(expr)
+        else:
+            self.visit_expr(expr)
         return self._expr_result
 
     def _has_body_content(self, stmt: _ir.Stmt) -> bool:

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -124,6 +124,18 @@ def test_tensor_matmul_with_transpose():
     assert "torch.matmul" in code
 
 
+def test_tensor_matmul_respects_out_dtype():
+    """tensor.matmul with out_dtype should cast result to the requested dtype."""
+    a = _tensor_var("a", [64, 128], DataType.BF16)
+    b = _tensor_var("b", [128, 64], DataType.BF16)
+    out = _tensor_var("out", [64, 64], DataType.FP32)
+    call = _op_call("tensor.matmul", [a, b], {"a_trans": False, "b_trans": False, "out_dtype": DataType.FP32})
+    assign = ir.AssignStmt(out, call, _span())
+    func = _simple_function("f", [a, b], assign)
+    code = torch_codegen(func)
+    assert "torch.matmul(a, b).to(torch.float32)" in code
+
+
 def test_tensor_cast():
     """tensor.cast should emit .to(dtype)."""
     a = _tensor_var("a", [64])
@@ -133,6 +145,22 @@ def test_tensor_cast():
     func = _simple_function("f", [a], assign)
     code = torch_codegen(func)
     assert ".to(torch.float16)" in code
+
+
+def test_nested_call_arg_preserves_call_codegen():
+    """Nested call arg (cast(slice(...))) should emit slice expression, not tuple."""
+    hidden_states = _tensor_var("hidden_states", [16, 512], DataType.BF16)
+    out = _tensor_var("out", [16, 512], DataType.FP32)
+    shapes = _make_tuple(_int(16), _int(512))
+    offsets = _make_tuple(_int(0), _int(0))
+    slice_call = _op_call("tensor.slice", [hidden_states, shapes, offsets])
+    cast_call = _op_call("tensor.cast", [slice_call], {"target_type": DataType.FP32, "mode": 2})
+    assign = ir.AssignStmt(out, cast_call, _span())
+    func = _simple_function("f", [hidden_states], assign)
+    code = torch_codegen(func)
+
+    assert "_tensor_slice(hidden_states, (0, 0), (16, 512)).to(torch.float32)" in code
+    assert "(0, 0).to(torch.float32)" not in code
 
 
 def test_tensor_row_reduction():
@@ -656,6 +684,52 @@ def test_tensor_assemble_writes_source():
     assert result_val[0, 0] == 5.0
     assert result_val[3, 3] == 5.0
     assert result_val[4, 4] == 0.0
+
+
+def test_tensor_slice_out_of_bounds_is_padded():
+    """tensor.slice should pad to requested shape when slicing out of bounds."""
+    src = _tensor_var("src", [96, 64], DataType.FP32)
+    result = _tensor_var("result", [64, 64], DataType.FP32)
+    shapes = _make_tuple(_int(64), _int(64))
+    offsets = _make_tuple(_int(64), _int(0))
+    call = _op_call("tensor.slice", [src, shapes, offsets])
+    assign = ir.AssignStmt(result, call, _span())
+    ret = ir.ReturnStmt([result], _span())
+    body = ir.SeqStmts([assign, ret], _span())
+    func = _simple_function("f", [src], body, [ir.TensorType([64, 64], DataType.FP32)])
+    code = torch_codegen(func)
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    x = torch.ones(96, 64, dtype=torch.float32)
+    out = ns["f"](x)
+    assert out.shape == (64, 64)
+    assert torch.allclose(out[:32, :], torch.ones(32, 64))
+    assert torch.allclose(out[32:, :], torch.zeros(32, 64))
+
+
+def test_tensor_fillpad_min_uses_valid_shape():
+    """tensor.fillpad should apply pad_value outside valid_shape metadata."""
+    src = _tensor_var("src", [8, 64], DataType.FP32)
+    result = _tensor_var("result", [8, 64], DataType.FP32)
+    shapes = _make_tuple(_int(8), _int(64))
+    offsets = _make_tuple(_int(0), _int(0))
+    valid_shapes = _make_tuple(_int(8), _int(32))
+    sliced = _op_call("tensor.slice", [src, shapes, offsets, valid_shapes])
+    padded = _op_call("tensor.fillpad", [sliced], {"pad_value": ir.PadValue.min})
+    assign = ir.AssignStmt(result, padded, _span())
+    ret = ir.ReturnStmt([result], _span())
+    body = ir.SeqStmts([assign, ret], _span())
+    func = _simple_function("f", [src], body, [ir.TensorType([8, 64], DataType.FP32)])
+    code = torch_codegen(func)
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    x = torch.rand(8, 64, dtype=torch.float32)
+    out = ns["f"](x)
+    assert out.shape == (8, 64)
+    assert torch.allclose(out[:, :32], x[:, :32])
+    assert torch.all(out[:, 32:] == torch.finfo(torch.float32).min)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix nested call expression emission in torch codegen so nested Call nodes are lowered correctly.
- Respect out_dtype for tensor.matmul and tensor.matmul_acc in generated torch expressions.
- Implement boundary-aware tensor slice materialization and fillpad behavior for valid-shape paths.
- Add regression coverage in tests/ut/debug/test_torch_codegen.py for nested-call args, matmul out dtype, out-of-bounds slice padding, and fillpad min semantics.

## Testing
- python -m pytest tests/ut/debug/test_torch_codegen.py -k "test_tensor_matmul_respects_out_dtype or test_nested_call_arg_preserves_call_codegen or test_tensor_slice_out_of_bounds_is_padded or test_tensor_fillpad_min_uses_valid_shape" -v