### PR TITLE
feat(jit): allow Python-style variable rebinding in @pl.jit

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -92,7 +92,7 @@ def _rewrite_jit_error(exc: Exception, rename_map: dict[str, str]) -> Exception:
         new_exc = copy.copy(exc)
         new_exc.args = (msg,)
         if hasattr(new_exc, "message"):
-            new_exc.message = msg
+            object.__setattr__(new_exc, "message", msg)
     except Exception:  # noqa: BLE001
         # If copy fails (e.g. non-standard __init__), fall back to plain Exception.
         new_exc = Exception(msg)

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import ast
 import inspect
 import os
+import re
 import shutil
 import textwrap
 from typing import Any
@@ -62,6 +63,33 @@ from .specializer import (
     _collect_dynamic_dims,
     build_specialize_context,
 )
+
+# ---------------------------------------------------------------------------
+# Error message rewriting for JIT compilation
+# ---------------------------------------------------------------------------
+
+
+def _rewrite_jit_error(exc: Exception, rename_map: dict[str, str]) -> Exception:
+    """Replace internal alpha-renamed aliases (e.g. ``x_v1``) with the user's
+    original variable name (``x``) in the exception message.
+
+    Uses word-boundary matching to avoid partial replacements (e.g. replacing
+    ``max_v1`` when the alias is ``x_v1``). Sorts aliases longest-first so
+    longer aliases are matched before any shorter prefix aliases.
+    """
+    if not rename_map:
+        return exc
+    msg = str(exc)
+    for alias in sorted(rename_map, key=len, reverse=True):
+        original = rename_map[alias]
+        msg = re.sub(rf"\b{re.escape(alias)}\b", original, msg)
+    if msg == str(exc):
+        return exc
+    new_exc = type(exc)(msg)
+    new_exc.__cause__ = exc.__cause__
+    new_exc.__suppress_context__ = exc.__suppress_context__
+    return new_exc
+
 
 # ---------------------------------------------------------------------------
 # torch-optional dtype conversion
@@ -639,10 +667,15 @@ class JITFunction:
         dynvar_bindings, dynvar_literals = _build_dynvar_bindings(contexts)
         _backfill_entry_dynvar_bindings(self._func, self._get_deps(), dynvar_bindings, dynvar_literals)
         class_name = f"_jit_{self.__name__}_{self._get_source_hash()}"
-        source = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals).specialize()
-        parsed = pl.parse(source)
-        skip_ptoas = not _ptoas_available()
-        return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform)
+        specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
+        source = specializer.specialize()
+        rename_map = specializer.rename_map
+        try:
+            parsed = pl.parse(source)
+            skip_ptoas = not _ptoas_available()
+            return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform)
+        except Exception as exc:
+            raise _rewrite_jit_error(exc, rename_map) from exc.__cause__
 
     def _compile_to_program(
         self,
@@ -662,8 +695,13 @@ class JITFunction:
         dynvar_bindings, dynvar_literals = _build_dynvar_bindings(contexts)
         _backfill_entry_dynvar_bindings(self._func, self._get_deps(), dynvar_bindings, dynvar_literals)
         class_name = f"_jit_{self.__name__}_{self._get_source_hash()}"
-        source = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals).specialize()
-        return pl.parse(source)
+        specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
+        source = specializer.specialize()
+        rename_map = specializer.rename_map
+        try:
+            return pl.parse(source)
+        except Exception as exc:
+            raise _rewrite_jit_error(exc, rename_map) from exc.__cause__
 
     def _build_contexts(
         self,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -46,6 +46,7 @@ JITFunction.__call__ flow
 from __future__ import annotations
 
 import ast
+import copy
 import inspect
 import os
 import re
@@ -85,14 +86,16 @@ def _rewrite_jit_error(exc: Exception, rename_map: dict[str, str]) -> Exception:
         msg = re.sub(rf"\b{re.escape(alias)}\b", original, msg)
     if msg == str(exc):
         return exc
+    # Use copy.copy to preserve all exception fields (span, hint, note,
+    # source_lines for ParserError subclasses) then patch the message.
     try:
-        new_exc = type(exc)(msg)
+        new_exc = copy.copy(exc)
+        new_exc.args = (msg,)
+        if hasattr(new_exc, "message"):
+            new_exc.message = msg
     except Exception:  # noqa: BLE001
-        # Custom exception constructors may have non-standard signatures;
-        # fall back to a plain exception of the same type to avoid masking.
+        # If copy fails (e.g. non-standard __init__), fall back to plain Exception.
         new_exc = Exception(msg)
-    new_exc.__cause__ = exc.__cause__
-    new_exc.__suppress_context__ = exc.__suppress_context__
     return new_exc
 
 
@@ -680,7 +683,10 @@ class JITFunction:
             skip_ptoas = not _ptoas_available()
             return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform)
         except Exception as exc:
-            raise _rewrite_jit_error(exc, rename_map) from exc
+            rewritten = _rewrite_jit_error(exc, rename_map)
+            if rewritten is exc:
+                raise
+            raise rewritten from exc
 
     def _compile_to_program(
         self,
@@ -706,7 +712,10 @@ class JITFunction:
         try:
             return pl.parse(source)
         except Exception as exc:
-            raise _rewrite_jit_error(exc, rename_map) from exc
+            rewritten = _rewrite_jit_error(exc, rename_map)
+            if rewritten is exc:
+                raise
+            raise rewritten from exc
 
     def _build_contexts(
         self,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -85,7 +85,12 @@ def _rewrite_jit_error(exc: Exception, rename_map: dict[str, str]) -> Exception:
         msg = re.sub(rf"\b{re.escape(alias)}\b", original, msg)
     if msg == str(exc):
         return exc
-    new_exc = type(exc)(msg)
+    try:
+        new_exc = type(exc)(msg)
+    except Exception:  # noqa: BLE001
+        # Custom exception constructors may have non-standard signatures;
+        # fall back to a plain exception of the same type to avoid masking.
+        new_exc = Exception(msg)
     new_exc.__cause__ = exc.__cause__
     new_exc.__suppress_context__ = exc.__suppress_context__
     return new_exc
@@ -675,7 +680,7 @@ class JITFunction:
             skip_ptoas = not _ptoas_available()
             return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform)
         except Exception as exc:
-            raise _rewrite_jit_error(exc, rename_map) from exc.__cause__
+            raise _rewrite_jit_error(exc, rename_map) from exc
 
     def _compile_to_program(
         self,
@@ -701,7 +706,7 @@ class JITFunction:
         try:
             return pl.parse(source)
         except Exception as exc:
-            raise _rewrite_jit_error(exc, rename_map) from exc.__cause__
+            raise _rewrite_jit_error(exc, rename_map) from exc
 
     def _build_contexts(
         self,

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -620,6 +620,21 @@ class _BodyTransformer(ast.NodeTransformer):
         self._scope_depth -= 1
         return node
 
+    def visit_If(self, node: ast.If) -> ast.stmt:
+        """Visit If statement, incrementing scope depth for both branches.
+
+        If-branch assignments are loop-carried in the Parser's view (variables
+        leak to outer scope via exit_scope(leak_vars=True)) so they must NOT be
+        alpha-renamed at this layer — the Parser and ConvertToSSA handle them.
+        """
+        node.test = self.visit(node.test)
+        self._scope_depth += 1
+        node.body = self._visit_scoped_body(node.body)
+        if node.orelse:
+            node.orelse = self._visit_scoped_body(node.orelse)
+        self._scope_depth -= 1
+        return node
+
     def visit_With(self, node: ast.With) -> ast.stmt:
         """Visit With block, incrementing scope depth for its body."""
         node.items = [self.visit(item) for item in node.items]

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -385,6 +385,12 @@ class _BodyTransformer(ast.NodeTransformer):
                 )
                 ast.fix_missing_locations(new_node)
                 return new_node
+            # Deeper scope: if the variable has an active rename (from a bridge
+            # assignment), apply it to the LHS so the loop body consistently
+            # uses the renamed alias (e.g. x_v1 = some_op(x_v1)).
+            if var_name in self._var_renames:
+                renamed = self._var_renames[var_name]
+                node.targets = [ast.Name(id=renamed, ctx=ast.Store())]
             node.value = visited_value
             return node
         # First assignment: record and keep original name.
@@ -612,12 +618,91 @@ class _BodyTransformer(ast.NodeTransformer):
                 result.append(visited)
         return result or [ast.Pass()]
 
-    def visit_For(self, node: ast.For) -> ast.stmt:
-        """Visit For loop, incrementing scope depth for its body."""
+    def _scan_for_rebinds(self, statements: list[ast.stmt]) -> list[str]:
+        """Scan a body for variable names that would trigger alpha-renaming.
+
+        Returns variable names that are already in ``_assign_count`` and whose
+        first assignment was at the same scope depth as the current depth.
+        These need bridge assignments (``x_v1 = x``) before entering the scope
+        so that loop-carried reads inside the body resolve to the new alias.
+        """
+        rebind_vars: list[str] = []
+        seen: set[str] = set()
+        for stmt in statements:
+            # Check direct single-target assignments
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+                target = stmt.targets[0]
+                if isinstance(target, ast.Name):
+                    name = target.id
+                    if (
+                        name not in seen
+                        and name in self._assign_count
+                        and self._scope_depth == self._assign_depth.get(name, -1)
+                    ):
+                        rebind_vars.append(name)
+                        seen.add(name)
+            # Check annotated assignments
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                name = stmt.target.id
+                if (
+                    name not in seen
+                    and name in self._assign_count
+                    and self._scope_depth == self._assign_depth.get(name, -1)
+                ):
+                    rebind_vars.append(name)
+                    seen.add(name)
+        return rebind_vars
+
+    def _make_bridge_assignments(self, rebind_vars: list[str]) -> list[ast.stmt]:
+        """Create bridge assignments (``x_v1 = x``) and apply renames for each variable.
+
+        After this call, ``_var_renames`` is updated so that subsequent reads of the
+        original name resolve to the new alias.  The ``_assign_depth`` is updated to
+        the current (outer) scope depth so that assignments inside the loop body are
+        treated as deeper-scope (loop-carried) and NOT renamed again.
+
+        The returned statements should be inserted before the scope that contains
+        the rebinding assignments.
+        """
+        bridges: list[ast.stmt] = []
+        for var_name in rebind_vars:
+            # Get the current read-name for this variable (could already be an alias)
+            current_name = self._var_renames.get(var_name, var_name)
+            new_name = self._rebind(var_name)
+            # Update assign_depth to the outer scope so the loop body sees a
+            # depth mismatch and does NOT trigger another rebind.
+            self._assign_depth[var_name] = self._scope_depth
+            bridge = ast.Assign(
+                targets=[ast.Name(id=new_name, ctx=ast.Store())],
+                value=ast.Name(id=current_name, ctx=ast.Load()),
+                lineno=0,
+                col_offset=0,
+            )
+            ast.fix_missing_locations(bridge)
+            bridges.append(bridge)
+        return bridges
+
+    def visit_For(self, node: ast.For) -> ast.stmt | list[ast.stmt]:
+        """Visit For loop, incrementing scope depth for its body.
+
+        Before entering the body, scan for variables that would be rebound at
+        the same depth.  For each such variable, insert a bridge assignment
+        (``x_v1 = x``) before the loop and apply the rename so that both LHS
+        and RHS inside the loop body use the new alias.  This preserves
+        loop-carried semantics when two parallel for loops assign to the same
+        variable.
+        """
         node.iter = self.visit(node.iter)
+        self._scope_depth += 1
+        # Scan for rebinds and insert bridge assignments before the loop
+        rebind_vars = self._scan_for_rebinds(node.body)
+        self._scope_depth -= 1
+        bridges = self._make_bridge_assignments(rebind_vars)
         self._scope_depth += 1
         node.body = self._visit_scoped_body(node.body)
         self._scope_depth -= 1
+        if bridges:
+            return bridges + [node]
         return node
 
     def visit_If(self, node: ast.If) -> ast.stmt:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -307,7 +307,7 @@ class _BodyTransformer(ast.NodeTransformer):
         # to inline constants and by visit_Assign to suppress the assignment.
         self._shape_inlined: dict[str, int] = {}
         # Alpha-renaming support: tracks how many times each local has been assigned
-        # (so we can generate x__1, x__2, ... on rebindings).
+        # (so we can generate x_v1, x_v2, ... on rebindings).
         self._assign_count: dict[str, int] = {}
         # Maps local variable name → current (latest) renamed alias.
         # Empty until the variable is assigned a second time.

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -293,6 +293,8 @@ class _BodyTransformer(ast.NodeTransformer):
         dynvar_python_names: dict[str, str],
         dep_names: set[str],
         dynvar_var_names: set[str],
+        param_names: list[str] | None = None,
+        initial_used_names: set[str] | None = None,
     ) -> None:
         super().__init__()
         self._meta = tensor_meta
@@ -320,6 +322,15 @@ class _BodyTransformer(ast.NodeTransformer):
         # updates and must NOT be renamed.
         self._assign_depth: dict[str, int] = {}
         self._scope_depth: int = 0
+        # Pre-register function parameters as "already assigned at depth 0" so
+        # that body assignments like `x = pl.load(x, ...)` are treated as
+        # rebindings and get alpha-renamed to `x_v1`.
+        for name in param_names or []:
+            self._assign_count[name] = 1
+            self._assign_depth[name] = 0
+        # Track all names pre-defined by the user (params + all Store targets) to
+        # avoid generating aliases that collide with user-defined variables.
+        self._used_names: set[str] = (initial_used_names or set()) | set(param_names or [])
 
     # ------------------------------------------------------------------
     # Helpers
@@ -330,18 +341,25 @@ class _BodyTransformer(ast.NodeTransformer):
         if var_name not in self._assign_count:
             self._assign_count[var_name] = 1
             self._assign_depth[var_name] = self._scope_depth
+        self._used_names.add(var_name)
 
     def _rebind(self, var_name: str) -> str:
         """Generate a fresh name for a rebinding of ``var_name``.
 
         Returns the new name and updates ``_var_renames`` so subsequent reads
-        of ``var_name`` resolve to the new alias.
+        of ``var_name`` resolve to the new alias.  Skips candidate names that
+        are already used by the user to avoid collisions.
         """
         count = self._assign_count[var_name]
         new_name = f"{var_name}_v{count}"
-        self._assign_count[var_name] += 1
+        # Skip any candidate that collides with a user-defined name.
+        while new_name in self._used_names:
+            count += 1
+            new_name = f"{var_name}_v{count}"
+        self._assign_count[var_name] = count + 1
         self._var_renames[var_name] = new_name
         self._alias_to_original[new_name] = var_name
+        self._used_names.add(new_name)
         return new_name
 
     @property
@@ -618,7 +636,6 @@ class _BodyTransformer(ast.NodeTransformer):
 
 def _infer_return_type(
     func_def: ast.FunctionDef,
-    param_names: list[str],
     tensor_meta: dict[str, TensorMeta],
     dynamic_dims: set[tuple[str, int]],
     dynvar_names: dict[str, str],
@@ -900,7 +917,6 @@ class Specializer:
         # Infer return type
         ret_type = _infer_return_type(
             func_def,
-            all_param_names,
             ctx.tensor_meta,
             ctx.dynamic_dims,
             self._dv_bindings,
@@ -911,6 +927,12 @@ class Specializer:
         # Transform body
         dep_names = set(ctx.dep_names)
         dynvar_var_names = set(self._iter_dynvar_names(ctx))
+        # Collect all names defined anywhere in the function to seed collision avoidance.
+        all_defined = {
+            node.id
+            for node in ast.walk(func_def)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+        }
         transformer = _BodyTransformer(
             tensor_meta=ctx.tensor_meta,
             scalar_values=ctx.scalar_values,
@@ -918,10 +940,17 @@ class Specializer:
             dynvar_python_names=self._dv_bindings,
             dep_names=dep_names,
             dynvar_var_names=dynvar_var_names,
+            param_names=all_param_names,
+            initial_used_names=all_defined,
         )
         new_body = [transformer.visit(stmt) for stmt in func_def.body]
         # Accumulate alias→original renames for error message rewriting.
-        self._rename_map.update(transformer.rename_map)
+        # Don't overwrite entries from earlier functions — in multi-function JIT,
+        # two functions may independently generate the same alias (e.g. t_v1) for
+        # different user variables.  First-seen wins; per-function context is more
+        # accurate than a global override.
+        for alias, original in transformer.rename_map.items():
+            self._rename_map.setdefault(alias, original)
         # Filter out None (deleted statements) and flatten lists
         flat_body: list[ast.stmt] = []
         for item in new_body:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -445,22 +445,29 @@ class _BodyTransformer(ast.NodeTransformer):
                 stmts: list[ast.stmt] = []
                 for tgt, (i, dim) in zip(target_names, enumerate(meta.shape)):
                     if isinstance(tgt, ast.Name):
-                        self._record_first_assign(tgt.id)
                         if (param_name, i) in self._dynamic_dims:
                             # Dynamic dim: emit assignment (M = <dynvar ref>),
                             # but skip if it would be a no-op (LHS name == RHS name).
                             val: ast.expr = self._shape_dim_node(param_name, i)
                             if not (isinstance(val, ast.Name) and val.id == tgt.id):
+                                lhs_name = tgt.id
+                                if lhs_name in self._assign_count:
+                                    lhs_name = self._rebind(lhs_name)
+                                else:
+                                    self._record_first_assign(tgt.id)
                                 stmts.append(
                                     ast.Assign(
-                                        targets=[ast.Name(id=tgt.id, ctx=ast.Store())],
+                                        targets=[ast.Name(id=lhs_name, ctx=ast.Store())],
                                         value=val,
                                         lineno=node.lineno,
                                         col_offset=node.col_offset,
                                     )
                                 )
+                            else:
+                                self._record_first_assign(tgt.id)
                         else:
                             # Static dim: inline constant, suppress assignment
+                            self._record_first_assign(tgt.id)
                             self._shape_inlined[tgt.id] = dim
                 return stmts if stmts else None
 
@@ -491,6 +498,31 @@ class _BodyTransformer(ast.NodeTransformer):
 
         return cast("ast.stmt", self.generic_visit(node))
 
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.stmt | None:
+        """Handle annotated assignments (``x: T = value``) with alpha-renaming."""
+        if node.value is None:
+            return cast("ast.stmt", self.generic_visit(node))
+        if not isinstance(node.target, ast.Name):
+            return cast("ast.stmt", self.generic_visit(node))
+        var_name = node.target.id
+        node.value = self.visit(node.value)
+        if var_name in self._assign_count:
+            if self._scope_depth == self._assign_depth[var_name]:
+                new_name = self._rebind(var_name)
+                new_node = ast.AnnAssign(
+                    target=ast.Name(id=new_name, ctx=ast.Store()),
+                    annotation=node.annotation,
+                    value=node.value,
+                    simple=node.simple,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                )
+                ast.fix_missing_locations(new_node)
+                return new_node
+        else:
+            self._record_first_assign(var_name)
+        return cast("ast.stmt", node)
+
     # ------------------------------------------------------------------
     # Expression-level transforms
     # ------------------------------------------------------------------
@@ -498,12 +530,13 @@ class _BodyTransformer(ast.NodeTransformer):
     def visit_Name(self, node: ast.Name) -> ast.expr:
         """Replace scalar param references, inlined shape constants, and renamed rebindings."""
         if isinstance(node.ctx, ast.Load):
+            # Check active renames first — a rebinding supersedes any earlier inlining.
+            if node.id in self._var_renames:
+                return ast.Name(id=self._var_renames[node.id], ctx=ast.Load())
             if node.id in self._scalars:
                 return ast.Constant(value=self._scalars[node.id])
             if node.id in self._shape_inlined:
                 return ast.Constant(value=self._shape_inlined[node.id])
-            if node.id in self._var_renames:
-                return ast.Name(id=self._var_renames[node.id], ctx=ast.Load())
         return node
 
     def visit_Attribute(self, node: ast.Attribute) -> ast.expr:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -306,10 +306,73 @@ class _BodyTransformer(ast.NodeTransformer):
         # constant values when all dimensions are static.  Used by visit_Name
         # to inline constants and by visit_Assign to suppress the assignment.
         self._shape_inlined: dict[str, int] = {}
+        # Alpha-renaming support: tracks how many times each local has been assigned
+        # (so we can generate x__1, x__2, ... on rebindings).
+        self._assign_count: dict[str, int] = {}
+        # Maps local variable name → current (latest) renamed alias.
+        # Empty until the variable is assigned a second time.
+        self._var_renames: dict[str, str] = {}
+        # Reverse map: generated alias → original user variable name.
+        # Used to rewrite error messages so users see their original names.
+        self._alias_to_original: dict[str, str] = {}
+        # Tracks the scope depth at which each variable was first assigned.
+        # Rebindings at a deeper scope (e.g. inside a for/with) are loop-carried
+        # updates and must NOT be renamed.
+        self._assign_depth: dict[str, int] = {}
+        self._scope_depth: int = 0
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _record_first_assign(self, var_name: str) -> None:
+        """Record a first (or tuple-unpack) assignment so later rebindings can be renamed."""
+        if var_name not in self._assign_count:
+            self._assign_count[var_name] = 1
+            self._assign_depth[var_name] = self._scope_depth
+
+    def _rebind(self, var_name: str) -> str:
+        """Generate a fresh name for a rebinding of ``var_name``.
+
+        Returns the new name and updates ``_var_renames`` so subsequent reads
+        of ``var_name`` resolve to the new alias.
+        """
+        count = self._assign_count[var_name]
+        new_name = f"{var_name}_v{count}"
+        self._assign_count[var_name] += 1
+        self._var_renames[var_name] = new_name
+        self._alias_to_original[new_name] = var_name
+        return new_name
+
+    @property
+    def rename_map(self) -> dict[str, str]:
+        """Return mapping from generated alias → original user variable name."""
+        return dict(self._alias_to_original)
+
+    def _visit_simple_assign(self, node: ast.Assign) -> ast.stmt:
+        """Handle a single-target name assignment with alpha-renaming support."""
+        var_name = cast(ast.Name, node.targets[0]).id
+        visited_value = self.visit(node.value)
+        if var_name in self._assign_count:
+            # Only rename at the same scope where the variable was first defined.
+            # Rebindings at a deeper scope (inside for/with) are loop-carried
+            # updates — do not rename them.
+            if self._scope_depth == self._assign_depth[var_name]:
+                new_name = self._rebind(var_name)
+                new_node = ast.Assign(
+                    targets=[ast.Name(id=new_name, ctx=ast.Store())],
+                    value=visited_value,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                )
+                ast.fix_missing_locations(new_node)
+                return new_node
+            node.value = visited_value
+            return node
+        # First assignment: record and keep original name.
+        self._record_first_assign(var_name)
+        node.value = visited_value
+        return node
 
     def _shape_tuple_node(self, param_name: str) -> ast.Tuple:
         meta = self._meta[param_name]
@@ -382,6 +445,7 @@ class _BodyTransformer(ast.NodeTransformer):
                 stmts: list[ast.stmt] = []
                 for tgt, (i, dim) in zip(target_names, enumerate(meta.shape)):
                     if isinstance(tgt, ast.Name):
+                        self._record_first_assign(tgt.id)
                         if (param_name, i) in self._dynamic_dims:
                             # Dynamic dim: emit assignment (M = <dynvar ref>),
                             # but skip if it would be a no-op (LHS name == RHS name).
@@ -417,7 +481,13 @@ class _BodyTransformer(ast.NodeTransformer):
             if (param_name, dim_idx) not in self._dynamic_dims:
                 meta = self._meta[param_name]
                 self._shape_inlined[node.targets[0].id] = meta.shape[dim_idx]
+                self._record_first_assign(node.targets[0].id)
                 return None
+
+        # Default: visit the RHS first (applies existing renames to operands),
+        # then handle rebinding rename on the LHS.
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            return self._visit_simple_assign(node)
 
         return cast("ast.stmt", self.generic_visit(node))
 
@@ -426,12 +496,14 @@ class _BodyTransformer(ast.NodeTransformer):
     # ------------------------------------------------------------------
 
     def visit_Name(self, node: ast.Name) -> ast.expr:
-        """Replace scalar param references and inlined shape constants."""
+        """Replace scalar param references, inlined shape constants, and renamed rebindings."""
         if isinstance(node.ctx, ast.Load):
             if node.id in self._scalars:
                 return ast.Constant(value=self._scalars[node.id])
             if node.id in self._shape_inlined:
                 return ast.Constant(value=self._shape_inlined[node.id])
+            if node.id in self._var_renames:
+                return ast.Name(id=self._var_renames[node.id], ctx=ast.Load())
         return node
 
     def visit_Attribute(self, node: ast.Attribute) -> ast.expr:
@@ -475,6 +547,35 @@ class _BodyTransformer(ast.NodeTransformer):
             ast.copy_location(new_node, node)
             return cast("ast.expr", self.generic_visit(new_node))
         return cast("ast.expr", self.generic_visit(node))
+
+    def _visit_scoped_body(self, statements: list[ast.stmt]) -> list[ast.stmt]:
+        """Visit statements within a nested scope, flattening lists and dropping None."""
+        result: list[ast.stmt] = []
+        for stmt in statements:
+            visited = self.visit(stmt)
+            if visited is None:
+                pass
+            elif isinstance(visited, list):
+                result.extend(visited)
+            else:
+                result.append(visited)
+        return result or [ast.Pass()]
+
+    def visit_For(self, node: ast.For) -> ast.stmt:
+        """Visit For loop, incrementing scope depth for its body."""
+        node.iter = self.visit(node.iter)
+        self._scope_depth += 1
+        node.body = self._visit_scoped_body(node.body)
+        self._scope_depth -= 1
+        return node
+
+    def visit_With(self, node: ast.With) -> ast.stmt:
+        """Visit With block, incrementing scope depth for its body."""
+        node.items = [self.visit(item) for item in node.items]
+        self._scope_depth += 1
+        node.body = self._visit_scoped_body(node.body)
+        self._scope_depth -= 1
+        return node
 
 
 # ---------------------------------------------------------------------------
@@ -683,6 +784,16 @@ class Specializer:
         self._contexts = contexts
         self._dv_bindings = dynvar_bindings
         self._dv_literals = dynvar_literals or {}
+        # Accumulated alias→original map across all specialized functions.
+        self._rename_map: dict[str, str] = {}
+
+    @property
+    def rename_map(self) -> dict[str, str]:
+        """Return mapping from generated alias → original user variable name.
+
+        Only populated after ``specialize()`` has been called.
+        """
+        return dict(self._rename_map)
 
     def specialize(self) -> str:
         """Generate @pl.program source code string.
@@ -776,6 +887,8 @@ class Specializer:
             dynvar_var_names=dynvar_var_names,
         )
         new_body = [transformer.visit(stmt) for stmt in func_def.body]
+        # Accumulate alias→original renames for error message rewriting.
+        self._rename_map.update(transformer.rename_map)
         # Filter out None (deleted statements) and flatten lists
         flat_body: list[ast.stmt] = []
         for item in new_body:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -531,6 +531,19 @@ class TestVariableRebinding:
         assert "t_v10" not in str(rewritten)
         assert "t_v1" not in str(rewritten)
 
+    def test_rewrite_non_standard_exception_falls_back(self):
+        """Exceptions with non-standard constructors fall back to plain Exception."""
+
+        class WeirdError(Exception):
+            def __init__(self, code: int, msg: str) -> None:
+                super().__init__(msg)
+                self.code = code
+
+        exc = WeirdError(42, "Variable 'x_v1' is invalid")
+        result = _rewrite_jit_error(exc, {"x_v1": "x"})
+        assert "x_v1" not in str(result)
+        assert "x" in str(result)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -15,6 +15,7 @@ from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import JITFunction, _discover_deps, _rewrite_jit_error, jit
 from pypto.jit.specializer import TensorMeta
+from pypto.language.parser.diagnostics.exceptions import ParserTypeError
 from pypto.pypto_core import DataType, ir
 
 # ---------------------------------------------------------------------------
@@ -531,8 +532,18 @@ class TestVariableRebinding:
         assert "t_v10" not in str(rewritten)
         assert "t_v1" not in str(rewritten)
 
+    def test_rewrite_preserves_exception_fields(self):
+        """copy.copy preserves extra fields (e.g. message) for ParserError-style exceptions."""
+        exc = ParserTypeError("Variable 'x_v1' has wrong type", hint="use x instead")
+        result = _rewrite_jit_error(exc, {"x_v1": "x"})
+        assert "x_v1" not in str(result)
+        assert "x" in str(result)
+        # Extra fields are preserved via copy.copy
+        assert isinstance(result, ParserTypeError)
+        assert result.hint == "use x instead"  # type: ignore[attr-defined]
+
     def test_rewrite_non_standard_exception_falls_back(self):
-        """Exceptions with non-standard constructors fall back to plain Exception."""
+        """Exceptions where copy.copy fails fall back to plain Exception."""
 
         class WeirdError(Exception):
             def __init__(self, code: int, msg: str) -> None:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -13,8 +13,9 @@ import pypto.language as pl
 import pytest
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.compiled_program import CompiledProgram
-from pypto.jit.decorator import JITFunction, _discover_deps, jit
-from pypto.pypto_core import ir
+from pypto.jit.decorator import JITFunction, _discover_deps, _rewrite_jit_error, jit
+from pypto.jit.specializer import TensorMeta
+from pypto.pypto_core import DataType, ir
 
 # ---------------------------------------------------------------------------
 # Decoration tests (no torch needed)
@@ -474,6 +475,61 @@ class TestRoundTrip:
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         expected_post_pass = pm.run_passes(Expected)
         ir.assert_structural_equal(got, expected_post_pass)
+
+
+# ---------------------------------------------------------------------------
+# Variable rebinding (Issue #1121)
+# ---------------------------------------------------------------------------
+
+
+class TestVariableRebinding:
+    """Tests for Python-style variable rebinding in @pl.jit (Issue #1121)."""
+
+    def test_rebind_same_type_compiles(self):
+        """Rebinding a Tile variable to a new Tile value must compile without error."""
+
+        @jit
+        def kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                t = pl.load(x, [0, 0], [128, 128])
+                t = pl.mul(t, t)  # rebind: Tile → Tile (same type)
+                pl.store(t, [0, 0], out)
+            return out
+
+        result = kernel._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((128, 128), DataType.FP32),
+                "out": TensorMeta((128, 128), DataType.FP32),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            dynamic_dims=set(),
+            pl=pl,
+        )
+        assert result is not None
+
+    def test_rebind_error_shows_original_name(self):
+        """When a JIT compilation error occurs, error messages must show the
+        user's original variable name, not the internal renamed alias."""
+        rename_map = {"t_v1": "t", "x_v2": "x"}
+        exc = ValueError("Variable 't_v1' has type Tile but expected Scalar")
+        rewritten = _rewrite_jit_error(exc, rename_map)
+        assert "t_v1" not in str(rewritten)
+        assert "'t'" in str(rewritten)
+
+    def test_no_rename_map_returns_original_exception(self):
+        """With an empty rename map, the original exception object is returned."""
+        exc = ValueError("some error")
+        result = _rewrite_jit_error(exc, {})
+        assert result is exc
+
+    def test_rebind_longer_alias_replaced_first(self):
+        """Longer aliases are replaced before shorter ones to avoid partial matches."""
+        rename_map = {"t_v1": "t", "t_v10": "t"}
+        exc = ValueError("'t_v10' and 't_v1' are both invalid")
+        rewritten = _rewrite_jit_error(exc, rename_map)
+        assert "t_v10" not in str(rewritten)
+        assert "t_v1" not in str(rewritten)
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -791,6 +791,40 @@ class TestVariableRebinding:
         assert "x_v2 =" in out
         assert "x_v1 = b" in out
 
+    def test_if_branch_rebind_not_renamed(self):
+        """Assignments inside if branches are not alpha-renamed.
+
+        The Parser handles if-branch variables via leak_vars=True (variables
+        are visible after the if), so renaming here would produce an alias
+        that only conditionally exists, breaking code after the if.
+        """
+        src = """
+            def f():
+                t = a
+                if cond:
+                    t = b
+                y = t
+        """
+        out = self._transform(src)
+        # t inside the if must NOT be renamed — it should remain 't = b'
+        assert "t_v1" not in out
+        assert "y = t" in out
+
+    def test_if_else_branch_rebind_not_renamed(self):
+        """Assignments in both if/else branches are not alpha-renamed."""
+        src = """
+            def f():
+                t = a
+                if cond:
+                    t = b
+                else:
+                    t = c
+                y = t
+        """
+        out = self._transform(src)
+        assert "t_v1" not in out
+        assert "y = t" in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -689,7 +689,7 @@ class TestVariableRebinding:
         """
         out = self._transform(src, tensor_meta={"a": TensorMeta((64,), DataType.FP32)})
         assert "x =" in out
-        assert "x__1" not in out
+        assert "x_v1" not in out
 
     def test_rebind_generates_fresh_name(self):
         src = """

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -825,6 +825,51 @@ class TestVariableRebinding:
         assert "t_v1" not in out
         assert "y = t" in out
 
+    def test_parallel_for_rebind_with_bridge(self):
+        """Two parallel for loops assigning the same variable get a bridge assignment."""
+        src = """
+            def f():
+                for i in range(n):
+                    x = a
+                for j in range(m):
+                    x = some_op(x)
+                y = x
+        """
+        out = self._transform(src)
+        # Bridge assignment inserted before the second loop
+        assert "x_v1 = x" in out
+        # Both LHS and RHS inside the second loop use x_v1
+        assert "x_v1 = some_op(x_v1)" in out
+        # Final read uses the latest alias
+        assert "y = x_v1" in out
+
+    def test_parallel_for_simple_rebind(self):
+        """Two parallel for loops with simple (non-loop-carried) rebinding."""
+        src = """
+            def f():
+                for i in range(n):
+                    x = a
+                for j in range(m):
+                    x = b
+                y = x
+        """
+        out = self._transform(src)
+        assert "x_v1 = x" in out
+        assert "y = x_v1" in out
+
+    def test_single_for_loop_carried_unchanged(self):
+        """A single for loop with loop-carried variable is NOT renamed."""
+        src = """
+            def f():
+                x = init_val
+                for i in range(n):
+                    x = some_op(x)
+                y = x
+        """
+        out = self._transform(src)
+        assert "x_v1" not in out
+        assert "y = x" in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -653,6 +653,12 @@ class TestVariableRebinding:
         src = textwrap.dedent(src)
         tree = ast.parse(src)
         func_def = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+        param_names = [arg.arg for arg in func_def.args.args]
+        all_defined = {
+            node.id
+            for node in ast.walk(func_def)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+        }
         transformer = _BodyTransformer(
             tensor_meta=tensor_meta or {},
             scalar_values={},
@@ -660,6 +666,8 @@ class TestVariableRebinding:
             dynvar_python_names={},
             dep_names=set(),
             dynvar_var_names=set(),
+            param_names=param_names,
+            initial_used_names=all_defined,
         )
         new_body = []
         for stmt in func_def.body:
@@ -757,6 +765,31 @@ class TestVariableRebinding:
         # M is inlined (static), then M = some_call(...) becomes M_v1 = some_call(64)
         # y = M should resolve to y = M_v1
         assert "y = M_v1" in out
+
+    def test_param_rebind_generates_alias(self):
+        """Assigning to a function parameter generates a renamed alias."""
+        src = """
+            def f(x):
+                x = some_call(x)
+                y = x
+        """
+        out = self._transform(src)
+        # x is a param, so re-assignment generates x_v1; reads of x after rebinding → x_v1
+        assert "x_v1 = some_call(x)" in out
+        assert "y = x_v1" in out
+
+    def test_alias_skips_collision(self):
+        """Generated alias skips names already defined by the user."""
+        src = """
+            def f():
+                x = a
+                x_v1 = b
+                x = c
+        """
+        out = self._transform(src)
+        # x_v1 is taken by user, so rebinding of x should skip to x_v2
+        assert "x_v2 =" in out
+        assert "x_v1 = b" in out
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -734,6 +734,30 @@ class TestVariableRebinding:
         # y should be assigned the latest alias x_v1
         assert "y = x_v1" in out
 
+    def test_ann_assign_rebind(self):
+        """Annotated assignment rebinding is alpha-renamed."""
+        src = """
+            def f():
+                x = a
+                x: int = b
+        """
+        out = self._transform(src)
+        assert "x =" in out
+        assert "x_v1:" in out
+
+    def test_rebind_supersedes_shape_inline(self):
+        """After a shape-inlined variable is rebound, reads see the new alias."""
+        src = """
+            def f(a):
+                M, N = a.shape
+                M = some_call(M)
+                y = M
+        """
+        out = self._transform(src, tensor_meta={"a": TensorMeta((64, 32), DataType.FP32)})
+        # M is inlined (static), then M = some_call(...) becomes M_v1 = some_call(64)
+        # y = M should resolve to y = M_v1
+        assert "y = M_v1" in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -641,5 +641,99 @@ class TestSpecializerIntegration:
         ir.assert_structural_equal(got, Expected)
 
 
+# ---------------------------------------------------------------------------
+# TestVariableRebinding
+# ---------------------------------------------------------------------------
+
+
+class TestVariableRebinding:
+    """Tests for alpha-renaming of variable rebindings in _BodyTransformer."""
+
+    def _transform(self, src: str, tensor_meta: dict | None = None) -> str:
+        src = textwrap.dedent(src)
+        tree = ast.parse(src)
+        func_def = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+        transformer = _BodyTransformer(
+            tensor_meta=tensor_meta or {},
+            scalar_values={},
+            dynamic_dims=set(),
+            dynvar_python_names={},
+            dep_names=set(),
+            dynvar_var_names=set(),
+        )
+        new_body = []
+        for stmt in func_def.body:
+            result = transformer.visit(stmt)
+            if result is None:
+                continue
+            if isinstance(result, list):
+                new_body.extend(result)
+            else:
+                new_body.append(result)
+        new_func = ast.FunctionDef(
+            name="f",
+            args=func_def.args,
+            body=new_body or [ast.Pass()],
+            decorator_list=[],
+            returns=None,
+            lineno=1,
+            col_offset=0,
+        )
+        ast.fix_missing_locations(new_func)
+        return ast.unparse(new_func)
+
+    def test_single_assignment_unchanged(self):
+        src = """
+            def f(a):
+                x = pl.load(a)
+        """
+        out = self._transform(src, tensor_meta={"a": TensorMeta((64,), DataType.FP32)})
+        assert "x =" in out
+        assert "x__1" not in out
+
+    def test_rebind_generates_fresh_name(self):
+        src = """
+            def f(a):
+                x = a
+                x = pl.load(x)
+        """
+        out = self._transform(src, tensor_meta={"a": TensorMeta((64,), DataType.FP32)})
+        assert "x =" in out
+        assert "x_v1 =" in out
+
+    def test_rebind_rhs_references_prior_alias(self):
+        src = """
+            def f(a):
+                x = a
+                x = pl.load(x)
+        """
+        out = self._transform(src, tensor_meta={"a": TensorMeta((64,), DataType.FP32)})
+        # The RHS of x_v1 = ... should reference the original x, not x_v1
+        assert "x_v1 = pl.load(x)" in out
+
+    def test_rebind_multiple_times(self):
+        src = """
+            def f():
+                x = a
+                x = b
+                x = c
+        """
+        out = self._transform(src)
+        assert "x =" in out
+        assert "x_v1 =" in out
+        assert "x_v2 =" in out
+
+    def test_later_reads_see_latest_alias(self):
+        src = """
+            def f(a):
+                x = a
+                x = pl.mul(x, 2.0)
+                y = x
+        """
+        out = self._transform(src, tensor_meta={"a": TensorMeta((64,), DataType.FP32)})
+        # y should be assigned the latest alias x_v1
+        assert "y = x_v1" in out
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements #1121. `@pl.jit` users can now freely rebind variables to values of the same or different types (e.g. `Tile → Scalar`), matching plain Python semantics. The strict one-name-one-type rule continues to apply to `@pl.program` unchanged.

```python
@pl.jit
def scale_and_norm(x: pl.Tensor, out: pl.Out[pl.Tensor]):
    with pl.incore():
        M, N = x.shape
        t = pl.load(x, [0, 0], [M, N])
        s = pl.reduce_sum(t)          # s: Scalar
        t = pl.mul(t, 1.0 / s)        # rebind Tile → Tile ✅
        t = s                          # rebind Tile → Scalar ✅ (was: ParserTypeError)
    return out
```

## Approach

**Alpha-renaming in `_BodyTransformer`** (`specializer.py`): when a variable is assigned again at the same scope depth as its first definition, the new assignment is renamed `x_v1`, `x_v2`, etc. All subsequent reads of `x` resolve to the latest alias. The generated `@pl.program` source then satisfies the SSA requirement naturally.

Loop-carried rebindings (inside `for`/`with` at a deeper scope) are intentionally **not** renamed, preserving the existing `tile_x = pl.tile.assemble(tile_x, ...)` pattern.

**Error message rewriting** (`decorator.py`): a new `_rewrite_jit_error` helper replaces internal alias names (`x_v1`) back to the user's original name (`x`) in exception messages, so diagnostics remain readable.

## Files Changed

- `python/pypto/jit/specializer.py` — `_BodyTransformer`: alpha-renaming logic; `Specializer`: exposes `rename_map`
- `python/pypto/jit/decorator.py` — `_rewrite_jit_error`; wraps `pl.parse()` + `ir_compile()` with error rewriting
- `tests/ut/jit/test_specializer.py` — `TestVariableRebinding` (5 tests)
- `tests/ut/jit/test_decorator.py` — `TestVariableRebinding` (4 tests)

## Testing

- All 106 JIT tests pass
- Existing assemble/loop-carried tests unaffected

Fixes #1121