### PR TITLE
docs(passes): Document OutlineHierarchyScopes pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -20,7 +20,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 05 | `05-flatten_call_expr.md` | 5th pass |
 | 06 | `06-split_chunked_loops.md` | 6th pass |
 | 07 | `07-interchange_chunk_loops.md` | 7th pass |
-| 08 | *(no doc yet)* | 8th pass (`OutlineHierarchyScopes`) |
+| 08 | `08-outline_hierarchy_scopes.md` | 8th pass |
 | 09 | `09-outline_incore_scopes.md` | 9th pass |
 | 10 | `10-outline_cluster_scopes.md` | 10th pass |
 | 11 | `11-convert_tensor_to_tile_ops.md` | 11th pass |

--- a/docs/en/dev/passes/08-outline_hierarchy_scopes.md
+++ b/docs/en/dev/passes/08-outline_hierarchy_scopes.md
@@ -5,9 +5,16 @@ Outlines Hierarchy scopes into separate functions that carry `level` and `role` 
 ## Overview
 
 This pass transforms `ScopeStmt(Hierarchy)` nodes — produced by
-`with pl.at(level=..., role=...)` for any level other than `CORE_GROUP` — into
-separate `Function(Opaque, level, role)` definitions and replaces each scope
-with a Call to the outlined function.
+`with pl.at(level=..., role=...)` — into separate
+`Function(Opaque, level, role)` definitions and replaces each scope with a
+Call to the outlined function.
+
+> **DSL note**: `pl.at(level=pl.Level.CORE_GROUP, ...)` is a special case at
+> the parser level — it produces an `InCore` (or `AutoInCore`) scope rather
+> than a Hierarchy scope, and is handled later by `OutlineIncoreScopes` (see
+> `python/pypto/language/dsl_api.py:984`). Hierarchy scopes at `CORE_GROUP`
+> can still arise from direct IR construction; the C++ name table below
+> covers all `Level` values for completeness.
 
 **Requirements**:
 
@@ -88,8 +95,8 @@ component is lowercase; the role suffix is omitted when the scope has no role.
 
 | Role enum | Suffix |
 | --------- | ------ |
-| `Orchestrator` | `_orch` |
-| `Worker` | `_worker` |
+| `Orchestrator` | `orch` |
+| `Worker` | `worker` |
 
 Examples:
 

