### PR TITLE
fix(pass): forward CTTo added outputs through Spmd/Group wrappers

### DIFF
--- a/docs/en/dev/passes/09-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/09-convert_tensor_to_tile_ops.md
@@ -33,7 +33,7 @@ program_tiled = convert_pass(program)
 
 ## Algorithm
 
-The pass operates in two program-level phases:
+The pass operates in three program-level phases:
 
 ### Phase 1: Transform InCore Functions
 
@@ -47,12 +47,38 @@ For each `FunctionType::InCore` function:
 
 4. **Insert tile.store (exit stores)**: For each return value converted from `TensorType` to `TileType`, add an `Out` parameter and insert `tile.store(tile, zeros, out_param)`. If the return value comes from a `tile.assemble` loop, the loop is rewritten to use `tile.store` directly (conversion-time assemble-loop rewrite; distinct from `OptimizeOrchTensors` Pattern 3 which handles cross-function optimization).
 
-### Phase 2: Update Call Sites
+### Phase 2a: Propagate Added Outputs Through Spmd/Group Wrappers
 
-For each non-InCore function that calls a transformed InCore function:
+`OutlineClusterScopes` produces Spmd/Group wrappers that are transparent 1:1
+forwarders of their params to a single inner InCore call. When Phase 1 appends
+`Out` params to that InCore callee, the wrapper must mirror the appended params
+on its own signature and forward them through the inner call — otherwise
+orchestration codegen's `BuildWrapperReorderedParams` invariant (every inner-call
+`Var` arg resolves to a wrapper param) breaks.
+
+For each `FunctionType::Spmd` / `FunctionType::Group` function:
+
+1. `ForwardedCallFinder` locates the first call to a transformed InCore (one
+   whose Phase 1 added at least one `Out` param).
+2. If found, the wrapper signature is extended with matching `Out` params (same
+   type as the InCore's appended params, reusing the `name_hint_`), and
+   `WrapperForwardMutator` rewrites the inner call to append the new vars as
+   forward args and adopt the callee's new return type. `tensor.create` is
+   *not* synthesised in the wrapper — allocation remains the caller's
+   responsibility.
+3. If no forwarded transformed-InCore call is found, the wrapper is left
+   unchanged.
+
+### Phase 2b: Update Orchestration Call Sites
+
+For each orchestration / opaque function that calls a transformed InCore
+function or a wrapper that absorbed output params in Phase 2a:
 
 1. Insert `tensor.create` for each added output parameter
 2. Append created tensors as extra arguments to the call
+
+InCore, Spmd, and Group functions are skipped from this phase — they were
+already rewritten in Phase 1 / 2a.
 
 ## MatmulSlice Pattern
 
@@ -131,13 +157,16 @@ Key changes:
 | `MatmulSlicePatternCollector` | IRVisitor — finds slice→matmul patterns for Mat-space loads |
 | `TypePropagatingMutator` | Base IRMutator — propagates type changes through control flow |
 | `TensorToTileMutator` | IRMutator — converts tensor ops to tile ops via OpConversionRegistry |
-| `CallSiteUpdateMutator` | IRMutator — inserts tensor.create at orchestration call sites |
+| `ForwardedCallFinder` | IRVisitor — locates the wrapper's call into a transformed InCore (Phase 2a) |
+| `WrapperForwardMutator` | IRMutator — appends new Out args to the wrapper's inner call (Phase 2a) |
+| `CallSiteUpdateMutator` | IRMutator — inserts tensor.create at orchestration call sites (Phase 2b) |
 | `IncoreTileOpsVerifier` | IRVisitor — verifies no TensorType ops remain in InCore functions |
 
 ## Scope
 
 | Function type | Action |
 | ------------- | ------ |
-| InCore | Converted (tensor ops → tile ops) |
-| Orchestration / Opaque | Call sites updated (tensor.create inserted) |
-| Group | Unchanged |
+| InCore | Converted (tensor ops → tile ops); Phase 1 may append `Out` params |
+| Spmd / Group (forwarding to a transformed InCore) | Signature mirrors the InCore's new `Out` params; inner call forwards them (Phase 2a) |
+| Spmd / Group (no transformed-InCore forwarding) | Unchanged |
+| Orchestration / Opaque | Call sites updated — `tensor.create` inserted for each new `Out` param (Phase 2b) |

--- a/docs/zh-cn/dev/passes/09-convert_tensor_to_tile_ops.md
+++ b/docs/zh-cn/dev/passes/09-convert_tensor_to_tile_ops.md
@@ -33,7 +33,7 @@ program_tiled = convert_pass(program)
 
 ## 算法
 
-本 pass 在 Program 级别分两阶段执行：
+本 pass 在 Program 级别分三阶段执行：
 
 ### 阶段一：转换 InCore 函数
 
@@ -47,12 +47,33 @@ program_tiled = convert_pass(program)
 
 4. **插入 tile.store（出口存储）**：对每个从 `TensorType` 转换为 `TileType` 的返回值，添加 `Out` 参数并插入 `tile.store(tile, zeros, out_param)`。如果返回值来自 `tile.assemble` 循环，则将循环重写为直接使用 `tile.store`（转换时 assemble-loop 重写；与 `OptimizeOrchTensors` 模式 3 不同，该模式处理跨函数优化）。
 
-### 阶段二：更新调用点
+### 阶段二a：通过 Spmd/Group 包装函数转发新增 Out 参数
 
-对每个调用了已转换 InCore 函数的非 InCore 函数：
+`OutlineClusterScopes` 产生的 Spmd/Group 包装函数是对其参数到单个内部 InCore
+调用的透明 1:1 转发器。当阶段一为该 InCore 被调用者新增 `Out` 参数时，
+包装函数必须在自身签名上镜像这些新增参数并通过内部调用转发给被调用者 ——
+否则编排层代码生成的 `BuildWrapperReorderedParams` 不变式（每个内部调用的
+`Var` 实参都能解析到某个包装函数参数）会被破坏。
+
+对每个 `FunctionType::Spmd` / `FunctionType::Group` 函数：
+
+1. `ForwardedCallFinder` 查找第一个调用转换后 InCore（阶段一新增了至少一个
+   `Out` 参数）的调用点。
+2. 若找到，则在包装函数签名末尾追加与 InCore 新增参数类型相同（复用
+   `name_hint_`）的 `Out` 参数，并由 `WrapperForwardMutator` 重写该内部调用：
+   将新变量追加到实参列表、更新调用返回类型为被调用者新的返回类型。包装
+   函数体内部**不会**合成 `tensor.create` —— 分配职责保留在调用者侧。
+3. 若未找到转发到转换后 InCore 的调用，则包装函数保持不变。
+
+### 阶段二b：更新编排函数调用点
+
+对每个调用了转换后 InCore 函数或阶段二a 吸收了新增 Out 参数的包装函数的
+编排 / 不透明函数：
 
 1. 为每个新增的输出参数插入 `tensor.create`
 2. 将创建的张量作为额外参数追加到调用中
+
+InCore、Spmd、Group 函数在本阶段被跳过 —— 它们已在阶段一 / 二a 中被改写。
 
 ## MatmulSlice 模式
 
@@ -131,13 +152,16 @@ class After:
 | `MatmulSlicePatternCollector` | IRVisitor — 查找 slice→matmul 模式以生成 Mat 空间加载 |
 | `TypePropagatingMutator` | 基类 IRMutator — 通过控制流传播类型变更 |
 | `TensorToTileMutator` | IRMutator — 通过 OpConversionRegistry 将 tensor op 转换为 tile op |
-| `CallSiteUpdateMutator` | IRMutator — 在编排函数调用点插入 tensor.create |
+| `ForwardedCallFinder` | IRVisitor — 定位包装函数对转换后 InCore 的调用（阶段二a） |
+| `WrapperForwardMutator` | IRMutator — 将新增 Out 参数追加到包装函数的内部调用（阶段二a） |
+| `CallSiteUpdateMutator` | IRMutator — 在编排函数调用点插入 tensor.create（阶段二b） |
 | `IncoreTileOpsVerifier` | IRVisitor — 验证 InCore 函数中不再包含 TensorType 操作 |
 
 ## 作用范围
 
 | 函数类型 | 操作 |
 | -------- | ---- |
-| InCore | 转换（tensor ops → tile ops） |
-| Orchestration / Opaque | 更新调用点（插入 tensor.create） |
-| Group | 不变 |
+| InCore | 转换（tensor ops → tile ops）；阶段一可能新增 `Out` 参数 |
+| Spmd / Group（转发到转换后 InCore） | 签名镜像 InCore 新增的 `Out` 参数，内部调用转发这些参数（阶段二a） |
+| Spmd / Group（未转发到转换后 InCore） | 不变 |
+| Orchestration / Opaque | 更新调用点 —— 为每个新增 `Out` 参数插入 `tensor.create`（阶段二b） |

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1436,6 +1436,8 @@ class WrapperForwardMutator : public TypePropagatingMutator {
         transformed_incore_funcs_(transformed_incore_funcs),
         new_output_vars_(std::move(new_output_vars)) {}
 
+  [[nodiscard]] bool applied() const { return applied_; }
+
  protected:
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     auto new_value = VisitExpr(op->value_);
@@ -1514,8 +1516,14 @@ WrapperTransformResult PropagateOutputsThroughWrapper(
   auto gv = std::dynamic_pointer_cast<const GlobalVar>(target_call->op_);
   INTERNAL_CHECK_SPAN(gv != nullptr, target_call->span_)
       << "Internal error: forwarded call op is not a GlobalVar";
-  size_t num_added = incore_added_outputs.at(gv->name_);
-  const auto& incore_func = transformed_incore_funcs.at(gv->name_);
+  auto added_outputs_it = incore_added_outputs.find(gv->name_);
+  INTERNAL_CHECK_SPAN(added_outputs_it != incore_added_outputs.end(), target_call->span_)
+      << "Internal error: missing added-output metadata for forwarded callee " << gv->name_;
+  auto transformed_incore_func_it = transformed_incore_funcs.find(gv->name_);
+  INTERNAL_CHECK_SPAN(transformed_incore_func_it != transformed_incore_funcs.end(), target_call->span_)
+      << "Internal error: missing transformed InCore function for forwarded callee " << gv->name_;
+  size_t num_added = added_outputs_it->second;
+  const auto& incore_func = transformed_incore_func_it->second;
 
   // Mirror the InCore's appended Out params on the wrapper: same type, Out
   // direction. Names are scoped to the wrapper so the clone is safe.
@@ -1534,6 +1542,14 @@ WrapperTransformResult PropagateOutputsThroughWrapper(
 
   WrapperForwardMutator mutator(incore_added_outputs, transformed_incore_funcs, new_output_vars);
   auto new_body = mutator.VisitStmt(func->body_);
+  // Outlined Spmd/Group wrappers always forward via an `out = self.kernel(x, ...);
+  // return out` AssignStmt — WrapperForwardMutator rewrites that shape. If
+  // ForwardedCallFinder found a target call but the mutator failed to apply,
+  // the wrapper's signature has been mirrored but its inner call was not
+  // updated — a silent mis-rewrite. Fail fast instead.
+  INTERNAL_CHECK_SPAN(mutator.applied(), target_call->span_)
+      << "Wrapper forward propagation identified a forwarded call in " << func->name_
+      << " but could not rewrite it (call not in AssignStmt RHS form expected by outlining invariant)";
 
   std::vector<TypePtr> new_return_types = incore_func->return_types_;
   auto new_func =
@@ -1704,6 +1720,12 @@ Pass ConvertTensorToTileOps() {
     std::vector<FunctionPtr> functions_phase2b;
     functions_phase2b.reserve(functions_phase2a.size());
     for (const auto& func : functions_phase2a) {
+      // Skip InCore (rewritten in Phase 1) and every Spmd/Group (rewritten in
+      // Phase 2a when forwarding a transformed InCore; otherwise nothing to
+      // forward because ForwardedCallFinder rejects callees that gained zero
+      // Out params). The postcondition check in PropagateOutputsThroughWrapper
+      // turns any finder/mutator mismatch into a hard INTERNAL_CHECK rather
+      // than a silent mis-rewrite.
       if (func->func_type_ == FunctionType::InCore || func->func_type_ == FunctionType::Spmd ||
           func->func_type_ == FunctionType::Group) {
         functions_phase2b.push_back(func);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1382,9 +1382,171 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
 }
 
 // ============================================================================
+// Wrapper forward propagation: Spmd/Group wrappers produced by
+// OutlineClusterScopes are transparent 1:1 forwarders from their params to a
+// single inner InCore call. When the InCore callee gains output params
+// (Phase 1), the wrapper must mirror those params on its own signature and
+// forward them to the inner call, instead of synthesising tensor.create in
+// the wrapper body. Orchestration codegen's BuildWrapperReorderedParams
+// relies on every inner-call Var arg resolving to a wrapper param.
+// ============================================================================
+
+/// Find the first Call in a stmt tree whose callee is a transformed InCore
+/// function (listed in `incore_added_outputs` with >0 added outputs). Used to
+/// pre-size the wrapper's new Out params before the mutator runs.
+class ForwardedCallFinder : public IRVisitor {
+ public:
+  explicit ForwardedCallFinder(const std::unordered_map<std::string, size_t>& incore_added_outputs)
+      : incore_added_outputs_(incore_added_outputs) {}
+
+  [[nodiscard]] const CallPtr& GetFound() const { return found_; }
+
+  void VisitExpr_(const CallPtr& op) override {
+    if (!found_) {
+      auto gv = std::dynamic_pointer_cast<const GlobalVar>(op->op_);
+      if (gv) {
+        auto it = incore_added_outputs_.find(gv->name_);
+        if (it != incore_added_outputs_.end() && it->second > 0) {
+          found_ = op;
+          return;
+        }
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  const std::unordered_map<std::string, size_t>& incore_added_outputs_;
+  CallPtr found_;
+};
+
+/// Mutator that rewrites a wrapper's forwarding call: append the
+/// pre-allocated `new_output_vars_` (wrapper-level Out params) to the call's
+/// arg list and update the call's return type to match the transformed
+/// InCore callee. Does NOT insert tensor.create — the allocation is the
+/// responsibility of the wrapper's caller. Recurses through nested control
+/// flow via IRMutator's base behavior, so forwarded calls inside ForStmt /
+/// IfStmt / WhileStmt bodies are handled correctly.
+class WrapperForwardMutator : public TypePropagatingMutator {
+ public:
+  WrapperForwardMutator(const std::unordered_map<std::string, size_t>& incore_added_outputs,
+                        const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs,
+                        std::vector<VarPtr> new_output_vars)
+      : incore_added_outputs_(incore_added_outputs),
+        transformed_incore_funcs_(transformed_incore_funcs),
+        new_output_vars_(std::move(new_output_vars)) {}
+
+ protected:
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto new_value = VisitExpr(op->value_);
+    auto call = As<Call>(new_value);
+    if (!call) return HandlePassThroughAssign(op, new_value);
+    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    if (!global_var) return HandlePassThroughAssign(op, new_value);
+
+    auto it = incore_added_outputs_.find(global_var->name_);
+    if (it == incore_added_outputs_.end() || it->second == 0) {
+      return HandlePassThroughAssign(op, new_value);
+    }
+
+    INTERNAL_CHECK_SPAN(!applied_, call->span_)
+        << "Wrapper forward propagation saw more than one forwarded call; outlining invariant violated";
+    INTERNAL_CHECK_SPAN(it->second == new_output_vars_.size(), call->span_)
+        << "Wrapper new-output count mismatch: callee added " << it->second << ", wrapper prepared "
+        << new_output_vars_.size();
+
+    auto incore_func_it = transformed_incore_funcs_.find(global_var->name_);
+    INTERNAL_CHECK_SPAN(incore_func_it != transformed_incore_funcs_.end(), call->span_)
+        << "Internal error: transformed InCore function not found: " << global_var->name_;
+    const auto& incore_func = incore_func_it->second;
+
+    std::vector<ExprPtr> new_args = call->args_;
+    for (const auto& v : new_output_vars_) {
+      new_args.push_back(v);
+    }
+
+    TypePtr new_return_type;
+    if (incore_func->return_types_.empty()) {
+      new_return_type = nullptr;
+    } else if (incore_func->return_types_.size() == 1) {
+      new_return_type = incore_func->return_types_[0];
+    } else {
+      new_return_type = std::make_shared<TupleType>(incore_func->return_types_);
+    }
+
+    auto new_call = new_return_type ? std::make_shared<Call>(call->op_, new_args, call->kwargs_,
+                                                             new_return_type, call->span_)
+                                    : std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
+
+    auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
+    auto new_assign = MutableCopy(op);
+    new_assign->var_ = new_assign_var;
+    new_assign->value_ = new_call;
+    var_remap_[op->var_.get()] = new_assign_var;
+    applied_ = true;
+    return new_assign;
+  }
+
+ private:
+  const std::unordered_map<std::string, size_t>& incore_added_outputs_;
+  const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs_;
+  std::vector<VarPtr> new_output_vars_;
+  bool applied_ = false;
+};
+
+struct WrapperTransformResult {
+  FunctionPtr func;
+  size_t num_added_outputs;
+};
+
+/// Propagate a transformed InCore's added output params through a Spmd/Group
+/// wrapper: mirror them on the wrapper's signature and forward them to the
+/// inner call. Returns {func, 0} if the wrapper does not forward to any
+/// transformed InCore callee.
+WrapperTransformResult PropagateOutputsThroughWrapper(
+    const FunctionPtr& func, const std::unordered_map<std::string, size_t>& incore_added_outputs,
+    const std::unordered_map<std::string, FunctionPtr>& transformed_incore_funcs) {
+  ForwardedCallFinder finder(incore_added_outputs);
+  finder.VisitStmt(func->body_);
+  const auto& target_call = finder.GetFound();
+  if (!target_call) return {func, 0};
+
+  auto gv = std::dynamic_pointer_cast<const GlobalVar>(target_call->op_);
+  INTERNAL_CHECK_SPAN(gv != nullptr, target_call->span_)
+      << "Internal error: forwarded call op is not a GlobalVar";
+  size_t num_added = incore_added_outputs.at(gv->name_);
+  const auto& incore_func = transformed_incore_funcs.at(gv->name_);
+
+  // Mirror the InCore's appended Out params on the wrapper: same type, Out
+  // direction. Names are scoped to the wrapper so the clone is safe.
+  std::vector<VarPtr> new_params = func->params_;
+  std::vector<ParamDirection> new_dirs = func->param_directions_;
+  std::vector<VarPtr> new_output_vars;
+  new_output_vars.reserve(num_added);
+  size_t orig_incore_param_count = incore_func->params_.size() - num_added;
+  for (size_t i = 0; i < num_added; ++i) {
+    const auto& out_param = incore_func->params_[orig_incore_param_count + i];
+    auto new_var = std::make_shared<Var>(out_param->name_hint_, out_param->GetType(), func->span_);
+    new_params.push_back(new_var);
+    new_dirs.push_back(ParamDirection::Out);
+    new_output_vars.push_back(new_var);
+  }
+
+  WrapperForwardMutator mutator(incore_added_outputs, transformed_incore_funcs, new_output_vars);
+  auto new_body = mutator.VisitStmt(func->body_);
+
+  std::vector<TypePtr> new_return_types = incore_func->return_types_;
+  auto new_func =
+      std::make_shared<Function>(func->name_, new_params, new_dirs, new_return_types, new_body, func->span_,
+                                 func->func_type_, func->level_, func->role_, func->attrs_);
+  return {new_func, num_added};
+}
+
+// ============================================================================
 // CallSiteUpdateMutator: updates call sites in orchestration/opaque functions.
-// For each call to a transformed InCore function, inserts tensor.create for
-// output params and adds them as extra arguments.
+// For each call to a transformed InCore function or a wrapper that has
+// absorbed output params, inserts tensor.create for each output param and
+// appends them as extra arguments.
 // ============================================================================
 
 class CallSiteUpdateMutator : public TypePropagatingMutator {
@@ -1511,17 +1673,46 @@ Pass ConvertTensorToTileOps() {
       }
     }
 
-    // Phase 2: Update call sites in non-InCore functions
-    std::vector<FunctionPtr> functions_phase2;
+    // Phase 2a: Propagate added output params through Spmd/Group wrappers so
+    // they remain transparent 1:1 forwarders of their params to the inner
+    // call (an invariant relied on by orchestration codegen).
+    std::unordered_map<std::string, size_t> wrapper_added_outputs;
+    std::unordered_map<std::string, FunctionPtr> transformed_wrapper_funcs;
+    std::vector<FunctionPtr> functions_phase2a;
+    functions_phase2a.reserve(functions_phase1.size());
     for (const auto& func : functions_phase1) {
-      if (func->func_type_ != FunctionType::InCore) {
-        functions_phase2.push_back(UpdateCallSites(func, incore_added_outputs, transformed_incore_funcs));
+      if (func->func_type_ == FunctionType::Spmd || func->func_type_ == FunctionType::Group) {
+        auto result = PropagateOutputsThroughWrapper(func, incore_added_outputs, transformed_incore_funcs);
+        functions_phase2a.push_back(result.func);
+        if (result.num_added_outputs > 0) {
+          wrapper_added_outputs[func->name_] = result.num_added_outputs;
+          transformed_wrapper_funcs[func->name_] = result.func;
+        }
       } else {
-        functions_phase2.push_back(func);
+        functions_phase2a.push_back(func);
       }
     }
 
-    return std::make_shared<Program>(functions_phase2, program->name_, program->span_);
+    // Phase 2b: Update call sites in orchestration/opaque functions. The
+    // callee map covers both transformed InCore functions and wrappers that
+    // absorbed their output params.
+    std::unordered_map<std::string, size_t> all_added_outputs = incore_added_outputs;
+    all_added_outputs.insert(wrapper_added_outputs.begin(), wrapper_added_outputs.end());
+    std::unordered_map<std::string, FunctionPtr> all_transformed_funcs = transformed_incore_funcs;
+    all_transformed_funcs.insert(transformed_wrapper_funcs.begin(), transformed_wrapper_funcs.end());
+
+    std::vector<FunctionPtr> functions_phase2b;
+    functions_phase2b.reserve(functions_phase2a.size());
+    for (const auto& func : functions_phase2a) {
+      if (func->func_type_ == FunctionType::InCore || func->func_type_ == FunctionType::Spmd ||
+          func->func_type_ == FunctionType::Group) {
+        functions_phase2b.push_back(func);
+      } else {
+        functions_phase2b.push_back(UpdateCallSites(func, all_added_outputs, all_transformed_funcs));
+      }
+    }
+
+    return std::make_shared<Program>(functions_phase2b, program->name_, program->span_);
   };
 
   return CreateProgramPass(pass_func, "ConvertTensorToTileOps", kConvertTensorToTileOpsProperties);

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -199,6 +199,34 @@ def _assert_convert_equal(before: ir.Program, expected: ir.Program) -> None:
     ir.assert_structural_equal(after, expected)
 
 
+class _FirstCallFinder(ir.IRVisitor):
+    """Record the first ``Call`` whose callee ``Op`` has the given name.
+
+    Matches both function-typed calls (``Call.op`` is a ``GlobalVar`` whose
+    ``name`` equals the function name) and op-typed calls (``Call.op`` is a
+    built-in ``Op``, e.g. ``"tensor.create"``).
+    """
+
+    def __init__(self, op_name: str) -> None:
+        super().__init__()
+        self.op_name = op_name
+        self.found: ir.Call | None = None
+
+    def visit_call(self, op: ir.Call) -> None:
+        if self.found is None and op.op.name == self.op_name:
+            self.found = op
+        super().visit_call(op)
+
+
+def _find_first_call_to(func: ir.Function, op_name: str) -> ir.Call | None:
+    """Return the first Call in ``func.body`` whose callee ``Op`` has name
+    ``op_name``. Used by wrapper-propagation tests to inspect per-call arg
+    counts after the pass rewrites them."""
+    finder = _FirstCallFinder(op_name)
+    finder.visit_stmt(func.body)
+    return finder.found
+
+
 # ---------------------------------------------------------------------------
 # Op family parametrization tables.
 # ---------------------------------------------------------------------------
@@ -1922,6 +1950,167 @@ class TestConvertGatherOp:
             tile_op=lambda ts: tile_ops.gather(ts[0], mask_pattern=1),
         )
         _assert_convert_equal(before, expected)
+
+
+class TestWrapperForwardPropagation:
+    """Phase 2a: propagate Phase-1 added Out params through Spmd/Group wrappers.
+
+    When TransformIncoreFunction appends Out tensor params to an InCore
+    signature, each Spmd/Group wrapper that forwards into that InCore must
+    mirror the appended params on its own signature and forward them through
+    the inner call — otherwise orchestration codegen's
+    BuildWrapperReorderedParams invariant (every inner-call Var arg maps to a
+    wrapper param) breaks and downstream codegen references an undeclared
+    identifier.
+    """
+
+    def test_spmd_wrapper_forwards_added_output(self):
+        """Spmd wrapper gains Out param mirroring the InCore's appended Out."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def wrapper(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.kernel(x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.wrapper(x)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+
+        kernel = After.get_function("kernel")
+        wrapper = After.get_function("wrapper")
+        main = After.get_function("main")
+        assert kernel is not None and wrapper is not None and main is not None
+
+        # InCore gained one Out param (Phase 1).
+        assert kernel.func_type == ir.FunctionType.InCore
+        assert len(kernel.params) == 2
+        assert kernel.param_directions[-1] == ir.ParamDirection.Out
+
+        # Wrapper mirrors the signature change (Phase 2a) — still Spmd, same
+        # attrs, one extra param matching the InCore's Out param type.
+        assert wrapper.func_type == ir.FunctionType.Spmd
+        assert wrapper.attrs.get("core_num") == 4
+        assert len(wrapper.params) == 2
+        assert wrapper.param_directions[0] == ir.ParamDirection.In
+        assert wrapper.param_directions[-1] == ir.ParamDirection.Out
+        assert ir.structural_equal(wrapper.params[-1].type, kernel.params[-1].type)
+
+        # Wrapper's inner call now forwards the new Out arg (1 in + 1 out).
+        inner_call = _find_first_call_to(wrapper, "kernel")
+        assert inner_call is not None
+        assert len(inner_call.args) == 2
+
+        # Orchestration allocates the Out tensor and passes it to the wrapper
+        # (Phase 2b, now covering both transformed InCore and transformed
+        # wrappers via the merged callee map).
+        assert main.func_type == ir.FunctionType.Orchestration
+        assert _find_first_call_to(main, "tensor.create") is not None
+        orch_call = _find_first_call_to(main, "wrapper")
+        assert orch_call is not None
+        assert len(orch_call.args) == 2
+
+    def test_group_wrapper_forwards_added_output(self):
+        """Group wrapper gains Out param mirroring the InCore's appended Out."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Group)
+            def wrapper(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.kernel(x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.wrapper(x)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+
+        kernel = After.get_function("kernel")
+        wrapper = After.get_function("wrapper")
+        main = After.get_function("main")
+        assert kernel is not None and wrapper is not None and main is not None
+
+        assert wrapper.func_type == ir.FunctionType.Group
+        assert len(wrapper.params) == 2
+        assert wrapper.param_directions[-1] == ir.ParamDirection.Out
+        assert ir.structural_equal(wrapper.params[-1].type, kernel.params[-1].type)
+
+        inner_call = _find_first_call_to(wrapper, "kernel")
+        assert inner_call is not None
+        assert len(inner_call.args) == 2
+
+        orch_call = _find_first_call_to(main, "wrapper")
+        assert orch_call is not None
+        assert len(orch_call.args) == 2
+
+    def test_wrapper_without_transformed_incore_unchanged(self):
+        """Wrapper that does NOT forward to a transformed InCore is pass-through.
+
+        The callee InCore is already pure-tile (no tensor ops to lower), so
+        Phase 1 appends zero Out params, ForwardedCallFinder finds no
+        matching call, and Phase 2a leaves the wrapper's signature and its
+        inner call arg list unchanged.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.add(x_tile, x_tile)
+                out_: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out)
+                return out_
+
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def wrapper(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out_: pl.Tensor[[64], pl.FP32] = self.kernel(x, out)
+                return out_
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out_: pl.Tensor[[64], pl.FP32] = self.wrapper(x, out)
+                return out_
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+
+        before_wrapper = Before.get_function("wrapper")
+        after_wrapper = After.get_function("wrapper")
+        assert before_wrapper is not None and after_wrapper is not None
+        # Wrapper's signature and call-forwarding are untouched by Phase 2a.
+        assert len(after_wrapper.params) == len(before_wrapper.params)
+        assert after_wrapper.param_directions == before_wrapper.param_directions
+        inner_call = _find_first_call_to(after_wrapper, "kernel")
+        before_inner_call = _find_first_call_to(before_wrapper, "kernel")
+        assert inner_call is not None and before_inner_call is not None
+        assert len(inner_call.args) == len(before_inner_call.args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When `TransformIncoreFunction` (Phase 1 of `ConvertTensorToTileOps`) appends
`Out` tensor params to an InCore signature, Phase 2 only updated orchestration
/ opaque call sites. Spmd/Group wrappers produced by `OutlineClusterScopes`
that forward to that InCore were left unchanged, violating the
`BuildWrapperReorderedParams` invariant at
`src/codegen/orchestration/orchestration_codegen.cpp:618` that every
inner-call `Var` arg resolves 1:1 to a wrapper param. Downstream
orchestration codegen then referenced an undeclared identifier
(`out__ssa_v1` in the qwen3 MLP-down failure that motivated the fix).

This PR splits Phase 2 into:

- **Phase 2a** (`PropagateOutputsThroughWrapper`): mirrors the InCore's
  appended `Out` params on each Spmd/Group wrapper and forwards them through
  the inner call. `ForwardedCallFinder` locates the single inner call
  (the outlining invariant guarantees exactly one; `WrapperForwardMutator`'s
  `applied_` flag enforces it via `INTERNAL_CHECK_SPAN`).
  `WrapperForwardMutator` rewrites the call's args and return type — it does
  **not** synthesise `tensor.create` in the wrapper body; allocation remains
  the caller's responsibility.
- **Phase 2b** (`UpdateCallSites`): uses a merged callee map covering both
  transformed InCore and transformed wrappers. InCore / Spmd / Group are
  explicitly skipped — they were already rewritten in Phase 1 / 2a.

## Edge cases

- Wrappers that don't forward to a transformed InCore are passed through
  unchanged (`ForwardedCallFinder` returns null → early return in
  `PropagateOutputsThroughWrapper`).
- `WrapperForwardMutator::applied_` enforces "exactly one forwarded call" per
  wrapper, matching the outlining invariant for Spmd/Group wrappers.
  Violations produce `INTERNAL_CHECK_SPAN`, not silent miscompiles.
- The new wrapper `Out` param reuses the InCore param's `name_hint_`; the
  outlined-wrapper naming convention makes collisions unlikely.

## Test plan

- [x] New `TestWrapperForwardPropagation` adds three cases:
  - `test_spmd_wrapper_forwards_added_output` — Spmd wrapper gains matching
    `Out` param; inner call gets the new forward arg; orchestration
    allocates the tensor and passes it.
  - `test_group_wrapper_forwards_added_output` — same shape for a Group
    wrapper.
  - `test_wrapper_without_transformed_incore_unchanged` — wrapper whose
    callee InCore already has no tensor ops is left untouched.
- [x] Sanity-checked: without the patch, the Spmd/Group tests fail on
  `len(wrapper.params) == 2` (wrapper stays 1-param); with the patch they
  pass. The negative case passes either way.
- [x] `tests/ut/ir/transforms/` full sweep: 1114 passed, 12 skipped.
- [x] `clang-tidy --diff-base HEAD` clean.
- [x] Pre-commit hooks (clang-format, cpplint, markdownlint-cli2, ruff,
  pyright) all pass.

## Docs

Updates `docs/en/dev/passes/09-convert_tensor_to_tile_ops.md` and the
Chinese mirror to describe the new Phase 2a / 2b split, list the new
`ForwardedCallFinder` / `WrapperForwardMutator` components, and correct
the Scope table entry for Spmd / Group wrappers.