### PR TITLE
ci: cache pip/ccache/ptoas and parametrize device ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: ccache -s || true
 
       - name: Test system tests
-        run: pytest tests/st -v --device="$DEVICE_RANGE" -n 3 --precompile-workers=128 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=64 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
 
       - name: Test swimlane output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: ccache -s || true
 
       - name: Test system tests
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=64 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
 
       - name: Test swimlane output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: v0.26
       PTOAS_SHA256: 8e8239f92b169d88fd117f7d4841739c129ecbdd8d3a01f96087df576ecd7814
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_MAXSIZE: 5G
+      PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -95,8 +101,12 @@ jobs:
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
         -v /usr/local/Ascend:/usr/local/Ascend:ro
         -v /dev:/dev
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
         -e DEVICE_ID
+        -e DEVICE_RANGE
     steps:
       - uses: actions/checkout@v4
         with:
@@ -106,43 +116,53 @@ jobs:
         run: |
           npu-smi info
 
+      - name: Show ccache stats (before)
+        run: ccache -s || true
+
       - name: Install project and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -v .[dev]
+          pip install --no-build-isolation .[dev]
 
-      - name: Cache ptoas binary
-        id: cache-ptoas
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
+      - name: Install ptoas (local cache)
+        env:
+          PTOAS_CACHE_DIR: /opt/ptoas-cache
         run: |
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
-             -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+          if [ ! -f "$CACHE_ARCHIVE" ]; then
+            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
+            mkdir -p "$PTOAS_CACHE_DIR"
+            curl --fail --location --retry 3 --retry-all-errors \
+              https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+              -o "$CACHE_ARCHIVE.tmp"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+          else
+            echo "Cache hit — using $CACHE_ARCHIVE"
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
+          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
 
       - name: Add Ascend tools to PATH
         run: echo "/usr/local/Ascend/cann-8.5.0/bin" >> $GITHUB_PATH
 
       - name: Install simpler
-        run: pip install -v ./runtime
+        run: |
+          rm -rf ./runtime/build
+          pip install --no-build-isolation ./runtime
+
+      - name: Show ccache stats (after)
+        run: ccache -s || true
 
       - name: Test system tests
-        run: pytest tests/st -v --device=$DEVICE_ID --forked --precompile-workers=128 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st -v --device="$DEVICE_RANGE" -n 3 --precompile-workers=128 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device=$DEVICE_ID --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
 
   system-tests-a5sim:
     runs-on: ubuntu-latest
@@ -182,7 +202,9 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
       - name: Install simpler
-        run: pip install -v ./runtime
+        run: |
+          rm -rf ./runtime/build
+          pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
         run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
@@ -209,7 +231,9 @@ jobs:
           pip install -v .[dev]
 
       - name: Install simpler
-        run: pip install -v ./runtime
+        run: |
+          rm -rf ./runtime/build
+          pip install -v ./runtime
 
       - name: Run fuzz tests (sim mode)
         id: run_fuzz

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -15,11 +15,13 @@ harness package (migrated from pto-testing-framework).
 """
 
 import inspect
+import os
 import random
 import re
 import shutil
 import sys
 import tempfile
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -55,6 +57,10 @@ from pypto.runtime.runner import RunConfig  # noqa: E402
 # Cleaned up in pytest_sessionfinish.
 _temp_precompile_dirs: list[Path] = []
 
+# Per-device test counter populated by ``_report_device`` and dumped at
+# session end via ``pytest_terminal_summary``.
+_device_counter: Counter[int] = Counter()
+
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_simpler_dependency(request):
@@ -87,9 +93,15 @@ def pytest_addoption(parser):
     parser.addoption(
         "--device",
         action="store",
-        default=0,
-        type=int,
-        help="Device ID for hardware tests (default: 0)",
+        default="0",
+        type=str,
+        help=(
+            "Device id(s) for hardware tests. Accepts a single id ('0'), an "
+            "inclusive range ('0-7'), or a comma-separated list ('0,1,12'). "
+            "Ranges and lists may be mixed ('0-3,8,12-15'). When pytest-xdist "
+            "is active, each worker picks one device round-robin; otherwise "
+            "the first id is used (default: 0)."
+        ),
     )
     parser.addoption(
         "--strategy",
@@ -164,6 +176,54 @@ def pytest_addoption(parser):
     )
 
 
+def _parse_device_option(raw: str | int) -> list[int]:
+    """Parse the ``--device`` option into a list of device ids.
+
+    Accepts a single integer (``"0"`` or ``0``), an inclusive range
+    (``"0-7"``), a comma-separated list (``"0,1,12"``), or any combination
+    (``"0-3,8,12-15"``). Device ids may be non-contiguous.
+    """
+    text = str(raw).strip()
+    if not text:
+        raise pytest.UsageError("--device must not be empty")
+
+    devices: list[int] = []
+    for token in text.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start_str, end_str = token.split("-", 1)
+            start, end = int(start_str), int(end_str)
+            if end < start:
+                raise pytest.UsageError(
+                    f"--device range must be non-decreasing, got {token!r}"
+                )
+            devices.extend(range(start, end + 1))
+        else:
+            devices.append(int(token))
+
+    if not devices:
+        raise pytest.UsageError(f"--device yielded no device ids: {raw!r}")
+    # Preserve order while deduplicating (user ordering dictates worker mapping).
+    return list(dict.fromkeys(devices))
+
+
+def _resolve_device_id(raw: str | int) -> int:
+    """Pick a single device id from the ``--device`` option.
+
+    When pytest-xdist is active (``PYTEST_XDIST_WORKER=gwN``), each worker
+    takes a slot round-robin from the available range so concurrent workers
+    target distinct cards. Otherwise the first id in the range is used.
+    """
+    devices = _parse_device_option(raw)
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "")
+    match = re.fullmatch(r"gw(\d+)", worker)
+    if match and len(devices) > 1:
+        return devices[int(match.group(1)) % len(devices)]
+    return devices[0]
+
+
 def _parse_platform_filter(raw: str) -> tuple[str, ...]:
     """Parse the comma-separated ``--platform`` value into an ordered tuple.
 
@@ -186,6 +246,37 @@ def _parse_platform_filter(raw: str) -> tuple[str, ...]:
             f"--platform must include at least one of: {', '.join(ALL_PLATFORM_IDS)}; got {raw!r}"
         )
     return valid
