### PR TITLE
fix(codegen): localize split tpop valid shape

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -142,8 +142,8 @@ print(pto_code)
 | --------------- | ----------------- | ----------- |
 | `tile.tpush_to_aiv(tile, split=N)` | `pto.tpush_to_aiv ins(%tile : type) {split = N}` | Cube → Vector push |
 | `tile.tpush_to_aic(tile, split=N)` | `pto.tpush_to_aic ins(%tile : type) {split = N}` | Vector → Cube push |
-| `tile.tpop_from_aic(split=N)` | `pto.tpop_from_aic outs(%buf : type) {split = N}` | Pop from Cube pipe |
-| `tile.tpop_from_aiv(split=N)` | `pto.tpop_from_aiv outs(%buf : type) {split = N}` | Pop from Vector pipe |
+| `tile.tpop_from_aic(split=N)` | `%buf = pto.tpop_from_aic {split = N} -> type` | Pop from Cube pipe |
+| `tile.tpop_from_aiv(split=N)` | `%buf = pto.tpop_from_aiv {split = N} -> type` | Pop from Vector pipe |
 | `system.tfree_to_aic(tile_from_tpop)` | `pto.tfree_from_aic {split = N}` | Release a consumer slot back to Cube |
 | `system.tfree_to_aiv(tile_from_tpop)` | `pto.tfree_from_aiv {split = N}` | Release a consumer slot back to Vector |
 | `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube pipe init |
@@ -153,7 +153,8 @@ print(pto_code)
 
 **Notes:**
 
-- Push ops use `ins()` clause with typed tile buffer; pop ops use `outs()` clause
+- Push ops use an `ins()` clause with a typed tile buffer; frontend pop ops produce an SSA result with a `-> !pto.tile_buf<...>` result type
+- When a tpop result `TileView.valid_shape` contains dynamic expressions, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. The tile type keeps `?` for the dynamic valid shape while the operands carry runtime extents.
 - `system.tfree_*` derives `split` from its tile argument, so the frontend must free the exact SSA value produced by `tile.tpop_*`, even though the PTO instruction itself does not take the tile as an explicit operand
 - `ExpandMixedKernel` now auto-generates consumer-side `system.tfree_*` after split-generated `tile.tpop_*`, preserving `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` and `import_reserved_buffer` return `i32` SSA values; `initialize_pipe` references them as operands

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -142,8 +142,8 @@ print(pto_code)
 | ---------- | -------------- | ---- |
 | `tile.tpush_to_aiv(tile, split=N)` | `pto.tpush_to_aiv ins(%tile : type) {split = N}` | Cube → Vector 推送 |
 | `tile.tpush_to_aic(tile, split=N)` | `pto.tpush_to_aic ins(%tile : type) {split = N}` | Vector → Cube 推送 |
-| `tile.tpop_from_aic(split=N)` | `pto.tpop_from_aic outs(%buf : type) {split = N}` | 从 Cube 管道弹出 |
-| `tile.tpop_from_aiv(split=N)` | `pto.tpop_from_aiv outs(%buf : type) {split = N}` | 从 Vector 管道弹出 |
+| `tile.tpop_from_aic(split=N)` | `%buf = pto.tpop_from_aic {split = N} -> type` | 从 Cube 管道弹出 |
+| `tile.tpop_from_aiv(split=N)` | `%buf = pto.tpop_from_aiv {split = N} -> type` | 从 Vector 管道弹出 |
 | `system.tfree_to_aic(tile_from_tpop)` | `pto.tfree_from_aic {split = N}` | 将消费侧槽位释放回 Cube |
 | `system.tfree_to_aiv(tile_from_tpop)` | `pto.tfree_from_aiv {split = N}` | 将消费侧槽位释放回 Vector |
 | `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube 管道初始化 |
@@ -153,7 +153,8 @@ print(pto_code)
 
 **说明：**
 
