### PR TITLE
test(ir): Remove unnecessary enable_auto_mapping=True from pass transform tests

### DIFF
--- a/docs/en/dev/ir/03-structural_comparison.md
+++ b/docs/en/dev/ir/03-structural_comparison.md
@@ -153,10 +153,17 @@ assert not ir.structural_equal(var, const)  # False
 
 | Use Case | Setting |
 | -------- | ------- |
+| Pass transform tests (Before/Expected pattern) | `False` (default) — DefFields always auto-map |
+| Serialization round-trip tests | `True` — deserialized Vars are never DefFields |
 | Pattern matching regardless of variable names | `True` |
 | Template matching for optimization rules | `True` |
 | Exact matching with same variables | `False` |
 | CSE (Common Subexpression Elimination) | `False` |
+
+> **Why pass tests don't need it:** `VisitDefField` always enables auto-mapping
+> internally (see `structural_equal.cpp:650`), populating the bidirectional Var
+> maps. When the same Vars later appear as UsualField references, they are found
+> in the maps — even with `enable_auto_mapping=False`.
 
 ## structural_hash Function
 

--- a/docs/zh-cn/dev/ir/03-structural_comparison.md
+++ b/docs/zh-cn/dev/ir/03-structural_comparison.md
@@ -153,10 +153,17 @@ assert not ir.structural_equal(var, const)  # False
 
 | 使用场景 | 设置 |
 | -------- | ---- |
+| Pass 变换测试（Before/Expected 模式） | `False`（默认）— DefField 始终自动映射 |
+| 序列化往返测试 | `True` — 反序列化的变量不会是 DefField |
 | 不考虑变量名的模式匹配 | `True` |
 | 优化规则的模板匹配 | `True` |
 | 使用相同变量的精确匹配 | `False` |
 | CSE（公共子表达式消除） | `False` |
+
+> **为何 pass 测试不需要：** `VisitDefField` 内部始终启用自动映射
+> （见 `structural_equal.cpp:650`），填充双向变量映射表。
+> 当相同的变量之后作为 UsualField 引用出现时，会在映射表中找到 —
+> 即使 `enable_auto_mapping=False`。
 
 ## structural_hash 函数
 

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -54,7 +54,7 @@ def test_allocate_memory_addr_simple():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_multiple_tiles():
@@ -101,7 +101,7 @@ def test_allocate_memory_addr_multiple_tiles():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_resolves_auto_reserve_buffer_before_tiles():
@@ -145,7 +145,7 @@ def test_allocate_memory_addr_resolves_auto_reserve_buffer_before_tiles():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_rejects_overlapping_reserve_buffer_ranges():
@@ -242,7 +242,7 @@ def test_allocate_memory_addr_reuses_right_buffer_when_moves_sink_to_consumer():
     After = passes.init_mem_ref()(After)
     After = passes.memory_reuse()(After)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_empty_function():
@@ -261,7 +261,7 @@ def test_allocate_memory_addr_empty_function():
             return output
 
     After = passes.allocate_memory_addr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_allocs_are_prepended_to_body():
