### PR TITLE
fix(ir): Allow MemoryReuse to fuse 2D tiles with divergent valid_shape

### DIFF
--- a/docs/en/dev/passes/16-memory_reuse.md
+++ b/docs/en/dev/passes/16-memory_reuse.md
@@ -53,10 +53,11 @@ program_optimized = reuse_pass(program)
 - Non-overlapping lifetimes (no interference). Two variables do NOT overlap when `prev.last_use <= curr.def` (i.e., the source's last use can be at the same statement as the target's definition, since inputs are read before outputs are written within a single statement).
 - Same memory space
 - Compatible sizes (reuse target must be large enough)
-- Full TileType compatibility — checked by `AreTileTypesCompatible`:
+- TileType compatibility — checked by `AreTileTypesCompatible`:
   - Same shape (all dimensions must match exactly)
   - Same dtype (e.g., FP32 vs BF16 prevents reuse, handling `tile.cast` automatically)
-  - Same TileView attributes when present: all fields (`valid_shape`, `stride`, `start_offset`, `blayout`, `slayout`, `fractal`, `pad`) are compared via `TileView::operator==` (e.g., `tile.fillpad` changes `valid_shape` and `pad`, so its output cannot reuse its input)
+  - Same TileView storage attributes when present: `stride`, `start_offset`, `blayout`, `slayout`, `fractal`, `pad` must all match structurally (e.g., `tile.fillpad` changes `pad`, so its output cannot reuse its input — `pad` divergence alone blocks reuse)
+  - `valid_shape` is **not** required to match for 2D tiles: each reused tile keeps its own `valid_shape` in its TileType, and PTO codegen emits per-variable `alloc_tile` declarations that alias the shared buffer with each member's own static valid extent. This lets sibling-branch tiles produced by `PartialUnrollTileLoops` (differing only in boundary-guard `valid_shape`) share one backing allocation. For N-D tiles, `valid_shape` divergence still blocks reuse.
 
 **Alloc cleanup**:
 

--- a/docs/zh-cn/dev/passes/16-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/16-memory_reuse.md
@@ -53,10 +53,11 @@ program_optimized = reuse_pass(program)
 - 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）
 - 相同内存空间
 - 大小兼容（复用目标必须足够大）
-- 完整的 TileType 兼容性 — 由 `AreTileTypesCompatible` 检查：
+- TileType 兼容性 — 由 `AreTileTypesCompatible` 检查：
   - 相同 shape（所有维度必须精确匹配）
   - 相同 dtype（例如 FP32 与 BF16 阻止复用，自动处理 `tile.cast`）
-  - 相同 TileView 属性：所有字段（`valid_shape`、`stride`、`start_offset`、`blayout`、`slayout`、`fractal`、`pad`）通过 `TileView::operator==` 比较（例如 `tile.fillpad` 改变 `valid_shape` 和 `pad`，因此其输出不能复用其输入）
+  - 相同 TileView 存储属性：`stride`、`start_offset`、`blayout`、`slayout`、`fractal`、`pad` 必须都结构相等（例如 `tile.fillpad` 改变 `pad`，因此其输出不能复用其输入 —— 仅 `pad` 不一致即阻止复用）
+  - 对于 2D tile，`valid_shape` 不要求匹配：复用后每个 tile 在自己的 TileType 中保留各自的 `valid_shape`，PTO codegen 会为每个变量发射带有各自静态 valid 范围的 `alloc_tile` 声明，它们共享底层 buffer。这样，`PartialUnrollTileLoops` 产生的仅在边界守护 `valid_shape` 上不同的兄弟分支 tile 可以共用一个后备分配。对于 N-D tile，`valid_shape` 不一致仍然阻止复用。
 
 **Alloc 清理**：
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -848,22 +848,30 @@ static bool AreTileExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::v
   return true;
 }
 
