### PR TITLE
perf(runtime): Bump default aicpu_thread_num to 4 in execute_on_device

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -467,7 +467,7 @@ def execute_on_device(
     device_id: int,
     *,
     block_dim: int = 24,
-    aicpu_thread_num: int = 3,
+    aicpu_thread_num: int = 4,
     enable_profiling: bool = False,
     runtime_env: dict[str, str] | None = None,
 ) -> None:


### PR DESCRIPTION
## Summary
- Change `aicpu_thread_num` default from `3` to `4` in `execute_on_device()` for better performance.
- `block_dim=24` default remains evenly divisible by the new thread count (`24 % 4 == 0`), so the hardware divisibility constraint is still satisfied.

## Testing
- [x] Code review completed (no red flags)
- [ ] Tests — no unit test exercises device execution defaults; covered by downstream benchmarks