### PR TITLE
Add tile-level merge sort (tmrgsort) op

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1025,27 +1025,27 @@ def mrgsort(
     src1: Expr | None = None,
     src2: Expr | None = None,
     src3: Expr | None = None,
-    tmp: Expr | None = None,
-    executed: Expr | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Expr | None = None,
     span: Span | None = None,
 ) -> Call:
-    """Merge sort — format1 (single-list) or format2 (4-way merge), tensor-level.
+    """Merge sort — format1 (single-list) or format2 (2-4 way merge), tensor-level.
 
     Tensor-level counterpart of ``tile.mrgsort``. Format1 sorts a tensor
     containing multiple pre-sorted runs of length ``block_len``. Format2 merges
-    4 pre-sorted input tensors into one sorted output.
+    2, 3, or 4 pre-sorted input tensors into one sorted output.
+
+    The scratch ``tmp`` and ``executed`` tiles required by the tile-level op are
+    synthesized automatically during ConvertTensorToTileOps as local Vec tiles —
+    users do not pass them at the tensor level.
 
     Args:
         src0: For format1: input tensor with pre-sorted runs (FP16 or FP32).
               For format2: first sorted input tensor.
         src1: (format2) Second sorted input tensor.
-        src2: (format2) Third sorted input tensor.
-        src3: (format2) Fourth sorted input tensor.
-        tmp: (format2) Temporary workspace tensor.
-        executed: (format2) Exhaustion status tensor (written by hardware).
+        src2: (format2, optional) Third sorted input tensor (3-way or 4-way).
+        src3: (format2, optional) Fourth sorted input tensor (4-way only).
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
         span: Optional source span for debugging.
@@ -1055,9 +1055,9 @@ def mrgsort(
     """
     actual_span = _get_span_or_capture(span)
     if block_len is not None:
-        if exhausted or any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if exhausted or any(arg is not None for arg in (src1, src2, src3)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ...) "
                 "are mutually exclusive; do not pass format2 arguments or exhausted=True with block_len"
             )
         if isinstance(block_len, _ir_core.ConstInt):
@@ -1067,15 +1067,20 @@ def mrgsort(
         else:
             block_len_expr = _ir_core.ConstInt(block_len, DataType.INT32, actual_span)
         return _ir_core.create_op_call("tensor.mrgsort_format1", [src0, block_len_expr], {}, actual_span)
-    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+    # format2: 2-4 way merge
+    if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, executed) for format2"
+            "or at least (src0, src1) for format2"
         )
     kwargs: dict[str, Any] = {"exhausted": exhausted}
-    return _ir_core.create_op_call(
-        "tensor.mrgsort_format2", [src0, src1, src2, src3, tmp, executed], kwargs, actual_span
-    )
+    if src2 is None:
+        args = [src0, src1]
+    elif src3 is None:
+        args = [src0, src1, src2]
+    else:
+        args = [src0, src1, src2, src3]
+    return _ir_core.create_op_call("tensor.mrgsort_format2", args, kwargs, actual_span)
 
 
 def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None) -> Call:
@@ -1086,21 +1091,23 @@ def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None)
     return mrgsort(src0, block_len=block_len, span=span)
 
 
-def mrgsort_format2(
-    src0: Expr,
-    src1: Expr,
-    src2: Expr,
-    src3: Expr,
-    tmp: Expr,
-    executed: Expr,
-    exhausted: bool = False,
-    span: Span | None = None,
-) -> Call:
-    """4-way merge sort (format2). Used by the parser for roundtrip fidelity.
+def mrgsort_format2(*args: Expr, exhausted: bool = False, span: Span | None = None) -> Call:
+    """2-4 way merge sort (format2). Used by the parser for roundtrip fidelity.
 
-    Prefer ``mrgsort(src0, src1, src2, src3, tmp, executed)`` in user code.
+    Positional args: ``(src0, src1[, src2[, src3]])``.
+
+    Prefer ``mrgsort(src0, src1[, src2[, src3]])`` in user code.
     """
-    return mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=exhausted, span=span)
+    if len(args) < 2 or len(args) > 4:
+        raise ValueError(
+            f"mrgsort_format2() requires 2-4 positional arguments "
+            f"(src0, src1[, src2[, src3]]), got {len(args)}"
+        )
+    src0 = args[0]
+    src1 = args[1]
+    src2 = args[2] if len(args) > 2 else None
+    src3 = args[3] if len(args) > 3 else None
+    return mrgsort(src0, src1, src2, src3, exhausted=exhausted, span=span)
 
 
 # ============================================================================

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2233,19 +2233,19 @@ def mrgsort(
     block_len: int | Expr | None = None,
     span: Span | None = None,
 ) -> Call:
-    """Merge sort — format1 (single-list) or format2 (4-way merge).
+    """Merge sort — format1 (single-list) or format2 (2-4 way merge).
 
     Format1 (block_len form): sorts a tile containing multiple pre-sorted runs.
-    Format2 (4-way form): merges 4 pre-sorted input tiles into one sorted output.
+    Format2 (2-4 way form): merges 2, 3, or 4 pre-sorted input tiles.
 
     Args:
         src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
               For format2: first sorted input tile.
         src1: (format2) Second sorted input tile.
-        src2: (format2) Third sorted input tile.
-        src3: (format2) Fourth sorted input tile.
-        tmp: (format2) Temporary workspace tile.
-        executed: (format2) Exhaustion status tile (written by hardware).
+        src2: (format2, optional) Third sorted input tile (3-way or 4-way).
+        src3: (format2, optional) Fourth sorted input tile (4-way only).
+        tmp: (format2) Temporary workspace tile, must be passed as keyword arg for 2/3-way.
+        executed: (format2) Exhaustion status tile (written by hardware), keyword arg for 2/3-way.
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
         span: Optional source span for debugging.
@@ -2258,7 +2258,7 @@ def mrgsort(
         # format1: single-list merge sort (pto.tmrgsort format1)
         if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp, executed) "
                 "are mutually exclusive; do not pass format2 arguments with block_len"
             )
         # PTO ISA requires block_len as i32. The parser may emit ConstInt with INDEX dtype,