@@ -304,7 +304,7 @@ def test_allocate_memory_addr_allocs_are_prepended_to_body():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocate_memory_addr_raw_pointer_uniqueness():
@@ -352,7 +352,7 @@ def test_allocate_memory_addr_raw_pointer_uniqueness():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_allocated_memory_addr_verifier_passes_after_add_alloc():
@@ -395,7 +395,7 @@ def test_allocated_memory_addr_verifier_passes_after_add_alloc():
 
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_memrefs_before_allocate_have_unallocated_addr():
@@ -527,7 +527,7 @@ def test_allocate_memory_addr_uses_default_policy_without_backend():
 
         After = passes.init_mem_ref()(Before)
         After = passes.allocate_memory_addr()(After)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
     finally:
         if was_configured:
             reset_for_testing()

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -210,7 +210,7 @@ def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
 
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
@@ -318,7 +318,7 @@ def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
 
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_v2c_boundary_uses_nz_layout_on_a2a3():
@@ -431,7 +431,7 @@ def test_v2c_boundary_uses_nz_layout_on_a2a3():
             return result
 
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
@@ -531,7 +531,7 @@ def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
             return result
 
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_gm_pipe_buffer_per_call_allocation():
@@ -650,7 +650,7 @@ def test_gm_pipe_buffer_per_call_allocation():
 
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_gm_pipe_buffer_per_call_inside_for_loop():
@@ -759,7 +759,7 @@ def test_gm_pipe_buffer_per_call_inside_for_loop():
 
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_gm_pipe_buffer_param_direction_is_out():
@@ -870,7 +870,7 @@ def test_gm_pipe_buffer_param_direction_is_out():
 
     Expected = _patch_tensor_create_manual_dep(Expected, "main")
     After = _run_pipeline(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_accumulator_with_tile_create_classifies_as_pure_aic():

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -534,7 +534,7 @@ class TestFlattenPreservesFuncType:
                 return result
 
         After = passes.flatten_call_expr()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_preserve_incore_func_type(self):
         """func_type=InCore is preserved after flattening."""
@@ -555,7 +555,7 @@ class TestFlattenPreservesFuncType:
                 return result
 
         After = passes.flatten_call_expr()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestFlattenCallInScopeStmt:

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -78,7 +78,7 @@ class TestInferTileMemorySpaceKwargOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_load_with_mat_kwarg(self):
         """tile.load(target_memory=Mat) -> Mat."""
@@ -130,7 +130,7 @@ class TestInferTileMemorySpaceKwargOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_move_with_left_kwarg(self):
         """tile.move(target_memory=Left) -> Left."""
@@ -186,7 +186,7 @@ class TestInferTileMemorySpaceKwargOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_create_default_vec(self):
         """tile.create without target_memory kwarg defaults to Vec."""
@@ -232,7 +232,7 @@ class TestInferTileMemorySpaceKwargOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInferTileMemorySpaceCubeOps:
@@ -298,7 +298,7 @@ class TestInferTileMemorySpaceCubeOps:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_full_pipeline(self):
         """Full matmul pipeline: load->Mat, move->Left/Right, matmul->Acc."""
@@ -370,7 +370,7 @@ class TestInferTileMemorySpaceCubeOps:
                 return sij
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInferTileMemorySpaceOtherOps:
@@ -418,7 +418,7 @@ class TestInferTileMemorySpaceOtherOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_elementwise_after_matmul_gets_vec(self):
         """tile.add after matmul: auto-insert move Acc->Vec before add."""
@@ -503,7 +503,7 @@ class TestInferTileMemorySpaceOtherOps:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_chained_elementwise_inherits(self):
         """Chained elementwise ops: add then mul both inherit Vec."""
@@ -549,7 +549,7 @@ class TestInferTileMemorySpaceOtherOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInferTileMemorySpaceEdgeCases:
@@ -639,7 +639,7 @@ class TestInferTileMemorySpaceEdgeCases:
                 return a
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_pass_is_idempotent(self):
         """Running the pass twice produces the same result."""
@@ -779,7 +779,7 @@ class TestInferTileMemorySpaceInheritOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_slice_inherits_vec(self):
         """tile.slice inherits Vec memory space from input tile."""
@@ -823,7 +823,7 @@ class TestInferTileMemorySpaceInheritOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_reshape_inherits_mat(self):
         """tile.reshape inherits Mat memory space from input loaded to Mat."""
@@ -886,7 +886,7 @@ class TestInferTileMemorySpaceInheritOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_slice_inherits_mat(self):
         """tile.slice inherits Mat memory space from Mat input."""
@@ -942,7 +942,7 @@ class TestInferTileMemorySpaceInheritOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_chained_view_ops_inherit(self):
         """reshape(slice(load(Mat))) — all inherit Mat from the load."""
@@ -1005,7 +1005,7 @@ class TestInferTileMemorySpaceInheritOps:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestAutoMoveInsertion:
@@ -1071,7 +1071,7 @@ class TestAutoMoveInsertion:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_auto_moves_from_mat(self):
         """tile.matmul with Mat inputs -> auto-insert moves to Left/Right."""
@@ -1141,7 +1141,7 @@ class TestAutoMoveInsertion:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_moves_are_inserted_at_first_consumer(self):
         """Auto-inserted moves should be materialized at first constrained use.
@@ -1231,7 +1231,7 @@ class TestAutoMoveInsertion:
                 return result
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_no_move_when_already_correct(self):
         """No move inserted when input already in correct space."""
@@ -1303,7 +1303,7 @@ class TestAutoMoveInsertion:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_eval_stmt_consumer_collects_and_inserts_move(self):
         """EvalStmt consumers should also trigger required auto-inserted moves."""
@@ -1345,7 +1345,7 @@ class TestAutoMoveInsertion:
                 return out_0
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_store_no_move_for_vec(self):
         """tile.store accepts Vec — no move needed for Vec tile."""
@@ -1387,7 +1387,7 @@ class TestAutoMoveInsertion:
                 return y
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_store_no_move_for_acc(self):
         """tile.store accepts Acc — no move needed for matmul output."""
@@ -1459,7 +1459,7 @@ class TestAutoMoveInsertion:
                 return z
 
         After = passes.infer_tile_memory_space()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -12,6 +12,8 @@
 Most tests use the Before/Expected pattern with
 ``ir.assert_structural_equal(After, Expected)``.
 DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
+This aligns MemRef objects consistently: if two tiles share a MemRef in
+``After``, the corresponding tiles in ``Expected`` must also share.
 
 Two tests are kept as raw-IR / diagnostic tests because the inputs cannot be
 expressed via the DSL:

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -10,10 +10,8 @@
 """Tests for InitMemRefPass.
 
 Most tests use the Before/Expected pattern with
-`ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)`.
-`auto_mapping=True` aligns MemRef objects consistently across the comparison:
-if two tiles share a MemRef in ``After``, the corresponding tiles in
-``Expected`` must also share (i.e. use the same ``mem_*`` pointer name).
+``ir.assert_structural_equal(After, Expected)``.
+DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
 
 Two tests are kept as raw-IR / diagnostic tests because the inputs cannot be
 expressed via the DSL:
@@ -79,7 +77,7 @@ class TestBasic:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_pipeline(self):
         """load→move→matmul→store: Vec/Mat/Left/Right/Acc memory spaces each get their own MemRef."""
@@ -148,7 +146,7 @@ class TestBasic:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestMemRefSharing:
@@ -189,7 +187,7 @@ class TestMemRefSharing:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_view_op_shares_memref_with_input(self):
         """tile.reshape chain shares a single MemRef (only 1 alloc needed)."""
@@ -233,7 +231,7 @@ class TestMemRefSharing:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_acc_shares_memref_with_accumulator(self):
         """tile.matmul_acc output shares MemRef with its accumulator input (arg[0])."""
@@ -308,7 +306,7 @@ class TestMemRefSharing:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestYieldMemRef:
@@ -376,7 +374,7 @@ class TestYieldMemRef:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_yield_return_var_shares_memref(self):
         """IfStmt: return_var shares MemRef with the then-branch yield value."""
@@ -452,7 +450,7 @@ class TestYieldMemRef:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_tile_alias_shares_source_memref(self):
         """Tile alias (``a = b``) shares MemRef with source tile, not a fresh one."""
@@ -513,7 +511,7 @@ class TestYieldMemRef:
                 return result
 
         After = passes.init_mem_ref()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestDynamicValidShape:

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -10,9 +10,9 @@
 """Unit tests for InterchangeChunkLoops pass.
 
 Test strategy:
-  Build a `Before` program, run prerequisite passes + InterchangeChunkLoops,
-  and compare to an explicitly-constructed `Expected` program using
-  `ir.assert_structural_equal(...)`.
+  Build a ``Before`` program, run prerequisite passes + InterchangeChunkLoops,
+  and compare to an explicitly-constructed ``Expected`` program using
+  ``ir.assert_structural_equal(After, Expected)``.
 """
 
 import re

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -12,7 +12,7 @@
 Test strategy:
   Build a `Before` program, run prerequisite passes + InterchangeChunkLoops,
   and compare to an explicitly-constructed `Expected` program using
-  `ir.assert_structural_equal(..., enable_auto_mapping=True)`.
+  `ir.assert_structural_equal(...)`.
 """
 
 import re
@@ -64,7 +64,7 @@ class TestSingleParallelChunk:
                 return x5
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestNestedParallelChunks:
@@ -108,7 +108,7 @@ class TestNestedParallelChunks:
                 return x9
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_two_nested_parallel_with_iter_args(self):
         """Two nested parallel chunked loops with iter_args: verify SSA threading.
@@ -153,7 +153,7 @@ class TestNestedParallelChunks:
                 return x9
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestNestedChunkChainsInitSubstitution:
@@ -206,7 +206,7 @@ class TestNestedChunkChainsInitSubstitution:
                 return x9
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_nested_chains_outline_no_crash(self):
         """Nested parallel chunk chains followed by OutlineIncoreScopes must not crash.
@@ -332,7 +332,7 @@ class TestNestedChunksWithInterveningStatements:
                 return x10
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_no_crash_with_intervening_stmt(self):
         """Nested chunks with intervening stmt: outline must not crash."""
@@ -382,7 +382,7 @@ class TestChunkWithRemainderInChain:
                 return x7
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_chunk_with_remainder_body_contains_remainder_loop(self):
         """Remainder loop inside chain body is preserved after interchange.
@@ -422,7 +422,7 @@ class TestChunkWithRemainderInChain:
                 return x7
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestRemainderLoops:
@@ -491,7 +491,7 @@ class TestRemainderLoops:
                 return x22
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestNonChunkedLoops:
@@ -518,7 +518,7 @@ class TestNonChunkedLoops:
                 return x3
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestSequentialChunks:
@@ -553,7 +553,7 @@ class TestSequentialChunks:
                 return x5
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_nested_sequential_chunks_get_incore(self):
         """Nested sequential chunked loops: no interchange, but get InCore wrapping."""
@@ -593,7 +593,7 @@ class TestSequentialChunks:
                 return x9
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestExistingInCore:
@@ -629,7 +629,7 @@ class TestExistingInCore:
                 return x5
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestAutoIncoreConsumed:
@@ -669,7 +669,7 @@ class TestAutoIncoreConsumed:
                 return x5
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestPassProperties:
@@ -773,7 +773,7 @@ class TestNonChunkStatementsWrapping:
                 return x1
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_standalone_op_before_parallel_chunk(self):
         """Standalone op before parallel chunk: op wrapped separately, chunk interchanged."""
@@ -807,7 +807,7 @@ class TestNonChunkStatementsWrapping:
                 return x6
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_standalone_op_after_parallel_chunk(self):
         """Standalone op after parallel chunk: chunk interchanged, op wrapped separately."""
@@ -841,7 +841,7 @@ class TestNonChunkStatementsWrapping:
                 return x6
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_host_side_assemble_after_parallel_chunk_not_wrapped(self):
         """Host-side tail assemble after a chunk stays outside InCore."""
@@ -880,7 +880,7 @@ class TestNonChunkStatementsWrapping:
                 return out_1_0
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_multiple_parallel_chunks_no_regression(self):
         """Multiple parallel chunks with no standalone ops: all interchanged, no extra wrapping."""
@@ -923,7 +923,7 @@ class TestNonChunkStatementsWrapping:
                 return x10
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_non_chunked_loop_inside_auto_incore_wrapped(self):
         """Non-chunked loop with tensor ops inside auto_incore gets wrapped in InCore."""
@@ -948,7 +948,7 @@ class TestNonChunkStatementsWrapping:
                 return x3
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_mixed_parallel_and_sequential_chunks(self):
         """Mixed parallel chunk + sequential chunk: parallel interchanged, sequential wrapped."""
@@ -991,7 +991,7 @@ class TestNonChunkStatementsWrapping:
                 return x10
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestScalarAssignmentNotWrapped:
@@ -1034,7 +1034,7 @@ class TestScalarAssignmentNotWrapped:
                 return x8
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_scalar_assign_not_wrapped_outline_no_crash(self):
         """Scalar assignment stays in orchestration after outline — no undefined variable."""

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -16,10 +16,8 @@ view-like operations (fillpad, reshape).
 
 Test strategy:
 - IR-level tests use the Before/Expected pattern with
-  ``ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)``.
-  ``enable_auto_mapping`` makes structural comparison sensitive to MemRef
-  identity sharing — two tiles that share a MemRef before vs. two tiles
-  with separate MemRefs after the split is visible structurally.
+  ``ir.assert_structural_equal(After, Expected)``.
+  DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
 - TestLegalizeWithCodegen retains the IRBuilder-based construction and MLIR
   string assertions, since those tests verify codegen output (alloc counts,
   addresses, dynamic-shape rendering) rather than IR shape.