+// Compare TileView fields that govern physical storage.  `valid_shape` is
+// intentionally excluded: it is per-use metadata that PTO codegen carries on
+// each tile var's own alloc_tile declaration.  Two reused tiles that share a
+// MemRef but differ in `valid_shape` end up as multiple alloc_tile
+// declarations aliased to the same address, each with its own static valid
+// extent — which PTO already supports for view-op chains.  See issue #1094.
 static bool AreTileViewsEqual(const TileView& a, const TileView& b) {
-  return AreTileExprVectorsEqual(a.valid_shape, b.valid_shape) &&
-         AreTileExprVectorsEqual(a.stride, b.stride) && AreTileExprsEqual(a.start_offset, b.start_offset) &&
+  return AreTileExprVectorsEqual(a.stride, b.stride) && AreTileExprsEqual(a.start_offset, b.start_offset) &&
          a.blayout == b.blayout && a.slayout == b.slayout && a.fractal == b.fractal && a.pad == b.pad;
 }
 
 /**
- * @brief Check if two TileType variables have fully compatible tile attributes
+ * @brief Check if two TileType variables have compatible storage attributes.
  *
- * PTO codegen binds a single alloc_tile declaration (shape, dtype, blayout, pad, etc.)
- * to each buffer.  All operations referencing that buffer share the same declaration.
- * Reuse between tiles with different attributes would cause attribute mismatches in
- * the generated PTO IR, leading to incorrect codegen or hardware behaviour.
+ * PTO codegen binds an alloc_tile declaration to each tile var; multiple
+ * declarations may alias the same physical buffer.  Reuse between tiles
+ * with mismatched storage attributes would cause attribute conflicts in the
+ * generated PTO IR.
  *
- * Checked attributes: shape, dtype, and TileView (all fields compared via the
- * structural comparison helpers above).
+ * Checked attributes: shape, dtype, and TileView fields governing storage
+ * (stride, start_offset, layouts, fractal, pad).  `valid_shape` is allowed
+ * to differ for 2D tiles — each tile var keeps its own valid_shape on its
+ * own alloc_tile declaration.  The 2D restriction matches `tile.set_validshape`
+ * which only supports 2D tiles; for N-D tiles we keep the strict check.
  */
 bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   auto t1 = As<TileType>(var1->GetType());
@@ -876,7 +884,17 @@ bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
   bool has_view1 = t1->tile_view_.has_value();
   bool has_view2 = t2->tile_view_.has_value();
   if (has_view1 != has_view2) return false;
-  if (has_view1 && !AreTileViewsEqual(t1->tile_view_.value(), t2->tile_view_.value())) return false;
+  if (has_view1) {
+    const auto& v1 = t1->tile_view_.value();
+    const auto& v2 = t2->tile_view_.value();
+    if (!AreTileViewsEqual(v1, v2)) return false;
+    // Relaxation applies only to 2D tiles.  For N-D tiles, keep the strict
+    // behaviour and require valid_shape to match.  `t1->shape_.size()` is
+    // safe to use for both tiles here because `t1->shape_ == t2->shape_`
+    // was already verified above.
+    const bool is_2d = t1->shape_.size() == 2;
+    if (!is_2d && !AreTileExprVectorsEqual(v1.valid_shape, v2.valid_shape)) return false;
+  }
   return true;
 }
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -672,6 +672,134 @@ class TestFillpad:
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
 
