### PR TITLE
feat(ir): introduce two-layer direction model with Call::arg_directions_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/normalize_return_order_pass.cpp
     src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
     src/ir/transforms/optimize_orch_tensors_pass.cpp
+    src/ir/transforms/derive_call_directions_pass.cpp
     src/ir/transforms/convert_to_ssa_pass.cpp
     src/ir/transforms/ctrl_flow_transform_pass.cpp
     src/ir/transforms/flatten_call_expr_pass.cpp
@@ -198,6 +199,7 @@ set(PYPTO_SOURCES
     src/ir/verifier/verify_out_param_pass.cpp
     src/ir/verifier/verify_inout_use.cpp
     src/ir/verifier/verify_pipeline_resolved.cpp
+    src/ir/verifier/verify_call_directions.cpp
     src/ir/verifier/warning_verifier_registry.cpp
     src/ir/verifier/warning_unused_var.cpp
 

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -72,7 +72,7 @@ is present, `memory_space` must also be present on the `TileType`.
 | **ConstInt** | `value_`, `dtype_` | Integer constant |
 | **ConstBool** | `value_` | Boolean constant (always BOOL dtype) |
 | **ConstFloat** | `value_`, `dtype_` | Floating-point constant |
-| **Call** | `op_`, `args_`, `kwargs_` | Function/operator call |
+| **Call** | `op_`, `args_`, `kwargs_`, `attrs_` | Function/operator call (see [Call attrs vs kwargs](#call-attrs-vs-kwargs)) |
 | **TupleGetItemExpr** | `tuple_`, `index_` | Tuple element access |
 
 ### Var Identity
@@ -131,6 +131,26 @@ All unary expressions have: `operand_`, `dtype_`
 op = ir.Op("my_function"); call = ir.Call(op, [x, y], span)  # External
 gvar = ir.GlobalVar("helper"); call = ir.Call(gvar, [x], span)  # Internal
 ```
+
+### Call attrs vs kwargs
+
+`Call` carries two ordered string-keyed maps with identical C++ types
+(`std::vector<std::pair<std::string, std::any>>`) but different ownership and
+intent:
+
+| Field | Purpose | Producer | Reserved keys |
+| ----- | ------- | -------- | ------------- |
+| `kwargs_` | Language-level keyword arguments supplied by the user at the call site (e.g. `kernel(x, y, axis=2)`). Round-tripped through the parser, printer, and bindings as user-facing data. | Frontend / DSL parser | None — keys come from user code. |
+| `attrs_` | Compiler-internal node metadata produced and consumed by passes/verifiers. Not visible as DSL keyword arguments. | Compiler passes (and the deserializer for legacy payloads) | `"arg_directions"` — see below. Future internal attributes should use namespaced keys such as `"hint.*"` or `"profile.*"`. |
+
+**`arg_directions` storage.** Resolved per-argument `ArgDirection` values are
+stored under the reserved key `attrs_["arg_directions"]` as
+`std::vector<ArgDirection>`. The accessors `Call::HasArgDirections()` and
+`Call::GetArgDirections()` (and the Python `Call.arg_directions` property) are
+thin wrappers over this attr; `WithArgDirectionsAttr(...)` is the canonical way
+to construct an `attrs` vector with the entry set. The existence of this attr
+is what `IRProperty::CallDirectionsResolved` verifies after the
+`DeriveCallDirections` pass.
 
 ### IterArg - Loop-Carried Values
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -72,7 +72,7 @@
 | **ConstInt** | `value_`, `dtype_` | 整数常量 |
 | **ConstBool** | `value_` | 布尔常量（始终为 BOOL dtype） |
 | **ConstFloat** | `value_`, `dtype_` | 浮点常量 |
-| **Call** | `op_`, `args_`, `kwargs_` | 函数/运算符调用 |
+| **Call** | `op_`, `args_`, `kwargs_`, `attrs_` | 函数/运算符调用（参见 [Call attrs 与 kwargs 的区别](#call-attrs-与-kwargs-的区别)） |
 | **TupleGetItemExpr** | `tuple_`, `index_` | 元组元素访问 |
 
 ### Var 的标识（Identity）
@@ -131,6 +131,24 @@ auto x_ref = x1;
 op = ir.Op("my_function"); call = ir.Call(op, [x, y], span)  # External
 gvar = ir.GlobalVar("helper"); call = ir.Call(gvar, [x], span)  # Internal
 ```
+
+### Call attrs 与 kwargs 的区别
+
+`Call` 同时持有两个有序的字符串键映射，C++ 类型完全一致
+（`std::vector<std::pair<std::string, std::any>>`），但所有权与语义完全不同：
+
+| 字段 | 用途 | 来源 | 保留键 |
+| ---- | ---- | ---- | ------ |
+| `kwargs_` | 用户在调用点书写的语言层关键字参数（例如 `kernel(x, y, axis=2)`），在 parser、printer 与 Python bindings 之间作为面向用户的数据原样往返。 | 前端 / DSL 解析 | 无 —— 键由用户代码决定。 |
+| `attrs_` | 编译器内部的节点元数据，由 pass / verifier 生产与消费，不会作为 DSL 关键字参数暴露给用户。 | 编译器 pass（以及反序列化器在加载旧 payload 时使用） | `"arg_directions"`（见下文）。后续新增的内部属性建议使用 `"hint.*"`、`"profile.*"` 这类带前缀的命名空间。 |
+
+**`arg_directions` 的存放位置。** 解析后的逐参数 `ArgDirection` 序列以
+`std::vector<ArgDirection>` 形式存储在保留键 `attrs_["arg_directions"]` 下；
+访问器 `Call::HasArgDirections()`、`Call::GetArgDirections()`（以及 Python
+端的 `Call.arg_directions` 属性）都是该 attr 的薄封装，
+`WithArgDirectionsAttr(...)` 是构造带该 attr 的 `attrs` 向量的标准入口。
+`IRProperty::CallDirectionsResolved` 校验的就是该 attr 在 `DeriveCallDirections`
+pass 之后是否存在。
 
 ### IterArg - 循环携带值
 

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -15,7 +15,6 @@
 #include <map>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -132,43 +131,6 @@ class VarLineageCollector : public ir::IRVisitor {
   [[nodiscard]] const ir::Var* ResolveExpr(const ir::ExprPtr& expr) const;
 
   ir::ProgramPtr program_;
-};
-
-/**
- * @brief Compute effective call-site parameter directions for orchestration calls
- *
- * Resolves the semantic mismatch between function-level ParamDirection (a property
- * of the callee: "this function reads/writes this parameter") and orchestration
- * call-site direction (a property of the task submission: "establish dependencies
- * and manage memory for this buffer").
- *
- * Key rule: when a locally allocated tensor (from tensor.create / alloc_tensors)
- * is passed as Out to an InCore call, the call-site direction must be InOut so
- * that the runtime establishes WAW dependencies between tasks sharing the buffer.
- *
- * Uses BufferRootCollector results to trace each argument back to its buffer root
- * and determine whether it originates from a function parameter (external) or a
- * local tensor.create (pre-allocated).
- */
-class CallSiteDirectionResolver : public ir::IRVisitor {
- public:
-  CallSiteDirectionResolver(ir::ProgramPtr program,
-                            const std::unordered_map<const ir::Var*, const ir::Var*>& buffer_roots,
-                            const std::vector<ir::VarPtr>& params);
-
-  /// Per-call effective directions. Only populated for calls that need overrides
-  /// (i.e., at least one Out parameter targets a locally allocated buffer).
-  std::unordered_map<const ir::Call*, std::vector<ir::ParamDirection>> call_site_directions;
-
- protected:
-  void VisitExpr_(const ir::CallPtr& call) override;
-
- private:
-  [[nodiscard]] bool IsLocallyAllocated(const ir::Var* var) const;
-
-  ir::ProgramPtr program_;
-  const std::unordered_map<const ir::Var*, const ir::Var*>& buffer_roots_;
-  std::unordered_set<const ir::Var*> param_vars_;
 };
 
 /// Compute effective param directions for a Group function.

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -321,16 +321,96 @@ class IterArg : public Var {
 using IterArgPtr = std::shared_ptr<const IterArg>;
 
 /**
+ * @brief Call-site argument direction classification
+ *
+ * Models the runtime task-submission semantics for each positional argument of a Call.
+ * Mirrors the runtime TensorArgType enum (INPUT/OUTPUT/INOUT/OUTPUT_EXISTING/NO_DEP)
+ * one-to-one, plus a Scalar tag for non-tensor arguments.
+ *
+ * Distinct from `ParamDirection` (which lives on the callee Function and describes
+ * the function-signature contract — "I read/write this parameter"). `ArgDirection`
+ * describes the call-site task behavior — "this submission establishes these
+ * dependencies and uses this memory ownership model".
+ *
+ * - Input:           Read-only input → runtime add_input, TensorArgType::INPUT
+ * - Output:          Runtime allocates a new buffer → add_output(create_info),
+ *                    TensorArgType::OUTPUT
+ * - InOut:           Read-then-write → add_inout, TensorArgType::INOUT
+ * - OutputExisting:  Write into an already-existing tensor (skips OverlapMap,
+ *                    keeps creator dependency) → add_output(tensor),
+ *                    TensorArgType::OUTPUT_EXISTING
+ * - NoDep:           No-dependency existing tensor (skips OverlapMap, no publish)
+ *                    → add_no_dep, TensorArgType::NO_DEP
+ * - Scalar:          Non-tensor scalar argument → add_scalar (must follow all
+ *                    tensors in the runtime arg list)
+ */
+enum class ArgDirection : uint8_t {
+  Input = 0,           ///< Read-only input (default for tensors)
+  Output = 1,          ///< Runtime-allocated output buffer
+  InOut = 2,           ///< Read-then-write
+  OutputExisting = 3,  ///< Write-only into an existing tensor
+  NoDep = 4,           ///< No-dependency existing tensor
+  Scalar = 5,          ///< Scalar (non-tensor) argument
+};
+
+/**
+ * @brief Convert ArgDirection to string
+ */
+inline std::string ArgDirectionToString(ArgDirection dir) {
+  switch (dir) {
+    case ArgDirection::Input:
+      return "Input";
+    case ArgDirection::Output:
+      return "Output";
+    case ArgDirection::InOut:
+      return "InOut";
+    case ArgDirection::OutputExisting:
+      return "OutputExisting";
+    case ArgDirection::NoDep:
+      return "NoDep";
+    case ArgDirection::Scalar:
+      return "Scalar";
+  }
+  throw pypto::TypeError("Unknown ArgDirection");
+}
+
+/**
+ * @brief Convert string to ArgDirection
+ */
+inline ArgDirection StringToArgDirection(const std::string& str) {
+  if (str == "Input") {
+    return ArgDirection::Input;
+  } else if (str == "Output") {
+    return ArgDirection::Output;
+  } else if (str == "InOut") {
+    return ArgDirection::InOut;
+  } else if (str == "OutputExisting") {
+    return ArgDirection::OutputExisting;
+  } else if (str == "NoDep") {
+    return ArgDirection::NoDep;
+  } else if (str == "Scalar") {
+    return ArgDirection::Scalar;
+  }
+  throw pypto::TypeError("Unknown ArgDirection: " + str);
+}
+
+/**
  * @brief Function call expression
  *
  * Represents a function call with an operation and arguments.
  * Can accept any Expr as arguments, not just scalar expressions.
  * Supports keyword arguments (kwargs) for operator metadata.
+ *
+ * Optional `arg_directions_` carries call-site task-submission semantics for each
+ * positional argument. When non-empty it must have the same length as `args_`.
+ * When empty the call falls back to legacy behavior where codegen derives
+ * directions from the callee Function's `param_directions_`.
  */
 class Call : public Expr {
  public:
   OpPtr op_;                                              // Operation/function
   std::vector<ExprPtr> args_;                             // Positional arguments
+  std::vector<ArgDirection> arg_directions_;              // Optional call-site directions (empty = legacy)
   std::vector<std::pair<std::string, std::any>> kwargs_;  // Keyword arguments (metadata, ordered)
 
   /**
@@ -341,7 +421,7 @@ class Call : public Expr {
    * @param span Source location
    */
   Call(OpPtr op, std::vector<ExprPtr> args, Span span)
-      : Expr(std::move(span)), op_(std::move(op)), args_(std::move(args)), kwargs_() {}
+      : Expr(std::move(span)), op_(std::move(op)), args_(std::move(args)), arg_directions_(), kwargs_() {}
 
   /**
    * @brief Create a function call expression with explicit type
@@ -352,7 +432,11 @@ class Call : public Expr {
    * @param span Source location
    */
   Call(OpPtr op, std::vector<ExprPtr> args, TypePtr type, Span span)
-      : Expr(std::move(span), std::move(type)), op_(std::move(op)), args_(std::move(args)), kwargs_() {}
+      : Expr(std::move(span), std::move(type)),
+        op_(std::move(op)),
+        args_(std::move(args)),
+        arg_directions_(),
+        kwargs_() {}
 
   /**
    * @brief Create a function call expression with kwargs
@@ -363,7 +447,11 @@ class Call : public Expr {
    * @param span Source location
    */
   Call(OpPtr op, std::vector<ExprPtr> args, std::vector<std::pair<std::string, std::any>> kwargs, Span span)
-      : Expr(std::move(span)), op_(std::move(op)), args_(std::move(args)), kwargs_(std::move(kwargs)) {}
+      : Expr(std::move(span)),
+        op_(std::move(op)),
+        args_(std::move(args)),
+        arg_directions_(),
+        kwargs_(std::move(kwargs)) {}
 
   /**
    * @brief Create a function call expression with kwargs and explicit type
@@ -379,7 +467,31 @@ class Call : public Expr {
       : Expr(std::move(span), std::move(type)),
         op_(std::move(op)),
         args_(std::move(args)),
+        arg_directions_(),
         kwargs_(std::move(kwargs)) {}
+
+  /**
+   * @brief Create a function call expression with explicit call-site arg directions
+   *
+   * @param op Operation/function to call
+   * @param args List of argument expressions
+   * @param arg_directions Per-argument call-site directions (must be empty or same length as args)
+   * @param kwargs Keyword arguments (metadata)
+   * @param type Result type of the call
+   * @param span Source location
+   */
+  Call(OpPtr op, std::vector<ExprPtr> args, std::vector<ArgDirection> arg_directions,
+       std::vector<std::pair<std::string, std::any>> kwargs, TypePtr type, Span span)
+      : Expr(std::move(span), std::move(type)),
+        op_(std::move(op)),
+        args_(std::move(args)),
+        arg_directions_(std::move(arg_directions)),
+        kwargs_(std::move(kwargs)) {
+    if (!arg_directions_.empty() && arg_directions_.size() != args_.size()) {
+      throw pypto::TypeError("Call::arg_directions_ size (" + std::to_string(arg_directions_.size()) +
+                             ") must match args_ size (" + std::to_string(args_.size()) + ")");
+    }
+  }
 
   /**
    * @brief Get a kwarg value with type checking
@@ -420,12 +532,13 @@ class Call : public Expr {
   /**
    * @brief Get field descriptors for reflection-based visitation
    *
-   * @return Tuple of field descriptors (op, args, and kwargs as USUAL fields)
+   * @return Tuple of field descriptors (op, args, arg_directions, and kwargs as USUAL fields)
    */
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(Expr::GetFieldDescriptors(),
                           std::make_tuple(reflection::UsualField(&Call::op_, "op"),
                                           reflection::UsualField(&Call::args_, "args"),
+                                          reflection::UsualField(&Call::arg_directions_, "arg_directions"),
                                           reflection::UsualField(&Call::kwargs_, "kwargs")));
   }
 };

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -395,22 +395,34 @@ inline ArgDirection StringToArgDirection(const std::string& str) {
 }
 
 /**
+ * @brief Reserved attrs key for call-site argument directions
+ *
+ * The value stored under this key is a `std::vector<ArgDirection>` whose length
+ * matches `Call::args_`. See `Call::GetArgDirections` for details.
+ */
+inline constexpr const char* kAttrArgDirections = "arg_directions";
+
+/**
  * @brief Function call expression
  *
  * Represents a function call with an operation and arguments.
  * Can accept any Expr as arguments, not just scalar expressions.
- * Supports keyword arguments (kwargs) for operator metadata.
+ * Supports keyword arguments (kwargs) for operator metadata, plus a generic
+ * `attrs_` map for compiler-internal node metadata (e.g., call-site argument
+ * directions). Both containers share the `vector<pair<string, any>>` shape so
+ * they reuse the same serialization / structural-comparison machinery.
  *
- * Optional `arg_directions_` carries call-site task-submission semantics for each
- * positional argument. When non-empty it must have the same length as `args_`.
- * When empty the call falls back to legacy behavior where codegen derives
- * directions from the callee Function's `param_directions_`.
+ * Call-site argument directions are stored as an optional attr under the
+ * reserved key `kAttrArgDirections` (value type: `std::vector<ArgDirection>`).
+ * Absence means legacy / pre-DeriveCallDirections state; consumers that require
+ * resolved call-site behavior (codegen, runtime task submission) must run
+ * DeriveCallDirections before they observe the IR.
  */
 class Call : public Expr {
  public:
   OpPtr op_;                                              // Operation/function
   std::vector<ExprPtr> args_;                             // Positional arguments
-  std::vector<ArgDirection> arg_directions_;              // Optional call-site directions (empty = legacy)
+  std::vector<std::pair<std::string, std::any>> attrs_;   // Compiler-internal metadata (ordered)
   std::vector<std::pair<std::string, std::any>> kwargs_;  // Keyword arguments (metadata, ordered)
 
   /**
@@ -421,7 +433,7 @@ class Call : public Expr {
    * @param span Source location
    */
   Call(OpPtr op, std::vector<ExprPtr> args, Span span)
-      : Expr(std::move(span)), op_(std::move(op)), args_(std::move(args)), arg_directions_(), kwargs_() {}
+      : Expr(std::move(span)), op_(std::move(op)), args_(std::move(args)), attrs_(), kwargs_() {}
 
   /**
    * @brief Create a function call expression with explicit type
@@ -435,7 +447,7 @@ class Call : public Expr {
       : Expr(std::move(span), std::move(type)),
         op_(std::move(op)),
         args_(std::move(args)),
-        arg_directions_(),
+        attrs_(),
         kwargs_() {}
 
   /**
@@ -450,7 +462,7 @@ class Call : public Expr {
       : Expr(std::move(span)),
         op_(std::move(op)),
         args_(std::move(args)),
-        arg_directions_(),
+        attrs_(),
         kwargs_(std::move(kwargs)) {}
 
   /**
@@ -467,30 +479,30 @@ class Call : public Expr {
       : Expr(std::move(span), std::move(type)),
         op_(std::move(op)),
         args_(std::move(args)),
-        arg_directions_(),
+        attrs_(),
         kwargs_(std::move(kwargs)) {}
 
   /**
-   * @brief Create a function call expression with explicit call-site arg directions
+   * @brief Create a function call expression with attrs, kwargs, and explicit type
    *
    * @param op Operation/function to call
    * @param args List of argument expressions
-   * @param arg_directions Per-argument call-site directions (must be empty or same length as args)
    * @param kwargs Keyword arguments (metadata)
+   * @param attrs Compiler-internal metadata (e.g., reserved key `arg_directions`)
    * @param type Result type of the call
    * @param span Source location
+   *
+   * Validates that, when present, `attrs[kAttrArgDirections]` is a
+   * `std::vector<ArgDirection>` with the same length as `args`.
    */
-  Call(OpPtr op, std::vector<ExprPtr> args, std::vector<ArgDirection> arg_directions,
-       std::vector<std::pair<std::string, std::any>> kwargs, TypePtr type, Span span)
+  Call(OpPtr op, std::vector<ExprPtr> args, std::vector<std::pair<std::string, std::any>> kwargs,
+       std::vector<std::pair<std::string, std::any>> attrs, TypePtr type, Span span)
       : Expr(std::move(span), std::move(type)),
         op_(std::move(op)),
         args_(std::move(args)),
-        arg_directions_(std::move(arg_directions)),
+        attrs_(std::move(attrs)),
         kwargs_(std::move(kwargs)) {
-    if (!arg_directions_.empty() && arg_directions_.size() != args_.size()) {
-      throw pypto::TypeError("Call::arg_directions_ size (" + std::to_string(arg_directions_.size()) +
-                             ") must match args_ size (" + std::to_string(args_.size()) + ")");
-    }
+    ValidateArgDirectionsAttr();
   }
 
   /**
@@ -526,24 +538,109 @@ class Call : public Expr {
     return false;
   }
 
+  /**
+   * @brief Get an attr value with type checking
+   *
+   * @tparam T Type of the attr value
+   * @param key Attr key
+   * @param default_value Default value if key doesn't exist
+   * @return The attr value or default
+   */
+  template <typename T>
+  [[nodiscard]] T GetAttr(const std::string& key, const T& default_value = T{}) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) {
+        return AnyCast<T>(v, "attr key: " + key);
+      }
+    }
+    return default_value;
+  }
+
+  /**
+   * @brief Check if an attr exists
+   *
+   * @param key Attr key
+   * @return true if the attr exists
+   */
+  [[nodiscard]] bool HasAttr(const std::string& key) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @brief Check if call-site arg directions have been resolved
+   *
+   * @return true if attrs_ contains a non-empty arg_directions vector
+   */
+  [[nodiscard]] bool HasArgDirections() const { return HasAttr(kAttrArgDirections); }
+
+  /**
+   * @brief Get the resolved call-site arg directions
+   *
+   * @return Per-argument directions, or empty vector if not yet resolved.
+   */
+  [[nodiscard]] std::vector<ArgDirection> GetArgDirections() const {
+    return GetAttr<std::vector<ArgDirection>>(kAttrArgDirections);
+  }
+
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::Call; }
   [[nodiscard]] std::string TypeName() const override { return "Call"; }
 
   /**
    * @brief Get field descriptors for reflection-based visitation
    *
-   * @return Tuple of field descriptors (op, args, arg_directions, and kwargs as USUAL fields)
+   * @return Tuple of field descriptors (op, args, attrs, and kwargs as USUAL fields)
    */
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(Expr::GetFieldDescriptors(),
                           std::make_tuple(reflection::UsualField(&Call::op_, "op"),
                                           reflection::UsualField(&Call::args_, "args"),
-                                          reflection::UsualField(&Call::arg_directions_, "arg_directions"),
+                                          reflection::UsualField(&Call::attrs_, "attrs"),
                                           reflection::UsualField(&Call::kwargs_, "kwargs")));
+  }
+
+ private:
+  void ValidateArgDirectionsAttr() const {
+    for (const auto& [k, v] : attrs_) {
+      if (k != kAttrArgDirections) {
+        continue;
+      }
+      if (v.type() != typeid(std::vector<ArgDirection>)) {
+        throw pypto::TypeError("Call attrs['" + std::string(kAttrArgDirections) +
+                               "'] must be std::vector<ArgDirection>");
+      }
+      const auto& dirs = AnyCast<std::vector<ArgDirection>>(v, "attr key: arg_directions");
+      if (!dirs.empty() && dirs.size() != args_.size()) {
+        throw pypto::TypeError("Call attrs['arg_directions'] size (" + std::to_string(dirs.size()) +
+                               ") must match args size (" + std::to_string(args_.size()) + ")");
+      }
+      return;
+    }
   }
 };
 
 using CallPtr = std::shared_ptr<const Call>;
