### PR TITLE
feat(ir): Accept 0/inf/-inf literals as fillpad pad_value sugar

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -79,7 +79,7 @@ Transfer data between memory hierarchy levels.
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | Move tile between memory levels (including Vec→Vec) |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
-| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; tensor inputs lower to tile fillpad in InCore code |
+| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -79,7 +79,7 @@ Transfer data between memory hierarchy levels.
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | Move tile between memory levels (including Vec→Vec) |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
-| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |
+| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `0.0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -74,7 +74,7 @@
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
-| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
+| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
 
 ## Tile 算术（`pl.tile.*`）

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -74,7 +74,7 @@
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
-| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
+| `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`0.0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
 
 ## Tile 算术（`pl.tile.*`）

--- a/python/pypto/ir/op/_pad_value.py
+++ b/python/pypto/ir/op/_pad_value.py
@@ -20,7 +20,8 @@ import math
 from pypto.pypto_core.ir import PadValue
 
 _HINT = (
-    "Use pl.PadValue.zero / pl.PadValue.max / pl.PadValue.min, or one of the literals 0, math.inf, -math.inf."
+    "Use pl.PadValue.zero / pl.PadValue.max / pl.PadValue.min, "
+    "or one of the literals 0, 0.0, math.inf, -math.inf."
 )
 
 
@@ -66,6 +67,6 @@ def normalize_pad_value(pad_value: object) -> PadValue:
         )
     raise TypeError(
         f"fillpad pad_value must be a PadValue or one of "
-        f"0 / math.inf / -math.inf; got {type(pad_value).__name__} "
+        f"0 / 0.0 / math.inf / -math.inf; got {type(pad_value).__name__} "
         f"{pad_value!r}. {_HINT}"
     )

--- a/python/pypto/ir/op/_pad_value.py
+++ b/python/pypto/ir/op/_pad_value.py
@@ -1,0 +1,71 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Normalization for the ``fillpad`` ``pad_value`` keyword argument.
+
+The hardware only supports the three padding modes encoded by ``PadValue``
+(``zero`` / ``max`` / ``min``). To make the DSL friendlier we accept three
+numeric literals as sugar that map onto those modes; anything else raises
+with a clear hint so the user is never silently given a different value.
+"""
+
+import math
+
+from pypto.pypto_core.ir import PadValue
+
+_HINT = (
+    "Use pl.PadValue.zero / pl.PadValue.max / pl.PadValue.min, or one of the literals 0, math.inf, -math.inf."
+)
+
+
+def normalize_pad_value(pad_value: object) -> PadValue:
+    """Coerce a fillpad ``pad_value`` argument to a ``PadValue`` enum.
+
+    Accepted inputs:
+      * ``PadValue.zero`` / ``max`` / ``min`` — returned unchanged.
+      * ``0`` / ``0.0`` — mapped to ``PadValue.zero``.
+      * ``math.inf`` — mapped to ``PadValue.max``.
+      * ``-math.inf`` — mapped to ``PadValue.min``.
+
+    ``PadValue.null`` is rejected because "no padding mode" is meaningless
+    for an op that exists to write a fill value. Anything else (other
+    numbers, ``NaN``, ``bool``, ``str``, ``None``, ...) also raises.
+    """
+    if isinstance(pad_value, PadValue):
+        if pad_value == PadValue.null:
+            raise ValueError(
+                f"fillpad pad_value cannot be PadValue.null — that means no padding mode. {_HINT}"
+            )
+        return pad_value
+    # bool subclasses int — reject explicitly so True/False don't sneak in as 0/1.
+    if isinstance(pad_value, bool):
+        raise TypeError(f"fillpad pad_value cannot be bool ({pad_value!r}). {_HINT}")
+    if isinstance(pad_value, int):
+        if pad_value == 0:
+            return PadValue.zero
+        raise ValueError(
+            f"fillpad pad_value only accepts the integer literal 0 "
+            f"(mapped to PadValue.zero); got {pad_value!r}. {_HINT}"
+        )
+    if isinstance(pad_value, float):
+        if math.isnan(pad_value):
+            raise ValueError(f"fillpad pad_value cannot be NaN. {_HINT}")
+        if pad_value == 0.0:
+            return PadValue.zero
+        if math.isinf(pad_value):
+            return PadValue.max if pad_value > 0 else PadValue.min
+        raise ValueError(
+            f"fillpad pad_value only accepts the float literals 0.0, "
+            f"math.inf, or -math.inf; got {pad_value!r}. {_HINT}"
+        )
+    raise TypeError(
+        f"fillpad pad_value must be a PadValue or one of "
+        f"0 / math.inf / -math.inf; got {type(pad_value).__name__} "
+        f"{pad_value!r}. {_HINT}"
+    )

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -17,6 +17,7 @@ from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import Call, ConstFloat, ConstInt, Expr, PadValue, ScalarType, Span, TensorLayout
 
 from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
+from ._pad_value import normalize_pad_value
 
 
 def create(
@@ -179,19 +180,25 @@ def slice(
     return _ir_core.create_op_call("tensor.slice", args, {}, actual_span)
 
 
-def fillpad(tensor: Expr, pad_value: PadValue = PadValue.zero, span: Span | None = None) -> Call:
+def fillpad(
+    tensor: Expr, pad_value: PadValue | int | float = PadValue.zero, span: Span | None = None
+) -> Call:
     """Fill invalid tensor view elements with the specified padding value.
 
     Args:
         tensor: Input tensor expression
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min)
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Other values
+            raise — the hardware only supports the three padding modes.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression creating a padded tensor
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tensor.fillpad", [tensor], {"pad_value": pad_value}, actual_span)
+    return _ir_core.create_op_call(
+        "tensor.fillpad", [tensor], {"pad_value": normalize_pad_value(pad_value)}, actual_span
+    )
 
 
 def matmul(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -32,6 +32,7 @@ from pypto.pypto_core.ir import (
 )
 
 from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
+from ._pad_value import normalize_pad_value
 
 
 def _validate_offsets_shapes(offsets_tuple: _ir_core.MakeTuple, shapes_tuple: _ir_core.MakeTuple) -> None:
@@ -479,22 +480,29 @@ def full(
     return _ir_core.create_op_call("tile.full", [shape_tuple, value_expr], kwargs, actual_span)
 
 
-def fillpad(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span | None = None) -> Call:
+def fillpad(tile: Expr, pad_value: PadValue | int | float = PadValue.zero, span: Span | None = None) -> Call:
     """Fill remaining tile elements with specified padding value.
 
     Args:
         tile: Input tile (TileType)
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression that returns the filled and padded tile
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.fillpad", [tile], {"pad_value": pad_value}, actual_span)
+    return _ir_core.create_op_call(
+        "tile.fillpad", [tile], {"pad_value": normalize_pad_value(pad_value)}, actual_span
+    )
 
 
-def fillpad_inplace(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span | None = None) -> Call:
+def fillpad_inplace(
+    tile: Expr, pad_value: PadValue | int | float = PadValue.zero, span: Span | None = None
+) -> Call:
     """Fill padding elements of input tile in place with specified pad value.
 
     Unlike fillpad which returns a new tile, this operation mutates the input
@@ -503,14 +511,19 @@ def fillpad_inplace(tile: Expr, pad_value: PadValue = PadValue.zero, span: Span 
 
     Args:
         tile: Input tile (TileType)
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression (result typically discarded since op is in-place)
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.fillpad_inplace", [tile], {"pad_value": pad_value}, actual_span)
+    return _ir_core.create_op_call(
+        "tile.fillpad_inplace", [tile], {"pad_value": normalize_pad_value(pad_value)}, actual_span
+    )
 
 
 # ============================================================================

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -182,12 +182,15 @@ def slice(
     return Tensor(expr=call_expr)
 
 
-def fillpad(tensor: Tensor, pad_value: PadValue = PadValue.zero) -> Tensor:
+def fillpad(tensor: Tensor, pad_value: PadValue | int | float = PadValue.zero) -> Tensor:
     """Fill invalid tensor view elements with the specified padding value.
 
     Args:
         tensor: Input tensor
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min)
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
 
     Returns:
         Tensor wrapping the fillpad operation

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -413,12 +413,15 @@ def full(shape: list[int], dtype: DataType, value: int | float) -> Tile:
     return Tile(expr=call_expr)
 
 
-def fillpad(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
+def fillpad(tile: Tile, pad_value: PadValue | int | float = PadValue.zero) -> Tile:
     """Fill remaining tile elements with specified padding value.
 
     Args:
         tile: Input tile
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
 
     Returns:
         Tile wrapping the fillpad operation
@@ -427,7 +430,7 @@ def fillpad(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
     return Tile(expr=call_expr)
 
 
-def fillpad_inplace(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
+def fillpad_inplace(tile: Tile, pad_value: PadValue | int | float = PadValue.zero) -> Tile:
     """Fill padding elements of input tile in place.
 
     Unlike fillpad which allocates a new output tile, this operation reuses
@@ -436,7 +439,10 @@ def fillpad_inplace(tile: Tile, pad_value: PadValue = PadValue.zero) -> Tile:
 
     Args:
         tile: Input tile
-        pad_value: Padding mode (PadValue.zero, PadValue.max, or PadValue.min). Default is zero.
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
 
     Returns:
         Tile with padding filled (shares memory with the input tile).

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -345,8 +345,13 @@ def slice(
     raise TypeError(f"slice: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def fillpad(value: T, pad_value: PadValue = PadValue.zero) -> T:
-    """Fill invalid elements, dispatched by input type."""
+def fillpad(value: T, pad_value: PadValue | int | float = PadValue.zero) -> T:
+    """Fill invalid elements, dispatched by input type.
+
+    ``pad_value`` accepts the ``PadValue`` enum or the literal sugars ``0``,
+    ``math.inf``, ``-math.inf``. Other values raise — the hardware only
+    supports the three padding modes.
+    """
     if isinstance(value, Tensor):
         return _tensor.fillpad(value, pad_value)
     if isinstance(value, Tile):

--- a/tests/ut/language/test_fillpad_pad_value.py
+++ b/tests/ut/language/test_fillpad_pad_value.py
@@ -1,0 +1,141 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for fillpad ``pad_value`` literal sugar.
+
+The hardware only supports ``PadValue.zero`` / ``max`` / ``min``. The DSL
+accepts the literal sugars ``0``, ``math.inf``, ``-math.inf`` as a friendlier
+form; everything else must raise so a user is never silently given a different
+fill value.
+"""
+
+import math
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.ir.op._pad_value import normalize_pad_value
+from pypto.language.parser.diagnostics.exceptions import InvalidOperationError
+
+
+class TestNormalizePadValueAccepts:
+    """``normalize_pad_value`` accepts the enum and three numeric literals."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (ir.PadValue.zero, ir.PadValue.zero),
+            (ir.PadValue.max, ir.PadValue.max),
+            (ir.PadValue.min, ir.PadValue.min),
+            (0, ir.PadValue.zero),
+            (0.0, ir.PadValue.zero),
+            (math.inf, ir.PadValue.max),
+            (-math.inf, ir.PadValue.min),
+        ],
+    )
+    def test_accepts(self, value, expected):
+        assert normalize_pad_value(value) is expected
+
+
+class TestNormalizePadValueRejects:
+    """``normalize_pad_value`` rejects every other input with a clear hint."""
+
+    @pytest.mark.parametrize(
+        "value,exc_type",
+        [
+            (ir.PadValue.null, ValueError),
+            (1, ValueError),
+            (-1, ValueError),
+            (42, ValueError),
+            (3.14, ValueError),
+            (-3.14, ValueError),
+            (math.nan, ValueError),
+            (True, TypeError),
+            (False, TypeError),
+            ("zero", TypeError),
+            (None, TypeError),
+            ([0], TypeError),
+        ],
+    )
+    def test_rejects(self, value, exc_type):
+        with pytest.raises(exc_type, match="fillpad pad_value"):
+            normalize_pad_value(value)
+
+
+class TestFillpadSugarMatchesEnum:
+    """End-to-end: ``pl.fillpad`` with sugar IRs identically to the enum form."""
+
+    @pytest.mark.parametrize(
+        "literal,enum",
+        [
+            (0, ir.PadValue.zero),
+            (math.inf, ir.PadValue.max),
+            (-math.inf, ir.PadValue.min),
+        ],
+    )
+    def test_tensor_fillpad(self, literal, enum):
+        @pl.program
+        class Sugared:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=literal)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=enum)
+                return y
+
+        ir.assert_structural_equal(Sugared, Expected)
+
+
+class TestFillpadEndToEndRejection:
+    """Invalid pad_value inside @pl.function bodies surfaces at parse time.
+
+    The parser wraps the underlying ``TypeError`` / ``ValueError`` from
+    ``normalize_pad_value`` in an ``InvalidOperationError`` (its standard
+    behavior for any exception raised by an op builder), but the original
+    hint text is preserved in the message so users still see the explanation.
+    """
+
+    def test_pl_fillpad_rejects_arbitrary_int(self):
+        with pytest.raises(InvalidOperationError, match="fillpad pad_value"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=7)
+                    return y
+
+    def test_pl_fillpad_rejects_arbitrary_float(self):
+        with pytest.raises(InvalidOperationError, match="fillpad pad_value"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=3.14)
+                    return y
+
+    def test_pl_fillpad_rejects_string(self):
+        with pytest.raises(InvalidOperationError, match="fillpad pad_value"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value="zero")  # type: ignore[arg-type]
+                    return y
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add literal-value sugar (`0`, `math.inf`, `-math.inf`) for the `fillpad` `pad_value` kwarg, normalized at the IR-layer builders to the existing `PadValue` enum.
- Reject everything else (other numbers, NaN, bool, strings, `PadValue.null`) with a `TypeError`/`ValueError` whose message lists every accepted form.
- The hardware itself only supports the three padding modes; this is purely a DSL ergonomics change.

## Implementation
- New helper `python/pypto/ir/op/_pad_value.py::normalize_pad_value` — the single chokepoint, applied at `tensor.fillpad` / `tile.fillpad` / `tile.fillpad_inplace` builders.
- Language-layer wrappers and the `pl.fillpad` dispatcher only widen the type annotation — they delegate to the IR layer, which normalizes once.
- User docs (EN + zh-CN) updated to reflect the new signature.

## Example
```python
import math
import pypto.language as pl

# All equivalent
pl.fillpad(x, pad_value=pl.PadValue.zero)
pl.fillpad(x, pad_value=0)
pl.fillpad(x, pad_value=0.0)

pl.fillpad(x, pad_value=pl.PadValue.max)
pl.fillpad(x, pad_value=math.inf)

pl.fillpad(x, pad_value=pl.PadValue.min)
pl.fillpad(x, pad_value=-math.inf)

# Anything else raises with a clear hint
pl.fillpad(x, pad_value=7)        # ValueError: only accepts integer literal 0...
pl.fillpad(x, pad_value=3.14)     # ValueError: only accepts 0.0, math.inf, or -math.inf...
pl.fillpad(x, pad_value=math.nan) # ValueError: cannot be NaN...
```

## Test plan
- [x] `tests/ut/language/test_fillpad_pad_value.py` — 24 tests covering helper accept/reject paths and end-to-end sugar/rejection through `@pl.function` parsing
- [x] All 516 tests in impacted IR / language / codegen suites pass
- [x] Pre-commit (ruff, pyright, headers) passes