+
+
+@pytest.fixture(autouse=True)
+def _report_device(request) -> None:
+    """Print the resolved device id at the start of every hardware test.
+
+    Helps diagnose multi-card CI scheduling when ``--device`` is a range or
+    list. The line is prefixed so it stands out in pytest's per-test output:
+
+        [DEVICE] tests/st/runtime/test_x.py::test_y -> device 12 (worker=gw3)
+
+    Aggregate per-device counts are emitted at session end via
+    ``pytest_terminal_summary``.
+    """
+    device_id = _resolve_device_id(request.config.getoption("--device"))
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    sys.stdout.write(
+        f"\n[DEVICE] {request.node.nodeid} -> device {device_id} (worker={worker})\n"
+    )
+    sys.stdout.flush()
+    _device_counter[device_id] += 1
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:  # noqa: ARG001
+    """Emit a per-device test count summary at the end of the session."""
+    if not _device_counter:
+        return
+    total = sum(_device_counter.values())
+    terminalreporter.write_sep("=", f"per-device test count ({total} total)")
+    for dev in sorted(_device_counter):
+        terminalreporter.write_line(f"  device {dev:>3}: {_device_counter[dev]} tests")
 
 
 @pytest.fixture(scope="session")
@@ -213,7 +304,7 @@ def test_config(request) -> RunConfig:
 
     return RunConfig(
         platform=fallback_platform,
-        device_id=request.config.getoption("--device"),
+        device_id=_resolve_device_id(request.config.getoption("--device")),
         save_kernels=save_kernels,
         save_kernels_dir=save_kernels_dir,
         dump_passes=request.config.getoption("--dump-passes"),

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -190,16 +190,17 @@ def _parse_device_option(raw: str | int) -> list[int]:
         token = token.strip()
         if not token:
             continue
-        if "-" in token:
-            start_str, end_str = token.split("-", 1)
-            start, end = int(start_str), int(end_str)
-            if end < start:
-                raise pytest.UsageError(
-                    f"--device range must be non-decreasing, got {token!r}"
-                )
-            devices.extend(range(start, end + 1))
-        else:
-            devices.append(int(token))
+        try:
+            if "-" in token:
+                start_str, end_str = token.split("-", 1)
+                start, end = int(start_str), int(end_str)
+                if end < start:
+                    raise pytest.UsageError(f"--device range must be non-decreasing, got {token!r}")
+                devices.extend(range(start, end + 1))
+            else:
+                devices.append(int(token))
+        except ValueError:
+            raise pytest.UsageError(f"Invalid device ID or range in --device: {token!r}") from None
 
     if not devices:
         raise pytest.UsageError(f"--device yielded no device ids: {raw!r}")
@@ -260,9 +261,7 @@ def _report_device(request) -> None:
     _last_device["value"] = None
     if device_id is None:
         return
-    sys.stdout.write(
-        f"\n[DEVICE] {request.node.nodeid} -> device {device_id}\n"
-    )
+    sys.stdout.write(f"\n[DEVICE] {request.node.nodeid} -> device {device_id}\n")
     sys.stdout.flush()
     _device_counter[device_id] += 1
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -15,7 +15,7 @@ harness package (migrated from pto-testing-framework).
 """
 
 import inspect
-import os
+import queue
 import random
 import re
 import shutil
@@ -45,10 +45,8 @@ from harness.core.harness import ALL_PLATFORM_IDS, PTOTestCase  # noqa: E402
 from harness.core.test_runner import (  # noqa: E402
     TestRunner,
     _cache_key,
-    _precompile_cache,
-    _resolve_platform,
-    prebuild_binaries,
-    precompile_test_cases,
+    shutdown_pipeline,
+    start_pipeline,
 )
 from pypto import LogLevel, set_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
@@ -210,18 +208,15 @@ def _parse_device_option(raw: str | int) -> list[int]:
 
 
 def _resolve_device_id(raw: str | int) -> int:
-    """Pick a single device id from the ``--device`` option.
+    """Return a representative device id for the session RunConfig.
 
-    When pytest-xdist is active (``PYTEST_XDIST_WORKER=gwN``), each worker
-    takes a slot round-robin from the available range so concurrent workers
-    target distinct cards. Otherwise the first id in the range is used.
+    With xdist removed, per-test device selection happens inside the pipeline
+    execute task (see ``_fused_execute_task`` in ``harness.core.test_runner``).
+    This value is consulted only by the legacy inline-compile fallback in
+    :meth:`TestRunner._run_inline` when a test case was not discovered at
+    collection time.
     """
-    devices = _parse_device_option(raw)
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "")
-    match = re.fullmatch(r"gw(\d+)", worker)
-    if match and len(devices) > 1:
-        return devices[int(match.group(1)) % len(devices)]
-    return devices[0]
+    return _parse_device_option(raw)[0]
 
 
 def _parse_platform_filter(raw: str) -> tuple[str, ...]:
@@ -250,20 +245,23 @@ def _parse_platform_filter(raw: str) -> tuple[str, ...]:
 
 @pytest.fixture(autouse=True)
 def _report_device(request) -> None:
-    """Print the resolved device id at the start of every hardware test.
+    """Report which device executed each test at the end of the test body.
 