--- a/docs/en/dev/passes/08-outline_hierarchy_scopes.md
+++ b/docs/en/dev/passes/08-outline_hierarchy_scopes.md
@@ -1,0 +1,250 @@
+# OutlineHierarchyScopes Pass
+
+Outlines Hierarchy scopes into separate functions that carry `level` and `role` metadata.
+
+## Overview
+
+This pass transforms `ScopeStmt(Hierarchy)` nodes — produced by
+`with pl.at(level=..., role=...)` for any level other than `CORE_GROUP` — into
+separate `Function(Opaque, level, role)` definitions and replaces each scope
+with a Call to the outlined function.
+
+**Requirements**:
+
+- Input IR must be in SSA form (run `ConvertToSSA` first); SSAForm is preserved
+  (produced) by this pass
+- Only processes `Opaque` functions; other function types are left unchanged
+- Should run **before** `OutlineIncoreScopes` and `OutlineClusterScopes`
+
+**When to use**: Run after `InterchangeChunkLoops` and before the InCore /
+Cluster outlining passes when the IR contains `with pl.at(level=..., role=...)`
+regions that should be lifted into level/role-tagged functions for downstream
+hierarchy-aware lowering.
+
+**Parent function type is preserved.** Unlike `OutlineIncoreScopes`, this pass
+does **not** promote the parent to `Orchestration`. Hierarchy is orthogonal to
+`FunctionType`: the outlined child stays `Opaque` and carries the level/role on
+its function metadata.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::OutlineHierarchyScopes()` | `passes.outline_hierarchy_scopes()` | Program-level |
+
+**Factory function**:
+
+```cpp
+Pass OutlineHierarchyScopes();
+```
+
+**Python usage**:
+
+```python
+from pypto.pypto_core import passes
+
+outline_pass = passes.outline_hierarchy_scopes()
+program_outlined = outline_pass(program)
+```
+
+## Algorithm
+
+1. **Iterate functions**: For each function in the program, skip non-`Opaque`
+   functions and emit them unchanged.
+2. **Build symbol table**: Collect parameter types/objects and known names via
+   `outline_utils::VarCollector` over the function body.
+3. **Outline Hierarchy scopes**: Walk the body with
+   `outline_utils::ScopeOutliner` configured for `ScopeKind::Hierarchy`. For
+   each scope encountered:
+   - Determine inputs (variables defined outside the scope but used inside).
+   - Determine outputs (variables defined inside the scope but used after).
+   - Recurse into nested Hierarchy scopes (inner scopes are outlined first and
+     replaced with calls before the outer scope is lifted).
+4. **Create outlined function**: Build a new `Function(FunctionType::Opaque)`
+   carrying the scope's `level` and `role`, with parameters = inputs and
+   returns = outputs.
+5. **Replace scope with Call**: Substitute the original `ScopeStmt(Hierarchy)`
+   with a Call to the outlined function plus `AssignStmt`s for each output.
+6. **Assemble program**: Prepend all outlined functions before the originals
+   and return a new `Program`. Parent function types are unchanged.
+
+## Naming
+
+Outlined functions follow `{parent}_{level}[_{role}]_{counter}`. The level
+component is lowercase; the role suffix is omitted when the scope has no role.
+
+| Level enum | Suffix |
+| ---------- | ------ |
+| `AIV` | `aiv` |
+| `AIC` | `aic` |
+| `CORE_GROUP` | `core_group` |
+| `CHIP_DIE` | `chip_die` |
+| `CHIP` | `chip` |
+| `HOST` | `host` |
+| `CLUSTER_0` | `cluster0` |
+| `CLUSTER_1` | `cluster1` |
+| `CLUSTER_2` | `cluster2` |
+| `GLOBAL` | `global` |
+
+| Role enum | Suffix |
+| --------- | ------ |
+| `Orchestrator` | `_orch` |
+| `Worker` | `_worker` |
+
+Examples:
+
+- `pl.at(level=pl.Level.HOST, role=pl.Role.Worker)` → `main_host_worker_0`
+- `pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)` → `main_global_orch_0`
+- `pl.at(level=pl.Level.CHIP)` → `main_chip_0`
+
+**Level aliases** (`POD = CLUSTER_0`, `NODE = HOST`, `UMA = CHIP`, etc.)
+resolve to the canonical underlying name. For example,
+`pl.at(pl.Level.POD)` produces `main_cluster0_0`.
+
+## Example
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function  # Opaque function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
+            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return y
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Worker)
+    def main_host_worker_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return y
+
+    @pl.function  # Opaque (unchanged — parent type is preserved)
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = self.main_host_worker_0(x)
+        return y
+```
+
+## Nested Hierarchy Example
+
+Nested Hierarchy scopes are outlined recursively. Inner scopes are extracted
+first and replaced with calls inside the outer outlined function, producing
+chained names like `main_global_orch_0_host_worker_0`.
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator):
+            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+            with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+        return z
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Worker)
+    def main_global_orch_0_host_worker_0(
+        self, y: pl.Tensor[[64], pl.FP32]
+    ) -> pl.Tensor[[64], pl.FP32]:
+        z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+        return z
+
+    @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
+    def main_global_orch_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0_host_worker_0(y)
+        return z
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0(x)
+        return z
+```
+
+`InCore` scopes nested inside a Hierarchy scope are preserved — they are left
+untouched here and lifted later by `OutlineIncoreScopes` (which runs against
+the resulting Opaque hierarchy functions).
+
+## Implementation
+
+**Header**: `include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass OutlineHierarchyScopes();
+```
+
+**Implementation**: `src/ir/transforms/outline_hierarchy_scopes_pass.cpp`
+
+- Drives `outline_utils::ScopeOutliner` with `ScopeKind::Hierarchy` and
+  `FunctionType::Opaque`
+- Builds the symbol table via `outline_utils::VarCollector`
+- Preserves the parent function type via `MutableCopy`
+- Prepends outlined functions to the program's function list
+
+**Python binding**: `python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("outline_hierarchy_scopes", &pass::OutlineHierarchyScopes,
+           "Create a pass that outlines Hierarchy scopes into separate level/role functions");
+```
+
+**Tests**: `tests/ut/ir/transforms/test_outline_hierarchy_scopes.py`
+
+- Basic single-scope outlining (with and without role)
+- Multiple scopes per function (independent counter)
+- Nested Hierarchy scopes (recursive outlining and chained naming)
+- InCore / Cluster scopes are not touched
+- Multiple inputs / multiple outputs / no outputs
+- Outlining inside control flow
+- Parent function type preserved as `Opaque`
+- Level alias resolution (`POD` → `cluster0`)
+- Independent counters across functions
+- Print → re-parse round-trip
+- `OutlineIncoreScopes` runs cleanly on the hierarchy-outlined output
+- `HierarchyOutlined` property verifier behaviour
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | SSAForm |
+| Produced | SSAForm, HierarchyOutlined |
+| Invalidated | — |
+
+## HierarchyOutlined Property Verifier
+
+The `HierarchyOutlined` IRProperty asserts that no `ScopeStmt(Hierarchy)`
+remains anywhere in the program where this pass is responsible — that is, in
+`Opaque` functions. The verifier (`HierarchyOutlinedPropertyVerifierImpl`)
+walks each `Opaque` function body and reports any leftover Hierarchy scope
+with the message `"Hierarchy ScopeStmt found in function (should have been
+outlined)"`.
+
+Hierarchy scopes inside non-`Opaque` functions are intentionally **not**
+flagged, mirroring the pass's own scope: this pass does not process them, so
+the verifier should not require them to be absent.
+
+## Relationship to Sibling Outlining Passes
+
+| Aspect | OutlineHierarchyScopes | OutlineIncoreScopes | OutlineClusterScopes |
+| ------ | ---------------------- | ------------------- | -------------------- |
+| Scope kind | `ScopeKind::Hierarchy` | `ScopeKind::InCore` | `ScopeKind::Cluster` / standalone `ScopeKind::Spmd` |
+| Output function type | `FunctionType::Opaque` (with `level` / `role`) | `FunctionType::InCore` | `FunctionType::Group` / `FunctionType::Spmd` |
+| Naming pattern | `{func}_{level}[_{role}]_{n}` | `{func}_incore_{n}` | `{func}_cluster_{n}` / `{func}_spmd_{n}` |
+| Promotes parent to | *(unchanged)* | Orchestration | *(unchanged)* |
+| Processes | Opaque functions only | Opaque functions only | Opaque + Orchestration |
+| Pipeline position | 8 (before InCore / Cluster) | 9 | 10 |

