### PR TITLE
fix(runtime): restore swimlane auto-conversion and add missing-script warning

### DIFF
--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -492,6 +492,11 @@ def _generate_swimlane(
     """
     swimlane_script = simpler_root / "tools" / "swimlane_converter.py"
     if not swimlane_script.exists():
+        print(
+            f"Warning: swimlane_converter.py not found at {swimlane_script}, "
+            f"skipping auto-conversion. Run manually with: "
+            f"python examples/swimlane_converter.py <perf_swimlane_*.json>"
+        )
         return
 
     if perf_file is None:


### PR DESCRIPTION
## Summary

On real-device profiling runs (`-p a2a3 --runtime-profiling`), only
`perf_swimlane_*.json` may be generated while `merged_swimlane_*.json` is not
auto-produced.

## Root Cause

1. Runtime wheel assets were missing `tools/swimlane_converter.py`.
2. [_generate_swimlane()](cci:1://file:///Users/wzr/ForPR/pypto/python/pypto/runtime/runner.py:468:0-532:91) in [python/pypto/runtime/runner.py](cci:7://file:///Users/wzr/ForPR/pypto/python/pypto/runtime/runner.py:0:0-0:0) silently returned
   when the converter script was missing, with no user-facing signal.

## Changes

- [python/pypto/runtime/runner.py](cci:7://file:///Users/wzr/ForPR/pypto/python/pypto/runtime/runner.py:0:0-0:0)
  - Add an explicit warning when `swimlane_converter.py` is not found.
  - Keep graceful fallback behavior (skip conversion instead of hard failure).
- [runtime](cci:9://file:///Users/wzr/ForPR/pypto/runtime:0:0-0:0) submodule
  - Bump to the `simpler` commit that packages [tools/](cci:9://file:///Users/wzr/ForPR/pypto/runtime/tools:0:0-0:0) into wheel assets.

## Dependency

- Simpler PR: `<SIMPLER_PR_URL>`

## Testing

- Missing-script path now prints a clear warning instead of silent return.
- With updated runtime assets, auto-conversion can locate
  `swimlane_converter.py` and proceed.
- Simulator path remains unaffected.