### PR TITLE
fix(ir): Avoid over-promoting parallel-loop Out args to InOut (#1086)

### DIFF
--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -22,6 +22,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
@@ -45,16 +46,230 @@ bool IsTensorTypedArg(const ExprPtr& arg) {
   return false;
 }
 
-/// IRMutator that rewrites every non-builtin Call in a function body and writes
-/// the per-argument ArgDirection vector based on callee param directions and the
-/// pre-computed buffer-root map for that function.
-class CallDirectionMutator : public IRMutator {
+/// Compute the per-position ParamDirection vector for a callee, expanding Group/Spmd
+/// callees whose effective directions depend on inner-task call sites.
+std::vector<ParamDirection> ResolveCalleeDirections(const ProgramPtr& program, const CallPtr& call,
+                                                    const FunctionPtr& callee) {
+  if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
+    return ComputeGroupEffectiveDirections(callee, program);
+  }
+  return callee->param_directions_;
+}
+
+/// Resolve the buffer root for an argument expression and decide whether that root
+/// is locally allocated (i.e. not rooted at a function parameter).
+/// Returns the root Var* if local, nullptr otherwise (non-var arg, unknown root,
+/// or root that maps to an external function parameter).
+const Var* ResolveLocalRoot(const ExprPtr& arg,
+                            const std::unordered_map<const Var*, const Var*>& buffer_roots,
+                            const std::unordered_set<const Var*>& param_vars) {
+  auto var = AsVarLike(arg);
+  if (!var) return nullptr;
+  auto it = buffer_roots.find(var.get());
+  if (it == buffer_roots.end()) return nullptr;
+  const Var* root = it->second;
+  if (param_vars.count(root) > 0) return nullptr;
+  return root;
+}
+
+/// Pre-pass that decides, per (Call, local root), whether the call is the "first
+/// writer" of that root within its enclosing scope, treating ForStmt/WhileStmt/
+/// IfStmt as opaque writer-units. ScopeStmt and SeqStmts are transparent.
+///
+/// Two phases:
+///   1. PrecomputeWrittenRoots: bottom-up cache of the union of local roots
+///      written by any non-builtin call inside each subtree.
+///   2. AnalyzeScope: top-down scan that maintains a `seen_roots` set of roots
+///      already written by prior siblings; for each Call, every Out-param arg
+///      whose root is *not* in `seen_roots` is recorded as "first writer".
+class PriorWriterCollector {
  public:
-  CallDirectionMutator(ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
+  PriorWriterCollector(ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
                        const std::unordered_set<const Var*>& param_vars)
       : program_(std::move(program)), buffer_roots_(buffer_roots), param_vars_(param_vars) {}
 
+  void Run(const StmtPtr& body) {
+    if (!body) return;
+    PrecomputeWrittenRoots(body);
+    std::unordered_set<const Var*> seen;
+    AnalyzeScope(body, seen);
+  }
+
+  /// Per-Call set of roots for which the call is the first writer in its scope.
+  /// Roots not in the set (or Calls absent from the map) are by definition
+  /// preceded by another writer-unit and therefore subject to R-prior promotion.
+  std::unordered_map<const Call*, std::unordered_set<const Var*>> first_writer_roots;
+
+ private:
+  /// Compute (and cache) the set of local roots written by any non-builtin Call
+  /// inside the subtree rooted at `stmt`. The result is treated as the "writer
+  /// footprint" of the stmt when it appears as a sibling in an outer scope.
+  const std::unordered_set<const Var*>& PrecomputeWrittenRoots(const StmtPtr& stmt) {
+    auto cached = written_roots_.find(stmt.get());
+    if (cached != written_roots_.end()) return cached->second;
+    auto& result = written_roots_[stmt.get()];
+    if (!stmt) return result;
+
+    if (auto seq = As<SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) {
+        const auto& child = PrecomputeWrittenRoots(s);
+        result.insert(child.begin(), child.end());
+      }
+    } else if (auto for_stmt = As<ForStmt>(stmt)) {
+      const auto& body_roots = PrecomputeWrittenRoots(for_stmt->body_);
+      result.insert(body_roots.begin(), body_roots.end());
+    } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+      const auto& body_roots = PrecomputeWrittenRoots(while_stmt->body_);
+      result.insert(body_roots.begin(), body_roots.end());
+    } else if (auto if_stmt = As<IfStmt>(stmt)) {
+      const auto& then_roots = PrecomputeWrittenRoots(if_stmt->then_body_);
+      result.insert(then_roots.begin(), then_roots.end());
+      if (if_stmt->else_body_.has_value() && if_stmt->else_body_.value()) {
+        const auto& else_roots = PrecomputeWrittenRoots(if_stmt->else_body_.value());
+        result.insert(else_roots.begin(), else_roots.end());
+      }
+    } else if (auto scope = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
+      const auto& body_roots = PrecomputeWrittenRoots(scope->body_);
+      result.insert(body_roots.begin(), body_roots.end());
+    } else if (auto assign = As<AssignStmt>(stmt)) {
+      CollectCallWrittenRoots(assign->value_, result);
+    } else if (auto eval = As<EvalStmt>(stmt)) {
+      CollectCallWrittenRoots(eval->expr_, result);
+    }
+    // YieldStmt / ReturnStmt / BreakStmt / ContinueStmt: no writes.
+    return result;
+  }
+
+  /// If `expr` is a non-builtin Call, add every Out/InOut local root it writes
+  /// into `out`.
+  void CollectCallWrittenRoots(const ExprPtr& expr, std::unordered_set<const Var*>& out) {
+    auto call = As<Call>(expr);
+    if (!call) return;
+    if (IsBuiltinOp(call->op_->name_)) return;
+    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    if (!callee) return;
+
+    auto dirs = ResolveCalleeDirections(program_, call, callee);
+    for (size_t i = 0; i < dirs.size() && i < call->args_.size(); ++i) {
+      if (dirs[i] != ParamDirection::Out && dirs[i] != ParamDirection::InOut) continue;
+      if (const Var* root = ResolveLocalRoot(call->args_[i], buffer_roots_, param_vars_)) {
+        out.insert(root);
+      }
+    }
+  }
+
+  /// Top-down analysis. `seen` carries the set of local roots already written by
+  /// prior siblings (or ancestors' prior siblings) in the surrounding scope.
+  /// For/While/If subtrees are entered with a *snapshot copy* of `seen`, so that
+  /// writes within the subtree do not leak into the outer scope's sibling tracking.
+  /// The unit's pre-computed `written_roots` is then merged into the outer `seen`.
+  /// ScopeStmt and SeqStmts are transparent and share the same `seen`.
+  void AnalyzeScope(const StmtPtr& stmt, std::unordered_set<const Var*>& seen) {
+    if (!stmt) return;
+    if (auto seq = As<SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) {
+        AnalyzeScope(s, seen);
+      }
+    } else if (auto for_stmt = As<ForStmt>(stmt)) {
+      auto inner = seen;
+      AnalyzeScope(for_stmt->body_, inner);
+      const auto& written = PrecomputeWrittenRoots(for_stmt->body_);
+      seen.insert(written.begin(), written.end());
+    } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+      auto inner = seen;
+      AnalyzeScope(while_stmt->body_, inner);
+      const auto& written = PrecomputeWrittenRoots(while_stmt->body_);
+      seen.insert(written.begin(), written.end());
+    } else if (auto if_stmt = As<IfStmt>(stmt)) {
+      auto then_seen = seen;
+      AnalyzeScope(if_stmt->then_body_, then_seen);
+      if (if_stmt->else_body_.has_value() && if_stmt->else_body_.value()) {
+        auto else_seen = seen;
+        AnalyzeScope(if_stmt->else_body_.value(), else_seen);
+      }
+      const auto& written_then = PrecomputeWrittenRoots(if_stmt->then_body_);
+      seen.insert(written_then.begin(), written_then.end());
+      if (if_stmt->else_body_.has_value() && if_stmt->else_body_.value()) {
+        const auto& written_else = PrecomputeWrittenRoots(if_stmt->else_body_.value());
+        seen.insert(written_else.begin(), written_else.end());
+      }
+    } else if (auto scope = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
+      AnalyzeScope(scope->body_, seen);
+    } else if (auto assign = As<AssignStmt>(stmt)) {
+      AnalyzeCall(assign->value_, seen);
+    } else if (auto eval = As<EvalStmt>(stmt)) {
+      AnalyzeCall(eval->expr_, seen);
+    }
+    // Other stmts (Yield/Return/Break/Continue): no Calls to analyze.
+  }
+
+  /// For a single Call expression, mark "first writer" roots and update `seen`.
+  void AnalyzeCall(const ExprPtr& expr, std::unordered_set<const Var*>& seen) {
+    auto call = As<Call>(expr);
+    if (!call) return;
+    if (IsBuiltinOp(call->op_->name_)) return;
+    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    if (!callee) return;
+
+    auto dirs = ResolveCalleeDirections(program_, call, callee);
+    std::unordered_set<const Var*> roots_this_call;
+    for (size_t i = 0; i < dirs.size() && i < call->args_.size(); ++i) {
+      // Only Out is decision-relevant for promotion (InOut is already InOut).
+      // We still register InOut roots into `roots_this_call` so subsequent
+      // siblings see them as prior writers.
+      if (dirs[i] != ParamDirection::Out && dirs[i] != ParamDirection::InOut) continue;
+      const Var* root = ResolveLocalRoot(call->args_[i], buffer_roots_, param_vars_);
+      if (!root) continue;
+      if (dirs[i] == ParamDirection::Out && seen.count(root) == 0) {
+        first_writer_roots[call.get()].insert(root);
+      }
+      roots_this_call.insert(root);
+    }
+    seen.insert(roots_this_call.begin(), roots_this_call.end());
+  }
+
+  ProgramPtr program_;
+  const std::unordered_map<const Var*, const Var*>& buffer_roots_;
+  const std::unordered_set<const Var*>& param_vars_;
+  std::unordered_map<const Stmt*, std::unordered_set<const Var*>> written_roots_;
+};
+
+/// IRMutator that rewrites every non-builtin Call in a function body and writes
+/// the per-argument ArgDirection vector based on callee param directions, the
+/// pre-computed buffer-root map, and prior-writer / sequential-context analysis.
+///
+/// Promotion rules for callee Out + locally-allocated buffer:
+///   - R-seq:   any sequential ancestor (For{Sequential,Unroll,Pipeline} or While)  → InOut
+///   - R-prior: a prior writer-unit in the same scope wrote to the same root        → InOut
+///   - default: OutputExisting (write into a pre-allocated buffer that the runtime
+///              treats as an output slot, no extra dependency edge introduced).
+class CallDirectionMutator : public IRMutator {
+ public:
+  CallDirectionMutator(
+      ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
+      const std::unordered_set<const Var*>& param_vars,
+      const std::unordered_map<const Call*, std::unordered_set<const Var*>>& first_writer_roots)
+      : program_(std::move(program)),
+        buffer_roots_(buffer_roots),
+        param_vars_(param_vars),
+        first_writer_roots_(first_writer_roots) {}
+
  protected:
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    bool is_sequential = op->kind_ != ForKind::Parallel;
+    if (is_sequential) ++sequential_depth_;
+    auto out = IRMutator::VisitStmt_(op);
+    if (is_sequential) --sequential_depth_;
+    return out;
+  }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+    ++sequential_depth_;
+    auto out = IRMutator::VisitStmt_(op);
+    --sequential_depth_;
+    return out;
+  }
+
   ExprPtr VisitExpr_(const CallPtr& op) override {
     // First descend so nested Calls also get arg_directions assigned.
     auto base = IRMutator::VisitExpr_(op);
@@ -71,11 +286,7 @@ class CallDirectionMutator : public IRMutator {
       return call;
     }
 
-    std::vector<ParamDirection> effective = callee->param_directions_;
-    if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
-      effective = ComputeGroupEffectiveDirections(callee, program_);
-    }
-
+    auto effective = ResolveCalleeDirections(program_, call, callee);
     if (effective.size() != call->args_.size()) {
       // Safety: if the length disagrees we can't produce a sound mapping.
       // Leave directions empty so the verify pass surfaces a clear error.
@@ -89,6 +300,14 @@ class CallDirectionMutator : public IRMutator {
     if (call->HasArgDirections()) {
       return call;
     }
+
+    // Look up first-writer info computed against the *original* Call object.
+    // The mutator may produce a new shared_ptr above (when nested Calls are
+    // rewritten), but the prior-writer collector keyed on the original op.
+    const Call* original_call = op.get();
+    auto fw_it = first_writer_roots_.find(original_call);
+    const std::unordered_set<const Var*>* first_writer_set =
+        fw_it != first_writer_roots_.end() ? &fw_it->second : nullptr;
 
     std::vector<ArgDirection> dirs;
     dirs.reserve(call->args_.size());
@@ -106,21 +325,26 @@ class CallDirectionMutator : public IRMutator {
       } else if (cd == ParamDirection::InOut) {
         dirs.push_back(ArgDirection::InOut);
       } else {
-        // ParamDirection::Out
-        if (auto arg_var = AsVarLike(arg)) {
-          if (IsLocallyAllocated(arg_var.get())) {
-            // WAW promotion: the runtime needs InOut to chain dependencies on
-            // a pre-allocated local buffer being reused across tasks.
-            dirs.push_back(ArgDirection::InOut);
-          } else {
-            // External (param-rooted) buffer: treat as write-only into an existing tensor.
-            dirs.push_back(ArgDirection::OutputExisting);
-          }
-        } else {
-          // Non-var Out argument is unusual; fall back to OutputExisting which is
-          // the conservative choice (no allocation done by the runtime).
+        // ParamDirection::Out — apply the promotion rules.
+        const Var* local_root = ResolveLocalRoot(arg, buffer_roots_, param_vars_);
+        if (!local_root) {
+          // External/param-rooted destination: write into an existing tensor.
           dirs.push_back(ArgDirection::OutputExisting);
+          continue;
         }
+        // R-seq: any sequential ancestor forces InOut to keep iteration WAW chains correct.
+        if (sequential_depth_ > 0) {
+          dirs.push_back(ArgDirection::InOut);
+          continue;
+        }
+        // R-prior: a prior writer-unit in this scope already wrote to this root → InOut.
+        bool is_first_writer = first_writer_set != nullptr && first_writer_set->count(local_root) > 0;
+        if (!is_first_writer) {
+          dirs.push_back(ArgDirection::InOut);
+          continue;
+        }
+        // Default: locally-allocated, first writer, no sequential ancestor → OutputExisting.
+        dirs.push_back(ArgDirection::OutputExisting);
       }
     }
 
@@ -135,16 +359,11 @@ class CallDirectionMutator : public IRMutator {
   }
 
  private:
-  bool IsLocallyAllocated(const Var* var) const {
-    auto it = buffer_roots_.find(var);
-    if (it == buffer_roots_.end()) return false;
-    const Var* root = it->second;
-    return param_vars_.count(root) == 0;
-  }
-
   ProgramPtr program_;
   const std::unordered_map<const Var*, const Var*>& buffer_roots_;
   const std::unordered_set<const Var*>& param_vars_;
+  const std::unordered_map<const Call*, std::unordered_set<const Var*>>& first_writer_roots_;
+  int sequential_depth_ = 0;
 };
 
 }  // namespace
