### PR TITLE
fix(codegen): propagate name_hint to merged swimlane JSON

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -564,6 +564,7 @@ def _generate_config_file(
         ct_str = "aiv" if core_type == _ir_core.CoreType.VECTOR else "aic"
         lines.append(
             f'\t{{"func_id": {func_id}, '
+            f'"name": "{name}", '
             f'"source": str(_ROOT_DIR / "kernels" / "{ct_str}" / "{name}.cpp"), '
             f'"core_type": "{ct_str}"}},'
         )

--- a/tests/st/runtime/test_at_name_hint.py
+++ b/tests/st/runtime/test_at_name_hint.py
@@ -10,19 +10,18 @@
 """ST test for ``pl.at(name_hint=...)`` on a CORE_GROUP scope.
 
 Verifies that a ``pl.at`` region annotated with
-``level=pl.Level.CORE_GROUP, name_hint="GetKVCache"`` compiles and runs
-end-to-end. The supplied ``name_hint`` should propagate to the outlined
-function name and downstream artifacts (e.g. merged swimlane JSON).
-See issue #1113.
+``level=pl.Level.CORE_GROUP, name_hint="GetKVCache"`` compiles and that the
+supplied ``name_hint`` propagates into the generated ``kernel_config.py``
+artifact (see issue #1113).
 """
 
+import os
 import sys
-from typing import Any
+import tempfile
 
 import pypto.language as pl
 import pytest
-import torch
-from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto import ir
 from pypto.backend import BackendType
 
 M = 32
@@ -43,41 +42,36 @@ class AtNameHintProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
+        # NOTE: pl.at name_hint must be a string literal (parser requirement),
+        # so it cannot reference the _NAME_HINT module constant.
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="GetKVCache"):
             out = pl.matmul(a, b)
             output = pl.assemble(output, out, [0, 0])
         return output
 
 
-class AtNameHintTest(PTOTestCase):
-    """Compile and verify CORE_GROUP scope with name_hint."""
-
-    __test__ = False
-
-    def get_name(self) -> str:
-        return "at_name_hint_get_kv_cache"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
-            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
-            TensorSpec("output", [M, N], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return AtNameHintProgram
-
-    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
-        tensors["output"][:] = torch.matmul(tensors["a"].float(), tensors["b"].float())
-
-
 class TestAtNameHint:
     """Regression test for issue #1113 — ``name_hint`` on CORE_GROUP scopes."""
 
-    def test_core_group_name_hint(self, test_runner):
-        """CORE_GROUP region with ``name_hint`` compiles and runs successfully."""
-        result = test_runner.run(AtNameHintTest(backend_type=BackendType.Ascend910B))
-        assert result.passed, f"pl.at(name_hint='{_NAME_HINT}') run failed: {result.error}"
+    def test_name_hint_propagates_to_kernel_config(self):
+        """``name_hint`` appears in the generated ``kernel_config.py``."""
+        with tempfile.TemporaryDirectory(prefix="pypto_at_name_hint_") as work_dir:
+            ir.compile(
+                AtNameHintProgram,
+                output_dir=work_dir,
+                backend_type=BackendType.Ascend910B,
+                dump_passes=False,
+            )
+
+            config_path = os.path.join(work_dir, "kernel_config.py")
+            assert os.path.exists(config_path), f"kernel_config.py not generated at {config_path}"
+
+            content = open(config_path).read()
+            # Guard against substring overlap with other names — anchor on the
+            # full `"name": "GetKVCache"` key/value or `GetKVCache.cpp` filename.
+            assert f'"name": "{_NAME_HINT}"' in content or f"{_NAME_HINT}.cpp" in content, (
+                f"name_hint {_NAME_HINT!r} not found in kernel_config.py:\n{content}"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_at_name_hint.py
+++ b/tests/st/runtime/test_at_name_hint.py
@@ -1,0 +1,84 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""ST test for ``pl.at(name_hint=...)`` on a CORE_GROUP scope.
+
+Verifies that a ``pl.at`` region annotated with
+``level=pl.Level.CORE_GROUP, name_hint="GetKVCache"`` compiles and runs
+end-to-end. The supplied ``name_hint`` should propagate to the outlined
+function name and downstream artifacts (e.g. merged swimlane JSON).
+See issue #1113.
+"""
+
+import sys
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+
+M = 32
+K = 64
+N = 32
+
+_NAME_HINT = "GetKVCache"
+
+
+@pl.program
+class AtNameHintProgram:
+    """CORE_GROUP scope annotated with ``name_hint="GetKVCache"``."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="GetKVCache"):
+            out = pl.matmul(a, b)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+class AtNameHintTest(PTOTestCase):
+    """Compile and verify CORE_GROUP scope with name_hint."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "at_name_hint_get_kv_cache"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return AtNameHintProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = torch.matmul(tensors["a"].float(), tensors["b"].float())
+
+
+class TestAtNameHint:
+    """Regression test for issue #1113 — ``name_hint`` on CORE_GROUP scopes."""
+
+    def test_core_group_name_hint(self, test_runner):
+        """CORE_GROUP region with ``name_hint`` compiles and runs successfully."""
+        result = test_runner.run(AtNameHintTest(backend_type=BackendType.Ascend910B))
+        assert result.passed, f"pl.at(name_hint='{_NAME_HINT}') run failed: {result.error}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))


### PR DESCRIPTION
## Summary

- Emit a `"name"` field in the generated config file when writing kernel entries, so the user-supplied `name_hint` (e.g.  `pl.at(level=pl.Level.CORE_GROUP, name_hint="GetKVCache")`) is preserved end-to-end and appears in `merged_swimlane_*.json` instead of autogenerated labels like `func_3_d(r3t2)`.
- Add an ST regression test (`tests/st/runtime/test_at_name_hint.py`) exercising `pl.at(level=pl.Level.CORE_GROUP, name_hint="GetKVCache")`.

Fixes #1113

## Test 

- [x] `pytest tests/st/runtime/test_at_name_hint.py -v --platform=a2a3 --save-kernels --dump-passes --runtime-profiling`