### PR TITLE
feat(debug): add cross-core runtime support to torch_codegen

### DIFF
--- a/docs/en/dev/codegen/02-torch_codegen.md
+++ b/docs/en/dev/codegen/02-torch_codegen.md
@@ -1,0 +1,269 @@
+# Torch Code Generation (Torch Codegen)
+
+## Overview
+
+`torch_codegen` lowers PyPTO IR into an executable Python/PyTorch script that can be run with `exec()` for debugging and numerical validation.
+
+Unlike production codegen (PTO/Orchestration), `torch_codegen` is designed to:
+
+- quickly reproduce IR semantics,
+- expose intermediate behavior in Python,
+- provide executable references for pass debugging and system tests.
+
+**Source location:** `python/pypto/debug/torch_codegen.py`
+
+**Public entry API:**
+
+```python
+torch_codegen(node: _ir.Program | _ir.Function, check_shapes: bool = False) -> str
+```
+
+## Goals and Boundaries
+
+### Goals
+
+- Keep IR-to-Python expression/statement mapping readable.
+- Cover common tensor/tile operations.
+- Simulate concurrent cross-core `tpush/tpop` behavior.
+- Provide actionable diagnostics for suspicious inputs (timeouts, invalid split dimensions, etc.).
+
+### Non-goals
+
+- No performance optimization.
+- No cycle-accurate Ascend hardware timing/memory simulation.
+- Not a production backend for training/inference.
+
+## High-Level Architecture
+
+Generated code is assembled from three parts:
+
+1. **Runtime preamble (`_PREAMBLE`)**
+   Provides helpers, tile/tensor boundary handling, cross-core runtime, and mixed-kernel scheduler.
+2. **Group metadata injection (`_GROUP_META.update(...)`)**
+   Injected only when input is a `Program` and Group/AIC/AIV pairs are detected.
+3. **Function bodies**
+   Emitted by `TorchCodegen(IRVisitor)` function-by-function and statement-by-statement.
+
+Data flow:
+
+`Program/Function IR -> (optional _build_group_meta) -> TorchCodegen visitor emission -> final script string`
+
+## Expression and Statement Emission Model
+
+### Expression layer
+
+- `_OP_MAP` maps `op_name` to `OpHandler(args, kwargs) -> str`.
+- `_visit_expr_str()` forces nested `Call` nodes through Python-side `visit_call`, avoiding nested-call result loss in some C++ visitor paths.
+- Binary/unary IR nodes are emitted through `_BINARY_OP_STR` plus generic visitor adapters.
+
+### Statement layer
+
+- `AssignStmt`: `var = expr`
+- `EvalStmt`: emit expression as-is (for side-effect calls)
+- `ReturnStmt`: supports single and tuple returns
+- `ScopeStmt`: transparent passthrough
+- `ForStmt`/`WhileStmt`: lower SSA `iter_args + yield` into mutable variable updates
+- `IfStmt`: branch-local `yield` writes back to `return_vars`
+
+## Naming and Function Isolation
+
+`_unique_name()` normalizes variables by:
+
+- replacing non-identifier characters with `_`,
+- collapsing repeated underscores,
+- avoiding Python keywords and digit-leading names.
+
+`visit_function()` resets `_var_names/_name_counter/_yield_targets` per function to prevent cross-function name pollution when object IDs are reused.
+
+## Operation Mapping System (`_OP_MAP`)
+
+Mappings are registered by category:
+
+- tensor/tile elementwise, broadcast, reduction, logic, bitwise
+- `matmul/matmul_acc` and tile variants
+- `create/full/cast/slice/read/write/assemble/fillpad`
+- cross-core pipe operations
+- `system.*` operations (no-op in debug codegen)
+
+### Cross-core operation mappings
+
+- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split)`
+- `tile.tpush_to_aic` -> `_cross_core_rt.push_to_aic(tile, split)`
+- `tile.tpop_from_aic` -> `_cross_core_rt.pop_from_aic(split)`
+- `tile.tpop_from_aiv` -> `_cross_core_rt.pop_from_aiv(split)`
+- `tile.get_subblock_idx` -> `_get_subblock_idx()`
+
+`split` is normalized by `_split_mode_to_int()`:
+
+- `0`: NONE
+- `1`: UP_DOWN
+- `2`: LEFT_RIGHT
+- invalid/unparsable values: raise `ValueError` (fail fast)
+
+## Tile/Tensor Boundary and Valid-Region Semantics
+
+Helpers in `_PREAMBLE` define boundary behavior:
+
+- `_tile_load`: zero-pad to requested shape on OOB and attach valid region
+- `_tile_store`: store only the valid region
+- `_tensor_slice`: materialize requested shape even when slicing out-of-bounds
+- `_fillpad`: pad invalid area with `zero/min/max`
+- `_assemble`: write source valid region into target at offsets
+
+Valid region is propagated via dynamic attributes:
+
+- `_pypto_valid_shape`
+- `_pypto_full_shape`
+
+Cross-core queueing/split/merge paths preserve these attributes as well, so
+boundary-tile valid regions remain consistent through `tpush/tpop`.
+
+## Cross-Core Runtime Design
+
+### Structure
+
+`_CrossCoreRuntime` uses `threading.Condition` to implement blocking queue semantics.
+It maintains:
+
+- normal channels:
+  - to AIV: `_to_aiv` and `_to_aiv_split[split][lane]`
+  - to AIC: `_to_aic` and `_to_aic_split[split][lane]`
+- no-split dual-dispatch channels:
+  - to AIV: `_to_aiv_dual_nosplit[lane]`
+  - to AIC: `_to_aic_dual_nosplit[lane]`
+
+It also provides:
+
+- `reset(no_split_dual_aiv_dispatch=False)`: clear channels and configure no-split dual-dispatch mode before each mixed-group call
+- `snapshot()`: queue-depth snapshot for timeout diagnostics, including no-split dual-dispatch mode and dual-nosplit queue depths
+
+### Push/Pop semantics
+
+### `push_to_aiv(tile, split)` / `pop_from_aic(split)`
+
+- `split=0` and `no_split_dual_aiv_dispatch=False`: single queue
+- `split=0` and `no_split_dual_aiv_dispatch=True`:
+  - `push_to_aiv` broadcasts one tile copy to both lane queues
+  - `pop_from_aic` consumes from the current lane queue (`lane in {0,1}`)
+- `split=1/2`: push splits tile into lane0/lane1; pop consumes by current lane
+
+### `push_to_aic(tile, split)` / `pop_from_aiv(split)`
+
+- `split=0` and `no_split_dual_aiv_dispatch=False`: single queue
+- `split=0` and `no_split_dual_aiv_dispatch=True`:
+  - `push_to_aic` enqueues by current lane (`lane in {0,1}`)
+  - `pop_from_aiv` waits for both lane queues, then consumes a pair and returns lane0 payload
+- `split=1/2`: push enqueues by current lane; pop waits until both lanes are ready, then merges
+
+Split dimension semantics:
+
+- `split=1` (UP_DOWN): split/merge on `dim=0`
+- `split=2` (LEFT_RIGHT): split/merge on `dim=1`
+
+### Synchronization and timeouts
+
+- per-pop timeout: `_PIPE_WAIT_TIMEOUT_SEC` (default 10s)
+- mixed-kernel group timeout: `_MIXED_KERNEL_TIMEOUT_SEC` (default 30s)
+- on mixed-kernel timeout/failure, runtime signals cancellation and notifies
+  all waiters to avoid stale blocked threads polluting subsequent runs
+
+Timeout errors include:
+
+- operation name, split, lane
+- alive thread names (group timeout)
+- current pipe snapshot (queue depths)
+
+## Group Mixed-Kernel Concurrent Scheduler
+
+### Metadata construction (`_build_group_meta`)
+
+For each `FunctionType.Group` function in a `Program`, codegen pairs by naming convention:
+
+- `<group>_aic`
+- `<group>_aiv`
+
+Metadata fields:
+
+- `aic` / `aiv`: callee names
+- `split`: Group split first; fallback to AIV split when Group split is 0
+- `dual_aiv_dispatch`: read from AIV attrs; for `split==0`, this forces dual AIV-lane dispatch in debug runtime
+
+### Scheduler entry
+
+In `visit_call()`, for `GlobalVar` calls:
+
+- if name exists in `_group_meta`, emit `_run_group_call(group_name, *args)`
+- otherwise emit a normal direct function call
+
+`_run_group_call()` dispatches to `_run_mixed_kernels()` when metadata exists.
+
+### Thread model
+
+`_run_mixed_kernels(group_name, meta, *args)` behavior:
+
+- exactly 1 AIC thread
+- AIV thread count:
+  - `split in (1,2)` -> 2 lanes
+  - `split == 0 and dual_aiv_dispatch == True` -> 2 lanes
+  - `split == 0 and dual_aiv_dispatch == False` -> 1 lane
+- each thread writes thread-local `subblock_idx` (AIC uses 0, AIV uses lane id)
+- runtime mode switch:
+  - scheduler calls `reset(no_split_dual_aiv_dispatch=(split == 0 and dual_aiv_dispatch))`
+  - no-split dual-lane pipe semantics are enabled only when required by group metadata
+- return contract: only `aiv lane0` return value is propagated as Group return;
+  if other lanes/roles produce non-`None` returns, runtime raises a contract violation error
+
+## Shape/Type Checks (`check_shapes`)
+
+When `check_shapes=True`:
+
+- for function parameters: dtype check only, shape check disabled
+  - rationale: InCore parameters may be boundary tiles with partial data
+- for assignment targets: tensor type and dtype checks enabled; shape checks follow static/dynamic strategy
+
+Dynamic-dimension strategy:
+
+- if dimensions are not all static `ConstInt`, codegen checks `ndim` plus each static dimension index.
+
+## Error Handling and Observability
+
+Main error classes:
+
+- `TypeError`: invalid entry node type
+- `ValueError`: unsupported op, invalid split/lane, non-even split dimension
+- `RuntimeError`: pipe wait timeout, mixed-kernel thread failure/timeout
+
+For concurrency failures, codegen reports the first captured thread traceback to improve localization by function and lane.
+
+## Current Limitations
+
+- `system.*` ops are emitted as no-ops in debug mode
+- Group pairing relies on `<group>_aic/_aiv` naming convention
+- `split=1/2` requires the split dimension to be divisible by 2
+- Group return is fixed to AIV lane0 output
+- Runtime is a Python semantic simulator, not equivalent to hardware pipeline timing
+
+## Recommended Test Coverage
+
+Recommended coverage dimensions:
+
+- all split modes: `NONE/UP_DOWN/LEFT_RIGHT`
+- all communication directions: `V->C`, `C->V`, bidirectional `V<->C`
+- lane semantics via `tile.get_subblock_idx`
+- no-split + `dual_aiv_dispatch` lane behavior (`lane0` + `lane1`)
+- Group call rewrite path (`_run_group_call`)
+- timeout/error paths (for example, intentionally unpaired push/pop)
+
+References:
+
+- `tests/ut/debug/test_torch_codegen.py`
+- `tests/st/codegen/test_torch_codegen_cross_core.py`
+- `tests/st/codegen/test_torch_codegen_qwen3_decode_scope3_mixed.py`
+
+## Relation to Other Codegen Docs
+
+- This document: Python debug codegen (`torch_codegen`)
+- [00-pto_codegen.md](00-pto_codegen.md): PTO kernel codegen
+- [01-orchestration_codegen.md](01-orchestration_codegen.md): orchestration-side C++ codegen
+
+They are complementary: `torch_codegen` provides executable semantic reference, while PTO/Orchestration target production generation.

--- a/docs/zh-cn/dev/codegen/02-torch_codegen.md
+++ b/docs/zh-cn/dev/codegen/02-torch_codegen.md
@@ -1,0 +1,268 @@
+# Torch 代码生成（Torch Codegen）
+
+## 概述
+
+`torch_codegen` 将 PyPTO IR 直接生成为可 `exec()` 的 Python/PyTorch 脚本，用于调试与数值一致性验证。
+
+与生产代码生成（PTO/Orchestration）不同，`torch_codegen` 的核心目标是：
+
+- 快速复现 IR 语义
+- 在 Python 环境中观察中间行为
+- 为 Pass 调试和系统用例提供可执行参考
+
+**源码位置：** `python/pypto/debug/torch_codegen.py`
+
+**入口 API：**
+
+```python
+torch_codegen(node: _ir.Program | _ir.Function, check_shapes: bool = False) -> str
+```
+
+## 设计目标与边界
+
+### 设计目标
+
+- 保持 IR 到 Python 表达式/语句的可读映射
+- 尽量覆盖 tensor/tile 常见算子
+- 支持 cross-core `tpush/tpop` 的并发语义模拟
+- 对可疑输入提供可定位的错误信息（超时、split 维度不合法等）
+
+### 非目标
+
+- 不追求执行性能
+- 不模拟 Ascend 真实硬件时序和内存模型
+- 不作为训练/推理生产后端
+
+## 整体架构
+
+生成结果由三部分拼接而成：
+
+1. **运行时前导（`_PREAMBLE`）**
+   提供 helper 函数、tile/tensor 边界处理、cross-core 运行时和并发调度器。
+2. **Group 元信息注入（`_GROUP_META.update(...)`）**
+   仅当输入是 `Program` 且存在 Group/AIC/AIV 配对函数时注入。
+3. **函数体代码**
+   `TorchCodegen(IRVisitor)` 逐个函数、逐条语句发射 Python 代码。
+
+数据流：
+
+`Program/Function IR -> (可选 _build_group_meta) -> TorchCodegen 访存发射 -> 拼接成字符串脚本`
+
+## 表达式与语句生成模型
+
+### 表达式层
+
+- `_OP_MAP` 将 `op_name` 映射到 `OpHandler(args, kwargs) -> str`
+- `_visit_expr_str()` 强制嵌套 `Call` 走 Python 侧 `visit_call`，避免底层 C++ 访问器在嵌套调用时丢失表达式
+- 对二元/一元 IR 节点通过 `_BINARY_OP_STR` 与统一 visitor 适配方法生成
+
+### 语句层
+
+- `AssignStmt`：`var = expr`
+- `EvalStmt`：发射表达式本体（用于副作用调用）
+- `ReturnStmt`：支持单返回与多返回 tuple
+- `ScopeStmt`：透明展开
+- `ForStmt`/`WhileStmt`：将 SSA `iter_args + yield` 降为可变变量更新
+- `IfStmt`：分支内通过 `yield` 写回 `return_vars`
+
+## 命名与函数隔离
+
+变量命名通过 `_unique_name()` 做三类规整：
+
+- 非标识符字符替换为 `_`
+- 连续下划线折叠
+- 关键字与数字开头规避
+
+`visit_function()` 会重置 `_var_names/_name_counter/_yield_targets`。这是为了避免 Program 多函数场景下对象 id 复用导致的名字串扰。
+
+## 算子映射系统（`_OP_MAP`）
+
+算子映射按类别注册：
+
+- Tensor/Tile 通用逐元素、广播、规约、逻辑和位运算
+- `matmul/matmul_acc` 及其 tile 变体
+- `create/full/cast/slice/read/write/assemble/fillpad`
+- cross-core 管道操作
+- `system.*` 操作（调试场景下按 no-op 处理）
+
+### cross-core 相关映射
+
+- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split)`
+- `tile.tpush_to_aic` -> `_cross_core_rt.push_to_aic(tile, split)`
+- `tile.tpop_from_aic` -> `_cross_core_rt.pop_from_aic(split)`
+- `tile.tpop_from_aiv` -> `_cross_core_rt.pop_from_aiv(split)`
+- `tile.get_subblock_idx` -> `_get_subblock_idx()`
+
+`split` 参数统一通过 `_split_mode_to_int()` 归一化为整数：
+
+- `0`: NONE
+- `1`: UP_DOWN
+- `2`: LEFT_RIGHT
+- 非法或不可解析取值：抛出 `ValueError`（fail fast）
+
+## Tile/Tensor 边界与有效区语义
+
+`_PREAMBLE` 中的 helper 负责调试执行时的边界行为：
+
+- `_tile_load`：越界时按请求形状补零，并记录有效区
+- `_tile_store`：仅回写有效区
+- `_tensor_slice`：越界时物化到请求形状
+- `_fillpad`：按 `zero/min/max` 填充无效区域
+- `_assemble`：按偏移将 source 的有效区拼回 target
+
+有效区通过两个动态属性传播：
+
+- `_pypto_valid_shape`
+- `_pypto_full_shape`
+
+Cross-core 的入队/切分/合并路径同样会保留这两个属性，确保边界 tile
+在 `tpush/tpop` 过程中不丢失有效区语义。
+
+## Cross-Core 运行时设计
+
+### 结构
+
+`_CrossCoreRuntime` 基于 `threading.Condition` 实现阻塞队列语义，维护：
+
+- 常规通道：
+  - 发往 AIV：`_to_aiv` 与 `_to_aiv_split[split][lane]`
+  - 发往 AIC：`_to_aic` 与 `_to_aic_split[split][lane]`
+- no-split 双分发通道：
+  - 发往 AIV：`_to_aiv_dual_nosplit[lane]`
+  - 发往 AIC：`_to_aic_dual_nosplit[lane]`
+
+同时提供：
+
+- `reset(no_split_dual_aiv_dispatch=False)`：每次 Group 调度前清空通道，并配置 no-split 双分发模式
+- `snapshot()`：输出当前队列深度，用于超时诊断，包含 no-split 双分发模式与 dual-nosplit 队列深度
+
+### push/pop 语义
+
+### `push_to_aiv(tile, split)` / `pop_from_aic(split)`
+
+- `split=0` 且 `no_split_dual_aiv_dispatch=False`：单队列传输
+- `split=0` 且 `no_split_dual_aiv_dispatch=True`：
+  - `push_to_aiv` 会把同一 tile 复制后广播到 lane0/lane1 两路队列
+  - `pop_from_aic` 按当前 lane (`lane in {0,1}`) 从对应队列消费
+- `split=1/2`：push 时按 split 维度切成 lane0/lane1 两块；pop 按当前 lane 消费
+
+### `push_to_aic(tile, split)` / `pop_from_aiv(split)`
+
+- `split=0` 且 `no_split_dual_aiv_dispatch=False`：单队列传输
+- `split=0` 且 `no_split_dual_aiv_dispatch=True`：
+  - `push_to_aic` 按当前 lane (`lane in {0,1}`) 分路入队
+  - `pop_from_aiv` 等待两路都就绪后成对消费，并返回 lane0 的 payload
+- `split=1/2`：push 按当前 lane 入队；pop 端等待两路齐备后 merge 返回
+
+split 维度定义：
+
+- `split=1`（UP_DOWN）：按 `dim=0` 切分/拼接
+- `split=2`（LEFT_RIGHT）：按 `dim=1` 切分/拼接
+
+### 同步与超时
+
+- 单次 `pop` 等待超时：`_PIPE_WAIT_TIMEOUT_SEC`（默认 10s）
+- Group 混合核整体等待超时：`_MIXED_KERNEL_TIMEOUT_SEC`（默认 30s）
+- Group 超时/失败时，运行时会发出取消信号并唤醒全部等待线程，
+  避免阻塞线程污染后续调度
+
+超时异常会包含：
+
+- 操作名、split、lane
+- 活跃线程名（Group 超时）
+- 当前 pipe 快照（队列深度）
+
+## Group 混合核并发调度
+
+### 元信息构建（`_build_group_meta`）
+
+对 Program 扫描 `FunctionType.Group` 函数，并按命名约定配对：
+
+- `<group>_aic`
+- `<group>_aiv`
+
+元信息字段：
+
+- `aic` / `aiv`：对应函数名
+- `split`：优先取 Group 的 split；若为 0，则回退 AIV 的 split
+- `dual_aiv_dispatch`：从 AIV attrs 读取；当 `split==0` 时，该标记会强制 debug 运行时按双 AIV lane 调度
+
+### 调度入口
+
+`visit_call()` 遇到 `GlobalVar` 调用时：
+
+- 若命中 `_group_meta`，改写为 `_run_group_call(group_name, *args)`
+- 否则保持普通函数调用
+
+`_run_group_call()` 在有 meta 时走 `_run_mixed_kernels()`。
+
+### 线程模型
+
+`_run_mixed_kernels(group_name, meta, *args)` 行为：
+
+- 固定 1 个 AIC 线程
+- AIV 线程数：
+  - `split in (1,2)` -> 2 lane
+  - `split == 0 and dual_aiv_dispatch == True` -> 2 lane
+  - `split == 0 and dual_aiv_dispatch == False` -> 1 lane
+- 每线程写入 thread-local `subblock_idx`（AIC 设为 0，AIV 为 lane id）
+- 运行时模式切换：
+  - 调度器调用 `reset(no_split_dual_aiv_dispatch=(split == 0 and dual_aiv_dispatch))`
+  - 仅在 group meta 指定时启用 no-split 双 lane pipe 语义
+- 返回值约定：仅采集 `aiv lane0` 的返回作为 Group 返回值；
+  若其他 lane/role 产生非 `None` 返回，会抛出返回契约错误
+
+## 形状/类型检查（`check_shapes`）
+
+开启 `check_shapes=True` 时：
+
+- 对函数参数：只检查 dtype，不检查 shape
+  - 原因：InCore 参数在边界 tile 场景可能是部分数据
+- 对赋值目标：检查 tensor 类型与 dtype；shape 按静态/动态维分别检查
+
+动态维策略：
+
+- 若并非全静态 `ConstInt`，则检查 `ndim` + 静态维位置值
+
+## 错误处理与可观测性
+
+主要错误类型：
+
+- `TypeError`：入口 node 类型错误
+- `ValueError`：不支持的 op、非法 split、lane 不合法、split 维度不可二分
+- `RuntimeError`：pipe 等待超时、混合核线程失败/超时
+
+并发失败时保留首个线程 traceback，便于快速定位具体函数和 lane。
+
+## 当前限制
+
+- `system.*` 操作按 no-op 处理，仅保留语义占位
+- Group 配对依赖命名约定 `<group>_aic/_aiv`
+- `split=1/2` 依赖对应切分维度可被 2 整除
+- Group 返回值固定取 AIV lane0
+- 该运行时为单机 Python 语义模拟，不等价于硬件流水线时序
+
+## 测试建议与覆盖点
+
+建议至少覆盖以下维度：
+
+- 三类 split：`NONE/UP_DOWN/LEFT_RIGHT`
+- 三类方向：`V->C`、`C->V`、双向 `V<->C`
+- `tile.get_subblock_idx` lane 语义
+- `split=0 + dual_aiv_dispatch` 下的双 lane 行为（`lane0` + `lane1`）
+- Group 调度路径是否改写为 `_run_group_call`
+- 超时和异常路径（必要时通过构造不配对 push/pop）
+
+可参考：
+
+- `tests/ut/debug/test_torch_codegen.py`
+- `tests/st/codegen/test_torch_codegen_cross_core.py`
+- `tests/st/codegen/test_torch_codegen_qwen3_decode_scope3_mixed.py`
+
+## 与其它代码生成文档的关系
+
+- 本文档：Python 调试代码生成（`torch_codegen`）
+- [00-pto_codegen.md](00-pto_codegen.md)：PTO 内核代码生成
+- [01-orchestration_codegen.md](01-orchestration_codegen.md)：编排侧 C++ 代码生成
+
+三者职责互补：`torch_codegen` 负责“可执行语义对照”，PTO/Orchestration 负责“生产链路生成”。

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -59,9 +59,372 @@ _CMP_OPS: dict[int, str] = {
 # ---------------------------------------------------------------------------
 _PREAMBLE = """\
 import torch
+import threading
+import time
+import traceback
 from collections import deque
 
-_pipes = {'to_aiv': deque(), 'to_aic': deque()}
+_PIPE_WAIT_TIMEOUT_SEC = 10.0
+_MIXED_KERNEL_TIMEOUT_SEC = 30.0
+
+_GROUP_META = {}
+_thread_local = threading.local()
+_runtime_cancel_event = None
+
+
+def _set_subblock_idx(idx):
+    _thread_local.subblock_idx = int(idx)
+
+
+def _get_subblock_idx():
+    return int(getattr(_thread_local, "subblock_idx", 0))
+
+
+def _set_runtime_cancel_event(event):
+    global _runtime_cancel_event
+    _runtime_cancel_event = event
+
+
+def _get_runtime_cancel_event():
+    return _runtime_cancel_event
+
+
+def _copy_region_attrs(src, dst):
+    valid_shape = getattr(src, "_pypto_valid_shape", None)
+    full_shape = getattr(src, "_pypto_full_shape", None)
+    if valid_shape is not None:
+        dst._pypto_valid_shape = tuple(int(s) for s in valid_shape)
+    if full_shape is not None:
+        dst._pypto_full_shape = tuple(int(s) for s in full_shape)
+    return dst
+
+
+class _CrossCoreRuntime:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._cv = threading.Condition(self._lock)
+        self.reset()
+
+    def reset(self, no_split_dual_aiv_dispatch=False):
+        with self._cv:
+            self._no_split_dual_aiv_dispatch = bool(no_split_dual_aiv_dispatch)
+            self._to_aiv = deque()
+            self._to_aiv_split = {1: {0: deque(), 1: deque()}, 2: {0: deque(), 1: deque()}}
+            self._to_aiv_dual_nosplit = {0: deque(), 1: deque()}
+            self._to_aic = deque()
+            self._to_aic_split = {1: {0: deque(), 1: deque()}, 2: {0: deque(), 1: deque()}}
+            self._to_aic_dual_nosplit = {0: deque(), 1: deque()}
+            self._cv.notify_all()
+
+    def snapshot(self):
+        with self._lock:
+            return self._snapshot_locked()
+
+    def notify_all(self):
+        with self._cv:
+            self._cv.notify_all()
+
+    def _snapshot_locked(self):
+        return {
+            "no_split_dual_aiv_dispatch": self._no_split_dual_aiv_dispatch,
+            "to_aiv": len(self._to_aiv),
+            "to_aiv_dual_nosplit": {
+                0: len(self._to_aiv_dual_nosplit[0]),
+                1: len(self._to_aiv_dual_nosplit[1]),
+            },
+            "to_aiv_split": {
+                1: {0: len(self._to_aiv_split[1][0]), 1: len(self._to_aiv_split[1][1])},
+                2: {0: len(self._to_aiv_split[2][0]), 1: len(self._to_aiv_split[2][1])},
+            },
+            "to_aic": len(self._to_aic),
+            "to_aic_dual_nosplit": {
+                0: len(self._to_aic_dual_nosplit[0]),
+                1: len(self._to_aic_dual_nosplit[1]),
+            },
+            "to_aic_split": {
+                1: {0: len(self._to_aic_split[1][0]), 1: len(self._to_aic_split[1][1])},
+                2: {0: len(self._to_aic_split[2][0]), 1: len(self._to_aic_split[2][1])},
+            },
+        }
+
+    def _wait_for_locked(self, predicate, op_name, split, lane):
+        deadline = time.monotonic() + _PIPE_WAIT_TIMEOUT_SEC
+        while not predicate():
+            cancel_event = _get_runtime_cancel_event()
+            if cancel_event is not None and cancel_event.is_set():
+                raise RuntimeError(
+                    f"{op_name} cancelled (split={split}, lane={lane}); "
+                    f"pipe_state={self._snapshot_locked()}"
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"{op_name} timeout (split={split}, lane={lane}); "
+                    f"pipe_state={self._snapshot_locked()}"
+                )
+            self._cv.wait(timeout=min(0.05, remaining))
+
+    @staticmethod
+    def _split_tile(tile, split):
+        dim = 0 if split == 1 else 1
+        size = int(tile.shape[dim])
+        if size % 2 != 0:
+            raise ValueError(f"Split mode {split} requires even dimension size, got {size}")
+        half = size // 2
+        if dim == 0:
+            part0 = tile[:half, ...].clone()
+            part1 = tile[half:, ...].clone()
+        else:
+            part0 = tile[:, :half, ...].clone()
+            part1 = tile[:, half:, ...].clone()
+
+        full_shape = getattr(tile, "_pypto_full_shape", None)
+        if full_shape is not None:
+            full0 = list(int(s) for s in full_shape)
+            full1 = list(int(s) for s in full_shape)
+            full0[dim] = min(full0[dim], half)
+            full1[dim] = max(full1[dim] - half, 0)
+            part0._pypto_full_shape = tuple(full0)
+            part1._pypto_full_shape = tuple(full1)
+
+        valid_shape = getattr(tile, "_pypto_valid_shape", None)
+        if valid_shape is not None:
+            valid0 = list(int(s) for s in valid_shape)
+            valid1 = list(int(s) for s in valid_shape)
+            valid0[dim] = min(valid0[dim], half)
+            valid1[dim] = max(valid1[dim] - half, 0)
+            part0._pypto_valid_shape = tuple(valid0)
+            part1._pypto_valid_shape = tuple(valid1)
+
+        return part0, part1
+
+    @staticmethod
+    def _merge_tile(part0, part1, split):
+        dim = 0 if split == 1 else 1
+        merged = torch.cat([part0, part1], dim=dim)
+
+        full0 = getattr(part0, "_pypto_full_shape", tuple(part0.shape))
+        full1 = getattr(part1, "_pypto_full_shape", tuple(part1.shape))
+        if len(full0) == len(full1):
+            merged_full = list(int(s) for s in full0)
+            merged_full[dim] = int(full0[dim]) + int(full1[dim])
+            merged._pypto_full_shape = tuple(merged_full)
+
+        valid0 = getattr(part0, "_pypto_valid_shape", tuple(part0.shape))
+        valid1 = getattr(part1, "_pypto_valid_shape", tuple(part1.shape))
+        if len(valid0) == len(valid1):
+            merged_valid = list(int(s) for s in valid0)
+            merged_valid[dim] = int(valid0[dim]) + int(valid1[dim])
+            full_shape = getattr(merged, "_pypto_full_shape", None)
+            if full_shape is not None:
+                merged_valid = [min(v, int(f)) for v, f in zip(merged_valid, full_shape)]
+            merged._pypto_valid_shape = tuple(merged_valid)
+
+        return merged
+
+    def push_to_aiv(self, tile, split):
+        split = int(split)
+        with self._cv:
+            if split == 0:
+                if self._no_split_dual_aiv_dispatch:
+                    self._to_aiv_dual_nosplit[0].append(_copy_region_attrs(tile, tile.clone()))
+                    self._to_aiv_dual_nosplit[1].append(_copy_region_attrs(tile, tile.clone()))
+                else:
+                    self._to_aiv.append(_copy_region_attrs(tile, tile.clone()))
+            elif split in (1, 2):
+                lane0, lane1 = self._split_tile(tile, split)
+                self._to_aiv_split[split][0].append(lane0)
+                self._to_aiv_split[split][1].append(lane1)
+            else:
+                raise ValueError(f"Unsupported split mode for push_to_aiv: {split}")
+            self._cv.notify_all()
+
+    def pop_from_aic(self, split):
+        split = int(split)
+        lane = _get_subblock_idx()
+        with self._cv:
+            if split == 0:
+                if self._no_split_dual_aiv_dispatch:
+                    if lane not in (0, 1):
+                        raise ValueError(
+                            f"No-split dual-dispatch tpop_from_aic requires lane in {{0,1}}, got {lane}"
+                        )
+                    queue = self._to_aiv_dual_nosplit[lane]
+                    self._wait_for_locked(lambda: len(queue) > 0, "tpop_from_aic", split, lane)
+                    return queue.popleft()
+                self._wait_for_locked(lambda: len(self._to_aiv) > 0, "tpop_from_aic", split, lane)
+                return self._to_aiv.popleft()
+            if split in (1, 2):
+                if lane not in (0, 1):
+                    raise ValueError(f"Split tpop_from_aic requires lane in {{0,1}}, got {lane}")
+                queue = self._to_aiv_split[split][lane]
+                self._wait_for_locked(lambda: len(queue) > 0, "tpop_from_aic", split, lane)
+                return queue.popleft()
+            raise ValueError(f"Unsupported split mode for pop_from_aic: {split}")
+
+    def push_to_aic(self, tile, split):
+        split = int(split)
+        lane = _get_subblock_idx()
+        with self._cv:
+            if split == 0:
+                if self._no_split_dual_aiv_dispatch:
+                    if lane not in (0, 1):
+                        raise ValueError(
+                            f"No-split dual-dispatch tpush_to_aic requires lane in {{0,1}}, got {lane}"
+                        )
+                    self._to_aic_dual_nosplit[lane].append(_copy_region_attrs(tile, tile.clone()))
+                else:
+                    self._to_aic.append(_copy_region_attrs(tile, tile.clone()))
+            elif split in (1, 2):
+                if lane not in (0, 1):
+                    raise ValueError(f"Split tpush_to_aic requires lane in {{0,1}}, got {lane}")
+                self._to_aic_split[split][lane].append(_copy_region_attrs(tile, tile.clone()))
+            else:
+                raise ValueError(f"Unsupported split mode for push_to_aic: {split}")
+            self._cv.notify_all()
+
+    def pop_from_aiv(self, split):
+        split = int(split)
+        lane = _get_subblock_idx()
+        with self._cv:
+            if split == 0:
+                if self._no_split_dual_aiv_dispatch:
+                    lane0_q = self._to_aic_dual_nosplit[0]
+                    lane1_q = self._to_aic_dual_nosplit[1]
+                    self._wait_for_locked(
+                        lambda: len(lane0_q) > 0 and len(lane1_q) > 0,
+                        "tpop_from_aiv",
+                        split,
+                        lane,
+                    )
+                    lane0_tile = lane0_q.popleft()
+                    lane1_q.popleft()
+                    return lane0_tile
+                self._wait_for_locked(lambda: len(self._to_aic) > 0, "tpop_from_aiv", split, lane)
+                return self._to_aic.popleft()
+            if split in (1, 2):
+                lane0_q = self._to_aic_split[split][0]
+                lane1_q = self._to_aic_split[split][1]
+                self._wait_for_locked(
+                    lambda: len(lane0_q) > 0 and len(lane1_q) > 0,
+                    "tpop_from_aiv",
+                    split,
+                    lane,
+                )
+                part0 = lane0_q.popleft()
+                part1 = lane1_q.popleft()
+                return self._merge_tile(part0, part1, split)
+            raise ValueError(f"Unsupported split mode for pop_from_aiv: {split}")
+
+
+_cross_core_rt = _CrossCoreRuntime()
+
+
+def _run_mixed_kernels(group_name, meta, *args):
+    aic_name = meta["aic"]
+    aiv_name = meta["aiv"]
+    split = int(meta.get("split", 0))
+    dual_aiv_dispatch = bool(meta.get("dual_aiv_dispatch", False))
+    num_aiv_lanes = 2 if split in (1, 2) or dual_aiv_dispatch else 1
+
+    _cross_core_rt.reset(no_split_dual_aiv_dispatch=(split == 0 and dual_aiv_dispatch))
+    aic_fn = globals().get(aic_name)
+    aiv_fn = globals().get(aiv_name)
+    if aic_fn is None or aiv_fn is None:
+        raise RuntimeError(
+            f"Mixed-kernel function lookup failed for {group_name}: "
+            f"aic={aic_name!r}, aiv={aiv_name!r}"
+        )
+
+    run_cancel = threading.Event()
+    _set_runtime_cancel_event(run_cancel)
+    failures = []
+    failure_lock = threading.Lock()
+    results = {}
+    results_lock = threading.Lock()
+
+    def _runner(func, func_name, role, lane):
+        try:
+            _set_subblock_idx(0 if lane is None else lane)
+            value = func(*args)
+            with results_lock:
+                results[(role, lane)] = value
+        except Exception:
+            if run_cancel.is_set():
+                return
+            with failure_lock:
+                failures.append((func_name, lane, traceback.format_exc()))
+        finally:
+            _set_subblock_idx(0)
+
+    try:
+        threads = [
+            threading.Thread(
+                target=_runner,
+                args=(aic_fn, aic_name, "aic", None),
+                name=f"{group_name}-aic",
+            )
+        ]
+        for lane in range(num_aiv_lanes):
+            threads.append(
+                threading.Thread(
+                    target=_runner,
+                    args=(aiv_fn, aiv_name, "aiv", lane),
+                    name=f"{group_name}-aiv-lane{lane}",
+                )
+            )
+
+        for t in threads:
+            t.start()
+
+        deadline = time.monotonic() + _MIXED_KERNEL_TIMEOUT_SEC
+        for t in threads:
+            remaining = max(0.0, deadline - time.monotonic())
+            t.join(timeout=remaining)
+
+        alive = [t.name for t in threads if t.is_alive()]
+        timed_out = len(alive) > 0
+
+        if timed_out or failures:
+            run_cancel.set()
+            _cross_core_rt.notify_all()
+            for t in threads:
+                if t.is_alive():
+                    t.join(timeout=0.2)
+
+        if timed_out:
+            alive_after_cancel = [t.name for t in threads if t.is_alive()]
+            if alive_after_cancel:
+                alive = alive_after_cancel
+            raise RuntimeError(
+                f"Mixed-kernel execution timeout for {group_name}; "
+                f"alive_threads={alive}; pipe_state={_cross_core_rt.snapshot()}"
+            )
+        if failures:
+            fn, lane, tb = failures[0]
+            raise RuntimeError(
+                f"Mixed-kernel execution failed in {fn} (lane={lane}) for {group_name}\\n{tb}"
+            )
+
+        if ("aiv", 0) in results:
+            return results[("aiv", 0)]
+        non_none_keys = [f"{role}:{lane}" for (role, lane), value in results.items() if value is not None]
+        if non_none_keys:
+            raise RuntimeError(
+                f"Mixed-kernel return contract violation for {group_name}; "
+                f"expected aiv lane 0, got non-None returns from {non_none_keys}"
+            )
+        return None
+    finally:
+        _set_runtime_cancel_event(None)
+        _set_subblock_idx(0)
+
+
+def _run_group_call(group_name, *args):
+    meta = _GROUP_META.get(group_name)
+    if meta is None:
+        return globals()[group_name](*args)
+    return _run_mixed_kernels(group_name, meta, *args)
 
 def _coerce_shape(shape):
     return tuple(int(s) for s in shape)
@@ -303,6 +666,68 @@ def _handle_fillpad(a: list[str], kw: dict[str, Any]) -> str:
     return f"_fillpad({a[0]}, {_pad_mode_literal(kw)})"
 
 
+def _split_mode_to_int(split_mode: Any) -> int:
+    if split_mode is None:
+        return 0
+    if isinstance(split_mode, int):
+        return int(split_mode)
+    value = getattr(split_mode, "value", None)
+    if value is not None:
+        return int(value)
+    try:
+        return int(split_mode)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid split mode: {split_mode!r}") from exc
+
+
+def _split_kwarg(kw: dict[str, Any]) -> int:
+    return _split_mode_to_int(kw.get("split", 0))
+
+
+def _handle_tpush_to_aiv(a: list[str], kw: dict[str, Any]) -> str:
+    return f"_cross_core_rt.push_to_aiv({a[0]}, {_split_kwarg(kw)})"
+
+
+def _handle_tpush_to_aic(a: list[str], kw: dict[str, Any]) -> str:
+    return f"_cross_core_rt.push_to_aic({a[0]}, {_split_kwarg(kw)})"
+
+
+def _handle_tpop_from_aic(_a: list[str], kw: dict[str, Any]) -> str:
+    return f"_cross_core_rt.pop_from_aic({_split_kwarg(kw)})"
+
+
+def _handle_tpop_from_aiv(_a: list[str], kw: dict[str, Any]) -> str:
+    return f"_cross_core_rt.pop_from_aiv({_split_kwarg(kw)})"
+
+
+def _build_group_meta(program: _ir.Program) -> dict[str, dict[str, Any]]:
+    funcs_by_name = {func.name: func for func in program.functions.values()}
+    group_meta: dict[str, dict[str, Any]] = {}
+
+    for func in program.functions.values():
+        if func.func_type != _ir.FunctionType.Group:
+            continue
+
+        aic_name = f"{func.name}_aic"
+        aiv_name = f"{func.name}_aiv"
+        if aic_name not in funcs_by_name or aiv_name not in funcs_by_name:
+            continue
+
+        aiv_func = funcs_by_name[aiv_name]
+        split = _split_mode_to_int(func.split)
+        if split == 0:
+            split = _split_mode_to_int(aiv_func.split)
+        dual_aiv_dispatch = bool(getattr(aiv_func, "attrs", {}).get("dual_aiv_dispatch", False))
+        group_meta[func.name] = {
+            "aic": aic_name,
+            "aiv": aiv_name,
+            "split": split,
+            "dual_aiv_dispatch": dual_aiv_dispatch,
+        }
+
+    return group_meta
+
+
 # Build the dispatch table
 _OP_MAP: dict[str, OpHandler] = {}
 
@@ -445,10 +870,11 @@ def _register_ops() -> None:
     m["tile.subsc"] = lambda a, _kw: f"({a[0]} - {a[1]} - {a[2]})"
 
     # --- Cross-core pipe ops ---
-    m["tile.tpush_to_aiv"] = lambda a, _kw: f"_pipes['to_aiv'].append({a[0]}.clone())"
-    m["tile.tpush_to_aic"] = lambda a, _kw: f"_pipes['to_aic'].append({a[0]}.clone())"
-    m["tile.tpop_from_aic"] = lambda _a, _kw: "_pipes['to_aic'].popleft()"
-    m["tile.tpop_from_aiv"] = lambda _a, _kw: "_pipes['to_aiv'].popleft()"
+    m["tile.tpush_to_aiv"] = _handle_tpush_to_aiv
+    m["tile.tpush_to_aic"] = _handle_tpush_to_aic
+    m["tile.tpop_from_aic"] = _handle_tpop_from_aic
+    m["tile.tpop_from_aiv"] = _handle_tpop_from_aiv
+    m["tile.get_subblock_idx"] = lambda _a, _kw: "_get_subblock_idx()"
 
     # --- System ops (no-ops) ---
     for op_name in (
@@ -508,15 +934,24 @@ _BINARY_OP_STR: dict[type, str] = {
 class TorchCodegen(_ir.IRVisitor):
     """Emit executable PyTorch code from PyPTO IR."""
 
-    def __init__(self, *, check_shapes: bool = False) -> None:
+    def __init__(
+        self, *, check_shapes: bool = False, group_meta: dict[str, dict[str, Any]] | None = None
+    ) -> None:
         super().__init__()
         self._lines: list[str] = []
         self._indent: int = 0
         self._expr_result: str = ""
-        self._var_names: dict[int, str] = {}  # id(Var) -> unique name
+        # Fast-path name cache keyed by Python wrapper id.
+        self._var_names_by_id: dict[int, str] = {}
+        # Stable name cache keyed by semantic variable identity.
+        self._var_names_by_key: dict[tuple[Any, ...], str] = {}
+        # Keep wrapper refs alive during one function emission to avoid Python
+        # reusing object ids for short-lived nanobind wrappers.
+        self._seen_var_refs: list[_ir.Var] = []
         self._name_counter: dict[str, int] = {}
         self._yield_targets: list[str] = []  # names to assign on yield
         self._check_shapes: bool = check_shapes
+        self._group_meta: dict[str, dict[str, Any]] = group_meta or {}
 
     # -- helpers --
 
@@ -543,10 +978,47 @@ class TorchCodegen(_ir.IRVisitor):
         return f"{base}_{count}"
 
     def _name_of(self, var: _ir.Var) -> str:
+        key = self._var_semantic_key(var)
         vid = id(var)
-        if vid not in self._var_names:
-            self._var_names[vid] = self._unique_name(var.name_hint)
-        return self._var_names[vid]
+        if vid in self._var_names_by_id:
+            return self._var_names_by_id[vid]
+
+        if key in self._var_names_by_key:
+            name = self._var_names_by_key[key]
+        else:
+            name = self._unique_name(var.name_hint)
+            self._var_names_by_key[key] = name
+
+        self._var_names_by_id[vid] = name
+        self._seen_var_refs.append(var)
+        return name
+
+    @staticmethod
+    def _var_semantic_key(var: _ir.Var) -> tuple[Any, ...]:
+        """Build a stable key for nanobind-backed IR vars.
+
+        IR callbacks may wrap the same underlying C++ Var with different Python
+        objects, so ``id(var)`` alone is not stable across visits. We key by
+        semantic fields that remain stable across wrappers.
+        """
+        span = getattr(var, "span", None)
+        span_key: tuple[Any, ...] | None = None
+        if span is not None and getattr(span, "is_valid", False):
+            span_key = (
+                getattr(span, "filename", ""),
+                int(getattr(span, "begin_line", 0)),
+                int(getattr(span, "begin_column", 0)),
+                int(getattr(span, "end_line", 0)),
+                int(getattr(span, "end_column", 0)),
+            )
+
+        var_type = getattr(var, "type", None)
+        return (
+            type(var).__name__,
+            getattr(var, "name_hint", ""),
+            span_key,
+            str(var_type) if var_type is not None else "",
+        )
 
     def _visit_expr_str(self, expr: _ir.Expr) -> str:
         # Force nested Call nodes through our Python visit_call implementation.
@@ -577,7 +1049,9 @@ class TorchCodegen(_ir.IRVisitor):
     def _alias_return_vars(self, return_vars: list[_ir.Var], names: list[str]) -> None:
         """Map return_vars to the same names as iter_args after a loop."""
         for rv, name in zip(return_vars, names):
-            self._var_names[id(rv)] = name
+            self._var_names_by_id[id(rv)] = name
+            self._var_names_by_key[self._var_semantic_key(rv)] = name
+            self._seen_var_refs.append(rv)
 
     # -- top-level --
 
@@ -586,6 +1060,14 @@ class TorchCodegen(_ir.IRVisitor):
             self.visit_function(func)
 
     def visit_function(self, func: _ir.Function) -> None:
+        # Keep names function-local. IR may reuse object ids across functions;
+        # sharing maps at program scope can emit stale names.
+        self._var_names_by_id = {}
+        self._var_names_by_key = {}
+        self._seen_var_refs = []
+        self._name_counter = {}
+        self._yield_targets = []
+
         params = [self._name_of(p) for p in func.params]
         self._emit(f"def {func.name}({', '.join(params)}):")
         self._indent += 1
@@ -667,7 +1149,14 @@ class TorchCodegen(_ir.IRVisitor):
             self._expr_result = handler(arg_strs, kw)
         elif isinstance(op.op, _ir.GlobalVar):
             # Cross-function call
-            self._expr_result = f"{op_name}({', '.join(arg_strs)})"
+            if op_name in self._group_meta:
+                args_str = ", ".join(arg_strs)
+                if args_str:
+                    self._expr_result = f"_run_group_call('{op_name}', {args_str})"
+                else:
+                    self._expr_result = f"_run_group_call('{op_name}')"
+            else:
+                self._expr_result = f"{op_name}({', '.join(arg_strs)})"
         else:
             raise ValueError(
                 f"Unsupported op '{op_name}' in torch_codegen. "
@@ -887,8 +1376,15 @@ def torch_codegen(node: _ir.Program | _ir.Function, *, check_shapes: bool = Fals
     Returns:
         String of executable Python/PyTorch code
     """
-    cg = TorchCodegen(check_shapes=check_shapes)
+    group_meta: dict[str, dict[str, Any]] = {}
+    if isinstance(node, _ir.Program):
+        group_meta = _build_group_meta(node)
+
+    cg = TorchCodegen(check_shapes=check_shapes, group_meta=group_meta)
     lines = [_PREAMBLE]
+    if group_meta:
+        lines.append(f"_GROUP_META.update({group_meta!r})")
+        lines.append("")
 
     if isinstance(node, _ir.Program):
         cg.visit_program(node)

--- a/tests/st/codegen/test_torch_codegen_cross_core.py
+++ b/tests/st/codegen/test_torch_codegen_cross_core.py
@@ -1,0 +1,382 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""System tests for torch codegen on cross-core tpush/tpop scenarios.
+
+Generates executable PyTorch code from cross-core IR via torch_codegen,
+runs it with test tensors, and compares outputs to the golden reference.
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, platform_to_backend
+from pypto import ir as _ir
+from pypto.backend import reset_for_testing, set_backend_type
+from pypto.debug import torch_codegen
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+
+M = 32
+K = 64
+N = 512
+N_BLOCK = 64
+N_BLOCKS = N // N_BLOCK
+
+
+@pl.program
+class V2CUDProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[32, 32], pl.FP32],
+        b: pl.Tensor[[32, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
+            a_plus_b = pl.add(a, b)
+            sub = pl.sub(a, b)
+            out = pl.matmul(a_plus_b, sub)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class V2CLRProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[32, 32], pl.FP32],
+        b: pl.Tensor[[32, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
+            a_plus_b = pl.add(a, b)
+            sub = pl.sub(a, b)
+            out = pl.matmul(a_plus_b, sub)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class V2CNoSplitProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[32, 32], pl.FP32],
+        b: pl.Tensor[[32, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+        ):
+            a_plus_b = pl.add(a, b)
+            sub = pl.sub(a, b)
+            out = pl.matmul(a_plus_b, sub)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class C2VLRProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+@pl.program
+class C2VUDProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+@pl.program
+class C2VNoSplitProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+@pl.program
+class BiDirectUDProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                a_add = pl.add(a, 1.0)
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a_add, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+@pl.program
+class BiDirectLRProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                a_add = pl.add(a, 1.0)
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a_add, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+@pl.program
+class BiDirectNoSplitProgram:
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        c: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+        ):
+            for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
+                n0 = nb * N_BLOCK
+                c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
+                a_add = pl.add(a, 1.0)
+                b_chunk = pl.slice(b, [K, N_BLOCK], [0, n0])
+                c_next = pl.add(c_prev, pl.matmul(a_add, b_chunk))
+                c = pl.assemble(c, c_next, [0, n0])
+        return c
+
+
+def _build_v2c_tensors() -> dict[str, torch.Tensor]:
+    return {
+        "a": torch.randn(32, 32, dtype=torch.float32),
+        "b": torch.randn(32, 32, dtype=torch.float32),
+        "output": torch.zeros(32, 32, dtype=torch.float32),
+    }
+
+
+def _build_c2v_tensors() -> dict[str, torch.Tensor]:
+    return {
+        "a": torch.randn(M, K, dtype=torch.float32),
+        "b": torch.randn(K, N, dtype=torch.float32),
+        "c": torch.randn(M, N, dtype=torch.float32),
+    }
+
+
+def _golden_v2c(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    tensors["output"][:] = torch.matmul(tensors["a"] + tensors["b"], tensors["a"] - tensors["b"])
+    return tensors["output"]
+
+
+def _golden_c2v(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    c_prev = tensors["c"].clone()
+    tensors["c"][:] = c_prev + torch.matmul(tensors["a"], tensors["b"])
+    return tensors["c"]
+
+
+def _golden_bidirect(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    c_prev = tensors["c"].clone()
+    tensors["c"][:] = c_prev + torch.matmul(tensors["a"] + 1, tensors["b"])
+    return tensors["c"]
+
+
+def _run_codegen_and_check(
+    program: _ir.Program | _ir.Function,
+    tensors: dict[str, torch.Tensor],
+    arg_order: list[str],
+    out_name: str,
+    expected: torch.Tensor,
+) -> None:
+    code = torch_codegen(program, check_shapes=True)
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+
+    args = [tensors[name] for name in arg_order]
+    result = ns["main"](*args)
+    actual = tensors[out_name]
+
+    assert torch.allclose(actual, expected, rtol=5e-2, atol=5e-2), (
+        f"max abs diff = {(expected - actual).abs().max().item():.6e}"
+    )
+    if isinstance(result, torch.Tensor):
+        assert torch.allclose(result, expected, rtol=5e-2, atol=5e-2), (
+            f"returned tensor max abs diff = {(expected - result).abs().max().item():.6e}"
+        )
+
+
+def _run_codegen_after_default_pass_and_check(
+    program: _ir.Program | _ir.Function,
+    tensors: dict[str, torch.Tensor],
+    arg_order: list[str],
+    out_name: str,
+    expected: torch.Tensor,
+    platform: str,
+) -> None:
+    backend_type = platform_to_backend(platform)
+
+    reset_for_testing()
+    set_backend_type(backend_type)
+    try:
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+        code = torch_codegen(transformed, check_shapes=True)
+    finally:
+        reset_for_testing()
+
+    assert "_cross_core_rt.push_to_" in code
+    assert "_cross_core_rt.pop_from_" in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+
+    args = [tensors[name] for name in arg_order]
+    result = ns["main"](*args)
+    actual = tensors[out_name]
+
+    assert torch.allclose(actual, expected, rtol=5e-2, atol=5e-2), (
+        f"max abs diff = {(expected - actual).abs().max().item():.6e}"
+    )
+    if isinstance(result, torch.Tensor):
+        assert torch.allclose(result, expected, rtol=5e-2, atol=5e-2), (
+            f"returned tensor max abs diff = {(expected - result).abs().max().item():.6e}"
+        )
+
+
+_SCENARIOS = [
+    ("v2c_updown", V2CUDProgram, _build_v2c_tensors, ["a", "b", "output"], "output", _golden_v2c),
+    ("v2c_leftright", V2CLRProgram, _build_v2c_tensors, ["a", "b", "output"], "output", _golden_v2c),
+    ("v2c_nosplit", V2CNoSplitProgram, _build_v2c_tensors, ["a", "b", "output"], "output", _golden_v2c),
+    ("c2v_leftright", C2VLRProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_c2v),
+    ("c2v_updown", C2VUDProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_c2v),
+    ("c2v_nosplit", C2VNoSplitProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_c2v),
+    ("bidirect_updown", BiDirectUDProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_bidirect),
+    ("bidirect_leftright", BiDirectLRProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_bidirect),
+    ("bidirect_nosplit", BiDirectNoSplitProgram, _build_c2v_tensors, ["a", "b", "c"], "c", _golden_bidirect),
+]
+
+
+@pytest.mark.parametrize(
+    ("_name", "program", "builder", "arg_order", "out_name", "golden_fn"),
+    _SCENARIOS,
+    ids=[s[0] for s in _SCENARIOS],
+)
+def test_cross_core_codegen_vs_golden(
+    _name: str,
+    program: _ir.Program | _ir.Function,
+    builder,
+    arg_order: list[str],
+    out_name: str,
+    golden_fn,
+):
+    """Torch codegen of cross-core scenarios should match golden references."""
+    torch.manual_seed(42)
+    base_tensors = builder()
+    golden_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    expected = golden_fn(golden_tensors)
+    codegen_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    _run_codegen_and_check(program, codegen_tensors, arg_order, out_name, expected)
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+@pytest.mark.parametrize(
+    ("_name", "program", "builder", "arg_order", "out_name", "golden_fn"),
+    _SCENARIOS,
+    ids=[s[0] for s in _SCENARIOS],
+)
+def test_cross_core_codegen_after_default_pass_vs_golden(
+    platform: str,
+    _name: str,
+    program: _ir.Program | _ir.Function,
+    builder,
+    arg_order: list[str],
+    out_name: str,
+    golden_fn,
+):
+    """Pass-expanded cross-core IR should codegen to correct tpush/tpop behavior."""
+    torch.manual_seed(42)
+    base_tensors = builder()
+    golden_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    expected = golden_fn(golden_tensors)
+    codegen_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    _run_codegen_after_default_pass_and_check(
+        program,
+        codegen_tensors,
+        arg_order,
+        out_name,
+        expected,
+        platform,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/codegen/test_torch_codegen_qwen3_decode_scope3_mixed.py
+++ b/tests/st/codegen/test_torch_codegen_qwen3_decode_scope3_mixed.py
@@ -1,0 +1,171 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""System test for torch codegen on Qwen3 decode scope3 mixed kernel.
+
+Generates executable PyTorch code from the runtime scope3-mixed IR via
+torch_codegen, runs it with test tensors, and compares outputs to the
+golden reference.
+"""
+
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, platform_to_backend
+from pypto.backend import reset_for_testing, set_backend_type
+from pypto.debug import torch_codegen
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+
+from tests.st.runtime.test_qwen3_decode_scope3_mixed import (
+    build_qwen3_scope3_program,
+    golden,
+)
+
+
+def _build_tensors(batch: int, hidden_size: int, intermediate_size: int) -> dict[str, torch.Tensor]:
+    attn_out = (torch.randn([batch, hidden_size], dtype=torch.float32) / (hidden_size**0.5)).to(
+        torch.bfloat16
+    )
+    hidden_states = (torch.randn([batch, hidden_size], dtype=torch.float32) / (hidden_size**0.5)).to(
+        torch.bfloat16
+    )
+    wo = (torch.randn([hidden_size, hidden_size], dtype=torch.float32) / (hidden_size**0.5)).to(
+        torch.bfloat16
+    )
+    post_rms_weight = torch.randn([1, hidden_size], dtype=torch.float32) / (hidden_size**0.5)
+    w_gate = (
+        torch.randn([hidden_size, intermediate_size], dtype=torch.float32) / (intermediate_size**0.5)
+    ).to(torch.bfloat16)
+    w_up = (torch.randn([hidden_size, intermediate_size], dtype=torch.float32) / (intermediate_size**0.5)).to(
+        torch.bfloat16
+    )
+    w_down = (torch.randn([intermediate_size, hidden_size], dtype=torch.float32) / (hidden_size**0.5)).to(
+        torch.bfloat16
+    )
+    out = torch.zeros([batch, hidden_size], dtype=torch.bfloat16)
+
+    return {
+        "attn_out": attn_out,
+        "hidden_states": hidden_states,
+        "wo": wo,
+        "post_rms_weight": post_rms_weight,
+        "w_gate": w_gate,
+        "w_up": w_up,
+        "w_down": w_down,
+        "out": out,
+    }
+
+
+def _run_scope3_generated_code_and_check(
+    code: str,
+    tensors: dict[str, torch.Tensor],
+    expected: torch.Tensor,
+) -> None:
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+
+    codegen_out = tensors["out"].clone()
+    ns["scope3"](
+        tensors["attn_out"],
+        tensors["hidden_states"],
+        tensors["wo"],
+        tensors["post_rms_weight"],
+        tensors["w_gate"],
+        tensors["w_up"],
+        tensors["w_down"],
+        codegen_out,
+    )
+
+    assert torch.allclose(codegen_out, expected, rtol=5e-2, atol=5e-2), (
+        f"out max abs diff = {(expected - codegen_out).abs().max().item():.6e}"
+    )
+
+
+def _run_codegen_after_default_pass_and_check(
+    program,
+    tensors: dict[str, torch.Tensor],
+    expected: torch.Tensor,
+    platform: str,
+) -> None:
+    backend_type = platform_to_backend(platform)
+
+    reset_for_testing()
+    set_backend_type(backend_type)
+    try:
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+        code = torch_codegen(transformed, check_shapes=True)
+    finally:
+        reset_for_testing()
+
+    assert "_cross_core_rt.push_to_" in code
+    assert "_cross_core_rt.pop_from_" in code
+
+    _run_scope3_generated_code_and_check(code, tensors, expected)
+
+
+def test_qwen3_decode_scope3_mixed_codegen_vs_golden():
+    """Torch codegen of qwen3 decode scope3 mixed should match golden."""
+    # Keep dimensions moderate for system-test runtime while preserving
+    # K_CHUNK/Q_OUT_CHUNK/MLP_OUT_CHUNK divisibility.
+    batch = 16
+    hidden_size = 512
+    intermediate_size = 1024
+
+    program = build_qwen3_scope3_program(
+        batch=batch,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    code = torch_codegen(program, check_shapes=True)
+
+    torch.manual_seed(42)
+    tensors = _build_tensors(
+        batch=batch,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+
+    golden_tensors = {k: v.clone() for k, v in tensors.items()}
+    golden(golden_tensors)
+    golden_out = golden_tensors["out"]
+    _run_scope3_generated_code_and_check(code, tensors, golden_out)
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+def test_qwen3_decode_scope3_mixed_codegen_after_default_pass_vs_golden(platform: str):
+    """Pass-expanded qwen3 decode scope3 mixed should match golden."""
+    batch = 16
+    hidden_size = 512
+    intermediate_size = 1024
+
+    program = build_qwen3_scope3_program(
+        batch=batch,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+
+    torch.manual_seed(42)
+    tensors = _build_tensors(
+        batch=batch,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    golden_tensors = {k: v.clone() for k, v in tensors.items()}
+    golden(golden_tensors)
+    golden_out = golden_tensors["out"]
+
+    _run_codegen_after_default_pass_and_check(
+        program=program,
+        tensors=tensors,
+        expected=golden_out,
+        platform=platform,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -9,11 +9,17 @@
 
 """Tests for PyTorch code emission from PyPTO IR."""
 
+import importlib
+from typing import Any
+
+import pypto.language as pl
 import pytest
 import torch
 from pypto import DataType, ir
 from pypto.debug import torch_codegen
 from pypto.debug.torch_codegen import TorchCodegen
+
+torch_codegen_module = importlib.import_module("pypto.debug.torch_codegen")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -415,7 +421,395 @@ def test_pipe_ops():
     body = ir.EvalStmt(push_call, _span())
     func = _simple_function("f", [tile], body)
     code = torch_codegen(func)
-    assert "_pipes['to_aiv'].append" in code
+    assert "_cross_core_rt.push_to_aiv(tile, 0)" in code
+
+
+def test_get_subblock_idx():
+    """tile.get_subblock_idx should emit thread-local lane helper."""
+    idx = _scalar("idx", DataType.INDEX)
+    call = _op_call("tile.get_subblock_idx", [])
+    assign = ir.AssignStmt(idx, call, _span())
+    ret = ir.ReturnStmt([idx], _span())
+    body = ir.SeqStmts([assign, ret], _span())
+    func = _simple_function("f", [], body, [ir.ScalarType(DataType.INDEX)])
+    code = torch_codegen(func)
+    assert "_get_subblock_idx()" in code
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    assert ns["f"]() == 0
+
+
+def test_group_cross_core_split_runs_with_runtime_scheduler():
+    """Group calls with split cross-core ops should route through _run_group_call."""
+
+    @pl.program
+    class SplitCrossCoreProgram:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cross_aic(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ):
+            recv: pl.Tile[[4, 2], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
+                shape=[4, 2], dtype=pl.FP32, split=1
+            )
+            out = pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cross_aiv(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            lane: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+            tile: pl.Tile[[2, 2], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [lane * 2, 0], [2, 2])
+            pl.tpush_to_aic(tile, split=1)
+            return out
+
+        @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cross(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            self.cross_aic(inp, out)
+            result: pl.Tensor[[4, 2], pl.FP32] = self.cross_aiv(inp, out)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            return self.cross(inp, out)
+
+    code = torch_codegen(SplitCrossCoreProgram)
+    assert "_run_group_call('cross'" in code
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    src = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    dst = torch.zeros_like(src)
+    out = ns["main"](src, dst)
+    assert torch.allclose(out, src)
+
+
+def test_group_cross_core_left_right_c2v_runs_with_runtime_scheduler():
+    """LEFT_RIGHT split C->V path should route through _run_group_call and preserve data."""
+
+    @pl.program
+    class SplitLeftRightC2VProgram:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def cross_aic(
+            self,
+            inp: pl.Tensor[[2, 4], pl.FP32],
+            out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+        ):
+            tile: pl.Tile[[2, 4], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                inp, [0, 0], [2, 4], target_memory=pl.MemorySpace.Mat
+            )
+            pl.tpush_to_aiv(tile, split=2)
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def cross_aiv(
+            self,
+            inp: pl.Tensor[[2, 4], pl.FP32],
+            out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+        ) -> pl.Tensor[[2, 4], pl.FP32]:
+            lane: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+            recv: pl.Tile[[2, 2], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
+                shape=[2, 2], dtype=pl.FP32, split=2
+            )
+            out = pl.store(recv, [0, lane * 2], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def cross(
+            self,
+            inp: pl.Tensor[[2, 4], pl.FP32],
+            out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+        ) -> pl.Tensor[[2, 4], pl.FP32]:
+            self.cross_aic(inp, out)
+            result: pl.Tensor[[2, 4], pl.FP32] = self.cross_aiv(inp, out)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            inp: pl.Tensor[[2, 4], pl.FP32],
+            out: pl.Out[pl.Tensor[[2, 4], pl.FP32]],
+        ) -> pl.Tensor[[2, 4], pl.FP32]:
+            return self.cross(inp, out)
+
+    code = torch_codegen(SplitLeftRightC2VProgram)
+    assert "_run_group_call('cross'" in code
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    src = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    dst = torch.zeros_like(src)
+    out = ns["main"](src, dst)
+    assert torch.allclose(out, src)
+
+
+def test_group_cross_core_no_split_bidirect_runs_with_runtime_scheduler():
+    """No-split bidirectional path should run concurrently without deadlock."""
+
+    @pl.program
+    class NoSplitBidirectProgram:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cross_aic(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ):
+            recv: pl.Tile[[4, 2], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(
+                shape=[4, 2], dtype=pl.FP32, split=0
+            )
+            twice: pl.Tile[[4, 2], pl.FP32, pl.MemorySpace.Mat] = pl.add(recv, recv)
+            pl.tpush_to_aiv(twice, split=0)
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def cross_aiv(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            tile: pl.Tile[[4, 2], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [4, 2])
+            pl.tpush_to_aic(tile, split=0)
+            recv: pl.Tile[[4, 2], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(
+                shape=[4, 2], dtype=pl.FP32, split=0
+            )
+            out = pl.store(recv, [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Group)
+        def cross(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            self.cross_aic(inp, out)
+            result: pl.Tensor[[4, 2], pl.FP32] = self.cross_aiv(inp, out)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            inp: pl.Tensor[[4, 2], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 2], pl.FP32]],
+        ) -> pl.Tensor[[4, 2], pl.FP32]:
+            return self.cross(inp, out)
+
+    code = torch_codegen(NoSplitBidirectProgram)
+    assert "_run_group_call('cross'" in code
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    src = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    dst = torch.zeros_like(src)
+    out = ns["main"](src, dst)
+    assert torch.allclose(out, src * 2)
+
+
+def test_split_mode_to_int_invalid_value_raises():
+    """Invalid split value should fail fast with a clear error."""
+    with pytest.raises(ValueError, match="Invalid split mode"):
+        torch_codegen_module._split_mode_to_int("bad_split")
+
+
+def test_cross_core_split_merge_preserves_region_attrs():
+    """Split/merge path should preserve valid/full region metadata."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    rt = ns["_cross_core_rt"]
+    set_lane = ns["_set_subblock_idx"]
+
+    tile = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    setattr(tile, "_pypto_valid_shape", (2, 3))
+    setattr(tile, "_pypto_full_shape", (2, 4))
+
+    rt.push_to_aiv(tile, 2)
+    set_lane(0)
+    lane0 = rt.pop_from_aic(2)
+    set_lane(1)
+    lane1 = rt.pop_from_aic(2)
+
+    assert getattr(lane0, "_pypto_valid_shape", None) == (2, 2)
+    assert getattr(lane1, "_pypto_valid_shape", None) == (2, 1)
+    assert getattr(lane0, "_pypto_full_shape", None) == (2, 2)
+    assert getattr(lane1, "_pypto_full_shape", None) == (2, 2)
+
+    set_lane(0)
+    rt.push_to_aic(lane0, 2)
+    set_lane(1)
+    rt.push_to_aic(lane1, 2)
+    set_lane(0)
+    merged = rt.pop_from_aiv(2)
+
+    assert tuple(merged.shape) == (2, 4)
+    assert getattr(merged, "_pypto_valid_shape", None) == (2, 3)
+    assert getattr(merged, "_pypto_full_shape", None) == (2, 4)
+
+
+def test_cross_core_no_split_dual_dispatch_runtime_pipe_pairing():
+    """No-split dual-dispatch runtime should broadcast AIC->AIV and pair AIV->AIC traffic."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    rt = ns["_cross_core_rt"]
+    set_lane = ns["_set_subblock_idx"]
+
+    rt.reset(no_split_dual_aiv_dispatch=True)
+    assert rt.snapshot()["no_split_dual_aiv_dispatch"] is True
+
+    to_aiv_tile = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    rt.push_to_aiv(to_aiv_tile, 0)
+    set_lane(0)
+    lane0_recv = rt.pop_from_aic(0)
+    set_lane(1)
+    lane1_recv = rt.pop_from_aic(0)
+    assert torch.equal(lane0_recv, to_aiv_tile)
+    assert torch.equal(lane1_recv, to_aiv_tile)
+    assert rt.snapshot()["to_aiv_dual_nosplit"] == {0: 0, 1: 0}
+
+    lane0_tile = torch.full((2, 2), 1.0, dtype=torch.float32)
+    lane1_tile = torch.full((2, 2), 2.0, dtype=torch.float32)
+    set_lane(0)
+    rt.push_to_aic(lane0_tile, 0)
+    set_lane(1)
+    rt.push_to_aic(lane1_tile, 0)
+    set_lane(0)
+    paired = rt.pop_from_aiv(0)
+    assert torch.equal(paired, lane0_tile)
+    assert rt.snapshot()["to_aic_dual_nosplit"] == {0: 0, 1: 0}
+
+
+def test_mixed_kernel_timeout_cancels_waiters_and_runtime_recovers():
+    """Timeout should cancel blocked waiters and clear cancel event for next runs."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    ns["_PIPE_WAIT_TIMEOUT_SEC"] = 60.0
+    ns["_MIXED_KERNEL_TIMEOUT_SEC"] = 0.2
+
+    def blocked_aic(_x):
+        return ns["_cross_core_rt"].pop_from_aiv(0)
+
+    def blocked_aiv(_x):
+        return ns["_cross_core_rt"].pop_from_aic(0)
+
+    ns["blocked_aic"] = blocked_aic
+    ns["blocked_aiv"] = blocked_aiv
+
+    with pytest.raises(RuntimeError, match="Mixed-kernel execution timeout"):
+        ns["_run_mixed_kernels"](
+            "blocked_group",
+            {"aic": "blocked_aic", "aiv": "blocked_aiv", "split": 0},
+            torch.tensor(0.0),
+        )
+
+    assert ns["_get_runtime_cancel_event"]() is None
+
+    def ok_aic(_x):
+        return None
+
+    def ok_aiv(_x):
+        return torch.tensor([1.0], dtype=torch.float32)
+
+    ns["ok_aic"] = ok_aic
+    ns["ok_aiv"] = ok_aiv
+    out = ns["_run_mixed_kernels"](
+        "ok_group",
+        {"aic": "ok_aic", "aiv": "ok_aiv", "split": 0},
+        torch.tensor(0.0),
+    )
+    assert torch.equal(out, torch.tensor([1.0], dtype=torch.float32))
+
+
+def test_mixed_kernel_no_split_dual_aiv_dispatch_bidirect_pipe_runs():
+    """No-split dual-dispatch bidirectional pipe should complete without deadlock."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    def aic(_x):
+        recv = ns["_cross_core_rt"].pop_from_aiv(0)
+        ns["_cross_core_rt"].push_to_aiv(recv + 10.0, 0)
+
+    def aiv(_x):
+        lane = ns["_get_subblock_idx"]()
+        payload = torch.tensor([float(lane + 1)], dtype=torch.float32)
+        ns["_cross_core_rt"].push_to_aic(payload, 0)
+        recv = ns["_cross_core_rt"].pop_from_aic(0)
+        if lane == 0:
+            return recv
+        return None
+
+    ns["aic"] = aic
+    ns["aiv"] = aiv
+    out = ns["_run_mixed_kernels"](
+        "dual_bidirect_group",
+        {"aic": "aic", "aiv": "aiv", "split": 0, "dual_aiv_dispatch": True},
+        torch.tensor(0.0),
+    )
+    assert torch.equal(out, torch.tensor([11.0], dtype=torch.float32))
+
+
+def test_mixed_kernel_no_split_dual_aiv_dispatch_runs_two_lanes():
+    """No-split + dual_aiv_dispatch should dispatch AIV on lane0 and lane1."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    lanes_seen: list[int] = []
+    lane_lock = ns["threading"].Lock()
+
+    def aic(_x):
+        return None
+
+    def aiv(_x):
+        lane = ns["_get_subblock_idx"]()
+        with lane_lock:
+            lanes_seen.append(lane)
+        if lane == 0:
+            return torch.tensor([1.0], dtype=torch.float32)
+        return None
+
+    ns["aic"] = aic
+    ns["aiv"] = aiv
+    out = ns["_run_mixed_kernels"](
+        "dual_dispatch_group",
+        {"aic": "aic", "aiv": "aiv", "split": 0, "dual_aiv_dispatch": True},
+        torch.tensor(0.0),
+    )
+    assert torch.equal(out, torch.tensor([1.0], dtype=torch.float32))
+    assert sorted(lanes_seen) == [0, 1]
+
+
+def test_mixed_kernel_no_split_without_dual_dispatch_runs_single_lane():
+    """No-split without dual_aiv_dispatch should only run AIV lane0."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    lanes_seen: list[int] = []
+    lane_lock = ns["threading"].Lock()
+
+    def aic(_x):
+        return None
+
+    def aiv(_x):
+        lane = ns["_get_subblock_idx"]()
+        with lane_lock:
+            lanes_seen.append(lane)
+        return torch.tensor([1.0], dtype=torch.float32)
+
+    ns["aic"] = aic
+    ns["aiv"] = aiv
+    out = ns["_run_mixed_kernels"](
+        "single_dispatch_group",
+        {"aic": "aic", "aiv": "aiv", "split": 0},
+        torch.tensor(0.0),
+    )
+    assert torch.equal(out, torch.tensor([1.0], dtype=torch.float32))
+    assert lanes_seen == [0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rework `torch_codegen` cross-core debug runtime in preamble: replace legacy pipe model with `_CrossCoreRuntime`, mixed-kernel concurrent scheduler, timeout/cancellation handling, and thread-level diagnostics.
- Route Group mixed-kernel `GlobalVar` calls through `_run_group_call` using Program-derived metadata (`split` with Group->AIV fallback and `dual_aiv_dispatch`).
- Implement no-split dual-dispatch runtime semantics for `split=0 + dual_aiv_dispatch`: use per-lane dual queues, broadcast AIC->AIV traffic, and pair AIV->AIC traffic to avoid lane deadlocks.
- Preserve boundary-region metadata (`_pypto_valid_shape` / `_pypto_full_shape`) across split/merge and cross-core queue paths.
- Fix torch_codegen variable-name mapping for pass-expanded SSA flows so generated code does not hit undefined-name errors.
- Keep split parsing strict: invalid/unparsable split values fail fast with clear errors.
- Add and align bilingual design docs for `torch_codegen` under `docs/en/dev/codegen/02-torch_codegen.md` and `docs/zh-cn/dev/codegen/02-torch_codegen.md` with the latest runtime architecture and no-split dual-dispatch behavior.

## Testing
- Added `tests/st/codegen/test_torch_codegen_cross_core.py` covering V2C/C2V/BiDirect across `UP_DOWN` / `LEFT_RIGHT` / `NONE` split modes.
- Added pass-expanded verification in `test_torch_codegen_cross_core.py`: run `PassManager(Default)` first, then feed transformed IR into `torch_codegen` and compare against golden.
- Added `tests/st/codegen/test_torch_codegen_qwen3_decode_scope3_mixed.py` for Qwen3 decode scope3 mixed-kernel numerical checks.
- Added pass-expanded verification for Qwen3 scope3 mixed in `test_torch_codegen_qwen3_decode_scope3_mixed.py` (Default pass -> torch_codegen -> golden compare).
- Extended `tests/ut/debug/test_torch_codegen.py` with coverage for:
  - invalid split fail-fast behavior,
  - region metadata preservation through split/merge,
  - timeout cancellation and recovery,
  - no-split `dual_aiv_dispatch` lane behavior and bidirectional pipe pairing,
  - split/no-split runtime scheduler scenarios and `tile.get_subblock_idx`.

## Issue
#1032