+
+/**
+ * @brief Build a copy of `attrs` with `kAttrArgDirections` set to `dirs`
+ *
+ * Replaces an existing entry if present; otherwise appends.
+ */
+inline std::vector<std::pair<std::string, std::any>> WithArgDirectionsAttr(
+    std::vector<std::pair<std::string, std::any>> attrs, std::vector<ArgDirection> dirs) {
+  for (auto& [k, v] : attrs) {
+    if (k == kAttrArgDirections) {
+      v = std::move(dirs);
+      return attrs;
+    }
+  }
+  attrs.emplace_back(kAttrArgDirections, std::move(dirs));
+  return attrs;
+}
 
 /**
  * @brief Expression to create a tuple from multiple expressions

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -52,6 +52,7 @@ enum class IRProperty : uint64_t {
   NoNestedInCore,           ///< No nested InCore scopes (ScopeStmt inside ScopeStmt)
   InOutUseValid,            ///< No reads of InOut/Out-passed variables after the call (RFC #1026)
   PipelineResolved,         ///< No ForKind::Pipeline survives; produced by CanonicalizeIOOrder
+  CallDirectionsResolved,   ///< Every non-builtin Call has explicit Call::arg_directions_
   kCount                    ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -52,7 +52,7 @@ enum class IRProperty : uint64_t {
   NoNestedInCore,           ///< No nested InCore scopes (ScopeStmt inside ScopeStmt)
   InOutUseValid,            ///< No reads of InOut/Out-passed variables after the call (RFC #1026)
   PipelineResolved,         ///< No ForKind::Pipeline survives; produced by CanonicalizeIOOrder
-  CallDirectionsResolved,   ///< Every non-builtin Call has explicit Call::arg_directions_
+  CallDirectionsResolved,   ///< Every non-builtin Call has explicit attrs['arg_directions']
   kCount                    ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -174,6 +174,16 @@ inline const PassProperties kCanonicalizeIOOrderProperties{
                  IRProperty::TileOps2D, IRProperty::TileMemoryInferred, IRProperty::NormalizedStmtStructure,
                  IRProperty::PipelineResolved}};
 
+// -- Call-site direction pass -----------------------------------------------
+//
+// The integrity of ``Call::arg_directions_`` is checked by the
+// ``CallDirectionsResolved`` PropertyVerifier (registered in
+// PropertyVerifierRegistry), so PassPipeline auto-verifies it whenever this
+// pass produces the property — no separate verify pass is needed.
+
+inline const PassProperties kDeriveCallDirectionsProperties{.required = {IRProperty::SplitIncoreOrch},
+                                                            .produced = {IRProperty::CallDirectionsResolved}};
+
 }  // namespace pass
 }  // namespace ir
 }  // namespace pypto

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -176,7 +176,7 @@ inline const PassProperties kCanonicalizeIOOrderProperties{
 
 // -- Call-site direction pass -----------------------------------------------
 //
-// The integrity of ``Call::arg_directions_`` is checked by the
+// The integrity of ``Call::attrs_["arg_directions"]`` is checked by the
 // ``CallDirectionsResolved`` PropertyVerifier (registered in
 // PropertyVerifierRegistry), so PassPipeline auto-verifies it whenever this
 // pass produces the property — no separate verify pass is needed.

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -470,11 +470,13 @@ Pass NormalizeReturnOrder();
 Pass FuseCreateAssembleToSlice();
 
 /**
- * @brief Derive Call::arg_directions_ from callee param directions and buffer lineage.
+ * @brief Derive Call::GetArgDirections() (stored in attrs_["arg_directions"]) from
+ *        callee param directions and buffer lineage.
  *
  * For every non-builtin call in Orchestration / Group / Spmd functions,
  * compute the runtime call-site direction (Input/Output/InOut/OutputExisting/Scalar)
- * for each argument and write it into Call::arg_directions_.
+ * for each argument and write it into Call::attrs_ under the reserved key
+ * ``"arg_directions"``.
  *
  * Mapping:
  *   - scalar argument                        -> ArgDirection::Scalar

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -470,6 +470,29 @@ Pass NormalizeReturnOrder();
 Pass FuseCreateAssembleToSlice();
 
 /**
+ * @brief Derive Call::arg_directions_ from callee param directions and buffer lineage.
+ *
+ * For every non-builtin call in Orchestration / Group / Spmd functions,
+ * compute the runtime call-site direction (Input/Output/InOut/OutputExisting/Scalar)
+ * for each argument and write it into Call::arg_directions_.
+ *
+ * Mapping:
+ *   - scalar argument                        -> ArgDirection::Scalar
+ *   - tensor + callee dir == In              -> ArgDirection::Input
+ *   - tensor + callee dir == InOut           -> ArgDirection::InOut
+ *   - tensor + callee dir == Out, locally allocated buffer
+ *                                            -> ArgDirection::InOut (WAW promotion)
+ *   - tensor + callee dir == Out, external (param-rooted) buffer
+ *                                            -> ArgDirection::OutputExisting
+ *
+ * Builtin ops (tensor.*, tile.*, system.*) are left untouched (arg_directions empty).
+ *
+ * Requirements:
+ *   - InCore scopes outlined (run OutlineIncoreScopes first)
+ */
+Pass DeriveCallDirections();
+
+/**
  * @brief Verify properties on a program and throw on errors
  *
  * Uses PropertyVerifierRegistry to verify the given properties and throws

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -252,9 +252,11 @@ PropertyVerifierPtr CreatePipelineResolvedPropertyVerifier();
  * @brief Factory function for creating CallDirectionsResolved property verifier
  *
  * Verifies that every non-builtin ``Call`` in the program carries a fully
- * populated ``Call::arg_directions_`` vector that is internally consistent
- * with the callee's ``param_directions_``. Specifically, for each call:
- *   - ``arg_directions_.size() == args_.size()`` and is non-empty;
+ * populated ``attrs_["arg_directions"]`` vector (accessed via
+ * ``Call::GetArgDirections``) that is internally consistent with the callee's
+ * ``param_directions_``. Specifically, for each call:
+ *   - the ``arg_directions`` attr is present, has size ``args_.size()`` and
+ *     is non-empty;
  *   - tensor arguments carry a non-Scalar direction; scalar arguments carry
  *     ``ArgDirection::Scalar``;
  *   - the per-argument ``ArgDirection`` is consistent with the callee's

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -248,6 +248,31 @@ PropertyVerifierPtr CreateInOutUseValidPropertyVerifier();
  */
 PropertyVerifierPtr CreatePipelineResolvedPropertyVerifier();
 
+/**
+ * @brief Factory function for creating CallDirectionsResolved property verifier
+ *
+ * Verifies that every non-builtin ``Call`` in the program carries a fully
+ * populated ``Call::arg_directions_`` vector that is internally consistent
+ * with the callee's ``param_directions_``. Specifically, for each call:
+ *   - ``arg_directions_.size() == args_.size()`` and is non-empty;
+ *   - tensor arguments carry a non-Scalar direction; scalar arguments carry
+ *     ``ArgDirection::Scalar``;
+ *   - the per-argument ``ArgDirection`` is consistent with the callee's
+ *     ``ParamDirection`` (``In`` ↔ ``Input``; ``InOut`` ↔ ``InOut``;
+ *     ``Out`` ↔ ``Output`` / ``OutputExisting`` / ``InOut`` for WAW promotion).
+ *
+ * The runtime requirement that ``add_input/add_output`` come before
+ * ``add_scalar`` is satisfied by orchestration codegen (``stable_partition``
+ * over ``ParamEntry``); the IR Call itself is allowed to interleave tensors
+ * and scalars to preserve the user's parameter order.
+ *
+ * This is the post-condition of the ``DeriveCallDirections`` pass and is
+ * automatically run by ``PassPipeline`` whenever that pass is executed.
+ *
+ * @return Shared pointer to CallDirectionsResolved PropertyVerifier
+ */
+PropertyVerifierPtr CreateCallDirectionsResolvedPropertyVerifier();
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -128,6 +128,8 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       kwargs.emplace_back(key, nb::cast<PadValue>(item.second));
     } else if (nb::isinstance<LoopOrigin>(item.second)) {
       kwargs.emplace_back(key, nb::cast<LoopOrigin>(item.second));
+    } else if (nb::isinstance<ArgDirection>(item.second)) {
+      kwargs.emplace_back(key, nb::cast<ArgDirection>(item.second));
     } else if (nb::isinstance<nb::bool_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<bool>(item.second));
     } else if (nb::isinstance<nb::int_>(item.second)) {
@@ -136,6 +138,18 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       kwargs.emplace_back(key, nb::cast<std::string>(item.second));
     } else if (nb::isinstance<nb::float_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<double>(item.second));
+    } else if (nb::isinstance<nb::list>(item.second) || nb::isinstance<nb::tuple>(item.second)) {
+      // Lists/tuples currently only used to carry `vector<ArgDirection>` (e.g. attrs["arg_directions"]).
+      // Reject non-ArgDirection sequences to avoid silently dropping metadata.
+      std::vector<ArgDirection> dirs;
+      for (auto elem : nb::cast<nb::sequence>(item.second)) {
+        if (!nb::isinstance<ArgDirection>(elem)) {
+          throw pypto::TypeError("Unsupported list element type for key: " + key +
+                                 " (expected ArgDirection)");
+        }
+        dirs.push_back(nb::cast<ArgDirection>(elem));
+      }
+      kwargs.emplace_back(key, std::move(dirs));
     } else {
       throw pypto::TypeError("Unsupported kwarg type for key: " + key);
     }
@@ -612,52 +626,79 @@ void BindIR(nb::module_& m) {
       nb::arg("op"), nb::arg("args"), nb::arg("kwargs"), nb::arg("type"), nb::arg("span"),
       "Create a function call expression with kwargs and explicit type");
 
-  // Constructor with explicit per-argument call-site directions
+  // Constructor with kwargs and explicit attrs (e.g. {"arg_directions": [...]}) and type
   call_class.def(
       "__init__",
-      [](Call* self, const OpPtr& op, const std::vector<ExprPtr>& args,
-         const std::vector<ArgDirection>& arg_directions, const nb::dict& kwargs_dict, const TypePtr& type,
-         const Span& span) {
+      [](Call* self, const OpPtr& op, const std::vector<ExprPtr>& args, const nb::dict& kwargs_dict,
+         const nb::object& attrs_or_none, const TypePtr& type, const Span& span) {
         auto kwargs = ConvertKwargsDict(kwargs_dict);
-        new (self) Call(op, args, arg_directions, kwargs, type, span);
+        auto attrs = ConvertAttrsFromPython(attrs_or_none);
+        new (self) Call(op, args, std::move(kwargs), std::move(attrs), type, span);
       },
-      nb::arg("op"), nb::arg("args"), nb::arg("arg_directions"), nb::arg("kwargs"), nb::arg("type"),
+      nb::arg("op"), nb::arg("args"), nb::arg("kwargs"), nb::arg("attrs").none(), nb::arg("type"),
       nb::arg("span"),
-      "Create a function call expression with explicit call-site arg directions, kwargs and type");
+      "Create a function call expression with kwargs and explicit attrs map and type. "
+      "Reserved attrs keys: 'arg_directions' -> list[ArgDirection].");
 
   BindFields<Call>(call_class);
 
-  // Expose kwargs as a read-only property
+  // Convert a vector<pair<string, any>> kwargs/attrs container to a Python dict.
+  auto kwargs_to_pydict = [](const std::vector<std::pair<std::string, std::any>>& items) {
+    nb::dict result;
+    for (const auto& [key, value] : items) {
+      if (value.type() == typeid(int)) {
+        result[key.c_str()] = AnyCast<int>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(bool)) {
+        result[key.c_str()] = AnyCast<bool>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(std::string)) {
+        result[key.c_str()] = AnyCast<std::string>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(double)) {
+        result[key.c_str()] = AnyCast<double>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(float)) {
+        result[key.c_str()] = AnyCast<float>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(DataType)) {
+        result[key.c_str()] = AnyCast<DataType>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(MemorySpace)) {
+        result[key.c_str()] = AnyCast<MemorySpace>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(TensorLayout)) {
+        result[key.c_str()] = AnyCast<TensorLayout>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(TileLayout)) {
+        result[key.c_str()] = AnyCast<TileLayout>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(PadValue)) {
+        result[key.c_str()] = AnyCast<PadValue>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(LoopOrigin)) {
+        result[key.c_str()] = AnyCast<LoopOrigin>(value, "converting to Python: " + key);
+      } else if (value.type() == typeid(std::vector<ArgDirection>)) {
+        const auto& dirs = AnyCast<std::vector<ArgDirection>>(value, "converting to Python: " + key);
+        nb::list lst;
+        for (auto d : dirs) {
+          lst.append(nb::cast(d));
+        }
+        result[key.c_str()] = lst;
+      }
+    }
+    return result;
+  };
+
   call_class.def_prop_ro(
-      "kwargs",
+      "kwargs", [kwargs_to_pydict](const CallPtr& self) { return kwargs_to_pydict(self->kwargs_); },
+      "Keyword arguments (metadata) for this call");
+
+  call_class.def_prop_ro(
+      "attrs", [kwargs_to_pydict](const CallPtr& self) { return kwargs_to_pydict(self->attrs_); },
+      "Compiler-internal node metadata. Reserved keys: 'arg_directions' -> list[ArgDirection].");
+
+  call_class.def_prop_ro(
+      "arg_directions",
       [](const CallPtr& self) {
-        nb::dict result;
-        for (const auto& [key, value] : self->kwargs_) {
-          if (value.type() == typeid(int)) {
-            result[key.c_str()] = AnyCast<int>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(bool)) {
-            result[key.c_str()] = AnyCast<bool>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(std::string)) {
-            result[key.c_str()] = AnyCast<std::string>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(double)) {
-            result[key.c_str()] = AnyCast<double>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(float)) {
-            result[key.c_str()] = AnyCast<float>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(DataType)) {
-            result[key.c_str()] = AnyCast<DataType>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(MemorySpace)) {
-            result[key.c_str()] = AnyCast<MemorySpace>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(TensorLayout)) {
-            result[key.c_str()] = AnyCast<TensorLayout>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(TileLayout)) {
-            result[key.c_str()] = AnyCast<TileLayout>(value, "converting to Python: " + key);
-          } else if (value.type() == typeid(PadValue)) {
-            result[key.c_str()] = AnyCast<PadValue>(value, "converting to Python: " + key);
-          }
+        nb::list result;
+        for (auto d : self->GetArgDirections()) {
+          result.append(nb::cast(d));
         }
         return result;
       },
-      "Keyword arguments (metadata) for this call");
+      "Resolved per-argument call-site directions (empty list when not yet derived). "
+      "Stored under attrs['arg_directions'].");
 
   // MakeTuple - const shared_ptr
   auto make_tuple_class = nb::class_<MakeTuple, Expr>(ir, "MakeTuple", "Tuple construction expression");
@@ -1097,8 +1138,10 @@ void BindIR(nb::module_& m) {
              "(add_output(tensor) / TensorArgType::OUTPUT_EXISTING)")
       .value("NoDep", ArgDirection::NoDep,
              "No-dependency existing tensor (add_no_dep / TensorArgType::NO_DEP)")
