### PR TITLE
fix(parser): Keep dotted identifiers intact in diagnostic renderer

### DIFF
--- a/python/pypto/language/parser/diagnostics/renderer.py
+++ b/python/pypto/language/parser/diagnostics/renderer.py
@@ -10,9 +10,14 @@
 """Error rendering and formatting for pretty error messages."""
 
 import os
+import re
 import sys
 
 from .exceptions import ParserError, SSAViolationError
+
+# Sentence boundary: a period followed by whitespace or end of string. Avoids
+# splitting inside dotted identifiers like `pl.range()` or `module.attr`.
+_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
 
 
 class ErrorRenderer:
@@ -273,13 +278,31 @@ class ErrorRenderer:
         if column >= len(line_content):
             return 1
 
+        def is_ident_char(c: str) -> bool:
+            return c.isalnum() or c == "_"
+
         token_chars = 0
-        for i in range(column, len(line_content)):
+        i = column
+        while i < len(line_content):
             char = line_content[i]
-            if char.isalnum() or char == "_":
+            if is_ident_char(char):
                 token_chars += 1
-            else:
-                break
+                i += 1
+                continue
+            # Extend across `.` only when it's part of a dotted identifier
+            # (identifier char on both sides), so dotted callees like
+            # `pl.range` render as a single token.
+            if (
+                char == "."
+                and i > column
+                and is_ident_char(line_content[i - 1])
+                and i + 1 < len(line_content)
+                and is_ident_char(line_content[i + 1])
+            ):
+                token_chars += 1
+                i += 1
+                continue
+            break
 
         return token_chars if token_chars > 0 else 1
 
@@ -357,7 +380,8 @@ class ErrorRenderer:
         # Add short inline message if available
         inline_msg = ""
         if message:
-            short_msg = message.split(".")[0].split("\n")[0]
+            first_line = message.split("\n", 1)[0]
+            short_msg = _SENTENCE_BOUNDARY.split(first_line, maxsplit=1)[0]
             if len(short_msg) < 50:
                 inline_msg = self._red(f" {short_msg}")
 

