### PR TITLE
feat(ir): propagate AutoInCore name_hint to generated InCore scopes

### DIFF
--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -225,14 +225,15 @@ static bool NeedsInCoreWrapping(const StmtPtr& stmt) {
  * Control flow statements (YieldStmt, ReturnStmt) are never wrapped.
  */
 static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& span,
-                                               std::optional<SplitMode> split = std::nullopt) {
+                                               std::optional<SplitMode> split = std::nullopt,
+                                               const std::string& name_hint = "") {
   // When a ForStmt contains InCore scopes in its body (e.g. a pl.range loop
   // wrapping interchanged parallel chunks), recurse into it so that non-InCore
   // statements *inside* the loop body also get wrapped.
   auto maybe_recurse_into_compound = [&](const StmtPtr& s) -> StmtPtr {
     auto fs = std::dynamic_pointer_cast<const ForStmt>(s);
     if (fs && ContainsInCoreScope(fs->body_)) {
-      auto new_body = WrapNonIncoreStatementsInInCore(fs->body_, span, split);
+      auto new_body = WrapNonIncoreStatementsInInCore(fs->body_, span, split, name_hint);
       if (new_body.get() != fs->body_.get()) {
         auto new_for = MutableCopy(fs);
         new_for->body_ = new_body;
@@ -245,7 +246,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
   auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
   if (!seq) {
     if (NeedsInCoreWrapping(body)) {
-      return std::make_shared<InCoreScopeStmt>(split, "", body, span);
+      return std::make_shared<InCoreScopeStmt>(split, name_hint, body, span);
     }
     return maybe_recurse_into_compound(body);
   }
@@ -272,7 +273,7 @@ static StmtPtr WrapNonIncoreStatementsInInCore(const StmtPtr& body, const Span& 
   auto flush = [&]() {
     if (pending.empty()) return;
     StmtPtr content = SeqStmts::Flatten(std::vector<StmtPtr>(pending), span);
-    result.push_back(std::make_shared<InCoreScopeStmt>(split, "", content, span));
+    result.push_back(std::make_shared<InCoreScopeStmt>(split, name_hint, content, span));
     pending.clear();
   };
 
@@ -319,14 +320,17 @@ class InterchangeChunkLoopsMutator : public IRMutator {
   StmtPtr VisitStmt_(const AutoInCoreScopeStmtPtr& op) override {
     bool prev = inside_auto_incore_;
     auto prev_split = current_split_;
+    auto prev_name_hint = current_name_hint_;
     inside_auto_incore_ = true;
     current_split_ = op->split_;
+    current_name_hint_ = op->name_hint_;
     auto new_body = VisitStmt(op->body_);
     inside_auto_incore_ = prev;
     current_split_ = prev_split;
     // Consume the AutoInCore wrapper — return body directly.
-    // Wrap any statements that lack InCore coverage, propagating split.
-    new_body = WrapNonIncoreStatementsInInCore(new_body, op->span_, op->split_);
+    // Wrap any statements that lack InCore coverage, propagating split and name_hint.
+    new_body = WrapNonIncoreStatementsInInCore(new_body, op->span_, op->split_, op->name_hint_);
+    current_name_hint_ = prev_name_hint;
     return new_body;
   }
 
@@ -378,6 +382,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
   bool inside_auto_incore_ = false;
   bool inside_incore_context_ = false;
   std::optional<SplitMode> current_split_;
+  std::string current_name_hint_;
   std::unordered_map<const Var*, ExprPtr> substitution_map_;
 
   /**
@@ -531,7 +536,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     auto new_body = VisitStmt(op->body_);
 
     // Wrap standalone parallel ChunkRemainder sub-loops in InCore
-    new_body = WrapSubRemainderLoopsInInCore(new_body, op->span_, current_split_);
+    new_body = WrapSubRemainderLoopsInInCore(new_body, op->span_, current_split_, current_name_hint_);
 
     if (new_body.get() == op->body_.get() && !iter_args_changed) {
       return op;
@@ -550,7 +555,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
    * Parallel and whose body doesn't already contain InCore.
    */
   static StmtPtr WrapSubRemainderLoopsInInCore(const StmtPtr& body, const Span& span,
-                                               std::optional<SplitMode> split = std::nullopt) {
+                                               std::optional<SplitMode> split = std::nullopt,
+                                               const std::string& name_hint = "") {
     auto should_wrap = [](const StmtPtr& s) -> bool {
       auto fs = std::dynamic_pointer_cast<const ForStmt>(s);
       return fs && fs->GetAttr<LoopOrigin>("loop_origin") == LoopOrigin::ChunkRemainder &&
@@ -563,7 +569,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       bool changed = false;
       for (const auto& s : seq->stmts_) {
         if (should_wrap(s)) {
-          new_stmts.push_back(std::make_shared<InCoreScopeStmt>(split, "", s, span));
+          new_stmts.push_back(std::make_shared<InCoreScopeStmt>(split, name_hint, s, span));
           changed = true;
         } else {
           new_stmts.push_back(s);
@@ -575,7 +581,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
 
     // Single statement
     if (should_wrap(body)) {
-      return std::make_shared<InCoreScopeStmt>(split, "", body, span);
+      return std::make_shared<InCoreScopeStmt>(split, name_hint, body, span);
     }
     return body;
   }
@@ -624,7 +630,7 @@ class InterchangeChunkLoopsMutator : public IRMutator {
 
     // Wrap in InCore — skip if a parent chain already provides InCore context
     if (!prev_incore) {
-      current = std::make_shared<InCoreScopeStmt>(current_split_, "", current, span);
+      current = std::make_shared<InCoreScopeStmt>(current_split_, current_name_hint_, current, span);
     }
 
     // Build outers inside-out, preserving the original ForKind.
@@ -776,7 +782,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
             incore_content = SeqStmts::Flatten(std::move(incore_stmts), span);
           }
 
-          auto incore_scope = std::make_shared<InCoreScopeStmt>(current_split_, "", incore_content, span);
+          auto incore_scope =
+              std::make_shared<InCoreScopeStmt>(current_split_, current_name_hint_, incore_content, span);
           auto new_body = SeqStmts::Flatten(std::vector<StmtPtr>{incore_scope, last_stmt}, span);
 
           current = std::make_shared<ForStmt>(
@@ -785,7 +792,8 @@ class InterchangeChunkLoopsMutator : public IRMutator {
               std::nullopt, MakeLoopAttrs(outer_for->attrs_, LoopOrigin::ChunkOuter));
         } else {
           // No yield, wrap entire body
-          auto incore_scope = std::make_shared<InCoreScopeStmt>(current_split_, "", incore_body, span);
+          auto incore_scope =
+              std::make_shared<InCoreScopeStmt>(current_split_, current_name_hint_, incore_body, span);
           current = std::make_shared<ForStmt>(
               outer_for->loop_var_, outer_for->start_, outer_for->stop_, outer_for->step_,
               outer_for->iter_args_, incore_scope, outer_for->return_vars_, outer_for->span_,

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -325,11 +325,11 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     current_split_ = op->split_;
     current_name_hint_ = op->name_hint_;
     auto new_body = VisitStmt(op->body_);
-    inside_auto_incore_ = prev;
-    current_split_ = prev_split;
     // Consume the AutoInCore wrapper — return body directly.
     // Wrap any statements that lack InCore coverage, propagating split and name_hint.
-    new_body = WrapNonIncoreStatementsInInCore(new_body, op->span_, op->split_, op->name_hint_);
+    new_body = WrapNonIncoreStatementsInInCore(new_body, op->span_, current_split_, current_name_hint_);
+    inside_auto_incore_ = prev;
+    current_split_ = prev_split;
     current_name_hint_ = prev_name_hint;
     return new_body;
   }

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -1140,5 +1140,138 @@ class TestEndToEndNoComputeLeaks:
         self._assert_no_compute_leaks(After, min_incore_funcs=1)
 
 
+class TestNameHintPropagation:
+    """Tests that ``name_hint`` on AutoInCore is propagated to generated InCore scopes.
+
+    The pass creates InCoreScopeStmts at several sites (interchange wrapping,
+    sub-remainder wrapping, non-chunk statement wrapping, yield-aware wrapping).
+    All of them must carry the AutoInCore's ``name_hint`` so the downstream
+    outlining pass can name the resulting function.
+    """
+
+    @staticmethod
+    def _collect_incore_scopes(program: ir.Program) -> list[ir.InCoreScopeStmt]:
+        found: list[ir.InCoreScopeStmt] = []
+
+        class Collector(ir.IRVisitor):
+            def visit_in_core_scope_stmt(self, op: ir.InCoreScopeStmt) -> None:
+                found.append(op)
+                super().visit_in_core_scope_stmt(op)
+
+        Collector().visit_program(program)
+        return found
+
+    def _assert_all_incore_have_hint(self, program: ir.Program, hint: str) -> None:
+        scopes = self._collect_incore_scopes(program)
+        assert scopes, "expected at least one InCoreScopeStmt in the program"
+        for scope in scopes:
+            assert scope.name_hint == hint, (
+                f"InCoreScopeStmt has name_hint={scope.name_hint!r}, expected {hint!r}"
+            )
+
+    def test_single_parallel_chunk_propagates_hint(self):
+        """Single parallel chunk: generated InCore carries the AutoInCore name_hint."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    optimization=pl.chunked_loop_optimizer,
+                    name_hint="my_kernel",
+                ):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        self._assert_all_incore_have_hint(After, "my_kernel")
+
+    def test_nested_parallel_chunks_propagate_hint(self):
+        """Two nested parallel chunks (full interchange): all InCores get the hint."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    optimization=pl.chunked_loop_optimizer,
+                    name_hint="nested_hint",
+                ):
+                    for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
+                        for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
+                            x = pl.add(x, y)
+                return x
+
+        After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        self._assert_all_incore_have_hint(After, "nested_hint")
+
+    def test_non_chunk_statement_wrapping_propagates_hint(self):
+        """Standalone tensor op inside AutoInCore: the wrapping InCore gets the hint."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    optimization=pl.chunked_loop_optimizer,
+                    name_hint="wrap_hint",
+                ):
+                    x = pl.add(x, 1.0)
+                return x
+
+        After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        self._assert_all_incore_have_hint(After, "wrap_hint")
+
+    def test_empty_name_hint_default(self):
+        """No name_hint provided: generated InCores have empty name_hint (regression guard)."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        self._assert_all_incore_have_hint(After, "")
+
+    def test_chunk_remainder_wrapping_propagates_hint(self):
+        """Non-divisible nested chunks produce ChunkRemainder sub-loops; the
+        remainder-wrapping path (WrapSubRemainderLoopsInInCore) must also
+        propagate the hint.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    optimization=pl.chunked_loop_optimizer,
+                    name_hint="remainder_hint",
+                ):
+                    for b in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):
+                        for h in pl.parallel(0, 14, 1, chunk=4, chunk_policy="leading_full"):
+                            x = pl.add(x, y)
+                return x
+
+        After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        self._assert_all_incore_have_hint(After, "remainder_hint")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- `InterchangeChunkLoops` previously hardcoded the `name_hint` of every generated `InCoreScopeStmt` to `""`, dropping any hint set on the source `AutoInCoreScopeStmt` (e.g. via `pl.at(..., name_hint=...)`).
- Capture `AutoInCoreScopeStmt::name_hint_` on entry and thread it through all 7 `InCoreScopeStmt` construction sites (interchange wrapping, sub-remainder wrapping, non-chunk statement wrapping, yield-aware wrapping). `WrapNonIncoreStatementsInInCore` and `WrapSubRemainderLoopsInInCore` gain a `name_hint` parameter.
- Add `TestNameHintPropagation` (5 tests) covering single chunk, nested chunks, non-chunk wrapping, `ChunkRemainder` sub-loop wrapping, and the empty-default regression guard.

## Testing
- [x] Targeted suite: 38/38 passed (`tests/ut/ir/transforms/test_interchange_chunk_loops.py`)
- [x] Regression: 1095 passed, 12 skipped (`tests/ut/ir/transforms/`)
- [x] clang-tidy clean
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)