-      .value("Scalar", ArgDirection::Scalar, "Scalar (non-tensor) argument (add_scalar)")
-      .export_values();
+      .value("Scalar", ArgDirection::Scalar, "Scalar (non-tensor) argument (add_scalar)");
+  // Intentionally do NOT call .export_values(): ArgDirection::InOut would shadow
+  // ParamDirection::InOut at module scope. Users access values via the enum class
+  // (ir.ArgDirection.InOut) to keep the two direction models cleanly separated.
 
   // IsInCoreType helper
   ir.def("is_incore_type", &IsInCoreType, nb::arg("func_type"),

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -612,6 +612,19 @@ void BindIR(nb::module_& m) {
       nb::arg("op"), nb::arg("args"), nb::arg("kwargs"), nb::arg("type"), nb::arg("span"),
       "Create a function call expression with kwargs and explicit type");
 
+  // Constructor with explicit per-argument call-site directions
+  call_class.def(
+      "__init__",
+      [](Call* self, const OpPtr& op, const std::vector<ExprPtr>& args,
+         const std::vector<ArgDirection>& arg_directions, const nb::dict& kwargs_dict, const TypePtr& type,
+         const Span& span) {
+        auto kwargs = ConvertKwargsDict(kwargs_dict);
+        new (self) Call(op, args, arg_directions, kwargs, type, span);
+      },
+      nb::arg("op"), nb::arg("args"), nb::arg("arg_directions"), nb::arg("kwargs"), nb::arg("type"),
+      nb::arg("span"),
+      "Create a function call expression with explicit call-site arg directions, kwargs and type");
+
   BindFields<Call>(call_class);
 
   // Expose kwargs as a read-only property
@@ -1071,6 +1084,20 @@ void BindIR(nb::module_& m) {
       .value("In", ParamDirection::In, "Read-only input (default)")
       .value("Out", ParamDirection::Out, "Write-only output")
       .value("InOut", ParamDirection::InOut, "Read-write input/output")
+      .export_values();
+
+  // ArgDirection enum (call-site task-submission semantics)
+  nb::enum_<ArgDirection>(ir, "ArgDirection", "Call-site argument direction (mirrors runtime TensorArgType)")
+      .value("Input", ArgDirection::Input, "Read-only input (add_input / TensorArgType::INPUT)")
+      .value("Output", ArgDirection::Output,
+             "Runtime-allocated output buffer (add_output(create_info) / TensorArgType::OUTPUT)")
+      .value("InOut", ArgDirection::InOut, "Read-then-write (add_inout / TensorArgType::INOUT)")
+      .value("OutputExisting", ArgDirection::OutputExisting,
+             "Write-only into an existing tensor "
+             "(add_output(tensor) / TensorArgType::OUTPUT_EXISTING)")
+      .value("NoDep", ArgDirection::NoDep,
+             "No-dependency existing tensor (add_no_dep / TensorArgType::NO_DEP)")
+      .value("Scalar", ArgDirection::Scalar, "Scalar (non-tensor) argument (add_scalar)")
       .export_values();
 
   // IsInCoreType helper

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -77,7 +77,7 @@ void BindPass(nb::module_& m) {
       .value("PipelineResolved", IRProperty::PipelineResolved,
              "No ForKind::Pipeline survives; produced by CanonicalizeIOOrder")
       .value("CallDirectionsResolved", IRProperty::CallDirectionsResolved,
-             "Every non-builtin Call has explicit Call::arg_directions_");
+             "Every non-builtin Call has explicit attrs['arg_directions'] (see Call::GetArgDirections)");
 
   // Bind IRPropertySet
   nb::class_<IRPropertySet>(passes, "IRPropertySet", "A set of IR properties")
@@ -391,12 +391,12 @@ void BindPass(nb::module_& m) {
   passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure,
              "Create a pass that normalizes statement structure");
   passes.def("derive_call_directions", &pass::DeriveCallDirections,
-             "Derive Call::arg_directions_ from callee param directions and buffer lineage.\n\n"
+             "Derive Call attrs['arg_directions'] from callee param directions and buffer lineage.\n\n"
              "Writes per-argument runtime ArgDirection (Input / Output / InOut /\n"
              "OutputExisting / Scalar) onto every non-builtin Call. Locally allocated\n"
              "Out arguments are promoted to InOut to model WAW dependencies.\n\n"
              "Post-condition: ``IRProperty::CallDirectionsResolved``. The integrity of\n"
-             "the produced ``Call::arg_directions_`` is verified automatically by the\n"
+             "the produced ``Call.attrs['arg_directions']`` is verified automatically by the\n"
              "``CallDirectionsResolved`` PropertyVerifier (no separate verify pass).");
   // Bind DiagnosticSeverity enum
   nb::enum_<DiagnosticSeverity>(passes, "DiagnosticSeverity", "Severity level for diagnostics")

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -75,7 +75,9 @@ void BindPass(nb::module_& m) {
       .value("InOutUseValid", IRProperty::InOutUseValid,
              "No reads of InOut/Out-passed variables after the call (RFC #1026)")
       .value("PipelineResolved", IRProperty::PipelineResolved,
-             "No ForKind::Pipeline survives; produced by CanonicalizeIOOrder");
+             "No ForKind::Pipeline survives; produced by CanonicalizeIOOrder")
+      .value("CallDirectionsResolved", IRProperty::CallDirectionsResolved,
+             "Every non-builtin Call has explicit Call::arg_directions_");
 
   // Bind IRPropertySet
   nb::class_<IRPropertySet>(passes, "IRPropertySet", "A set of IR properties")
@@ -388,6 +390,14 @@ void BindPass(nb::module_& m) {
              "Create a pass that flattens nested call expressions");
   passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure,
              "Create a pass that normalizes statement structure");
+  passes.def("derive_call_directions", &pass::DeriveCallDirections,
+             "Derive Call::arg_directions_ from callee param directions and buffer lineage.\n\n"
+             "Writes per-argument runtime ArgDirection (Input / Output / InOut /\n"
+             "OutputExisting / Scalar) onto every non-builtin Call. Locally allocated\n"
+             "Out arguments are promoted to InOut to model WAW dependencies.\n\n"
+             "Post-condition: ``IRProperty::CallDirectionsResolved``. The integrity of\n"
+             "the produced ``Call::arg_directions_`` is verified automatically by the\n"
+             "``CallDirectionsResolved`` PropertyVerifier (no separate verify pass).");
   // Bind DiagnosticSeverity enum
   nb::enum_<DiagnosticSeverity>(passes, "DiagnosticSeverity", "Severity level for diagnostics")
       .value("Error", DiagnosticSeverity::Error, "Error that must be fixed")

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -117,6 +117,12 @@ __all__ = [
     "make_roundtrip_instrument",
     "directions",
     "make_call",
+    "input",
+    "output",
+    "output_existing",
+    "inout",
+    "no_dep",
+    "scalar_dir",
 ]  # fmt: skip
 
 # Re-export the lowercase ArgDirection aliases at the top level so callers can

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -33,6 +33,9 @@ from pypto.pypto_core.passes import (
     WarningLevel,
 )
 
+# Import call-site direction helpers (input/output/inout/...) for hand-written IR.
+from . import directions as _directions
+
 # Import operation modules
 from . import op, operators  # noqa: F401
 
@@ -42,6 +45,7 @@ from .builder import IRBuilder
 # Import high-level API functions
 from .compile import compile
 from .compiled_program import CompiledProgram
+from .directions import make_call
 
 # Import roundtrip instrument factory
 from .instruments import make_roundtrip_instrument
@@ -111,7 +115,22 @@ __all__ = [
     "op_conversion",
     "register_op_conversion",
     "make_roundtrip_instrument",
+    "directions",
+    "make_call",
 ]  # fmt: skip
+
+# Re-export the lowercase ArgDirection aliases at the top level so callers can
+# spell ``ir.input``, ``ir.output``, etc. without importing the submodule.
+# These intentionally shadow the builtin ``input`` name; users only ever access
+# them via ``ir.input``, which keeps the global builtin untouched.
+input = _directions.input
+output = _directions.output
+output_existing = _directions.output_existing
+inout = _directions.inout
+no_dep = _directions.no_dep
+scalar_dir = _directions.scalar  # avoid clashing with potential ``ir.scalar`` op helpers
+directions = _directions
+del _directions
 
 # Register ruff as the format callback for IR printing (best-effort: no-op if ruff is unavailable)
 try:

--- a/python/pypto/ir/__init__.pyi
+++ b/python/pypto/ir/__init__.pyi
@@ -18,6 +18,9 @@ accept integer arguments, but the public type signature is unchanged.
 from pypto.pypto_core import DataType as DataType
 from pypto.pypto_core.ir import *  # noqa: F401, F403
 from pypto.pypto_core.ir import (
+    ArgDirection as ArgDirection,
+)
+from pypto.pypto_core.ir import (
     IRMutator,
     IRVisitor,
     TensorType,
@@ -27,13 +30,23 @@ from pypto.pypto_core.ir import (
 )
 from pypto.pypto_core.passes import PassContext, VerificationLevel, VerificationMode
 
+from . import directions as directions
 from . import op as op
 from .builder import IRBuilder
 from .compile import compile
+from .directions import make_call
 from .instruments import make_roundtrip_instrument
 from .op_conversion import ConversionContext, op_conversion, register_op_conversion
 from .pass_manager import OptimizationStrategy, PassManager
 from .printer import python_print
+
+# Per-call-site direction aliases re-exported at the top level.
+input: ArgDirection
+output: ArgDirection
+output_existing: ArgDirection
+inout: ArgDirection
+no_dep: ArgDirection
+scalar_dir: ArgDirection
 
 # DataType aliases (mirrors runtime __init__.py)
 FP4: DataType
@@ -77,4 +90,13 @@ __all__ = [
     "op_conversion",
     "register_op_conversion",
     "make_roundtrip_instrument",
+    "directions",
+    "make_call",
+    "input",
+    "output",
+    "output_existing",
+    "inout",
+    "no_dep",
+    "scalar_dir",
+    "ArgDirection",
 ]

--- a/python/pypto/ir/directions.py
+++ b/python/pypto/ir/directions.py
@@ -90,11 +90,11 @@ def make_call(
 
 __all__ = [
     "ArgDirection",
+    "inout",
     "input",
+    "make_call",
+    "no_dep",
     "output",
     "output_existing",
-    "inout",
-    "no_dep",
     "scalar",
-    "make_call",
 ]

--- a/python/pypto/ir/directions.py
+++ b/python/pypto/ir/directions.py
@@ -58,9 +58,9 @@ def make_call(
         args: Positional argument expressions.
         directions: Optional explicit per-argument :class:`ArgDirection` vector.
             When ``None`` the resulting call has an empty ``arg_directions``
-            vector (matches legacy behavior; codegen falls back to deriving from
-            the callee's :attr:`ParamDirection`). When provided the length must
-            match ``args``.
+            vector (legacy / pre-DeriveCallDirections state). Run
+            ``DeriveCallDirections`` before consumers that require resolved
+            call-site directions. When provided the length must match ``args``.
         kwargs: Optional keyword arguments to attach to the call.
         type: Optional explicit return type.
         span: Optional source span; defaults to :meth:`ir.Span.unknown`.
@@ -84,7 +84,8 @@ def make_call(
         raise ValueError(
             f"make_call: directions length ({len(directions_list)}) must match args length ({len(args_list)})"
         )
-    return _ir.Call(op, args_list, directions_list, actual_kwargs, actual_type, actual_span)
+    attrs: dict[str, Any] = {"arg_directions": directions_list}
+    return _ir.Call(op, args_list, actual_kwargs, attrs, actual_type, actual_span)
 
 
 __all__ = [

--- a/python/pypto/ir/directions.py
+++ b/python/pypto/ir/directions.py
@@ -1,0 +1,99 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Friendly module-level helpers for building :class:`ir.Call` arg_directions vectors.
+
+These helpers exist for tests, examples and hand-written IR code that need to
+attach :class:`ir.ArgDirection` values to a call without importing the enum
+explicitly. They mirror the runtime ``add_input/add_output/add_output(Tensor)
+/add_inout/add_no_dep/add_scalar`` API on the call site.
+
+The user-facing DSL (``pypto.language``) keeps using :class:`pl.Out` and
+:class:`pl.InOut` on the *callee* parameter list — those map to
+:class:`ir.ParamDirection`. The helpers here are about the *call* site and
+populate :attr:`ir.Call.arg_directions`. A :class:`Pass` (``DeriveCallDirections``)
+can recompute the same vector from the callee's :class:`ir.ParamDirection` and
+buffer lineage, so explicit usage is reserved for hand-built IR fragments.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pypto.pypto_core import ir as _ir
+
+ArgDirection = _ir.ArgDirection
+
+# Per-call-site direction aliases (lowercase, named after the runtime methods).
+# ``input`` intentionally shadows the Python builtin within this module; users
+# access it via ``ir.directions.input`` or ``ir.input``, never as a free name.
+input = ArgDirection.Input
+output = ArgDirection.Output
+output_existing = ArgDirection.OutputExisting
+inout = ArgDirection.InOut
+no_dep = ArgDirection.NoDep
+scalar = ArgDirection.Scalar
+
+
+def make_call(
+    op: _ir.Op,
+    args: Sequence[_ir.Expr],
+    *,
+    directions: Sequence[ArgDirection] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    type: _ir.Type | None = None,
+    span: _ir.Span | None = None,
+) -> _ir.Call:
+    """Build a :class:`ir.Call` while populating ``arg_directions`` in one place.
+
+    Args:
+        op: Callee operation (typically an :class:`ir.GlobalVar` for a function).
+        args: Positional argument expressions.
+        directions: Optional explicit per-argument :class:`ArgDirection` vector.
+            When ``None`` the resulting call has an empty ``arg_directions``
+            vector (matches legacy behavior; codegen falls back to deriving from
+            the callee's :attr:`ParamDirection`). When provided the length must
+            match ``args``.
+        kwargs: Optional keyword arguments to attach to the call.
+        type: Optional explicit return type.
+        span: Optional source span; defaults to :meth:`ir.Span.unknown`.
+
+    Returns:
+        The constructed :class:`ir.Call`.
+
+    Raises:
+        ValueError: If ``directions`` has a length other than ``len(args)``.
+    """
+    actual_span = span if span is not None else _ir.Span.unknown()
+    actual_type = type if type is not None else _ir.UnknownType()
+    actual_kwargs = dict(kwargs or {})
+    args_list = list(args)
+
+    if directions is None:
+        return _ir.Call(op, args_list, actual_kwargs, actual_type, actual_span)
+
+    directions_list = list(directions)
+    if len(directions_list) != len(args_list):
+        raise ValueError(
+            f"make_call: directions length ({len(directions_list)}) must match args length ({len(args_list)})"
+        )
+    return _ir.Call(op, args_list, directions_list, actual_kwargs, actual_type, actual_span)
+
+
+__all__ = [
+    "ArgDirection",
+    "input",
+    "output",
+    "output_existing",
+    "inout",
+    "no_dep",
+    "scalar",
+    "make_call",
+]

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -23,6 +23,7 @@ def create(
     shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     dtype: DataType,
     layout: TensorLayout = TensorLayout.ND,
+    manual_dep: bool = False,
     span: Span | None = None,
 ) -> Call:
     """Create a new tensor with specified shape and dtype.
@@ -31,6 +32,10 @@ def create(
         shape: List of dimension sizes (int or Expr), or a MakeTuple
         dtype: Data type of tensor elements
         layout: Tensor layout (default: ND)
+        manual_dep: When True, mark the buffer as ``manual_dep`` so codegen
+            opts out of automatic dependency tracking. Used by passes that
+            inject orchestrator workspace buffers (e.g. GM pipe buffer); most
+            users should leave it as the default ``False``.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -42,6 +47,8 @@ def create(
 
     args = [shape_tuple]
     kwargs: dict[str, Any] = {"dtype": dtype, "layout": layout}
+    if manual_dep:
+        kwargs["manual_dep"] = True
 
     return _ir_core.create_op_call("tensor.create", args, kwargs, actual_span)
 
@@ -875,8 +882,8 @@ def reshape(
 
 def transpose(
     tensor: Expr,
-    axis1: int,
-    axis2: int,
+    axis1: int | ConstInt,
+    axis2: int | ConstInt,
     valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -884,8 +891,8 @@ def transpose(
 
     Args:
         tensor: Input tensor expression
-        axis1: First axis to swap (supports negative indexing)
-        axis2: Second axis to swap (supports negative indexing)
+        axis1: First axis to swap as an int or ConstInt (supports negative indexing)
+        axis2: Second axis to swap as an int or ConstInt (supports negative indexing)
         valid_shape: Valid shape dimensions (optional, defaults to empty)
         span: Optional source span for debugging (auto-captured if not provided)
 
@@ -893,8 +900,19 @@ def transpose(
         Call expression for tensor transpose
     """
     actual_span = _get_span_or_capture(span)
-    axis1_expr = ConstInt(axis1, DataType.INDEX, actual_span)
-    axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
+    if isinstance(axis1, ConstInt):
+        axis1_expr = axis1
+    elif isinstance(axis1, int):
+        axis1_expr = ConstInt(axis1, DataType.INDEX, actual_span)
+    else:
+        raise TypeError(f"axis1 must be int or ConstInt, got {type(axis1)}")
+
+    if isinstance(axis2, ConstInt):
+        axis2_expr = axis2
+    elif isinstance(axis2, int):
+        axis2_expr = ConstInt(axis2, DataType.INDEX, actual_span)
+    else:
+        raise TypeError(f"axis2 must be int or ConstInt, got {type(axis2)}")
 
     args = [tensor, axis1_expr, axis2_expr]
     if valid_shape is not None:

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -152,6 +152,7 @@ class PassManager:
             ("LegalizePTOBufferReuse", lambda: passes.legalize_pto_buffer_reuse()),
             ("AllocateMemoryAddr", lambda: passes.allocate_memory_addr()),
             ("FuseCreateAssembleToSlice", lambda: passes.fuse_create_assemble_to_slice()),
+            ("DeriveCallDirections", lambda: passes.derive_call_directions()),
             ("Simplify", lambda: passes.simplify()),
         ]
         cls._strategy_passes = {

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -57,6 +57,7 @@ from pypto.pypto_core.ir import (
     TileLayout,
 )
 
+from . import arg_direction as adir
 from . import optimizations, parser
 from .dsl_api import (
     at,
@@ -256,6 +257,7 @@ __all__ = [
     "optimizations",
     "split",
     "auto_chunk",
+    "adir",
     "tile",
     "system",
     "tensor",

--- a/python/pypto/language/arg_direction.py
+++ b/python/pypto/language/arg_direction.py
@@ -1,0 +1,119 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Per-call-site direction markers for PyPTO Language DSL.
+
+These wrappers attach an explicit :class:`pypto.ir.ArgDirection` to a call
+argument. They are identity functions at Python runtime and are recognized
+by the parser, which strips them and stores the direction on
+``ir.Call.arg_directions_``.
+
+Usage in a printed (or hand-written) DSL Orchestration function::
+
+    import pypto.language as pl
+
+    result = self.kernel_process(
+        pl.adir.input(a),
+        pl.adir.scalar(is_first),
+        pl.adir.inout(result),
+    )
+
+The wrappers correspond 1:1 with the runtime task-submission methods on
+``PTOParam`` (``add_input`` / ``add_output`` / ``add_inout`` /
+``add_no_dep`` / ``add_scalar``) and with :class:`ir.ArgDirection` enum
+values:
+
+==================== ================================
+Helper               ``ArgDirection``
+==================== ================================
+``pl.adir.input``            ``Input``
+``pl.adir.output``           ``Output``
+``pl.adir.output_existing``  ``OutputExisting``
+``pl.adir.inout``            ``InOut``
+``pl.adir.no_dep``           ``NoDep``
+``pl.adir.scalar``           ``Scalar``
+==================== ================================
+
+The wrappers exist so that ``Call.arg_directions_`` survives a
+``python_print`` → ``parse`` round-trip (it is otherwise a derived field
+populated by the ``DeriveCallDirections`` pass and not visible in the
+DSL surface syntax).
+
+User-facing parameter direction is still expressed via ``pl.Out[T]`` /
+``pl.InOut[T]`` on the *callee*'s parameter list — those map to
+``ir.ParamDirection`` and remain the recommended way to declare a
+function's contract.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from pypto.pypto_core import ir as _ir
+
+T = TypeVar("T")
+
+ArgDirection = _ir.ArgDirection
+
+
+def input(x: T) -> T:  # noqa: A001 -- shadows builtin within this module only
+    """Mark a call argument as an ``Input`` (read-only tensor) at the call site."""
+    return x
+
+
+def output(x: T) -> T:
+    """Mark a call argument as an ``Output`` (freshly allocated, single writer)."""
+    return x
+
+
+def output_existing(x: T) -> T:
+    """Mark a call argument as an ``OutputExisting`` (writes into an externally provided buffer)."""
+    return x
+
+
+def inout(x: T) -> T:
+    """Mark a call argument as ``InOut`` (read-modify-write, e.g. WAW promotion)."""
+    return x
+
+
+def no_dep(x: T) -> T:
+    """Mark a call argument as ``NoDep`` (explicitly opt out of the dataflow)."""
+    return x
+
+
+def scalar(x: T) -> T:
+    """Mark a call argument as a ``Scalar`` (passed by value, not as a tensor handle)."""
+    return x
+
+
+# Mapping from the wrapper's leaf attribute name to the IR enum value.
+# Used by both the printer (enum → name) and parser (name → enum).
+NAME_TO_DIRECTION: dict[str, ArgDirection] = {
+    "input": ArgDirection.Input,
+    "output": ArgDirection.Output,
+    "output_existing": ArgDirection.OutputExisting,
+    "inout": ArgDirection.InOut,
+    "no_dep": ArgDirection.NoDep,
+    "scalar": ArgDirection.Scalar,
+}
+
+DIRECTION_TO_NAME: dict[ArgDirection, str] = {v: k for k, v in NAME_TO_DIRECTION.items()}
+
+
+__all__ = [
+    "ArgDirection",
+    "DIRECTION_TO_NAME",
+    "NAME_TO_DIRECTION",
+    "input",
+    "inout",
+    "no_dep",
+    "output",
+    "output_existing",
+    "scalar",
+]

--- a/python/pypto/language/arg_direction.py
+++ b/python/pypto/language/arg_direction.py
@@ -9,29 +9,32 @@
 
 """Per-call-site direction markers for PyPTO Language DSL.
 
-These wrappers attach an explicit :class:`pypto.ir.ArgDirection` to a call
-argument. They are identity functions at Python runtime and are recognized
-by the parser, which strips them and stores the direction vector on
-``ir.Call.attrs['arg_directions']`` (also accessible via the
-``ir.Call.arg_directions`` shortcut property).
+These markers attach an explicit :class:`pypto.ir.ArgDirection` to a call
+argument and are stored on ``ir.Call.attrs['arg_directions']`` (also
+accessible via the ``ir.Call.arg_directions`` shortcut property).
 
-Usage in a printed (or hand-written) DSL Orchestration function::
+The printer surfaces the direction vector via a trailing ``attrs=`` keyword
+on cross-function calls so that ``python_print`` → ``parse`` round-trips
+preserve the metadata::
 
     import pypto.language as pl
 
     result = self.kernel_process(
-        pl.adir.input(a),
-        pl.adir.scalar(is_first),
-        pl.adir.inout(result),
+        a, is_first, result,
+        attrs={"arg_directions": [pl.adir.input, pl.adir.scalar, pl.adir.inout]},
     )
 
-The wrappers correspond 1:1 with the runtime task-submission methods on
+Each ``pl.adir.<name>`` symbol is a direct alias of the matching
+:class:`ir.ArgDirection` enum value — they are not callable. Per-argument
+wrapper forms such as ``pl.adir.input(x)`` are intentionally not supported.
+
+The markers correspond 1:1 with the runtime task-submission methods on
 ``PTOParam`` (``add_input`` / ``add_output`` / ``add_inout`` /
 ``add_no_dep`` / ``add_scalar``) and with :class:`ir.ArgDirection` enum
 values:
 
 ==================== ================================
-Helper               ``ArgDirection``
+Marker               ``ArgDirection``
 ==================== ================================
 ``pl.adir.input``            ``Input``
 ``pl.adir.output``           ``Output``
@@ -41,11 +44,6 @@ Helper               ``ArgDirection``
 ``pl.adir.scalar``           ``Scalar``
 ==================== ================================
 
-The wrappers exist so that ``Call.attrs['arg_directions']`` survives a
-``python_print`` → ``parse`` round-trip (it is otherwise a derived attr
-populated by the ``DeriveCallDirections`` pass and not visible in the
-DSL surface syntax).
-
 User-facing parameter direction is still expressed via ``pl.Out[T]`` /
 ``pl.InOut[T]`` on the *callee*'s parameter list — those map to
 ``ir.ParamDirection`` and remain the recommended way to declare a
@@ -54,47 +52,22 @@ function's contract.
 
 from __future__ import annotations
 
-from typing import TypeVar
-
 from pypto.pypto_core import ir as _ir
-
-T = TypeVar("T")
 
 ArgDirection = _ir.ArgDirection
 
+# Direct aliases of the enum values. Bare references like ``pl.adir.input`` are
+# the only supported surface form; ``pl.adir.input(x)`` would be a TypeError
+# at runtime since enum values are not callable.
+input = ArgDirection.Input  # noqa: A001 -- shadows builtin within this module only
+output = ArgDirection.Output
+output_existing = ArgDirection.OutputExisting
+inout = ArgDirection.InOut
+no_dep = ArgDirection.NoDep
+scalar = ArgDirection.Scalar
 
-def input(x: T) -> T:  # noqa: A001 -- shadows builtin within this module only
-    """Mark a call argument as an ``Input`` (read-only tensor) at the call site."""
-    return x
-
-
-def output(x: T) -> T:
-    """Mark a call argument as an ``Output`` (freshly allocated, single writer)."""
-    return x
-
-
-def output_existing(x: T) -> T:
-    """Mark a call argument as an ``OutputExisting`` (writes into an externally provided buffer)."""
-    return x
-
-
-def inout(x: T) -> T:
-    """Mark a call argument as ``InOut`` (read-modify-write, e.g. WAW promotion)."""
-    return x
-
-
-def no_dep(x: T) -> T:
-    """Mark a call argument as ``NoDep`` (explicitly opt out of the dataflow)."""
-    return x
-
-
-def scalar(x: T) -> T:
-    """Mark a call argument as a ``Scalar`` (passed by value, not as a tensor handle)."""
-    return x
-
-
-# Mapping from the wrapper's leaf attribute name to the IR enum value.
-# Used by both the printer (enum → name) and parser (name → enum).
+# Mapping from the marker's leaf attribute name to the IR enum value.
+# Used by both the printer (enum -> name) and parser (name -> enum).
 NAME_TO_DIRECTION: dict[str, ArgDirection] = {
     "input": ArgDirection.Input,
     "output": ArgDirection.Output,

--- a/python/pypto/language/arg_direction.py
+++ b/python/pypto/language/arg_direction.py
@@ -11,8 +11,9 @@
 
 These wrappers attach an explicit :class:`pypto.ir.ArgDirection` to a call
 argument. They are identity functions at Python runtime and are recognized
-by the parser, which strips them and stores the direction on
-``ir.Call.arg_directions_``.
+by the parser, which strips them and stores the direction vector on
+``ir.Call.attrs['arg_directions']`` (also accessible via the
+``ir.Call.arg_directions`` shortcut property).
 
 Usage in a printed (or hand-written) DSL Orchestration function::
 
@@ -40,8 +41,8 @@ Helper               ``ArgDirection``
 ``pl.adir.scalar``           ``Scalar``
 ==================== ================================
 
-The wrappers exist so that ``Call.arg_directions_`` survives a
-``python_print`` → ``parse`` round-trip (it is otherwise a derived field
+The wrappers exist so that ``Call.attrs['arg_directions']`` survives a
+``python_print`` → ``parse`` round-trip (it is otherwise a derived attr
 populated by the ``DeriveCallDirections`` pass and not visible in the
 DSL surface syntax).
 
@@ -110,8 +111,8 @@ __all__ = [
     "ArgDirection",
     "DIRECTION_TO_NAME",
     "NAME_TO_DIRECTION",
-    "input",
     "inout",
+    "input",
     "no_dep",
     "output",
     "output_existing",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -88,18 +88,27 @@ def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
 
 
-def create(shape: Sequence[IntLike], dtype: DataType, layout: TensorLayout = TensorLayout.ND) -> Tensor:
+def create(
+    shape: Sequence[IntLike],
+    dtype: DataType,
+    layout: TensorLayout = TensorLayout.ND,
+    manual_dep: bool = False,
+) -> Tensor:
     """Create a new tensor with specified shape and dtype.
 
     Args:
         shape: List of dimension sizes (int or Expr)
         dtype: Data type of tensor elements
         layout: Tensor layout (default: ND)
+        manual_dep: When True, the tensor opts out of automatic dependency
+            tracking by codegen (used internally for orchestrator-injected
+            workspace buffers like the GM pipe buffer). Most user code should
+            leave this as False.
 
     Returns:
         Tensor wrapping the create operation
     """
-    call_expr = _ir_ops.create(_normalize_intlike(shape), dtype, layout)
+    call_expr = _ir_ops.create(_normalize_intlike(shape), dtype, layout, manual_dep=manual_dep)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3217,10 +3217,10 @@ class ASTParser:
             span: Source span for the call
             arg_directions: Optional explicit per-argument :class:`ir.ArgDirection`
                 vector. When non-empty its length must equal ``len(args)`` and the
-                resulting :class:`ir.Call` is constructed via the directions
-                overload so that ``arg_directions_`` is populated. When ``None``
-                or empty the call is constructed without explicit directions
-                (legacy form; ``DeriveCallDirections`` will fill them in later).
+                resulting :class:`ir.Call` is constructed via the attrs overload
+                with ``attrs['arg_directions']`` populated. When ``None`` or empty
+                the call is constructed without explicit directions (legacy form;
+                ``DeriveCallDirections`` will fill them in later).
         """
         if not return_types:
             return_type: ir.Type = ir.UnknownType()
@@ -3230,7 +3230,8 @@ class ASTParser:
             return_type = ir.TupleType(return_types)
 
         if arg_directions:
-            return ir.Call(gvar, args, list(arg_directions), {}, return_type, span)
+            attrs = {"arg_directions": list(arg_directions)}
+            return ir.Call(gvar, args, {}, attrs, return_type, span)
 
         if not return_types:
             return ir.Call(gvar, args, span)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3050,7 +3050,10 @@ class ASTParser:
                     if func_obj is not None:
                         self._validate_call_arg_count(method_name, func_obj, len(call.args), span)
 
-                    args = [self.parse_expression(arg) for arg in call.args]
+                    raw_args, arg_directions = self._strip_arg_direction_wrappers(
+                        method_name, call.args, span
+                    )
+                    args = [self.parse_expression(arg) for arg in raw_args]
                     return_types = func_obj.return_types if func_obj else []
                     if func_obj is not None and return_types:
                         return_types = ir.deduce_call_return_type(
@@ -3058,7 +3061,9 @@ class ASTParser:
                             args,
                             return_types,
                         )
-                    return self._make_call_with_return_type(gvar, args, return_types, span)
+                    return self._make_call_with_return_type(
+                        gvar, args, return_types, span, arg_directions=arg_directions
+                    )
                 else:
                     raise UndefinedVariableError(
                         f"Function '{method_name}' not defined in program",
@@ -3201,20 +3206,112 @@ class ASTParser:
         args: list[ir.Expr],
         return_types: list[ir.Type],
         span: ir.Span,
+        arg_directions: list[ir.ArgDirection] | None = None,
     ) -> ir.Expr:
-        """Create an ir.Call, attaching the return type when known.
+        """Create an ir.Call, attaching the return type and (optional) call-site directions.
 
         Args:
             gvar: GlobalVar identifying the callee
             args: Parsed argument expressions
             return_types: The callee's return type list (may be empty)
             span: Source span for the call
+            arg_directions: Optional explicit per-argument :class:`ir.ArgDirection`
+                vector. When non-empty its length must equal ``len(args)`` and the
+                resulting :class:`ir.Call` is constructed via the directions
+                overload so that ``arg_directions_`` is populated. When ``None``
+                or empty the call is constructed without explicit directions
+                (legacy form; ``DeriveCallDirections`` will fill them in later).
         """
         if not return_types:
+            return_type: ir.Type = ir.UnknownType()
+        elif len(return_types) == 1:
+            return_type = return_types[0]
+        else:
+            return_type = ir.TupleType(return_types)
+
+        if arg_directions:
+            return ir.Call(gvar, args, list(arg_directions), {}, return_type, span)
+
+        if not return_types:
             return ir.Call(gvar, args, span)
-        if len(return_types) == 1:
-            return ir.Call(gvar, args, return_types[0], span)
-        return ir.Call(gvar, args, ir.TupleType(return_types), span)
+        return ir.Call(gvar, args, return_type, span)
+
+    def _strip_arg_direction_wrappers(
+        self,
+        method_name: str,
+        ast_args: list[ast.expr],
+        span: ir.Span,
+    ) -> tuple[list[ast.expr], list[ir.ArgDirection]]:
+        """Detect ``pl.adir.<dir>(inner)`` wrappers around ``self.method`` arguments.
+
+        Either every positional argument is wrapped or none are (mixed forms are
+        rejected). When all wrappers are present, returns the unwrapped inner AST
+        nodes and the matching :class:`ir.ArgDirection` vector. When none are
+        wrapped, returns the original args and an empty vector (legacy form).
+
+        Args:
+            method_name: Name of the cross-function method being called (used in
+                error messages).
+            ast_args: Positional ``ast.expr`` nodes from the call.
+            span: Source span of the call (used for error reporting).
+
+        Returns:
+            ``(inner_args, directions)`` where ``directions`` is empty if no
+            wrapper was found.
+
+        Raises:
+            ParserSyntaxError: If wrappers are partially present or use an
+                unknown direction name.
+        """
+        from pypto.language.arg_direction import NAME_TO_DIRECTION  # noqa: PLC0415
+
+        wrapper_info: list[tuple[ast.expr, ir.ArgDirection] | None] = []
+        for arg in ast_args:
+            if not isinstance(arg, ast.Call):
+                wrapper_info.append(None)
+                continue
+            func = arg.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "adir"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id == "pl"
+            ):
+                dir_name = func.attr
+                if dir_name not in NAME_TO_DIRECTION:
+                    raise ParserSyntaxError(
+                        f"Unknown call-site direction marker 'pl.adir.{dir_name}' in call to '{method_name}'",
+                        span=self.span_tracker.get_span(arg),
+                        hint=("Valid markers: " + ", ".join(f"pl.adir.{n}" for n in NAME_TO_DIRECTION)),
+                    )
+                if len(arg.args) != 1 or arg.keywords:
+                    raise ParserSyntaxError(
+                        f"'pl.adir.{dir_name}' must wrap exactly one positional argument",
+                        span=self.span_tracker.get_span(arg),
+                    )
+                wrapper_info.append((arg.args[0], NAME_TO_DIRECTION[dir_name]))
+            else:
+                wrapper_info.append(None)
+
+        wrapped_count = sum(1 for w in wrapper_info if w is not None)
+        if wrapped_count == 0:
+            return list(ast_args), []
+        if wrapped_count != len(ast_args):
+            raise ParserSyntaxError(
+                f"Call to '{method_name}' mixes wrapped (pl.adir.*) and bare "
+                f"arguments; either wrap all of them or none",
+                span=span,
+            )
+
+        inner_args: list[ast.expr] = []
+        directions: list[ir.ArgDirection] = []
+        for entry in wrapper_info:
+            assert entry is not None  # narrowed by wrapped_count check
+            inner, direction = entry
+            inner_args.append(inner)
+            directions.append(direction)
+        return inner_args, directions
 
     @staticmethod
     def _reject_keyword_args(func_name: str, call: ast.Call, span: ir.Span) -> None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3043,17 +3043,20 @@ class ASTParser:
                 if method_name in self.global_vars:
                     gvar = self.global_vars[method_name]
                     span = self.span_tracker.get_span(call)
-                    self._reject_keyword_args(method_name, call, span)
+                    # ``attrs={"arg_directions": [...]}`` is the preferred way to
+                    # surface call-site directions on cross-function calls; any
+                    # other keyword argument is still rejected.
+                    self._reject_keyword_args(method_name, call, span, allowed={"attrs"})
 
                     # Validate argument count before parsing args to fail fast
                     func_obj = self.gvar_to_func.get(gvar)
                     if func_obj is not None:
                         self._validate_call_arg_count(method_name, func_obj, len(call.args), span)
 
-                    raw_args, arg_directions = self._strip_arg_direction_wrappers(
-                        method_name, call.args, span
-                    )
-                    args = [self.parse_expression(arg) for arg in raw_args]
+                    arg_directions = self._extract_arg_directions_from_attrs(method_name, call, span)
+                    if arg_directions is None:
+                        arg_directions = []
+                    args = [self.parse_expression(arg) for arg in call.args]
                     return_types = func_obj.return_types if func_obj else []
                     if func_obj is not None and return_types:
                         return_types = ir.deduce_call_return_type(
@@ -3237,92 +3240,129 @@ class ASTParser:
             return ir.Call(gvar, args, span)
         return ir.Call(gvar, args, return_type, span)
 
-    def _strip_arg_direction_wrappers(
-        self,
-        method_name: str,
-        ast_args: list[ast.expr],
+    @staticmethod
+    def _reject_keyword_args(
+        func_name: str,
+        call: ast.Call,
         span: ir.Span,
-    ) -> tuple[list[ast.expr], list[ir.ArgDirection]]:
-        """Detect ``pl.adir.<dir>(inner)`` wrappers around ``self.method`` arguments.
-
-        Either every positional argument is wrapped or none are (mixed forms are
-        rejected). When all wrappers are present, returns the unwrapped inner AST
-        nodes and the matching :class:`ir.ArgDirection` vector. When none are
-        wrapped, returns the original args and an empty vector (legacy form).
+        allowed: set[str] | None = None,
+    ) -> None:
+        """Reject keyword arguments not in *allowed*.
 
         Args:
-            method_name: Name of the cross-function method being called (used in
-                error messages).
-            ast_args: Positional ``ast.expr`` nodes from the call.
+            func_name: Function name used in error messages.
+            call: AST call node.
+            span: Source span of the call.
+            allowed: Optional set of keyword names that are permitted. When
+                ``None``, all keyword arguments are rejected (the default).
+        """
+        allowed = allowed or set()
+        for kw in call.keywords:
+            if kw.arg not in allowed:
+                hint = (
+                    f"Allowed keyword arguments: {sorted(allowed)}"
+                    if allowed
+                    else "Pass all arguments positionally"
+                )
+                raise ParserTypeError(
+                    f"Function '{func_name}' does not accept keyword argument '{kw.arg}'",
+                    span=span,
+                    hint=hint,
+                )
+
+    def _extract_arg_directions_from_attrs(
+        self,
+        method_name: str,
+        call: ast.Call,
+        span: ir.Span,
+    ) -> list[ir.ArgDirection] | None:
+        """Extract ``arg_directions`` from an ``attrs={"arg_directions": [...]}`` kwarg.
+
+        Recognized form::
+
+            self.kernel(x, y, attrs={"arg_directions": [pl.adir.input, pl.adir.output]})
+
+        The list elements must be bare attribute references of the form
+        ``pl.adir.<name>`` where ``<name>`` is a valid direction marker.
+
+        Args:
+            method_name: Name of the cross-function method being called (used
+                in error messages).
+            call: AST call node.
             span: Source span of the call (used for error reporting).
 
         Returns:
-            ``(inner_args, directions)`` where ``directions`` is empty if no
-            wrapper was found.
+            The parsed direction vector, or ``None`` when no ``attrs=`` keyword
+            argument is present.
 
         Raises:
-            ParserSyntaxError: If wrappers are partially present or use an
-                unknown direction name.
+            ParserSyntaxError / ParserTypeError: If the ``attrs=`` value does
+                not match the expected shape or uses an unknown direction name.
         """
         from pypto.language.arg_direction import NAME_TO_DIRECTION  # noqa: PLC0415
 
-        wrapper_info: list[tuple[ast.expr, ir.ArgDirection] | None] = []
-        for arg in ast_args:
-            if not isinstance(arg, ast.Call):
-                wrapper_info.append(None)
-                continue
-            func = arg.func
-            if (
-                isinstance(func, ast.Attribute)
-                and isinstance(func.value, ast.Attribute)
-                and func.value.attr == "adir"
-                and isinstance(func.value.value, ast.Name)
-                and func.value.value.id == "pl"
-            ):
-                dir_name = func.attr
-                if dir_name not in NAME_TO_DIRECTION:
+        attrs_kw: ast.keyword | None = next((kw for kw in call.keywords if kw.arg == "attrs"), None)
+        if attrs_kw is None:
+            return None
+
+        if not isinstance(attrs_kw.value, ast.Dict):
+            raise ParserTypeError(
+                f"'attrs=' on call to '{method_name}' must be a dict literal",
+                span=self.span_tracker.get_span(attrs_kw.value),
+                hint='e.g. attrs={"arg_directions": [pl.adir.input, ...]}',
+            )
+
+        directions: list[ir.ArgDirection] | None = None
+        for key_node, value_node in zip(attrs_kw.value.keys, attrs_kw.value.values):
+            if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
+                raise ParserSyntaxError(
+                    f"'attrs=' on call to '{method_name}' must use string-literal keys",
+                    span=self.span_tracker.get_span(key_node) if key_node else span,
+                )
+            if key_node.value != "arg_directions":
+                raise ParserSyntaxError(
+                    f"Unsupported attrs key '{key_node.value}' on call to '{method_name}'",
+                    span=self.span_tracker.get_span(key_node),
+                    hint="Only 'arg_directions' is currently recognized",
+                )
+            if not isinstance(value_node, ast.List):
+                raise ParserTypeError(
+                    f"attrs['arg_directions'] on call to '{method_name}' must be a list literal",
+                    span=self.span_tracker.get_span(value_node),
+                )
+            parsed: list[ir.ArgDirection] = []
+            for elt in value_node.elts:
+                if not (
+                    isinstance(elt, ast.Attribute)
+                    and isinstance(elt.value, ast.Attribute)
+                    and elt.value.attr == "adir"
+                    and isinstance(elt.value.value, ast.Name)
+                    and elt.value.value.id == "pl"
+                ):
                     raise ParserSyntaxError(
-                        f"Unknown call-site direction marker 'pl.adir.{dir_name}' in call to '{method_name}'",
-                        span=self.span_tracker.get_span(arg),
+                        f"attrs['arg_directions'] on call to '{method_name}' must contain "
+                        "'pl.adir.<name>' references only",
+                        span=self.span_tracker.get_span(elt),
+                    )
+                if elt.attr not in NAME_TO_DIRECTION:
+                    raise ParserSyntaxError(
+                        f"Unknown call-site direction marker 'pl.adir.{elt.attr}' in call to '{method_name}'",
+                        span=self.span_tracker.get_span(elt),
                         hint=("Valid markers: " + ", ".join(f"pl.adir.{n}" for n in NAME_TO_DIRECTION)),
                     )
-                if len(arg.args) != 1 or arg.keywords:
-                    raise ParserSyntaxError(
-                        f"'pl.adir.{dir_name}' must wrap exactly one positional argument",
-                        span=self.span_tracker.get_span(arg),
-                    )
-                wrapper_info.append((arg.args[0], NAME_TO_DIRECTION[dir_name]))
-            else:
-                wrapper_info.append(None)
+                parsed.append(NAME_TO_DIRECTION[elt.attr])
+            directions = parsed
 
-        wrapped_count = sum(1 for w in wrapper_info if w is not None)
-        if wrapped_count == 0:
-            return list(ast_args), []
-        if wrapped_count != len(ast_args):
-            raise ParserSyntaxError(
-                f"Call to '{method_name}' mixes wrapped (pl.adir.*) and bare "
-                f"arguments; either wrap all of them or none",
-                span=span,
-            )
+        if directions is None:
+            return []
 
-        inner_args: list[ast.expr] = []
-        directions: list[ir.ArgDirection] = []
-        for entry in wrapper_info:
-            assert entry is not None  # narrowed by wrapped_count check
-            inner, direction = entry
-            inner_args.append(inner)
-            directions.append(direction)
-        return inner_args, directions
-
-    @staticmethod
-    def _reject_keyword_args(func_name: str, call: ast.Call, span: ir.Span) -> None:
-        """Reject keyword arguments on function calls that only support positional args."""
-        if call.keywords:
+        if directions and len(directions) != len(call.args):
             raise ParserTypeError(
-                f"Function '{func_name}' does not accept keyword arguments",
+                f"attrs['arg_directions'] length ({len(directions)}) on call to "
+                f"'{method_name}' must match positional arg count ({len(call.args)})",
                 span=span,
-                hint="Pass all arguments positionally",
             )
+        return directions
 
     @staticmethod
     def _validate_call_arg_count(func_name: str, func: ir.Function, got: int, span: ir.Span) -> None:

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1070,14 +1070,25 @@ class Call(Expr):
     args: Final[Sequence[Expr]]
     """Positional arguments."""
 
-    arg_directions: Final[Sequence[ArgDirection]]
-    """Optional per-argument call-site directions.
+    @property
+    def arg_directions(self) -> Sequence[ArgDirection]:
+        """Resolved per-argument call-site directions.
 
-    Empty by default for backward compatibility (codegen falls back to deriving
-    from the callee's `param_directions`). When non-empty must have the same
-    length as `args` and is the source of truth for runtime task-submission
-    semantics.
-    """
+        Stored under ``attrs['arg_directions']``. Returns an empty list when
+        not yet derived (legacy / pre-DeriveCallDirections state). When non-empty
+        the length must match ``args`` and is the source of truth for runtime
+        task-submission semantics.
+        """
+
+    @property
+    def attrs(self) -> Mapping[str, Any]:
+        """Compiler-internal node metadata.
+
+        Reserved keys:
+
+        - ``"arg_directions"`` -> ``list[ArgDirection]`` (use the
+          :attr:`arg_directions` shortcut for typed access).
+        """
 
     kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue]]
     """Keyword arguments (metadata)."""
@@ -1155,18 +1166,19 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        arg_directions: Sequence[ArgDirection],
         kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        attrs: Mapping[str, object] | Sequence[tuple[str, object]] | None,
         type: Type,
         span: Span,
     ) -> None:
-        """Create a function call expression with explicit call-site directions.
+        """Create a function call expression with kwargs, explicit attrs and type.
 
         Args:
             op: Operation/function to call
             args: List of argument expressions
-            arg_directions: Per-argument call-site directions (empty or len(args))
             kwargs: Keyword arguments (metadata)
+            attrs: Compiler-internal node metadata. Reserved keys:
+                ``"arg_directions"`` -> ``Sequence[ArgDirection]``.
             type: Explicit result type
             span: Source location
         """

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -770,6 +770,33 @@ class ParamDirection(enum.Enum):
     InOut = ...
     """Read-write input/output."""
 
+class ArgDirection(enum.Enum):
+    """Call-site argument direction (mirrors runtime TensorArgType one-to-one).
+
+    Distinct from `ParamDirection` (callee function-signature contract).
+    `ArgDirection` describes the call-site task-submission behavior:
+    which runtime API to invoke, what dependency edges to establish,
+    and whether the buffer is allocated by the runtime.
+    """
+
+    Input = ...
+    """Read-only input → add_input / TensorArgType::INPUT."""
+
+    Output = ...
+    """Runtime-allocated output buffer → add_output(create_info) / TensorArgType::OUTPUT."""
+
+    InOut = ...
+    """Read-then-write → add_inout / TensorArgType::INOUT."""
+
+    OutputExisting = ...
+    """Write-only into an existing tensor → add_output(tensor) / TensorArgType::OUTPUT_EXISTING."""
+
+    NoDep = ...
+    """No-dependency existing tensor → add_no_dep / TensorArgType::NO_DEP."""
+
+    Scalar = ...
+    """Scalar (non-tensor) argument → add_scalar."""
+
 class ForKind(enum.Enum):
     """For loop kind classification.
 
@@ -1043,6 +1070,15 @@ class Call(Expr):
     args: Final[Sequence[Expr]]
     """Positional arguments."""
 
+    arg_directions: Final[Sequence[ArgDirection]]
+    """Optional per-argument call-site directions.
+
+    Empty by default for backward compatibility (codegen falls back to deriving
+    from the callee's `param_directions`). When non-empty must have the same
+    length as `args` and is the source of truth for runtime task-submission
+    semantics.
+    """
+
     kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue]]
     """Keyword arguments (metadata)."""
 
@@ -1108,6 +1144,28 @@ class Call(Expr):
         Args:
             op: Operation/function to call
             args: List of argument expressions
+            kwargs: Keyword arguments (metadata)
+            type: Explicit result type
+            span: Source location
+        """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        op: Op,
+        args: Sequence[Expr],
+        arg_directions: Sequence[ArgDirection],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        type: Type,
+        span: Span,
+    ) -> None:
+        """Create a function call expression with explicit call-site directions.
+
+        Args:
+            op: Operation/function to call
+            args: List of argument expressions
+            arg_directions: Per-argument call-site directions (empty or len(args))
             kwargs: Keyword arguments (metadata)
             type: Explicit result type
             span: Source location

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -398,7 +398,7 @@ def simplify() -> Pass:
 def derive_call_directions() -> Pass:
     """Create a pass that derives per-argument :class:`ir.ArgDirection` for every cross-function ``Call``.
 
-    Walks each ``Function``'s body and writes ``Call::arg_directions_`` based on
+    Walks each ``Function``'s body and writes ``Call.attrs['arg_directions']`` based on
     callee :class:`ir.ParamDirection` and argument origin (function param vs.
     locally allocated tensor vs. scalar). Establishes the
     :class:`IRProperty.CallDirectionsResolved` post-condition, which is then

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -38,6 +38,9 @@ class IRProperty(Enum):
     VectorKernelSplit = ...
     OutParamNotShadowed = ...
     NoNestedInCore = ...
+    InOutUseValid = ...
+    PipelineResolved = ...
+    CallDirectionsResolved = ...
 
 class IRPropertySet:
     """A set of IR properties backed by a bitset."""
@@ -392,6 +395,16 @@ def split_vector_kernel() -> Pass:
 def simplify() -> Pass:
     """Create a pass that simplifies expressions and statements using algebraic rules and bound analysis."""
 
+def derive_call_directions() -> Pass:
+    """Create a pass that derives per-argument :class:`ir.ArgDirection` for every cross-function ``Call``.
+
+    Walks each ``Function``'s body and writes ``Call::arg_directions_`` based on
+    callee :class:`ir.ParamDirection` and argument origin (function param vs.
+    locally allocated tensor vs. scalar). Establishes the
+    :class:`IRProperty.CallDirectionsResolved` post-condition, which is then
+    auto-verified by the pipeline.
+    """
+
 def flatten_call_expr() -> Pass:
     """Create a pass that flattens nested call expressions."""
 
@@ -520,6 +533,7 @@ __all__ = [
     "simplify",
     "flatten_call_expr",
     "normalize_stmt_structure",
+    "derive_call_directions",
     "NestedCallErrorType",
     "UseAfterDefErrorType",
     "DiagnosticSeverity",

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -341,63 +341,6 @@ const Var* VarLineageCollector::ResolveExpr(const ExprPtr& expr) const {
 }
 
 // ---------------------------------------------------------------------------
-// CallSiteDirectionResolver
-// ---------------------------------------------------------------------------
-
-CallSiteDirectionResolver::CallSiteDirectionResolver(
-    ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
-    const std::vector<VarPtr>& params)
-    : program_(std::move(program)), buffer_roots_(buffer_roots) {
-  for (const auto& p : params) {
-    param_vars_.insert(p.get());
-  }
-}
-
-bool CallSiteDirectionResolver::IsLocallyAllocated(const Var* var) const {
-  auto it = buffer_roots_.find(var);
-  if (it == buffer_roots_.end()) return false;
-  const Var* root = it->second;
-  return param_vars_.count(root) == 0;
-}
-
-void CallSiteDirectionResolver::VisitExpr_(const CallPtr& call) {
-  if (IsBuiltinOp(call->op_->name_)) {
-    IRVisitor::VisitExpr_(call);
-    return;
-  }
-
-  auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
-  if (!callee) {
-    IRVisitor::VisitExpr_(call);
-    return;
-  }
-
-  std::vector<ParamDirection> effective_dirs = callee->param_directions_;
-  if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
-    effective_dirs = ComputeGroupEffectiveDirections(callee, program_);
-  }
-
-  bool has_override = false;
-  for (size_t i = 0; i < call->args_.size() && i < effective_dirs.size(); ++i) {
-    if (effective_dirs[i] != ParamDirection::Out) continue;
-
-    auto arg_var = AsVarLike(call->args_[i]);
-    if (!arg_var) continue;
-
-    if (IsLocallyAllocated(arg_var.get())) {
-      effective_dirs[i] = ParamDirection::InOut;
-      has_override = true;
-    }
-  }
-
-  if (has_override) {
-    call_site_directions[call.get()] = std::move(effective_dirs);
-  }
-
-  IRVisitor::VisitExpr_(call);
-}
-
-// ---------------------------------------------------------------------------
 // ComputeGroupEffectiveDirections
 // ---------------------------------------------------------------------------
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -441,8 +441,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Phase-5 invariant: every Call entering codegen must carry an explicit
     // ArgDirection vector (populated by the DeriveCallDirections IR pass).
     // The legacy ParamDirection fallback has been removed.
-    INTERNAL_CHECK_SPAN(call->arg_directions_.size() == call->args_.size(), call->span_)
-        << "Call to '" << callee_name << "' has arg_directions size " << call->arg_directions_.size()
+    auto call_arg_directions = call->GetArgDirections();
+    INTERNAL_CHECK_SPAN(call_arg_directions.size() == call->args_.size(), call->span_)
+        << "Call to '" << callee_name << "' has arg_directions size " << call_arg_directions.size()
         << " but args size " << call->args_.size()
         << ". DeriveCallDirections must run before orchestration codegen.";
 
@@ -457,7 +458,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
 
         std::string ext_name = GetExternalTensorName(var_name);
-        params.push_back({call->arg_directions_[arg_idx], ext_name});
+        params.push_back({call_arg_directions[arg_idx], ext_name});
       } else if (auto const_int = As<ConstInt>(arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
@@ -468,8 +469,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
         params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
       } else if (auto const_bool = As<ConstBool>(arg)) {
         params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+      } else {
+        INTERNAL_CHECK_SPAN(false, call->span_) << "Call to '" << callee_name << "' arg " << arg_idx
+                                                << " is neither a variable nor a recognized constant literal "
+                                                << "(unsupported expression kind for orchestration codegen).";
       }
     }
+
+    INTERNAL_CHECK_SPAN(params.size() == call->args_.size(), call->span_)
+        << "Call to '" << callee_name << "' built " << params.size() << " params for " << call->args_.size()
+        << " call args (1:1 invariant violated).";
 
     // New PTOParam API: tensors must precede scalars (see check_add_tensor_valid() in pto_types.h)
     std::stable_partition(params.begin(), params.end(),
@@ -618,9 +627,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Phase-5 invariant: the outer Call must carry explicit arg_directions
     // (populated by DeriveCallDirections). The legacy ParamDirection fallback
     // has been removed from codegen.
-    INTERNAL_CHECK_SPAN(outer_call->arg_directions_.size() == outer_call->args_.size(), outer_call->span_)
+    auto outer_arg_directions = outer_call->GetArgDirections();
+    INTERNAL_CHECK_SPAN(outer_arg_directions.size() == outer_call->args_.size(), outer_call->span_)
         << "Outer call to wrapper '" << wrapper_func->name_ << "' has arg_directions size "
-        << outer_call->arg_directions_.size() << " but args size " << outer_call->args_.size()
+        << outer_arg_directions.size() << " but args size " << outer_call->args_.size()
         << ". DeriveCallDirections must run before orchestration codegen.";
 
     std::vector<ParamEntry> params;
@@ -663,7 +673,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
 
         std::string ext_name = GetExternalTensorName(var_name);
-        params.push_back({outer_call->arg_directions_[outer_idx], ext_name});
+        params.push_back({outer_arg_directions[outer_idx], ext_name});
       } else if (auto const_int = As<ConstInt>(outer_arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
@@ -674,8 +684,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
         params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
       } else if (auto const_bool = As<ConstBool>(outer_arg)) {
         params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+      } else {
+        INTERNAL_CHECK_SPAN(false, outer_call->span_)
+            << "Outer call to wrapper '" << wrapper_func->name_ << "' arg " << outer_idx
+            << " is neither a variable nor a recognized constant literal "
+            << "(unsupported expression kind for orchestration codegen).";
       }
     }
+
+    INTERNAL_CHECK_SPAN(params.size() == inner_call->args_.size(), inner_call->span_)
+        << "Wrapper '" << wrapper_func->name_ << "' built " << params.size() << " params for "
+        << inner_call->args_.size() << " inner-call args (1:1 invariant violated).";
 
     // Tensors must precede scalars
     std::stable_partition(params.begin(), params.end(),

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -186,10 +186,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetCallToTupleKey(const std::map<const Call*, std::string>& mapping) { call_to_tuple_key_ = mapping; }
 
-  void SetCallSiteDirections(std::unordered_map<const Call*, std::vector<ParamDirection>> directions) {
-    call_site_directions_ = std::move(directions);
-  }
-
   void SetInitialIndent(int indent) { indent_ = indent; }
 
   void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
@@ -406,34 +402,49 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return name;
   }
 
-  enum class ParamKind { Input, Output, InOut, Scalar };
-
-  static const char* ParamKindToMethodName(ParamKind kind) {
-    switch (kind) {
-      case ParamKind::Input:
+  // Map an IR ArgDirection directly to the runtime Arg::add_* method name.
+  // ArgDirection is the single source of truth for codegen.
+  static const char* ArgDirectionToMethodName(ArgDirection dir) {
+    switch (dir) {
+      case ArgDirection::Input:
         return "add_input";
-      case ParamKind::Output:
+      case ArgDirection::Output:
+      case ArgDirection::OutputExisting:
+        // The runtime overloads add_output on the argument type:
+        //   add_output(TensorCreateInfo&)  -> OUTPUT       (runtime allocates)
+        //   add_output(Tensor&)            -> OUTPUT_EXISTING (write-only existing tensor)
+        // The codegen pre-allocates via tensor.create + alloc_tensors, so the emitted
+        // call site always passes a Tensor& and the OUTPUT_EXISTING overload is selected.
+        // We still distinguish the two ArgDirections in the IR to let downstream phases
+        // switch to the runtime-allocated form without an IR change.
         return "add_output";
-      case ParamKind::InOut:
+      case ArgDirection::InOut:
         return "add_inout";
-      case ParamKind::Scalar:
+      case ArgDirection::NoDep:
+        return "add_no_dep";
+      case ArgDirection::Scalar:
         return "add_scalar";
     }
-    INTERNAL_CHECK(false) << "Internal error: unexpected ParamKind value";
+    INTERNAL_CHECK(false) << "Internal error: unexpected ArgDirection value";
     return "";
   }
 
   struct ParamEntry {
-    ParamKind kind;
+    ArgDirection direction;
     std::string value;
   };
 
-  std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func,
-                                          const std::vector<ParamDirection>* directions_override = nullptr) {
+  std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
     std::vector<ParamEntry> params;
     const std::string& callee_name = callee_func->name_;
-    const auto& directions =
-        directions_override != nullptr ? *directions_override : callee_func->param_directions_;
+
+    // Phase-5 invariant: every Call entering codegen must carry an explicit
+    // ArgDirection vector (populated by the DeriveCallDirections IR pass).
+    // The legacy ParamDirection fallback has been removed.
+    INTERNAL_CHECK_SPAN(call->arg_directions_.size() == call->args_.size(), call->span_)
+        << "Call to '" << callee_name << "' has arg_directions size " << call->arg_directions_.size()
+        << " but args size " << call->args_.size()
+        << ". DeriveCallDirections must run before orchestration codegen.";
 
     for (size_t arg_idx = 0; arg_idx < call->args_.size(); ++arg_idx) {
       const auto& arg = call->args_[arg_idx];
@@ -441,47 +452,28 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (!var_name.empty()) {
         if (auto scalar_type = As<ScalarType>(arg->GetType())) {
           std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-          params.push_back({ParamKind::Scalar, EncodeScalarVar(var_name, cpp_type)});
+          params.push_back({ArgDirection::Scalar, EncodeScalarVar(var_name, cpp_type)});
           continue;
         }
 
         std::string ext_name = GetExternalTensorName(var_name);
-
-        INTERNAL_CHECK_SPAN(arg_idx < directions.size(), call->span_)
-            << "arg count (" << call->args_.size() << ") exceeds param count (" << directions.size()
-            << ") for callee '" << callee_name << "'";
-
-        ParamDirection dir = directions[arg_idx];
-        switch (dir) {
-          case ParamDirection::Out:
-            params.push_back({ParamKind::Output, ext_name});
-            break;
-          case ParamDirection::InOut:
-            params.push_back({ParamKind::InOut, ext_name});
-            break;
-          case ParamDirection::In:
-            params.push_back({ParamKind::Input, ext_name});
-            break;
-          default:
-            INTERNAL_CHECK_SPAN(false, call->span_)
-                << "Internal error: unexpected ParamDirection value " << static_cast<int>(dir);
-        }
+        params.push_back({call->arg_directions_[arg_idx], ext_name});
       } else if (auto const_int = As<ConstInt>(arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
-        params.push_back({ParamKind::Scalar, "(uint64_t)" + value});
+        params.push_back({ArgDirection::Scalar, "(uint64_t)" + value});
       } else if (auto const_float = As<ConstFloat>(arg)) {
         std::string cpp_type = const_float->dtype().ToCTypeString();
         std::string value = FormatConstFloatValue(const_float, cpp_type);
-        params.push_back({ParamKind::Scalar, EncodeScalarConst(value, cpp_type)});
+        params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
       } else if (auto const_bool = As<ConstBool>(arg)) {
-        params.push_back({ParamKind::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+        params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
       }
     }
 
     // New PTOParam API: tensors must precede scalars (see check_add_tensor_valid() in pto_types.h)
     std::stable_partition(params.begin(), params.end(),
-                          [](const ParamEntry& p) { return p.kind != ParamKind::Scalar; });
+                          [](const ParamEntry& p) { return p.direction != ArgDirection::Scalar; });
 
     return params;
   }
@@ -623,6 +615,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       wrapper_param_to_outer_idx[wrapper_func->params_[i].get()] = i;
     }
 
+    // Phase-5 invariant: the outer Call must carry explicit arg_directions
+    // (populated by DeriveCallDirections). The legacy ParamDirection fallback
+    // has been removed from codegen.
+    INTERNAL_CHECK_SPAN(outer_call->arg_directions_.size() == outer_call->args_.size(), outer_call->span_)
+        << "Outer call to wrapper '" << wrapper_func->name_ << "' has arg_directions size "
+        << outer_call->arg_directions_.size() << " but args size " << outer_call->args_.size()
+        << ". DeriveCallDirections must run before orchestration codegen.";
+
     std::vector<ParamEntry> params;
     for (size_t inner_idx = 0; inner_idx < inner_call->args_.size(); ++inner_idx) {
       const auto& inner_arg = inner_call->args_[inner_idx];
@@ -633,13 +633,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (auto const_int = As<ConstInt>(inner_arg)) {
           std::string cpp_type = const_int->dtype().ToCTypeString();
           std::string value = FormatConstIntValue(const_int, cpp_type);
-          params.push_back({ParamKind::Scalar, "(uint64_t)" + value});
+          params.push_back({ArgDirection::Scalar, "(uint64_t)" + value});
         } else if (auto const_float = As<ConstFloat>(inner_arg)) {
           std::string cpp_type = const_float->dtype().ToCTypeString();
           std::string value = FormatConstFloatValue(const_float, cpp_type);
-          params.push_back({ParamKind::Scalar, EncodeScalarConst(value, cpp_type)});
+          params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
         } else if (auto const_bool = As<ConstBool>(inner_arg)) {
-          params.push_back({ParamKind::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+          params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
         } else {
           INTERNAL_CHECK_SPAN(false, inner_call->span_) << "Internal error: inner call arg " << inner_idx
                                                         << " is neither a variable nor a recognized constant";
@@ -658,58 +658,28 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (!var_name.empty()) {
         if (auto scalar_type = As<ScalarType>(outer_arg->GetType())) {
           std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-          params.push_back({ParamKind::Scalar, EncodeScalarVar(var_name, cpp_type)});
+          params.push_back({ArgDirection::Scalar, EncodeScalarVar(var_name, cpp_type)});
           continue;
         }
 
         std::string ext_name = GetExternalTensorName(var_name);
-
-        INTERNAL_CHECK_SPAN(inner_idx < inner_callee->param_directions_.size(), inner_call->span_)
-            << "arg index " << inner_idx << " exceeds param count (" << inner_callee->param_directions_.size()
-            << ") for callee '" << inner_callee->name_ << "'";
-
-        ParamDirection dir = inner_callee->param_directions_[inner_idx];
-
-        // Apply call-site direction override: if the outer call has an override
-        // (e.g., Out→InOut for locally allocated tensors), use it.
-        auto cs_it = call_site_directions_.find(outer_call.get());
-        if (cs_it != call_site_directions_.end() && outer_idx < cs_it->second.size()) {
-          ParamDirection call_site_dir = cs_it->second[outer_idx];
-          if (dir == ParamDirection::Out && call_site_dir == ParamDirection::InOut) {
-            dir = ParamDirection::InOut;
-          }
-        }
-
-        switch (dir) {
-          case ParamDirection::Out:
-            params.push_back({ParamKind::Output, ext_name});
-            break;
-          case ParamDirection::InOut:
-            params.push_back({ParamKind::InOut, ext_name});
-            break;
-          case ParamDirection::In:
-            params.push_back({ParamKind::Input, ext_name});
-            break;
-          default:
-            INTERNAL_CHECK_SPAN(false, inner_call->span_)
-                << "Internal error: unexpected ParamDirection value " << static_cast<int>(dir);
-        }
+        params.push_back({outer_call->arg_directions_[outer_idx], ext_name});
       } else if (auto const_int = As<ConstInt>(outer_arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
-        params.push_back({ParamKind::Scalar, "(uint64_t)" + value});
+        params.push_back({ArgDirection::Scalar, "(uint64_t)" + value});
       } else if (auto const_float = As<ConstFloat>(outer_arg)) {
         std::string cpp_type = const_float->dtype().ToCTypeString();
         std::string value = FormatConstFloatValue(const_float, cpp_type);
-        params.push_back({ParamKind::Scalar, EncodeScalarConst(value, cpp_type)});
+        params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
       } else if (auto const_bool = As<ConstBool>(outer_arg)) {
-        params.push_back({ParamKind::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
+        params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
       }
     }
 
     // Tensors must precede scalars
     std::stable_partition(params.begin(), params.end(),
-                          [](const ParamEntry& p) { return p.kind != ParamKind::Scalar; });
+                          [](const ParamEntry& p) { return p.direction != ArgDirection::Scalar; });
 
     return params;
   }
@@ -869,7 +839,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     int func_id = GetOrCreateFuncId(callee_name, func_name_to_id_, next_func_id_);
 
-    auto params = BuildTaskParams(call, callee_func, LookupCallSiteDirections(call));
+    auto params = BuildTaskParams(call, callee_func);
 
     std::string ind = Indent();
     std::string task_var = "params_t" + std::to_string(task_counter_);
@@ -877,7 +847,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << ind << "// Task " << task_counter_ << ": " << callee_name << "\n";
     code_ << ind << "Arg " << task_var << ";\n";
     for (const auto& p : params) {
-      code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
+      code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
 
     std::string submit_expr =
@@ -908,7 +878,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << ind << "// Spmd " << spmd_func->name_ << ": " << callee_name << "\n";
     code_ << ind << "Arg " << task_var << ";\n";
     for (const auto& p : params) {
-      code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
+      code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
     EmitLaunchSpec(ind, task_var, spmd_func);
 
@@ -946,7 +916,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << "// Group " << group_name << ": AIV-only SPMD\n";
       code_ << ind << "Arg " << task_var << ";\n";
       for (const auto& p : params) {
-        code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
+        code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
       }
 
       EmitLaunchSpec(ind, task_var, launch_func);
@@ -987,7 +957,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << ind << "// Group " << group_name << ": MixedKernels (AIC + AIV lanes)\n";
     code_ << ind << "Arg " << task_var << ";\n";
     for (const auto& p : params) {
-      code_ << ind << task_var << "." << ParamKindToMethodName(p.kind) << "(" << p.value << ");\n";
+      code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
     // Split AIV groups dispatch the same kernel on both vector lanes. The
     // kernel body uses tile.get_subblock_idx() to select its lane-local slice.
@@ -1138,13 +1108,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::map<const Call*, std::string> call_to_tuple_key_;
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
-  std::unordered_map<const Call*, std::vector<ParamDirection>> call_site_directions_;
   std::unordered_set<const Var*> effective_uses_;
-
-  const std::vector<ParamDirection>* LookupCallSiteDirections(const CallPtr& call) const {
-    auto it = call_site_directions_.find(call.get());
-    return it != call_site_directions_.end() ? &it->second : nullptr;
-  }
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {
@@ -1167,9 +1131,6 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   BufferRootCollector root_collector(program);
   root_collector.Initialize(func->params_);
   root_collector.VisitStmt(func->body_);
-
-  CallSiteDirectionResolver direction_resolver(program, root_collector.buffer_roots, func->params_);
-  direction_resolver.VisitStmt(func->body_);
 
   CodegenEffectiveUseCollector use_collector;
   use_collector.VisitStmt(func->body_);
@@ -1213,7 +1174,6 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
                                         std::move(param_name_to_orch_index));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
-  stmt_codegen.SetCallSiteDirections(std::move(direction_resolver.call_site_directions));
   stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -103,6 +103,8 @@ class FieldSerializerVisitor {
   result_type VisitLeafField(const std::optional<bool>& field);
   result_type VisitLeafField(const ParamDirection& field);
   result_type VisitLeafField(const std::vector<ParamDirection>& field);
+  result_type VisitLeafField(const ArgDirection& field);
+  result_type VisitLeafField(const std::vector<ArgDirection>& field);
   result_type VisitLeafField(const std::vector<std::string>& field);
   result_type VisitLeafField(const TypePtr& field);
   result_type VisitLeafField(const OpPtr& field);
@@ -622,6 +624,19 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(const ParamDirection& fie
 }
 
 msgpack::object FieldSerializerVisitor::VisitLeafField(const std::vector<ParamDirection>& field) {
+  std::vector<msgpack::object> vec;
+  vec.reserve(field.size());
+  for (const auto& dir : field) {
+    vec.emplace_back(static_cast<uint8_t>(dir), zone_);
+  }
+  return msgpack::object(vec, zone_);
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const ArgDirection& field) {
+  return msgpack::object(static_cast<uint8_t>(field), zone_);
+}
+
+msgpack::object FieldSerializerVisitor::VisitLeafField(const std::vector<ArgDirection>& field) {
   std::vector<msgpack::object> vec;
   vec.reserve(field.size());
   for (const auto& dir : field) {

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -749,10 +749,17 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(
       origin_map["type"] = msgpack::object("LoopOrigin", zone_);
       origin_map["value"] = msgpack::object(LoopOriginToString(origin), zone_);
       kwargs_msgs.push_back(make_pair(key, msgpack::object(origin_map, zone_)));
+    } else if (value.type() == typeid(std::vector<ArgDirection>)) {
+      const auto& dirs = AnyCast<std::vector<ArgDirection>>(value, "serializing kwarg: " + key);
+      std::map<std::string, msgpack::object> dir_map;
+      dir_map["type"] = msgpack::object("ArgDirectionVector", zone_);
+      dir_map["value"] = VisitLeafField(dirs);
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(dir_map, zone_)));
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
                       ", expected int, bool, std::string, double, float, DataType, MemorySpace, "
-                      "TensorLayout, TileLayout, PadValue, or LoopOrigin, but got " +
+                      "TensorLayout, TileLayout, PadValue, LoopOrigin, or "
+                      "std::vector<ArgDirection>, but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -326,11 +326,28 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
     }
   }
 
+  // Optional arg_directions: backward compatible — absent in old .pir, and empty means "legacy /
+  // not yet derived" (codegen will fall back to deriving from callee param_directions).
+  std::vector<ArgDirection> arg_directions;
+  auto arg_dirs_opt = GetOptionalFieldObj(fields_obj, "arg_directions", ctx);
+  if (arg_dirs_opt.has_value() && arg_dirs_opt->type == msgpack::type::ARRAY &&
+      arg_dirs_opt->via.array.size > 0) {
+    arg_directions.reserve(arg_dirs_opt->via.array.size);
+    for (uint32_t i = 0; i < arg_dirs_opt->via.array.size; ++i) {
+      uint8_t code = arg_dirs_opt->via.array.ptr[i].as<uint8_t>();
+      CHECK(code <= static_cast<uint8_t>(ArgDirection::Scalar))
+          << "Invalid ArgDirection value: " << static_cast<int>(code);
+      arg_directions.push_back(static_cast<ArgDirection>(code));
+    }
+    CHECK(arg_directions.size() == args.size()) << "Call arg_directions size (" << arg_directions.size()
+                                                << ") must match args size (" << args.size() << ")";
+  }
+
   // Deserialize kwargs (preserve order using vector)
   auto kwargs_obj = GET_FIELD_OBJ("kwargs");
   std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs");
 
-  return std::make_shared<Call>(op, args, kwargs, type, span);
+  return std::make_shared<Call>(op, args, std::move(arg_directions), kwargs, type, span);
 }
 
 // Macro for binary expressions

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -182,6 +182,8 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
       // Try to deserialize as DataType or TensorLayout
       std::string type_name;
       std::string value_str;
+      msgpack::object value_obj_inner;
+      bool has_value_obj = false;
       msgpack::object_kv* const map_p = value_obj.via.map.ptr;
       msgpack::object_kv* const map_pend = value_obj.via.map.ptr + value_obj.via.map.size;
       for (auto* it = map_p; it < map_pend; ++it) {
@@ -190,10 +192,29 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
         if (field_key == "type") {
           it->val.convert(type_name);
         } else if (field_key == "value") {
-          it->val.convert(value_str);
+          value_obj_inner = it->val;
+          has_value_obj = true;
+          if (it->val.type == msgpack::type::STR) {
+            it->val.convert(value_str);
+          }
         }
       }
-      if (type_name == "TensorLayout") {
+      if (type_name == "ArgDirectionVector") {
+        if (!has_value_obj || value_obj_inner.type != msgpack::type::ARRAY) {
+          throw TypeError("ArgDirectionVector kwarg '" + key + "' must have ARRAY value");
+        }
+        std::vector<ArgDirection> dirs;
+        dirs.reserve(value_obj_inner.via.array.size);
+        for (uint32_t j = 0; j < value_obj_inner.via.array.size; ++j) {
+          uint8_t code = value_obj_inner.via.array.ptr[j].as<uint8_t>();
+          if (code > static_cast<uint8_t>(ArgDirection::Scalar)) {
+            throw TypeError("Invalid ArgDirection value " + std::to_string(static_cast<int>(code)) +
+                            " for kwarg: " + key);
+          }
+          dirs.push_back(static_cast<ArgDirection>(code));
+        }
+        kwargs.emplace_back(key, std::move(dirs));
+      } else if (type_name == "TensorLayout") {
         if (value_str.empty()) {
           throw TypeError("Missing 'value' field for TensorLayout kwarg: " + key);
         }
@@ -326,12 +347,24 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
     }
   }
 
-  // Optional arg_directions: backward compatible — absent in old .pir, and empty means "legacy /
-  // not yet derived" (codegen will fall back to deriving from callee param_directions).
-  std::vector<ArgDirection> arg_directions;
+  // Deserialize generic attrs map (preserve order using vector). Optional in payloads
+  // produced by older serializers that only carried a top-level `arg_directions` field.
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_opt, "attrs");
+  }
+
+  // Backward compatibility: legacy .pir payloads stored arg_directions as a top-level
+  // ARRAY field on Call. Lift it into attrs_["arg_directions"] so consumers continue
+  // to work via the new GetArgDirections() API. Absent or NIL means "legacy /
+  // not yet derived"; any other msgpack type indicates a malformed payload.
   auto arg_dirs_opt = GetOptionalFieldObj(fields_obj, "arg_directions", ctx);
-  if (arg_dirs_opt.has_value() && arg_dirs_opt->type == msgpack::type::ARRAY &&
-      arg_dirs_opt->via.array.size > 0) {
+  if (arg_dirs_opt.has_value() && arg_dirs_opt->type != msgpack::type::NIL) {
+    CHECK(arg_dirs_opt->type == msgpack::type::ARRAY)
+        << "Invalid arg_directions field for Call: expected ARRAY, got msgpack type "
+        << static_cast<int>(arg_dirs_opt->type);
+    std::vector<ArgDirection> arg_directions;
     arg_directions.reserve(arg_dirs_opt->via.array.size);
     for (uint32_t i = 0; i < arg_dirs_opt->via.array.size; ++i) {
       uint8_t code = arg_dirs_opt->via.array.ptr[i].as<uint8_t>();
@@ -339,15 +372,18 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
           << "Invalid ArgDirection value: " << static_cast<int>(code);
       arg_directions.push_back(static_cast<ArgDirection>(code));
     }
-    CHECK(arg_directions.size() == args.size()) << "Call arg_directions size (" << arg_directions.size()
-                                                << ") must match args size (" << args.size() << ")";
+    if (!arg_directions.empty()) {
+      CHECK(arg_directions.size() == args.size()) << "Call arg_directions size (" << arg_directions.size()
+                                                  << ") must match args size (" << args.size() << ")";
+      attrs = WithArgDirectionsAttr(std::move(attrs), std::move(arg_directions));
+    }
   }
 
   // Deserialize kwargs (preserve order using vector)
   auto kwargs_obj = GET_FIELD_OBJ("kwargs");
   std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs");
 
-  return std::make_shared<Call>(op, args, std::move(arg_directions), kwargs, type, span);
+  return std::make_shared<Call>(op, args, std::move(kwargs), std::move(attrs), type, span);
 }
 
 // Macro for binary expressions

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "pypto/codegen/orchestration/orchestration_analysis.h"
-#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -118,11 +117,12 @@ class CallDirectionMutator : public IRMutator {
     }
 
     // Skip rewriting if directions are unchanged.
-    if (call->arg_directions_ == dirs) {
+    if (call->GetArgDirections() == dirs) {
       return call;
     }
 
-    return std::make_shared<const Call>(call->op_, call->args_, std::move(dirs), call->kwargs_,
+    auto new_attrs = WithArgDirectionsAttr(call->attrs_, std::move(dirs));
+    return std::make_shared<const Call>(call->op_, call->args_, call->kwargs_, std::move(new_attrs),
                                         call->GetType(), call->span_);
   }
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -82,6 +82,14 @@ class CallDirectionMutator : public IRMutator {
       return call;
     }
 
+    // Respect explicit call-site directions. The Call constructor's
+    // ValidateArgDirectionsAttr already enforces size == args_.size(), and
+    // some directions (e.g. NoDep) are not derivable here, so a populated
+    // attrs['arg_directions'] is treated as authoritative and left as-is.
+    if (call->HasArgDirections()) {
+      return call;
+    }
+
     std::vector<ArgDirection> dirs;
     dirs.reserve(call->args_.size());
     for (size_t i = 0; i < call->args_.size(); ++i) {

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pypto/codegen/orchestration/orchestration_analysis.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+using ::pypto::codegen::BufferRootCollector;
+using ::pypto::codegen::ComputeGroupEffectiveDirections;
+using ::pypto::codegen::IsBuiltinOp;
+
+/// Decide whether an argument expression refers to a tensor (not a scalar/index).
+bool IsTensorTypedArg(const ExprPtr& arg) {
+  TypePtr ty = arg ? arg->GetType() : TypePtr{};
+  if (!ty) return false;
+  if (As<TensorType>(ty)) return true;
+  if (As<TupleType>(ty)) return true;
+  return false;
+}
+
+/// IRMutator that rewrites every non-builtin Call in a function body and writes
+/// the per-argument ArgDirection vector based on callee param directions and the
+/// pre-computed buffer-root map for that function.
+class CallDirectionMutator : public IRMutator {
+ public:
+  CallDirectionMutator(ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
+                       const std::unordered_set<const Var*>& param_vars)
+      : program_(std::move(program)), buffer_roots_(buffer_roots), param_vars_(param_vars) {}
+
+ protected:
+  ExprPtr VisitExpr_(const CallPtr& op) override {
+    // First descend so nested Calls also get arg_directions assigned.
+    auto base = IRMutator::VisitExpr_(op);
+    auto call = As<Call>(base);
+    if (!call) return base;
+
+    if (IsBuiltinOp(call->op_->name_)) {
+      return call;
+    }
+
+    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    if (!callee) {
+      // Unknown op (e.g. Opaque function not in program). Leave directions empty.
+      return call;
+    }
+
+    std::vector<ParamDirection> effective = callee->param_directions_;
+    if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
+      effective = ComputeGroupEffectiveDirections(callee, program_);
+    }
+
+    if (effective.size() != call->args_.size()) {
+      // Safety: if the length disagrees we can't produce a sound mapping.
+      // Leave directions empty so the verify pass surfaces a clear error.
+      return call;
+    }
+
+    std::vector<ArgDirection> dirs;
+    dirs.reserve(call->args_.size());
+    for (size_t i = 0; i < call->args_.size(); ++i) {
+      const auto& arg = call->args_[i];
+      bool is_tensor = IsTensorTypedArg(arg);
+      if (!is_tensor) {
+        dirs.push_back(ArgDirection::Scalar);
+        continue;
+      }
+
+      ParamDirection cd = effective[i];
+      if (cd == ParamDirection::In) {
+        dirs.push_back(ArgDirection::Input);
+      } else if (cd == ParamDirection::InOut) {
+        dirs.push_back(ArgDirection::InOut);
+      } else {
+        // ParamDirection::Out
+        if (auto arg_var = AsVarLike(arg)) {
+          if (IsLocallyAllocated(arg_var.get())) {
+            // WAW promotion: the runtime needs InOut to chain dependencies on
+            // a pre-allocated local buffer being reused across tasks.
+            dirs.push_back(ArgDirection::InOut);
+          } else {
+            // External (param-rooted) buffer: treat as write-only into an existing tensor.
+            dirs.push_back(ArgDirection::OutputExisting);
+          }
+        } else {
+          // Non-var Out argument is unusual; fall back to OutputExisting which is
+          // the conservative choice (no allocation done by the runtime).
+          dirs.push_back(ArgDirection::OutputExisting);
+        }
+      }
+    }
+
+    // Skip rewriting if directions are unchanged.
+    if (call->arg_directions_ == dirs) {
+      return call;
+    }
+
+    return std::make_shared<const Call>(call->op_, call->args_, std::move(dirs), call->kwargs_,
+                                        call->GetType(), call->span_);
+  }
+
+ private:
+  bool IsLocallyAllocated(const Var* var) const {
+    auto it = buffer_roots_.find(var);
+    if (it == buffer_roots_.end()) return false;
+    const Var* root = it->second;
+    return param_vars_.count(root) == 0;
+  }
+
+  ProgramPtr program_;
+  const std::unordered_map<const Var*, const Var*>& buffer_roots_;
+  const std::unordered_set<const Var*>& param_vars_;
+};
+
+}  // namespace
+
+namespace pass {
+
+Pass DeriveCallDirections() {
+  auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
+    if (!program) return program;
+
+    // We need a non-const handle to rewrite functions with new bodies.
+    auto new_functions = program->functions_;
+
+    for (auto& [gvar, func] : new_functions) {
+      if (!func || !func->body_) continue;
+
+      BufferRootCollector br_collector(program);
+      br_collector.Initialize(func->params_);
+      br_collector.VisitStmt(func->body_);
+
+      std::unordered_set<const Var*> param_vars;
+      param_vars.reserve(func->params_.size());
+      for (const auto& p : func->params_) {
+        param_vars.insert(p.get());
+      }
+
+      CallDirectionMutator mutator(program, br_collector.buffer_roots, param_vars);
+      auto new_body = mutator.VisitStmt(func->body_);
+      if (new_body.get() == func->body_.get()) continue;
+
+      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                        func->return_types_, new_body, func->span_, func->func_type_,
+                                        func->level_, func->role_, func->attrs_);
+    }
+
+    if (new_functions == program->functions_) {
+      return program;
+    }
+    return std::make_shared<Program>(std::move(new_functions), program->name_, program->span_);
+  };
+
+  return CreateProgramPass(pass_func, "DeriveCallDirections", kDeriveCallDirectionsProperties);
+}
+
+}  // namespace pass
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1057,7 +1057,7 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
 /// Create a tensor.create Call for the GM pipe buffer workspace.
 CallPtr CreateGMPipeBufferTensorCreate(int64_t buffer_size_bytes, const Span& span) {
   int64_t shape_dim = (buffer_size_bytes + 3) / 4;  // FP32 elements (ceil)
-  auto shape_elem = std::make_shared<ConstInt>(shape_dim, DataType::INT64, span);
+  auto shape_elem = std::make_shared<ConstInt>(shape_dim, DataType::INDEX, span);
   auto shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{shape_elem}, span);
   return OpRegistry::GetInstance().Create("tensor.create", {shape_tuple},
                                           {{"dtype", std::any(DataType::FP32)},

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -65,6 +65,10 @@ std::string IRPropertyToString(IRProperty prop) {
       return "NoNestedInCore";
     case IRProperty::InOutUseValid:
       return "InOutUseValid";
+    case IRProperty::PipelineResolved:
+      return "PipelineResolved";
+    case IRProperty::CallDirectionsResolved:
+      return "CallDirectionsResolved";
     default:
       return "Unknown";
   }
@@ -106,7 +110,8 @@ const IRPropertySet& GetVerifiedProperties() {
                                    IRProperty::AllocatedMemoryAddr,
                                    IRProperty::BreakContinueValid,
                                    IRProperty::NoRedundantBlocks,
-                                   IRProperty::InOutUseValid};
+                                   IRProperty::InOutUseValid,
+                                   IRProperty::CallDirectionsResolved};
   return props;
 }
 

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -193,7 +193,10 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
   }
 
   if (changed) {
-    return std::make_shared<const Call>(op->op_, std::move(new_args), op->kwargs_, op->GetType(), op->span_);
+    // Preserve arg_directions_ across mutation: callers of the base mutator should not lose
+    // call-site direction metadata when only argument expressions change.
+    return std::make_shared<const Call>(op->op_, std::move(new_args), op->arg_directions_, op->kwargs_,
+                                        op->GetType(), op->span_);
   }
   return op;
 }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -193,10 +193,10 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
   }
 
   if (changed) {
-    // Preserve arg_directions_ across mutation: callers of the base mutator should not lose
-    // call-site direction metadata when only argument expressions change.
-    return std::make_shared<const Call>(op->op_, std::move(new_args), op->arg_directions_, op->kwargs_,
-                                        op->GetType(), op->span_);
+    // Preserve attrs_ across mutation: callers of the base mutator should not lose
+    // compiler-internal metadata (e.g., arg_directions) when only argument expressions change.
+    return std::make_shared<const Call>(op->op_, std::move(new_args), op->kwargs_, op->attrs_, op->GetType(),
+                                        op->span_);
   }
   return op;
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -522,10 +522,15 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       // This is a cross-function call - print as self.method_name()
       stream_ << "self." << gvar->name_ << "(";
 
+      for (size_t i = 0; i < op->args_.size(); ++i) {
+        if (i > 0) stream_ << ", ";
+        VisitExpr(op->args_[i]);
+      }
+
       // When ``attrs_["arg_directions"]`` is populated (post DeriveCallDirections),
-      // wrap each argument with ``pl.adir.<dir>(...)`` so the parser can recover
-      // the direction vector on the round-trip. When empty (legacy / pre-derive)
-      // print bare arguments to keep the DSL clean and back-compatible.
+      // surface the direction vector as a trailing ``attrs={"arg_directions": [...]}``
+      // keyword so the parser can recover it on the round-trip. When empty
+      // (legacy / pre-derive) keep the call bare for back-compatibility.
       // A non-empty vector with a mismatched size is invalid IR — fail loudly
       // instead of silently dropping the metadata.
       auto call_arg_directions = op->GetArgDirections();
@@ -533,18 +538,12 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
         INTERNAL_CHECK_SPAN(call_arg_directions.size() == op->args_.size(), op->span_)
             << "Call arg_directions size (" << call_arg_directions.size() << ") must match args size ("
             << op->args_.size() << ")";
-      }
-      const bool emit_directions = !call_arg_directions.empty();
-
-      for (size_t i = 0; i < op->args_.size(); ++i) {
-        if (i > 0) stream_ << ", ";
-        if (emit_directions) {
-          stream_ << prefix_ << ".adir." << ArgDirectionToDslName(call_arg_directions[i]) << "(";
-          VisitExpr(op->args_[i]);
-          stream_ << ")";
-        } else {
-          VisitExpr(op->args_[i]);
+        stream_ << ", attrs={\"arg_directions\": [";
+        for (size_t i = 0; i < call_arg_directions.size(); ++i) {
+          if (i > 0) stream_ << ", ";
+          stream_ << prefix_ << ".adir." << ArgDirectionToDslName(call_arg_directions[i]);
         }
+        stream_ << "]}";
       }
 
       stream_ << ")";

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -522,17 +522,24 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       // This is a cross-function call - print as self.method_name()
       stream_ << "self." << gvar->name_ << "(";
 
-      // When ``arg_directions_`` is populated (post DeriveCallDirections), wrap
-      // each argument with ``pl.adir.<dir>(...)`` so the parser can recover the
-      // direction vector on the round-trip. When empty (legacy / pre-derive)
+      // When ``attrs_["arg_directions"]`` is populated (post DeriveCallDirections),
+      // wrap each argument with ``pl.adir.<dir>(...)`` so the parser can recover
+      // the direction vector on the round-trip. When empty (legacy / pre-derive)
       // print bare arguments to keep the DSL clean and back-compatible.
-      const bool emit_directions =
-          !op->arg_directions_.empty() && op->arg_directions_.size() == op->args_.size();
+      // A non-empty vector with a mismatched size is invalid IR — fail loudly
+      // instead of silently dropping the metadata.
+      auto call_arg_directions = op->GetArgDirections();
+      if (!call_arg_directions.empty()) {
+        INTERNAL_CHECK_SPAN(call_arg_directions.size() == op->args_.size(), op->span_)
+            << "Call arg_directions size (" << call_arg_directions.size() << ") must match args size ("
+            << op->args_.size() << ")";
+      }
+      const bool emit_directions = !call_arg_directions.empty();
 
       for (size_t i = 0; i < op->args_.size(); ++i) {
         if (i > 0) stream_ << ", ";
         if (emit_directions) {
-          stream_ << prefix_ << ".adir." << ArgDirectionToDslName(op->arg_directions_[i]) << "(";
+          stream_ << prefix_ << ".adir." << ArgDirectionToDslName(call_arg_directions[i]) << "(";
           VisitExpr(op->args_[i]);
           stream_ << ")";
         } else {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -492,6 +492,27 @@ void IRPythonPrinter::VisitExpr_(const ConstFloatPtr& op) {
 
 void IRPythonPrinter::VisitExpr_(const ConstBoolPtr& op) { stream_ << (op->value_ ? "True" : "False"); }
 
+// Lowercase-snake-case names for ArgDirection used by the DSL helpers in
+// ``pypto.language.arg_direction`` (``pl.adir.<name>``). Kept in sync with
+// ``python/pypto/language/arg_direction.py::NAME_TO_DIRECTION``.
+static const char* ArgDirectionToDslName(ArgDirection dir) {
+  switch (dir) {
+    case ArgDirection::Input:
+      return "input";
+    case ArgDirection::Output:
+      return "output";
+    case ArgDirection::OutputExisting:
+      return "output_existing";
+    case ArgDirection::InOut:
+      return "inout";
+    case ArgDirection::NoDep:
+      return "no_dep";
+    case ArgDirection::Scalar:
+      return "scalar";
+  }
+  throw pypto::TypeError("Unknown ArgDirection in printer");
+}
+
 void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   INTERNAL_CHECK_SPAN(op->op_, op->span_) << "Call has null op";
   // Check if this is a GlobalVar call within a Program context
@@ -501,10 +522,22 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       // This is a cross-function call - print as self.method_name()
       stream_ << "self." << gvar->name_ << "(";
 
-      // Print positional arguments
+      // When ``arg_directions_`` is populated (post DeriveCallDirections), wrap
+      // each argument with ``pl.adir.<dir>(...)`` so the parser can recover the
+      // direction vector on the round-trip. When empty (legacy / pre-derive)
+      // print bare arguments to keep the DSL clean and back-compatible.
+      const bool emit_directions =
+          !op->arg_directions_.empty() && op->arg_directions_.size() == op->args_.size();
+
       for (size_t i = 0; i < op->args_.size(); ++i) {
         if (i > 0) stream_ << ", ";
-        VisitExpr(op->args_[i]);
+        if (emit_directions) {
+          stream_ << prefix_ << ".adir." << ArgDirectionToDslName(op->arg_directions_[i]) << "(";
+          VisitExpr(op->args_[i]);
+          stream_ << ")";
+        } else {
+          VisitExpr(op->args_[i]);
+        }
       }
 
       stream_ << ")";

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -105,7 +105,8 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     if (new_type.get() == base->GetType().get()) return base;
     auto call = std::dynamic_pointer_cast<const Call>(base);
     if (!call) return base;
-    return std::make_shared<const Call>(call->op_, call->args_, call->kwargs_, new_type, call->span_);
+    return std::make_shared<const Call>(call->op_, call->args_, call->kwargs_, call->attrs_, new_type,
+                                        call->span_);
   }
 
   /// Fold arithmetic nodes (Add/Sub/Mul/Div/Min/Max/compare/bitwise/logical)

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -608,6 +608,12 @@ class StructuralEqualImpl {
       } else if (lhs_val.type() == typeid(float)) {
         values_equal = (AnyCast<float>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
                         AnyCast<float>(rhs_val, "comparing kwarg: " + lhs[i].first));
+      } else if (lhs_val.type() == typeid(std::vector<ArgDirection>)) {
+        const auto& lhs_dirs =
+            AnyCast<std::vector<ArgDirection>>(lhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& rhs_dirs =
+            AnyCast<std::vector<ArgDirection>>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        values_equal = VisitLeafField(lhs_dirs, rhs_dirs);
       } else {
         INTERNAL_CHECK(false) << "Unsupported kwargs value type for key '" << lhs[i].first
                               << "': " << DemangleTypeName(lhs_val.type().name());

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -511,6 +511,36 @@ class StructuralEqualImpl {
     return true;
   }
 
+  result_type VisitLeafField(const ArgDirection& lhs, const ArgDirection& rhs) {
+    if (lhs != rhs) {
+      if constexpr (AssertMode) {
+        std::ostringstream msg;
+        msg << "ArgDirection mismatch (" << ArgDirectionToString(lhs) << " != " << ArgDirectionToString(rhs)
+            << ")";
+        ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    return true;
+  }
+
+  result_type VisitLeafField(const std::vector<ArgDirection>& lhs, const std::vector<ArgDirection>& rhs) {
+    if (lhs.size() != rhs.size()) {
+      if constexpr (AssertMode) {
+        std::ostringstream msg;
+        msg << "ArgDirection vector size mismatch (" << lhs.size() << " != " << rhs.size() << ")";
+        ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      if (!VisitLeafField(lhs[i], rhs[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // Compare kwargs (vector of pairs to preserve order)
   result_type VisitLeafField(const std::vector<std::pair<std::string, std::any>>& lhs,
                              const std::vector<std::pair<std::string, std::any>>& rhs) {

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -338,6 +338,9 @@ class StructuralHasher {
       } else if (value.type() == typeid(PadValue)) {
         h = hash_combine(
             h, std::hash<uint8_t>{}(static_cast<uint8_t>(AnyCast<PadValue>(value, "hashing kwarg: " + key))));
+      } else if (value.type() == typeid(std::vector<ArgDirection>)) {
+        h = hash_combine(h,
+                         VisitLeafField(AnyCast<std::vector<ArgDirection>>(value, "hashing kwarg: " + key)));
       } else {
         throw TypeError("Unsupported kwarg type for key: " + key + ": " +
                         DemangleTypeName(value.type().name()));

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -265,6 +265,18 @@ class StructuralHasher {
     return h;
   }
 
+  result_type VisitLeafField(const ArgDirection& field) {
+    return static_cast<result_type>(std::hash<uint8_t>{}(static_cast<uint8_t>(field)));
+  }
+
+  result_type VisitLeafField(const std::vector<ArgDirection>& field) {
+    result_type h = 0;
+    for (const auto& dir : field) {
+      h = hash_combine(h, VisitLeafField(dir));
+    }
+    return h;
+  }
+
   result_type VisitLeafField(const MemorySpace& field) {
     return static_cast<result_type>(std::hash<int>{}(static_cast<int>(field)));
   }

--- a/src/ir/verifier/property_verifier_registry.cpp
+++ b/src/ir/verifier/property_verifier_registry.cpp
@@ -60,6 +60,7 @@ PropertyVerifierRegistry::PropertyVerifierRegistry() {
   Register(IRProperty::NoNestedInCore, CreateNoNestedIncorePropertyVerifier);
   Register(IRProperty::InOutUseValid, CreateInOutUseValidPropertyVerifier);
   Register(IRProperty::PipelineResolved, CreatePipelineResolvedPropertyVerifier);
+  Register(IRProperty::CallDirectionsResolved, CreateCallDirectionsResolvedPropertyVerifier);
 }
 
 void PropertyVerifierRegistry::Register(IRProperty prop, std::function<PropertyVerifierPtr()> factory) {

--- a/src/ir/verifier/verify_call_directions.cpp
+++ b/src/ir/verifier/verify_call_directions.cpp
@@ -42,7 +42,8 @@ bool IsTensorTypedArg(const ExprPtr& arg) {
 }
 
 /// Walks every non-builtin Call in a function body and validates the integrity
-/// of ``Call::arg_directions_`` against the callee's ``param_directions_``.
+/// of ``Call::GetArgDirections()`` (stored in ``attrs_["arg_directions"]``)
+/// against the callee's ``param_directions_``.
 class CallDirectionChecker : public IRVisitor {
  public:
   CallDirectionChecker(ProgramPtr program, std::vector<Diagnostic>& diagnostics, std::string func_name)
@@ -56,13 +57,18 @@ class CallDirectionChecker : public IRVisitor {
     auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
     if (!callee) return;  // Opaque / not in program — skip.
 
-    if (call->arg_directions_.empty()) {
-      Fail(call, "Call::arg_directions_ is empty after DeriveCallDirections");
+    if (!call->HasArgDirections()) {
+      Fail(call, "Call attrs['arg_directions'] is missing after DeriveCallDirections");
       return;
     }
-    if (call->arg_directions_.size() != call->args_.size()) {
+    auto arg_dirs = call->GetArgDirections();
+    if (arg_dirs.empty()) {
+      Fail(call, "Call attrs['arg_directions'] is empty after DeriveCallDirections");
+      return;
+    }
+    if (arg_dirs.size() != call->args_.size()) {
       std::ostringstream oss;
-      oss << "Call::arg_directions_ size (" << call->arg_directions_.size() << ") != args_ size ("
+      oss << "Call attrs['arg_directions'] size (" << arg_dirs.size() << ") != args_ size ("
           << call->args_.size() << ")";
       Fail(call, oss.str());
       return;
@@ -74,7 +80,7 @@ class CallDirectionChecker : public IRVisitor {
     }
 
     for (size_t i = 0; i < call->args_.size(); ++i) {
-      ArgDirection d = call->arg_directions_[i];
+      ArgDirection d = arg_dirs[i];
       bool is_tensor = IsTensorTypedArg(call->args_[i]);
 
       // 1) Scalar / tensor consistency

--- a/src/ir/verifier/verify_call_directions.cpp
+++ b/src/ir/verifier/verify_call_directions.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/codegen/orchestration/orchestration_analysis.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verifier.h"
+
+namespace pypto {
+namespace ir {
+namespace {
+
+using ::pypto::codegen::ComputeGroupEffectiveDirections;
+using ::pypto::codegen::IsBuiltinOp;
+
+bool IsTensorTypedArg(const ExprPtr& arg) {
+  TypePtr ty = arg ? arg->GetType() : TypePtr{};
+  if (!ty) return false;
+  if (As<TensorType>(ty)) return true;
+  if (As<TupleType>(ty)) return true;
+  return false;
+}
+
+/// Walks every non-builtin Call in a function body and validates the integrity
+/// of ``Call::arg_directions_`` against the callee's ``param_directions_``.
+class CallDirectionChecker : public IRVisitor {
+ public:
+  CallDirectionChecker(ProgramPtr program, std::vector<Diagnostic>& diagnostics, std::string func_name)
+      : program_(std::move(program)), diagnostics_(diagnostics), func_name_(std::move(func_name)) {}
+
+ protected:
+  void VisitExpr_(const CallPtr& call) override {
+    IRVisitor::VisitExpr_(call);
+    if (IsBuiltinOp(call->op_->name_)) return;
+
+    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    if (!callee) return;  // Opaque / not in program — skip.
+
+    if (call->arg_directions_.empty()) {
+      Fail(call, "Call::arg_directions_ is empty after DeriveCallDirections");
+      return;
+    }
+    if (call->arg_directions_.size() != call->args_.size()) {
+      std::ostringstream oss;
+      oss << "Call::arg_directions_ size (" << call->arg_directions_.size() << ") != args_ size ("
+          << call->args_.size() << ")";
+      Fail(call, oss.str());
+      return;
+    }
+
+    std::vector<ParamDirection> effective = callee->param_directions_;
+    if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
+      effective = ComputeGroupEffectiveDirections(callee, program_);
+    }
+
+    for (size_t i = 0; i < call->args_.size(); ++i) {
+      ArgDirection d = call->arg_directions_[i];
+      bool is_tensor = IsTensorTypedArg(call->args_[i]);
+
+      // 1) Scalar / tensor consistency
+      if (is_tensor && d == ArgDirection::Scalar) {
+        std::ostringstream oss;
+        oss << "tensor argument at index " << i << " has ArgDirection::Scalar";
+        Fail(call, oss.str());
+        return;
+      }
+      if (!is_tensor && d != ArgDirection::Scalar) {
+        std::ostringstream oss;
+        oss << "non-tensor argument at index " << i << " has " << ArgDirectionToString(d)
+            << " (expected Scalar)";
+        Fail(call, oss.str());
+        return;
+      }
+
+      // NOTE: We deliberately do NOT enforce a "tensors precede scalars" order
+      // here. The IR Call preserves the user's parameter order (e.g.
+      // ``kernel(t_in, 1.0, t_out)`` is a legitimate signature). The runtime
+      // requirement that ``add_input/add_output`` come before ``add_scalar`` is
+      // satisfied by orchestration codegen via ``std::stable_partition`` over
+      // ``ParamEntry`` (see orchestration_codegen.cpp), so the call site itself
+      // is free to interleave tensors and scalars.
+
+      if (i >= effective.size()) continue;
+      ParamDirection cd = effective[i];
+      if (cd == ParamDirection::In && is_tensor) {
+        if (d != ArgDirection::Input) {
+          std::ostringstream oss;
+          oss << "tensor argument at index " << i << " has " << ArgDirectionToString(d)
+              << " but callee param direction is In";
+          Fail(call, oss.str());
+          return;
+        }
+      } else if (cd == ParamDirection::InOut && is_tensor) {
+        if (d != ArgDirection::InOut) {
+          std::ostringstream oss;
+          oss << "tensor argument at index " << i << " has " << ArgDirectionToString(d)
+              << " but callee param direction is InOut";
+          Fail(call, oss.str());
+          return;
+        }
+      } else if (cd == ParamDirection::Out && is_tensor) {
+        // Allowed: Output / OutputExisting / InOut (WAW promotion).
+        if (d != ArgDirection::Output && d != ArgDirection::OutputExisting && d != ArgDirection::InOut) {
+          std::ostringstream oss;
+          oss << "tensor argument at index " << i << " has " << ArgDirectionToString(d)
+              << " but callee param direction is Out";
+          Fail(call, oss.str());
+          return;
+        }
+      }
+    }
+  }
+
+ private:
+  void Fail(const CallPtr& call, const std::string& msg) {
+    std::ostringstream oss;
+    oss << "in function '" << func_name_ << "', call to '" << call->op_->name_ << "': " << msg;
+    diagnostics_.emplace_back(DiagnosticSeverity::Error, "CallDirectionsResolved", 0, oss.str(), call->span_);
+  }
+
+  ProgramPtr program_;
+  std::vector<Diagnostic>& diagnostics_;
+  std::string func_name_;
+};
+
+class CallDirectionsResolvedPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "CallDirectionsResolved"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+    for (const auto& [gv, func] : program->functions_) {
+      if (!func || !func->body_) continue;
+      CallDirectionChecker checker(program, diagnostics, func->name_);
+      checker.VisitStmt(func->body_);
+    }
+  }
+};
+
+}  // namespace
+
+PropertyVerifierPtr CreateCallDirectionsResolvedPropertyVerifier() {
+  return std::make_shared<CallDirectionsResolvedPropertyVerifierImpl>();
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -40,8 +40,20 @@ def assert_code_equal(actual: str, expected: str) -> None:
         raise AssertionError(f"Code mismatch:\n{diff}")
 
 
+def _ensure_arg_directions(program):
+    """Phase-5 invariant: codegen requires Call.arg_directions to be populated.
+
+    Tests that hand-build IR (without going through PassManager) need to invoke
+    DeriveCallDirections before codegen so the Call sites carry explicit
+    ArgDirection vectors. This helper makes that step a no-op when the program
+    was already produced by the pass pipeline.
+    """
+    return passes.derive_call_directions()(program)
+
+
 def _generate_orch_code(program) -> str:
     """Generate orchestration code using backend-agnostic codegen."""
+    program = _ensure_arg_directions(program)
     for func in program.functions.values():
         if func.func_type == ir.FunctionType.Orchestration:
             result = codegen.generate_orchestration(program, func)
@@ -51,6 +63,7 @@ def _generate_orch_code(program) -> str:
 
 def _generate_orch_result(program) -> "codegen.OrchestrationResult":
     """Generate orchestration result using backend-agnostic codegen."""
+    program = _ensure_arg_directions(program)
     for func in program.functions.values():
         if func.func_type == ir.FunctionType.Orchestration:
             return codegen.generate_orchestration(program, func)
@@ -2237,12 +2250,17 @@ class TestUnregisteredOpError:
             codegen.generate_orchestration(program, orch_func)
 
 
-class TestCallSiteDirectionResolver:
+class TestLocalAllocWAWPromotion:
     """Test that locally allocated tensors get add_inout instead of add_output.
 
     Issue #1022: when a tensor is pre-allocated via alloc_tensors and then
     passed as Out to multiple InCore tasks in separate loops, the codegen
     must use add_inout (not add_output) to establish WAW dependencies.
+
+    The promotion is now performed by the ``DeriveCallDirections`` IR pass,
+    which writes ``ArgDirection::InOut`` into ``Call::arg_directions_`` for
+    locally allocated buffers (replacing the legacy ``CallSiteDirectionResolver``
+    analysis that lived in orchestration codegen).
     """
 
     def test_alloc_tensor_two_loops_gets_inout(self):
@@ -2337,6 +2355,119 @@ class TestCallSiteDirectionResolver:
 
         assert "add_output(ext_out)" in code, (
             f"External (parameter) tensor should keep add_output. Generated code:\n{code}"
+        )
+
+
+class TestArgDirectionsCodegen:
+    """Verify that orchestration codegen prefers Call.arg_directions_ when present.
+
+    These tests exercise the new ArgDirection-driven path in BuildTaskParams:
+    every recognised ArgDirection enum value is mapped to the matching runtime
+    method (add_input / add_output / add_inout / add_no_dep / add_scalar) and
+    the value emitted at the call site reflects the per-argument direction
+    written by the DeriveCallDirections pass — independently of the callee's
+    ParamDirection.
+    """
+
+    @staticmethod
+    def _generate_orch_direct(program) -> str:
+        """Bypass ``_ensure_arg_directions`` so explicit overrides survive."""
+        for func in program.functions.values():
+            if func.func_type == ir.FunctionType.Orchestration:
+                return codegen.generate_orchestration(program, func).code
+        raise ValueError("No orchestration function found in program")
+
+    def _build_program_with_arg_directions(self, arg_dirs):
+        """Build a tiny Orchestration program where the call site has explicit arg_directions.
+
+        The callee declares ``Out`` for the second parameter, and the orchestration
+        body pre-allocates the tensor with ``tensor.create``. We then patch the
+        call expression with the requested ``arg_directions`` so that codegen
+        consumes them directly (bypassing the legacy ParamDirection mapping).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ArgDirProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                buf: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                buf = self.kernel(a, buf)
+                out = self.kernel(buf, out)
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        program = pm.run_passes(ArgDirProgram)
+
+        rewritten = self._rewrite_kernel_calls(program, arg_dirs)
+        return rewritten
+
+    @staticmethod
+    def _rewrite_kernel_calls(program, arg_dirs):
+        """Replace every ``self.kernel(...)`` Call with a copy carrying the given arg_directions."""
+
+        class _RewriteKernel(ir.IRMutator):
+            def visit_call(self, op: ir.Call) -> ir.Expr:
+                expr = super().visit_call(op)
+                call = expr if isinstance(expr, ir.Call) else op
+                if call.op.name != "kernel" or len(call.args) != len(arg_dirs):
+                    return expr
+                return ir.Call(
+                    call.op, list(call.args), list(arg_dirs), dict(call.kwargs), call.type, call.span
+                )
+
+        return _RewriteKernel().visit_program(program)
+
+    def test_arg_direction_inout_emits_add_inout(self):
+        program = self._build_program_with_arg_directions([ir.ArgDirection.Input, ir.ArgDirection.InOut])
+        code = self._generate_orch_direct(program)
+        assert "add_inout(buf)" in code, (
+            f"ArgDirection::InOut on the second argument must produce add_inout(...). Generated code:\n{code}"
+        )
+
+    def test_arg_direction_output_existing_emits_add_output(self):
+        program = self._build_program_with_arg_directions(
+            [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        )
+        code = self._generate_orch_direct(program)
+        assert "add_output(" in code, (
+            f"ArgDirection::OutputExisting must produce add_output(...). Generated code:\n{code}"
+        )
+        assert "add_inout(" not in code or code.count("add_inout(") < code.count("add_output("), (
+            f"Expected add_output to dominate over add_inout. Generated code:\n{code}"
+        )
+
+    def test_arg_direction_no_dep_emits_add_no_dep(self):
+        program = self._build_program_with_arg_directions([ir.ArgDirection.Input, ir.ArgDirection.NoDep])
+        code = self._generate_orch_direct(program)
+        assert "add_no_dep(" in code, (
+            f"ArgDirection::NoDep must produce add_no_dep(...). Generated code:\n{code}"
+        )
+
+    def test_arg_direction_input_emits_add_input(self):
+        program = self._build_program_with_arg_directions([ir.ArgDirection.Input, ir.ArgDirection.Input])
+        code = self._generate_orch_direct(program)
+        assert "add_input(" in code, (
+            f"ArgDirection::Input must produce add_input(...). Generated code:\n{code}"
+        )
+        assert "add_output(" not in code and "add_inout(" not in code, (
+            "When all tensor args are ArgDirection::Input the codegen must not emit add_output/add_inout. "
+            f"Generated code:\n{code}"
         )
 
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2258,7 +2258,7 @@ class TestLocalAllocWAWPromotion:
     must use add_inout (not add_output) to establish WAW dependencies.
 
     The promotion is now performed by the ``DeriveCallDirections`` IR pass,
-    which writes ``ArgDirection::InOut`` into ``Call::arg_directions_`` for
+    which writes ``ArgDirection::InOut`` into ``Call.attrs['arg_directions']`` for
     locally allocated buffers (replacing the legacy ``CallSiteDirectionResolver``
     analysis that lived in orchestration codegen).
     """
@@ -2359,7 +2359,7 @@ class TestLocalAllocWAWPromotion:
 
 
 class TestArgDirectionsCodegen:
-    """Verify that orchestration codegen prefers Call.arg_directions_ when present.
+    """Verify that orchestration codegen prefers Call.attrs['arg_directions'] when present.
 
     These tests exercise the new ArgDirection-driven path in BuildTaskParams:
     every recognised ArgDirection enum value is mapped to the matching runtime
@@ -2427,9 +2427,8 @@ class TestArgDirectionsCodegen:
                 call = expr if isinstance(expr, ir.Call) else op
                 if call.op.name != "kernel" or len(call.args) != len(arg_dirs):
                     return expr
-                return ir.Call(
-                    call.op, list(call.args), list(arg_dirs), dict(call.kwargs), call.type, call.span
-                )
+                attrs = {"arg_directions": list(arg_dirs)}
+                return ir.Call(call.op, list(call.args), dict(call.kwargs), attrs, call.type, call.span)
 
         return _RewriteKernel().visit_program(program)
 

--- a/tests/ut/ir/expressions/test_call_arg_directions.py
+++ b/tests/ut/ir/expressions/test_call_arg_directions.py
@@ -7,7 +7,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Tests for Call.arg_directions: bindings, construction, structural eq/hash, and serialization."""
+"""Tests for Call.arg_directions / Call.attrs.
+
+Covers Python bindings, construction overloads, structural equality / hashing,
+and serialization round-trip of the ``arg_directions`` value carried under
+``Call.attrs['arg_directions']``.
+"""
 
 import pytest
 from pypto import DataType, ir
@@ -32,6 +37,10 @@ def _make_op() -> ir.Op:
 
 def _make_type() -> ir.Type:
     return ir.UnknownType()
+
+
+def _attrs_with_dirs(dirs):
+    return {"arg_directions": list(dirs)}
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +71,7 @@ class TestArgDirectionEnum:
 
 
 class TestCallArgDirectionsConstruction:
-    """Call construction with the new arg_directions field."""
+    """Call construction with the new attrs-based arg_directions storage."""
 
     def test_legacy_constructors_default_to_empty(self):
         op = _make_op()
@@ -72,6 +81,7 @@ class TestCallArgDirectionsConstruction:
         c4 = ir.Call(op, [_scalar_var("x")], {}, _make_type(), _span())
         for c in (c1, c2, c3, c4):
             assert list(c.arg_directions) == []
+            assert c.attrs == {}
 
     def test_explicit_directions_round_trip(self):
         op = _make_op()
@@ -81,23 +91,25 @@ class TestCallArgDirectionsConstruction:
             ir.ArgDirection.Output,
             ir.ArgDirection.InOut,
         ]
-        call = ir.Call(op, [x, y, z], dirs, {}, _make_type(), _span())
+        call = ir.Call(op, [x, y, z], {}, _attrs_with_dirs(dirs), _make_type(), _span())
         assert [d for d in call.arg_directions] == dirs
+        assert "arg_directions" in call.attrs
+        assert list(call.attrs["arg_directions"]) == dirs
 
-    def test_explicit_empty_directions_allowed(self):
-        # An explicit empty list is equivalent to "legacy / not yet derived".
+    def test_attrs_none_is_equivalent_to_empty(self):
         op = _make_op()
-        call = ir.Call(op, [_scalar_var("x")], [], {}, _make_type(), _span())
+        call = ir.Call(op, [_scalar_var("x")], {}, None, _make_type(), _span())
         assert list(call.arg_directions) == []
+        assert call.attrs == {}
 
     def test_size_mismatch_raises(self):
         op = _make_op()
-        with pytest.raises(Exception):  # noqa: PT011  TypeError raised from C++
+        with pytest.raises(TypeError, match=r"attrs\['arg_directions'\] size .* must match args size"):
             ir.Call(
                 op,
                 [_scalar_var("x"), _scalar_var("y")],
-                [ir.ArgDirection.Input],  # length 1, args length 2
                 {},
+                _attrs_with_dirs([ir.ArgDirection.Input]),  # length 1, args length 2
                 _make_type(),
                 _span(),
             )
@@ -107,13 +119,26 @@ class TestCallArgDirectionsConstruction:
         call = ir.Call(
             op,
             [_scalar_var("x")],
-            [ir.ArgDirection.Output],
             {},
+            _attrs_with_dirs([ir.ArgDirection.Output]),
             _make_type(),
             _span(),
         )
         with pytest.raises(AttributeError):
             call.arg_directions = []  # type: ignore[misc]
+
+    def test_attrs_is_read_only(self):
+        op = _make_op()
+        call = ir.Call(
+            op,
+            [_scalar_var("x")],
+            {},
+            _attrs_with_dirs([ir.ArgDirection.Output]),
+            _make_type(),
+            _span(),
+        )
+        with pytest.raises(AttributeError):
+            call.attrs = {}  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -122,13 +147,13 @@ class TestCallArgDirectionsConstruction:
 
 
 class TestCallArgDirectionsStructural:
-    """arg_directions participates in structural_hash / structural_equal."""
+    """arg_directions stored under attrs participates in structural_hash / structural_equal."""
 
     def _make_pair(self, dirs_a, dirs_b):
         op = _make_op()
         x = _scalar_var("x")
-        a = ir.Call(op, [x], list(dirs_a), {}, _make_type(), _span())
-        b = ir.Call(op, [x], list(dirs_b), {}, _make_type(), _span())
+        a = ir.Call(op, [x], {}, _attrs_with_dirs(dirs_a), _make_type(), _span())
+        b = ir.Call(op, [x], {}, _attrs_with_dirs(dirs_b), _make_type(), _span())
         return a, b
 
     def test_equal_when_directions_match(self):
@@ -146,9 +171,12 @@ class TestCallArgDirectionsStructural:
         )
         assert not ir.structural_equal(a, b, enable_auto_mapping=True)
 
-    def test_legacy_empty_vs_explicit_input_unequal(self):
-        # Empty (legacy) and explicitly Input should be distinguishable.
-        a, b = self._make_pair([], [ir.ArgDirection.Input])
+    def test_legacy_no_attrs_vs_explicit_input_unequal(self):
+        # No attrs (legacy) and explicitly Input should be distinguishable.
+        op = _make_op()
+        x = _scalar_var("x")
+        a = ir.Call(op, [x], {}, _make_type(), _span())
+        b = ir.Call(op, [x], {}, _attrs_with_dirs([ir.ArgDirection.Input]), _make_type(), _span())
         assert not ir.structural_equal(a, b, enable_auto_mapping=True)
 
 
@@ -158,13 +186,13 @@ class TestCallArgDirectionsStructural:
 
 
 class TestCallArgDirectionsSerialization:
-    """arg_directions survives serialize/deserialize round-trip."""
+    """arg_directions stored under attrs survives serialize/deserialize round-trip."""
 
     def test_round_trip_preserves_directions(self):
         op = _make_op()
         x, y = _scalar_var("x"), _scalar_var("y")
         dirs = [ir.ArgDirection.Input, ir.ArgDirection.Output]
-        call = ir.Call(op, [x, y], dirs, {}, _make_type(), _span())
+        call = ir.Call(op, [x, y], {}, _attrs_with_dirs(dirs), _make_type(), _span())
 
         data = ir.serialize(call)
         restored = ir.deserialize(data)
@@ -173,10 +201,10 @@ class TestCallArgDirectionsSerialization:
         assert isinstance(restored, ir.Call)
         assert [d for d in restored.arg_directions] == dirs
 
-    def test_round_trip_empty_directions(self):
+    def test_round_trip_no_directions(self):
         op = _make_op()
         x = _scalar_var("x")
-        call = ir.Call(op, [x], _span())  # legacy constructor → empty
+        call = ir.Call(op, [x], _span())  # legacy constructor → no attrs
 
         data = ir.serialize(call)
         restored = ir.deserialize(data)
@@ -184,6 +212,7 @@ class TestCallArgDirectionsSerialization:
         ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
         assert isinstance(restored, ir.Call)
         assert list(restored.arg_directions) == []
+        assert restored.attrs == {}
 
     def test_round_trip_all_six_kinds(self):
         op = _make_op()
@@ -196,7 +225,7 @@ class TestCallArgDirectionsSerialization:
             ir.ArgDirection.NoDep,
             ir.ArgDirection.Scalar,
         ]
-        call = ir.Call(op, vars_, dirs, {}, _make_type(), _span())
+        call = ir.Call(op, vars_, {}, _attrs_with_dirs(dirs), _make_type(), _span())
 
         data = ir.serialize(call)
         restored = ir.deserialize(data)
@@ -204,6 +233,36 @@ class TestCallArgDirectionsSerialization:
         ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
         assert isinstance(restored, ir.Call)
         assert [d for d in restored.arg_directions] == dirs
+
+
+class TestLegacyArgDirectionsCompat:
+    """Backward compatibility: deserialize legacy .pir payloads with top-level arg_directions."""
+
+    def test_legacy_top_level_arg_directions_lifted_into_attrs(self):
+        msgpack = pytest.importorskip("msgpack")
+
+        op = _make_op()
+        x, y = _scalar_var("x"), _scalar_var("y")
+        dirs = [ir.ArgDirection.Input, ir.ArgDirection.Output]
+        call = ir.Call(op, [x, y], {}, _attrs_with_dirs(dirs), _make_type(), _span())
+
+        # Round-trip through msgpack to mutate the wire format: strip the new
+        # `attrs` field and inject a legacy top-level `arg_directions` array.
+        payload = bytes(ir.serialize(call))
+        root = msgpack.unpackb(payload, raw=False, strict_map_key=False)
+        assert root["type"] == "Call"
+        fields = root["fields"]
+        # Drop the new attrs container so only the legacy field remains.
+        fields.pop("attrs", None)
+        fields["arg_directions"] = [int(d.value) for d in dirs]
+        legacy_payload = msgpack.packb(root, use_bin_type=True)
+
+        restored = ir.deserialize(legacy_payload)
+
+        assert isinstance(restored, ir.Call)
+        assert [d for d in restored.arg_directions] == dirs
+        assert "arg_directions" in restored.attrs
+        assert list(restored.attrs["arg_directions"]) == dirs
 
 
 class TestDirectionHelpers:
@@ -230,11 +289,13 @@ class TestDirectionHelpers:
         x, y = _scalar_var("x"), _scalar_var("y")
         call = ir.make_call(op, [x, y], directions=[ir.input, ir.inout])
         assert [d for d in call.arg_directions] == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        assert "arg_directions" in call.attrs
 
     def test_make_call_without_directions_is_legacy(self):
         op = _make_op()
         call = ir.make_call(op, [_scalar_var("x")])
         assert list(call.arg_directions) == []
+        assert call.attrs == {}
 
     def test_make_call_size_mismatch_raises(self):
         op = _make_op()

--- a/tests/ut/ir/expressions/test_call_arg_directions.py
+++ b/tests/ut/ir/expressions/test_call_arg_directions.py
@@ -1,0 +1,242 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for Call.arg_directions: bindings, construction, structural eq/hash, and serialization."""
+
+import pytest
+from pypto import DataType, ir
+from pypto.ir import directions
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _span() -> ir.Span:
+    return ir.Span.unknown()
+
+
+def _scalar_var(name: str) -> ir.Var:
+    return ir.Var(name, ir.ScalarType(DataType.INT64), _span())
+
+
+def _make_op() -> ir.Op:
+    return ir.Op("test.kernel")
+
+
+def _make_type() -> ir.Type:
+    return ir.UnknownType()
+
+
+# ---------------------------------------------------------------------------
+# Enum bindings
+# ---------------------------------------------------------------------------
+
+
+class TestArgDirectionEnum:
+    """ArgDirection enum exposes the runtime task-submission semantics."""
+
+    def test_all_six_members_present(self):
+        members = {d.name for d in ir.ArgDirection}
+        assert members == {"Input", "Output", "InOut", "OutputExisting", "NoDep", "Scalar"}
+
+    def test_values_are_stable(self):
+        # Wire format relies on these integer codes.
+        assert ir.ArgDirection.Input.value == 0
+        assert ir.ArgDirection.Output.value == 1
+        assert ir.ArgDirection.InOut.value == 2
+        assert ir.ArgDirection.OutputExisting.value == 3
+        assert ir.ArgDirection.NoDep.value == 4
+        assert ir.ArgDirection.Scalar.value == 5
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestCallArgDirectionsConstruction:
+    """Call construction with the new arg_directions field."""
+
+    def test_legacy_constructors_default_to_empty(self):
+        op = _make_op()
+        c1 = ir.Call(op, [], _span())
+        c2 = ir.Call(op, [_scalar_var("x")], _make_type(), _span())
+        c3 = ir.Call(op, [_scalar_var("x")], {}, _span())
+        c4 = ir.Call(op, [_scalar_var("x")], {}, _make_type(), _span())
+        for c in (c1, c2, c3, c4):
+            assert list(c.arg_directions) == []
+
+    def test_explicit_directions_round_trip(self):
+        op = _make_op()
+        x, y, z = _scalar_var("x"), _scalar_var("y"), _scalar_var("z")
+        dirs = [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.Output,
+            ir.ArgDirection.InOut,
+        ]
+        call = ir.Call(op, [x, y, z], dirs, {}, _make_type(), _span())
+        assert [d for d in call.arg_directions] == dirs
+
+    def test_explicit_empty_directions_allowed(self):
+        # An explicit empty list is equivalent to "legacy / not yet derived".
+        op = _make_op()
+        call = ir.Call(op, [_scalar_var("x")], [], {}, _make_type(), _span())
+        assert list(call.arg_directions) == []
+
+    def test_size_mismatch_raises(self):
+        op = _make_op()
+        with pytest.raises(Exception):  # noqa: PT011  TypeError raised from C++
+            ir.Call(
+                op,
+                [_scalar_var("x"), _scalar_var("y")],
+                [ir.ArgDirection.Input],  # length 1, args length 2
+                {},
+                _make_type(),
+                _span(),
+            )
+
+    def test_arg_directions_is_read_only(self):
+        op = _make_op()
+        call = ir.Call(
+            op,
+            [_scalar_var("x")],
+            [ir.ArgDirection.Output],
+            {},
+            _make_type(),
+            _span(),
+        )
+        with pytest.raises(AttributeError):
+            call.arg_directions = []  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Structural equality and hashing
+# ---------------------------------------------------------------------------
+
+
+class TestCallArgDirectionsStructural:
+    """arg_directions participates in structural_hash / structural_equal."""
+
+    def _make_pair(self, dirs_a, dirs_b):
+        op = _make_op()
+        x = _scalar_var("x")
+        a = ir.Call(op, [x], list(dirs_a), {}, _make_type(), _span())
+        b = ir.Call(op, [x], list(dirs_b), {}, _make_type(), _span())
+        return a, b
+
+    def test_equal_when_directions_match(self):
+        a, b = self._make_pair(
+            [ir.ArgDirection.InOut],
+            [ir.ArgDirection.InOut],
+        )
+        assert ir.structural_equal(a, b, enable_auto_mapping=True)
+        assert ir.structural_hash(a) == ir.structural_hash(b)
+
+    def test_unequal_when_directions_differ(self):
+        a, b = self._make_pair(
+            [ir.ArgDirection.Input],
+            [ir.ArgDirection.Output],
+        )
+        assert not ir.structural_equal(a, b, enable_auto_mapping=True)
+
+    def test_legacy_empty_vs_explicit_input_unequal(self):
+        # Empty (legacy) and explicitly Input should be distinguishable.
+        a, b = self._make_pair([], [ir.ArgDirection.Input])
+        assert not ir.structural_equal(a, b, enable_auto_mapping=True)
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCallArgDirectionsSerialization:
+    """arg_directions survives serialize/deserialize round-trip."""
+
+    def test_round_trip_preserves_directions(self):
+        op = _make_op()
+        x, y = _scalar_var("x"), _scalar_var("y")
+        dirs = [ir.ArgDirection.Input, ir.ArgDirection.Output]
+        call = ir.Call(op, [x, y], dirs, {}, _make_type(), _span())
+
+        data = ir.serialize(call)
+        restored = ir.deserialize(data)
+
+        ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+        assert isinstance(restored, ir.Call)
+        assert [d for d in restored.arg_directions] == dirs
+
+    def test_round_trip_empty_directions(self):
+        op = _make_op()
+        x = _scalar_var("x")
+        call = ir.Call(op, [x], _span())  # legacy constructor → empty
+
+        data = ir.serialize(call)
+        restored = ir.deserialize(data)
+
+        ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+        assert isinstance(restored, ir.Call)
+        assert list(restored.arg_directions) == []
+
+    def test_round_trip_all_six_kinds(self):
+        op = _make_op()
+        vars_ = [_scalar_var(f"v{i}") for i in range(6)]
+        dirs = [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.Output,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.OutputExisting,
+            ir.ArgDirection.NoDep,
+            ir.ArgDirection.Scalar,
+        ]
+        call = ir.Call(op, vars_, dirs, {}, _make_type(), _span())
+
+        data = ir.serialize(call)
+        restored = ir.deserialize(data)
+
+        ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+        assert isinstance(restored, ir.Call)
+        assert [d for d in restored.arg_directions] == dirs
+
+
+class TestDirectionHelpers:
+    """``ir.input/output/...`` are stable aliases of ``ArgDirection`` values."""
+
+    def test_aliases_match_enum(self):
+        assert ir.input is ir.ArgDirection.Input
+        assert ir.output is ir.ArgDirection.Output
+        assert ir.output_existing is ir.ArgDirection.OutputExisting
+        assert ir.inout is ir.ArgDirection.InOut
+        assert ir.no_dep is ir.ArgDirection.NoDep
+        assert ir.scalar_dir is ir.ArgDirection.Scalar
+
+    def test_directions_module_reexports(self):
+        assert directions.input is ir.input
+        assert directions.output is ir.output
+        assert directions.inout is ir.inout
+        assert directions.no_dep is ir.no_dep
+        assert directions.output_existing is ir.output_existing
+        assert directions.scalar is ir.scalar_dir
+
+    def test_make_call_with_explicit_directions(self):
+        op = _make_op()
+        x, y = _scalar_var("x"), _scalar_var("y")
+        call = ir.make_call(op, [x, y], directions=[ir.input, ir.inout])
+        assert [d for d in call.arg_directions] == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_make_call_without_directions_is_legacy(self):
+        op = _make_op()
+        call = ir.make_call(op, [_scalar_var("x")])
+        assert list(call.arg_directions) == []
+
+    def test_make_call_size_mismatch_raises(self):
+        op = _make_op()
+        with pytest.raises(ValueError, match="must match args length"):
+            ir.make_call(op, [_scalar_var("x"), _scalar_var("y")], directions=[ir.input])

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -1,0 +1,363 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the DeriveCallDirections pass and its CallDirectionsResolved verifier."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir, passes
+from pypto.pypto_core import passes as _core_passes
+
+
+def _verify_call_directions(program):
+    """Run the CallDirectionsResolved property verifier on *program*.
+
+    Replaces the now-deleted ``passes.verify_call_directions()`` pass: the
+    integrity of ``Call::arg_directions_`` is now a verifiable IR property
+    (``IRProperty.CallDirectionsResolved``) auto-checked by the pipeline.
+    """
+    props = _core_passes.IRPropertySet()
+    props.insert(_core_passes.IRProperty.CallDirectionsResolved)
+    _core_passes.PropertyVerifierRegistry.verify_or_throw(props, program)
+
+
+@pytest.fixture(autouse=True)
+def pass_verification_context():
+    """Override the global roundtrip-verification fixture for this module.
+
+    The python_printer/parser do not yet emit Call.arg_directions, so the
+    print -> parse -> structural_equal roundtrip fails immediately after
+    DeriveCallDirections. We fall back to the lighter BEFORE_AND_AFTER
+    property-verification mode here.
+    """
+    instruments: list[_core_passes.PassInstrument] = [
+        _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+    ]
+    with _core_passes.PassContext(instruments):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _UserCallCollector(ir.IRVisitor):
+    """Collect every non-builtin Call from a Program for inspection."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls: list = []
+
+    def visit_call(self, op):
+        name = op.op.name
+        if not (name.startswith("tile.") or name.startswith("tensor.") or name.startswith("system.")):
+            self.calls.append(op)
+        super().visit_call(op)
+
+
+def _user_calls(program):
+    collector = _UserCallCollector()
+    collector.visit_program(program)
+    return collector.calls
+
+
+def _dirs(call):
+    return [d for d in call.arg_directions]
+
+
+# ---------------------------------------------------------------------------
+# Derive pass: per-direction matrix
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveDirectionMatrix:
+    """One test per cell of the (callee_dir, arg_origin) mapping table."""
+
+    def test_in_param_tensor_to_input(self):
+        """Callee In + tensor argument → Input."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                # `x` is a function param: callee In keeps Input.
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        # Position 0 is callee In + tensor → Input.
+        assert _dirs(calls[0])[0] == ir.ArgDirection.Input
+
+    def test_inout_param_tensor_to_inout(self):
+        """Callee InOut + tensor argument → InOut."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                t2: pl.Tile[[64], pl.FP32] = pl.tile.add(t, t)
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t2, [0], x)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.InOut]
+
+    def test_out_param_external_buffer_to_output_existing(self):
+        """Callee Out + arg rooted at a function param → OutputExisting."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+
+    def test_out_param_local_buffer_promoted_to_inout(self):
+        """Callee Out + locally allocated buffer → InOut (WAW promotion)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_builtin_calls_left_untouched(self):
+        """tensor.create / tile.* are builtin and keep arg_directions empty."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+
+        class _BuiltinCallChecker(ir.IRVisitor):
+            def __init__(self):
+                super().__init__()
+                self.builtin_calls: list = []
+
+            def visit_call(self, op):
+                if op.op.name.startswith(("tile.", "tensor.", "system.")):
+                    self.builtin_calls.append(op)
+                super().visit_call(op)
+
+        checker = _BuiltinCallChecker()
+        checker.visit_program(out)
+        # Every builtin keeps the legacy empty arg_directions.
+        assert len(checker.builtin_calls) > 0
+        assert all(list(c.arg_directions) == [] for c in checker.builtin_calls)
+
+
+# ---------------------------------------------------------------------------
+# Derive pass: idempotency and stability
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveIdempotent:
+    """Running derive twice produces structurally identical IR."""
+
+    def test_idempotent(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
+                return r
+
+        once = passes.derive_call_directions()(Prog)
+        twice = passes.derive_call_directions()(once)
+        ir.assert_structural_equal(once, twice)
+
+
+# ---------------------------------------------------------------------------
+# Verify pass: positive case
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPositive:
+    """Verify pass accepts the output of derive."""
+
+    def test_verify_succeeds_after_derive(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
+                return r
+
+        out = passes.derive_call_directions()(Prog)
+        # Should not raise.
+        _verify_call_directions(out)
+
+
+# ---------------------------------------------------------------------------
+# Verify pass: negative cases (manually mutated IR)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyNegative:
+    """Verify pass rejects ill-formed Call::arg_directions_ assignments."""
+
+    @staticmethod
+    def _build_program(call_dirs):
+        """Build a tiny program whose single user call uses *call_dirs*."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                return r
+
+        return _RewriteUserCall(call_dirs).run(Prog)
+
+    def test_input_with_output_rejected(self):
+        # Position 0 is callee In; using Output there must fail.
+        prog = self._build_program([ir.ArgDirection.Output, ir.ArgDirection.OutputExisting])
+        with pytest.raises(Exception):  # noqa: PT011
+            _verify_call_directions(prog)
+
+    def test_out_with_input_rejected(self):
+        # Position 1 is callee Out; using Input there must fail.
+        prog = self._build_program([ir.ArgDirection.Input, ir.ArgDirection.Input])
+        with pytest.raises(Exception):  # noqa: PT011
+            _verify_call_directions(prog)
+
+
+# ---------------------------------------------------------------------------
+# Helper: rewrite the user call with a custom arg_directions vector.
+# ---------------------------------------------------------------------------
+
+
+class _RewriteUserCall(ir.IRMutator):
+    """Replace every non-builtin Call's arg_directions with *new_dirs*."""
+
+    def __init__(self, new_dirs):
+        super().__init__()
+        self._new_dirs = list(new_dirs)
+
+    def visit_call(self, op):
+        name = op.op.name
+        if name.startswith(("tile.", "tensor.", "system.")):
+            return super().visit_call(op)
+        new_args = [self.visit_expr(a) for a in op.args]
+        return ir.Call(op.op, new_args, list(self._new_dirs), op.kwargs, op.type, op.span)
+
+    def run(self, program):
+        return self.visit_program(program)

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -19,7 +19,7 @@ def _verify_call_directions(program):
     """Run the CallDirectionsResolved property verifier on *program*.
 
     Replaces the now-deleted ``passes.verify_call_directions()`` pass: the
-    integrity of ``Call::arg_directions_`` is now a verifiable IR property
+    integrity of ``Call.attrs['arg_directions']`` is now a verifiable IR property
     (``IRProperty.CallDirectionsResolved``) auto-checked by the pipeline.
     """
     props = _core_passes.IRPropertySet()