@@ -2270,16 +2270,28 @@ def mrgsort(
         else:
             block_len_expr = _ir_core.ConstInt(block_len, DataType.INT32, actual_span)
         return _ir_core.create_op_call("tile.mrgsort_format1", [src0, block_len_expr], {}, actual_span)
-    # format2: 4-way merge (pto.tmrgsort format2)
-    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+    # format2: 2-4 way merge (pto.tmrgsort format2)
+    if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, executed) for format2"
+            "or at least (src0, src1, tmp=<tile>, executed=<tile>) for format2"
+        )
+    if tmp is None or executed is None:
+        raise ValueError(
+            "mrgsort() format2 requires tmp and executed to be provided as keyword arguments; "
+            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)"
         )
     kwargs: dict[str, Any] = {"exhausted": exhausted}
-    return _ir_core.create_op_call(
-        "tile.mrgsort_format2", [src0, src1, src2, src3, tmp, executed], kwargs, actual_span
-    )
+    if src2 is None:
+        # 2-way merge
+        args = [src0, src1, tmp, executed]
+    elif src3 is None:
+        # 3-way merge
+        args = [src0, src1, src2, tmp, executed]
+    else:
+        # 4-way merge
+        args = [src0, src1, src2, src3, tmp, executed]
+    return _ir_core.create_op_call("tile.mrgsort_format2", args, kwargs, actual_span)
 
 
 def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None) -> Call:
@@ -2290,18 +2302,24 @@ def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None)
     return mrgsort(src0, block_len=block_len, span=span)
 
 
-def mrgsort_format2(
-    src0: Expr,
-    src1: Expr,
-    src2: Expr,
-    src3: Expr,
-    tmp: Expr,
-    executed: Expr,
-    exhausted: bool = False,
-    span: Span | None = None,
-) -> Call:
-    """4-way merge sort (format2). Used by the parser for roundtrip fidelity.
+def mrgsort_format2(*args: Expr, exhausted: bool = False, span: Span | None = None) -> Call:
+    """2-4 way merge sort (format2). Used by the parser for roundtrip fidelity.
 
-    Prefer ``mrgsort(src0, src1, src2, src3, tmp, executed)`` in user code.
+    Positional args: ``(src0, src1[, src2[, src3]], tmp, executed)``
+    The last 2 positional args are always ``tmp`` and ``executed``.
+
+    Prefer ``mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)`` in user code.
     """
-    return mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=exhausted, span=span)
+    if len(args) < 4 or len(args) > 6:
+        raise ValueError(
+            f"mrgsort_format2() requires 4-6 positional arguments "
+            f"(src0, src1[, src2[, src3]], tmp, executed), got {len(args)}"
+        )
+    srcs = args[:-2]
+    tmp = args[-2]
+    executed = args[-1]
+    src0 = srcs[0]
+    src1 = srcs[1]
+    src2 = srcs[2] if len(srcs) > 2 else None
+    src3 = srcs[3] if len(srcs) > 3 else None
+    return mrgsort(src0, src1, src2, src3, tmp=tmp, executed=executed, exhausted=exhausted, span=span)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -857,14 +857,16 @@ def mrgsort(src0: Tensor, *, block_len: int | Scalar) -> Tensor: ...
 
 
 @overload
+def mrgsort(src0: Tensor, src1: Tensor, exhausted: bool = ...) -> Tensor: ...
+
+
+@overload
+def mrgsort(src0: Tensor, src1: Tensor, src2: Tensor, exhausted: bool = ...) -> Tensor: ...
+
+
+@overload
 def mrgsort(
-    src0: Tensor,
-    src1: Tensor,
-    src2: Tensor,
-    src3: Tensor,
-    tmp: Tensor,
-    executed: Tensor,
-    exhausted: bool = ...,
+    src0: Tensor, src1: Tensor, src2: Tensor, src3: Tensor, exhausted: bool = ...
 ) -> Tensor: ...
 
 
@@ -873,31 +875,31 @@ def mrgsort(
     src1: Tensor | None = None,
     src2: Tensor | None = None,
     src3: Tensor | None = None,
-    tmp: Tensor | None = None,
-    executed: Tensor | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Scalar | None = None,
 ) -> Tensor:
-    """Merge sort — format1 (single-list) or format2 (4-way merge), tensor-level.
+    """Merge sort — format1 (single-list) or format2 (2-4 way merge), tensor-level.
 
-    Tensor-level counterpart of ``pl.tile.mrgsort``.
+    Tensor-level counterpart of ``pl.tile.mrgsort``. The scratch ``tmp`` and
+    ``executed`` tiles required by the tile-level op are synthesized
+    automatically during conversion as local Vec tiles — users do not pass them.
 
     Format1 usage (keyword block_len):
         out = mrgsort(src, block_len=64)
 
-    Format2 usage (6 positional args):
-        out = mrgsort(src0, src1, src2, src3, tmp, executed)
-        out = mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=True)
+    Format2 usage:
+        out = mrgsort(src0, src1)                # 2-way
+        out = mrgsort(src0, src1, src2)          # 3-way
+        out = mrgsort(src0, src1, src2, src3)    # 4-way
+        out = mrgsort(src0, src1, exhausted=True)
 
     Args:
         src0: For format1: input tensor with pre-sorted runs (FP16 or FP32).
               For format2: first sorted input tensor.
         src1: (format2) Second sorted input tensor.
-        src2: (format2) Third sorted input tensor.
-        src3: (format2) Fourth sorted input tensor.
-        tmp: (format2) Temporary workspace tensor.
-        executed: (format2) Exhaustion status tensor (written by hardware).
+        src2: (format2, optional) Third sorted input tensor (3-way or 4-way).
+        src3: (format2, optional) Fourth sorted input tensor (4-way only).
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
 
@@ -905,27 +907,26 @@ def mrgsort(
         Tensor with merged sorted elements
     """
     if block_len is not None:
-        if exhausted or any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if exhausted or any(arg is not None for arg in (src1, src2, src3)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ...) "
                 "are mutually exclusive; do not pass format2 arguments or exhausted=True with block_len"
             )
         block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
         call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
         return Tensor(expr=call_expr)