@@ -92,7 +90,7 @@ class TestLegalSharingPreserved:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_fillpad_view_keeps_shared(self):
         """fillpad changes pad but keeps same shape -> legal view."""
@@ -140,7 +138,7 @@ class TestLegalSharingPreserved:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestAscend910BSplitLoadTpopHazard:
@@ -181,7 +179,7 @@ class TestAscend910BSplitLoadTpopHazard:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_ascend950_keeps_compatible_share(self):
         backend.reset_for_testing()
@@ -220,7 +218,7 @@ class TestAscend910BSplitLoadTpopHazard:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +268,7 @@ class TestIllegalSharingSplit:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_split_propagates_through_view_chain(self):
         """A split writer's legal views should follow the new MemRef."""
@@ -325,7 +323,7 @@ class TestIllegalSharingSplit:
                 return result
 
         After = passes.legalize_pto_buffer_reuse()(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -18,6 +18,8 @@ Test strategy:
 - IR-level tests use the Before/Expected pattern with
   ``ir.assert_structural_equal(After, Expected)``.
   DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
+  This makes structural comparison sensitive to MemRef identity sharing:
+  two tiles that share a MemRef in ``After`` must also share in ``Expected``.
 - TestLegalizeWithCodegen retains the IRBuilder-based construction and MLIR
   string assertions, since those tests verify codegen output (alloc counts,
   addresses, dynamic-shape rendering) rather than IR shape.

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -10,10 +10,8 @@
 """Tests for MemoryReusePass.
 
 Most tests use the Before/Expected pattern with
-``ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)``.
-``enable_auto_mapping=True`` aligns MemRef objects consistently across the
-comparison: if two tiles share a MemRef in ``After``, the corresponding tiles
-in ``Expected`` must also share (i.e. use the same ``mem_*`` pointer name).
+``ir.assert_structural_equal(After, Expected)``.
+DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
 """
 
 import pypto.language as pl
@@ -83,7 +81,7 @@ class TestBasic:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_sequential(self):
         """Sequential chain: tile_a/c/e share one buffer, tile_b/d share another."""
@@ -136,7 +134,7 @@ class TestBasic:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_different_sizes(self):
         """Different-shaped tiles cannot reuse each other's buffer."""
@@ -202,7 +200,7 @@ class TestBasic:
                 return result_f
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_empty_function(self):
         """Empty function (no TileType) should pass through unchanged."""
@@ -226,7 +224,7 @@ class TestBasic:
                 return output
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_transitive_conflict(self):
         """Transitive conflict: tile_c and tile_d cannot share."""
@@ -280,7 +278,7 @@ class TestBasic:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestAllocCleanup:
@@ -331,7 +329,7 @@ class TestAllocCleanup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_partial_reuse_with_overlapping_lifetimes(self):
         """When some lifetimes truly overlap, only partial reuse happens.
@@ -379,7 +377,7 @@ class TestAllocCleanup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestDtype:
@@ -439,7 +437,7 @@ class TestDtype:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestFillpad:
@@ -499,7 +497,7 @@ class TestFillpad:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_fillpad_different_pad_no_reuse(self):
         """Two fillpad outputs with different pad values cannot reuse each other."""
@@ -585,7 +583,7 @@ class TestFillpad:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_fillpad_same_pad_can_reuse(self):
         """Two fillpad outputs with identical TileView attributes CAN reuse."""
@@ -669,7 +667,7 @@ class TestFillpad:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestViewOps:
@@ -720,7 +718,7 @@ class TestViewOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_reshape_not_broken_by_memory_reuse(self):
         """MemoryReuse should propagate reuse to ALL variables sharing MemRef.
@@ -776,7 +774,7 @@ class TestViewOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_reshape_shared_buffer_can_be_reused_after_all_dead(self):
         """After all aliases are dead, shared buffer can be reused."""
@@ -827,7 +825,7 @@ class TestViewOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInplaceOps:
@@ -872,7 +870,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_inplace_unsafe_op_allows_non_producer_consumer_reuse(self):
         """tile.recip output must never share a buffer with its input.
@@ -937,7 +935,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_inplace_safe_op_allows_producer_consumer_reuse(self):
         """tile.add (inplace-safe) CAN reuse its input's buffer."""
@@ -976,7 +974,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_ands_no_producer_consumer_reuse(self):
         """tile.ands must NOT reuse its input's buffer."""
@@ -1016,7 +1014,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_xors_no_producer_consumer_reuse(self):
         """tile.xors must NOT reuse its input's buffer."""
@@ -1066,7 +1064,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_inplace_unsafe_two_level_transitive_chain(self):
         """tile.recip must not reuse a buffer occupied by its input via a two-level chain.
@@ -1132,7 +1130,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestYieldFixup:
@@ -1193,7 +1191,7 @@ class TestYieldFixup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_simple_loop_memrefs_unified(self):
         """Simple loop: iter_arg/initValue/return_var/next_0 all land in a
@@ -1243,7 +1241,7 @@ class TestYieldFixup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_multiple_iter_args_producers_retyped_independently(self):
         """With 2 iter_args, the retargeter retypes each yield producer
@@ -1314,7 +1312,7 @@ class TestYieldFixup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_stmt_return_var_memref_patched(self):
         """tile_b/tile_c reuse tile_a's MemRef; if_result picks up the patched MemRef."""
@@ -1396,7 +1394,7 @@ class TestYieldFixup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_stmt_tile_move_when_branch_memrefs_differ(self):
         """When IfStmt branches yield tiles with different MemRefs, the pass
@@ -1471,7 +1469,7 @@ class TestYieldFixup:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestControlFlow:
@@ -1542,7 +1540,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_different_if_branches_can_share(self):
         """Variables in different IfStmt branches CAN share MemRef (non-overlapping lifetimes)."""
@@ -1614,7 +1612,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_loop_local_var_can_be_reused(self):
         """Loop-local vars share a scratch buffer; the yield producer is
@@ -1685,7 +1683,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_nested_for_loops_outer_var_extends_to_outer_end(self):
         """Variable defined before nested loops, used in inner loop body --
@@ -1764,7 +1762,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_without_else_branch(self):
         """IfStmt with only then branch (no else): tile_a is alive through the
@@ -1823,7 +1821,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_for_with_if_multiple_vars_competing(self):
         """ForStmt with IfStmt inside: `tile_a` and `tile_b` are live across
@@ -1907,7 +1905,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_branch_local_var_does_not_leak(self):
         """A variable defined and consumed entirely inside one IfStmt branch
@@ -1973,7 +1971,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_loop_return_var_blocks_init_memref_reuse(self):
         """Return_var used after loop must block reuse of initValue's MemRef.
@@ -2056,7 +2054,7 @@ class TestControlFlow:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestTopDownRetargeter:
@@ -2160,7 +2158,7 @@ class TestTopDownRetargeter:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_retargeter_declines_when_target_still_live(self):
         """Safety check: if target's base is read after the candidate
@@ -2232,7 +2230,7 @@ class TestTopDownRetargeter:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_retargeter_declines_when_read_after_nested_if(self):
         """Regression test for the ancestor-walking liveness check.
@@ -2318,7 +2316,7 @@ class TestTopDownRetargeter:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_retargeter_declines_for_not_inplace_safe_op(self):
         """Regression test for the not_inplace_safe check.
@@ -2406,7 +2404,7 @@ class TestTopDownRetargeter:
                 return out_val
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestMetadata:
@@ -2449,7 +2447,7 @@ class TestMetadata:
                 return result
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
         # Sanity: split metadata round-trips through the pass.
         after_vp = After.get_function("vector_producer")

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -12,6 +12,8 @@
 Most tests use the Before/Expected pattern with
 ``ir.assert_structural_equal(After, Expected)``.
 DefFields always auto-map, so ``enable_auto_mapping=True`` is unnecessary.
+This aligns MemRef objects consistently: if two tiles share a MemRef in
+``After``, the corresponding tiles in ``Expected`` must also share.
 """
 
 import pypto.language as pl

--- a/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
+++ b/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
@@ -123,7 +123,7 @@ class TestNonParallelCodeBetweenChunks:
                 return x8
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_interleaved_range_loop_gets_incore(self):
         """A range loop between parallel chunks must get an InCore scope.
@@ -205,7 +205,7 @@ class TestNonParallelCodeBetweenChunks:
                 return x9
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_all_ops_outlined_end_to_end(self):
         """End-to-end: all compute ops inside auto_incore must be outlined.
@@ -277,7 +277,7 @@ class TestNonParallelCodeBetweenChunks:
                 return x8
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestNestedForStmtRecursion:
@@ -353,7 +353,7 @@ class TestNestedForStmtRecursion:
                 return x10
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_single_forstmt_body_with_mixed_children(self):
         """auto_incore body is a single ForStmt (not SeqStmts).
@@ -406,7 +406,7 @@ class TestNestedForStmtRecursion:
                 return x6
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_multiple_non_parallel_ops_between_chunks(self):
         """Multiple consecutive non-parallel ops between chunks must all be wrapped."""
@@ -474,7 +474,7 @@ class TestNestedForStmtRecursion:
                 return x9
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_no_parallel_chunks_no_wrapping(self):
         """auto_incore with only non-parallel code (no chunks) should not crash.
@@ -513,7 +513,7 @@ class TestNestedForStmtRecursion:
                 return x1
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestHostSideTailOps:
@@ -560,7 +560,7 @@ class TestHostSideTailOps:
                 return out_1
 
         After = _run_pipeline(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -84,7 +84,7 @@ class TestResolveBackendOpLayouts:
                 return stored
 
         After = _run_pass(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_rewrites_column_vector_abs_through_row_major_reshape(self):
         """`tile.abs` (unary) on `[N, 1]` col_major vector should be repaired."""
@@ -130,7 +130,7 @@ class TestResolveBackendOpLayouts:
                 return stored
 
         After = _run_pass(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
     def test_rewrites_column_vector_muls_through_row_major_reshape(self):
         """`tile.muls` (tile x scalar) on `[N, 1]` col_major should repair only the tile input."""
@@ -176,7 +176,7 @@ class TestResolveBackendOpLayouts:
                 return stored
 
         After = _run_pass(Before)
-        ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+        ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_verify_no_nested_call_pass.py
+++ b/tests/ut/ir/transforms/test_verify_no_nested_call_pass.py
@@ -39,7 +39,7 @@ def test_nested_call_in_call_args():
             return result
 
     After = passes.flatten_call_expr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_deeply_nested_calls():
@@ -62,7 +62,7 @@ def test_deeply_nested_calls():
             return result
 
     After = passes.flatten_call_expr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_multiple_nested_calls():
@@ -93,7 +93,7 @@ def test_multiple_nested_calls():
             return result
 
     After = passes.flatten_call_expr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_nested_calls_in_control_flow():
@@ -131,7 +131,7 @@ def test_nested_calls_in_control_flow():
             return r5
 
     After = passes.flatten_call_expr()(passes.convert_to_ssa()(Before))
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_flatten_preserves_flat_code():
@@ -154,7 +154,7 @@ def test_flatten_preserves_flat_code():
             return result
 
     After = passes.flatten_call_expr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_complex_nested_expression_tree():
@@ -182,7 +182,7 @@ def test_complex_nested_expression_tree():
             return result
 
     After = passes.flatten_call_expr()(Before)
-    ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
+    ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -432,7 +432,7 @@ class TestMultiFuncIntegration:
         got = add_entry.compile_for_test(a, b, c)
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         expected_post_pass = pm.run_passes(Expected)
-        ir.assert_structural_equal(got, expected_post_pass, enable_auto_mapping=True)
+        ir.assert_structural_equal(got, expected_post_pass)
 
 
 class TestRoundTrip:


### PR DESCRIPTION
## Summary
- Remove `enable_auto_mapping=True` from ~130 `assert_structural_equal` calls across 12 pass transform test files
- Update docstrings in `test_memory_reuse.py`, `test_init_memref.py`, and `test_legalize_pto_buffer_reuse.py` to explain that DefFields always auto-map
- The parameter is kept in serialization round-trip tests and explicit `structural_equal` feature tests where it is genuinely needed

## Why
`VisitDefField` in `structural_equal.cpp:650` always forces auto-mapping to `true` when traversing DefFields (variable definitions). When those same Vars later appear as UsualField references, they are found in the bidirectional Var maps — even with `enable_auto_mapping=False`. So the parameter is redundant for Before/Expected pass transform tests.

## Testing
- [x] All 3887 tests pass
- [x] Code review completed
- [x] Pre-commit hooks pass (ruff, pyright)