### PR TITLE
fix(pass): mark tensor.assemble destinations as InOut during outlining

### DIFF
--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -842,25 +842,65 @@ class ScopeOutliner : public IRMutator {
   /// Infer parameter directions for the outlined function by examining the scope body.
   ///
   /// Strategy:
-  ///   1. Find the first function call in the scope body
-  ///   2. Look up the callee's param_directions_ via program_
-  ///   3. Map input_vars to callee args by Var pointer identity
-  ///   4. Copy callee directions; store targets get InOut; rest default to In
+  ///   1. Mark tile.store targets (from ``store_output_set``) as InOut
+  ///   2. Mark tensor.assemble destinations as InOut (SSA-pure but
+  ///      semantically a destination update; without this the spmd wrapper for
+  ///      ``for n0 in pl.spmd(...): out = pl.assemble(out, slice, [...])``
+  ///      keeps direction In on the shared output and the orchestration
+  ///      codegen drops the SSA-result alias for the inout call)
+  ///   3. Merge ``Out``/``InOut`` directions from inner GlobalVar calls
   std::vector<ParamDirection> InferParamDirections(
       const std::vector<VarPtr>& input_vars, const StmtPtr& body,
       const std::unordered_set<const Var*>& store_output_set) const {
     std::vector<ParamDirection> directions(input_vars.size(), ParamDirection::In);
 
-    // Mark store targets as InOut
+    // Build input_var pointer → index map (shared by every inference step below).
+    std::unordered_map<const Var*, size_t> var_to_idx;
+    for (size_t i = 0; i < input_vars.size(); ++i) {
+      var_to_idx[input_vars[i].get()] = i;
+    }
+
+    // Step 1: mark tile.store targets as InOut
     for (size_t i = 0; i < input_vars.size(); ++i) {
       if (store_output_set.count(input_vars[i].get())) {
         directions[i] = ParamDirection::InOut;
       }
     }
 
+    // Step 2: mark tensor.assemble destinations as InOut. ``tensor.assemble``
+    // is SSA-pure (returns a fresh Tensor) but the first arg is a destination
+    // that the result aliases — when the destination is a parameter the
+    // function effectively reads and writes the same backing buffer.
+    class AssembleDestUpgrader : public IRVisitor {
+     public:
+      AssembleDestUpgrader(const std::unordered_map<const Var*, size_t>& var_to_idx,
+                           std::vector<ParamDirection>& directions)
+          : var_to_idx_(var_to_idx), directions_(directions) {}
+
+     protected:
+      void VisitExpr_(const CallPtr& call) override {
+        auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
+        if (opnode && opnode->name_ == "tensor.assemble" && !call->args_.empty()) {
+          if (auto var = As<Var>(call->args_[0])) {
+            auto it = var_to_idx_.find(var.get());
+            if (it != var_to_idx_.end() && directions_[it->second] == ParamDirection::In) {
+              directions_[it->second] = ParamDirection::InOut;
+            }
+          }
+        }
+        IRVisitor::VisitExpr_(call);
+      }
+
+     private:
+      const std::unordered_map<const Var*, size_t>& var_to_idx_;
+      std::vector<ParamDirection>& directions_;
+    };
+    AssembleDestUpgrader(var_to_idx, directions).VisitStmt(body);
+
     if (!program_) return directions;
 
-    // Collect all GlobalVar function calls in the body to infer directions across all of them.
+    // Step 3: collect all GlobalVar function calls in the body and merge
+    // ``Out``/``InOut`` directions from their callees onto our parameters.
     class CallFinder : public IRVisitor {
      public:
       std::vector<CallPtr> found_calls;
@@ -875,12 +915,6 @@ class ScopeOutliner : public IRMutator {
     CallFinder finder;
     finder.VisitStmt(body);
     if (finder.found_calls.empty()) return directions;
-
-    // Build input_var pointer → index map
-    std::unordered_map<const Var*, size_t> var_to_idx;
-    for (size_t i = 0; i < input_vars.size(); ++i) {
-      var_to_idx[input_vars[i].get()] = i;
-    }
 
     // Merge directions from all calls, preferring Out/InOut over In
     for (const auto& call : finder.found_calls) {

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -365,6 +365,48 @@ class TestOutlineClusterScopes:
         After = passes.outline_cluster_scopes()(After)
         ir.assert_structural_equal(After, Expected)
 
+    def test_outline_spmd_for_loop_marks_assemble_dest_as_inout(self):
+        """`for n0 in pl.spmd(N): out = pl.assemble(out, slice, [n0, ...])`
+        must make `out` an InOut parameter on both the outlined InCore and
+        Spmd wrapper. Without this, the orchestration codegen later drops the
+        SSA-result alias for the inout call and emits a use of an undeclared
+        ``out__ssa_vN`` C++ identifier.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for n0 in pl.spmd(4):
+                    offset = n0 * 128
+                    chunk: pl.Tensor[[128, 128], pl.FP32] = pl.slice(a, [128, 128], [offset, 0])
+                    out = pl.assemble(out, chunk, [offset, 0])
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_incore_scopes()(Before)
+        After = passes.outline_cluster_scopes()(After)
+
+        spmd_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.Spmd]
+        assert len(spmd_funcs) == 1, "expected exactly one outlined Spmd wrapper"
+        spmd_func = spmd_funcs[0]
+        assert ir.ParamDirection.InOut in spmd_func.param_directions, (
+            "spmd wrapper's assemble-destination parameter should be InOut, "
+            f"got {list(spmd_func.param_directions)}"
+        )
+
+        incore_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore]
+        assert len(incore_funcs) == 1, "expected exactly one outlined InCore wrapper"
+        incore_func = incore_funcs[0]
+        assert ir.ParamDirection.InOut in incore_func.param_directions, (
+            "incore wrapper's assemble-destination parameter should be InOut, "
+            f"got {list(incore_func.param_directions)}"
+        )
+
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):
         """Test that ClusterOutlined verifier flags Cluster scopes in InCore functions."""
 

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -391,20 +391,32 @@ class TestOutlineClusterScopes:
         After = passes.outline_incore_scopes()(Before)
         After = passes.outline_cluster_scopes()(After)
 
+        def directions_by_hint(func):
+            return {p.name_hint: d for p, d in zip(func.params, func.param_directions)}
+
+        def find_param(hints, prefix):
+            matches = [h for h in hints if h == prefix or h.startswith(prefix + "__")]
+            assert len(matches) == 1, f"expected exactly one param starting with {prefix!r}, got {matches}"
+            return matches[0]
+
         spmd_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.Spmd]
         assert len(spmd_funcs) == 1, "expected exactly one outlined Spmd wrapper"
-        spmd_func = spmd_funcs[0]
-        assert ir.ParamDirection.InOut in spmd_func.param_directions, (
-            "spmd wrapper's assemble-destination parameter should be InOut, "
-            f"got {list(spmd_func.param_directions)}"
+        spmd_dirs = directions_by_hint(spmd_funcs[0])
+        assert spmd_dirs[find_param(spmd_dirs, "out")] == ir.ParamDirection.InOut, (
+            f"spmd wrapper's `out` param should be InOut, got {spmd_dirs}"
+        )
+        assert spmd_dirs[find_param(spmd_dirs, "a")] == ir.ParamDirection.In, (
+            f"spmd wrapper's `a` param should remain In, got {spmd_dirs}"
         )
 
         incore_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore]
         assert len(incore_funcs) == 1, "expected exactly one outlined InCore wrapper"
-        incore_func = incore_funcs[0]
-        assert ir.ParamDirection.InOut in incore_func.param_directions, (
-            "incore wrapper's assemble-destination parameter should be InOut, "
-            f"got {list(incore_func.param_directions)}"
+        incore_dirs = directions_by_hint(incore_funcs[0])
+        assert incore_dirs[find_param(incore_dirs, "out")] == ir.ParamDirection.InOut, (
+            f"incore wrapper's `out` param should be InOut, got {incore_dirs}"
+        )
+        assert incore_dirs[find_param(incore_dirs, "a")] == ir.ParamDirection.In, (
+            f"incore wrapper's `a` param should remain In, got {incore_dirs}"
         )
 
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):


### PR DESCRIPTION
## Summary

`ScopeOutliner::InferParamDirections` previously marked only `tile.store` targets as `InOut` and merged `Out`/`InOut` directions from inner `GlobalVar` callees. For

```python
@pl.function(type=pl.FunctionType.Orchestration)
def main(self, a, out: pl.Out[...]):
    for n0 in pl.spmd(N):
        chunk = pl.slice(a, [...], [n0 * T, 0])
        out = pl.assemble(out, chunk, [n0 * T, 0])
    return out
```

this left the outlined Spmd wrapper's `out` parameter as `In`, even though the wrapper reads and writes the same backing buffer.

## Symptom

Downstream, `OrchestrationStmtCodegen::CollectOutIndices` returns empty for calls whose wrapper param is `In`, `EmitTensorAlias` is never invoked for the SSA result of the inout call, and the emitted orchestration C++ references an undeclared identifier like `out__ssa_v1`. End-to-end reproduced on qwen3 MLP-down.

## Fix

Add a step to `InferParamDirections` that finds `tensor.assemble` first-arg destinations and upgrades matching wrapper inputs from `In` to `InOut`. `tensor.assemble` is SSA-pure (returns a fresh `Tensor`) but the result aliases the destination, so when the destination is a parameter the function effectively reads and writes the same backing buffer.

Implementation also restructures the inference into three explicit numbered steps and hoists the shared `var_to_idx` map so step 2 and step 3 share a single index build.

## Edge cases

- Upgrades `In → InOut` only; `Out` and pre-existing `InOut` are untouched.
- Triggers only for a `tensor.assemble` whose first arg matches a wrapper input `Var` by pointer identity; a fresh local destination does not affect any parameter direction — no-op.
- Pure direction-label change at outlining time; no IR structure changes.
- Downstream passes already correctly handle `InOut` params, so no follow-up changes are required in codegen.

## Tests

- New regression test `test_outline_spmd_for_loop_marks_assemble_dest_as_inout` in `tests/ut/ir/transforms/test_outline_cluster_scopes.py` — verifies both the outlined InCore and Spmd wrappers end with `ParamDirection.InOut` among their `param_directions` after `outline_incore_scopes` + `outline_cluster_scopes`.
- Full `tests/ut/ir/transforms/` sweep passes (1108 passed, 12 skipped, 0 failed).

## Note on scope

This is PR1 of two independent fixes for the end-to-end qwen3 MLP-down failure. PR2 separately addresses a Phase 1 → Phase 2 inconsistency in `ConvertTensorToTileOps` where new `Out` tensor params appended to a transformed InCore leave Spmd/Group wrappers stale. That change is in a different file and is not included here.