-    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+    # format2: 2-4 way merge
+    if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, executed) for format2"
+            "or at least (src0, src1) for format2"
         )
     call_expr = _ir_ops.mrgsort(
         src0.unwrap(),
         src1.unwrap(),
-        src2.unwrap(),
-        src3.unwrap(),
-        tmp.unwrap(),
-        executed.unwrap(),
-        exhausted,
+        src2.unwrap() if src2 is not None else None,
+        src3.unwrap() if src3 is not None else None,
+        exhausted=exhausted,
     )
     return Tensor(expr=call_expr)
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1796,6 +1796,29 @@ def mrgsort(src0: Tile, *, block_len: int | Scalar) -> Tile: ...
 def mrgsort(
     src0: Tile,
     src1: Tile,
+    *,
+    tmp: Tile,
+    executed: Tile,
+    exhausted: bool = ...,
+) -> Tile: ...
+
+
+@overload
+def mrgsort(
+    src0: Tile,
+    src1: Tile,
+    src2: Tile,
+    *,
+    tmp: Tile,
+    executed: Tile,
+    exhausted: bool = ...,
+) -> Tile: ...
+
+
+@overload
+def mrgsort(
+    src0: Tile,
+    src1: Tile,
     src2: Tile,
     src3: Tile,
     tmp: Tile,
@@ -1815,15 +1838,22 @@ def mrgsort(
     *,
     block_len: int | Scalar | None = None,
 ) -> Tile:
-    """Merge sort — format1 (single-list) or format2 (4-way merge).
+    """Merge sort — format1 (single-list) or format2 (2-4 way merge).
 
     Format1: sorts a tile containing multiple pre-sorted runs of length block_len.
-    Format2: performs a 4-way merge of 4 pre-sorted input tiles.
+    Format2: merges 2, 3, or 4 pre-sorted input tiles into one sorted output.
 
     Format1 usage (keyword block_len):
         out = mrgsort(src, block_len=64)
 
-    Format2 usage (6 positional args):
+    Format2 2-way usage (keyword tmp and executed):
+        out = mrgsort(src0, src1, tmp=tmp_tile, executed=exec_tile)
+        out = mrgsort(src0, src1, tmp=tmp_tile, executed=exec_tile, exhausted=True)
+
+    Format2 3-way usage:
+        out = mrgsort(src0, src1, src2, tmp=tmp_tile, executed=exec_tile)
+
+    Format2 4-way usage (6 positional args):
         out = mrgsort(src0, src1, src2, src3, tmp, executed)
         out = mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=True)
 
@@ -1831,10 +1861,12 @@ def mrgsort(
         src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
               For format2: first sorted input tile.
         src1: (format2) Second sorted input tile.
-        src2: (format2) Third sorted input tile.
-        src3: (format2) Fourth sorted input tile.
-        tmp: (format2) Temporary workspace tile.
-        executed: (format2) Exhaustion status tile (written by hardware).
+        src2: (format2, optional) Third sorted input tile (3-way or 4-way).
+        src3: (format2, optional) Fourth sorted input tile (4-way only).
+        tmp: (format2) Temporary workspace tile (same shape as output).
+              Pass as keyword arg for 2-way and 3-way.
+        executed: (format2) Exhaustion status tile written by hardware (shape [1, 4] INT16).
+                  Pass as keyword arg for 2-way and 3-way.
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
 
@@ -1845,25 +1877,30 @@ def mrgsort(
         # format1: single-list merge sort
         if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, src2, src3, tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp, executed) "
                 "are mutually exclusive; do not pass format2 arguments with block_len"
             )
         block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
         call_expr = _ir_ops.mrgsort(src0.unwrap(), block_len=block_len_expr)
         return Tile(expr=call_expr)
-    # format2: 4-way merge
-    if src1 is None or src2 is None or src3 is None or tmp is None or executed is None:
+    # format2: 2-4 way merge
+    if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or (src0, src1, src2, src3, tmp, executed) for format2"
+            "or at least (src0, src1, tmp=<tile>, executed=<tile>) for format2"
+        )
+    if tmp is None or executed is None:
+        raise ValueError(
+            "mrgsort() format2 requires tmp and executed; "
+            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)"
         )
     call_expr = _ir_ops.mrgsort(
         src0.unwrap(),
         src1.unwrap(),
-        src2.unwrap(),
-        src3.unwrap(),
-        tmp.unwrap(),
-        executed.unwrap(),
-        exhausted,
+        src2.unwrap() if src2 is not None else None,
+        src3.unwrap() if src3 is not None else None,
+        tmp=tmp.unwrap(),
+        executed=executed.unwrap(),
+        exhausted=exhausted,
     )
     return Tile(expr=call_expr)

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -532,42 +532,61 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 }
 
 // Helper function for MrgSort format2: emits pto.tmrgsort
-// format2: ins(src0, src1, src2, src3 {exhausted = <bool>} : types...)
-//          outs(dst, tmp, executed : dst_type, tmp_type, vector<4xi16>)
+// Supports 2-4 way merge:
+//   2-way (4 args): ins(src0, src1 {exhausted} : types...) outs(dst, tmp, executed : ...)
+//   3-way (5 args): ins(src0, src1, src2 {exhausted} : types...) outs(dst, tmp, executed : ...)
+//   4-way (6 args): ins(src0, src1, src2, src3 {exhausted} : types...) outs(dst, tmp, executed : ...)
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 6) << "Operation:[" << pto_op_name
-                               << "] requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
-                               << op->args_.size();
+  CHECK(op->args_.size() >= 4 && op->args_.size() <= 6)
+      << "Operation:[" << pto_op_name << "] requires 4-6 arguments (2-4 srcs + tmp + executed), but got "
+      << op->args_.size();
 
-  // ins: src0, src1, src2, src3 (args 0-3)
-  std::string src0 = codegen.GetExprAsCode(op->args_[0]);
-  std::string src1 = codegen.GetExprAsCode(op->args_[1]);
-  std::string src2 = codegen.GetExprAsCode(op->args_[2]);
-  std::string src3 = codegen.GetExprAsCode(op->args_[3]);
-  std::string s0t = codegen.GetExprTypeAnnotation(op->args_[0]);
-  std::string s1t = codegen.GetExprTypeAnnotation(op->args_[1]);
-  std::string s2t = codegen.GetExprTypeAnnotation(op->args_[2]);
-  std::string s3t = codegen.GetExprTypeAnnotation(op->args_[3]);
+  size_t n_srcs = op->args_.size() - 2;
 