@@ -171,7 +390,11 @@ Pass DeriveCallDirections() {
         param_vars.insert(p.get());
       }
 
-      CallDirectionMutator mutator(program, br_collector.buffer_roots, param_vars);
+      PriorWriterCollector pw_collector(program, br_collector.buffer_roots, param_vars);
+      pw_collector.Run(func->body_);
+
+      CallDirectionMutator mutator(program, br_collector.buffer_roots, param_vars,
+                                   pw_collector.first_writer_roots);
       auto new_body = mutator.VisitStmt(func->body_);
       if (new_body.get() == func->body_.get()) continue;
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -141,7 +141,7 @@ class TestOrchestration:
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_inout(c);
+                    params_t0.add_output(c);
                     pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add
@@ -393,20 +393,20 @@ class TestOrchestration:
                     Arg params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
-                    params_t0.add_inout(c);
+                    params_t0.add_output(c);
                     pto2_rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add_scalar
                     Arg params_t1;
                     params_t1.add_input(c);
-                    params_t1.add_inout(d);
+                    params_t1.add_output(d);
                     params_t1.add_scalar(to_u64(1.000000f));
                     pto2_rt_submit_aiv_task(1, params_t1);
 
                     // Task 2: kernel_add_scalar
                     Arg params_t2;
                     params_t2.add_input(c);