+class TestValidShapeDivergence:
+    """Tiles with identical storage but divergent ``valid_shape`` can share a MemRef.
+
+    Reproduces the scenario from issue #1094: unrolled / partially-unrolled
+    kernels produce sibling branches whose tiles differ only in ``valid_shape``
+    (driven by per-branch boundary guards). Those tiles should share a backing
+    allocation; each variable keeps its own ``valid_shape`` at every use site.
+    """
+
+    def test_different_valid_shape_can_reuse(self):
+        """Two sequential loads with different static ``valid_shape`` share one MemRef."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                output_a: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                )
+                _res_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], output_a)
+                tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_a, [0, 0], [64, 64], valid_shapes=[32, 64]
+                )
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output_b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_0", 0, 16384)],
+                output_a: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
+                output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 16384)]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                tile_a: pl.Tile[
+                    [64, 64],
+                    pl.FP32,
+                    pl.MemRef(mem_vec_3, 0, 16384),
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[48, 64]),
+                ] = pl.tile.load(
+                    input_a, [0, 0], [64, 64], [48, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                _res_a: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                    tile_a, [0, 0], output_a
+                )
+                tile_b: pl.Tile[
+                    [64, 64],
+                    pl.FP32,
+                    pl.MemRef(mem_vec_3, 0, 16384),
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[32, 64]),
+                ] = pl.tile.load(
+                    input_a, [0, 0], [64, 64], [32, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 16384)] = pl.tile.store(
+                    tile_b, [0, 0], output_b
+                )
+                return result
+
+        After = _run_pipeline(Before)
+        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+
+    def test_non_2d_divergent_valid_shape_blocks_reuse(self):
+        """3D tiles with divergent ``valid_shape`` must NOT reuse (set_validshape is 2D-only)."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[4, 64, 64], pl.FP32],
+                output_a: pl.Out[pl.Tensor[[4, 64, 64], pl.FP32]],
+                output_b: pl.Out[pl.Tensor[[4, 64, 64], pl.FP32]],
+            ) -> pl.Tensor[[4, 64, 64], pl.FP32]:
+                tile_a: pl.Tile[[4, 64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_a, [0, 0, 0], [4, 64, 64], valid_shapes=[4, 48, 64]
+                )
+                _res_a: pl.Tensor[[4, 64, 64], pl.FP32] = pl.store(tile_a, [0, 0, 0], output_a)
+                tile_b: pl.Tile[[4, 64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_a, [0, 0, 0], [4, 64, 64], valid_shapes=[4, 32, 64]
+                )
+                result: pl.Tensor[[4, 64, 64], pl.FP32] = pl.store(tile_b, [0, 0, 0], output_b)
+                return result
+
+        After = _run_pipeline(Before)
+        # Collect base_ptr names from every tile AssignStmt in the After IR.
+        # 3D tiles with divergent valid_shape must NOT share a MemRef — the
+        # compatibility check's 2D guard keeps them on the strict path.
+        bases = _collect_tile_memref_bases(After)
+        tile_a_base = bases.get("tile_a")
+        tile_b_base = bases.get("tile_b")
+        assert tile_a_base is not None and tile_b_base is not None, (
+            f"Expected tile_a and tile_b in After IR; got bases: {bases}"
+        )
+        assert tile_a_base != tile_b_base, (
+            f"3D divergent-valid_shape tiles should NOT share a MemRef, but both bind to {tile_a_base}"
+        )
+
+
+def _collect_tile_memref_bases(program: ir.Program) -> dict[str, str]:
+    """Return ``{tile_var_name: memref_base_name}`` for every AssignStmt in the program.
+
+    Walks the first function's body using a small IRVisitor subclass that
+    records the MemRef base name when a tile-typed variable is assigned.
+    """
+    result: dict[str, str] = {}
+    main_func = next(iter(program.functions.values()))
+
+    class _Collector(ir.IRVisitor):
+        def visit_assign_stmt(self, stmt):  # type: ignore[override]
+            var_type = stmt.var.type
+            if isinstance(var_type, ir.TileType) and var_type.memref is not None:
+                result[stmt.var.name_hint] = var_type.memref.base_.name_hint
+            super().visit_assign_stmt(stmt)
+
+    visitor = _Collector()
+    visitor.visit_stmt(main_func.body)
+    return result
+
+
 class TestViewOps:
     """Tests for view operations (reshape) with memory reuse."""
 


### PR DESCRIPTION
## Summary

Relax `MemoryReuse` tile compatibility so two 2D tile allocations with identical storage shape but different `valid_shape` can share a backing allocation.

- Drop `valid_shape` from `AreTileViewsEqual` in `src/ir/transforms/memory_reuse_pass.cpp` so it no longer participates in the per-tile equality check.
- Add a 2D guard in `AreTileTypesCompatible` — the relaxation only applies to 2D tiles to match the rank constraint of `tile.set_validshape`; N-D tiles keep the strict check.
- No codegen change: per-var `alloc_tile` codegen already supports multiple `pto.alloc_tile` declarations aliased to the same address, each carrying its own static valid extent. The same lowering pattern is exercised by view-op chains (e.g. fillpad).

## Motivation

In `qwen3_decode_incore_16` after `PartialUnrollTileLoops`, sibling `IfStmt` branches hold tiles whose `TileView` matches in every storage attribute (shape, stride, start_offset, layouts, fractal, pad) and differs only in `valid_shape` (`[16, pl.min(25600 - k, 64)]` vs `[16, pl.min(25600 - (k + 64), 64)]`). Their lifetimes are mutually exclusive but the strict view-equality check left 4× `mem_left_*` and 4× `mem_right_*` allocations per iteration where 1 each suffices.

## Test plan

- [x] Targeted: `python -m pytest tests/ut/ir/transforms/test_memory_reuse.py -v` — 41 passed (includes new `TestValidShapeDivergence`)
- [x] Broader: `python -m pytest tests/ut/ -n auto --maxprocesses 8` — 3889 passed, 16 skipped, 0 failed
- [x] clang-tidy clean on the modified C++

Closes #1094.