-  // outs: dst (result target), tmp (arg4), executed (arg5)
+  // Collect ins: src tiles (args 0..n_srcs-1)
+  std::vector<std::string> srcs, src_types;
+  for (size_t i = 0; i < n_srcs; ++i) {
+    srcs.push_back(codegen.GetExprAsCode(op->args_[i]));
+    src_types.push_back(codegen.GetExprTypeAnnotation(op->args_[i]));
+  }
+
+  // outs: dst (result target), tmp (args[n_srcs]), executed (args[n_srcs+1])
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
-  std::string tmp = codegen.GetExprAsCode(op->args_[4]);
-  std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[4]);
-  std::string executed = codegen.GetExprAsCode(op->args_[5]);
+  std::string tmp = codegen.GetExprAsCode(op->args_[n_srcs]);
+  std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[n_srcs]);
+  std::string executed_vec = codegen.NewNamedTemp("executed_vec");
+  codegen.Emit(executed_vec + " = arith.constant dense<0> : vector<4xi16>");
 
   bool exhausted = op->GetKwarg<bool>("exhausted", false);
   std::string exhausted_attr = exhausted ? "{exhausted = true}" : "{exhausted = false}";
 
   std::ostringstream oss;
-  oss << pto_op_name << " ins(" << src0 << ", " << src1 << ", " << src2 << ", " << src3 << " "
-      << exhausted_attr;
-  if (!s0t.empty() || !s1t.empty() || !s2t.empty() || !s3t.empty()) {
-    oss << " : " << s0t << ", " << s1t << ", " << s2t << ", " << s3t;
+  oss << pto_op_name << " ins(";
+  for (size_t i = 0; i < n_srcs; ++i) {
+    if (i > 0) oss << ", ";
+    oss << srcs[i];
   }
-  oss << ") outs(" << dst << ", " << tmp << ", " << executed;
+  oss << " " << exhausted_attr;
+
+  bool has_types = false;
+  for (const auto& t : src_types) {
+    if (!t.empty()) {
+      has_types = true;
+      break;
+    }
+  }
+  if (has_types) {
+    oss << " : ";
+    for (size_t i = 0; i < n_srcs; ++i) {
+      if (i > 0) oss << ", ";
+      oss << src_types[i];
+    }
+  }
+
+  oss << ") outs(" << dst << ", " << tmp << ", " << executed_vec;
   if (!dst_type.empty() || !tmp_type.empty()) {
     oss << " : " << dst_type << ", " << tmp_type << ", vector<4xi16>";
   }

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -49,6 +49,10 @@ std::string DataTypeToMLIR(DataType dtype) {
     return "i8";
   } else if (dtype == DataType::UINT8) {
     return "ui8";
+  } else if (dtype == DataType::INT16) {
+    return "i16";
+  } else if (dtype == DataType::UINT16) {
+    return "ui16";
   } else if (dtype == DataType::BOOL) {
     return "i1";
   } else {

--- a/src/ir/op/tensor_ops/sort.cpp
+++ b/src/ir/op/tensor_ops/sort.cpp
@@ -101,15 +101,22 @@ REGISTER_OP("tensor.sort32")
     });
 
 // ============================================================================
-// tensor.mrgsort_format2 — 4-way merge sort (tensor-level).
+// tensor.mrgsort_format2 — 2-4 way merge sort (tensor-level).
+//
+// Unlike the tile-level op, the tensor-level mrgsort_format2 only takes source
+// tiles: the `tmp` scratch and `executed` status tiles are synthesized as
+// local Vec tile.create calls during ConvertTensorToTileOps. This keeps tiny
+// scratch (e.g. 1×4 INT16 executed) off the GM boundary, where they would
+// otherwise hit PTO tile alignment constraints (Cols * sizeof(dtype) % 32 == 0).
 // ============================================================================
 
 TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
                                 const std::string& op_name) {
-  CHECK(args.size() == 6) << "The operator " << op_name
-                          << " requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
-                          << args.size();
+  // Arg layout: (src0, ..., srcN-1)
+  //   2-way: 2 args, 3-way: 3 args, 4-way: 4 args
+  CHECK(args.size() >= 2 && args.size() <= 4)
+      << "The operator " << op_name << " requires 2-4 arguments (2-4 srcs), but got " << args.size();
 
   auto src0_type = As<TensorType>(args[0]->GetType());
   CHECK(src0_type) << "The operator " << op_name << " requires argument 0 to be a TensorType, but got "
@@ -117,8 +124,12 @@ TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
   CHECK(src0_type->dtype_ == DataType::FP16 || src0_type->dtype_ == DataType::FP32)
       << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
       << src0_type->dtype_.ToString();
+  CHECK(!src0_type->shape_.empty()) << "The operator " << op_name << " requires non-empty src shape";
 
-  for (size_t i = 1; i < 4; ++i) {
+  // All srcs must share dtype and rank.
+  std::vector<std::shared_ptr<const TensorType>> src_types;
+  src_types.push_back(src0_type);
+  for (size_t i = 1; i < args.size(); ++i) {
     auto src_type = As<TensorType>(args[i]->GetType());
     CHECK(src_type) << "The operator " << op_name << " requires argument " << i
                     << " to be a TensorType, but got " << args[i]->GetType()->TypeName();
@@ -126,29 +137,48 @@ TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
         << "The operator " << op_name << " requires all src tensors to have matching dtype, but argument "
         << i << " has " << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString()
         << ")";
+    CHECK(src_type->shape_.size() == src0_type->shape_.size())
+        << "The operator " << op_name << " requires all src tensors to have matching rank";
+    src_types.push_back(src_type);
   }
 
-  auto tmp_type = As<TensorType>(args[4]->GetType());
-  CHECK(tmp_type) << "The operator " << op_name << " requires argument 4 (tmp) to be a TensorType, but got "
-                  << args[4]->GetType()->TypeName();
-
-  auto exc_type = As<TensorType>(args[5]->GetType());
-  CHECK(exc_type) << "The operator " << op_name
-                  << " requires argument 5 (executed) to be a TensorType, but got "
-                  << args[5]->GetType()->TypeName();
-
-  return std::make_shared<TensorType>(tmp_type->shape_, src0_type->dtype_);
+  // Output shape: same as src0 except the last dim is the sum of all srcs' last dims
+  // (matches the `tmp` shape required at tile-level: merged destination buffer).
+  std::vector<ExprPtr> out_shape(src0_type->shape_.begin(), src0_type->shape_.end() - 1);
+  ExprPtr last_dim;
+  int64_t const_sum = 0;
+  bool all_const = true;
+  for (const auto& st : src_types) {
+    auto c = As<ConstInt>(st->shape_.back());
+    if (!c) {
+      all_const = false;
+      break;
+    }
+    const_sum += c->value_;
+  }
+  if (all_const) {
+    last_dim = std::make_shared<ConstInt>(const_sum, DataType::INDEX, Span::unknown());
+  } else {
+    last_dim = src_types[0]->shape_.back();
+    for (size_t i = 1; i < src_types.size(); ++i) {
+      last_dim = std::make_shared<Add>(last_dim, src_types[i]->shape_.back(), DataType::INDEX,
+                                       Span::unknown());
+    }
+  }
+  out_shape.push_back(last_dim);
+  return std::make_shared<TensorType>(out_shape, src0_type->dtype_);
 }
 
 REGISTER_OP("tensor.mrgsort_format2")
     .set_op_category("TensorOp")
-    .set_description("Merge sort 4 sorted lists, format2 (tensor-level, maps to tile.mrgsort_format2)")
+    .set_description("Merge sort 2-4 sorted lists, format2 (tensor-level). "
+                     "Args: (src0, src1[, src2[, src3]]). "
+                     "The scratch tmp and executed tiles required by tile.mrgsort_format2 are "
+                     "synthesized during conversion — users do not pass them at the tensor level.")
     .add_argument("src0", "First sorted input tensor (FP16 or FP32)")
     .add_argument("src1", "Second sorted input tensor")
-    .add_argument("src2", "Third sorted input tensor")
-    .add_argument("src3", "Fourth sorted input tensor")
-    .add_argument("tmp", "Temporary workspace tensor")
-    .add_argument("executed", "Exhaustion status output tensor")
+    .add_argument("src2", "(3/4-way only) Third sorted input tensor")
+    .add_argument("src3", "(4-way only) Fourth sorted input tensor")
     .set_attr<bool>("exhausted")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -115,17 +115,23 @@ REGISTER_OP("tile.sort32")
     });
 
 // ============================================================================
