### PR TITLE
fix(runtime): clamp block_dim to hardware AICore count on binned devices

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -484,6 +484,28 @@ def execute_on_device(
         enable_profiling: Enable runtime profiling.
         runtime_env: Optional per-example environment variable overrides.
     """
+    # Cap block_dim at actual AICore count to avoid TSCH dispatch hang
+    # on binned devices (e.g. 910B3 Bin6 has 20 cores, not 24).
+    # Also round down to nearest multiple of scheduler_thread_num so the
+    # C++ runtime can evenly distribute blocks across scheduler threads.
+    if not platform.endswith("sim"):
+        try:
+            import ctypes
+            _rt = ctypes.CDLL("libruntime.so")
+            _cnt = ctypes.c_uint32()
+            if _rt.rtGetAiCoreCount(ctypes.byref(_cnt)) == 0 and _cnt.value > 0:
+                hw_max = _cnt.value
+                if block_dim > hw_max:
+                    sched_threads = max(aicpu_thread_num - 1, 1)
+                    new_bd = (hw_max // sched_threads) * sched_threads
+                    if new_bd < 1:
+                        new_bd = sched_threads
+                    print(f"[WARN] block_dim={block_dim} exceeds AICore count={hw_max}; "
+                          f"clamping to {new_bd} (divisible by {sched_threads}).")
+                    block_dim = new_bd
+        except Exception:
+            pass  # best-effort; fall through to user-specified block_dim
+
     worker = Worker(level=2, device_id=device_id, platform=platform, runtime=runtime_name)
     worker.init()
 


### PR DESCRIPTION
## Summary

On binned Ascend 910B3 variants, physical AICore count can be lower than the
default `block_dim=24`. This mismatch may cause device execution to hang.

## Root Cause

`block_dim` was used directly without checking actual hardware AICore count.
On binned devices (for example, 20 cores), dispatch can target non-existent
cores, and runtime synchronization may block indefinitely.

## Changes

In [python/pypto/runtime/device_runner.py](cci:7://file:///Users/wzr/ForPR/pypto/python/pypto/runtime/device_runner.py:0:0-0:0) ([execute_on_device()](cci:1://file:///Users/wzr/ForPR/pypto/python/pypto/runtime/device_runner.py:461:0-520:18)):

- Query actual AICore count via `rtGetAiCoreCount` from `libruntime.so`.
- Clamp `block_dim` when it exceeds hardware AICore count.
- Round down to the nearest multiple of scheduler thread count
  (`aicpu_thread_num - 1`) for even distribution.
- Skip this logic on simulator platforms (`*sim`).
- Wrap detection in `try/except` for best-effort fallback.

## Why This Fix

- Prevents dispatch to non-existent cores on binned hardware.
- Avoids permanent hangs at synchronization points.
- Preserves compatibility on simulator and environments without runtime API access.

## Testing

- Real binned device: warning emitted and run completes.
- Typical adjustment observed: `block_dim` 24 -> 18 on a 20-core device with
  scheduler multiple constraints.
- Simulator path remains unaffected.