@@ -298,7 +298,7 @@ class TestVerifyPositive:
 
 
 class TestVerifyNegative:
-    """Verify pass rejects ill-formed Call::arg_directions_ assignments."""
+    """Verify pass rejects ill-formed Call.attrs['arg_directions'] assignments."""
 
     @staticmethod
     def _build_program(call_dirs):
@@ -330,13 +330,13 @@ class TestVerifyNegative:
     def test_input_with_output_rejected(self):
         # Position 0 is callee In; using Output there must fail.
         prog = self._build_program([ir.ArgDirection.Output, ir.ArgDirection.OutputExisting])
-        with pytest.raises(Exception):  # noqa: PT011
+        with pytest.raises(Exception, match=r"(?i)arg_direction|CallDirectionsResolved"):  # noqa: PT011
             _verify_call_directions(prog)
 
     def test_out_with_input_rejected(self):
         # Position 1 is callee Out; using Input there must fail.
         prog = self._build_program([ir.ArgDirection.Input, ir.ArgDirection.Input])
-        with pytest.raises(Exception):  # noqa: PT011
+        with pytest.raises(Exception, match=r"(?i)arg_direction|CallDirectionsResolved"):  # noqa: PT011
             _verify_call_directions(prog)
 
 
@@ -357,7 +357,8 @@ class _RewriteUserCall(ir.IRMutator):
         if name.startswith(("tile.", "tensor.", "system.")):
             return super().visit_call(op)
         new_args = [self.visit_expr(a) for a in op.args]