-// MrgSort: 4-way merge sort (format2) — maps to pto.tmrgsort
+// MrgSort: 2-4 way merge sort (format2) — maps to pto.tmrgsort
 // ============================================================================
 
 TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs,
                               const std::string& op_name) {
-  CHECK(args.size() == 6) << "The operator " << op_name
-                          << " requires 6 arguments (src0, src1, src2, src3, tmp, executed), but got "
-                          << args.size();
+  // Arg layout: (src0, ..., srcN-1, tmp, executed)
+  //   2-way: 4 args  (src0, src1, tmp, executed)
+  //   3-way: 5 args  (src0, src1, src2, tmp, executed)
+  //   4-way: 6 args  (src0, src1, src2, src3, tmp, executed)
+  CHECK(args.size() >= 4 && args.size() <= 6)
+      << "The operator " << op_name
+      << " requires 4-6 arguments (2-4 srcs + tmp + executed), but got " << args.size();
 
-  // First 4 args: sorted input tiles (f16 or f32, matching dtype)
+  size_t n_srcs = args.size() - 2;
+
+  // src0: sorted input tile (f16 or f32)
   auto src0_type = As<TileType>(args[0]->GetType());
   CHECK(src0_type) << "The operator " << op_name << " requires argument 0 to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
@@ -133,7 +139,8 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires src dtype to be FP16 or FP32, but got "
       << src0_type->dtype_.ToString();
 
-  for (size_t i = 1; i < 4; ++i) {
+  // src1..srcN-1: remaining source tiles — must match src0 dtype
+  for (size_t i = 1; i < n_srcs; ++i) {
     auto src_type = As<TileType>(args[i]->GetType());
     CHECK(src_type) << "The operator " << op_name << " requires argument " << i
                     << " to be a TileType, but got " << args[i]->GetType()->TypeName();
@@ -142,16 +149,15 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
         << " has " << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString() << ")";
   }
 
-  // arg4: tmp workspace tile
-  auto tmp_type = As<TileType>(args[4]->GetType());
-  CHECK(tmp_type) << "The operator " << op_name << " requires argument 4 (tmp) to be a TileType, but got "
-                  << args[4]->GetType()->TypeName();
+  // tmp workspace tile (second-to-last arg)
+  auto tmp_type = As<TileType>(args[n_srcs]->GetType());
+  CHECK(tmp_type) << "The operator " << op_name << " requires argument " << n_srcs
+                  << " (tmp) to be a TileType, but got " << args[n_srcs]->GetType()->TypeName();
 
-  // arg5: executed status tile
-  auto exc_type = As<TileType>(args[5]->GetType());
-  CHECK(exc_type) << "The operator " << op_name
-                  << " requires argument 5 (executed) to be a TileType, but got "
-                  << args[5]->GetType()->TypeName();
+  // executed status tile (last arg)
+  auto exc_type = As<TileType>(args[n_srcs + 1]->GetType());
+  CHECK(exc_type) << "The operator " << op_name << " requires argument " << (n_srcs + 1)
+                  << " (executed) to be a TileType, but got " << args[n_srcs + 1]->GetType()->TypeName();
 
   // kwarg: exhausted (bool, default false)
   [[maybe_unused]] bool exhausted = GetKwarg<bool>(kwargs, "exhausted", false);
@@ -165,20 +171,18 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
 
 REGISTER_OP("tile.mrgsort_format2")
     .set_op_category("TileOp")
-    .set_description("Merge sort 4 sorted lists, format2 (maps to pto.tmrgsort)")
+    .set_description("Merge sort 2-4 sorted lists, format2 (maps to pto.tmrgsort). "
+                     "Args: (src0, src1[, src2[, src3]], tmp, executed). "
+                     "2-way: 4 args, 3-way: 5 args, 4-way: 6 args.")
     .add_argument("src0", "First sorted input tile (FP16 or FP32)")
     .add_argument("src1", "Second sorted input tile")
-    .add_argument("src2", "Third sorted input tile")
-    .add_argument("src3", "Fourth sorted input tile")
-    .add_argument("tmp", "Temporary workspace tile")
-    .add_argument("executed", "Exhaustion status output tile")
+    .add_argument("tmp_or_src2", "Third sorted input tile (3/4-way) or tmp workspace (2-way)")
+    .add_argument("executed_or_src3", "Fourth sorted input tile (4-way), tmp (3-way), or executed (2-way)")
+    .add_argument("tmp", "(3/4-way only) Temporary workspace tile")
+    .add_argument("executed", "(4-way only) Exhaustion status output tile")
     .set_attr<bool>("exhausted")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
-    .set_input_memory(2, MemorySpace::Vec)
-    .set_input_memory(3, MemorySpace::Vec)
-    .set_input_memory(4, MemorySpace::Vec)
-    .set_input_memory(5, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -733,8 +733,100 @@ void OpConversionRegistry::RegisterReductionOps() {
 void OpConversionRegistry::RegisterSortOps() {
   RegisterSimple("tensor.sort32", "tile.sort32");
   RegisterSimple("tensor.mrgsort_format1", "tile.mrgsort_format1");
-  RegisterSimple("tensor.mrgsort_format2", "tile.mrgsort_format2");
   RegisterSimple("tensor.gather_mask", "tile.gather_mask");
+
+  // tensor.mrgsort_format2: 2-4 srcs → tile.mrgsort_format2 with synthesized
+  // scratch tmp + executed tiles allocated locally in Vec memory.
+  //
+  // The tile-level op requires (srcs..., tmp, executed). We don't expose tmp/
+  // executed at the tensor level because:
+  //   - tmp shape equals the merged output shape (sum of src last dims) — we
+  //     can derive it; no user-visible value.
+  //   - executed is a small [1, 4] INT16 hardware status tile that the PTO
+  //     codegen actually materializes as a vector<4xi16> constant (the passed
+  //     tile is a plumbing-only placeholder). Its shape can't round-trip
+  //     through GM because 4 * 2 bytes = 8 bytes violates the 32-byte tile
+  //     row alignment PTO enforces.
+  //
+  // Inputs (srcs) are auto-bridged to Vec tiles by the framework (input_reqs).
+  std::unordered_map<size_t, InputSpaceReq> mrgsort2_input_reqs;
+  for (size_t i = 0; i < 4; ++i) {
+    mrgsort2_input_reqs[i] = {MemorySpace::Vec, std::nullopt};
+  }
+  RegisterCustom(
+      "tensor.mrgsort_format2",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() >= 2 && args.size() <= 4)
+            << "tensor.mrgsort_format2 conversion expects 2-4 src args, got " << args.size();
+        auto& op_reg = OpRegistry::GetInstance();
+
+        // After the framework's input_reqs bridge, all srcs should be Vec tiles.
+        std::vector<std::shared_ptr<const TileType>> src_tile_types;
+        src_tile_types.reserve(args.size());
+        for (size_t i = 0; i < args.size(); ++i) {
+          auto tt = As<TileType>(args[i]->GetType());
+          CHECK(tt) << "tensor.mrgsort_format2 conversion expects bridged Vec tile at arg " << i;
+          src_tile_types.push_back(tt);
+        }
+        const auto& src0_tile = src_tile_types.front();
+
+        // tmp shape = same rank as src0, last dim = sum of all srcs' last dims.
+        std::vector<ExprPtr> tmp_shape(src0_tile->shape_.begin(), src0_tile->shape_.end() - 1);
+        int64_t const_sum = 0;
+        bool all_const = true;
+        for (const auto& st : src_tile_types) {
+          auto c = As<ConstInt>(st->shape_.back());
+          if (!c) {
+            all_const = false;
+            break;
+          }
+          const_sum += c->value_;
+        }
+        ExprPtr last_dim;
+        if (all_const) {
+          last_dim = std::make_shared<ConstInt>(const_sum, DataType::INDEX, span);
+        } else {
+          last_dim = src_tile_types[0]->shape_.back();
+          for (size_t i = 1; i < src_tile_types.size(); ++i) {
+            last_dim = std::make_shared<Add>(last_dim, src_tile_types[i]->shape_.back(),
+                                             DataType::INDEX, span);
+          }
+        }
+        tmp_shape.push_back(last_dim);
+
+        std::vector<StmtPtr> prologue;
+
+        // Synthesize tmp: tile.create(tmp_shape, dtype=src0.dtype, target_memory=Vec)
+        auto tmp_shape_tuple = std::make_shared<MakeTuple>(tmp_shape, span);
+        std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
+            {"dtype", src0_tile->dtype_}, {"target_memory", MemorySpace::Vec}};
+        auto tmp_create = op_reg.Create("tile.create", {tmp_shape_tuple}, tmp_create_kwargs, span);
+        auto tmp_var = std::make_shared<Var>("mrgsort2_tmp", tmp_create->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_create, span));
+
+        // Synthesize executed: tile.create([1, 4], dtype=INT16, target_memory=Vec).
+        // PTO codegen ignores the actual tile content and emits a vector<4xi16>
+        // constant; this tile is needed solely to satisfy the tile op's arity.
+        std::vector<ExprPtr> exe_shape = {
+            std::make_shared<ConstInt>(1, DataType::INDEX, span),
+            std::make_shared<ConstInt>(4, DataType::INDEX, span),
+        };
+        auto exe_shape_tuple = std::make_shared<MakeTuple>(exe_shape, span);
+        std::vector<std::pair<std::string, std::any>> exe_create_kwargs = {
+            {"dtype", DataType(DataType::INT16)}, {"target_memory", MemorySpace::Vec}};
+        auto exe_create = op_reg.Create("tile.create", {exe_shape_tuple}, exe_create_kwargs, span);
+        auto exe_var = std::make_shared<Var>("mrgsort2_executed", exe_create->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(exe_var, exe_create, span));
+
+        // Assemble tile.mrgsort_format2 call: (src0..srcN-1, tmp, executed) + kwargs.
+        std::vector<ExprPtr> tile_args(args.begin(), args.end());
+        tile_args.push_back(tmp_var);
+        tile_args.push_back(exe_var);
+        auto mrgsort_call = op_reg.Create("tile.mrgsort_format2", tile_args, kwargs, span);
+        return ConversionResult{std::move(prologue), mrgsort_call};
+      },
+      std::move(mrgsort2_input_reqs));
 }
 
 // ============================================================================

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -334,6 +334,60 @@ class MrgSort1DynFP32Program:
         return val_output, idx_output
 
 