-- Push 操作使用带类型的 `ins()` 子句；Pop 操作使用 `outs()` 子句
+- Push 操作使用带类型 tile buffer 的 `ins()` 子句；前端 Pop 操作生成 SSA 结果，并带 `-> !pto.tile_buf<...>` 结果类型
+- 当 tpop 结果的 `TileView.valid_shape` 包含动态表达式时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。tile 类型中动态 valid shape 仍保留为 `?`，运行时范围由操作数传递。
 - `system.tfree_*` 的 `split` 来自其 tile 参数，因此前端必须释放由 `tile.tpop_*` 产生的那个确切 SSA 值，即使 PTO 指令本身并不显式接收该 tile 作为操作数
 - `ExpandMixedKernel` 现在会在 split 生成的消费侧 `tile.tpop_*` 之后自动补 `system.tfree_*`，保持 `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` 和 `import_reserved_buffer` 返回 `i32` SSA 值；`initialize_pipe` 以操作数引用这些值

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -206,6 +206,16 @@ class PTOCodegen : public CodegenBase {
   std::string GetCurrentResultTileBufTypeStringFromTileType() const;
 
   /**
+   * @brief Get tpop result valid_shape operands as index-typed SSA values.
+   *
+   * PTOAS frontend tpop accepts optional `(valid_row, valid_col)` operands only
+   * when the result tile type carries dynamic valid shape (`v_row=?, v_col=?`).
+   * Returns empty strings when the current result does not require dynamic
+   * valid_shape operands.
+   */
+  std::pair<std::string, std::string> GetCurrentResultTpopValidShapeOperands();
+
+  /**
    * @brief Get tile_buf type string directly from a TileType
    *
    * Unlike GetTileBufTypeString(memref), this uses the shape/layout from the

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1198,9 +1198,16 @@ static std::string MakeTpopFromAicCodegenPTO(const CallPtr& op, codegen::Codegen
   INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_)
       << "tpop_from_aic requires assignment target (tile_buf)";
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+  auto [valid_row, valid_col] = codegen.GetCurrentResultTpopValidShapeOperands();
 
   std::ostringstream oss;
-  oss << result_buf << " = pto.tpop_from_aic {split = " << split << "}";
+  oss << result_buf << " = pto.tpop_from_aic";
+  if (!valid_row.empty() || !valid_col.empty()) {
+    INTERNAL_CHECK_SPAN(!valid_row.empty() && !valid_col.empty(), op->span_)
+        << "Internal error: tpop_from_aic dynamic valid_shape requires both valid_row and valid_col";
+    oss << "(" << valid_row << ", " << valid_col << ")";
+  }
+  oss << " {split = " << split << "}";
   if (!result_type.empty()) {
     oss << " -> " << result_type;
   }
@@ -1223,9 +1230,16 @@ static std::string MakeTpopFromAivCodegenPTO(const CallPtr& op, codegen::Codegen
   INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_)
       << "tpop_from_aiv requires assignment target (tile_buf)";
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+  auto [valid_row, valid_col] = codegen.GetCurrentResultTpopValidShapeOperands();
 
   std::ostringstream oss;
-  oss << result_buf << " = pto.tpop_from_aiv {split = " << split << "}";
+  oss << result_buf << " = pto.tpop_from_aiv";
+  if (!valid_row.empty() || !valid_col.empty()) {
+    INTERNAL_CHECK_SPAN(!valid_row.empty() && !valid_col.empty(), op->span_)
+        << "Internal error: tpop_from_aiv dynamic valid_shape requires both valid_row and valid_col";
+    oss << "(" << valid_row << ", " << valid_col << ")";
+  }
+  oss << " {split = " << split << "}";
   if (!result_type.empty()) {
     oss << " -> " << result_type;
   }

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -90,6 +90,11 @@ static std::pair<ExprPtr, ExprPtr> GetTileValidShapeExprs(
   return {valid_row_expr, valid_col_expr};
 }
 
+static bool HasDynamicTileValidShape(const std::shared_ptr<const ir::TileType>& tile_type) {
+  auto [valid_row_expr, valid_col_expr] = GetTileValidShapeExprs(tile_type);
+  return valid_row_expr || valid_col_expr;
+}
+
 // Visitor to collect all MemRef objects from TileType variables
 class MemRefCollectorVisitor : public ir::IRVisitor {
  public:
@@ -229,7 +234,10 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
     // Pre-populate type so body visitors (e.g., tile.reshape no-op check)
     // can query it before per-variable alloc_tile emission runs.
-    std::string type_str = GetTileBufTypeStringFromTileType(tile_type, HasFillpadConsumer(tile_var.get()));
+    bool force_all_dynamic =
+        HasFillpadConsumer(tile_var.get()) ||
+        (fs_.tpop_result_vars.count(tile_var.get()) > 0 && HasDynamicTileValidShape(tile_type));
+    std::string type_str = GetTileBufTypeStringFromTileType(tile_type, force_all_dynamic);
     fs_.ssa_to_tile_buf_type[ssa_name] = type_str;
 
     auto memref = ir::GetDefinedMemRef(tile_type);
@@ -890,8 +898,10 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       // This ensures that even when multiple variables share a MemRef, each
       // variable's SSA value carries its correct typed annotation.
       if (result_tile_type && !fs_.current_result_buf.empty()) {
-        bool fillpad_force = HasFillpadConsumer(op->var_.get());
-        std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type, fillpad_force);
+        bool force_all_dynamic =
+            HasFillpadConsumer(op->var_.get()) ||
+            (fs_.tpop_result_vars.count(op->var_.get()) > 0 && HasDynamicTileValidShape(result_tile_type));
+        std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type, force_all_dynamic);
         if (!var_type_str.empty()) {
           fs_.ssa_to_tile_buf_type[fs_.current_result_buf] = var_type_str;
         }
@@ -1185,6 +1195,81 @@ std::string PTOCodegen::GetCurrentResultTileBufTypeStringFromTileType() const {
     return GetTileBufTypeStringFromTileType(fs_.current_result_tile_type, fillpad_force);
   }
   return "";
+}
+
+std::pair<std::string, std::string> PTOCodegen::GetCurrentResultTpopValidShapeOperands() {
+  if (!fs_.current_result_tile_type) {
+    return {"", ""};
+  }
+
+  if (!fs_.current_result_tile_type->tile_view_.has_value()) {
+    return {"", ""};
+  }
+
+  const auto& valid_shape = fs_.current_result_tile_type->tile_view_->valid_shape;
+  ExprPtr valid_row_expr;
+  ExprPtr valid_col_expr;
+  bool has_dynamic_valid_shape = false;
+  if (valid_shape.size() >= 1 && valid_shape[0]) {
+    valid_row_expr = valid_shape[0];
+    has_dynamic_valid_shape = !As<ir::ConstInt>(valid_row_expr);
+  }
+  if (valid_shape.size() >= 2 && valid_shape[1]) {
+    valid_col_expr = valid_shape[1];
+    has_dynamic_valid_shape = has_dynamic_valid_shape || !As<ir::ConstInt>(valid_col_expr);
+  }
+  if (!has_dynamic_valid_shape) {
+    return {"", ""};
+  }
+
+  auto cast_scalar_to_index = [&](const std::string& ssa, const ScalarType* scalar_type) -> std::string {
+    bool is_integer_or_index = scalar_type->dtype_.IsInt() || scalar_type->dtype_ == DataType::INDEX;
+    CHECK(is_integer_or_index && scalar_type->dtype_.GetBit() != 1)
+        << "tpop valid_shape operand must be integer or index type, got "
+        << GetTypeString(scalar_type->dtype_);
+    if (scalar_type->dtype_ == DataType::INDEX) {
+      return ssa;
+    }
+    std::string idx = NewTemp();
+    std::string src_type = GetTypeString(scalar_type->dtype_);
+    Emit(idx + " = arith.index_cast " + ssa + " : " + src_type + " to index");
+    return idx;
+  };
+
+  auto get_index_operand = [&](const ExprPtr& expr, size_t dim_idx) -> std::string {
+    if (expr) {
+      if (auto const_int = As<ir::ConstInt>(expr)) {
+        return GetOrEmitConstant(const_int->value_, DataType::INDEX);
+      }
+      std::string ssa = GetExprAsCode(expr);
+      if (auto scalar_type = As<ScalarType>(expr->GetType())) {
+        return cast_scalar_to_index(ssa, scalar_type.get());
+      }
+      return ssa;
+    }
+
+    const auto& shape = fs_.current_result_tile_type->shape_;
+    ExprPtr shape_dim;
+    if (shape.size() >= 2 && dim_idx < shape.size()) {
+      shape_dim = shape[dim_idx];
+    } else if (shape.size() == 1) {
+      if (dim_idx == 0) {
+        return GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+      }
+      shape_dim = shape[0];
+    }
+    INTERNAL_CHECK(shape_dim) << "Internal error: tpop result tile type is missing shape dim " << dim_idx;
+    if (auto const_int = As<ir::ConstInt>(shape_dim)) {
+      return GetOrEmitConstant(const_int->value_, DataType::INDEX);
+    }
+    std::string ssa = GetExprAsCode(shape_dim);
+    if (auto scalar_type = As<ScalarType>(shape_dim->GetType())) {
+      return cast_scalar_to_index(ssa, scalar_type.get());
+    }
+    return ssa;
+  };
+
+  return {get_index_operand(valid_row_expr, 0), get_index_operand(valid_col_expr, 1)};
 }
 
 }  // namespace codegen

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,6 +32,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -179,6 +181,27 @@ ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size) {
   return MakeFloorDiv(dim_size, two, dim_size->span_);
 }
 
+ExprPtr MakeConstLike(const ExprPtr& ref, int64_t value, const Span& span) {
+  return std::make_shared<ConstInt>(value, GetScalarDtype(ref), span);
+}
+
+ExprPtr LocalizeValidDimForSplit(const ExprPtr& valid_dim, const ExprPtr& original_dim,
+                                 const ExprPtr& half_dim_size, const ExprPtr& subblock_idx) {
+  if (!valid_dim) return valid_dim;
+  if (!subblock_idx) {
+    return half_dim_size;
+  }
+  if (AreExprsEqual(valid_dim, original_dim)) {
+    return half_dim_size;
+  }
+
+  auto span = valid_dim->span_;
+  auto zero = MakeConstLike(valid_dim, 0, span);
+  auto subblock_offset = MakeMul(subblock_idx, half_dim_size, span);
+  auto remaining = MakeSub(valid_dim, subblock_offset, span);
+  return MakeMax(MakeMin(remaining, half_dim_size, span), zero, span);
+}
+
 CallPtr RebuildCallWithSplit(const CallPtr& call, int split_int) {
   std::vector<std::pair<std::string, std::any>> new_kwargs;
   bool has_split = false;
@@ -196,19 +219,21 @@ CallPtr RebuildCallWithSplit(const CallPtr& call, int split_int) {
   return std::make_shared<Call>(call->op_, call->args_, std::move(new_kwargs), call->GetType(), call->span_);
 }
 
-TypePtr HalveTileShape(const TypePtr& type, int dim) {
+TypePtr HalveTileShape(const TypePtr& type, int dim, const ExprPtr& subblock_idx) {
   auto tt = std::dynamic_pointer_cast<const TileType>(type);
   if (!tt || dim < 0 || dim >= static_cast<int>(tt->shape_.size())) return type;
 
   std::vector<ExprPtr> new_shape = tt->shape_;
   new_shape[dim] = ComputeHalfDimSize(tt->shape_[dim]);
 
-  // Keep TileView.valid_shape consistent with halved physical shape (was left at pre-split size).
+  // Keep TileView.valid_shape consistent with halved physical shape, and for
+  // partial valid regions localize the split dimension to the current subblock.
   std::optional<TileView> new_tile_view = tt->tile_view_;
   if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
     TileView tv = tile_view.value();
     if (dim < static_cast<int>(tv.valid_shape.size())) {
-      tv.valid_shape[dim] = ComputeHalfDimSize(tv.valid_shape[dim]);
+      tv.valid_shape[dim] =
+          LocalizeValidDimForSplit(tv.valid_shape[dim], tt->shape_[dim], new_shape[dim], subblock_idx);
     }
     new_tile_view = std::move(tv);
   }
@@ -224,8 +249,19 @@ ExprPtr HalveTupleElement(const ExprPtr& tuple_expr, int dim) {
   return std::make_shared<MakeTuple>(std::move(new_elements), tuple_expr->span_);
 }
 
-CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_int, int split_dim) {
-  auto new_result_type = HalveTileShape(call->GetType(), split_dim);
+ExprPtr LocalizeTupleElementForSplit(const ExprPtr& tuple_expr, int dim, const ExprPtr& original_dim,
+                                     const ExprPtr& half_dim_size, const ExprPtr& subblock_idx) {
+  auto tuple = std::dynamic_pointer_cast<const MakeTuple>(tuple_expr);
+  if (!tuple || dim < 0 || dim >= static_cast<int>(tuple->elements_.size())) return tuple_expr;
+  std::vector<ExprPtr> new_elements = tuple->elements_;
+  new_elements[dim] =
+      LocalizeValidDimForSplit(tuple->elements_[dim], original_dim, half_dim_size, subblock_idx);
+  return std::make_shared<MakeTuple>(std::move(new_elements), tuple_expr->span_);
+}
+
+CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_int, int split_dim,
+                                   const ExprPtr& subblock_idx) {
+  auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
 
   std::vector<std::pair<std::string, std::any>> new_kwargs;
   bool has_split = false;
@@ -282,7 +318,8 @@ ExprPtr AdjustOffsets(const ExprPtr& offsets_expr, int split_dim, const ExprPtr&
   return std::make_shared<MakeTuple>(std::move(new_elements), offsets->span_);
 }
 
-TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_dim_size) {
+TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_dim_size,
+                              const ExprPtr& subblock_idx) {
   auto tt = std::dynamic_pointer_cast<const TileType>(type);
   if (!tt || dim < 0 || dim >= static_cast<int>(tt->shape_.size())) return type;
 
@@ -293,7 +330,8 @@ TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_
   if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
     TileView tv = tile_view.value();
     if (dim < static_cast<int>(tv.valid_shape.size())) {
-      tv.valid_shape[dim] = half_dim_size;
+      tv.valid_shape[dim] =
+          LocalizeValidDimForSplit(tv.valid_shape[dim], tt->shape_[dim], half_dim_size, subblock_idx);
     }
     new_tile_view = std::move(tv);
   }
@@ -329,7 +367,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     }
     if (op_name == "tile.tpop_from_aic") {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
-      auto new_call = RebuildTpopWithHalvedShape(call, split_int, split_dim);
+      auto new_call = RebuildTpopWithHalvedShape(call, split_int, split_dim, subblock_idx);
       auto new_var =
           std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
       if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
@@ -352,27 +390,26 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
         return stmt;
       }
 
-      ExprPtr half_dim_size;
-      if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
+      // Rank-deficient tiles (for example rank-1 loads under LEFT_RIGHT) do
+      // not carry the split axis, so they must bypass split-specific rewrites.
+      if (!tt || split_dim >= static_cast<int>(tt->shape_.size())) {
+        return stmt;
       }
+      ExprPtr half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
 
-      auto new_result_type = HalveTileShape(call->GetType(), split_dim);
+      auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
       std::vector<ExprPtr> new_args = call->args_;
-      if (half_dim_size) {
-        new_args[1] = AdjustOffsets(call->args_[1], split_dim, half_dim_size, subblock_idx);
-      }
+      new_args[1] = AdjustOffsets(call->args_[1], split_dim, half_dim_size, subblock_idx);
       new_args[2] = HalveTupleElement(call->args_[2], split_dim);
-      new_args[3] = HalveTupleElement(call->args_[3], split_dim);
+      new_args[3] = LocalizeTupleElementForSplit(call->args_[3], split_dim, tt->shape_[split_dim],
+                                                 half_dim_size, subblock_idx);
 
       auto new_call =
           std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type, call->span_);
       auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
-      if (half_dim_size) {
-        TileInfo info{half_dim_size};
-        tile_vars[assign->var_.get()] = info;
-        tile_vars[new_var.get()] = info;
-      }
+      TileInfo info{half_dim_size};
+      tile_vars[assign->var_.get()] = info;
+      tile_vars[new_var.get()] = info;
       var_replacements[assign->var_.get()] = new_var;
       return std::make_shared<AssignStmt>(new_var, new_call, assign->span_);
     }
@@ -409,7 +446,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           return stmt;
         }
         auto half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
-        auto new_result_type = HalveTileShape(call->GetType(), split_dim);
+        auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
         std::vector<ExprPtr> new_args = call->args_;
         if ((op_name == "tile.full" || op_name == "tile.create") && call->args_.size() >= 1) {
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
@@ -485,7 +522,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             has_tracked_tile = true;
             tracked_info = it->second;
             tile_vars[ia.get()] = it->second;
-            new_type = ApplyTrackedTileShape(ia->GetType(), split_dim, it->second.half_dim_size);
+            new_type =
+                ApplyTrackedTileShape(ia->GetType(), split_dim, it->second.half_dim_size, subblock_idx);
           }
         }
       }
@@ -526,8 +564,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto it = tile_vars.find(new_iter_args[i].get());
       if (it != tile_vars.end()) {
         tile_vars[new_return_vars[i].get()] = it->second;
-        auto new_type =
-            ApplyTrackedTileShape(new_return_vars[i]->GetType(), split_dim, it->second.half_dim_size);
+        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), split_dim,
+                                              it->second.half_dim_size, subblock_idx);
         if (new_type != new_return_vars[i]->GetType()) {
           auto new_return_var =
               std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);

--- a/tests/st/runtime/test_cross_core_dynamic_valid_shape.py
+++ b/tests/st/runtime/test_cross_core_dynamic_valid_shape.py
@@ -1,0 +1,168 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime test for C2V tpop with dynamic valid_shape operands."""
+
+import sys
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.runtime.runner import RunConfig
+
+ROWS = 16
+COLS = 16
+VALID_ROWS = 8
+VALID_COLS = 12
+SLOT_SIZE_BYTES = ROWS * COLS * 4
+BUFFER_SIZE_BYTES = SLOT_SIZE_BYTES * 4
+
+
+class C2VDynamicTpopValidShapeTestCase(PTOTestCase):
+    """Cube pushes a full tile; vector tpop consumes only dynamic valid_shape."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        platform: str | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"cross_core_c2v_dynamic_tpop_valid_shape_{VALID_ROWS}x{VALID_COLS}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec(
+                "valid_shape",
+                [2],
+                DataType.INT64,
+                init_value=torch.tensor([VALID_ROWS, VALID_COLS], dtype=torch.int64),
+            ),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class C2VDynamicTpopValidShapeProgram:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def cube_producer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ):
+                c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+                pl.aic_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_peer,
+                )
+
+                a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                    a_mat, target_memory=pl.MemorySpace.Left
+                )
+                b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                    b_mat, target_memory=pl.MemorySpace.Right
+                )
+                acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+                pl.tpush_to_aiv(acc, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def vector_consumer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                c2v_buf = pl.reserve_buffer(
+                    name="c2v_slot_buffer",
+                    size=BUFFER_SIZE_BYTES,
+                    base=0x2000,
+                )
+                pl.aiv_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_buf,
+                )
+
+                popped: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tpop_from_aic(split=1)
+                incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+                pl.tfree_to_aic(popped)
+                return pl.store(incremented, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+            def group_func(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                self.cube_producer(a, b, output, valid_rows, valid_cols)
+                result = self.vector_consumer(a, b, output, valid_rows, valid_cols)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                valid_shape: pl.Tensor[[2], pl.INDEX],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                valid_rows: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [0])
+                valid_cols: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [1])
+                result = self.group_func(a, b, output, valid_rows, valid_cols)
+                return result
+
+        return C2VDynamicTpopValidShapeProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        valid_rows = int(tensors["valid_shape"][0])
+        valid_cols = int(tensors["valid_shape"][1])
+        matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
+
+
+class TestCrossCoreDynamicValidShape:
+    """Cross-core dynamic valid_shape runtime tests."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_c2v_tpop_dynamic_valid_shape(self, test_runner, platform):
+        """C2V tpop passes runtime valid_shape to vector-core compute and store."""
+        result = test_runner.run(C2VDynamicTpopValidShapeTestCase(platform=platform))
+        assert result.passed, f"C2V dynamic valid_shape tpop failed: {result.error}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -295,6 +295,91 @@ class TestCrossCoreTpushTpopCodegen:
         assert "{split = " in tfree_line, f"tfree should have split attribute: {tfree_line}"
         assert "pto.tmatmul" in cube_code, "Should contain matmul (Cube op)"
 
+    def test_tpop_dynamic_valid_shape_operands(self):
+        """Dynamic tpop result valid_shape should emit PTOAS frontend operands."""
+        span = ir.Span.unknown()
+        valid_row = ir.Var("valid_row", ir.ScalarType(pl.INDEX), span)
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, pl.INT64, span), 16 * 64 * 4, 0)
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [valid_row, valid_col]
+        tile_type = ir.TileType([16, 64], pl.FP32, memref, tile_view, ir.MemorySpace.Vec)
+        recv_tile = ir.Var("recv_tile", tile_type, span)
+        tpop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 2}, tile_type, span)
+        body = ir.SeqStmts([ir.AssignStmt(recv_tile, tpop_call, span)], span)
+        func = ir.Function(
+            "dynamic_tpop",
+            [(valid_row, ir.ParamDirection.In), (valid_col, ir.ParamDirection.In)],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "dynamic_tpop_program", span))
+        tpop_line = next(line.strip() for line in mlir_code.splitlines() if "pto.tpop_from_aic" in line)
+
+        assert "pto.tpop_from_aic(%arg0, %arg1) {split = 2}" in tpop_line
+        assert "v_row=?" in tpop_line
+        assert "v_col=?" in tpop_line
+        assert "pto.alloc_tile" not in mlir_code
+
+    def test_tpop_dynamic_valid_shape_keeps_static_counterpart_operand(self):
+        """If one tpop valid_shape dim is dynamic, the other dim is still passed explicitly."""
+        span = ir.Span.unknown()
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, pl.INT64, span), 16 * 64 * 4, 0)
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [ir.ConstInt(8, pl.INT64, span), valid_col]
+        tile_type = ir.TileType([16, 64], pl.FP32, memref, tile_view, ir.MemorySpace.Vec)
+        recv_tile = ir.Var("recv_tile", tile_type, span)
+        tpop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 0}, tile_type, span)
+        body = ir.SeqStmts([ir.AssignStmt(recv_tile, tpop_call, span)], span)
+        func = ir.Function(
+            "dynamic_tpop_static_row",
+            [(valid_col, ir.ParamDirection.In)],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "dynamic_tpop_static_row_program", span))
+        tpop_line = next(line.strip() for line in mlir_code.splitlines() if "pto.tpop_from_aic" in line)
+
+        assert "pto.tpop_from_aic(%c8_index, %arg0) {split = 0}" in tpop_line
+        assert "v_row=?" in tpop_line
+        assert "v_col=?" in tpop_line
+
+    def test_tpop_dynamic_valid_shape_rejects_bool_operand(self):
+        """Dynamic tpop valid_shape operands must be integer or index typed."""
+        span = ir.Span.unknown()
+        valid_row = ir.Var("valid_row", ir.ScalarType(pl.BOOL), span)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, pl.INT64, span), 16 * 64 * 4, 0)
+        tile_view = ir.TileView()
+        tile_view.valid_shape = [valid_row, ir.ConstInt(64, pl.INT64, span)]
+        tile_type = ir.TileType([16, 64], pl.FP32, memref, tile_view, ir.MemorySpace.Vec)
+        recv_tile = ir.Var("recv_tile", tile_type, span)
+        tpop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 0}, tile_type, span)
+        body = ir.SeqStmts([ir.AssignStmt(recv_tile, tpop_call, span)], span)
+        func = ir.Function(
+            "dynamic_tpop_bool_row",
+            [(valid_row, ir.ParamDirection.In)],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        with pytest.raises(Exception, match="tpop valid_shape operand must be integer or index type, got i1"):
+            codegen.PTOCodegen().generate(ir.Program([func], "dynamic_tpop_bool_row_program", span))
+
     def test_tpop_chain_ordering(self):
         """Test that tpop chains follow pop-use-free ordering per hardware requirement."""
         codes = self._compile_and_generate(CrossCoreTpushTpopProgram)

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -9,6 +9,8 @@
 
 """Unit tests for SplitVectorKernel pass."""
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import backend, ir, passes
@@ -126,6 +128,43 @@ class TestSplitVectorKernelUpDown:
                 return out_0_store
 
         _assert_split_matches_expected(Before, Expected)
+
+    def test_tpop_dynamic_valid_shape_is_localized_per_subblock(self):
+        """Dynamic valid_shape on split dim is localized to each AIV subblock."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(
+                self,
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                z_vec: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tpop_from_aic(split=1)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                return out_0_store
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        assert "pl.tile.get_subblock_idx()" in printed
+        assert re.search(r"pl\.tile\.tpop_from_aic\(\s*split=1\s*\)", printed)
+        assert "pl.max(pl.min(valid_rows__ssa_v0 - subblock_idx * 8, 8), 0)" in printed
+        assert "valid_rows__ssa_v0 // 2" not in printed
 
     def test_load_shape_halved_and_offset_adjusted(self):
         """tile.load in AIV: shape halved, offset adjusted in split dim (includes add of halved tiles)."""
@@ -600,6 +639,27 @@ class TestSplitVectorKernelLeftRight:
         assert "pl.tile.load(gamma__ssa_v0, [0, 0], [16, 1], [16, 1]" in printed
         assert "pl.tile.row_expand_mul(" in printed
         assert "pl.tile.store(" in printed
+
+    def test_rank1_load_is_preserved_when_left_right_split_axis_is_absent(self):
+        """Rank-1 tile.load must not be rewritten for LEFT_RIGHT split."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+            def main_aiv(
+                self, data: pl.Tensor[[128], pl.FP32], out_0: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                loaded: pl.Tile[[128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0], [128], target_memory=pl.MemorySpace.Vec
+                )
+                out: pl.Tensor[[128], pl.FP32] = pl.store(loaded, [0], out_0)
+                return out
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        assert "pl.tile.load(data__ssa_v0, [0], [128], [128]" in printed
+        assert "pl.tile.store(loaded__ssa_v0, [0], out_0__ssa_v0)" in printed
+        assert "subblock_idx *" not in printed
 
 
 class TestSplitVectorKernelNoSplitA2A3:


### PR DESCRIPTION
  ## Summary

  Fix dynamic `valid_shape` handling for split cross-core `tpop`.

  After `UP_DOWN` split, the split-dimension `valid_shape` is now localized per subblock instead of being blindly halved.
  PTO codegen also emits `tpop(valid_row, valid_col)` operands when the result tile has dynamic `valid_shape`.

  ## Changes

  - localize split-dimension `valid_shape` per subblock in `SplitVectorKernelPass`
  - emit dynamic `valid_shape` operands for `tpop` in PTO codegen
  - force dynamic `tile_buf` typing for `tpop` results with dynamic `valid_shape`
  - add UTs for split transform and codegen
  - add runtime coverage for cross-core dynamic `valid_shape` with `UP_DOWN` split

  ## Validation

  - `pytest tests/ut/ir/transforms/test_split_vector_kernel.py -k 'dynamic_valid_shape_is_localized_per_subblock or
  tpop_shape_halved_and_store_offset_adjusted'`
  - `pytest tests/ut/codegen/test_pto_codegen_cross_core.py -k 'tpop_dynamic_valid_shape_operands or
  tpop_dynamic_valid_shape_keeps_static_counterpart_operand'`
  - `task-submit` passed for `tests/st/runtime/test_cross_core_dynamic_valid_shape.py` on `a2a3`