-    Helps diagnose multi-card CI scheduling when ``--device`` is a range or
-    list. The line is prefixed so it stands out in pytest's per-test output:
-
-        [DEVICE] tests/st/runtime/test_x.py::test_y -> device 12 (worker=gw3)
-
-    Aggregate per-device counts are emitted at session end via
-    ``pytest_terminal_summary``.
+    ``TestRunner.run`` writes the resolved device id into a single-slot
+    stash (``_last_device``) right before returning to the test body.  We
+    read it after ``yield`` so the line shows the device the test actually
+    ran on.  Tests that don't go through ``TestRunner.run`` see ``None``
+    and are skipped from the per-device counter.
     """
-    device_id = _resolve_device_id(request.config.getoption("--device"))
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    yield
+    from harness.core.test_runner import _last_device  # noqa: PLC0415
+
+    device_id = _last_device["value"]
+    _last_device["value"] = None
+    if device_id is None:
+        return
     sys.stdout.write(
-        f"\n[DEVICE] {request.node.nodeid} -> device {device_id} (worker={worker})\n"
+        f"\n[DEVICE] {request.node.nodeid} -> device {device_id}\n"
     )
     sys.stdout.flush()
     _device_counter[device_id] += 1
@@ -501,13 +499,16 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     if not seen:
         return
 
-    dump_passes: bool = session.config.getoption("--dump-passes")
     max_workers: int | None = session.config.getoption("--precompile-workers")
-
-    # Without --precompile-workers the pre-compilation/cache phases are skipped
-    # entirely; each test compiles on demand inside TestRunner.run().
+    # Without --precompile-workers the pipeline is skipped entirely; each
+    # test compiles + executes inline inside TestRunner._run_inline().
     if max_workers is None:
         return
+
+    dump_passes: bool = session.config.getoption("--dump-passes")
+    codegen_only: bool = session.config.getoption("--codegen-only")
+    pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
+    runtime_profiling: bool = session.config.getoption("--runtime-profiling")
 
     # ── determine cache directory ─────────────────────────────────────────────
     save_kernels: bool = session.config.getoption("--save-kernels")
@@ -523,50 +524,38 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_"))
         _temp_precompile_dirs.append(cache_dir)
 
-    # ── compile in parallel ───────────────────────────────────────────────────
-    test_cases = list(seen.values())
-    workers_str = str(max_workers) if max_workers is not None else "auto"
     # ``--platform`` is a CSV allowlist; the per-test value resolved by
-    # ``tc.get_platform()`` overrides this fallback inside ``TestRunner``,
-    # so any one entry from the filter is sufficient here. We compute it
-    # *before* precompilation so the cache key reflects the resolved
-    # platform for legacy (non-parametrized) test cases.
+    # ``tc.get_platform()`` overrides this fallback inside the pipeline.
     platform_filter = _parse_platform_filter(session.config.getoption("--platform"))
-    platform: str = platform_filter[0] if platform_filter else "a2a3"
-    print(f"\n[PyPTO] Pre-compiling {len(test_cases)} test case(s) in parallel (workers={workers_str})…")
-    precompile_test_cases(
-        test_cases,
-        cache_dir,
-        platform=platform,
-        dump_passes=dump_passes,
-        max_workers=max_workers,
+    session_platform: str = platform_filter[0] if platform_filter else "a2a3"
+
+    # Build the device pool from --device.  N parallel executes max.
+    devices = _parse_device_option(session.config.getoption("--device"))
+    device_pool: queue.Queue[int] = queue.Queue()
+    for d in devices:
+        device_pool.put(d)
+
+    test_cases = list(seen.values())
+    print(
+        f"\n[PyPTO] Pipeline: {len(test_cases)} test case(s); "
+        f"compile_workers={max_workers}, devices={devices}"
     )
-
-    n_ok = sum(1 for _, err in _precompile_cache.values() if err is None)
-    n_fail = len(_precompile_cache) - n_ok
-    print(f"[PyPTO] Pre-compilation done — {n_ok} ok, {n_fail} failed\n")
-
-    # ── Phase 2: pre-build binary artifacts ──────────────────────────────
-    # Compile incore kernels and orchestration .so in parallel.
-    # Results are saved to work_dir/cache/.
-    if n_ok > 0 and not session.config.getoption("--codegen-only"):
-        ok_cases = []
-        for tc in test_cases:
-            key = _cache_key(tc, _resolve_platform(platform, tc))
-            if key in _precompile_cache and _precompile_cache[key][1] is None:
-                ok_cases.append(tc)
-        pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
-        print(
-            f"[PyPTO] Pre-building binary artifacts for {len(ok_cases)} test case(s)"
-            f" in parallel (workers={workers_str})…"
-        )
-        n_built = prebuild_binaries(
-            ok_cases, cache_dir, platform, max_workers=max_workers, pto_isa_commit=pto_isa_commit
-        )
-        print(f"[PyPTO] Binary pre-build done — {n_built} case(s) compiled\n")
+    start_pipeline(
+        test_cases=test_cases,
+        cache_dir=cache_dir,
+        session_platform=session_platform,
+        dump_passes=dump_passes,
+        codegen_only=codegen_only,
+        pto_isa_commit=pto_isa_commit,
+        compile_workers=max_workers,
+        device_pool=device_pool,
+        runtime_profiling=runtime_profiling,
+    )
+    print("[PyPTO] Pipeline scheduled — pytest item loop starting\n")
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
-    """Clean up temporary pre-compilation directories created during the session."""
+    """Tear down the pipeline and clean up temporary precompile directories."""
+    shutdown_pipeline()
     for d in _temp_precompile_dirs:
         shutil.rmtree(d, ignore_errors=True)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -292,9 +292,7 @@ def _fused_compile_task(
         _compile_for_cache(tc, work_dir, dump_passes)
         from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-        chip_callable, runtime_name = compile_and_assemble(
-            work_dir, resolved, pto_isa_commit=pto_isa_commit
-        )
+        chip_callable, runtime_name = compile_and_assemble(work_dir, resolved, pto_isa_commit=pto_isa_commit)
         return CompileArtifact(
             work_dir=work_dir,
             resolved_platform=resolved,
@@ -414,7 +412,7 @@ def start_pipeline(
     ``set_backend_type`` single-shot invariant without stalling pytest's
     progress reporting during collection.
     """
-    global _device_pool, _execute_pool, _pipeline_ctx
+    global _device_pool, _execute_pool, _pipeline_ctx  # noqa: PLW0603
 
     # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
     # start.  Otherwise concurrent workers race on `git clone` into the same
@@ -437,9 +435,7 @@ def start_pipeline(
         "runtime_profiling": runtime_profiling,
     }
     n_devices = device_pool.qsize()