+@pl.program
+class MrgSort2WayFP32Program:
+    """Tensor-level sort32 + format1 + format2 (2-way merge) for 1024 FP32 elements.
+
+    Mirrors ``MrgSort1DynFP32TensorValIdxProgram`` style, using ``pl.tensor.*``
+    APIs inside ``pl.at(CORE_GROUP)``.
+
+    Pipeline:
+      Left half  [1,512] → sort32 → [1,1024] → format1(64) → format1(256) → sorted [1,1024]
+      Right half [1,512] → sort32 → [1,1024] → format1(64) → format1(256) → sorted [1,1024]
+      format2 2-way merge → [1,2048] → gather(P0101) vals + gather(P1010,UINT32) idx
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[1, 1024], pl.FP32],
+        idx: pl.Tensor[[1, 1024], pl.UINT32],
+        val_output: pl.Out[pl.Tensor[[1, 1024], pl.FP32]],
+        idx_output: pl.Out[pl.Tensor[[1, 1024], pl.UINT32]],
+    ) -> tuple[pl.Tensor[[1, 1024], pl.FP32], pl.Tensor[[1, 1024], pl.UINT32]]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            # Slice src/idx into left and right halves.
+            left_src = pl.tensor.slice(src, shape=[1, 512], offset=[0, 0])
+            left_idx = pl.tensor.slice(idx, shape=[1, 512], offset=[0, 0])
+            right_src = pl.tensor.slice(src, shape=[1, 512], offset=[0, 512])
+            right_idx = pl.tensor.slice(idx, shape=[1, 512], offset=[0, 512])
+
+            # Sort left half: sort32 → [1,1024] interleaved, then 2x format1 → fully sorted.
+            left_s32 = pl.tensor.sort32(left_src, left_idx)
+            left_m1 = pl.tensor.mrgsort(left_s32, block_len=64)
+            left_sorted = pl.tensor.mrgsort(left_m1, block_len=256)
+
+            # Sort right half: same pipeline.
+            right_s32 = pl.tensor.sort32(right_src, right_idx)
+            right_m1 = pl.tensor.mrgsort(right_s32, block_len=64)
+            right_sorted = pl.tensor.mrgsort(right_m1, block_len=256)
+
+            # Format2 2-way merge: tmp/executed are synthesized by the conversion pass.
+            merged = pl.tensor.mrgsort(left_sorted, right_sorted)
+
+            # Extract sorted values (even columns) and indices (odd columns, reinterpret as UINT32).
+            vals = pl.tensor.gather(merged, mask_pattern=pl.tile.MaskPattern.P0101)
+            sorted_idx = pl.tensor.gather(
+                merged, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.UINT32
+            )
+            val_output = pl.assemble(val_output, vals, [0, 0])
+            idx_output = pl.assemble(idx_output, sorted_idx, [0, 0])
+        return val_output, idx_output
+
+
 # --- Test Cases ---
 
 
@@ -375,6 +429,16 @@ def _make_idx_1x2048():
 def _make_src_1x2048():
     """Random [1, 2048] FP32 source for mrgsort dynamic block_len test."""
     return torch.randn(2048).unsqueeze(0).contiguous()
+
+
+def _make_idx_1x1024():
+    """Global indices [0..1023] for mrgsort 2-way format2 test."""
+    return torch.arange(0, 1024, dtype=torch.int32).unsqueeze(0).contiguous()
+
+
+def _make_src_1x1024():
+    """Random [1, 1024] FP32 source for mrgsort 2-way format2 test."""
+    return torch.randn(1024).unsqueeze(0).contiguous()
 
 
 class MrgSort1FP32TestCase(PTOTestCase):
@@ -513,6 +577,41 @@ class MrgSort1DynFP32TensorValIdxTestCase(PTOTestCase):
         src = tensors["src"].flatten()
         idx = tensors["idx"].flatten()
         _, global_order = torch.sort(src, descending=True)
+        tensors["val_output"][:] = src[global_order].unsqueeze(0)
+        tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
+
+
+class MrgSort2WayFP32TestCase(PTOTestCase):
+    """Test sort32 → format1 (per 512-element half) → format2 2-way merge pipeline.
+
+    1024 FP32 elements are split into two 512-element halves. Each half is sorted
+    independently using sort32 + 2x mrgsort format1. The two sorted halves are then
+    merged via mrgsort format2 (2-way), and values/indices are extracted with gather.
+    """
+
+    def get_name(self) -> str:
+        return "mrgsort2_way_fp32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [1, 1024], DataType.FP32, init_value=_make_src_1x1024),
+            TensorSpec("idx", [1, 1024], DataType.UINT32, init_value=_make_idx_1x1024),
+            TensorSpec("val_output", [1, 1024], DataType.FP32, is_output=True),
+            TensorSpec("idx_output", [1, 1024], DataType.UINT32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return MrgSort2WayFP32Program
+
+    def compute_expected(self, tensors, params=None):
+        """Sort all 1024 elements descending; verify values and original indices."""
+        src = tensors["src"].flatten()  # [1024]
+        idx = tensors["idx"].flatten()  # [0, 1, 2, ..., 1023]
+        _, global_order = torch.sort(src, descending=True)
+
         tensors["val_output"][:] = src[global_order].unsqueeze(0)
         tensors["idx_output"][:] = idx[global_order].unsqueeze(0)
 
@@ -685,6 +784,18 @@ class TestSort:
     def test_mrgsort1_dyn_fp32_tensor_val_idx(self, test_runner, platform):
         """Tensor-level sort32 + mrgsort + P0101/P1010 mask-gather: returns values and indices."""
         result = test_runner.run(MrgSort1DynFP32TensorValIdxTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_mrgsort2_way_fp32(self, test_runner, platform):
+        """Tensor-level sort32 + format1 + format2 (2-way merge) for 1024-element sort.
+
+        Pipeline:
+          left  [1,512] → sort32 → format1(64) → format1(256) → sorted [1,1024]
+          right [1,512] → sort32 → format1(64) → format1(256) → sorted [1,1024]
+          format2 2-way merge → [1,2048] → gather → val [1,1024] + idx [1,1024]
+        """
+        result = test_runner.run(MrgSort2WayFP32TestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1910,28 +1910,22 @@ def test_tensor_mrgsort_format1_invalid_block_len():
 
 
 def test_tensor_mrgsort_format2():
-    """tensor.mrgsort(src0..src3, tmp, executed) emits tensor.mrgsort_format2."""
+    """tensor.mrgsort(src0..src3) emits tensor.mrgsort_format2 with summed last-dim shape."""
     span = ir.Span.unknown()
     d1 = ir.ConstInt(1, DataType.INT32, span)
     d128 = ir.ConstInt(128, DataType.INT32, span)
-    d4 = ir.ConstInt(4, DataType.INT32, span)
-    d512 = ir.ConstInt(512, DataType.INT32, span)
     src_t = ir.TensorType([d1, d128], DataType.FP32)
-    tmp_t = ir.TensorType([d1, d512], DataType.FP32)
-    exe_t = ir.TensorType([d4], DataType.INT32)
 
     srcs = [ir.Var(f"s{i}", src_t, span) for i in range(4)]
-    tmp = ir.Var("tmp", tmp_t, span)
-    exe = ir.Var("exe", exe_t, span)
 
-    call = ir.op.tensor.mrgsort(*srcs, tmp, exe)
+    call = ir.op.tensor.mrgsort(*srcs)
     assert isinstance(call, ir.Call)
     assert call.op.name == "tensor.mrgsort_format2"
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
-    # Output shape matches tmp tensor's shape
+    # Output shape: last dim = sum of all src last dims (4 * 128 = 512)
     assert isinstance(result_type.shape[1], ir.ConstInt)
     assert result_type.shape[1].value == 512
 
@@ -1948,11 +1942,9 @@ def test_tensor_mrgsort_format2_dtype_mismatch():
     s1 = ir.Var("s1", src_fp16, span)
     s2 = ir.Var("s2", src_fp32, span)
     s3 = ir.Var("s3", src_fp32, span)
-    tmp = ir.Var("tmp", src_fp32, span)
-    exe = ir.Var("exe", src_fp32, span)
 
     with pytest.raises(Exception, match=r"matching dtype"):
-        ir.op.tensor.mrgsort(s0, s1, s2, s3, tmp, exe)
+        ir.op.tensor.mrgsort(s0, s1, s2, s3)
 
 
 def test_tensor_mrgsort_mixed_args_rejected():

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2640,7 +2640,7 @@ class TestConvertSortOps:
         ir.assert_structural_equal(After, Expected)
 
     def test_mrgsort_format2_conversion(self):
-        """tensor.mrgsort(s0..s3, tmp, exe) -> 6 tile.loads + tile.mrgsort_format2 + tile.store."""
+        """tensor.mrgsort(s0..s3) -> tile.loads + synthesized tile.create(tmp/executed) + tile.mrgsort_format2 + tile.store."""
 
         @pl.program
         class Before:
@@ -2651,10 +2651,8 @@ class TestConvertSortOps:
                 s1: pl.Tensor[[1, 128], pl.FP32],
                 s2: pl.Tensor[[1, 128], pl.FP32],
                 s3: pl.Tensor[[1, 128], pl.FP32],
-                tmp: pl.Tensor[[1, 512], pl.FP32],
-                exe: pl.Tensor[[4], pl.INT32],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
-                out: pl.Tensor[[1, 512], pl.FP32] = pl.tensor.mrgsort(s0, s1, s2, s3, tmp, exe)
+                out: pl.Tensor[[1, 512], pl.FP32] = pl.tensor.mrgsort(s0, s1, s2, s3)
                 return out
 
             @pl.function
@@ -2664,10 +2662,8 @@ class TestConvertSortOps:
                 s1: pl.Tensor[[1, 128], pl.FP32],
                 s2: pl.Tensor[[1, 128], pl.FP32],
                 s3: pl.Tensor[[1, 128], pl.FP32],
-                tmp: pl.Tensor[[1, 512], pl.FP32],
-                exe: pl.Tensor[[4], pl.INT32],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
-                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, tmp, exe)
+                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3)
                 return out
 
         @pl.program
@@ -2679,18 +2675,16 @@ class TestConvertSortOps:
                 s1: pl.Tensor[[1, 128], pl.FP32],
                 s2: pl.Tensor[[1, 128], pl.FP32],
                 s3: pl.Tensor[[1, 128], pl.FP32],
-                tmp: pl.Tensor[[1, 512], pl.FP32],
-                exe: pl.Tensor[[4], pl.INT32],
                 out_0: pl.Out[pl.Tensor[[1, 512], pl.FP32]],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
                 s0_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s0, [0, 0], [1, 128])
                 s1_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s1, [0, 0], [1, 128])
                 s2_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s2, [0, 0], [1, 128])
                 s3_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s3, [0, 0], [1, 128])
-                tmp_tile: pl.Tile[[1, 512], pl.FP32] = pl.load(tmp, [0, 0], [1, 512])
-                exe_tile: pl.Tile[[4], pl.INT32] = pl.load(exe, [0], [4])
+                mrgsort2_tmp: pl.Tile[[1, 512], pl.FP32] = pl.tile.create([1, 512], dtype=pl.FP32)
+                mrgsort2_executed: pl.Tile[[1, 4], pl.INT16] = pl.tile.create([1, 4], dtype=pl.INT16)
                 out_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
-                    s0_tile, s1_tile, s2_tile, s3_tile, tmp_tile, exe_tile
+                    s0_tile, s1_tile, s2_tile, s3_tile, mrgsort2_tmp, mrgsort2_executed
                 )
                 out_store: pl.Tensor[[1, 512], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
                 return out_store
@@ -2702,11 +2696,9 @@ class TestConvertSortOps:
                 s1: pl.Tensor[[1, 128], pl.FP32],
                 s2: pl.Tensor[[1, 128], pl.FP32],
                 s3: pl.Tensor[[1, 128], pl.FP32],
-                tmp: pl.Tensor[[1, 512], pl.FP32],
-                exe: pl.Tensor[[4], pl.INT32],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
                 out_0: pl.Tensor[[1, 512], pl.FP32] = pl.create_tensor([1, 512], dtype=pl.FP32)
-                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, tmp, exe, out_0)
+                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, out_0)
                 return out
 
         After = passes.convert_tensor_to_tile_ops()(Before)


### PR DESCRIPTION
## Summary
- Extend sort op support across tensor and tile layers, including a new tile-level merge sort (tmrgsort) lowering
- Update op definitions in IR, language DSL, and backend common, and register the tensor-to-tile conversion
- Add runtime system test and update related unit/transform tests

## Testing
- [ ] All tests pass
- [ ] Code review completed
- [ ] Documentation updated