-                    params_t2.add_inout(e);
+                    params_t2.add_output(e);
                     params_t2.add_scalar(to_u64(2.000000f));
                     pto2_rt_submit_aiv_task(1, params_t2);
 
@@ -414,7 +414,7 @@ class TestOrchestration:
                     Arg params_t3;
                     params_t3.add_input(d);
                     params_t3.add_input(e);
-                    params_t3.add_inout(g);
+                    params_t3.add_output(g);
                     pto2_rt_submit_aiv_task(2, params_t3);
 
                     // Task 4: kernel_add
@@ -1525,8 +1525,11 @@ class TestOrchestration:
         assert code.count("TensorCreateInfo ret0__out_ci(") == 1
         assert code.count("TensorCreateInfo ret0__out_1_ci(") == 1
         assert "alloc_tensors(ret0__out_ci, ret0__out_1_ci)" in code
-        assert "params_t0.add_inout(ret0__out)" in code
-        assert "params_t1.add_inout(ret0__out_1)" in code
+        # Each ret0__out{,_1} is the unique writer of its local root in this scope
+        # and has no sequential ancestor, so DeriveCallDirections keeps both as
+        # OutputExisting (→ add_output) rather than promoting to InOut.
+        assert "params_t0.add_output(ret0__out)" in code
+        assert "params_t1.add_output(ret0__out_1)" in code
         assert "const Tensor& first = ret0__out;" in code
         assert "const Tensor& second" not in code
 