-    _execute_pool = ThreadPoolExecutor(
-        max_workers=max(1, n_devices), thread_name_prefix="pypto-exec"
-    )
+    _execute_pool = ThreadPoolExecutor(max_workers=max(1, n_devices), thread_name_prefix="pypto-exec")
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
@@ -449,9 +445,7 @@ def start_pipeline(
     for i, (backend_type, group) in enumerate(group_items):
         is_last = i == len(group_items) - 1
         set_backend_type(backend_type)
-        compile_pool = ThreadPoolExecutor(
-            max_workers=compile_workers, thread_name_prefix="pypto-compile"
-        )
+        compile_pool = ThreadPoolExecutor(max_workers=compile_workers, thread_name_prefix="pypto-compile")
         _compile_pools.append(compile_pool)
         group_futs: list[Future] = []
         for tc in group:
@@ -486,7 +480,7 @@ def start_pipeline(
 
 def shutdown_pipeline() -> None:
     """Tear down compile/execute pools; called from ``pytest_sessionfinish``."""
-    global _execute_pool, _compile_pools
+    global _execute_pool, _compile_pools  # noqa: PLW0603
     for pool in _compile_pools:
         pool.shutdown(wait=False, cancel_futures=True)
     _compile_pools = []

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -18,16 +18,18 @@ Orchestrates the full test execution pipeline:
 5. Validate results
 """
 
-import concurrent.futures
-import importlib.util
 import logging
+import queue
 import shutil
 import tempfile
 import threading
 import time
 import traceback
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
@@ -39,7 +41,6 @@ from pypto.runtime.golden_writer import (
     _save_data_files,
     generate_golden_source,
 )
-from pypto.runtime.kernel_compiler import KernelCompiler
 from pypto.runtime.runner import (
     RunConfig,
     RunResult,
@@ -55,18 +56,36 @@ _PROJECT_ROOT = _ST_DIR.parent.parent
 _log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Pre-compilation cache (Phase 1 / Phase 2 split)
+# Pipeline state (compile pool → device pool)
 # ---------------------------------------------------------------------------
+#
+# Replaces the old "compile-everything then run-everything" two-phase model.
+# A compile pool of ``--precompile-workers`` threads fuses IR compile + golden
+# generation + .so build into one task per test case.  As each compile future
+# completes, an execute pool (sized to the number of devices in --device)
+# picks the case up and dispatches it onto the next free device from the
+# DevicePool.  Pytest's per-item loop then calls ``TestRunner.run`` which
+# blocks on the matching execute future and returns the cached RunResult.
 
-# Maps cache_key → (work_dir, error_str | None).
-# The cache key combines test name and target platform (e.g.
-# "matmul_64x64x64@a2a3sim") so the same PTOTestCase can be compiled for
-# multiple platforms (a2a3 vs a5, sim vs onboard) without cache-key collisions.
-# Populated by precompile_test_cases() in the parent process during
-# pytest_collection_finish, before any test forks.  Forked children inherit
-# the populated dict via os.fork() copy-on-write and find their pre-compiled
-# artefacts on the filesystem under work_dir.
-_precompile_cache: dict[str, tuple[Path, str | None]] = {}
+# cache_key → Future[RunResult] populated in start_pipeline().
+_run_futures: dict[str, Future] = {}
+
+# cache_key → device id actually used by the execute task.  Read by
+# TestRunner.run after fut.result() and forwarded to the _report_device
+# fixture via _last_device.
+_executed_device: dict[str, int] = {}
+
+# Single-slot stash of the device id the most-recently-resolved test ran on.
+# pytest's item loop is single-threaded, so one slot is enough: TestRunner.run
+# writes, _report_device fixture reads.
+_last_device: dict[str, int | None] = {"value": None}
+
+# Session-scoped pipeline resources, set up by start_pipeline() and torn down
+# by shutdown_pipeline() from pytest_sessionfinish.
+_device_pool: "queue.Queue[int] | None" = None
+_execute_pool: ThreadPoolExecutor | None = None
+_compile_pools: list[ThreadPoolExecutor] = []
+_pipeline_ctx: dict = {}
 
 # set_backend_type is called once per backend-type group before the thread pool
 # starts.  Only get_program() needs serialisation because the @pl.program
@@ -232,185 +251,264 @@ def _compile_for_cache(test_case: "PTOTestCase", work_dir: Path, dump_passes: bo
     _write_golden_for_test_case(test_case, work_dir / "golden.py")
 
 
-def precompile_test_cases(
+@dataclass
+class CompileArtifact:
+    """Outcome of a fused compile task (IR → C++ → golden.py → .so).
+
+    Stored as the result of a compile-pool future and consumed by the matching
+    execute-pool task via ``_fused_execute_task``.
+    """
+
+    work_dir: Path
+    resolved_platform: str
+    error: str | None = None
+    runtime_name: str | None = None
+    chip_callable: Any | None = None
+
+
+def _fused_compile_task(
+    tc: "PTOTestCase",
+    cache_dir: Path,
+    session_platform: str,
+    dump_passes: bool,
+    pto_isa_commit: str | None,
+) -> CompileArtifact:
+    """Compile IR → kernels/orch C++ → golden.py → .so for one test case.
+
+    Runs on a compile-pool worker thread.  ``get_program`` is serialised via
+    ``_get_program_lock`` inside ``_compile_for_cache``; everything else runs
+    concurrently with other compile-pool workers.  The backend type must
+    already be set on the main thread before this task is submitted.
+    """
+    resolved = _resolve_platform(session_platform, tc)
+    work_dir = cache_dir / _cache_key(tc, resolved)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        _compile_for_cache(tc, work_dir, dump_passes)
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+        chip_callable, runtime_name = compile_and_assemble(
+            work_dir, resolved, pto_isa_commit=pto_isa_commit
+        )
+        return CompileArtifact(
+            work_dir=work_dir,
+            resolved_platform=resolved,
+            error=None,
+            runtime_name=runtime_name,
+            chip_callable=chip_callable,
+        )
+    except Exception as exc:
+        return CompileArtifact(
+            work_dir=work_dir,
+            resolved_platform=resolved,
+            error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+        )
+
+
+def _fused_execute_task(
+    tc: "PTOTestCase",
+    cache_key: str,
+    artifact: "CompileArtifact",
+) -> RunResult:
+    """Acquire a device slot, execute on device.
+
+    Runs on an execute-pool worker thread.  Called only after the matching
+    compile task has completed (via ``add_done_callback`` in
+    :func:`_schedule_execute`), so this task never blocks on compilation —
+    exec workers are free to grab the next device slot immediately.
+    """
+    start = time.time()
+    name = tc.get_name()
+    if artifact.error is not None:
+        return RunResult(
+            passed=False,
+            test_name=name,
+            error=f"Pre-compilation failed: {artifact.error}",
+            execution_time=time.time() - start,
+        )
+    if _pipeline_ctx.get("codegen_only"):
+        return RunResult(
+            passed=True,
+            test_name=name,
+            execution_time=time.time() - start,
+        )
+
+    assert _device_pool is not None, "device pool not initialised"
+    device_id = _device_pool.get()
+    try:
+        _executed_device[cache_key] = device_id
+        _execute_on_device(
+            artifact.work_dir,
+            artifact.work_dir / "golden.py",
+            artifact.chip_callable,
+            artifact.runtime_name,
+            artifact.resolved_platform,
+            device_id,
+            runtime_profiling=_pipeline_ctx.get("runtime_profiling", False),
+        )
+        return RunResult(
+            passed=True,
+            test_name=name,
+            execution_time=time.time() - start,
+        )
+    except Exception as exc:
+        return RunResult(
+            passed=False,
+            test_name=name,
+            error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+            execution_time=time.time() - start,
+        )
+    finally:
+        _device_pool.put(device_id)
+
+
+def _schedule_execute(
+    tc: "PTOTestCase",
+    cache_key: str,
+    compile_fut: "Future",
+    result_fut: "Future",
+) -> None:
+    """Chain a compile future to an execute-pool submission.
+
+    When ``compile_fut`` completes, submit an execute task and forward its
+    result to ``result_fut``.  This avoids tying up execute-pool workers
+    waiting on slow compiles — workers only receive work that is ready to
+    run, so the device pool stays evenly loaded even when compile latency
+    varies between cases.
+    """
+    name = tc.get_name()
+
+    def _on_compile_done(cf: "Future") -> None:
+        try:
+            artifact = cf.result()
+        except Exception as exc:
+            result_fut.set_result(
+                RunResult(
+                    passed=False,
+                    test_name=name,
+                    error=f"compile task crashed: {exc}\n{traceback.format_exc()}",
+                    execution_time=0.0,
+                )
+            )
+            return
+        assert _execute_pool is not None, "execute pool not initialised"
+        exec_fut = _execute_pool.submit(_fused_execute_task, tc, cache_key, artifact)
+
+        def _on_exec_done(ef: "Future") -> None:
+            try:
+                result_fut.set_result(ef.result())
+            except Exception as exc:
+                result_fut.set_result(
+                    RunResult(
+                        passed=False,
+                        test_name=name,
+                        error=f"execute task crashed: {exc}\n{traceback.format_exc()}",
+                        execution_time=0.0,
+                    )
+                )
+
+        exec_fut.add_done_callback(_on_exec_done)
+
+    compile_fut.add_done_callback(_on_compile_done)
+
+
+def start_pipeline(
+    *,
     test_cases: "list[PTOTestCase]",
     cache_dir: Path,
-    *,
-    platform: str | None = None,
-    dump_passes: bool = False,
-    max_workers: int | None = None,
+    session_platform: str,
+    dump_passes: bool,
+    codegen_only: bool,
+    pto_isa_commit: str | None,
+    compile_workers: int,
+    device_pool: "queue.Queue[int]",
+    runtime_profiling: bool = False,
 ) -> None:
-    """Compile all *test_cases* in parallel and populate :data:`_precompile_cache`.
+    """Spin up the compile→execute pipeline and populate :data:`_run_futures`.
 
-    This is **Phase 1** of the two-phase execution model.  Call this once in
-    the parent process (e.g. from a ``pytest_collection_finish`` hook) before
-    any test forks.  Forked child processes inherit the populated cache and the
-    pre-compiled artefacts on the filesystem.
+    Called from ``pytest_collection_finish``.  Test cases are grouped by
+    backend type (``set_backend_type`` is a global one-time setter); within
+    each group a compile pool of ``compile_workers`` threads feeds the shared
+    session-wide execute pool sized to the number of devices in ``device_pool``.
 
-    Because ``set_backend_type`` is a one-time global setter (calling it again
-    with a *different* value raises ``ValueError``), test cases are grouped by
-    backend type.  Each group is compiled sequentially with the backend set once;
-    ``get_program()`` is serialised within the group (via ``_get_program_lock``)
-    while ``compile_program()`` runs in parallel.  The backend is reset between
-    groups via ``reset_for_testing()``.
-
-    Args:
-        test_cases: Instances to compile (should be deduplicated by
-            ``_cache_key`` before calling).
-        cache_dir: Root output directory; each test case is compiled into
-            ``cache_dir / <cache_key>``.
-        platform: Session platform string used to resolve the cache key for
-            legacy (non-parametrized) test cases. ``None`` keeps the
-            backend-derived fallback.
-        dump_passes: If ``True``, dump intermediate IR after each pass.
-        max_workers: Thread-pool size per backend group.  Defaults to
-            ``os.cpu_count()``.
+    Only the *non-final* groups block on a barrier before the next
+    ``set_backend_type`` call; the last group returns immediately so pytest's
+    per-item loop can start consuming execute futures while compile+execute
+    are still running in the background.  This preserves the
+    ``set_backend_type`` single-shot invariant without stalling pytest's
+    progress reporting during collection.
     """
-    # Group by backend type so set_backend_type is called once per group.
+    global _device_pool, _execute_pool, _pipeline_ctx
+
+    _device_pool = device_pool
+    _pipeline_ctx = {
+        "cache_dir": cache_dir,
+        "session_platform": session_platform,
+        "dump_passes": dump_passes,
+        "codegen_only": codegen_only,
+        "pto_isa_commit": pto_isa_commit,
+        "runtime_profiling": runtime_profiling,
+    }
+    n_devices = device_pool.qsize()
+    _execute_pool = ThreadPoolExecutor(
+        max_workers=max(1, n_devices), thread_name_prefix="pypto-exec"
+    )
+
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
         groups.setdefault(tc.get_backend_type(), []).append(tc)
 
-    def _compile_one(tc: "PTOTestCase") -> tuple[str, Path, str | None]:
-        key = _cache_key(tc, _resolve_platform(platform, tc) if platform else None)
-        work_dir = cache_dir / key
-        work_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            _compile_for_cache(tc, work_dir, dump_passes)
-            return key, work_dir, None
-        except Exception as exc:
-            return key, work_dir, f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
-
-    for backend_type, group in groups.items():
-        # Set the backend type once for the whole group (idempotent if already
-        # set to the same value; reset_for_testing() between groups handles reuse).
+    group_items = list(groups.items())
+    for i, (backend_type, group) in enumerate(group_items):
+        is_last = i == len(group_items) - 1
         set_backend_type(backend_type)
-        try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-                futures = {pool.submit(_compile_one, tc): tc for tc in group}
-                for fut in concurrent.futures.as_completed(futures):
-                    key, work_dir, error = fut.result()
-                    _precompile_cache[key] = (work_dir, error)
-        finally:
-            # Reset so the next group can set a different backend type.
-            reset_for_testing()
-
-
-def prebuild_binaries(
-    test_cases: "list[PTOTestCase]",
-    cache_dir: Path,
-    platform: str,
-    *,
-    max_workers: int | None = None,
-    pto_isa_commit: str | None = None,
-) -> int:
-    """Phase 2: pre-compile binary artifacts for all test cases in parallel.
-
-    Must be called AFTER :func:`precompile_test_cases` so kernel/orchestration
-    C++ sources exist under ``work_dir``. Uses PyPTO's local KernelCompiler
-    to compile incore kernels and orchestration ``.so`` files, with binary
-    caching integrated into :mod:`pypto.runtime.device_runner`.
-
-    Args:
-        test_cases: Test case instances (deduplicated by cache key).
-        cache_dir: Root output directory used during precompilation.
-        platform: Session platform string (e.g. ``"a2a3"``).
-        max_workers: Thread-pool size. Defaults to ``min(32, cpu_count + 4)``.
-        pto_isa_commit: If set, pin the pto-isa clone to this specific git
-            commit (hash or tag).  ``None`` means use latest remote HEAD.
-
-    Returns:
-        Number of test cases whose kernels and orchestration were successfully
-        pre-built.
-    """
-    from pypto.runtime.device_runner import (  # noqa: PLC0415
-        compile_single_kernel,
-        compile_single_orchestration,
-        ensure_pto_isa_root,
-    )
-
-    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
-    if pto_isa_root is None:
-        return 0
-
-    def _load_kc(work_dir: Path):
-        config_path = work_dir / "kernel_config.py"
-        if not config_path.exists():
-            return None
-        spec = importlib.util.spec_from_file_location(f"_prebin_{work_dir.name}", str(config_path))
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-
-    # ── Collect configs for all valid test cases ──────────────────────────────
-    case_configs: list[tuple] = []
-    for tc in test_cases:
-        tc_platform = _resolve_platform(platform, tc)
-        key = _cache_key(tc, tc_platform)
-        if key not in _precompile_cache or _precompile_cache[key][1] is not None:
+        compile_pool = ThreadPoolExecutor(
+            max_workers=compile_workers, thread_name_prefix="pypto-compile"
+        )
+        _compile_pools.append(compile_pool)
+        group_futs: list[Future] = []
+        for tc in group:
+            key = _cache_key(tc, _resolve_platform(session_platform, tc))
+            cfut = compile_pool.submit(
+                _fused_compile_task,
+                tc,
+                cache_dir,
+                session_platform,
+                dump_passes,
+                pto_isa_commit,
+            )
+            # result_fut is what TestRunner.run() waits on.  It's completed by
+            # the exec-done callback inside _schedule_execute, which submits
+            # the execute task only after compile finishes — so exec-pool
+            # workers never block on compilation and the device pool is
+            # evenly drained across devices.
+            result_fut: Future = Future()
+            _schedule_execute(tc, key, cfut, result_fut)
+            _run_futures[key] = result_fut
+            group_futs.append(result_fut)
+        if is_last:
+            # Don't block: let pytest's per-item loop start running while
+            # compiles/executes continue in the background.  The compile
+            # pool stays alive; shutdown_pipeline() tears it down at
+            # session end.
             continue
-        work_dir = _precompile_cache[key][0]
-        mod = _load_kc(work_dir)
-        if mod is None:
-            continue
-        runtime_name = getattr(mod, "RUNTIME_CONFIG", {}).get("runtime", "host_build_graph")
-        compiler = KernelCompiler(platform=tc_platform)
-        case_configs.append(
-            (tc, compiler, tc_platform, runtime_name, mod.KERNELS, mod.ORCHESTRATION["source"])
-        )
+        # Non-final group: drain before the next set_backend_type so the
+        # global backend state transitions cleanly.
+        wait(group_futs)
+        compile_pool.shutdown(wait=True)
+        _compile_pools.remove(compile_pool)
+        reset_for_testing()
 
-    if not case_configs:
-        return 0
 
-    # ── Submit ALL tasks to a single flat pool ────────────────────────────────
-    def _compile_incore_task(compiler, tc_platform, kernel, runtime_name):
-        source = Path(kernel["source"])
-        prebuild_cache = source.parent.parent.parent / "cache"
-        compile_single_kernel(
-            kernel,
-            compiler,
-            tc_platform,
-            pto_isa_root,
-            runtime_name,
-            cache_dir=prebuild_cache,
-        )
-
-    def _compile_orch_task(compiler, runtime_name, orch_source):
-        source = Path(orch_source)
-        prebuild_cache = source.parent.parent / "cache"
-        compile_single_orchestration(
-            orch_source,
-            compiler,
-            runtime_name,
-            cache_dir=prebuild_cache,
-        )
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-        all_futs: list = []
-
-        # Per-test-case: each kernel and orchestration as independent tasks
-        tc_kernel_futs: list[tuple[list, concurrent.futures.Future]] = []
-        for tc, compiler, tc_platform, runtime_name, kernels, orch_source in case_configs:
-            kfuts = [
-                pool.submit(_compile_incore_task, compiler, tc_platform, k, runtime_name) for k in kernels
-            ]
-            ofut = pool.submit(_compile_orch_task, compiler, runtime_name, orch_source)
-            tc_kernel_futs.append((kfuts, ofut))
-            all_futs.extend(kfuts)
-            all_futs.append(ofut)
-
-        for fut in concurrent.futures.as_completed(all_futs):
-            try:
-                fut.result()
-            except Exception as e:
-                _log.debug("Pre-build task failed (will fall back to live compilation): %s", e)
-
-    n_ok = sum(
-        1
-        for kfuts, ofut in tc_kernel_futs
-        if all(f.exception() is None for f in kfuts) and ofut.exception() is None
-    )
-    return n_ok
+def shutdown_pipeline() -> None:
+    """Tear down compile/execute pools; called from ``pytest_sessionfinish``."""
+    global _execute_pool, _compile_pools
+    for pool in _compile_pools:
+        pool.shutdown(wait=False, cancel_futures=True)
+    _compile_pools = []
+    if _execute_pool is not None:
+        _execute_pool.shutdown(wait=False, cancel_futures=True)
+    _execute_pool = None
 
 
 class TestRunner:
@@ -440,68 +538,48 @@ class TestRunner:
     def run(self, test_case: PTOTestCase) -> RunResult:
         """Run a test case and return results.
 
+        When the test case was discovered at collection time, the compile→
+        execute pipeline has already produced its ``RunResult``; this method
+        returns it directly (blocking briefly if the execute future is still
+        in flight).  Otherwise the legacy inline compile+execute path runs on
+        the calling thread, using ``self.config.device_id`` as the device.
+
         Args:
             test_case: The test case to run.
 
         Returns:
             RunResult with pass/fail status and details.
         """
-        start_time = time.time()
-        test_name = test_case.get_name()
         resolved_platform = _resolve_platform(self.config.platform, test_case)
         cache_k = _cache_key(test_case, resolved_platform)
-
-        # --- Phase 2: pre-compiled artifacts available — skip compilation ---
-        if cache_k in _precompile_cache:
-            cached_dir, cached_error = _precompile_cache[cache_k]
-            if cached_error is not None:
-                return RunResult(
-                    passed=False,
-                    test_name=test_name,
-                    error=f"Pre-compilation failed: {cached_error}",
-                    execution_time=time.time() - start_time,
-                )
-            if self.config.codegen_only:
-                return RunResult(
-                    passed=True,
-                    test_name=test_name,
-                    execution_time=time.time() - start_time,
-                )
+        fut = _run_futures.get(cache_k)
+        if fut is not None:
             try:
-                # Re-write golden.py with the actual test case's tolerances.
-                # The pre-compiled golden.py may have been written with default
-                # tolerances (1e-5) because pytest_collection_finish instantiates
-                # test cases without their RunConfig constructor args.
-                _write_golden_for_test_case(test_case, cached_dir / "golden.py")
-                from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
-
-                chip_callable, runtime_name = compile_and_assemble(
-                    cached_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
-                )
-                _execute_on_device(
-                    cached_dir,
-                    cached_dir / "golden.py",
-                    chip_callable,
-                    runtime_name,
-                    resolved_platform,
-                    self.config.device_id,
-                )
-                return RunResult(
-                    passed=True,
-                    test_name=test_name,
-                    execution_time=time.time() - start_time,
-                )
-            except Exception as e:
+                result = fut.result()
+            except Exception as exc:
+                _last_device["value"] = None
                 return RunResult(
                     passed=False,
-                    test_name=test_name,
-                    error=f"{type(e).__name__}: {e}\n{traceback.format_exc()}",
-                    execution_time=time.time() - start_time,
+                    test_name=test_case.get_name(),
+                    error=f"pipeline future crashed: {exc}\n{traceback.format_exc()}",
+                    execution_time=0.0,
                 )
+            _last_device["value"] = _executed_device.get(cache_k)
+            return result
+        _last_device["value"] = self.config.device_id
+        return self._run_inline(test_case, resolved_platform)
 
-        # --- Original path: no cache, compile + execute in one step ---
+    def _run_inline(self, test_case: PTOTestCase, resolved_platform: str) -> RunResult:
+        """Compile + execute on the calling thread.
 
-        # Determine work directory based on save_kernels configuration
+        Used when ``--precompile-workers`` was not passed (pipeline disabled)
+        or for test cases that were not discoverable at collection time
+        (e.g. constructed dynamically inside a test body).  Single device only:
+        ``self.config.device_id`` (the first id in ``--device``).
+        """
+        start_time = time.time()
+        test_name = test_case.get_name()
+
         if self.config.save_kernels:
             if self.config.save_kernels_dir:
                 work_dir = Path(self.config.save_kernels_dir) / test_name
@@ -514,11 +592,9 @@ class TestRunner:
             use_temp = True
 
         try:
-            # Set PyPTO backend type for code generation
             backend_type = test_case.get_backend_type()
             set_backend_type(backend_type)
 
-            # 1. Get program
             program = test_case.get_program()
             if program is None:
                 raise ValueError(
@@ -526,7 +602,6 @@ class TestRunner:
                     "to return a @pl.program class or ir.Program"
                 )
 
-            # 2. Compile: generates kernels/, orchestration/ and patches headers
             strategy = test_case.get_strategy()
             compile_program(
                 program,
@@ -536,7 +611,6 @@ class TestRunner:
                 dump_passes=self.config.dump_passes,
             )
 
-            # 3. Validate that kernels and orchestration were generated
             if not list((work_dir / "kernels").rglob("*.cpp")):
                 raise ValueError(f"No kernels generated for {test_name}")
             if not list((work_dir / "orchestration").glob("*.cpp")):
@@ -546,11 +620,9 @@ class TestRunner:
                     "(decorated with @pl.function(type=pl.FunctionType.Orchestration))."
                 )
 
-            # 4. Generate golden.py in work_dir
             golden_path = work_dir / "golden.py"
             _write_golden_for_test_case(test_case, golden_path)
 
-            # 5. Execute via CodeRunner (skip if codegen_only)
             if self.config.codegen_only:
                 return RunResult(
                     passed=True,
@@ -558,18 +630,17 @@ class TestRunner:
                     execution_time=time.time() - start_time,
                 )
 
-            platform = resolved_platform
             from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
             chip_callable, runtime_name = compile_and_assemble(
-                work_dir, platform, pto_isa_commit=self.config.pto_isa_commit
+                work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
             )
             _execute_on_device(
                 work_dir,
                 golden_path,
                 chip_callable,
                 runtime_name,
-                platform,
+                resolved_platform,
                 self.config.device_id,
                 runtime_profiling=self.config.runtime_profiling,
             )

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -440,6 +440,17 @@ def start_pipeline(
     """
     global _device_pool, _execute_pool, _pipeline_ctx
 
+    # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
+    # start.  Otherwise concurrent workers race on `git clone` into the same
+    # path — the first wins, the rest fail with "destination already exists"
+    # and propagate "PTO_ISA_ROOT could not be resolved" as a pre-compilation
+    # error.  Once the env var is set, workers short-circuit via the env-var
+    # branch in ensure_pto_isa_root().
+    if not codegen_only:
+        from pypto.runtime.device_runner import ensure_pto_isa_root  # noqa: PLC0415
+
+        ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
+
     _device_pool = device_pool
     _pipeline_ctx = {
         "cache_dir": cache_dir,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -67,11 +67,16 @@ _log = logging.getLogger(__name__)
 # DevicePool.  Pytest's per-item loop then calls ``TestRunner.run`` which
 # blocks on the matching execute future and returns the cached RunResult.
 
-# cache_key → Future[RunResult] populated in start_pipeline().
-_run_futures: dict[str, Future] = {}
+# cache_key → Future[CompileArtifact] populated in start_pipeline().
+# TestRunner.run blocks on the compile future, rewrites golden.py with the
+# real RunConfig, then submits the execute task itself.  This keeps execute
+# work synchronised with pytest's per-item lifecycle so (a) RunConfig
+# tolerances reach golden.py and (b) C++ stdout from execute lands in the
+# right test's capture window.
+_compile_futures: dict[str, Future] = {}
 
 # cache_key → device id actually used by the execute task.  Read by
-# TestRunner.run after fut.result() and forwarded to the _report_device
+# TestRunner.run after exec_fut.result() and forwarded to the _report_device
 # fixture via _last_device.
 _executed_device: dict[str, int] = {}
 
@@ -312,10 +317,12 @@ def _fused_execute_task(
 ) -> RunResult:
     """Acquire a device slot, execute on device.
 
-    Runs on an execute-pool worker thread.  Called only after the matching
-    compile task has completed (via ``add_done_callback`` in
-    :func:`_schedule_execute`), so this task never blocks on compilation —
-    exec workers are free to grab the next device slot immediately.
+    Submitted by ``TestRunner.run`` after the compile future resolves and
+    after golden.py has been rewritten with the real ``RunConfig``.  Runs
+    on an execute-pool worker thread; multiple exec tasks can be in flight
+    when several pytest items resolve their compile futures concurrently
+    (e.g. under xdist), but the device pool bounds parallelism to the
+    number of devices in ``--device``.
     """
     start = time.time()
     name = tc.get_name()
@@ -362,54 +369,23 @@ def _fused_execute_task(
         _device_pool.put(device_id)
 
 
-def _schedule_execute(
+def _schedule_exec_after_golden(
     tc: "PTOTestCase",
     cache_key: str,
-    compile_fut: "Future",
-    result_fut: "Future",
-) -> None:
-    """Chain a compile future to an execute-pool submission.
+    artifact: "CompileArtifact",
+) -> Future:
+    """Rewrite ``golden.py`` for *tc* and submit the execute task.
 
-    When ``compile_fut`` completes, submit an execute task and forward its
-    result to ``result_fut``.  This avoids tying up execute-pool workers
-    waiting on slow compiles — workers only receive work that is ready to
-    run, so the device pool stays evenly loaded even when compile latency
-    varies between cases.
+    Called from ``TestRunner.run`` once the compile future has resolved.
+    The compile-time golden was written from a default-constructed
+    ``PTOTestCase`` (no ``RunConfig``) and therefore uses default 1e-5
+    tolerances; rewriting here picks up the real ``RunConfig`` passed by
+    the test body.
     """
-    name = tc.get_name()
-
-    def _on_compile_done(cf: "Future") -> None:
-        try:
-            artifact = cf.result()
-        except Exception as exc:
-            result_fut.set_result(
-                RunResult(
-                    passed=False,
-                    test_name=name,
-                    error=f"compile task crashed: {exc}\n{traceback.format_exc()}",
-                    execution_time=0.0,
-                )
-            )
-            return
-        assert _execute_pool is not None, "execute pool not initialised"
-        exec_fut = _execute_pool.submit(_fused_execute_task, tc, cache_key, artifact)
-
-        def _on_exec_done(ef: "Future") -> None:
-            try:
-                result_fut.set_result(ef.result())
-            except Exception as exc:
-                result_fut.set_result(
-                    RunResult(
-                        passed=False,
-                        test_name=name,
-                        error=f"execute task crashed: {exc}\n{traceback.format_exc()}",
-                        execution_time=0.0,
-                    )
-                )
-
-        exec_fut.add_done_callback(_on_exec_done)
-
-    compile_fut.add_done_callback(_on_compile_done)
+    if artifact.error is None and not _pipeline_ctx.get("codegen_only"):
+        _write_golden_for_test_case(tc, artifact.work_dir / "golden.py")
+    assert _execute_pool is not None, "execute pool not initialised"
+    return _execute_pool.submit(_fused_execute_task, tc, cache_key, artifact)
 
 
 def start_pipeline(
@@ -424,7 +400,7 @@ def start_pipeline(
     device_pool: "queue.Queue[int]",
     runtime_profiling: bool = False,
 ) -> None:
-    """Spin up the compile→execute pipeline and populate :data:`_run_futures`.
+    """Spin up the compile pipeline and populate :data:`_compile_futures`.
 
     Called from ``pytest_collection_finish``.  Test cases are grouped by
     backend type (``set_backend_type`` is a global one-time setter); within
@@ -488,20 +464,17 @@ def start_pipeline(
                 dump_passes,
                 pto_isa_commit,
             )
-            # result_fut is what TestRunner.run() waits on.  It's completed by
-            # the exec-done callback inside _schedule_execute, which submits
-            # the execute task only after compile finishes — so exec-pool
-            # workers never block on compilation and the device pool is
-            # evenly drained across devices.
-            result_fut: Future = Future()
-            _schedule_execute(tc, key, cfut, result_fut)
-            _run_futures[key] = result_fut
-            group_futs.append(result_fut)
+            # TestRunner.run() blocks on this compile future, rewrites
+            # golden.py with the real RunConfig, then submits the exec
+            # task itself.  Keeping exec submission on the main thread
+            # aligns C++ stdout with pytest's per-test capture window and
+            # ensures the real tolerances reach golden.py.
+            _compile_futures[key] = cfut
+            group_futs.append(cfut)
         if is_last:
             # Don't block: let pytest's per-item loop start running while
-            # compiles/executes continue in the background.  The compile
-            # pool stays alive; shutdown_pipeline() tears it down at
-            # session end.
+            # compiles continue in the background.  The compile pool stays
+            # alive; shutdown_pipeline() tears it down at session end.
             continue
         # Non-final group: drain before the next set_backend_type so the
         # global backend state transitions cleanly.
@@ -549,11 +522,12 @@ class TestRunner:
     def run(self, test_case: PTOTestCase) -> RunResult:
         """Run a test case and return results.
 
-        When the test case was discovered at collection time, the compile→
-        execute pipeline has already produced its ``RunResult``; this method
-        returns it directly (blocking briefly if the execute future is still
-        in flight).  Otherwise the legacy inline compile+execute path runs on
-        the calling thread, using ``self.config.device_id`` as the device.
+        When the test case was discovered at collection time, this method
+        waits for its compile future, rewrites ``golden.py`` with the
+        test's real ``RunConfig`` (compile-time golden used default 1e-5
+        tolerances because test classes are instantiated without args at
+        collection), then submits and awaits the execute task.  Otherwise
+        the legacy inline path runs on the calling thread.
 
         Args:
             test_case: The test case to run.
@@ -563,16 +537,27 @@ class TestRunner:
         """
         resolved_platform = _resolve_platform(self.config.platform, test_case)
         cache_k = _cache_key(test_case, resolved_platform)
-        fut = _run_futures.get(cache_k)
-        if fut is not None:
+        cfut = _compile_futures.get(cache_k)
+        if cfut is not None:
             try:
-                result = fut.result()
+                artifact = cfut.result()
             except Exception as exc:
                 _last_device["value"] = None
                 return RunResult(
                     passed=False,
                     test_name=test_case.get_name(),
-                    error=f"pipeline future crashed: {exc}\n{traceback.format_exc()}",
+                    error=f"compile task crashed: {exc}\n{traceback.format_exc()}",
+                    execution_time=0.0,
+                )
+            exec_fut = _schedule_exec_after_golden(test_case, cache_k, artifact)
+            try:
+                result = exec_fut.result()
+            except Exception as exc:
+                _last_device["value"] = None
+                return RunResult(
+                    passed=False,
+                    test_name=test_case.get_name(),
+                    error=f"execute task crashed: {exc}\n{traceback.format_exc()}",
                     execution_time=0.0,
                 )
             _last_device["value"] = _executed_device.get(cache_k)


### PR DESCRIPTION
Add local mount-based caches for pip wheels, ccache, and the ptoas release tarball on the self-hosted runner so repeat CI runs skip network downloads and rebuilds. Install PyPTO and the runtime with `--no-build-isolation` so ccache and the container toolchain are actually used, and clear `./runtime/build` before reinstall to avoid stale CMake state.

Also extend `--device` in `tests/st/conftest.py` to accept ranges and comma-separated lists (e.g. `0-7`, `0,1,12`, `0-3,8,12-15`) and, under pytest-xdist, assign workers to devices round-robin so parallel workers target distinct NPUs. The system-tests CI job now forwards a `DEVICE_RANGE` env var through to pytest.