### PR TITLE
feat(ir): add tensor.abs op for element-wise absolute value

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -760,6 +760,20 @@ def neg(input: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.neg", [input], {}, actual_span)
 
 
+def abs(input: Expr, span: Span | None = None) -> Call:
+    """Element-wise absolute value operation.
+
+    Args:
+        input: Input tensor
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for element-wise absolute value
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tensor.abs", [input], {}, actual_span)
+
+
 def recip(input: Expr, span: Span | None = None) -> Call:
     """Element-wise reciprocal (1/x) operation.
 

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -96,7 +96,6 @@ from .op.system_ops import (
 from .op.tensor_ops import assemble, create_tensor, dim, expand_clone, full, scatter_update
 from .op.tile_ops import (
     MemRefType,
-    abs,
     addc,
     addsc,
     and_,
@@ -141,6 +140,7 @@ from .op.tile_ops import (
     mscatter as mscatter,
 )
 from .op.unified_ops import (
+    abs,
     add,
     batch_matmul,
     cast,
@@ -293,6 +293,7 @@ __all__ = [
     "expand_clone",
     "expands",
     "neg",
+    "abs",
     "recip",
     "read",
     "write",
@@ -306,7 +307,6 @@ __all__ = [
     "sqrt",
     "rsqrt",
     "log",
-    "abs",
     "relu",
     "matmul_acc",
     "matmul_bias",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -53,6 +53,7 @@ __all__ = [
     "expand_clone",
     "exp",
     "neg",
+    "abs",
     "recip",
     "sqrt",
     "rsqrt",
@@ -705,6 +706,20 @@ def neg(input: Tensor) -> Tensor:
     """
     input_expr = input.unwrap()
     call_expr = _ir_ops.neg(input_expr)
+    return Tensor(expr=call_expr)
+
+
+def abs(input: Tensor) -> Tensor:
+    """Element-wise absolute value operation.
+
+    Args:
+        input: Input tensor
+
+    Returns:
+        Tensor wrapping the abs operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.abs(input_expr)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -26,6 +26,7 @@ __all__ = [
     "maximum",
     "exp",
     "neg",
+    "abs",
     "recip",
     "sqrt",
     "rsqrt",
@@ -179,6 +180,15 @@ def neg(input: T) -> T:
     if isinstance(input, Tile):
         return _tile.neg(input)
     raise TypeError(f"neg: expected Tensor or Tile, got {type(input).__name__}")
+
+
+def abs(input: T) -> T:
+    """Element-wise absolute value, dispatched by input type."""
+    if isinstance(input, Tensor):
+        return _tensor.abs(input)
+    if isinstance(input, Tile):
+        return _tile.abs(input)
+    raise TypeError(f"abs: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def recip(input: T) -> T:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3895,7 +3895,6 @@ class ASTParser:
         "gemv",
         "gemv_acc",
         "gemv_bias",
-        "abs",
         "create_tile",
         "tpush_to_aiv",
         "tpush_to_aic",

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file unary.cpp
- * @brief Unary tensor operations (neg, recip, exp, sqrt, rsqrt, cast)
+ * @brief Unary tensor operations (neg, recip, exp, sqrt, rsqrt, cast, abs)
  *
  * This file implements unary operations for tensors that operate element-wise.
  */
@@ -41,6 +41,18 @@ TypePtr DeduceTensorNegType(const std::vector<ExprPtr>& args,
                      << args[0]->GetType()->TypeName();
 
   // Negation preserves dtype (valid for both int and float)
+  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
+}
+
+TypePtr DeduceTensorAbsType(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 1) << "tensor.abs requires exactly 1 argument, but got " << args.size();
+
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.abs requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  // Absolute value preserves dtype (valid for both int and float)
   return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
 }
 
@@ -159,6 +171,15 @@ REGISTER_OP("tensor.neg")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorNegType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.abs")
+    .set_op_category("TensorOp")
+    .set_description("Element-wise absolute value operation")
+    .add_argument("input", "Input tensor (TensorType)")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorAbsType(args, kwargs);
     });
 
 REGISTER_OP("tensor.recip")

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -103,6 +103,7 @@ void OpConversionRegistry::RegisterScalarAndUnaryOps() {
   RegisterSimple("tensor.divs", "tile.divs");
 
   RegisterSimple("tensor.neg", "tile.neg");
+  RegisterSimple("tensor.abs", "tile.abs");
   RegisterSimple("tensor.recip", "tile.recip");
   RegisterSimple("tensor.exp", "tile.exp");
   RegisterSimple("tensor.sqrt", "tile.sqrt");

--- a/tests/st/runtime/test_abs.py
+++ b/tests/st/runtime/test_abs.py
@@ -1,0 +1,152 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Element-wise absolute value (abs) System Tests.
+
+Covers both DSL layers exposed by issue #1138 (tensor.abs):
+
+  TileAbsTest    : Tile level, pl.tile.abs(t)        out = abs(a)
+  TensorAbsTest  : Tensor level, pl.abs(x)           out = abs(x)
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+M = 16
+N = 16
+
+
+def _signed_input(shape: list[int]) -> torch.Tensor:
+    """Random tensor centered around zero so abs has work to do."""
+    return torch.randn(shape)
+
+
+# ---------------------------------------------------------------------------
+# Tile level: pl.tile.abs
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class TileAbsProgram:
+    """Tile-level absolute value."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        tile_a: pl.Tile[[M, N], pl.FP32] = pl.load(a, [0, 0], [M, N])
+        tile_c: pl.Tile[[M, N], pl.FP32] = pl.tile.abs(tile_a)
+        out = pl.store(tile_c, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        out = self.kernel(a, out)
+        return out
+
+
+class TileAbsTest(PTOTestCase):
+    """Tile abs: out = abs(a)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "tile_abs"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, N], DataType.FP32, init_value=_signed_input([M, N])),
+            TensorSpec("out", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileAbsProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = torch.abs(tensors["a"])
+
+
+# ---------------------------------------------------------------------------
+# Tensor level: pl.abs (issue #1138)
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class TensorAbsProgram:
+    """Tensor-level absolute value (lowered to tile.abs by ConvertTensorToTileOps)."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        x: pl.Tensor[[M, N], pl.FP16],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP16]],
+    ) -> pl.Tensor[[M, N], pl.FP16]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            y = pl.abs(x)
+            out = pl.assemble(out, y, [0, 0])
+        return out
+
+
+class TensorAbsTest(PTOTestCase):
+    """Tensor abs: out = pl.abs(x). Issue #1138 requested BF16, but pto.tabs only
+    supports f16/f32, so we use FP16 here."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "tensor_abs"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [M, N], DataType.FP16, init_value=_signed_input([M, N]).to(torch.float16)),
+            TensorSpec("out", [M, N], DataType.FP16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorAbsProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = torch.abs(tensors["x"])
+
+
+# ---------------------------------------------------------------------------
+# pytest wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestAbs:
+    """End-to-end abs tests at both Tile and Tensor DSL levels."""
+
+    def test_tile_abs(self, test_runner):
+        """Tile-level pl.tile.abs."""
+        result = test_runner.run(TileAbsTest())
+        assert result.passed, f"Tile abs failed: {result.error}"
+
+    def test_tensor_abs(self, test_runner):
+        """Tensor-level pl.abs (issue #1138)."""
+        result = test_runner.run(TensorAbsTest())
+        assert result.passed, f"Tensor abs failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/test_abs.py
+++ b/tests/st/runtime/test_abs.py
@@ -12,8 +12,10 @@ Element-wise absolute value (abs) System Tests.
 
 Covers both DSL layers exposed by issue #1138 (tensor.abs):
 
-  TileAbsTest    : Tile level, pl.tile.abs(t)        out = abs(a)
-  TensorAbsTest  : Tensor level, pl.abs(x)           out = abs(x)
+  TileAbsTest         : Tile level,   pl.tile.abs(t)      out = abs(a)
+  TensorAbsTestFP16   : Tensor level, pl.abs(x)  FP16     out = abs(x)
+  TensorAbsTestFP32   : Tensor level, pl.abs(x)  FP32     out = abs(x)
+  TensorAbsTestLarge  : Tensor level, pl.abs(x)  FP32 64x128 — exercises chunked_loop split
 """
 
 from typing import Any
@@ -89,8 +91,8 @@ class TileAbsTest(PTOTestCase):
 
 
 @pl.program
-class TensorAbsProgram:
-    """Tensor-level absolute value (lowered to tile.abs by ConvertTensorToTileOps)."""
+class TensorAbsProgramFP16:
+    """Tensor-level absolute value, FP16 (lowered to tile.abs by ConvertTensorToTileOps)."""
 
     @pl.function(type=pl.FunctionType.Opaque)
     def main(
@@ -107,14 +109,14 @@ class TensorAbsProgram:
         return out
 
 
-class TensorAbsTest(PTOTestCase):
-    """Tensor abs: out = pl.abs(x). Issue #1138 requested BF16, but pto.tabs only
+class TensorAbsTestFP16(PTOTestCase):
+    """Tensor abs FP16: out = pl.abs(x). Issue #1138 requested BF16, but pto.tabs only
     supports f16/f32, so we use FP16 here."""
 
     __test__ = False
 
     def get_name(self) -> str:
-        return "tensor_abs"
+        return "tensor_abs_fp16"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -123,7 +125,96 @@ class TensorAbsTest(PTOTestCase):
         ]
 
     def get_program(self) -> Any:
-        return TensorAbsProgram
+        return TensorAbsProgramFP16
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = torch.abs(tensors["x"])
+
+
+@pl.program
+class TensorAbsProgramFP32:
+    """Tensor-level absolute value, FP32."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        x: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            y = pl.abs(x)
+            out = pl.assemble(out, y, [0, 0])
+        return out
+
+
+class TensorAbsTestFP32(PTOTestCase):
+    """Tensor abs FP32: out = pl.abs(x)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "tensor_abs_fp32"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [M, N], DataType.FP32, init_value=_signed_input([M, N])),
+            TensorSpec("out", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorAbsProgramFP32
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = torch.abs(tensors["x"])
+
+
+LARGE_M = 64
+LARGE_N = 128
+
+
+@pl.program
+class TensorAbsProgramLarge:
+    """Tensor-level abs on a larger shape (64x128) to exercise the chunked-loop split path."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        x: pl.Tensor[[LARGE_M, LARGE_N], pl.FP32],
+        out: pl.Out[pl.Tensor[[LARGE_M, LARGE_N], pl.FP32]],
+    ) -> pl.Tensor[[LARGE_M, LARGE_N], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+        ):
+            y = pl.abs(x)
+            out = pl.assemble(out, y, [0, 0])
+        return out
+
+
+class TensorAbsTestLarge(PTOTestCase):
+    """Tensor abs on 64x128 FP32 — validates codegen under chunked-loop splitting."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "tensor_abs_large"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "x",
+                [LARGE_M, LARGE_N],
+                DataType.FP32,
+                init_value=_signed_input([LARGE_M, LARGE_N]),
+            ),
+            TensorSpec("out", [LARGE_M, LARGE_N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorAbsProgramLarge
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         tensors["out"][:] = torch.abs(tensors["x"])
@@ -142,10 +233,20 @@ class TestAbs:
         result = test_runner.run(TileAbsTest())
         assert result.passed, f"Tile abs failed: {result.error}"
 
-    def test_tensor_abs(self, test_runner):
-        """Tensor-level pl.abs (issue #1138)."""
-        result = test_runner.run(TensorAbsTest())
-        assert result.passed, f"Tensor abs failed: {result.error}"
+    def test_tensor_abs_fp16(self, test_runner):
+        """Tensor-level pl.abs, FP16 (issue #1138)."""
+        result = test_runner.run(TensorAbsTestFP16())
+        assert result.passed, f"Tensor abs FP16 failed: {result.error}"
+
+    def test_tensor_abs_fp32(self, test_runner):
+        """Tensor-level pl.abs, FP32."""
+        result = test_runner.run(TensorAbsTestFP32())
+        assert result.passed, f"Tensor abs FP32 failed: {result.error}"
+
+    def test_tensor_abs_large(self, test_runner):
+        """Tensor-level pl.abs on 64x128 — exercises chunked-loop split."""
+        result = test_runner.run(TensorAbsTestLarge())
+        assert result.passed, f"Tensor abs large failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -271,6 +271,42 @@ def test_tensor_neg_int_dtype():
 
 
 # =============================================================================
+# Tensor abs tests
+# =============================================================================
+
+
+def test_tensor_abs():
+    """Test tensor.abs operation."""
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim128], DataType.BF16)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.abs(tensor_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.abs"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.BF16
+    assert len(result_type.shape) == 2
+
+
+def test_tensor_abs_int_dtype():
+    """Test tensor.abs preserves integer dtype."""
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64], DataType.INT32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.abs(tensor_var)
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.INT32
+
+
+# =============================================================================
 # Tensor recip tests
 # =============================================================================
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -237,6 +237,7 @@ _UNARY_1D_OPS = [
     ("neg", tensor_ops.neg, tile_ops.neg),
     ("recip", tensor_ops.recip, tile_ops.recip),
     ("sqrt", tensor_ops.sqrt, tile_ops.sqrt),
+    ("abs", tensor_ops.abs, tile_ops.abs),
 ]
 
 # 2D row/col-expand-style binary ops with a vector side input.


### PR DESCRIPTION
## Summary

- Register `tensor.abs` with dtype-preserving type deduction
- Register `tensor.abs → tile.abs` in the tensor-to-tile conversion
- Add IR and DSL Python wrappers for `tensor.abs`
- Promote `pl.abs` to unified dispatch so it accepts both `Tensor` and `Tile`
- Remove `abs` from parser `_TILE_ONLY_OPS` so dispatch happens by operand type
- Add tensor.abs unit tests and extend the conversion pass parametrized suite
- Add ST coverage at both tile and tensor levels in `tests/st/runtime/test_abs.py`

## Dtype note (FP16/FP32 only)

Issue #1138 requested BF16, but the underlying PTOAS instruction `pto.tabs` only accepts `f16` / `f32`. The constraint is enforced by the PTOAS verifier — not by pypto:

- `PTOAS/lib/PTO/IR/PTO.cpp:1935-1936` (`TAbsOp::verify()`):
  ```cpp
  if (!(elemTy.isF16() || elemTy.isF32()))
    return emitOpError() << "expects element type to be f16 or f32";
  ```
- Op declared with `hasVerifier = 1` at `PTOAS/include/PTO/IR/PTOOps.td:2355` (`def TAbsOp`).

On the pypto side `tile.abs` is simply lowered to `pto.tabs` at `src/backend/common/pto_ops_common.cpp:1384`; type checking is delegated to PTOAS. The tensor-level ST therefore uses FP16 instead of BF16.

## Testing

- [x] `pytest tests/ut/ir/operators/ tests/ut/ir/transforms/ tests/ut/language/` — 2217 passed, 0 failed
- [x] `clang-tidy --diff-base HEAD` clean
- [x] pre-commit (cpplint, clang-format, ruff, pyright, …) clean

## Related Issues

Fixes #1138