--- a/docs/zh-cn/dev/passes/08-outline_hierarchy_scopes.md
+++ b/docs/zh-cn/dev/passes/08-outline_hierarchy_scopes.md
@@ -1,0 +1,238 @@
+# OutlineHierarchyScopes Pass
+
+将 Hierarchy 作用域提取为携带 `level` 与 `role` 元数据的独立函数。
+
+## 概述
+
+该 Pass 将 `ScopeStmt(Hierarchy)` 节点（由 `with pl.at(level=..., role=...)`
+对非 `CORE_GROUP` 层级生成）变换为独立的 `Function(Opaque, level, role)`
+定义，并将原作用域替换为对提取函数的调用。
+
+**前置条件**：
+
+- 输入 IR 必须为静态单赋值 (SSA) 形式（需先运行 `ConvertToSSA`）；该 Pass
+  保持（产生）SSAForm
+- 仅处理 `Opaque` 函数；其他类型的函数保持不变
+- 应在 `OutlineIncoreScopes` 与 `OutlineClusterScopes` **之前**运行
+
+**使用时机**：在 `InterchangeChunkLoops` 之后、InCore / Cluster 提取 Pass
+之前运行。当 IR 中包含 `with pl.at(level=..., role=...)` 区域，需要将其提升
+为带有层级 / 角色标签的函数以供后续层级感知 (hierarchy-aware) 下沉时使用。
+
+**父函数类型保持不变**。与 `OutlineIncoreScopes` 不同，该 Pass **不会**将父
+函数提升为 `Orchestration`。Hierarchy 与 `FunctionType` 是正交的：提取出的
+子函数仍为 `Opaque`，仅在函数元数据上携带 `level` / `role`。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::OutlineHierarchyScopes()` | `passes.outline_hierarchy_scopes()` | 程序级 |
+
+**工厂函数**：
+
+```cpp
+Pass OutlineHierarchyScopes();
+```
+
+**Python 用法**：
+
+```python
+from pypto.pypto_core import passes
+
+outline_pass = passes.outline_hierarchy_scopes()
+program_outlined = outline_pass(program)
+```
+
+## 算法
+
+1. **遍历函数**：对程序中的每个函数，跳过非 `Opaque` 函数并原样输出。
+2. **建立符号表**：通过 `outline_utils::VarCollector` 在函数体上收集形参的
+   类型 / 对象与已知名字。
+3. **提取 Hierarchy 作用域**：用配置为 `ScopeKind::Hierarchy` 的
+   `outline_utils::ScopeOutliner` 遍历函数体。对遇到的每个作用域：
+   - 确定输入（在作用域外定义、在作用域内使用的变量）。
+   - 确定输出（在作用域内定义、在作用域之后仍被使用的变量）。
+   - 递归处理嵌套的 Hierarchy 作用域（先提取内层并替换为调用，再处理外层）。
+4. **创建提取函数**：构造新的 `Function(FunctionType::Opaque)`，携带作用域的
+   `level` 与 `role`，参数 = 输入，返回值 = 输出。
+5. **替换为 Call**：用对提取函数的 Call 加上对应的 `AssignStmt` 替换原始的
+   `ScopeStmt(Hierarchy)`。
+6. **组装程序**：将所有提取出的函数前置在原始函数之前，返回新的 `Program`。
+   父函数的类型保持不变。
+
+## 命名
+
+提取函数的命名遵循 `{父函数}_{level}[_{role}]_{计数器}`。`level` 部分为小写；
+当作用域无 `role` 时省略 `role` 后缀。
+
+| Level 枚举 | 后缀 |
+| ---------- | ---- |
+| `AIV` | `aiv` |
+| `AIC` | `aic` |
+| `CORE_GROUP` | `core_group` |
+| `CHIP_DIE` | `chip_die` |
+| `CHIP` | `chip` |
+| `HOST` | `host` |
+| `CLUSTER_0` | `cluster0` |
+| `CLUSTER_1` | `cluster1` |
+| `CLUSTER_2` | `cluster2` |
+| `GLOBAL` | `global` |
+
+| Role 枚举 | 后缀 |
+| --------- | ---- |
+| `Orchestrator` | `_orch` |
+| `Worker` | `_worker` |
+
+示例：
+
+- `pl.at(level=pl.Level.HOST, role=pl.Role.Worker)` → `main_host_worker_0`
+- `pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)` → `main_global_orch_0`
+- `pl.at(level=pl.Level.CHIP)` → `main_chip_0`
+
+**层级别名**（如 `POD = CLUSTER_0`、`NODE = HOST`、`UMA = CHIP` 等）会解析为
+其规范的底层名称。例如 `pl.at(pl.Level.POD)` 生成 `main_cluster0_0`。
+
+## 示例
+
+**之前**：
+
+```python
+@pl.program
+class Before:
+    @pl.function  # Opaque function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
+            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return y
+```
+
+**之后**：
+
+```python
+@pl.program
+class After:
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Worker)
+    def main_host_worker_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return y
+
+    @pl.function  # Opaque（保持不变 —— 父函数类型不被提升）
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = self.main_host_worker_0(x)
+        return y
+```
+
+## 嵌套层级示例
+
+嵌套的 Hierarchy 作用域会被递归提取。内层作用域先被提取并替换为对应的 Call，
+然后才处理外层，从而生成形如 `main_global_orch_0_host_worker_0` 的链式名称。
+
+**之前**：
+
+```python
+@pl.program
+class Before:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator):
+            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+            with pl.at(level=pl.Level.HOST, role=pl.Role.Worker):
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+        return z
+```
+
+**之后**：
+
+```python
+@pl.program
+class After:
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Worker)
+    def main_global_orch_0_host_worker_0(
+        self, y: pl.Tensor[[64], pl.FP32]
+    ) -> pl.Tensor[[64], pl.FP32]:
+        z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+        return z
+
+    @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
+    def main_global_orch_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0_host_worker_0(y)
+        return z
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0(x)
+        return z
+```
+
+嵌套在 Hierarchy 作用域内的 `InCore` 作用域会被保留 —— 该 Pass 不会触碰它们；
+它们将在随后的 `OutlineIncoreScopes` 中（针对生成的 Opaque 层级函数）被提取。
+
+## 实现
+
+**头文件**：`include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass OutlineHierarchyScopes();
+```
+
+**实现文件**：`src/ir/transforms/outline_hierarchy_scopes_pass.cpp`
+
+- 以 `ScopeKind::Hierarchy` 与 `FunctionType::Opaque` 驱动
+  `outline_utils::ScopeOutliner`
+- 通过 `outline_utils::VarCollector` 构建符号表
+- 通过 `MutableCopy` 保持父函数类型不变
+- 将提取出的函数前置加入程序的函数列表
+
+**Python 绑定**：`python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("outline_hierarchy_scopes", &pass::OutlineHierarchyScopes,
+           "Create a pass that outlines Hierarchy scopes into separate level/role functions");
+```
+
+**测试**：`tests/ut/ir/transforms/test_outline_hierarchy_scopes.py`
+
+- 基本单作用域提取（带与不带 `role`）
+- 同一函数中的多个作用域（独立计数器）
+- 嵌套 Hierarchy 作用域（递归提取与链式命名）
+- InCore / Cluster 作用域不被触碰
+- 多输入 / 多输出 / 无输出
+- 控制流内部的作用域提取
+- 父函数类型保持为 `Opaque`
+- 层级别名解析（`POD` → `cluster0`）
+- 跨函数的独立计数器
+- 打印 → 再解析的往返一致性
+- `OutlineIncoreScopes` 在层级提取后的输出上能正常运行
+- `HierarchyOutlined` 属性验证器行为
+
+## Pass 属性
+
+| 属性 | 值 |
+| ---- | -- |
+| 所需 | SSAForm |
+| 产生 | SSAForm, HierarchyOutlined |
+| 失效 | — |
+
+## HierarchyOutlined 属性验证器
+
+`HierarchyOutlined` IRProperty 断言：在该 Pass 负责处理的范围 —— 即
+`Opaque` 函数 —— 中，不再存在任何 `ScopeStmt(Hierarchy)`。验证器
+（`HierarchyOutlinedPropertyVerifierImpl`）遍历每个 `Opaque` 函数体，并对
+任何遗留的 Hierarchy 作用域报告诊断信息：
+`"Hierarchy ScopeStmt found in function (should have been outlined)"`。
+
+非 `Opaque` 函数中的 Hierarchy 作用域**不会**被标记，这与该 Pass 自身的处理
+范围一致：既然该 Pass 不处理这些函数，验证器也不应要求它们的作用域被消除。
+
+## 与其他 Outline Pass 的关系
+
+| 方面 | OutlineHierarchyScopes | OutlineIncoreScopes | OutlineClusterScopes |
+| ---- | ---------------------- | ------------------- | -------------------- |
+| 作用域类型 | `ScopeKind::Hierarchy` | `ScopeKind::InCore` | `ScopeKind::Cluster` / standalone `ScopeKind::Spmd` |
+| 输出函数类型 | `FunctionType::Opaque`（带 `level` / `role`） | `FunctionType::InCore` | `FunctionType::Group` / `FunctionType::Spmd` |
+| 命名模式 | `{func}_{level}[_{role}]_{n}` | `{func}_incore_{n}` | `{func}_cluster_{n}` / `{func}_spmd_{n}` |
+| 提升父函数为 | *（不变）* | Orchestration | *（不变）* |
+| 处理对象 | 仅 Opaque 函数 | 仅 Opaque 函数 | Opaque + Orchestration |
+| 流水线位置 | 8（在 InCore / Cluster 之前） | 9 | 10 |

--- a/docs/zh-cn/dev/passes/08-outline_hierarchy_scopes.md
+++ b/docs/zh-cn/dev/passes/08-outline_hierarchy_scopes.md
@@ -5,8 +5,15 @@
 ## 概述
 
 该 Pass 将 `ScopeStmt(Hierarchy)` 节点（由 `with pl.at(level=..., role=...)`
-对非 `CORE_GROUP` 层级生成）变换为独立的 `Function(Opaque, level, role)`
-定义，并将原作用域替换为对提取函数的调用。
+生成）变换为独立的 `Function(Opaque, level, role)` 定义，并将原作用域替换为
+对提取函数的调用。
+
+> **DSL 说明**：`pl.at(level=pl.Level.CORE_GROUP, ...)` 在解析层是一个特例
+> —— 它生成的是 `InCore`（或 `AutoInCore`）作用域，而非 Hierarchy 作用域，
+> 后续由 `OutlineIncoreScopes` 处理（参见
+> `python/pypto/language/dsl_api.py:984`）。`CORE_GROUP` 层级的 Hierarchy
+> 作用域仍可能通过直接构造 IR 产生；下方 C++ 命名表覆盖所有 `Level` 枚举值
+> 以保持完整。
 
 **前置条件**：
 
@@ -81,8 +88,8 @@ program_outlined = outline_pass(program)
 
 | Role 枚举 | 后缀 |
 | --------- | ---- |
-| `Orchestrator` | `_orch` |
-| `Worker` | `_worker` |
+| `Orchestrator` | `orch` |
+| `Worker` | `worker` |
 
 示例：
 


### PR DESCRIPTION
## Summary

- Add `docs/en/dev/passes/08-outline_hierarchy_scopes.md` documenting the `OutlineHierarchyScopes` pass — slot 8 of the `Default` pipeline, between `InterchangeChunkLoops` (07) and `OutlineIncoreScopes` (09). Covers requirements, API, algorithm, naming convention with the `level`/`role` suffix tables, before/after examples (single + nested), implementation pointers, pass properties, the `HierarchyOutlined` verifier, and a comparison table against the sibling outlining passes.
- Mirror the doc under `docs/zh-cn/dev/passes/08-outline_hierarchy_scopes.md`.
- Update `.claude/rules/pass-doc-ordering.md` slot 8 from `*(no doc yet)*` to point at the new file.

Docs-only change. The pass implementation, properties, binding, and tests already exist; this only fills in the missing per-pass doc that #1161 audited.

## Testing

- [x] Code review (docs-only change reviewed against source — bindings, properties, naming logic, and test scenarios all match).
- [x] Markdown sanity (code-fence pairs balanced, both files under the 500-line cap).
- [x] No source code changed — pytest run skipped.

## Related Issues

Fixes #1163
Tracked under #1161