### PR TITLE
fix(codegen): correct tmrgsort emission format and bump PTOAS to v0.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.26
-      PTOAS_SHA256: 8e8239f92b169d88fd117f7d4841739c129ecbdd8d3a01f96087df576ecd7814
+      PTOAS_VERSION: v0.30
+      PTOAS_SHA256: 83cd91f1bbe3c1b5bc7b01462adeb73603fb22b1b56d8b39bd90644b373ba2a1
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -169,8 +169,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.26
-      PTOAS_SHA256: 5abf99f9729997e171bee08bdb25662a7a24b62921c5ecfc05790a56a6e1b076
+      PTOAS_VERSION: v0.30
+      PTOAS_SHA256: 9a918aa5e8e17e3a194db8aa6af2f945a6c177d5bc0813494c30ff5d15ca2740
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -532,10 +532,12 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 }
 
 // Helper function for MrgSort format2: emits pto.tmrgsort
-// Supports 2-4 way merge:
-//   2-way (4 args): ins(src0, src1 {exhausted} : types...) outs(dst, tmp, executed : ...)
-//   3-way (5 args): ins(src0, src1, src2 {exhausted} : types...) outs(dst, tmp, executed : ...)
-//   4-way (6 args): ins(src0, src1, src2, src3 {exhausted} : types...) outs(dst, tmp, executed : ...)
+// Supports 2-4 way merge. tmp is the last ins operand and carries the
+// {exhausted} attribute; outs holds dst plus the synthesized excuted vector:
+//   2-way: ins(src0, src1, tmp {exhausted} : src_types..., tmp_type)
+//          outs(dst, excuted : dst_type, vector<4xi16>)
+//   3-way: ins(src0, src1, src2, tmp {exhausted} : ...) outs(dst, excuted : ...)
+//   4-way: ins(src0, src1, src2, src3, tmp {exhausted} : ...) outs(dst, excuted : ...)
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -545,19 +547,17 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
 
   size_t n_srcs = op->args_.size() - 2;
 
-  // Collect ins: src tiles (args 0..n_srcs-1)
   std::vector<std::string> srcs, src_types;
   for (size_t i = 0; i < n_srcs; ++i) {
     srcs.push_back(codegen.GetExprAsCode(op->args_[i]));
     src_types.push_back(codegen.GetExprTypeAnnotation(op->args_[i]));
   }
 
-  // outs: dst (result target), tmp (args[n_srcs]), executed (args[n_srcs+1])
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
   std::string tmp = codegen.GetExprAsCode(op->args_[n_srcs]);
   std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[n_srcs]);
-  std::string executed_vec = codegen.NewNamedTemp("executed_vec");
+  std::string executed_vec = codegen.NewNamedTemp("excuted_vec");
   codegen.Emit(executed_vec + " = arith.constant dense<0> : vector<4xi16>");
 
   bool exhausted = op->GetKwarg<bool>("exhausted", false);
@@ -566,10 +566,9 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
   std::ostringstream oss;
   oss << pto_op_name << " ins(";
   for (size_t i = 0; i < n_srcs; ++i) {
-    if (i > 0) oss << ", ";
-    oss << srcs[i];
+    oss << srcs[i] << ", ";
   }
-  oss << " " << exhausted_attr;
+  oss << tmp << " " << exhausted_attr;
 
   bool has_types = false;
   for (const auto& t : src_types) {
@@ -581,14 +580,14 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
   if (has_types) {
     oss << " : ";
     for (size_t i = 0; i < n_srcs; ++i) {
-      if (i > 0) oss << ", ";
-      oss << src_types[i];
+      oss << src_types[i] << ", ";
     }
+    oss << tmp_type;
   }
 
-  oss << ") outs(" << dst << ", " << tmp << ", " << executed_vec;
-  if (!dst_type.empty() || !tmp_type.empty()) {
-    oss << " : " << dst_type << ", " << tmp_type << ", vector<4xi16>";
+  oss << ") outs(" << dst << ", " << executed_vec;
+  if (!dst_type.empty()) {
+    oss << " : " << dst_type << ", vector<4xi16>";
   }
   oss << ")";
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -533,11 +533,11 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 
 // Helper function for MrgSort format2: emits pto.tmrgsort
 // Supports 2-4 way merge. tmp is the last ins operand and carries the
-// {exhausted} attribute; outs holds dst plus the synthesized excuted vector:
+// {exhausted} attribute; outs holds dst plus the synthesized executed vector:
 //   2-way: ins(src0, src1, tmp {exhausted} : src_types..., tmp_type)
-//          outs(dst, excuted : dst_type, vector<4xi16>)
-//   3-way: ins(src0, src1, src2, tmp {exhausted} : ...) outs(dst, excuted : ...)
-//   4-way: ins(src0, src1, src2, src3, tmp {exhausted} : ...) outs(dst, excuted : ...)
+//          outs(dst, executed : dst_type, vector<4xi16>)
+//   3-way: ins(src0, src1, src2, tmp {exhausted} : ...) outs(dst, executed : ...)
+//   4-way: ins(src0, src1, src2, src3, tmp {exhausted} : ...) outs(dst, executed : ...)
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -557,7 +557,7 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
   std::string tmp = codegen.GetExprAsCode(op->args_[n_srcs]);
   std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[n_srcs]);
-  std::string executed_vec = codegen.NewNamedTemp("excuted_vec");
+  std::string executed_vec = codegen.NewNamedTemp("executed_vec");
   codegen.Emit(executed_vec + " = arith.constant dense<0> : vector<4xi16>");
 
   bool exhausted = op->GetKwarg<bool>("exhausted", false);
@@ -570,7 +570,7 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
   }
   oss << tmp << " " << exhausted_attr;
 
-  bool has_types = false;
+  bool has_types = !tmp_type.empty();
   for (const auto& t : src_types) {
     if (!t.empty()) {
       has_types = true;


### PR DESCRIPTION
## Summary
- Fix `MakeMrgSortCodegenPTO` to emit `tmp` as the last ins operand carrying the `{exhausted}` attribute, with `dst` and the synthesized `excuted_vec` in outs — matching the updated PTOAS v0.30 contract.
- Bump `PTOAS_VERSION` from v0.26 to v0.30 in CI and update SHA256 hashes accordingly.

## Testing
- [x] CI passes with new PTOAS v0.30
- [x] mrgsort codegen tests pass