--- a/tests/ut/language/parser/test_diagnostics_renderer.py
+++ b/tests/ut/language/parser/test_diagnostics_renderer.py
@@ -1,0 +1,95 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for the parser error renderer."""
+
+import pytest
+from pypto.language.parser.diagnostics import ParserSyntaxError
+from pypto.language.parser.diagnostics.renderer import ErrorRenderer
+
+
+@pytest.fixture
+def renderer() -> ErrorRenderer:
+    return ErrorRenderer(use_color=False)
+
+
+def _make_error(message: str, line: str, column: int, hint: str | None = None) -> ParserSyntaxError:
+    err = ParserSyntaxError(message, hint=hint)
+    err.span = {"filename": "test.py", "begin_line": 1, "begin_column": column, "line": 1, "column": column}
+    err.source_lines = [line]
+    return err
+
+
+class TestCaretTokenWidth:
+    """Caret should span the full dotted identifier, not stop at the first '.'."""
+
+    def test_dotted_callee(self, renderer: ErrorRenderer):
+        assert renderer._calculate_token_length("pl.piepline(1, 2, 3)", 0) == len("pl.piepline")
+
+    def test_multi_segment_dotted_identifier(self, renderer: ErrorRenderer):
+        assert renderer._calculate_token_length("foo.bar.baz(x)", 0) == len("foo.bar.baz")
+
+    def test_dotted_identifier_mid_line(self, renderer: ErrorRenderer):
+        line = "x + pl.range(n)"
+        assert renderer._calculate_token_length(line, 4) == len("pl.range")
+
+    def test_plain_identifier_unaffected(self, renderer: ErrorRenderer):
+        assert renderer._calculate_token_length("plain_name(x)", 0) == len("plain_name")
+
+    def test_trailing_dot_does_not_extend(self, renderer: ErrorRenderer):
+        # 'a.' has a dot with no identifier after — should not be absorbed.
+        assert renderer._calculate_token_length("a.", 0) == 1
+
+    def test_leading_dot_does_not_match(self, renderer: ErrorRenderer):
+        # Starting at a bare '.' (no identifier before) falls through to the
+        # minimum-1 behavior.
+        assert renderer._calculate_token_length(".foo", 0) == 1
+
+
+class TestInlineMessage:
+    """Inline caret annotation must not split messages inside dotted identifiers."""
+
+    def test_message_with_dotted_identifiers_is_not_truncated(self, renderer: ErrorRenderer):
+        """The reported bug: full message is 87 chars (>= 50) so no inline
+        annotation is emitted. The renderer must NOT fall back to the bogus
+        'For loop must use pl' fragment produced by splitting on the first '.'.
+        """
+        message = "For loop must use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), or pl.while_()"
+        line = " " * 10 + "pl.piepline(x):"
+        err = _make_error(message, line, column=10)
+        rendered = renderer.render(err)
+
+        assert "For loop must use pl\n" not in rendered
+        assert "For loop must use pl\033" not in rendered  # any ANSI wrap
+        assert "^" * len("pl.piepline") in rendered
+
+    def test_short_sentence_still_renders_inline(self, renderer: ErrorRenderer):
+        """For short messages, the first real sentence is still used."""
+        message = "Variable x not defined. Expected an assignment first."
+        line = "x + 1"
+        err = _make_error(message, line, column=0)
+        rendered = renderer.render(err)
+
+        caret_row = next(row for row in rendered.split("\n") if "^" in row)
+        assert "Variable x not defined" in caret_row
+        assert "Expected an assignment first" not in caret_row
+
+    def test_dotted_reference_within_message_preserved(self, renderer: ErrorRenderer):
+        """A message whose only 'period' sits inside a dotted identifier
+        should be emitted in full (when short enough), not truncated."""
+        message = "Missing argument for module.attr call"
+        line = "module.attr()"
+        err = _make_error(message, line, column=0)
+        rendered = renderer.render(err)
+
+        assert "Missing argument for module.attr call" in rendered
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #1102. The parser error renderer treated `.` as a word boundary in two places, which broke whenever error messages or source lines contained dotted code tokens (`pl.range()`, `module.attr`, ...):

- **Inline caret annotation**: `message.split(\".\")[0]` truncated any message with a dotted identifier at the first `.`. For the reported case, `\"For loop must use pl.range(), pl.parallel(), ...\"` rendered as the bogus fragment `\"For loop must use pl\"` next to the caret.
- **Caret width**: `_calculate_token_length` stopped at the first non-alnum/underscore character, so a pointer at `pl.piepline(...)` highlighted only `pl` (`^^`) instead of the full callee.

Fix:

- `_render_caret_line`: extract the short message with a sentence-boundary regex (`\.(?=\s|$)`), i.e. only split on `.` when followed by whitespace or end of string. Dotted identifiers are preserved; for messages that are a single long sentence (like the reported one), the `< 50` length gate now correctly suppresses the inline annotation instead of emitting a misleading fragment.
- `_calculate_token_length`: extend the token scan across `.` when identifier characters sit on both sides, so callees like `pl.piepline` and `foo.bar.baz` render as a single `^^^^^^^^^^^` span.

## Rendered before / after

Before:

```
    |                                       ^^ For loop must use pl
```

After:

```
    |                                       ^^^^^^^^^^^
```

The full message is still carried by the top-line `Error:` header and the `help:` line — no information is lost.

## Test plan

- [x] New regression test: `tests/ut/language/parser/test_diagnostics_renderer.py` — 9 cases covering `_calculate_token_length` (dotted callee, multi-segment dotted ident, plain ident, trailing/leading `.`) and `_render_caret_line` (bug repro, short-sentence inline annotation, dotted reference mid-message). All pass.
- [x] Existing parser error tests (`test_error_cases.py`, `test_error_wrapping.py`) — unchanged, 38 cases still pass.
- [x] Full suite: `cmake --build build --parallel && pytest tests/ut -n auto` — 3730 passed, 16 skipped, 0 failed.