-        return ir.Call(op.op, new_args, list(self._new_dirs), op.kwargs, op.type, op.span)
+        attrs = {"arg_directions": list(self._new_dirs)}
+        return ir.Call(op.op, new_args, op.kwargs, attrs, op.type, op.span)
 
     def run(self, program):
         return self.visit_program(program)

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -261,6 +261,54 @@ class TestDeriveIdempotent:
 
 
 # ---------------------------------------------------------------------------
+# Derive pass: explicit call-site directions are preserved
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePreservesExplicit:
+    """Pre-populated Call.attrs['arg_directions'] is treated as authoritative."""
+
+    def test_explicit_directions_not_overwritten(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                return r
+
+        # Pre-populate the Out-param slot with `Output` (runtime-allocation
+        # semantics). The derive pass would otherwise emit `OutputExisting`
+        # for an external/param-rooted destination, so this checks that the
+        # explicit call-site choice survives instead of being overwritten.
+        explicit = [ir.ArgDirection.Input, ir.ArgDirection.Output]
+        prog = _RewriteUserCall(explicit).run(Prog)
+
+        before = _user_calls(prog)
+        assert len(before) == 1
+        assert _dirs(before[0]) == explicit
+
+        derived = passes.derive_call_directions()(prog)
+
+        after = _user_calls(derived)
+        assert len(after) == 1
+        assert _dirs(after[0]) == explicit
+
+
+# ---------------------------------------------------------------------------
 # Verify pass: positive case
 # ---------------------------------------------------------------------------
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -201,7 +201,7 @@ def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
             out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             gm_pipe_buffer_0: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                [1024],
                 dtype=pl.FP32,
                 layout=pl.TensorLayout.ND,
             )
