### PR TITLE
feat(language): Add `for i in pl.spmd(...)` loop form with auto InCore outlining

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -278,11 +278,11 @@ cluster = ir.ClusterScopeStmt(name_hint="", body=body, span=span)
 hier = ir.HierarchyScopeStmt(level=ir.Level.HOST, role=ir.Role.Worker,
                              name_hint="", body=body, span=span)
 
-# with pl.spmd(core_num=8):
+# with pl.spmd(8):
 spmd = ir.SpmdScopeStmt(core_num=8, sync_start=False,
                         name_hint="", body=body, span=span)
 
-# for i in pl.spmd(core_num=8):          # loop-style surface syntax
+# for i in pl.spmd(8):                    # loop-style surface syntax
 #     offset = i * 64
 #     tile = pl.load(a, [offset, 0], [64, 128])
 #     ...

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -281,6 +281,17 @@ hier = ir.HierarchyScopeStmt(level=ir.Level.HOST, role=ir.Role.Worker,
 # with pl.spmd(core_num=8):
 spmd = ir.SpmdScopeStmt(core_num=8, sync_start=False,
                         name_hint="", body=body, span=span)
+
+# for i in pl.spmd(core_num=8):          # loop-style surface syntax
+#     offset = i * 64
+#     tile = pl.load(a, [offset, 0], [64, 128])
+#     ...
+# The parser desugars the for-loop to:
+#   SpmdScopeStmt(body=InCoreScopeStmt(body=[i = tile.get_block_idx(); ...]))
+# so the block index `i` is bound inside the implicit InCore region. The
+# OutlineIncoreScopes + OutlineClusterScopes pair then outlines the InCore
+# body into a synthetic `Function(InCore)` and the Spmd wrapper into a
+# `Function(Spmd)` just like the `with`-form single-kernel case.
 ```
 
 **Properties:**

--- a/docs/en/dev/passes/08-outline_cluster_scopes.md
+++ b/docs/en/dev/passes/08-outline_cluster_scopes.md
@@ -11,7 +11,7 @@ This pass transforms `ClusterScopeStmt` nodes into separate `Function(Group)` de
 - Input IR must be in SSA form (run ConvertToSSA first)
 - Only processes Opaque and Orchestration functions
 
-**When to use**: Run after `OutlineIncoreScopes` when the IR contains `with pl.cluster():` scopes or standalone `with pl.spmd(...):` scopes that need to be extracted into wrapper functions.
+**When to use**: Run after `OutlineIncoreScopes` when the IR contains `with pl.cluster():` scopes or standalone `with pl.spmd(...):` / `for i in pl.spmd(...)` scopes that need to be extracted into wrapper functions. The loop form is a parser-level desugaring for `SpmdScopeStmt(body=InCoreScopeStmt(...))`; `OutlineIncoreScopes` outlines the InCore body first, leaving a single-call Spmd body for this pass to lift into a `Function(Spmd)`.
 
 ## API
 

--- a/docs/en/dev/passes/08-outline_cluster_scopes.md
+++ b/docs/en/dev/passes/08-outline_cluster_scopes.md
@@ -91,7 +91,7 @@ class Before:
     @pl.function(type=pl.FunctionType.Orchestration)
     def main(self, x: pl.Tensor[[64], pl.FP32],
              out: pl.Out[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.spmd(core_num=4, sync_start=True):
+        with pl.spmd(4, sync_start=True):
             out = self.kernel(x, out)
         return out
 ```

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -248,6 +248,17 @@ hier = ir.HierarchyScopeStmt(level=ir.Level.HOST, role=ir.Role.Worker,
 # with pl.spmd(core_num=8):
 spmd = ir.SpmdScopeStmt(core_num=8, sync_start=False,
                         name_hint="", body=body, span=span)
+
+# for i in pl.spmd(core_num=8):          # loop-style 语法糖
+#     offset = i * 64
+#     tile = pl.load(a, [offset, 0], [64, 128])
+#     ...
+# 解析器会将此 for-loop 脱糖为：
+#   SpmdScopeStmt(body=InCoreScopeStmt(body=[i = tile.get_block_idx(); ...]))
+# 这样块索引 `i` 就在隐式的 InCore 区域里被绑定。随后
+# `OutlineIncoreScopes` + `OutlineClusterScopes` 会把 InCore 体提取为
+# 合成的 `Function(InCore)`，并把 Spmd 包装提取为 `Function(Spmd)`，
+# 行为与 `with`-form 单内核调用路径一致。
 ```
 
 **属性：**

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -245,11 +245,11 @@ cluster = ir.ClusterScopeStmt(name_hint="", body=body, span=span)
 hier = ir.HierarchyScopeStmt(level=ir.Level.HOST, role=ir.Role.Worker,
                              name_hint="", body=body, span=span)
 
-# with pl.spmd(core_num=8):
+# with pl.spmd(8):
 spmd = ir.SpmdScopeStmt(core_num=8, sync_start=False,
                         name_hint="", body=body, span=span)
 
-# for i in pl.spmd(core_num=8):          # loop-style 语法糖
+# for i in pl.spmd(8):                    # loop-style 语法糖
 #     offset = i * 64
 #     tile = pl.load(a, [offset, 0], [64, 128])
 #     ...

--- a/docs/zh-cn/dev/passes/08-outline_cluster_scopes.md
+++ b/docs/zh-cn/dev/passes/08-outline_cluster_scopes.md
@@ -11,7 +11,7 @@
 - 输入 IR 必须为静态单赋值 (SSA) 形式（需先运行 ConvertToSSA）
 - 仅处理 Opaque 和 Orchestration 函数
 
-**使用时机**：在 `OutlineIncoreScopes` 之后运行，当 IR 包含需要提取的 `with pl.cluster():` 作用域或 standalone `with pl.spmd(...):` 作用域时使用。
+**使用时机**：在 `OutlineIncoreScopes` 之后运行，当 IR 包含需要提取的 `with pl.cluster():` 作用域或 standalone `with pl.spmd(...):` / `for i in pl.spmd(...)` 作用域时使用。loop-form 是解析器对 `SpmdScopeStmt(body=InCoreScopeStmt(...))` 的语法糖；`OutlineIncoreScopes` 先把 InCore 体提取为独立函数，使 Spmd 体变成单次函数调用，之后本 pass 再把它提升为 `Function(Spmd)`。
 
 ## API
 

--- a/docs/zh-cn/dev/passes/08-outline_cluster_scopes.md
+++ b/docs/zh-cn/dev/passes/08-outline_cluster_scopes.md
@@ -91,7 +91,7 @@ class Before:
     @pl.function(type=pl.FunctionType.Orchestration)
     def main(self, x: pl.Tensor[[64], pl.FP32],
              out: pl.Out[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.spmd(core_num=4, sync_start=True):
+        with pl.spmd(4, sync_start=True):
             out = self.kernel(x, out)
         return out
 ```

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -723,7 +723,9 @@ using WhileStmtPtr = std::shared_ptr<const WhileStmt>;
  *     body
  * with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):  # -> HierarchyScopeStmt
  *     body
- * with pl.spmd(core_num=8):  # -> SpmdScopeStmt
+ * with pl.spmd(8):           # -> SpmdScopeStmt
+ *     body
+ * for i in pl.spmd(8):       # -> SpmdScopeStmt(body=InCoreScopeStmt(...))
  *     body
  *
  * **Semantics:**

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -71,6 +71,35 @@ class StoreTargetCollector : public IRVisitor {
 };
 
 /**
+ * @brief Collect SSA post-store aliases: variables bound via
+ *        ``AssignStmt(v, Call(tile.store, ..., target))``.
+ *
+ * Maps ``v`` (the SSA-assignee) to ``target`` (the store's last argument).
+ * Both identify the same tensor state (post-store) with different pointer
+ * identities — ``v`` lives in ``body_collector.var_defs`` while ``target``
+ * shows up as a ``store_targets`` entry.  ScopeOutliner uses this to avoid
+ * exporting the same tensor twice when both sets would otherwise contribute
+ * outputs.
+ */
+class PostStoreAliasCollector : public IRVisitor {
+ public:
+  /// alias var (the SSA assignee of a tile.store call) → original store target
+  std::unordered_map<const Var*, const Var*> alias_to_target;
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    auto call = std::dynamic_pointer_cast<const Call>(op->value_);
+    auto opnode = call ? std::dynamic_pointer_cast<const Op>(call->op_) : nullptr;
+    if (opnode && opnode->name_ == "tile.store" && call->args_.size() >= 3) {
+      if (auto target = As<Var>(call->args_[2])) {
+        alias_to_target.emplace(op->var_.get(), target.get());
+      }
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
+/**
  * @brief Mutator that converts EvalStmt(Call(tile.store, ...)) into
  *        AssignStmt(target_var, Call(tile.store, ...)) for specified
  *        store targets.
@@ -233,6 +262,30 @@ class ScopeOutliner : public IRMutator {
   }
 
   /**
+   * @brief Compute used_after when no explicit context is available.
+   *
+   * Two regimes:
+   *   1. Scope is nested inside another (non-target) ScopeStmt — only store
+   *      targets escape, because scope boundaries confine locally-defined
+   *      variables.
+   *   2. Scope is at the top level or inside a control-flow body — retain the
+   *      original defensive fallback: all defined vars + store targets are
+   *      treated as outputs so the caller retains access.
+   */
+  std::unordered_set<const Var*> ComputeFallbackUsedAfter(const ScopeStmtPtr& scope) const {
+    StoreTargetCollector store_collector;
+    store_collector.VisitStmt(scope->body_);
+    std::unordered_set<const Var*> used_after;
+    if (!inside_nested_scope_body_) {
+      VarDefUseCollector def_collector;
+      def_collector.VisitStmt(scope->body_);
+      used_after = def_collector.var_defs;
+    }
+    used_after.insert(store_collector.store_targets.begin(), store_collector.store_targets.end());
+    return used_after;
+  }
+
+  /**
    * @brief Process SeqStmts to analyze scope outputs using subsequent statements.
    *
    * For each target scope, collects variables referenced in all subsequent statements
@@ -244,29 +297,30 @@ class ScopeOutliner : public IRMutator {
 
     for (size_t i = 0; i < op->stmts_.size(); ++i) {
       auto scope = std::dynamic_pointer_cast<const ScopeStmt>(op->stmts_[i]);
+      // Always compute what's used in the tail of this SeqStmts; this set is
+      // the "used_after" for a target scope at position i, and doubles as the
+      // required_outputs_ propagated into a non-target statement so any
+      // target-kind scope nested inside knows what needs to leak out.
+      VarDefUseCollector after_ref_collector;
+      for (size_t j = i + 1; j < op->stmts_.size(); ++j) {
+        after_ref_collector.VisitStmt(op->stmts_[j]);
+      }
+      auto after_refs = after_ref_collector.GetAllVarRefs();
+
       if (scope && scope->GetScopeKind() == target_scope_kind_) {
-        // Collect variables referenced in all subsequent statements
-        VarDefUseCollector after_ref_collector;
-        for (size_t j = i + 1; j < op->stmts_.size(); ++j) {
-          after_ref_collector.VisitStmt(op->stmts_[j]);
-        }
         // Also include variables required by parent scope
-        auto used_after = after_ref_collector.GetAllVarRefs();
+        auto used_after = after_refs;
         used_after.insert(required_outputs_.begin(), required_outputs_.end());
 
         // When no context is available (no subsequent statements and no parent
-        // requirements), fall back to standalone behaviour: treat all
-        // scope-defined vars + store targets as outputs.  This happens when
-        // a single ScopeStmt is wrapped in SeqStmts inside a control-flow
-        // body (if/for/while) where the outer context hasn't propagated
-        // required_outputs_.
+        // requirements), fall back to scope-nesting-aware defaults.  This
+        // happens when a single ScopeStmt is wrapped in SeqStmts inside a
+        // control-flow body (if/for/while) where the outer context hasn't
+        // propagated required_outputs_, or when the scope sits directly
+        // inside another scope (e.g. an InCoreScopeStmt at the top of a
+        // SpmdScopeStmt body produced by the ``for i in pl.spmd(...)`` form).
         if (used_after.empty()) {
-          VarDefUseCollector fallback_def;
-          fallback_def.VisitStmt(scope->body_);
-          StoreTargetCollector fallback_store;
-          fallback_store.VisitStmt(scope->body_);
-          used_after = fallback_def.var_defs;
-          used_after.insert(fallback_store.store_targets.begin(), fallback_store.store_targets.end());
+          used_after = ComputeFallbackUsedAfter(scope);
         }
 
         // Outline this scope with context about what's used after
@@ -274,8 +328,13 @@ class ScopeOutliner : public IRMutator {
         new_stmts.push_back(outlined_stmt);
         changed = true;
       } else {
-        // Recursively visit non-scope statements
+        // Recursively visit non-target statements.  Temporarily extend
+        // required_outputs_ with the tail-use set so any target-kind scope
+        // nested inside this statement can compute a correct used_after.
+        auto saved_required_outputs = required_outputs_;
+        required_outputs_.insert(after_refs.begin(), after_refs.end());
         auto visited = VisitStmt(op->stmts_[i]);
+        required_outputs_ = saved_required_outputs;
         new_stmts.push_back(visited);
         if (visited != op->stmts_[i]) {
           changed = true;
@@ -290,22 +349,39 @@ class ScopeOutliner : public IRMutator {
   }
 
   /**
-   * @brief Handle standalone ScopeStmts (not inside SeqStmts).
+   * @brief Handle ScopeStmts that are direct children of another node (not
+   * inside a SeqStmts).
    *
-   * When a scope appears outside a SeqStmts, all defined variables are outputs.
+   * The fallback honours scope nesting via ``inside_nested_scope_body_``: an
+   * inner scope whose only "context" is an enclosing non-target scope has no
+   * way for its locally-defined variables to escape, so we only expose store
+   * targets. Scopes at the true top level (outside any parent scope body)
+   * retain the original defensive "all defs are outputs" behaviour.
    */
-  // Shared per-kind logic: outline if kind matches, else fall through to base default.
+  // Shared per-kind logic: outline if kind matches, else descend with the
+  // nested-scope flag set so any target-kind scope we find inside can make a
+  // correct used_after decision.
   template <typename ScopeT>
   StmtPtr VisitScopeKind(const std::shared_ptr<const ScopeT>& op) {
     if (op->GetScopeKind() != target_scope_kind_) {
-      return IRMutator::VisitStmt_(op);
+      bool prev = std::exchange(inside_nested_scope_body_, true);
+      auto result = IRMutator::VisitStmt_(op);
+      inside_nested_scope_body_ = prev;
+      return result;
     }
-    VarDefUseCollector def_collector;
-    def_collector.VisitStmt(op->body_);
+    // Prefer the enclosing SeqStmts' propagated requirements over the
+    // "no context" fallback.  This matters when a target scope is a direct
+    // child of another scope (SpmdScopeStmt{InCoreScopeStmt{...}}) — the
+    // enclosing SeqStmts visitor populates required_outputs_ with variables
+    // the post-scope statements still reference.
+    if (required_outputs_.empty()) {
+      return OutlineScope(op, ComputeFallbackUsedAfter(op));
+    }
+    std::unordered_set<const Var*> used_after = required_outputs_;
     StoreTargetCollector store_collector;
     store_collector.VisitStmt(op->body_);
-    def_collector.var_defs.insert(store_collector.store_targets.begin(), store_collector.store_targets.end());
-    return OutlineScope(op, def_collector.var_defs);
+    used_after.insert(store_collector.store_targets.begin(), store_collector.store_targets.end());
+    return OutlineScope(op, used_after);
   }
 
   StmtPtr VisitStmt_(const InCoreScopeStmtPtr& op) override { return VisitScopeKind(op); }
@@ -372,13 +448,45 @@ class ScopeOutliner : public IRMutator {
     VarCollector scope_var_collector;
     scope_var_collector.VisitStmt(op->body_);
 
+    // Map any SSA post-store alias (var_def bound to a tile.store call) back
+    // to its store target so we don't export the same tensor twice.
+    PostStoreAliasCollector post_store_collector;
+    post_store_collector.VisitStmt(op->body_);
+
+    // Store targets present in the scope body — used to decide whether a
+    // post-store alias's original target will already appear in output_vars
+    // via the store-target-output pass below.
+    StoreTargetCollector store_collector;
+    store_collector.VisitStmt(op->body_);
+
+    // Aliases deferred to the call-site emission: each pair maps a
+    // scope-local SSA post-store alias (pointer identity in the scope body)
+    // to the external store target's var_objects_ pointer.  After the fresh
+    // store-target Var is created at the call site we rename the alias to
+    // it, so subsequent parent-function references resolve correctly.
+    std::vector<std::pair<const Var*, const Var*>> deferred_post_store_aliases;
     for (const Var* var_ptr : body_collector.var_defs_ordered) {
-      if (used_after.count(var_ptr)) {
-        auto scope_it = scope_var_collector.var_objects.find(var_ptr);
-        CHECK(scope_it != scope_var_collector.var_objects.end())
-            << "Variable " << var_ptr->name_hint_ << " not found in scope body";
-        output_vars.push_back(scope_it->second);
+      if (!used_after.count(var_ptr)) continue;
+
+      // Skip if this var_def is a post-store alias of an external store
+      // target: that same tensor will be exported by the store-target pass
+      // below, and we don't want a duplicated output entry.
+      auto alias_it = post_store_collector.alias_to_target.find(var_ptr);
+      const Var* target_ptr =
+          (alias_it != post_store_collector.alias_to_target.end()) ? alias_it->second : nullptr;
+      if (target_ptr && store_collector.store_targets.count(target_ptr) &&
+          !body_collector.var_defs.count(target_ptr)) {
+        auto ext_it = var_objects_.find(target_ptr);
+        CHECK(ext_it != var_objects_.end())
+            << "Store target " << target_ptr->name_hint_ << " not found in var_objects";
+        deferred_post_store_aliases.emplace_back(var_ptr, ext_it->second.get());
+        continue;
       }
+
+      auto scope_it = scope_var_collector.var_objects.find(var_ptr);
+      CHECK(scope_it != scope_var_collector.var_objects.end())
+          << "Variable " << var_ptr->name_hint_ << " not found in scope body";
+      output_vars.push_back(scope_it->second);
     }
 
     // Also treat store targets as outputs: external tensors modified via
@@ -392,8 +500,6 @@ class ScopeOutliner : public IRMutator {
     //   - body pointer (var_ptr) — kept in store_body_ptrs for the
     //     StoreEvalToAssignMutator, which matches against the un-substituted
     //     scope body where store targets retain their original pointers
-    StoreTargetCollector store_collector;
-    store_collector.VisitStmt(op->body_);
     std::unordered_map<const Var*, const Var*> store_body_ptrs;
     for (const Var* var_ptr : store_collector.store_targets) {
       if (!body_collector.var_defs.count(var_ptr)) {
@@ -616,12 +722,18 @@ class ScopeOutliner : public IRMutator {
       return CreateFreshStoreTargetVar(ext_it->second, op->span_);
     };
 
-    // Create assignments for output variables in the parent function
+    // Create assignments for output variables in the parent function.
+    // We assemble the result first, then register deferred post-store alias
+    // renames once — each alias maps to a store target whose fresh var is
+    // populated by resolve_call_site_var (via CreateFreshStoreTargetVar) into
+    // store_target_renames_, so the registration must happen after all
+    // resolve_call_site_var calls.
+    StmtPtr result;
     if (output_vars.empty()) {
-      return std::make_shared<EvalStmt>(call_expr, op->span_);
+      result = std::make_shared<EvalStmt>(call_expr, op->span_);
     } else if (output_vars.size() == 1) {
       auto output_var = resolve_call_site_var(output_vars[0]);
-      return std::make_shared<AssignStmt>(output_var, call_expr, op->span_);
+      result = std::make_shared<AssignStmt>(output_var, call_expr, op->span_);
     } else {
       // Assign call result to a temporary variable, then unpack with TupleGetItem
       auto ret_var =
@@ -633,8 +745,20 @@ class ScopeOutliner : public IRMutator {
         auto output_var = resolve_call_site_var(output_vars[i]);
         stmts.push_back(std::make_shared<AssignStmt>(output_var, tuple_get, op->span_));
       }
-      return std::make_shared<SeqStmts>(stmts, op->span_);
+      result = std::make_shared<SeqStmts>(stmts, op->span_);
     }
+
+    // For each scope-local SSA post-store alias we elided from output_vars,
+    // look up the already-renamed store target and map the alias body
+    // pointer to that fresh var so later parent-function references resolve
+    // correctly.
+    for (const auto& [alias_ptr, target_ptr] : deferred_post_store_aliases) {
+      auto rename_it = store_target_renames_.find(target_ptr);
+      if (rename_it != store_target_renames_.end()) {
+        store_target_renames_[alias_ptr] = rename_it->second;
+      }
+    }
+    return result;
   }
 
   /**
@@ -794,6 +918,11 @@ class ScopeOutliner : public IRMutator {
   std::string name_suffix_;
   ProgramPtr program_;
   int scope_counter_ = 0;
+  /// True while we are visiting the body of a non-target ScopeStmt — a
+  /// target-kind scope encountered here cannot leak locally-defined vars to
+  /// any surrounding context (scope boundaries confine them), so the
+  /// used_after fallback exposes only store targets.
+  bool inside_nested_scope_body_ = false;
   std::vector<FunctionPtr> outlined_functions_;
 };
 

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, cast, overload
 
 if TYPE_CHECKING:
@@ -835,9 +836,12 @@ def cluster(*, name_hint: str = "") -> ClusterContext:
 
 
 class SpmdContext:
-    """Context manager for SPMD dispatch scope.
+    """Context manager / loop iterator for SPMD dispatch scope.
 
-    The parser recognizes this pattern and creates a ScopeStmt(Spmd).
+    The parser recognizes both ``with pl.spmd(...):`` (builds a
+    ``ScopeStmt(Spmd)`` whose body must be a single function call) and
+    ``for i in pl.spmd(...):`` (auto-outlines the loop body into an InCore
+    function with ``i`` bound to ``pl.tile.get_block_idx()``).
     """
 
     def __init__(
@@ -856,6 +860,13 @@ class SpmdContext:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         pass
 
+    def __iter__(self) -> Iterator[Any]:
+        # Lets `for i in pl.spmd(...)` type-check and parse at the Python
+        # level. Never executed at runtime — @pl.program / @pl.function
+        # intercept the AST and the parser replaces this construct with
+        # a SpmdScopeStmt wrapping an InCoreScopeStmt.
+        return iter(())
+
 
 def spmd(
     *,
@@ -865,8 +876,17 @@ def spmd(
 ) -> SpmdContext:
     """Dispatch a kernel with SPMD (Single Program Multiple Data) multi-block execution.
 
-    The body must contain exactly one function call. Can be used standalone
-    (creates an implicit cluster) or nested inside pl.cluster().
+    Two usage forms:
+
+    1. ``with pl.spmd(...):`` — body must be a single call to a pre-defined
+       InCore kernel. Can stand alone (implicit cluster) or nest inside
+       ``pl.cluster()``.
+
+    2. ``for i in pl.spmd(...):`` — loop-style. The iteration variable binds
+       the per-block index (equivalent to ``pl.tile.get_block_idx()``); the
+       body is auto-outlined into a synthetic InCore function, so inline
+       tile/tensor ops work without a separate ``@pl.function(type=InCore)``
+       declaration.
 
     Args:
         core_num: Number of blocks for SPMD dispatch. Must be a positive integer.
@@ -874,12 +894,19 @@ def spmd(
         name_hint: Optional name hint for the outlined function.
 
     Returns:
-        Context manager for SPMD scope
+        Context manager / loop iterator for the SPMD scope.
 
     Examples:
-        >>> # Standalone SPMD (pure AIV kernel)
+        >>> # Single-kernel context-manager form
         >>> with pl.spmd(core_num=4):
         ...     out = self.kernel(a, b, out)
+        >>>
+        >>> # Loop form — body runs per-block with i = tile.get_block_idx()
+        >>> for i in pl.spmd(core_num=4):
+        ...     offset = i * 128
+        ...     tile_a = pl.load(a, [offset, 0], [128, 128])
+        ...     tile_b = pl.load(b, [offset, 0], [128, 128])
+        ...     out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
         >>>
         >>> # SPMD inside cluster (mixed kernel)
         >>> with pl.cluster():

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -862,10 +862,16 @@ class SpmdContext:
 
     def __iter__(self) -> Iterator[Any]:
         # Lets `for i in pl.spmd(...)` type-check and parse at the Python
-        # level. Never executed at runtime — @pl.program / @pl.function
-        # intercept the AST and the parser replaces this construct with
-        # a SpmdScopeStmt wrapping an InCoreScopeStmt.
-        return iter(())
+        # level. The @pl.program / @pl.function decorators intercept the AST,
+        # so this method should never actually run — if it does, the caller
+        # is using pl.spmd() outside the DSL interception path. Raise
+        # loudly rather than silently yielding zero iterations.
+        raise RuntimeError(
+            "pl.spmd(...) loop form is only valid inside a @pl.program / "
+            "@pl.function body; the parser replaces the for-loop with an "
+            "SpmdScopeStmt. If you're seeing this, the surrounding function "
+            "was not decorated."
+        )
 
 
 def spmd(

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -869,27 +869,32 @@ class SpmdContext:
 
 
 def spmd(
-    *,
     core_num: int,
+    *,
     sync_start: bool = False,
     name_hint: str = "",
 ) -> SpmdContext:
     """Dispatch a kernel with SPMD (Single Program Multiple Data) multi-block execution.
 
+    The first argument is the number of blocks and is positional — mirroring
+    ``range(n)``. Loop start is fixed at 0 and step at 1; each block gets an
+    index ``i`` in ``[0, core_num)``.
+
     Two usage forms:
 
-    1. ``with pl.spmd(...):`` — body must be a single call to a pre-defined
+    1. ``with pl.spmd(n):`` — body must be a single call to a pre-defined
        InCore kernel. Can stand alone (implicit cluster) or nest inside
        ``pl.cluster()``.
 
-    2. ``for i in pl.spmd(...):`` — loop-style. The iteration variable binds
+    2. ``for i in pl.spmd(n):`` — loop-style. The iteration variable binds
        the per-block index (equivalent to ``pl.tile.get_block_idx()``); the
        body is auto-outlined into a synthetic InCore function, so inline
        tile/tensor ops work without a separate ``@pl.function(type=InCore)``
        declaration.
 
     Args:
-        core_num: Number of blocks for SPMD dispatch. Must be a positive integer.
+        core_num: Number of blocks for SPMD dispatch. Positional; must be a
+            positive integer.
         sync_start: If True, all blocks start execution simultaneously (default: False).
         name_hint: Optional name hint for the outlined function.
 
@@ -898,11 +903,11 @@ def spmd(
 
     Examples:
         >>> # Single-kernel context-manager form
-        >>> with pl.spmd(core_num=4):
+        >>> with pl.spmd(4):
         ...     out = self.kernel(a, b, out)
         >>>
         >>> # Loop form — body runs per-block with i = tile.get_block_idx()
-        >>> for i in pl.spmd(core_num=4):
+        >>> for i in pl.spmd(4):
         ...     offset = i * 128
         ...     tile_a = pl.load(a, [offset, 0], [128, 128])
         ...     tile_b = pl.load(b, [offset, 0], [128, 128])
@@ -910,7 +915,7 @@ def spmd(
         >>>
         >>> # SPMD inside cluster (mixed kernel)
         >>> with pl.cluster():
-        ...     with pl.spmd(core_num=4, sync_start=True):
+        ...     with pl.spmd(4, sync_start=True):
         ...         out = self.kernel(a, b, out)
     """
     if not isinstance(core_num, int) or isinstance(core_num, bool) or core_num <= 0:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1084,12 +1084,12 @@ class ASTParser:
                     # Will be resolved from loop outputs
                     self.scope_manager.define_var(var_name, f"loop_yield_{i}")
 
-    _VALID_ITERATORS = {"range", "parallel", "unroll", "pipeline", "while_"}
+    _VALID_ITERATORS = {"range", "parallel", "unroll", "pipeline", "while_", "spmd"}
     _ITERATOR_ERROR = (
-        "For loop must use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), or pl.while_()"
+        "For loop must use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), pl.while_(), or pl.spmd()"
     )
     _ITERATOR_HINT = (
-        "Use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), or pl.while_() as the iterator"
+        "Use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), pl.while_(), or pl.spmd() as the iterator"
     )
 
     def _validate_for_loop_iterator(self, stmt: ast.For) -> tuple[ast.Call, str]:
@@ -1187,6 +1187,11 @@ class ASTParser:
         # Handle pl.while_() case
         if iterator_type == "while_":
             self._parse_while_as_for(stmt, iter_call)
+            return
+
+        # Handle pl.spmd() loop form — auto-outlines into Spmd(InCore(body)).
+        if iterator_type == "spmd":
+            self._parse_spmd_for_loop(stmt, iter_call)
             return
 
         loop_var_name, iter_args_node, is_simple_for = self._parse_for_loop_target(stmt)
@@ -2392,23 +2397,30 @@ class ASTParser:
         span = self.span_tracker.get_span(stmt)
         self._parse_scope_body(stmt, scope_kind, span, split=split_mode, name_hint=name_hint)
 
-    def _parse_spmd_scope(
+    def _parse_spmd_kwargs(
         self,
-        stmt: ast.With,
-        context_expr: ast.Call,
-        scope_kind_map: dict[str, "ir.ScopeKind"],
-    ) -> None:
-        """Parse pl.spmd() context manager into a ScopeStmt(Spmd)."""
-        if context_expr.args:
+        anchor: ast.AST,
+        call: ast.Call,
+        *,
+        usage_hint: str,
+    ) -> tuple[int, bool | None, str]:
+        """Parse pl.spmd() keyword arguments.
+
+        Returns ``(core_num, sync_start, name_hint)``. Raises ParserSyntaxError
+        for missing core_num, non-literal values, or unexpected kwargs.
+        Callers that want to pre-screen loop-specific kwargs should do so
+        before calling this helper.
+        """
+        if call.args:
             raise ParserSyntaxError(
                 "pl.spmd() does not accept positional arguments",
-                span=self.span_tracker.get_span(stmt),
-                hint="Use 'with pl.spmd(core_num=4):'",
+                span=self.span_tracker.get_span(anchor),
+                hint=usage_hint,
             )
-        core_num = None
-        sync_start = None
+        core_num: int | None = None
+        sync_start: bool | None = None
         name_hint = ""
-        for kw in context_expr.keywords:
+        for kw in call.keywords:
             if kw.arg == "name_hint":
                 name_hint = self._parse_scope_name_hint(kw.value, "pl.spmd()")
             elif kw.arg == "core_num":
@@ -2419,40 +2431,54 @@ class ASTParser:
                 ):
                     raise ParserSyntaxError(
                         "core_num must be an integer literal",
-                        span=self.span_tracker.get_span(stmt),
-                        hint="Use 'with pl.spmd(core_num=8):'",
+                        span=self.span_tracker.get_span(anchor),
+                        hint=usage_hint,
                     )
                 if kw.value.value <= 0:
                     raise ParserSyntaxError(
                         f"core_num must be a positive integer, got {kw.value.value}",
-                        span=self.span_tracker.get_span(stmt),
-                        hint="Use 'with pl.spmd(core_num=8):'",
+                        span=self.span_tracker.get_span(anchor),
+                        hint=usage_hint,
                     )
                 core_num = kw.value.value
             elif kw.arg == "sync_start":
                 if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, bool):
                     raise ParserSyntaxError(
                         "sync_start must be a boolean literal (True/False)",
-                        span=self.span_tracker.get_span(stmt),
-                        hint="Use 'with pl.spmd(core_num=4, sync_start=True):'",
+                        span=self.span_tracker.get_span(anchor),
+                        hint=usage_hint,
                     )
                 sync_start = kw.value.value
             else:
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
-                    span=self.span_tracker.get_span(stmt),
+                    span=self.span_tracker.get_span(anchor),
                     hint="Supported keywords: 'core_num', 'sync_start', 'name_hint'",
                 )
         if core_num is None:
             raise ParserSyntaxError(
                 "pl.spmd() requires core_num argument",
-                span=self.span_tracker.get_span(stmt),
-                hint="Use 'with pl.spmd(core_num=4):'",
+                span=self.span_tracker.get_span(anchor),
+                hint=usage_hint,
             )
-        # Validate body is exactly one statement that is a function call
+        return core_num, sync_start, name_hint
+
+    def _parse_spmd_scope(
+        self,
+        stmt: ast.With,
+        context_expr: ast.Call,
+        scope_kind_map: dict[str, "ir.ScopeKind"],
+    ) -> None:
+        """Parse ``with pl.spmd(...):`` into a ScopeStmt(Spmd)."""
+        with_hint = "Use 'with pl.spmd(core_num=4):' with a single function call inside."
+        core_num, sync_start, name_hint = self._parse_spmd_kwargs(stmt, context_expr, usage_hint=with_hint)
+        # Validate body is exactly one statement that is a function call.
+        # The loop form (for i in pl.spmd(...):) is what accepts inline
+        # multi-statement bodies.
         spmd_hint = (
-            "The SPMD scope should wrap a single function call: "
-            "'with pl.spmd(core_num=4):\\n    out = self.kernel(a, b, out)'"
+            "The 'with pl.spmd()' form wraps a single kernel call. Use "
+            "'for i in pl.spmd(core_num=4):' to write inline tile/tensor "
+            "ops with access to the block index."
         )
         if len(stmt.body) != 1:
             raise ParserSyntaxError(
@@ -2482,6 +2508,64 @@ class ASTParser:
             core_num=core_num,
             sync_start=sync_start,
         )
+
+    def _parse_spmd_for_loop(self, stmt: ast.For, iter_call: ast.Call) -> None:
+        """Parse ``for i in pl.spmd(core_num=N, ...): body`` into
+        ``SpmdScopeStmt(body=InCoreScopeStmt(body=<bind i; body>))``.
+
+        The loop variable is bound to ``pl.tile.get_block_idx()`` as the first
+        statement of the auto-outlined InCore function, giving per-block code
+        direct access to the block index without a separate kernel
+        declaration.
+        """
+        spmd_hint = (
+            "Use 'for i in pl.spmd(core_num=4):' — the loop variable is bound "
+            "to the per-block index (equivalent to pl.tile.get_block_idx())."
+        )
+        if not isinstance(stmt.target, ast.Name):
+            raise ParserSyntaxError(
+                "for ... in pl.spmd(...) must use a single loop variable",
+                span=self.span_tracker.get_span(stmt.target),
+                hint=spmd_hint,
+            )
+        loop_var_name = stmt.target.id
+
+        # Reject loop-specific kwargs that make no sense for SPMD blocks.
+        disallowed_loop_kwargs = {"init_values", "chunk", "chunk_policy", "attrs", "step", "stage"}
+        for kw in iter_call.keywords:
+            if kw.arg in disallowed_loop_kwargs:
+                raise ParserSyntaxError(
+                    f"pl.spmd() loop form does not accept '{kw.arg}='",
+                    span=self.span_tracker.get_span(kw.value),
+                    hint=spmd_hint,
+                )
+
+        core_num, sync_start, name_hint = self._parse_spmd_kwargs(stmt, iter_call, usage_hint=spmd_hint)
+
+        span = self.span_tracker.get_span(stmt)
+        with self.builder.scope(
+            ir.ScopeKind.Spmd,
+            span,
+            name_hint=name_hint,
+            core_num=core_num,
+            sync_start=sync_start,
+        ):
+            with self._scope_kind_context(ir.ScopeKind.Spmd):
+                self.scope_manager.enter_scope("spmd_for")
+                with self.builder.scope(ir.ScopeKind.InCore, span):
+                    with self._scope_kind_context(ir.ScopeKind.InCore):
+                        # Bind `i = pl.tile.get_block_idx()` as the first
+                        # statement of the outlined InCore body.
+                        loop_var = self.builder.var(loop_var_name, ir.ScalarType(DataType.INDEX), span=span)
+                        self.scope_manager.define_var(loop_var_name, loop_var)
+                        self.builder.assign(loop_var, ir_op.tile.get_block_idx(span=span), span=span)
+                        self._parse_body_siblings(stmt.body)
+                self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
+                # Leak vars to parent so post-store rebindings (e.g.
+                # ``out = pl.store(...)`` inside the body) remain visible to
+                # subsequent statements like ``return out``. Matches Python's
+                # own for-loop variable-leaking semantics.
+                self.scope_manager.exit_scope(leak_vars=True)
 
     def _parse_scope_body(
         self,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2378,7 +2378,7 @@ class ASTParser:
                     raise ParserSyntaxError(
                         f"pl.{func_attr}() got unexpected keyword argument '{kw.arg}'",
                         span=self.span_tracker.get_span(stmt),
-                        hint="Supported keyword: 'name_hint'. For SPMD dispatch, use pl.spmd(core_num=4):",
+                        hint="Supported keyword: 'name_hint'. For SPMD dispatch, use pl.spmd(4):",
                     )
             scope_kind = scope_kind_map[func_attr]
             span = self.span_tracker.get_span(stmt)
@@ -2404,43 +2404,54 @@ class ASTParser:
         *,
         usage_hint: str,
     ) -> tuple[int, bool | None, str]:
-        """Parse pl.spmd() keyword arguments.
+        """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=)`` arguments.
 
-        Returns ``(core_num, sync_start, name_hint)``. Raises ParserSyntaxError
-        for missing core_num, non-literal values, or unexpected kwargs.
-        Callers that want to pre-screen loop-specific kwargs should do so
-        before calling this helper.
+        The first positional argument is ``core_num`` (range-like). Returns
+        ``(core_num, sync_start, name_hint)``. Raises ParserSyntaxError for
+        missing core_num, non-literal values, or unexpected kwargs.
         """
-        if call.args:
+
+        def _validate_core_num_node(value_node: ast.AST, source: ast.AST) -> int:
+            if (
+                not isinstance(value_node, ast.Constant)
+                or not isinstance(value_node.value, int)
+                or isinstance(value_node.value, bool)
+            ):
+                raise ParserSyntaxError(
+                    "core_num must be an integer literal",
+                    span=self.span_tracker.get_span(source),
+                    hint=usage_hint,
+                )
+            if value_node.value <= 0:
+                raise ParserSyntaxError(
+                    f"core_num must be a positive integer, got {value_node.value}",
+                    span=self.span_tracker.get_span(source),
+                    hint=usage_hint,
+                )
+            return value_node.value
+
+        if len(call.args) > 1:
             raise ParserSyntaxError(
-                "pl.spmd() does not accept positional arguments",
-                span=self.span_tracker.get_span(anchor),
+                "pl.spmd() accepts at most one positional argument (core_num)",
+                span=self.span_tracker.get_span(call.args[1]),
                 hint=usage_hint,
             )
         core_num: int | None = None
+        if call.args:
+            core_num = _validate_core_num_node(call.args[0], call.args[0])
         sync_start: bool | None = None
         name_hint = ""
         for kw in call.keywords:
             if kw.arg == "name_hint":
                 name_hint = self._parse_scope_name_hint(kw.value, "pl.spmd()")
             elif kw.arg == "core_num":
-                if (
-                    not isinstance(kw.value, ast.Constant)
-                    or not isinstance(kw.value.value, int)
-                    or isinstance(kw.value.value, bool)
-                ):
+                if core_num is not None:
                     raise ParserSyntaxError(
-                        "core_num must be an integer literal",
-                        span=self.span_tracker.get_span(anchor),
+                        "pl.spmd() got multiple values for argument 'core_num'",
+                        span=self.span_tracker.get_span(kw.value),
                         hint=usage_hint,
                     )
-                if kw.value.value <= 0:
-                    raise ParserSyntaxError(
-                        f"core_num must be a positive integer, got {kw.value.value}",
-                        span=self.span_tracker.get_span(anchor),
-                        hint=usage_hint,
-                    )
-                core_num = kw.value.value
+                core_num = _validate_core_num_node(kw.value, kw.value)
             elif kw.arg == "sync_start":
                 if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, bool):
                     raise ParserSyntaxError(
@@ -2453,11 +2464,11 @@ class ASTParser:
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
                     span=self.span_tracker.get_span(anchor),
-                    hint="Supported keywords: 'core_num', 'sync_start', 'name_hint'",
+                    hint="Supported keywords: 'sync_start', 'name_hint'",
                 )
         if core_num is None:
             raise ParserSyntaxError(
-                "pl.spmd() requires core_num argument",
+                "pl.spmd() requires core_num (first positional argument)",
                 span=self.span_tracker.get_span(anchor),
                 hint=usage_hint,
             )
@@ -2470,15 +2481,15 @@ class ASTParser:
         scope_kind_map: dict[str, "ir.ScopeKind"],
     ) -> None:
         """Parse ``with pl.spmd(...):`` into a ScopeStmt(Spmd)."""
-        with_hint = "Use 'with pl.spmd(core_num=4):' with a single function call inside."
+        with_hint = "Use 'with pl.spmd(4):' with a single function call inside."
         core_num, sync_start, name_hint = self._parse_spmd_kwargs(stmt, context_expr, usage_hint=with_hint)
         # Validate body is exactly one statement that is a function call.
-        # The loop form (for i in pl.spmd(...):) is what accepts inline
+        # The loop form (for i in pl.spmd(n):) is what accepts inline
         # multi-statement bodies.
         spmd_hint = (
             "The 'with pl.spmd()' form wraps a single kernel call. Use "
-            "'for i in pl.spmd(core_num=4):' to write inline tile/tensor "
-            "ops with access to the block index."
+            "'for i in pl.spmd(4):' to write inline tile/tensor ops with "
+            "access to the block index."
         )
         if len(stmt.body) != 1:
             raise ParserSyntaxError(
@@ -2510,7 +2521,7 @@ class ASTParser:
         )
 
     def _parse_spmd_for_loop(self, stmt: ast.For, iter_call: ast.Call) -> None:
-        """Parse ``for i in pl.spmd(core_num=N, ...): body`` into
+        """Parse ``for i in pl.spmd(N, ...): body`` into
         ``SpmdScopeStmt(body=InCoreScopeStmt(body=<bind i; body>))``.
 
         The loop variable is bound to ``pl.tile.get_block_idx()`` as the first
@@ -2519,8 +2530,8 @@ class ASTParser:
         declaration.
         """
         spmd_hint = (
-            "Use 'for i in pl.spmd(core_num=4):' — the loop variable is bound "
-            "to the per-block index (equivalent to pl.tile.get_block_idx())."
+            "Use 'for i in pl.spmd(4):' — the loop variable is bound to the "
+            "per-block index (equivalent to pl.tile.get_block_idx())."
         )
         if not isinstance(stmt.target, ast.Name):
             raise ParserSyntaxError(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2403,12 +2403,14 @@ class ASTParser:
         call: ast.Call,
         *,
         usage_hint: str,
-    ) -> tuple[int, bool | None, str]:
+    ) -> tuple[int, bool, str]:
         """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=)`` arguments.
 
         The first positional argument is ``core_num`` (range-like). Returns
-        ``(core_num, sync_start, name_hint)``. Raises ParserSyntaxError for
-        missing core_num, non-literal values, or unexpected kwargs.
+        ``(core_num, sync_start, name_hint)`` with ``sync_start`` defaulting
+        to ``False`` (matching the DSL default). Raises ParserSyntaxError for
+        missing core_num, non-literal values, unexpected kwargs, or
+        ``**kwargs`` unpacking.
         """
 
         def _validate_core_num_node(value_node: ast.AST, source: ast.AST) -> int:
@@ -2439,9 +2441,17 @@ class ASTParser:
         core_num: int | None = None
         if call.args:
             core_num = _validate_core_num_node(call.args[0], call.args[0])
-        sync_start: bool | None = None
+        sync_start: bool = False
         name_hint = ""
         for kw in call.keywords:
+            if kw.arg is None:
+                # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
+                raise ParserSyntaxError(
+                    "pl.spmd() does not accept **kwargs; pass core_num (positional) "
+                    "and sync_start=/name_hint= explicitly",
+                    span=self.span_tracker.get_span(kw.value),
+                    hint=usage_hint,
+                )
             if kw.arg == "name_hint":
                 name_hint = self._parse_scope_name_hint(kw.value, "pl.spmd()")
             elif kw.arg == "core_num":

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -39,10 +39,12 @@ namespace pass {
  *
  * Requirements:
  * - Input IR must be in SSA form (run ConvertToSSA first)
- * - Only processes Opaque functions (InCore functions are left unchanged)
+ * - Processes Opaque and Orchestration functions. Orchestration functions can
+ *   carry InCore scopes when the parser desugars high-level constructs
+ *   (e.g. ``for i in pl.spmd(...)``) into SpmdScopeStmt(InCoreScopeStmt(...)).
  *
  * Transformation:
- * 1. For each ScopeStmt(InCore) in an Opaque function:
+ * 1. For each ScopeStmt(InCore) in an Opaque/Orchestration function:
  *    - Analyze body to determine external variable references (inputs)
  *    - Analyze subsequent statements to determine which definitions are outputs
  *    - Extract body into new Function(InCore) with appropriate params/returns
@@ -50,7 +52,8 @@ namespace pass {
  *    - EvalStmt(store) calls on output tensors are converted to AssignStmt
  * 2. Recursively handles nested InCore scopes
  * 3. Add outlined functions to the program
- * 4. Promote the parent function from Opaque to Orchestration
+ * 4. Promote Opaque parents to Orchestration when at least one InCore scope is
+ *    outlined. Orchestration parents stay Orchestration.
  */
 Pass OutlineIncoreScopes() {
   auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
@@ -58,8 +61,10 @@ Pass OutlineIncoreScopes() {
     std::vector<FunctionPtr> all_outlined_functions;
 
     for (const auto& [gvar, func] : program->functions_) {
-      // Only process Opaque functions (InCore functions are already outlined)
-      if (func->func_type_ != FunctionType::Opaque) {
+      // Process Opaque and Orchestration functions; other function types
+      // (InCore/Group/Spmd) are already outlined or not expected to carry
+      // InCore scopes.
+      if (func->func_type_ != FunctionType::Opaque && func->func_type_ != FunctionType::Orchestration) {
         new_functions.push_back(func);
         continue;
       }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1105,6 +1105,44 @@ void IRPythonPrinter::VisitStmt_(const ClusterScopeStmtPtr& op) {
 }
 
 void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
+  // Detect the ``for i in pl.spmd(...):`` desugaring emitted by the parser:
+  // SpmdScopeStmt(body=InCoreScopeStmt(body=<AssignStmt(i, Call(tile.get_block_idx)), ...>)).
+  // Printing it back as a for-loop keeps round-trips stable (the
+  // with-form parser enforces a single kernel call, so printing a
+  // multi-statement InCore-wrapped body as `with pl.spmd():` would fail
+  // to reparse).
+  auto incore = As<InCoreScopeStmt>(op->body_);
+  auto incore_seq = incore ? As<SeqStmts>(incore->body_) : nullptr;
+  auto first_assign = incore_seq
+                          ? (incore_seq->stmts_.empty() ? nullptr : As<AssignStmt>(incore_seq->stmts_[0]))
+                          : (incore ? As<AssignStmt>(incore->body_) : nullptr);
+  auto first_call = first_assign ? As<Call>(first_assign->value_) : nullptr;
+  auto first_op = first_call ? As<Op>(first_call->op_) : nullptr;
+  if (first_op && first_op->name_ == "tile.get_block_idx") {
+    stream_ << "for " << first_assign->var_->name_hint_ << " in " << prefix_
+            << ".spmd(core_num=" << op->core_num_;
+    if (op->sync_start_) {
+      stream_ << ", sync_start=True";
+    }
+    if (!op->name_hint_.empty()) {
+      stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
+    }
+    stream_ << "):\n";
+    IncreaseIndent();
+    // Emit the InCore body skipping the get_block_idx binding we just
+    // materialized as the loop variable.
+    if (incore_seq && incore_seq->stmts_.size() > 1) {
+      for (size_t i = 1; i < incore_seq->stmts_.size(); ++i) {
+        PrintStmtBlock(incore_seq->stmts_[i]);
+        if (i + 1 < incore_seq->stmts_.size()) stream_ << "\n";
+      }
+    } else {
+      stream_ << GetIndent() << "pass\n";
+    }
+    DecreaseIndent();
+    return;
+  }
+
   stream_ << "with " << prefix_ << ".spmd(core_num=" << op->core_num_;
   if (op->sync_start_) {
     stream_ << ", sync_start=True";

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1119,8 +1119,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
   auto first_call = first_assign ? As<Call>(first_assign->value_) : nullptr;
   auto first_op = first_call ? As<Op>(first_call->op_) : nullptr;
   if (first_op && first_op->name_ == "tile.get_block_idx") {
-    stream_ << "for " << first_assign->var_->name_hint_ << " in " << prefix_
-            << ".spmd(core_num=" << op->core_num_;
+    stream_ << "for " << first_assign->var_->name_hint_ << " in " << prefix_ << ".spmd(" << op->core_num_;
     if (op->sync_start_) {
       stream_ << ", sync_start=True";
     }
@@ -1143,7 +1142,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     return;
   }
 
-  stream_ << "with " << prefix_ << ".spmd(core_num=" << op->core_num_;
+  stream_ << "with " << prefix_ << ".spmd(" << op->core_num_;
   if (op->sync_start_) {
     stream_ << ", sync_start=True";
   }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1119,7 +1119,8 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
   auto first_call = first_assign ? As<Call>(first_assign->value_) : nullptr;
   auto first_op = first_call ? As<Op>(first_call->op_) : nullptr;
   if (first_op && first_op->name_ == "tile.get_block_idx") {
-    stream_ << "for " << first_assign->var_->name_hint_ << " in " << prefix_ << ".spmd(" << op->core_num_;
+    stream_ << "for " << GetVarName(first_assign->var_.get()) << " in " << prefix_ << ".spmd("
+            << op->core_num_;
     if (op->sync_start_) {
       stream_ << ", sync_start=True";
     }

--- a/tests/st/runtime/test_spmd.py
+++ b/tests/st/runtime/test_spmd.py
@@ -10,9 +10,10 @@
 """
 Runtime tests for SPMD (Single Program Multiple Data) execution.
 
-This module tests multi-block data-parallel dispatch using pl.spmd(core_num=N)
-and pl.tile.get_block_idx(). Each block processes a different slice of the input
-tensors and writes its result to the corresponding output region.
+This module tests multi-block data-parallel dispatch using pl.spmd(N) (or the
+equivalent loop form ``for i in pl.spmd(N)``) together with pl.tile.get_block_idx().
+Each block processes a different slice of the input tensors and writes its result
+to the corresponding output region.
 
 Tests cover:
   - Single SPMD submission smoke tests (add, mul)
@@ -64,7 +65,7 @@ class SPMDAddProgram:
         b: pl.Tensor[[512, 128], pl.FP32],
         out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
     ) -> pl.Tensor[[512, 128], pl.FP32]:
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             out = self.spmd_add(a, b, out)
         return out
 
@@ -95,7 +96,7 @@ class SPMDMulProgram:
         b: pl.Tensor[[512, 128], pl.FP32],
         out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
     ) -> pl.Tensor[[512, 128], pl.FP32]:
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             out = self.spmd_mul(a, b, out)
         return out
 
@@ -164,11 +165,11 @@ class SPMDThreeSubmitProgram:
         t2: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
         out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
     ) -> pl.Tensor[[512, 128], pl.FP32]:
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             t1 = self.spmd_add(a, b, t1)
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             t2 = self.spmd_mul(t1, a, t2)
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             out = self.spmd_sub(t2, b, out)
         return out
 
@@ -211,15 +212,15 @@ class SPMDEscalating5Program:
         b: pl.Tensor[[2048, 128], pl.FP32],
         out: pl.Out[pl.Tensor[[2048, 128], pl.FP32]],
     ) -> pl.Tensor[[2048, 128], pl.FP32]:
-        with pl.spmd(core_num=1):
+        with pl.spmd(1):
             out = self.kernel_add(a, b, out, 0)
-        with pl.spmd(core_num=2):
+        with pl.spmd(2):
             out = self.kernel_add(a, b, out, 1)
-        with pl.spmd(core_num=3):
+        with pl.spmd(3):
             out = self.kernel_add(a, b, out, 3)
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             out = self.kernel_add(a, b, out, 6)
-        with pl.spmd(core_num=6):
+        with pl.spmd(6):
             out = self.kernel_add(a, b, out, 10)
         return out
 
@@ -274,7 +275,7 @@ class SPMDMixedKernelProgram:
         bias: pl.Tensor[[256, 64], pl.FP32],
         out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
     ) -> pl.Tensor[[256, 64], pl.FP32]:
-        with pl.spmd(core_num=4):
+        with pl.spmd(4):
             out = self.matmul_bias(a, b, bias, out)
         return out
 
@@ -313,7 +314,7 @@ class SPMDSyncStartProgram:
         b: pl.Tensor[[512, 128], pl.FP32],
         out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
     ) -> pl.Tensor[[512, 128], pl.FP32]:
-        with pl.spmd(core_num=4, sync_start=True):
+        with pl.spmd(4, sync_start=True):
             out = self.spmd_add(a, b, out)
         return out
 
@@ -352,13 +353,13 @@ class SPMDSyncStartMixedProgram:
         b: pl.Tensor[[3072, 128], pl.FP32],
         out: pl.Out[pl.Tensor[[3072, 128], pl.FP32]],
     ) -> pl.Tensor[[3072, 128], pl.FP32]:
-        with pl.spmd(core_num=2):  # T0: baseline
+        with pl.spmd(2):  # T0: baseline
             out = self.kernel_add(a, b, out, 0)
-        with pl.spmd(core_num=8, sync_start=True):  # T1
+        with pl.spmd(8, sync_start=True):  # T1
             out = self.kernel_add(a, b, out, 2)
-        with pl.spmd(core_num=2, sync_start=True):  # T2
+        with pl.spmd(2, sync_start=True):  # T2
             out = self.kernel_add(a, b, out, 10)
-        with pl.spmd(core_num=12, sync_start=True):  # T3
+        with pl.spmd(12, sync_start=True):  # T3
             out = self.kernel_add(a, b, out, 12)
         return out
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2190,7 +2190,7 @@ class TestTensorReadWriteOffsetCodegen:
                 bias: pl.Tensor[[64, 64], pl.FP32],
                 out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
-                with pl.spmd(core_num=4, sync_start=True):
+                with pl.spmd(4, sync_start=True):
                     out = self.kernel(a, b, bias, out)
                 return out
 

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -163,7 +163,7 @@ class TestOutlineClusterScopes:
                 x: pl.Tensor[[64], pl.FP32],
                 out: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.spmd(core_num=4, sync_start=True):
+                with pl.spmd(4, sync_start=True):
                     out = self.kernel(x, out)
                 return out
 

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -301,6 +301,60 @@ class TestOutlineClusterScopes:
         # Verify it has 2 return types (y and z)
         assert len(group_func.return_types) == 2
 
+    def test_outline_spmd_for_loop_auto_outlines_incore(self):
+        """`for i in pl.spmd(core_num=N)` auto-outlines into Spmd + InCore.
+
+        The new loop form binds the iteration variable to
+        ``pl.tile.get_block_idx()`` inside an implicit InCoreScopeStmt,
+        giving inline tile ops direct access to the block index without a
+        separate ``@pl.function(type=InCore)`` declaration.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                b: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(core_num=4):
+                    offset = i * 128
+                    tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    tile_b: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [offset, 0], [128, 128])
+                    out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
+                return out
+
+        After = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(After)
+        After = passes.outline_cluster_scopes()(After)
+
+        # The pipeline produces three functions: main (Orchestration), a Spmd
+        # wrapper, and an InCore leaf.  Check the structural properties that
+        # matter rather than pinning exact stmt counts, since downstream SSA
+        # and store-alias normalization inserts book-keeping assignments that
+        # are not user-visible.
+        func_names = sorted(f.name for f in After.functions.values())
+        assert func_names == ["main", "main_incore_0", "main_spmd_0"]
+
+        main_incore = next(f for f in After.functions.values() if f.name == "main_incore_0")
+        assert main_incore.func_type == pl.FunctionType.InCore
+
+        main_spmd = next(f for f in After.functions.values() if f.name == "main_spmd_0")
+        assert main_spmd.func_type == pl.FunctionType.Spmd
+        assert main_spmd.attrs.get("core_num") == 4
+
+        main_fn = next(f for f in After.functions.values() if f.name == "main")
+        assert main_fn.func_type == pl.FunctionType.Orchestration
+
+        # The InCore leaf must start by binding the block index.
+        body = main_incore.body
+        first = body.stmts[0] if isinstance(body, ir.SeqStmts) else body
+        assert isinstance(first, ir.AssignStmt)
+        assert isinstance(first.value, ir.Call)
+        assert first.value.op.name == "tile.get_block_idx"
+
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):
         """Test that ClusterOutlined verifier flags Cluster scopes in InCore functions."""
 

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -302,7 +302,7 @@ class TestOutlineClusterScopes:
         assert len(group_func.return_types) == 2
 
     def test_outline_spmd_for_loop_auto_outlines_incore(self):
-        """`for i in pl.spmd(core_num=N)` auto-outlines into Spmd + InCore.
+        """`for i in pl.spmd(N)` auto-outlines into Spmd + InCore.
 
         The new loop form binds the iteration variable to
         ``pl.tile.get_block_idx()`` inside an implicit InCoreScopeStmt,
@@ -316,44 +316,54 @@ class TestOutlineClusterScopes:
             def main(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                b: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(core_num=4):
+                for i in pl.spmd(4):
                     offset = i * 128
                     tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
-                    tile_b: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [offset, 0], [128, 128])
-                    out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
+                    out = pl.store(tile_a, [offset, 0], out)
                 return out
 
-        After = passes.convert_to_ssa()(Before)
-        After = passes.outline_incore_scopes()(After)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                i = pl.tile.get_block_idx()
+                offset = i * 128
+                tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                out = pl.store(tile_a, [offset, 0], out)
+                # The outline pass renames the post-store SSA result to the
+                # store target; express that explicit rename as an alias here.
+                out_final: pl.Tensor[[512, 128], pl.FP32] = out
+                return out_final
+
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def main_spmd_0(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.main_incore_0(a, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.main_spmd_0(a, out)
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
         After = passes.outline_cluster_scopes()(After)
-
-        # The pipeline produces three functions: main (Orchestration), a Spmd
-        # wrapper, and an InCore leaf.  Check the structural properties that
-        # matter rather than pinning exact stmt counts, since downstream SSA
-        # and store-alias normalization inserts book-keeping assignments that
-        # are not user-visible.
-        func_names = sorted(f.name for f in After.functions.values())
-        assert func_names == ["main", "main_incore_0", "main_spmd_0"]
-
-        main_incore = next(f for f in After.functions.values() if f.name == "main_incore_0")
-        assert main_incore.func_type == pl.FunctionType.InCore
-
-        main_spmd = next(f for f in After.functions.values() if f.name == "main_spmd_0")
-        assert main_spmd.func_type == pl.FunctionType.Spmd
-        assert main_spmd.attrs.get("core_num") == 4
-
-        main_fn = next(f for f in After.functions.values() if f.name == "main")
-        assert main_fn.func_type == pl.FunctionType.Orchestration
-
-        # The InCore leaf must start by binding the block index.
-        body = main_incore.body
-        first = body.stmts[0] if isinstance(body, ir.SeqStmts) else body
-        assert isinstance(first, ir.AssignStmt)
-        assert isinstance(first.value, ir.Call)
-        assert first.value.op.name == "tile.get_block_idx"
+        ir.assert_structural_equal(After, Expected)
 
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):
         """Test that ClusterOutlined verifier flags Cluster scopes in InCore functions."""

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -464,6 +464,61 @@ class TestSpmdForLoop:
                     _ = i
                 return a
 
+    def test_for_spmd_rejects_kwargs_unpacking(self):
+        """``pl.spmd(**cfg)`` raises a targeted diagnostic rather than the
+        confusing default error that tries to format ``kw.arg=None``.
+
+        The parser's kwarg walk sees ``ast.keyword(arg=None, value=...)``
+        for ``**`` unpacking; our handler rejects it before ever attempting
+        to evaluate the unpacked expression, so the value need not be a
+        supported expression kind.
+        """
+        with pytest.raises(ParserSyntaxError, match=r"does not accept \*\*kwargs"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(**a):  # type: ignore[misc]
+                    _ = i
+                return a
+
+    def test_for_spmd_loop_var_survives_ssa_shadowing_in_printer(self):
+        """Regression: when the outer scope already defines ``i``, SSA renames
+        the inner loop variable (e.g., ``i_1``). The printer must emit the
+        renamed name in the ``for ... in`` header so the header matches the
+        body."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                # Outer `i` shadows the loop var; the printer must rename.
+                i = 0  # noqa: F841
+                for i in pl.spmd(4):  # type: ignore[assignment]
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        printed = Original.as_python()
+        # Extract the `for <var> in pl.spmd(4):` header and verify `<var>` is
+        # referenced in the body (e.g. `<var> * 128`).
+        for line in printed.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("for ") and "pl.spmd(" in stripped:
+                header_var = stripped.split()[1]
+                break
+        else:
+            raise AssertionError(f"no for-spmd header in printed output:\n{printed}")
+        assert f"{header_var} * 128" in printed, (
+            f"loop var {header_var!r} from header not referenced in body; "
+            f"printer likely printed a stale raw name_hint:\n{printed}"
+        )
+        parse_program(printed)  # round-trips cleanly
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -233,7 +233,10 @@ class TestSpmdForLoop:
 
     def test_for_spmd_builds_spmd_scope_wrapping_incore(self):
         """Loop form emits SpmdScopeStmt containing an InCoreScopeStmt whose
-        first statement binds the loop var to pl.tile.get_block_idx()."""
+        first statement binds the loop var to pl.tile.get_block_idx().
+
+        ``core_num`` is positional — mirroring ``range(n)``.
+        """
 
         @pl.program
         class TestProgram:
@@ -244,7 +247,7 @@ class TestSpmdForLoop:
                 b: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(core_num=4):
+                for i in pl.spmd(4):
                     offset = i * 128
                     tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                     tile_b: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [offset, 0], [128, 128])
@@ -265,6 +268,27 @@ class TestSpmdForLoop:
         assert call.op.name == "tile.get_block_idx"
         assert first_stmt.var.name_hint == "i"
 
+    def test_for_spmd_accepts_core_num_kwarg(self):
+        """Backward-compat: ``pl.spmd(core_num=N)`` keyword form still parses."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(core_num=4):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        assert spmd.core_num == 4
+
     def test_for_spmd_sync_start_and_name_hint(self):
         """sync_start= and name_hint= pass through to SpmdScopeStmt."""
 
@@ -276,7 +300,7 @@ class TestSpmdForLoop:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(core_num=8, sync_start=True, name_hint="my_kernel"):
+                for i in pl.spmd(8, sync_start=True, name_hint="my_kernel"):
                     offset = i * 64
                     t: pl.Tile[[64, 128], pl.FP32] = pl.load(a, [offset, 0], [64, 128])
                     out = pl.store(t, [offset, 0], out)
@@ -310,7 +334,7 @@ class TestSpmdForLoop:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                with pl.spmd(core_num=4):
+                with pl.spmd(4):
                     out = self.kernel(a, out)
                 return out
 
@@ -337,7 +361,7 @@ class TestSpmdForLoop:
 
             @pl.function
             def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i, j in pl.spmd(core_num=4):  # type: ignore[misc]
+                for i, j in pl.spmd(4):  # type: ignore[misc]
                     _ = i + j
                 return a
 
@@ -347,7 +371,7 @@ class TestSpmdForLoop:
 
             @pl.function
             def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.spmd(core_num=4, chunk=2):  # type: ignore[call-arg]
+                for i in pl.spmd(4, chunk=2):  # type: ignore[call-arg]
                     _ = i
                 return a
 
@@ -357,7 +381,7 @@ class TestSpmdForLoop:
 
             @pl.function
             def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.spmd(core_num=4, init_values=(0,)):  # type: ignore[call-arg]
+                for i in pl.spmd(4, init_values=(0,)):  # type: ignore[call-arg]
                     _ = i
                 return a
 
@@ -377,7 +401,27 @@ class TestSpmdForLoop:
 
             @pl.function
             def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.spmd(core_num=0):
+                for i in pl.spmd(0):
+                    _ = i
+                return a
+
+    def test_for_spmd_rejects_duplicate_core_num(self):
+        """Supplying ``core_num`` positionally *and* as a kwarg is rejected."""
+        with pytest.raises(ParserSyntaxError, match="multiple values for argument 'core_num'"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, core_num=4):  # type: ignore[misc]
+                    _ = i
+                return a
+
+    def test_for_spmd_rejects_extra_positional(self):
+        """``pl.spmd`` takes a single positional ``core_num``; a second one is an error."""
+        with pytest.raises(ParserSyntaxError, match="at most one positional argument"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, 2):  # type: ignore[misc]
                     _ = i
                 return a
 
@@ -385,7 +429,7 @@ class TestSpmdForLoop:
         """Printing the for-spmd IR emits the loop form so it reparses cleanly.
 
         The printer detects the SpmdScopeStmt(InCoreScopeStmt(i = get_block_idx; ...))
-        pattern and emits ``for i in pl.spmd(core_num=N):``. Emitting the
+        pattern and emits ``for i in pl.spmd(N):`` (positional). Emitting the
         with-form here would fail because the body has multiple statements.
         """
 
@@ -397,14 +441,14 @@ class TestSpmdForLoop:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(core_num=4):
+                for i in pl.spmd(4):
                     offset = i * 128
                     t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                     out = pl.store(t, [offset, 0], out)
                 return out
 
         printed = Original.as_python()
-        assert "for i in pl.spmd(core_num=4):" in printed
+        assert "for i in pl.spmd(4):" in printed
 
         reparsed = parse_program(printed)
         main_fn = next(f for f in reparsed.functions.values() if f.name == "main")
@@ -416,7 +460,7 @@ class TestSpmdForLoop:
 
             @pl.function
             def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                for i in pl.spmd(core_num=4, sync_start=1):  # type: ignore[arg-type]
+                for i in pl.spmd(4, sync_start=1):  # type: ignore[arg-type]
                     _ = i
                 return a
 

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -13,6 +13,7 @@ import pypto.language as pl
 import pytest
 from pypto import ir
 from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
+from pypto.language.parser.text_parser import parse_program
 
 
 class TestScopeParsing:
@@ -201,6 +202,223 @@ class TestScopeNameParsing:
         assert isinstance(scope_stmt, ir.ScopeStmt)
         assert scope_stmt.name_hint == "host_func"
         assert scope_stmt.scope_kind == ir.ScopeKind.Hierarchy
+
+
+class TestSpmdForLoop:
+    """Test parsing of ``for i in pl.spmd(...):`` loop form.
+
+    The loop form is syntactic sugar that expands to
+    ``SpmdScopeStmt(body=InCoreScopeStmt(body=<i = tile.get_block_idx(); ...>))``
+    so inline tile/tensor ops have direct access to the per-block index
+    without a separate ``@pl.function(type=InCore)`` declaration.
+    """
+
+    @staticmethod
+    def _unique_descendant(node, cls):
+        """Return the single descendant of ``node`` that is an instance of ``cls``."""
+        found = []
+
+        def walk(n):
+            if isinstance(n, cls):
+                found.append(n)
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(node)
+        assert len(found) == 1, f"expected exactly one {cls.__name__}, got {len(found)}"
+        return found[0]
+
+    def test_for_spmd_builds_spmd_scope_wrapping_incore(self):
+        """Loop form emits SpmdScopeStmt containing an InCoreScopeStmt whose
+        first statement binds the loop var to pl.tile.get_block_idx()."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                b: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(core_num=4):
+                    offset = i * 128
+                    tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    tile_b: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [offset, 0], [128, 128])
+                    out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        assert spmd.core_num == 4
+        assert spmd.sync_start is False
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+
+        body = incore.body
+        first_stmt = body.stmts[0] if isinstance(body, ir.SeqStmts) else body
+        assert isinstance(first_stmt, ir.AssignStmt)
+        call = first_stmt.value
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.get_block_idx"
+        assert first_stmt.var.name_hint == "i"
+
+    def test_for_spmd_sync_start_and_name_hint(self):
+        """sync_start= and name_hint= pass through to SpmdScopeStmt."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(core_num=8, sync_start=True, name_hint="my_kernel"):
+                    offset = i * 64
+                    t: pl.Tile[[64, 128], pl.FP32] = pl.load(a, [offset, 0], [64, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        assert spmd.core_num == 8
+        assert spmd.sync_start is True
+        assert spmd.name_hint == "my_kernel"
+
+    def test_with_spmd_single_call_still_supported(self):
+        """Regression: the existing ``with pl.spmd(...):`` single-call form
+        still builds a direct SpmdScopeStmt(body=Call), no InCore wrapping."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(core_num=4):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = TestProgram.functions[list(TestProgram.functions.keys())[-1]]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        # Walk body — should NOT contain an InCoreScopeStmt (no implicit wrap).
+        found_incore = []
+
+        def walk(n):
+            if isinstance(n, ir.InCoreScopeStmt):
+                found_incore.append(n)
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(spmd.body)
+        assert not found_incore, "with-form should not insert an implicit InCoreScopeStmt"
+
+    def test_for_spmd_rejects_tuple_target(self):
+        """A tuple target on for-spmd is rejected (single loop var only)."""
+        with pytest.raises(ParserSyntaxError, match="single loop variable"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i, j in pl.spmd(core_num=4):  # type: ignore[misc]
+                    _ = i + j
+                return a
+
+    def test_for_spmd_rejects_chunk_kwarg(self):
+        """chunk= is a pl.parallel/pl.range kwarg and not valid on pl.spmd."""
+        with pytest.raises(ParserSyntaxError, match=r"does not accept 'chunk='"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(core_num=4, chunk=2):  # type: ignore[call-arg]
+                    _ = i
+                return a
+
+    def test_for_spmd_rejects_init_values(self):
+        """init_values= implies loop-carried state, which SPMD has no notion of."""
+        with pytest.raises(ParserSyntaxError, match=r"does not accept 'init_values='"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(core_num=4, init_values=(0,)):  # type: ignore[call-arg]
+                    _ = i
+                return a
+
+    def test_for_spmd_requires_core_num(self):
+        """Missing core_num raises a targeted diagnostic."""
+        with pytest.raises(ParserSyntaxError, match="requires core_num"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd():  # type: ignore[call-arg]
+                    _ = i
+                return a
+
+    def test_for_spmd_rejects_zero_core_num(self):
+        """core_num must be a positive integer."""
+        with pytest.raises(ParserSyntaxError, match="must be a positive integer"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(core_num=0):
+                    _ = i
+                return a
+
+    def test_for_spmd_print_reparse_roundtrip(self):
+        """Printing the for-spmd IR emits the loop form so it reparses cleanly.
+
+        The printer detects the SpmdScopeStmt(InCoreScopeStmt(i = get_block_idx; ...))
+        pattern and emits ``for i in pl.spmd(core_num=N):``. Emitting the
+        with-form here would fail because the body has multiple statements.
+        """
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(core_num=4):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        printed = Original.as_python()
+        assert "for i in pl.spmd(core_num=4):" in printed
+
+        reparsed = parse_program(printed)
+        main_fn = next(f for f in reparsed.functions.values() if f.name == "main")
+        ir.assert_structural_equal(main_fn, list(Original.functions.values())[0])
+
+    def test_for_spmd_rejects_non_bool_sync_start(self):
+        """sync_start must be a boolean literal (True/False)."""
+        with pytest.raises(ParserSyntaxError, match="sync_start must be a boolean literal"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(core_num=4, sync_start=1):  # type: ignore[arg-type]
+                    _ = i
+                return a
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Introduces a loop-style surface syntax for SPMD dispatch alongside the existing `with pl.spmd(...):` context-manager form. The parser desugars `for i in pl.spmd(N):` into `SpmdScopeStmt(body=InCoreScopeStmt(body=[i = tile.get_block_idx(); ...]))`, giving inline tile/tensor ops direct access to the per-block index without a separately declared `@pl.function(type=InCore)` kernel.

`pl.spmd()` now takes `core_num` as a **positional** argument — mirroring `range(n)`. The only constraints are `start=0, step=1`, so there's no need for extra keywords. The old `pl.spmd(core_num=N)` keyword form still parses for backward compatibility.

```python
# Existing form — now with positional core_num (kwarg still accepted)
@pl.function(type=pl.FunctionType.InCore)
def vec_add(self, a, b, out):
    i = pl.tile.get_block_idx()
    offset = i * 128
    tile_a = pl.load(a, [offset, 0], [128, 128])
    ...

@pl.function(type=pl.FunctionType.Orchestration)
def main(self, a, b, out):
    with pl.spmd(4):
        out = self.vec_add(a, b, out)
    return out

# New loop form — no separate @pl.function(type=InCore) needed
@pl.function(type=pl.FunctionType.Orchestration)
def main(self, a, b, out):
    for i in pl.spmd(4):
        offset = i * 128
        tile_a = pl.load(a, [offset, 0], [128, 128])
        tile_b = pl.load(b, [offset, 0], [128, 128])
        out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
    return out
```

## What's in the change

### Parser / DSL

- `pl.spmd(core_num, *, sync_start=, name_hint=)` — `core_num` is the first positional argument (range-like). The `core_num=` keyword form still parses for backward compat; specifying both forms raises a targeted error.
- `pl.spmd(...)` is now both a context manager and a loop iterator (`__iter__` stub on `SpmdContext`).
- `_parse_spmd_for_loop` handler: rejects tuple targets, `init_values=`, `chunk=`, etc. with targeted diagnostics; builds the desugared IR (SpmdScope wrapping an implicit InCoreScope with `i = tile.get_block_idx()` injected).
- Extracted the shared `_parse_spmd_kwargs` helper; the existing `with pl.spmd()` single-call path is unchanged.

### Pass pipeline

- `OutlineIncoreScopes` now also processes Orchestration-typed parents so it catches the implicit InCoreScopeStmt before `OutlineClusterScopes` wraps everything into a Spmd function.
- `ScopeOutliner` propagates `required_outputs_` from an enclosing `SeqStmts` into non-target siblings, and tracks an `inside_nested_scope_body_` flag so the no-context fallback only exposes store targets when the scope boundary already confines locally-defined vars.
- New `PostStoreAliasCollector` dedupes SSA post-store var-defs against their store targets at the call site, so the outlined InCore function returns a single tensor rather than a redundant tuple.

### Printer

- The Python printer detects the for-spmd desugared IR pattern and emits the for-loop form back out, keeping round-trips stable (with-form enforces a single kernel call, so multi-statement InCore bodies would otherwise fail to reparse).
- Both `with` and `for` forms print with `pl.spmd(N)` (positional) so the printed output matches the new canonical surface.

## Test plan

- [x] `tests/ut/language/parser/test_scope_parsing.py::TestSpmdForLoop` — happy path (positional), backward-compat kwarg still parses, with-form regression, rejected invalid forms (tuple target, `init_values=`, `chunk=`, duplicate positional+kwarg, extra positional, zero `core_num`, non-bool `sync_start`), print→reparse round-trip.
- [x] `tests/ut/ir/transforms/test_outline_cluster_scopes.py::test_outline_spmd_for_loop_auto_outlines_incore` — Before / Expected / `ir.assert_structural_equal` pattern, matching the rest of the file. Verifies `convert_to_ssa + outline_incore_scopes + outline_cluster_scopes` produces the expected `main` / `main_spmd_0` / `main_incore_0` split with the block-index binding as the first InCore statement.
- [x] Full `tests/ut` sweep: 3941 passed, 16 skipped.
- [x] Full `Default` compile pipeline runs end-to-end on both forms and produces semantically equivalent IR (verified on Ascend910B backend).
- [x] Clang-tidy clean on the diff; pre-commit hooks (ruff, pyright, clang-format, cpplint, markdownlint) all pass.

## Docs

- `docs/en/dev/ir/01-hierarchy.md` and `docs/en/dev/passes/08-outline_cluster_scopes.md` describe the loop form alongside the existing `with pl.spmd()` form, using positional `pl.spmd(N)` throughout.
- Chinese mirrors updated in lockstep.

## Out of scope (deliberate)

- Relaxing the `with pl.spmd(): ... tensor ops ...` form (original issue text) — deferred; without a block-index binding the semantics are ambiguous. The loop form is the recommended path for inline ops.
- Paged-attention SPMD example (#1051) — will follow in a separate PR.
- Multi-axis `for i, j in pl.spmd(...)` — single-index per scope covers the current hardware model.

## Related Issues

Fixes #1053
