### PR TITLE
feat(language): add pl.arange as top-level alias for pl.tensor.ci

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -219,7 +219,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype`), `tensor.ci` / `tensor.arange` (contiguous integer sequence generation; lowers to `tile.ci`)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype`), `tensor.ci` / `tensor.arange` (contiguous integer sequence generation; lowers to `tile.ci`; also exposed at top level as `pl.arange`)
 
 **Example:**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -216,7 +216,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`），`tensor.ci` / `tensor.arange`（生成连续整数序列，下层降到 `tile.ci`）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`），`tensor.ci` / `tensor.arange`（生成连续整数序列，下层降到 `tile.ci`；同时通过 `pl.arange` 暴露在顶层 namespace）
 
 **示例：**
 

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -94,6 +94,7 @@ from .op.system_ops import (
     tpush_to_aiv,
 )
 from .op.tensor_ops import assemble, create_tensor, dim, expand_clone, full, scatter_update
+from .op.tensor_ops import ci as arange
 from .op.tile_ops import (
     MemRefType,
     addc,
@@ -360,6 +361,7 @@ __all__ = [
     "dim",
     "full",
     "scatter_update",
+    "arange",
     "ChunkConfig",
     "ChunkPolicy",
     "FunctionType",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3880,6 +3880,7 @@ class ASTParser:
         "dim",
         "assemble",
         "full",
+        "arange",
     }
     _TILE_ONLY_OPS = {
         "load",

--- a/tests/st/runtime/test_ci.py
+++ b/tests/st/runtime/test_ci.py
@@ -17,6 +17,7 @@ Covers:
 5. tensor.ci descending.
 6. pl.tile.arange alias.
 7. pl.tensor.arange alias.
+8. pl.arange (top-level alias of pl.tensor.ci).
 """
 
 from typing import Any
@@ -203,6 +204,21 @@ class TensorArangeAliasProgram:
 
 
 @pl.program
+class TopLevelArangeProgram:
+    """pl.arange — top-level alias of pl.tensor.ci."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        output: pl.Out[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            seq = pl.arange(0, [ROWS, COLS], dtype=pl.INT32)
+            output = pl.assemble(output, seq, [0, 0])
+        return output
+
+
+@pl.program
 class CiUint32AscendProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def kernel(
@@ -381,6 +397,20 @@ class TensorArangeAliasTestCase(_CiBaseTestCase):
         tensors["output"][:] = torch.arange(N - 1, -1, -1, dtype=torch.int32).reshape(ROWS, COLS)
 
 
+class TopLevelArangeTestCase(_CiBaseTestCase):
+    def get_name(self) -> str:
+        return "top_level_arange"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [TensorSpec("output", [ROWS, COLS], DataType.INT32, is_output=True)]
+
+    def get_program(self) -> Any:
+        return TopLevelArangeProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["output"][:] = torch.arange(0, N, dtype=torch.int32).reshape(ROWS, COLS)
+
+
 class CiUint32AscendTestCase(_CiBaseTestCase):
     def get_name(self) -> str:
         return "ci_uint32_ascend"
@@ -449,6 +479,10 @@ class TestCi:
 
     def test_tensor_arange_ascending(self, test_runner):
         result = test_runner.run(TensorArangeAscendingTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_top_level_arange(self, test_runner):
+        result = test_runner.run(TopLevelArangeTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
     def test_ci_uint32_ascend(self, test_runner):

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2286,6 +2286,9 @@ class TestTensorCiOp:
     def test_tensor_arange_alias_is_ci(self):
         assert pl.tensor.arange is pl.tensor.ci
 
+    def test_top_level_arange_is_tensor_ci(self):
+        assert pl.arange is pl.tensor.ci
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Expose `pl.arange` at the top-level `pypto.language` namespace as an alias for `pl.tensor.ci`, providing a numpy-like API for contiguous integer sequence generation.
- Update docs (en + zh-cn) to mention the top-level alias.
- Add UT and ST coverage for `pl.arange`.

## Testing
- [x] UT: `tests/ut/ir/operators/test_tensor_ops.py::test_top_level_arange_is_tensor_ci`
- [x] ST: `tests/st/runtime/test_ci.py::TestCi::test_top_level_arange`