@@ -309,7 +309,7 @@ def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
             out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             gm_pipe_buffer_0: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                [1024],
                 dtype=pl.FP32,
                 layout=pl.TensorLayout.ND,
             )
@@ -635,13 +635,13 @@ def test_gm_pipe_buffer_per_call_allocation():
             out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             gm_pipe_buffer_0: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                [1024],
                 dtype=pl.FP32,
                 layout=pl.TensorLayout.ND,
             )
             out_1: pl.Tensor[[16, 16], pl.FP16] = self.group_func(a, out, gm_pipe_buffer_0)
             gm_pipe_buffer_1: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                [1024],
                 dtype=pl.FP32,
                 layout=pl.TensorLayout.ND,
             )
@@ -749,7 +749,7 @@ def test_gm_pipe_buffer_per_call_inside_for_loop():
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             for b, (out_iter,) in pl.range(4, init_values=(out,)):
                 gm_pipe_buffer_0: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                    [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                    [1024],
                     dtype=pl.FP32,
                     layout=pl.TensorLayout.ND,
                 )
@@ -861,7 +861,7 @@ def test_gm_pipe_buffer_param_direction_is_out():
             out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             gm_pipe_buffer_0: pl.Tensor[[1024], pl.FP32] = pl.tensor.create(
-                [pl.const(1024, pl.INT64)],  # pyright: ignore[reportArgumentType]
+                [1024],
                 dtype=pl.FP32,
                 layout=pl.TensorLayout.ND,
             )

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -49,6 +49,7 @@ TENSOR_OPTIMIZATION_PASSES = [
     "LegalizePTOBufferReuse",
     "AllocateMemoryAddr",
     "FuseCreateAssembleToSlice",
+    "DeriveCallDirections",
     "Simplify",
 ]
 