@@ -2355,6 +2358,100 @@ class TestLocalAllocWAWPromotion:
 
         assert "add_output(ext_out)" in code, (
             f"External (parameter) tensor should keep add_output. Generated code:\n{code}"
+        )
+
+    def test_parallel_loop_local_buf_keeps_add_output(self):
+        """Issue #1086: a single ``pl.parallel`` writer of a local buffer must
+        emit ``add_output`` (not ``add_inout``).
+
+        Promoting Out → InOut here injects a spurious WAW dependency that
+        forces the runtime to serialize otherwise independent iterations of
+        the parallel loop, causing the regression observed in Qwen3 decode.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SingleParallelProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def task(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                buf: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                for _i in pl.parallel(4):
+                    buf = self.task(a, buf)
+                out = self.task(buf, out)
+                return out
+
+        code = _generate_orch_code(SingleParallelProgram)
+
+        assert "add_output(buf)" in code, (
+            f"Local buf written from a single pl.parallel loop must use add_output, "
+            f"not add_inout (issue #1086). Generated code:\n{code}"
+        )
+        assert "add_inout(buf)" not in code, (
+            f"Local buf must not be promoted to add_inout when only a single "
+            f"pl.parallel loop writes it. Generated code:\n{code}"
+        )
+
+    def test_two_parallel_loops_promote_only_second(self):
+        """Two consecutive ``pl.parallel`` loops writing the same local buffer.
+
+        The first loop is the only writer-unit at its scope and stays
+        ``add_output``; the second loop hits R-prior so it is promoted to
+        ``add_inout`` to keep the cross-loop WAW dependency.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class TwoParallelProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def task(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                buf: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                for _i in pl.parallel(4):
+                    buf = self.task(a, buf)
+                for _j in pl.parallel(4):
+                    buf = self.task(a, buf)
+                out = self.task(buf, out)
+                return out
+
+        code = _generate_orch_code(TwoParallelProgram)
+
+        # Both add_output (first loop, R-prior not yet active) and add_inout
+        # (second loop, R-prior fires) must be present for the same `buf`.
+        assert "add_output(buf)" in code, (
+            f"First pl.parallel writer of buf should remain add_output. Generated code:\n{code}"
+        )
+        assert "add_inout(buf)" in code, (
+            f"Second pl.parallel writer of buf should be promoted to add_inout via R-prior. "
+            f"Generated code:\n{code}"
         )
 
 

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -162,8 +162,16 @@ class TestDeriveDirectionMatrix:
         assert len(calls) == 1
         assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
 
-    def test_out_param_local_buffer_promoted_to_inout(self):
-        """Callee Out + locally allocated buffer → InOut (WAW promotion)."""
+    def test_out_param_local_buffer_kept_output_existing(self):
+        """Callee Out + single-write locally allocated buffer → OutputExisting.
+
+        A buffer that is allocated locally and written to by exactly one Call at
+        top level (no sequential ancestor, no prior writer-unit in the same
+        scope) does not need the WAW chaining that ``InOut`` provides; keeping
+        it as ``OutputExisting`` lets the runtime treat the slot as an ordinary
+        output and avoids the spurious dependency that would otherwise serialize
+        the task with subsequent siblings.
+        """
 
         @pl.program
         class Prog:
@@ -186,7 +194,319 @@ class TestDeriveDirectionMatrix:
         out = passes.derive_call_directions()(Prog)
         calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
         assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+
+    def test_two_calls_top_level_second_promoted(self):
+        """Two consecutive top-level calls writing the same local root.
+
+        First writer keeps ``OutputExisting`` (no prior writes); the second
+        writer hits R-prior and is promoted to ``InOut`` so the runtime can
+        chain WAW dependencies on the shared buffer.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                local = self.kernel(x, local)
+                local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 2
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_out_local_in_parallel_keeps_output_existing(self):
+        """Single ``pl.parallel`` writer of a local buffer → ``OutputExisting``.
+
+        Regression test for issue #1086: tiled writes inside a ``pl.parallel``
+        loop should not be promoted to ``InOut`` just because they happen
+        inside a loop, because doing so injects a spurious dependency that
+        serializes otherwise independent iterations.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for _i in pl.parallel(4):
+                    local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+
+    def test_two_parallel_loops_promote_only_second(self):
+        """Two consecutive ``pl.parallel`` loops writing the same root.
+
+        The first loop is the only writer-unit at its scope and stays
+        ``OutputExisting``; the second loop hits R-prior and is promoted to
+        ``InOut`` so the cross-loop WAW dependency is preserved.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for _i in pl.parallel(4):
+                    local = self.kernel(x, local)
+                for _j in pl.parallel(4):
+                    local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 2
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_seq_inside_parallel_keeps_inout(self):
+        """``pl.range`` (sequential) inside ``pl.parallel`` triggers R-seq.
+
+        Even if the inner sequential loop is the only writer-unit, the
+        sequential ancestor forces ``InOut`` so cross-iteration WAW chains in
+        the inner loop body are preserved.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for _i in pl.parallel(4):
+                    for _j in pl.range(4):
+                        local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
         assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_parallel_inside_seq_keeps_inout(self):
+        """``pl.parallel`` inside ``pl.range`` still triggers R-seq.
+
+        The outer sequential loop is enough for R-seq, regardless of the kind
+        of inner loops it contains.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for _i in pl.range(4):
+                    for _j in pl.parallel(4):
+                        local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_top_level_call_then_parallel_promoted(self):
+        """Top-level writer followed by ``pl.parallel`` writer hits R-prior.
+
+        Mirror of the ``k2(local) for _ in pl.parallel: k1(local)`` scenario:
+        the first call is the sole writer-unit, the parallel loop sees a
+        prior writer-unit at sibling scope and is therefore promoted.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                local = self.kernel(x, local)
+                for _i in pl.parallel(4):
+                    local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 2
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_while_keeps_inout(self):
+        """``while`` loop body triggers R-seq (sequential writer-unit).
+
+        ``WhileStmt`` is treated like a sequential for loop: the body may run
+        any number of iterations, so cross-iteration WAW dependencies must be
+        preserved by promoting Out → InOut.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                i: pl.Scalar[pl.INDEX] = 0
+                while i < n:
+                    local = self.kernel(x, local)
+                    i = i + 1
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+
+    def test_if_first_writer_keeps_output_existing(self):
+        """First writer inside an ``if`` branch is the only writer-unit.
+
+        With no prior writer and no sequential ancestor, the call inside the
+        branch keeps ``OutputExisting``. Each branch is analyzed against an
+        independent ``seen_roots`` snapshot from the enclosing scope.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                if flag:
+                    local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+
+    def test_if_after_top_level_writer_promoted(self):
+        """``if`` branch following a top-level writer hits R-prior.
+
+        The outer scope's prior-writer set already contains the local root
+        when the ``if`` is entered, so the branch's snapshot starts with the
+        root in ``seen``; the call inside is no longer the first writer.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                local = self.kernel(x, local)
+                if flag:
+                    local = self.kernel(x, local)
+                return local
+
+        out = passes.derive_call_directions()(Prog)
+        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
+        assert len(calls) == 2
+        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
 
     def test_builtin_calls_left_untouched(self):
         """tensor.create / tile.* are builtin and keep arg_directions empty."""


### PR DESCRIPTION
## Summary

Fixes #1086.

`DeriveCallDirections` previously promoted **every** callee `Out` parameter that bound to a locally allocated buffer to `ArgDirection::InOut`. Inside a `pl.parallel` loop this injected a spurious WAW chain that serialized otherwise independent iterations (regression observed in Qwen3 decode `q_proj`).

`DeriveCallDirections` now defaults local-buffer `Out` arguments to `OutputExisting` and only promotes them to `InOut` when one of two rules fires:

- **R-seq**: any sequential ancestor (`ForKind::Sequential`/`Unroll`/`Pipeline` or `WhileStmt`) requires WAW chaining across iterations.
- **R-prior**: a prior writer-unit (`For`/`While`/`If` treated as opaque) in the same scope already wrote the same buffer root, so the new call participates in a cross-statement WAW dependency.

A new two-phase `PriorWriterCollector` pre-computes the writer footprint of each block-as-unit and then walks the body top-down to mark first writers per scope; `ScopeStmt`/`SeqStmts` are transparent and `IfStmt` branches use independent ``seen_roots`` snapshots.

## Behaviour matrix

| Scope of local-buffer Out write | Before | After |
| --- | --- | --- |
| Single top-level call | InOut | OutputExisting |
| Two consecutive top-level calls | InOut, InOut | OutputExisting, InOut |
| Single `pl.parallel` loop | InOut | OutputExisting (#1086 fix) |
| Two consecutive `pl.parallel` loops | InOut, InOut | OutputExisting, InOut |
| Sequential loop (any nesting) | InOut | InOut (R-seq) |
| `pl.parallel` inside `pl.range` | InOut | InOut (R-seq) |
| `while` body | InOut | InOut (R-seq) |
| First-writer in `if` branch | InOut | OutputExisting |
| `if` after a prior writer-unit | InOut | InOut (R-prior) |
| External (param-rooted) buffer | OutputExisting | OutputExisting (unchanged) |

## Testing

- [x] \`tests/ut/ir/transforms/test_derive_call_directions.py\` — added 9 cases covering parallel/two-parallel/seq-in-parallel/parallel-in-seq/two-top-level/while/if(first writer)/if(after prior writer); renamed the previous \`promoted_to_inout\` case to \`kept_output_existing\`. **19 passed.**
- [x] \`tests/ut/codegen/test_orchestration_codegen.py\` — added \`test_parallel_loop_local_buf_keeps_add_output\` (direct issue #1086 regression) and \`test_two_parallel_loops_promote_only_second\`; updated \`test_basic_structure\`/\`test_vector_example_dag\`/\`test_repeated_auto_output_buffers_get_unique_names\` to expect \`add_output\` for first-writer locals. **53 passed.**
- [x] Full unit suite: \`pytest tests/ut/\` — **4026 passed, 16 skipped.**
- [x] \`pre-commit run --files ...\` — clang-format / cpplint / ruff / pyright all pass.


Made with [Cursor](https://cursor.com)