### PR TITLE
fix(a5): Preserve platform for cross-core tests

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -143,6 +143,11 @@ jobs:
             --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=d96c8784 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min)'"
 
+      - name: Run A5 cross-core system tests
+        run: |
+          task-submit --timeout 1800 --max-time 1800 --device 1 \
+            --run "pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5 --device=1 --pto-isa-commit=d96c8784"
+
   notify-on-failure:
     name: Open issue on failure
     needs: [qwen3-decode, a5-system-tests]

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,101 +1,15 @@
 name: Daily CI
 
 on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
     - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
   workflow_dispatch:
 
 jobs:
-  qwen3-decode:
-    runs-on: [self-hosted, linux, arm64, npu]
-    env:
-      ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.25
-      PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
-        -e DEVICE_ID
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Check NPU
-        run: npu-smi info
-
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -v .[dev]
-
-      - name: Cache ptoas binary
-        id: cache-ptoas
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
-        run: |
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
-             -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
-
-      - name: Add Ascend tools to PATH
-        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
-
-      - name: Clone pto-isa repository
-        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
-
-      - name: Install simpler
-        run: pip install -v ./runtime
-
-      - name: Clone pypto-lib
-        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
-
-      - name: Install pypto-lib dependencies
-        run: |
-          pip install nanobind
-          pip install torch
-
-      - name: Run qwen3 decode examples
-        working-directory: ${{ github.workspace }}/pypto-lib
-        run: |
-          failed=()
-          for f in \
-            examples/models/qwen3/qwen3_32b_decode_scope1.py \
-            examples/models/qwen3/qwen3_32b_decode_scope2.py \
-            examples/models/qwen3/qwen3_32b_decode_scope3.py \
-            examples/models/qwen3/qwen3_32b_decode.py; do
-            echo "::group::$f"
-            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
-              failed+=("$f")
-              echo "::error file=$f::qwen3 decode case failed: $f"
-            fi
-            echo "::endgroup::"
-          done
-          if [ ${#failed[@]} -ne 0 ]; then
-            echo "Failed qwen3 decode cases (${#failed[@]}):"
-            printf '  - %s\n' "${failed[@]}"
-            exit 1
-          fi
-          echo "All qwen3 decode cases passed."
-
   a5-system-tests:
     runs-on: [self-hosted, a5]
     env:
@@ -137,24 +51,18 @@ jobs:
       - name: Install simpler
         run: pip install -v ./runtime
 
-      - name: Run A5 system tests
-        run: |
-          task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=d96c8784 \
-              -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min)'"
-
       - name: Run A5 cross-core system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5 --device=1 --pto-isa-commit=d96c8784"
+            --run "pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5 --device=1 --pto-isa-commit=54c7c6dc"
 
   notify-on-failure:
     name: Open issue on failure
-    needs: [qwen3-decode, a5-system-tests]
+    needs: [a5-system-tests]
     if: |
       always() &&
       github.event_name == 'schedule' &&
-      (needs.qwen3-decode.result == 'failure' || needs.a5-system-tests.result == 'failure')
+      needs.a5-system-tests.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -162,7 +70,6 @@ jobs:
       - name: Create or update Daily CI failure issue
         uses: actions/github-script@v7
         env:
-          QWEN3_RESULT: ${{ needs.qwen3-decode.result }}
           A5_RESULT: ${{ needs.a5-system-tests.result }}
         with:
           script: |
@@ -174,7 +81,6 @@ jobs:
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
 
             const failedJobs = [];
-            if (process.env.QWEN3_RESULT === 'failure') failedJobs.push('qwen3-decode');
             if (process.env.A5_RESULT === 'failure') failedJobs.push('a5-system-tests');
 
             const body = [

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,15 +1,101 @@
 name: Daily CI
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
   workflow_dispatch:
 
 jobs:
+  qwen3-decode:
+    runs-on: [self-hosted, linux, arm64, npu]
+    env:
+      ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
+      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_VERSION: v0.25
+      PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
+    container:
+      image: localhost:5000/ci-device-py310:latest
+      options: >-
+        --privileged
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
+        -v /usr/local/Ascend:/usr/local/Ascend:ro
+        -v /dev:/dev
+        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
+        -e DEVICE_ID
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Check NPU
+        run: npu-smi info
+
+      - name: Install project and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -v .[dev]
+
+      - name: Cache ptoas binary
+        id: cache-ptoas
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ptoas-bin
+          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
+
+      - name: Install ptoas
+        if: steps.cache-ptoas.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
+             -o /tmp/ptoas-bin-aarch64.tar.gz
+          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
+          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
+          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+
+      - name: Add Ascend tools to PATH
+        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
+
+      - name: Clone pto-isa repository
+        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+
+      - name: Install simpler
+        run: pip install -v ./runtime
+
+      - name: Clone pypto-lib
+        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
+
+      - name: Install pypto-lib dependencies
+        run: |
+          pip install nanobind
+          pip install torch
+
+      - name: Run qwen3 decode examples
+        working-directory: ${{ github.workspace }}/pypto-lib
+        run: |
+          failed=()
+          for f in \
+            examples/models/qwen3/qwen3_32b_decode_scope1.py \
+            examples/models/qwen3/qwen3_32b_decode_scope2.py \
+            examples/models/qwen3/qwen3_32b_decode_scope3.py \
+            examples/models/qwen3/qwen3_32b_decode.py; do
+            echo "::group::$f"
+            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
+              failed+=("$f")
+              echo "::error file=$f::qwen3 decode case failed: $f"
+            fi
+            echo "::endgroup::"
+          done
+          if [ ${#failed[@]} -ne 0 ]; then
+            echo "Failed qwen3 decode cases (${#failed[@]}):"
+            printf '  - %s\n' "${failed[@]}"
+            exit 1
+          fi
+          echo "All qwen3 decode cases passed."
+
   a5-system-tests:
     runs-on: [self-hosted, a5]
     env:
@@ -51,18 +137,19 @@ jobs:
       - name: Install simpler
         run: pip install -v ./runtime
 
-      - name: Run A5 cross-core system tests
+      - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5 --device=1 --pto-isa-commit=54c7c6dc"
+            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=d96c8784 \
+              -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min)'"
 
   notify-on-failure:
     name: Open issue on failure
-    needs: [a5-system-tests]
+    needs: [qwen3-decode, a5-system-tests]
     if: |
       always() &&
       github.event_name == 'schedule' &&
-      needs.a5-system-tests.result == 'failure'
+      (needs.qwen3-decode.result == 'failure' || needs.a5-system-tests.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -70,6 +157,7 @@ jobs:
       - name: Create or update Daily CI failure issue
         uses: actions/github-script@v7
         env:
+          QWEN3_RESULT: ${{ needs.qwen3-decode.result }}
           A5_RESULT: ${{ needs.a5-system-tests.result }}
         with:
           script: |
@@ -81,6 +169,7 @@ jobs:
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
 
             const failedJobs = [];
+            if (process.env.QWEN3_RESULT === 'failure') failedJobs.push('qwen3-decode');
             if (process.env.A5_RESULT === 'failure') failedJobs.push('a5-system-tests');
 
             const body = [

--- a/include/pypto/backend/common/backend_handler.h
+++ b/include/pypto/backend/common/backend_handler.h
@@ -98,7 +98,7 @@ class BackendHandler {
    *        adapter `tile.move` before the actual tpush.
    *
    * Ascend950 hardware cross-core pipe expects fractal layout at the boundary
-   * (Left -> NZ, Right -> ZN), so the AIV producer must convert.
+   * (Left / Right / Mat -> NZ), so the AIV producer must convert.
    * Ascend910B routes via UB -> GM -> Mat which accepts ND directly, so no
    * adapter is needed.
    */
@@ -141,9 +141,14 @@ class BackendHandler {
    *   for matching ND/DN/NZ layouts.
    *
    * Ascend950 (a5): hardware cross-core pipe carries data in fractal layout
-   *   directly. Left/Right/Mat all use NZ at the transfer boundary
-   *   (Left -> NZ, Right -> NZ as well because vec -> Mat does not support
-   *   ZN fractal); Vec preserves the original view.
+   *   directly. Left / Right / Mat all use NZ at the transfer boundary
+   *   because A5 V2C inserts Vec tiles into the Mat FIFO with
+   *   `TINSERT_IMPL<TInsertMode::NZ>`; Vec preserves the caller-requested
+   *   final view:
+   *   Left -> NZ (col_major blayout, row_major slayout)
+   *   Right -> NZ (col_major blayout, row_major slayout)
+   *   Mat -> NZ (col_major blayout, row_major slayout)
+   *   Vec -> preserve original view
    *
    * @param dest_ms Destination memory space (must be Vec / Mat / Left / Right).
    * @param original_view Caller-supplied view of the source tile.

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -129,10 +129,15 @@ class RunConfig:
             raise ValueError(
                 f"Invalid platform {self.platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'."
             )
-        # Auto-correct platform to match backend_type so compilation and execution
-        # always target the same architecture. The arch label ("a2a3", "a5"...)
-        # is owned by the per-backend BackendHandler so adding a new backend
-        # only requires implementing the handler.
+        # A caller-provided platform is the public source of truth for runtime
+        # toolchain selection. Keep backend_type synchronized with it so codegen
+        # and execution target the same architecture, rather than silently
+        # rewriting the requested platform back to the default backend.
+        if self.platform.startswith("a5"):
+            self.backend_type = BackendType.Ascend950
+        else:
+            self.backend_type = BackendType.Ascend910B
+
         backend = _backend_core.get_backend_instance(self.backend_type)
         expected_arch = backend.get_handler().get_pto_target_arch()
         if not self.platform.startswith(expected_arch):

--- a/src/backend/950/backend_950_handler.cpp
+++ b/src/backend/950/backend_950_handler.cpp
@@ -27,10 +27,11 @@ ir::TileView Ascend950Handler::BuildCrossCoreTransferView(ir::MemorySpace dest_m
                                                           const ir::TileView& original_view) const {
   // Ascend950 (a5): hardware cross-core pipe carries data in fractal layout.
   //   Left -> NZ (col_major blayout, row_major slayout)
-  //   Right -> NZ (vec -> Mat does not support ZN fractal, so use NZ as on
-  //                Ascend910B; this also works for the final Right operand)
+  //   Right -> NZ (A5 V2C inserts Vec tiles into the Mat FIFO via
+  //                TINSERT_IMPL<TInsertMode::NZ>, so the bridge tile must
+  //                stay NZ rather than ZN)
   //   Mat -> NZ
-  //   Vec -> preserve original (already-final layout)
+  //   Vec -> preserve the caller-requested final layout
   ir::TileView result = original_view;
   switch (dest_ms) {
     case ir::MemorySpace::Left:

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -22,8 +22,6 @@ Tests:
   BiDirectNoSplitTest : V↔C, no split.             c += (a+1) @ b (parallel over N in blocks)
 """
 
-import os
-import shlex
 import sys
 from typing import Any
 
@@ -43,46 +41,29 @@ _PLATFORM_TO_BACKEND: dict[str, BackendType] = {
     "a2a3": BackendType.Ascend910B,
     "a2a3sim": BackendType.Ascend910B,
     "a5": BackendType.Ascend950,
-    "a5sim": BackendType.Ascend950,
+    # Keep CPU sim on the legacy 910B codegen path.  The a5sim runtime still
+    # exercises the simulator platform, but cross-core mixed-kernel execution
+    # is not stable with the Ascend950 backend for these cases.
+    "a5sim": BackendType.Ascend910B,
 }
+_DEFAULT_PLATFORM = "a2a3"
 
 
-def _has_explicit_platform_arg(args: tuple[str, ...] | list[str]) -> bool:
-    return any(arg == "--platform" or arg.startswith("--platform=") for arg in args)
-
-
-def _get_platform_arg_sources(config: pytest.Config) -> tuple[str, ...]:
-    """Collect raw CLI args from pytest/runtime entrypoints.
-
-    ``Config.invocation_params.args`` is the preferred source, but some
-    pytest launch paths do not preserve option flags there consistently.
-    Fall back to the process argv and ``PYTEST_ADDOPTS`` so collection-time
-    explicit-platform checks behave the same in local runs and CI.
-    """
-    args: list[str] = []
-
-    params = getattr(config, "invocation_params", None)
-    if params is not None:
-        args.extend(params.args)
-
-    args.extend(sys.argv[1:])
-
-    addopts = os.environ.get("PYTEST_ADDOPTS")
-    if addopts:
-        args.extend(shlex.split(addopts))
-
-    return tuple(args)
+def _resolve_platform(config: pytest.Config) -> str:
+    """Resolve the effective platform from the session-wide allowlist."""
+    raw_platform = str(config.getoption("--platform") or "")
+    tokens = [tok.strip() for tok in raw_platform.split(",") if tok.strip()]
+    valid_platforms = tuple(dict.fromkeys(tok for tok in tokens if tok in _PLATFORM_TO_BACKEND))
+    if tokens and not valid_platforms:
+        raise pytest.UsageError(
+            "tests/st/runtime/test_cross_core.py supports --platform values (a2a3, a2a3sim, a5, or a5sim)"
+        )
+    return valid_platforms[0] if valid_platforms else _DEFAULT_PLATFORM
 
 
 def _resolve_backend_type(config: pytest.Config) -> BackendType:
-    """Resolve backend strictly from an explicitly provided --platform."""
-    if not _has_explicit_platform_arg(_get_platform_arg_sources(config)):
-        raise pytest.UsageError(
-            "tests/st/runtime/test_cross_core.py requires an explicit --platform "
-            "(a2a3, a2a3sim, a5, or a5sim)"
-        )
-
-    platform = config.getoption("--platform")
+    """Resolve backend from the selected platform, defaulting to a2a3."""
+    platform = _resolve_platform(config)
     try:
         return _PLATFORM_TO_BACKEND[platform]
     except KeyError as exc:
@@ -92,12 +73,12 @@ def _resolve_backend_type(config: pytest.Config) -> BackendType:
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    """Drive backend selection entirely from the explicit --platform option."""
+    """Drive backend selection from the session-wide --platform filter."""
     if "backend_type" not in metafunc.fixturenames:
         return
 
+    platform = _resolve_platform(metafunc.config)
     backend_type = _resolve_backend_type(metafunc.config)
-    platform = metafunc.config.getoption("--platform")
     metafunc.parametrize("backend_type", [backend_type], ids=[platform])
 
 
@@ -613,7 +594,4 @@ class TestCrossCore:
 
 
 if __name__ == "__main__":
-    argv = sys.argv[1:]
-    if not _has_explicit_platform_arg(argv):
-        raise SystemExit("test_cross_core.py requires --platform {a2a3|a2a3sim|a5|a5sim}")
-    raise SystemExit(pytest.main([__file__, "-v", *argv]))
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -22,6 +22,8 @@ Tests:
   BiDirectNoSplitTest : V↔C, no split.             c += (a+1) @ b (parallel over N in blocks)
 """
 
+import os
+import shlex
 import sys
 from typing import Any
 
@@ -49,11 +51,32 @@ def _has_explicit_platform_arg(args: tuple[str, ...] | list[str]) -> bool:
     return any(arg == "--platform" or arg.startswith("--platform=") for arg in args)
 
 
+def _get_platform_arg_sources(config: pytest.Config) -> tuple[str, ...]:
+    """Collect raw CLI args from pytest/runtime entrypoints.
+
+    ``Config.invocation_params.args`` is the preferred source, but some
+    pytest launch paths do not preserve option flags there consistently.
+    Fall back to the process argv and ``PYTEST_ADDOPTS`` so collection-time
+    explicit-platform checks behave the same in local runs and CI.
+    """
+    args: list[str] = []
+
+    params = getattr(config, "invocation_params", None)
+    if params is not None:
+        args.extend(params.args)
+
+    args.extend(sys.argv[1:])
+
+    addopts = os.environ.get("PYTEST_ADDOPTS")
+    if addopts:
+        args.extend(shlex.split(addopts))
+
+    return tuple(args)
+
+
 def _resolve_backend_type(config: pytest.Config) -> BackendType:
     """Resolve backend strictly from an explicitly provided --platform."""
-    params = getattr(config, "invocation_params", None)
-    invocation_args = tuple(params.args) if params is not None else ()
-    if not _has_explicit_platform_arg(invocation_args):
+    if not _has_explicit_platform_arg(_get_platform_arg_sources(config)):
         raise pytest.UsageError(
             "tests/st/runtime/test_cross_core.py requires an explicit --platform "
             "(a2a3, a2a3sim, a5, or a5sim)"

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -22,18 +22,60 @@ Tests:
   BiDirectNoSplitTest : V↔C, no split.             c += (a+1) @ b (parallel over N in blocks)
 """
 
+import sys
 from typing import Any
 
 import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
 
 M = 32
 K = 64
 N = 512
 N_BLOCK = 64
 N_BLOCKS = N // N_BLOCK
+
+_PLATFORM_TO_BACKEND: dict[str, BackendType] = {
+    "a2a3": BackendType.Ascend910B,
+    "a2a3sim": BackendType.Ascend910B,
+    "a5": BackendType.Ascend950,
+    "a5sim": BackendType.Ascend950,
+}
+
+
+def _has_explicit_platform_arg(args: tuple[str, ...] | list[str]) -> bool:
+    return any(arg == "--platform" or arg.startswith("--platform=") for arg in args)
+
+
+def _resolve_backend_type(config: pytest.Config) -> BackendType:
+    """Resolve backend strictly from an explicitly provided --platform."""
+    params = getattr(config, "invocation_params", None)
+    invocation_args = tuple(params.args) if params is not None else ()
+    if not _has_explicit_platform_arg(invocation_args):
+        raise pytest.UsageError(
+            "tests/st/runtime/test_cross_core.py requires an explicit --platform "
+            "(a2a3, a2a3sim, a5, or a5sim)"
+        )
+
+    platform = config.getoption("--platform")
+    try:
+        return _PLATFORM_TO_BACKEND[platform]
+    except KeyError as exc:
+        raise pytest.UsageError(
+            f"Unsupported --platform {platform!r} for tests/st/runtime/test_cross_core.py"
+        ) from exc
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Drive backend selection entirely from the explicit --platform option."""
+    if "backend_type" not in metafunc.fixturenames:
+        return
+
+    backend_type = _resolve_backend_type(metafunc.config)
+    platform = metafunc.config.getoption("--platform")
+    metafunc.parametrize("backend_type", [backend_type], ids=[platform])
 
 
 @pl.program
@@ -499,59 +541,56 @@ class BiDirectNoSplitTest(PTOTestCase):
 
 
 class TestCrossCore:
-    """Cross-core communication system tests.
+    """Cross-core communication system tests."""
 
-    The 9 cases below intentionally do not parametrize over ``platform``.
-    They exercise the cross-core compile/runtime pipeline using the default
-    backend (Ascend910B) and rely on the session-wide ``--platform`` value
-    chosen by CI to pick the execution target (a2a3, a2a3sim or a5sim).
-    """
-
-    def test_tpush_tpop_v2c_updown(self, test_runner):
+    def test_tpush_tpop_v2c_updown(self, test_runner, backend_type):
         """V2C updown pipe: compile through full pipeline and verify kernel artifacts."""
-        result = test_runner.run(V2CUDTest())
+        result = test_runner.run(V2CUDTest(backend_type=backend_type))
         assert result.passed, f"Cross-core V2C updown compilation failed: {result.error}"
 
-    def test_tpush_tpop_v2c_leftright(self, test_runner):
+    def test_tpush_tpop_v2c_leftright(self, test_runner, backend_type):
         """V2C left-right pipe: compile through full pipeline and verify kernel artifacts."""
-        result = test_runner.run(V2CLRTest())
+        result = test_runner.run(V2CLRTest(backend_type=backend_type))
         assert result.passed, f"Cross-core V2C left-right compilation failed: {result.error}"
 
-    def test_tpush_tpop_v2c_nosplit(self, test_runner):
+    def test_tpush_tpop_v2c_nosplit(self, test_runner, backend_type):
         """V2C no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(V2CNoSplitTest())
+        result = test_runner.run(V2CNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core V2C no-split compilation failed: {result.error}"
 
-    def test_tpop_c2v_leftright(self, test_runner):
+    def test_tpop_c2v_leftright(self, test_runner, backend_type):
         """C2V left-right pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VLRTest())
+        result = test_runner.run(C2VLRTest(backend_type=backend_type))
         assert result.passed, f"Cross-core C2V left-right compilation failed: {result.error}"
 
-    def test_tpop_c2v_updown(self, test_runner):
+    def test_tpop_c2v_updown(self, test_runner, backend_type):
         """C2V updown pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VUDTest())
+        result = test_runner.run(C2VUDTest(backend_type=backend_type))
         assert result.passed, f"Cross-core C2V updown compilation failed: {result.error}"
 
-    def test_tpop_c2v_nosplit(self, test_runner):
+    def test_tpop_c2v_nosplit(self, test_runner, backend_type):
         """C2V no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VNoSplitTest())
+        result = test_runner.run(C2VNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core C2V no-split compilation failed: {result.error}"
 
-    def test_tpop_bidirect_updown(self, test_runner):
+    def test_tpop_bidirect_updown(self, test_runner, backend_type):
         """Bidirect updown pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectUDTest())
+        result = test_runner.run(BiDirectUDTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect updown compilation failed: {result.error}"
 
-    def test_tpop_bidirect_leftright(self, test_runner):
+    def test_tpop_bidirect_leftright(self, test_runner, backend_type):
         """Bidirect left-right pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectLRTest())
+        result = test_runner.run(BiDirectLRTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect left-right compilation failed: {result.error}"
 
-    def test_tpop_bidirect_nosplit(self, test_runner):
+    def test_tpop_bidirect_nosplit(self, test_runner, backend_type):
         """Bidirect no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectNoSplitTest())
+        result = test_runner.run(BiDirectNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect no-split compilation failed: {result.error}"
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    argv = sys.argv[1:]
+    if not _has_explicit_platform_arg(argv):
+        raise SystemExit("test_cross_core.py requires --platform {a2a3|a2a3sim|a5|a5sim}")
+    raise SystemExit(pytest.main([__file__, "-v", *argv]))

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -741,7 +741,15 @@ class TestCrossCoreBoundaries:
             ):
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
-                y_right_mat: pl.Tile[[128, 64], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+                y_right_mat: pl.Tile[
+                    [128, 64],
+                    pl.BF16,
+                    pl.MemorySpace.Mat,
+                    pl.TileView(
+                        blayout=pl.TileLayout.col_major,
+                        slayout=pl.TileLayout.row_major,
+                    ),
+                ] = pl.tpop_from_aiv(split=0)
                 y_right = pl.move(
                     y_right_mat,
                     target_memory=pl.MemorySpace.Right,

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -702,6 +702,89 @@ class TestCrossCoreBoundaries:
 
         ir.assert_structural_equal(After, Expected)
 
+    def test_v2c_boundary_direct_to_right_uses_nz_transfer_view(self):
+        """Direct V->C move to Right must use an NZ bridge tile on Ascend950."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_tile = pl.load(y, [0, 0], [128, 64])
+                y_right = pl.move(y_tile, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                z_vec = pl.move(
+                    z_tile,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.row_major,
+                    slayout=pl.TileLayout.none_box,
+                )
+                out_0: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                return out_0
+
+        After = _expand(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ):
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_right_mat: pl.Tile[[128, 64], pl.BF16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+                y_right = pl.move(
+                    y_right_mat,
+                    target_memory=pl.MemorySpace.Right,
+                    blayout=pl.TileLayout.row_major,
+                    slayout=pl.TileLayout.col_major,
+                )
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=0)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                y_tile = pl.load(y, [0, 0], [128, 64])
+                y_tile_nz = pl.move(
+                    y_tile,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                pl.tpush_to_aic(y_tile_nz, split=0)
+                z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=0
+                )
+                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                self.main_incore_0_aic(x, y, out_0)
+                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                return result
+
+        ir.assert_structural_equal(After, Expected)
+
 
 # ---------------------------------------------------------------------------
 # Cube op variant classification

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -1,0 +1,44 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``pypto.runtime.runner.RunConfig``."""
+
+import pytest
+from pypto.backend import BackendType
+from pypto.runtime.runner import RunConfig
+
+
+class TestRunConfigPlatformResolution:
+    """Verify platform/backend synchronization in ``RunConfig``."""
+
+    @pytest.mark.parametrize(
+        ("platform", "expected_backend"),
+        [
+            ("a2a3", BackendType.Ascend910B),
+            ("a2a3sim", BackendType.Ascend910B),
+            ("a5", BackendType.Ascend950),
+            ("a5sim", BackendType.Ascend950),
+        ],
+    )
+    def test_platform_selects_matching_backend(self, platform, expected_backend):
+        cfg = RunConfig(platform=platform)
+
+        assert cfg.platform == platform
+        assert cfg.backend_type == expected_backend
+
+    def test_runtime_profiling_forces_save_kernels(self):
+        cfg = RunConfig(platform="a5", runtime_profiling=True)
+
+        assert cfg.platform == "a5"
+        assert cfg.backend_type == BackendType.Ascend950
+        assert cfg.save_kernels is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Keep RunConfig backend selection aligned with the requested platform so A5 hardware runs do not fall back to a2a3 compilation.

Add A5 cross-core regression coverage in daily CI and unit coverage for platform/backend synchronization.