@@ -74,6 +75,7 @@ DEBUG_TILE_OPTIMIZATION_PASSES = [
     "LegalizePTOBufferReuse",
     "AllocateMemoryAddr",
     "FuseCreateAssembleToSlice",
+    "DeriveCallDirections",
     "Simplify",
 ]
 

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -1,0 +1,349 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Printer + parser coverage for the ``pl.adir.<dir>(...)`` DSL surface syntax.
+
+``Call.arg_directions_`` is normally populated by the ``DeriveCallDirections``
+pass and is invisible in the DSL surface syntax. To make the field round-trip
+through ``python_print`` → ``parse``, the printer wraps each cross-function
+call argument with ``pl.adir.<dir>(...)`` (an identity helper provided by
+``pypto.language.arg_direction``). The parser then strips these wrappers and
+restores ``arg_directions_`` on the rebuilt :class:`ir.Call`.
+
+These tests pin down both halves of that contract independently of the
+``DeriveCallDirections`` pass.
+"""
+
+from __future__ import annotations
+
+import pypto.language as pl
+import pytest
+from pypto import ir, passes
+from pypto.language.arg_direction import DIRECTION_TO_NAME, NAME_TO_DIRECTION
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_calls(program: ir.Function | ir.Program, callee_name: str) -> list[ir.Call]:
+    """Collect every ``self.<callee_name>(...)`` Call in *program*."""
+    found: list[ir.Call] = []
+
+    class _Collector(ir.IRVisitor):
+        def visit_call(self, op):
+            if op.op.name == callee_name:
+                found.append(op)
+            super().visit_call(op)
+
+    assert isinstance(program, ir.Program), "expected a Program, not a bare Function"
+    _Collector().visit_program(program)
+    return found
+
+
+def _make_two_callsite_program() -> ir.Program:
+    """A minimal program with one Orchestration ``main`` calling ``kernel`` once.
+
+    ``kernel`` has signature ``(In tensor, Out tensor)`` so that after
+    ``DeriveCallDirections`` the call site has directions
+    ``[Input, OutputExisting]`` (param-rooted Out).
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+            ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+            return ret
+
+        @pl.function
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            dst: pl.Tensor[[64], pl.FP32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+            return r
+
+    return Prog
+
+
+# ---------------------------------------------------------------------------
+# Printer
+# ---------------------------------------------------------------------------
+
+
+class TestPrinterEmitsAdirWrappers:
+    """``IRPythonPrinter`` wraps cross-function call args with ``pl.adir.<dir>(...)``."""
+
+    def test_no_wrapper_when_arg_directions_empty(self):
+        """Legacy / pre-derive Call objects must print bare arguments."""
+        Prog = _make_two_callsite_program()
+        # Sanity: the freshly parsed call has no derived directions.
+        calls = _user_calls(Prog, "kernel")
+        assert len(calls) == 1
+        assert list(calls[0].arg_directions) == []
+
+        printed = Prog.as_python()
+        assert "self.kernel(x, dst)" in printed
+        assert "pl.adir." not in printed
+
+    def test_wrappers_emitted_after_derive(self):
+        """Once ``DeriveCallDirections`` has run, every arg is wrapped."""
+        Prog = _make_two_callsite_program()
+        out = passes.derive_call_directions()(Prog)
+        calls = _user_calls(out, "kernel")
+        assert len(calls) == 1
+        assert [d for d in calls[0].arg_directions] == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+        printed = out.as_python()
+        # Both args are wrapped, in the correct order, with the matching helper.
+        assert "self.kernel(pl.adir.input(x), pl.adir.output_existing(dst))" in printed
+
+    def test_wrapper_name_table_is_consistent(self):
+        """``DIRECTION_TO_NAME`` covers every enum value and matches the printer's choices."""
+        # Bijection between names and enum values.
+        assert {DIRECTION_TO_NAME[d] for d in ir.ArgDirection} == set(NAME_TO_DIRECTION)
+        for name, direction in NAME_TO_DIRECTION.items():
+            assert DIRECTION_TO_NAME[direction] == name
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TestParserStripsAdirWrappers:
+    """The parser recognizes ``pl.adir.<dir>(inner)`` and recovers ``arg_directions``."""
+
+    def test_parse_single_wrapper_populates_arg_directions(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x), pl.adir.output_existing(dst))
+        return r
+"""
+        prog = pl.parse(code)
+        calls = _user_calls(prog, "kernel")
+        assert len(calls) == 1
+        assert [d for d in calls[0].arg_directions] == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+    def test_parse_legacy_call_keeps_arg_directions_empty(self):
+        """A call with no wrappers must yield an empty ``arg_directions`` (legacy form)."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+        return r
+"""
+        prog = pl.parse(code)
+        calls = _user_calls(prog, "kernel")
+        assert len(calls) == 1
+        assert list(calls[0].arg_directions) == []
+
+    def test_all_six_wrappers_round_trip_through_parse(self):
+        """Each ``pl.adir.<name>`` helper resolves to its matching ``ArgDirection``."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[64], pl.FP32],
+        b: pl.Tensor[[64], pl.FP32],
+        c: pl.Tensor[[64], pl.FP32],
+        d: pl.Tensor[[64], pl.FP32],
+        e: pl.Tensor[[64], pl.FP32],
+        f: pl.Scalar[pl.INT64],
+    ):
+        t: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
+        pl.store(t, [0], a)
+
+    @pl.function
+    def main(
+        self,
+        a: pl.Tensor[[64], pl.FP32],
+        b: pl.Tensor[[64], pl.FP32],
+        c: pl.Tensor[[64], pl.FP32],
+        d: pl.Tensor[[64], pl.FP32],
+        e: pl.Tensor[[64], pl.FP32],
+        f: pl.Scalar[pl.INT64],
+    ):
+        self.kernel(
+            pl.adir.input(a),
+            pl.adir.output(b),
+            pl.adir.inout(c),
+            pl.adir.output_existing(d),
+            pl.adir.no_dep(e),
+            pl.adir.scalar(f),
+        )
+"""
+        prog = pl.parse(code)
+        calls = _user_calls(prog, "kernel")
+        assert len(calls) == 1
+        assert [d for d in calls[0].arg_directions] == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.Output,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.OutputExisting,
+            ir.ArgDirection.NoDep,
+            ir.ArgDirection.Scalar,
+        ]
+
+    def test_mixing_wrapped_and_bare_args_is_rejected(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x), dst)
+        return r
+"""
+        with pytest.raises(Exception, match="mixes wrapped"):
+            pl.parse(code)
+
+    def test_unknown_direction_marker_is_rejected(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], x)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.bogus(x))
+        return r
+"""
+        with pytest.raises(Exception, match="bogus"):
+            pl.parse(code)
+
+    def test_wrapper_must_take_single_positional_arg(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], x)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x, x))
+        return r
+"""
+        with pytest.raises(Exception, match="exactly one positional"):
+            pl.parse(code)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestAdirRoundTrip:
+    """Print → parse → structural_equal preserves ``arg_directions`` on cross-function calls."""
+
+    def test_round_trip_preserves_arg_directions(self):
+        Prog = _make_two_callsite_program()
+        derived = passes.derive_call_directions()(Prog)
+
+        printed = derived.as_python()
+        reparsed = pl.parse(printed)
+
+        # Structural equality covers ``arg_directions_`` because Call::arg_directions_
+        # is declared as ``UsualField`` in the IR reflection.
+        ir.assert_structural_equal(derived, reparsed, enable_auto_mapping=True)
+
+        # And the directions on the rebuilt call match the original ones explicitly.
+        original_call = _user_calls(derived, "kernel")[0]
+        rebuilt_call = _user_calls(reparsed, "kernel")[0]
+        assert [d for d in rebuilt_call.arg_directions] == [d for d in original_call.arg_directions]
+
+    def test_round_trip_legacy_program_remains_legacy(self):
+        """A program that has not been derived stays free of ``pl.adir.*`` after a round-trip."""
+        Prog = _make_two_callsite_program()
+        printed = Prog.as_python()
+        assert "pl.adir." not in printed
+
+        reparsed = pl.parse(printed)
+        ir.assert_structural_equal(Prog, reparsed, enable_auto_mapping=True)
+        assert list(_user_calls(reparsed, "kernel")[0].arg_directions) == []

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -7,15 +7,18 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Printer + parser coverage for the ``pl.adir.<dir>(...)`` DSL surface syntax.
+"""Printer + parser coverage for the ``Call.attrs['arg_directions']`` DSL surface.
 
 ``Call.attrs['arg_directions']`` is normally populated by the
 ``DeriveCallDirections`` pass and is invisible in the DSL surface syntax. To
-make the attr round-trip through ``python_print`` → ``parse``, the printer
-wraps each cross-function call argument with ``pl.adir.<dir>(...)`` (an
-identity helper provided by ``pypto.language.arg_direction``). The parser then
-strips these wrappers and restores ``arg_directions`` on the rebuilt
-:class:`ir.Call`.
+make the attr round-trip through ``python_print`` -> ``parse``, the printer
+emits a trailing ``attrs={"arg_directions": [pl.adir.<dir>, ...]}`` keyword on
+each cross-function call. The parser recognizes this keyword and restores
+``arg_directions`` on the rebuilt :class:`ir.Call`.
+
+The per-argument ``pl.adir.<dir>(arg)`` wrapper form is *not* supported on
+either the printer or the parser side -- ``pl.adir.<name>`` symbols are bare
+aliases of the matching :class:`ir.ArgDirection` enum value.
 
 These tests pin down both halves of that contract independently of the
 ``DeriveCallDirections`` pass.
@@ -85,11 +88,11 @@ def _make_two_callsite_program() -> ir.Program:
 # ---------------------------------------------------------------------------
 
 
-class TestPrinterEmitsAdirWrappers:
-    """``IRPythonPrinter`` wraps cross-function call args with ``pl.adir.<dir>(...)``."""
+class TestPrinterEmitsAttrsKwarg:
+    """``IRPythonPrinter`` surfaces ``arg_directions`` via a trailing ``attrs=`` keyword."""
 
-    def test_no_wrapper_when_arg_directions_empty(self):
-        """Legacy / pre-derive Call objects must print bare arguments."""
+    def test_no_attrs_when_arg_directions_empty(self):
+        """Legacy / pre-derive Call objects must print bare arguments without ``attrs=``."""
         Prog = _make_two_callsite_program()
         # Sanity: the freshly parsed call has no derived directions.
         calls = _user_calls(Prog, "kernel")
@@ -98,10 +101,11 @@ class TestPrinterEmitsAdirWrappers:
 
         printed = Prog.as_python()
         assert "self.kernel(x, dst)" in printed
+        assert "attrs=" not in printed
         assert "pl.adir." not in printed
 
-    def test_wrappers_emitted_after_derive(self):
-        """Once ``DeriveCallDirections`` has run, every arg is wrapped."""
+    def test_attrs_kwarg_emitted_after_derive(self):
+        """Once ``DeriveCallDirections`` has run, the call carries an ``attrs=`` kwarg."""
         Prog = _make_two_callsite_program()
         out = passes.derive_call_directions()(Prog)
         calls = _user_calls(out, "kernel")
@@ -112,8 +116,11 @@ class TestPrinterEmitsAdirWrappers:
         ]
 
         printed = out.as_python()
-        # Both args are wrapped, in the correct order, with the matching helper.
-        assert "self.kernel(pl.adir.input(x), pl.adir.output_existing(dst))" in printed
+        assert (
+            'self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})'
+        ) in printed
+        # Per-argument wrapper form is no longer emitted by the printer.
+        assert "pl.adir.input(x)" not in printed
 
     def test_wrapper_name_table_is_consistent(self):
         """``DIRECTION_TO_NAME`` covers every enum value and matches the printer's choices."""
@@ -122,81 +129,15 @@ class TestPrinterEmitsAdirWrappers:
         for name, direction in NAME_TO_DIRECTION.items():
             assert DIRECTION_TO_NAME[direction] == name
 
+    def test_printer_emits_each_direction_marker(self):
+        """The printer's ``pl.adir.<name>`` output covers every ``ArgDirection`` variant.
 
-# ---------------------------------------------------------------------------
-# Parser
-# ---------------------------------------------------------------------------
-
-
-class TestParserStripsAdirWrappers:
-    """The parser recognizes ``pl.adir.<dir>(inner)`` and recovers ``arg_directions``."""
-
-    def test_parse_single_wrapper_populates_arg_directions(self):
-        code = """
-import pypto.language as pl
-
-@pl.program
-class Prog:
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel(
-        self,
-        x: pl.Tensor[[64], pl.FP32],
-        out: pl.Out[pl.Tensor[[64], pl.FP32]],
-    ) -> pl.Tensor[[64], pl.FP32]:
-        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
-        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
-        return ret
-
-    @pl.function
-    def main(
-        self,
-        x: pl.Tensor[[64], pl.FP32],
-        dst: pl.Tensor[[64], pl.FP32],
-    ) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x), pl.adir.output_existing(dst))
-        return r
-"""
-        prog = pl.parse(code)
-        calls = _user_calls(prog, "kernel")
-        assert len(calls) == 1
-        assert [d for d in calls[0].arg_directions] == [
-            ir.ArgDirection.Input,
-            ir.ArgDirection.OutputExisting,
-        ]
-
-    def test_parse_legacy_call_keeps_arg_directions_empty(self):
-        """A call with no wrappers must yield an empty ``arg_directions`` (legacy form)."""
-        code = """
-import pypto.language as pl
-
-@pl.program
-class Prog:
-    @pl.function(type=pl.FunctionType.InCore)
-    def kernel(
-        self,
-        x: pl.Tensor[[64], pl.FP32],
-        out: pl.Out[pl.Tensor[[64], pl.FP32]],
-    ) -> pl.Tensor[[64], pl.FP32]:
-        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
-        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
-        return ret
-
-    @pl.function
-    def main(
-        self,
-        x: pl.Tensor[[64], pl.FP32],
-        dst: pl.Tensor[[64], pl.FP32],
-    ) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
-        return r
-"""
-        prog = pl.parse(code)
-        calls = _user_calls(prog, "kernel")
-        assert len(calls) == 1
-        assert list(calls[0].arg_directions) == []
-
-    def test_all_six_wrappers_round_trip_through_parse(self):
-        """Each ``pl.adir.<name>`` helper resolves to its matching ``ArgDirection``."""
+        Build the IR via the parser (using the supported ``attrs=`` kwarg form so
+        every direction is exercised), then re-print it and assert that the
+        emitted ``attrs={"arg_directions": [...]}`` lists each marker by its
+        canonical name. This guards the printer/parser contract end-to-end and
+        independently of ``DeriveCallDirections``.
+        """
         code = """
 import pypto.language as pl
 
@@ -226,15 +167,20 @@ class Prog:
         f: pl.Scalar[pl.INT64],
     ):
         self.kernel(
-            pl.adir.input(a),
-            pl.adir.output(b),
-            pl.adir.inout(c),
-            pl.adir.output_existing(d),
-            pl.adir.no_dep(e),
-            pl.adir.scalar(f),
+            a, b, c, d, e, f,
+            attrs={"arg_directions": [
+                pl.adir.input,
+                pl.adir.output,
+                pl.adir.inout,
+                pl.adir.output_existing,
+                pl.adir.no_dep,
+                pl.adir.scalar,
+            ]},
         )
 """
         prog = pl.parse(code)
+
+        # Sanity: the parsed Call carries all six directions in order.
         calls = _user_calls(prog, "kernel")
         assert len(calls) == 1
         assert [d for d in calls[0].arg_directions] == [
@@ -246,7 +192,26 @@ class Prog:
             ir.ArgDirection.Scalar,
         ]
 
-    def test_mixing_wrapped_and_bare_args_is_rejected(self):
+        printed = prog.as_python()
+        assert (
+            'self.kernel(a, b, c, d, e, f, attrs={"arg_directions": ['
+            "pl.adir.input, pl.adir.output, pl.adir.inout, "
+            "pl.adir.output_existing, pl.adir.no_dep, pl.adir.scalar]})"
+        ) in printed
+        # The wrapper form must never appear in printer output.
+        for name in NAME_TO_DIRECTION:
+            assert f"pl.adir.{name}(" not in printed
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TestParserExtractsAttrsKwarg:
+    """The parser recognizes ``attrs={"arg_directions": [...]}`` and restores the vector."""
+
+    def test_attrs_kwarg_populates_arg_directions(self):
         code = """
 import pypto.language as pl
 
@@ -268,13 +233,20 @@ class Prog:
         x: pl.Tensor[[64], pl.FP32],
         dst: pl.Tensor[[64], pl.FP32],
     ) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x), dst)
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(
+            x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+        )
         return r
 """
-        with pytest.raises(Exception, match="mixes wrapped"):
-            pl.parse(code)
+        prog = pl.parse(code)
+        calls = _user_calls(prog, "kernel")
+        assert len(calls) == 1
+        assert [d for d in calls[0].arg_directions] == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.OutputExisting,
+        ]
 
-    def test_unknown_direction_marker_is_rejected(self):
+    def test_attrs_kwarg_unknown_marker_rejected(self):
         code = """
 import pypto.language as pl
 
@@ -288,13 +260,41 @@ class Prog:
 
     @pl.function
     def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.bogus(x))
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, attrs={"arg_directions": [pl.adir.bogus]})
         return r
 """
         with pytest.raises(Exception, match="bogus"):
             pl.parse(code)
 
-    def test_wrapper_must_take_single_positional_arg(self):
+    def test_attrs_kwarg_size_mismatch_rejected(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input]})
+        return r
+"""
+        with pytest.raises(Exception, match=r"(?i)length|match"):
+            pl.parse(code)
+
+    def test_attrs_kwarg_unknown_key_rejected(self):
         code = """
 import pypto.language as pl
 
@@ -308,11 +308,65 @@ class Prog:
 
     @pl.function
     def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x, x))
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, attrs={"bogus": [pl.adir.input]})
         return r
 """
-        with pytest.raises(Exception, match="exactly one positional"):
+        with pytest.raises(Exception, match="bogus"):
             pl.parse(code)
+
+    def test_other_keyword_args_still_rejected(self):
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], x)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, foo=1)
+        return r
+"""
+        with pytest.raises(Exception, match="foo"):
+            pl.parse(code)
+
+    def test_per_argument_wrapper_form_no_longer_supported(self):
+        """``pl.adir.<dir>(arg)`` is removed; the markers are not callable."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], x)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(pl.adir.input(x))
+        return r
+"""
+        # The parser routes ``pl.adir.input(x)`` through the generic op-call
+        # path, where it is rejected as an unsupported function call.
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            pl.parse(code)
+
+    def test_marker_alias_resolves_to_enum_value(self):
+        """``pl.adir.<name>`` evaluates to the matching ``ArgDirection`` enum value."""
+        from pypto.language import adir  # noqa: PLC0415
+
+        assert adir.input is ir.ArgDirection.Input
+        assert adir.output is ir.ArgDirection.Output
+        assert adir.output_existing is ir.ArgDirection.OutputExisting
+        assert adir.inout is ir.ArgDirection.InOut
+        assert adir.no_dep is ir.ArgDirection.NoDep
+        assert adir.scalar is ir.ArgDirection.Scalar
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -9,12 +9,13 @@
 
 """Printer + parser coverage for the ``pl.adir.<dir>(...)`` DSL surface syntax.
 
-``Call.arg_directions_`` is normally populated by the ``DeriveCallDirections``
-pass and is invisible in the DSL surface syntax. To make the field round-trip
-through ``python_print`` → ``parse``, the printer wraps each cross-function
-call argument with ``pl.adir.<dir>(...)`` (an identity helper provided by
-``pypto.language.arg_direction``). The parser then strips these wrappers and
-restores ``arg_directions_`` on the rebuilt :class:`ir.Call`.
+``Call.attrs['arg_directions']`` is normally populated by the
+``DeriveCallDirections`` pass and is invisible in the DSL surface syntax. To
+make the attr round-trip through ``python_print`` → ``parse``, the printer
+wraps each cross-function call argument with ``pl.adir.<dir>(...)`` (an
+identity helper provided by ``pypto.language.arg_direction``). The parser then
+strips these wrappers and restores ``arg_directions`` on the rebuilt
+:class:`ir.Call`.
 
 These tests pin down both halves of that contract independently of the
 ``DeriveCallDirections`` pass.
@@ -329,8 +330,8 @@ class TestAdirRoundTrip:
         printed = derived.as_python()
         reparsed = pl.parse(printed)
 
-        # Structural equality covers ``arg_directions_`` because Call::arg_directions_
-        # is declared as ``UsualField`` in the IR reflection.
+        # Structural equality covers ``arg_directions`` because ``Call::attrs_`` is
+        # declared as ``UsualField`` in the IR reflection.
         ir.assert_structural_equal(derived, reparsed, enable_auto_mapping=True)
 
         # And the directions on the rebuilt call match the original ones explicitly.


### PR DESCRIPTION
Split argument direction into two layers: ParamDirection on Function parameters (callee-side contract) and a new ArgDirection on Call nodes (call-site behavior, mirroring TensorArgType plus Scalar). Codegen now consumes Call::arg_directions_ as the single source of truth, so dependency tracking and allocation match runtime semantics.

Highlights:
- Add ArgDirection enum and Call::arg_directions_ field with reflection, structural equal/hash, serializer, mutator, and Python bindings (pypto.ir.directions).
- Add DeriveCallDirectionsPass that derives per-arg directions from callee signatures and tensor argument origin; runs in the standard pipeline before the final Simplify.
- Add CallDirectionsResolved IRProperty + property verifier so the pass pipeline auto-checks the post-condition (no standalone pass).
- Add pl.adir.* DSL helpers (input/output/inout/output_existing/ no_dep/scalar) and round-trip them through python_printer ↔ ast_parser, keeping arg_directions stable across print → parse.
- Switch orchestration_codegen / orchestration_analysis to read from Call::arg_directions_ instead of recomputing from callee params.
- Document the model and DSL surface in docs/{en,zh-cn}/dev/ir/08-direction_model.md.

Collateral fixes surfaced by the new round-trip checks:
- tensor.transpose DSL/IR now accept both int and ConstInt for axis1/axis2.
- tensor.create gains a manual_dep kwarg (only emitted when True) so passes that set it round-trip cleanly.
- expand_mixed_kernel uses DataType::INDEX for shape ConstInts to match the parser's bare-int convention.
- Update test_pass_manager expected pass order; rewrite test_expand_mixed_kernel_a2a3 shape literals to bare ints.

Tests: tests/ut full suite — 3914 passed, 16 skipped.