### PR TITLE
docs(passes): Document ResolveBackendOpLayouts pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -28,7 +28,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 13 | `13-flatten_tile_nd_to_2d.md` | 13th pass |
 | 14 | *(no doc yet)* | 14th pass (`InferTileMemorySpace`) |
 | 15 | *(no doc yet)* | 15th pass (`ResolveTransposeLayout`) |
-| 16 | *(no doc yet)* | 16th pass (`ResolveBackendOpLayouts`) |
+| 16 | `16-resolve_backend_op_layouts.md` | 16th pass |
 | 17 | `17-expand_mixed_kernel.md` | 17th pass |
 | 18 | `18-inject_gm_pipe_buffer.md` | Runs immediately after `ExpandMixedKernel` (backend-gated, Ascend910B) |
 | 19 | *(no doc yet)* | 19th pass (`SplitVectorKernel`) |

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -364,7 +364,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 1. `FlattenTileNdTo2D`
 2. `InferTileMemorySpace`
 3. `ResolveTransposeLayout`
-4. `ResolveBackendOpLayouts`
+4. [`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md)
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
 7. `SplitVectorKernel`
@@ -380,12 +380,13 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 without the tensor-only prefix passes. Use `Default` for normal compilation and
 for non-strategy-specific tests so the maintained pipeline stays covered.
 
-`ResolveBackendOpLayouts` repairs backend-constrained elementwise tile ops using
-registered layout metadata. For the current PTO row-major elementwise ops, it
-rewrites `[N, 1]` vector operands into `[1, N] row_major` `tile.reshape`
-operations at the constrained use site, where row-major is inferred from the
-target shape. It then reshapes the result back to the original vector shape
-when needed.
+[`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md) repairs
+backend-constrained elementwise tile ops using registered layout metadata.
+For the current PTO row-major elementwise ops, it rewrites `[N, 1]` vector
+operands into `[1, N] row_major` `tile.reshape` operations at the
+constrained use site, where row-major is inferred from the target shape.
+It then reshapes the result back to the original vector shape when
+needed.
 
 `NormalizeReturnOrder` reorders `ReturnStmt::value_` in InCore functions so that
 `return[i]` corresponds to the i-th `Out`/`InOut` parameter in declaration order,

--- a/docs/en/dev/passes/16-resolve_backend_op_layouts.md
+++ b/docs/en/dev/passes/16-resolve_backend_op_layouts.md
@@ -1,0 +1,167 @@
+# ResolveBackendOpLayouts Pass
+
+Repairs backend-required tile layouts for elementwise ops by reshaping `[N, 1]` col-major vector inputs into `[1, N]` row-major views and reshaping the result back. Runs in the tile-PTO stage between `ResolveTransposeLayout` and the trailing `NormalizeStmtStructure`.
+
+## Overview
+
+After `FlattenTileNdTo2D` and `ResolveTransposeLayout`, every tile op is in 2-D form with a known layout. Several PTO elementwise ops (registered in `src/backend/common/pto_ops_common.cpp`) require their tile operands and result to be `row_major`. A column vector of shape `[N, 1]` has the same memory layout as a row vector of shape `[1, N]`, so this pass repairs the violation locally:
+
+1. For each `AssignStmt` / `EvalStmt` whose RHS is a `Call`, query `Backend::GetTileLayoutSpec(op_name)`.
+2. Skip if no spec is registered, or if no `[N, 1]` col-major input violates a `row_major` requirement.
+3. Otherwise insert `tile.reshape(arg, [1, N])` before the call, substitute the reshaped value into the call, and — if the original result is a `[N, 1]` col-major tile — append `tile.reshape(result, [N, 1])` to restore the user-visible shape.
+
+The pass is **backend-driven**: the set of constrained ops and their per-input requirements come from each op's `BackendOpRegistryEntry` (see `set_input_layout` / `set_output_layout` in `pto_ops_common.cpp`). The pass code itself stays backend-agnostic — adding a new constrained op only requires registering its layout spec, not editing this pass.
+
+**Requirements**:
+
+- Run after `FlattenTileNdTo2D` (assumes 2-D tile ops).
+- Function must be `InCore` — Orchestration / Group functions are skipped.
+- A backend must be configured via `BackendConfig::Set(...)`. Otherwise the pass is a no-op.
+
+**When to use**: As part of the `Default` tile-PTO pipeline, after layout-altering passes (`FlattenTileNdTo2D`, `InferTileMemorySpace`, `ResolveTransposeLayout`) and before `NormalizeStmtStructure`. The pass manager already places it in the correct slot.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::ResolveBackendOpLayouts()` | `passes.resolve_backend_op_layouts()` | Function-level |
+
+**Python usage**:
+
+```python
+from pypto.pypto_core import passes
+
+repair = passes.resolve_backend_op_layouts()
+program = repair(program)
+```
+
+## Algorithm
+
+```text
+For each function in the program:
+  Skip if function is not InCore.
+  Skip if no backend is configured.
+
+  Walk the body with IRMutator. For each AssignStmt / EvalStmt whose
+  RHS is a Call:
+    spec = backend.GetTileLayoutSpec(call.op.name)
+    if spec is None: continue
+    if no input violates spec.input_layouts (only [N,1] col-major inputs
+       targeting a row_major slot are repairable): continue
+
+    For each input i that violates the requirement:
+      reshape_var = fresh temp (name derived from result + "row_major" + "arg<i>")
+      emit  reshape_var = tile.reshape(arg_i, [1, N])
+      substitute reshape_var into the call
+
+    repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
+
+    If the original result is [N, 1] col-major (AssignStmt only):
+      tmp = fresh row-major temp
+      emit  tmp = repaired
+      emit  result_var = tile.reshape(tmp, [N, 1])
+    Else:
+      emit  result_var = repaired   (or EvalStmt with repaired)
+```
+
+Inputs that already satisfy the requirement, non-tile inputs (scalars, shapes), and inputs whose required layout is `nullopt` are left untouched. If a non-row-major, non-`[N, 1]` col-major input is found, the call is treated as not repairable and the statement is left alone.
+
+## Example
+
+(adapted from `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py::test_rewrites_column_vector_add_through_row_major_reshape`, with the Ascend910B backend active)
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.InCore)
+    def repro(
+        self,
+        data: pl.Tensor[[16, 256], pl.FP32],
+        out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    ) -> pl.Tensor[[16, 1], pl.FP32]:
+        acc_0: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+            [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        acc_1: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_0, 0.0)
+        chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+            [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
+        updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_1, partial)
+        stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+        return stored
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.InCore)
+    def repro(
+        self,
+        data: pl.Tensor[[16, 256], pl.FP32],
+        out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    ) -> pl.Tensor[[16, 1], pl.FP32]:
+        acc_0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+            [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        acc_0_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_0, [1, 16])
+        acc_1_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.muls(acc_0_rm, 0.0)
+        acc_1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_1_rm, [16, 1])
+        chunk: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+            [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        partial: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.row_sum(chunk, tmp)
+        acc_1_rm2: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_1, [1, 16])
+        partial_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(partial, [1, 16])
+        updated_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(acc_1_rm2, partial_rm)
+        updated: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(updated_rm, [16, 1])
+        stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+        return stored
+```
+
+`tile.muls`, `tile.add`, and similar elementwise PTO ops require `row_major` inputs and output. Each constrained call is wrapped: the `[16, 1]` operand is reshaped to `[1, 16]` immediately before the call, the call runs in row-major form, and the result is reshaped back to `[16, 1]` so downstream code (`tile.store`, return type) keeps the user-visible shape. `tile.row_sum` is unconstrained, so its inputs and output are left as-is.
+
+## Implementation
+
+| File | Role |
+| ---- | ---- |
+| `include/pypto/ir/transforms/passes.h` (`ResolveBackendOpLayouts`) | Public C++ factory |
+| `src/ir/transforms/resolve_backend_op_layouts_pass.cpp` | Mutator and pass body |
+| `include/pypto/ir/transforms/pass_properties.h` (`kResolveBackendOpLayoutsProperties`) | Pass properties |
+| `python/bindings/modules/passes.cpp` (`resolve_backend_op_layouts`) | Python binding |
+| `python/pypto/pypto_core/passes.pyi` (`resolve_backend_op_layouts`) | Type stub |
+| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | Unit tests (binary, unary, scalar-binary on `[N, 1]` vectors) |
+
+Layout constraints are registered per op via `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` in `src/backend/common/pto_ops_common.cpp` (e.g. row-major elementwise ops listed in `RequiresRowMajorLayout`, `tile.rsqrt`, `tile.cmps`, `tile.sort32`, `tile.mscatter`, ...).
+
+Key helpers in the pass source:
+
+- `IsRepairableCall` — true iff at least one tile input violates a `row_major` requirement and every violating input is a `[N, 1]` col-major tile.
+- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` — emit the pre-call reshape(s), rebuild the call, and (for `AssignStmt`) emit the post-call reshape when the result was a col-major column vector.
+- `RewriteFunction` — bypasses non-`InCore` functions and the unconfigured-backend case before invoking the mutator.
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| Produced | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| Invalidated | NormalizedStmtStructure |
+
+`NormalizedStmtStructure` is invalidated because each repair sequence wraps a previously single-statement op with extra `tile.reshape` assignments, breaking the canonical statement layout. The default pipeline re-runs `NormalizeStmtStructure` immediately after this pass to restore the invariant.
+
+## Design Decisions
+
+| Decision | Rationale |
+| -------- | --------- |
+| Drive layout requirements from `Backend::GetTileLayoutSpec` rather than hard-coded op lists in the pass | Each backend declares its own constraints next to its codegen registration. The pass stays backend-agnostic per `pass-context-config.md`; new constrained ops cost one `set_input_layout` call, not a pass edit. |
+| Repair via two `tile.reshape` ops instead of rejecting the program | `[N, 1]` col-major and `[1, N]` row-major share the same flat memory; a local reshape preserves user-visible shapes while satisfying the backend ISA without forcing kernel rewrites. |
+| Only repair `[N, 1]` col-major inputs (not arbitrary layout mismatches) | This is the only mismatch class observed for current PTO row-major elementwise ops. Broader cases would require a real layout-conversion pass and are out of scope; if one is found, `IsRepairableCall` returns false and the statement is left alone. |
+| Bypass when no backend is configured | Many tests build IR without selecting a backend. A no-op fast path keeps those green and avoids spurious mutations. |
+| Skip non-`InCore` functions | Layout constraints apply to per-core elementwise execution; Orchestration and Group functions only contain calls to lower-level kernels and have nothing to repair. |

--- a/docs/en/dev/passes/16-resolve_backend_op_layouts.md
+++ b/docs/en/dev/passes/16-resolve_backend_op_layouts.md
@@ -8,7 +8,7 @@ After `FlattenTileNdTo2D` and `ResolveTransposeLayout`, every tile op is in 2-D 
 
 1. For each `AssignStmt` / `EvalStmt` whose RHS is a `Call`, query `Backend::GetTileLayoutSpec(op_name)`.
 2. Skip if no spec is registered, or if no `[N, 1]` col-major input violates a `row_major` requirement.
-3. Otherwise insert `tile.reshape(arg, [1, N])` before the call, substitute the reshaped value into the call, and — if the original result is a `[N, 1]` col-major tile — append `tile.reshape(result, [N, 1])` to restore the user-visible shape.
+3. Otherwise insert `tile.reshape(arg, [1, N])` before the call, substitute the reshaped value into the call, and — for `AssignStmt` results, unless the result type is already a `[1, N]` row-major tile — append `tile.reshape(tmp, original_shape)` to restore the user-visible shape.
 
 The pass is **backend-driven**: the set of constrained ops and their per-input requirements come from each op's `BackendOpRegistryEntry` (see `set_input_layout` / `set_output_layout` in `pto_ops_common.cpp`). The pass code itself stays backend-agnostic — adding a new constrained op only requires registering its layout spec, not editing this pass.
 
@@ -49,22 +49,26 @@ For each function in the program:
     if no input violates spec.input_layouts (only [N,1] col-major inputs
        targeting a row_major slot are repairable): continue
 
-    For each input i that violates the requirement:
-      reshape_var = fresh temp (name derived from result + "row_major" + "arg<i>")
+    For each input i targeting a row_major slot:
+      Skip if the input is non-tile, or [1, N] row-major, or not [N, 1].
+      reshape_var = fresh temp
+        (AssignStmt: name derived from the result variable.
+         EvalStmt:  name derived from the literal "layout_fix".
+         Both forms add "row_major" + "arg<i>" qualifiers.)
       emit  reshape_var = tile.reshape(arg_i, [1, N])
       substitute reshape_var into the call
 
     repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
 
-    If the original result is [N, 1] col-major (AssignStmt only):
-      tmp = fresh row-major temp
+    If statement is AssignStmt and result_type is not [1, N] row-major:
+      tmp = fresh row-major temp ("row_major" qualifier on the result name)
       emit  tmp = repaired
-      emit  result_var = tile.reshape(tmp, [N, 1])
+      emit  result_var = tile.reshape(tmp, original_result_shape)
     Else:
       emit  result_var = repaired   (or EvalStmt with repaired)
 ```
 
-Inputs that already satisfy the requirement, non-tile inputs (scalars, shapes), and inputs whose required layout is `nullopt` are left untouched. If a non-row-major, non-`[N, 1]` col-major input is found, the call is treated as not repairable and the statement is left alone.
+Non-tile inputs (scalars, shapes) and inputs whose required layout is `nullopt` are left untouched. For tile inputs targeting a `row_major` slot, the per-input rewrite loop reshapes any `[N, 1]` operand (col-major *or* row-major) once the call has been classified as repairable; only `[1, N]` row-major and non-`[N, 1]` shapes are skipped. The call is classified as repairable (`IsRepairableCall`) only when at least one input violates `row_major` and every violating input is `[N, 1]` col-major — if any violating input falls outside that pattern, the statement is left alone.
 
 ## Example
 
@@ -81,16 +85,16 @@ class Before:
         data: pl.Tensor[[16, 256], pl.FP32],
         out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
     ) -> pl.Tensor[[16, 1], pl.FP32]:
-        acc_0: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+        acc_0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
             [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
-        acc_1: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_0, 0.0)
-        chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
-        tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+        acc_1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.muls(acc_0, 0.0)
+        chunk: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
             [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
-        partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
-        updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_1, partial)
+        partial: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.row_sum(chunk, tmp)
+        updated: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(acc_1, partial)
         stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
         return stored
 ```

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -364,7 +364,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 1. `FlattenTileNdTo2D`
 2. `InferTileMemorySpace`
 3. `ResolveTransposeLayout`
-4. `ResolveBackendOpLayouts`
+4. [`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md)
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
 7. `SplitVectorKernel`
@@ -380,11 +380,11 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用
 `Default`，以保证主维护流水线持续被覆盖。
 
-`ResolveBackendOpLayouts` 会根据 backend 注册的 layout 元数据修复受约束
-的逐元素 tile 操作。对于当前 PTO 上要求 `row_major` 的逐元素算子，它会
-在受约束 use-site 把 `[N, 1]` 向量操作数改写成 `[1, N]` 的
-`tile.reshape`，其 layout 由目标 shape 自动推导为 `row_major`，并在需要
-时把结果 reshape 回原始向量 shape。
+[`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md) 会根据
+backend 注册的 layout 元数据修复受约束的逐元素 tile 操作。对于当前 PTO
+上要求 `row_major` 的逐元素算子，它会在受约束 use-site 把 `[N, 1]`
+向量操作数改写成 `[1, N]` 的 `tile.reshape`，其 layout 由目标 shape
+自动推导为 `row_major`，并在需要时把结果 reshape 回原始向量 shape。
 
 `NormalizeReturnOrder` 对 InCore 函数的 `ReturnStmt::value_` 重新排序，使
 `return[i]` 对应声明顺序中第 i 个 `Out`/`InOut` 参数，并同步更新调用点的

--- a/docs/zh-cn/dev/passes/16-resolve_backend_op_layouts.md
+++ b/docs/zh-cn/dev/passes/16-resolve_backend_op_layouts.md
@@ -8,7 +8,7 @@
 
 1. 对每个 RHS 是 `Call` 的 `AssignStmt` / `EvalStmt`，调用 `Backend::GetTileLayoutSpec(op_name)` 查询约束。
 2. 若没有注册约束，或者没有 `[N, 1]` col-major 输入违反 `row_major` 要求，则跳过。
-3. 否则在 call 前插入 `tile.reshape(arg, [1, N])`，把 reshape 后的值代入 call；若原始结果是 `[N, 1]` col-major tile，再追加 `tile.reshape(result, [N, 1])` 把结果 reshape 回用户可见的形状。
+3. 否则在 call 前插入 `tile.reshape(arg, [1, N])`，把 reshape 后的值代入 call；对 `AssignStmt`，只要结果类型不是 `[1, N]` row-major tile，就再追加 `tile.reshape(tmp, original_shape)` 把结果 reshape 回用户可见的形状。
 
 本 Pass 是 **后端驱动** 的：被约束的 op 集合及其逐输入要求来自每个 op 的 `BackendOpRegistryEntry`（参见 `pto_ops_common.cpp` 中的 `set_input_layout` / `set_output_layout`）。Pass 自身保持后端无关——新增一个被约束的 op 只需登记它的 layout spec，无需修改本 Pass。
 
@@ -49,22 +49,26 @@ program = repair(program)
     若没有输入违反 spec.input_layouts（仅 [N,1] col-major 输入针对
        row_major 槽位时是可修复的）：跳过
 
-    对每个违反约束的输入 i：
-      reshape_var = 新临时变量（名字基于结果 + "row_major" + "arg<i>"）
+    对每个 row_major 槽位上的输入 i：
+      若输入非 tile、为 [1, N] row-major、或非 [N, 1]：跳过。
+      reshape_var = 新临时变量
+        （AssignStmt：名字基于结果变量；
+          EvalStmt：名字基于字面量 "layout_fix"。
+          两种形式都附加 "row_major" + "arg<i>" 限定符。）
       发射  reshape_var = tile.reshape(arg_i, [1, N])
       把 reshape_var 替换 call 中对应的实参
 
     repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
 
-    若原始结果是 [N, 1] col-major（仅 AssignStmt）：
-      tmp = 新的 row-major 临时变量
+    若语句是 AssignStmt 且 result_type 不是 [1, N] row-major：
+      tmp = 新的 row-major 临时变量（结果名字加 "row_major" 限定符）
       发射  tmp = repaired
-      发射  result_var = tile.reshape(tmp, [N, 1])
+      发射  result_var = tile.reshape(tmp, original_result_shape)
     否则：
       发射  result_var = repaired   （或 EvalStmt 中以 repaired 替换）
 ```
 
-已经满足要求的输入、非 tile 输入（标量、shape）、以及对应槽位 `required_layout` 为 `nullopt` 的输入都不会被改写。如果出现既非 row-major 也非 `[N, 1]` col-major 的输入，则该 call 被视为不可修复，整条语句保持不动。
+非 tile 输入（标量、shape）以及对应槽位 `required_layout` 为 `nullopt` 的输入不会被改写。对 `row_major` 槽位上的 tile 输入，一旦 call 被判定为可修复，逐输入改写循环就会 reshape 任何 `[N, 1]` 操作数（无论 col-major 还是 row-major）；只有 `[1, N]` row-major 和非 `[N, 1]` 形状会被跳过。call 是否可修复由 `IsRepairableCall` 决定：仅当至少有一个输入违反 `row_major` 要求、且每个违反约束的输入都是 `[N, 1]` col-major 时才返回 true；若有违反约束的输入不属于该模式，整条语句保持不动。
 
 ## 示例
 
@@ -81,16 +85,16 @@ class Before:
         data: pl.Tensor[[16, 256], pl.FP32],
         out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
     ) -> pl.Tensor[[16, 1], pl.FP32]:
-        acc_0: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+        acc_0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
             [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
-        acc_1: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_0, 0.0)
-        chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
-        tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+        acc_1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.muls(acc_0, 0.0)
+        chunk: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
             [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
-        partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
-        updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_1, partial)
+        partial: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.row_sum(chunk, tmp)
+        updated: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(acc_1, partial)
         stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
         return stored
 ```

--- a/docs/zh-cn/dev/passes/16-resolve_backend_op_layouts.md
+++ b/docs/zh-cn/dev/passes/16-resolve_backend_op_layouts.md
@@ -1,0 +1,167 @@
+# ResolveBackendOpLayouts Pass
+
+为后端有 layout 约束的 elementwise tile op 修复 layout：把 `[N, 1]` 的 col-major 向量输入 reshape 成 `[1, N]` 的 row-major 视图，必要时再把结果 reshape 回来。该 Pass 在 tile-PTO 阶段运行，位于 `ResolveTransposeLayout` 之后、收尾的 `NormalizeStmtStructure` 之前。
+
+## 概述
+
+经过 `FlattenTileNdTo2D` 和 `ResolveTransposeLayout` 之后，所有 tile op 都已是 2-D 形式且带有明确的 layout。多个 PTO elementwise op（在 `src/backend/common/pto_ops_common.cpp` 中注册）要求其 tile 操作数与结果均为 `row_major`。`[N, 1]` 列向量与 `[1, N]` 行向量在内存中的排布完全相同，因此本 Pass 在使用点局部修复约束违反：
+
+1. 对每个 RHS 是 `Call` 的 `AssignStmt` / `EvalStmt`，调用 `Backend::GetTileLayoutSpec(op_name)` 查询约束。
+2. 若没有注册约束，或者没有 `[N, 1]` col-major 输入违反 `row_major` 要求，则跳过。
+3. 否则在 call 前插入 `tile.reshape(arg, [1, N])`，把 reshape 后的值代入 call；若原始结果是 `[N, 1]` col-major tile，再追加 `tile.reshape(result, [N, 1])` 把结果 reshape 回用户可见的形状。
+
+本 Pass 是 **后端驱动** 的：被约束的 op 集合及其逐输入要求来自每个 op 的 `BackendOpRegistryEntry`（参见 `pto_ops_common.cpp` 中的 `set_input_layout` / `set_output_layout`）。Pass 自身保持后端无关——新增一个被约束的 op 只需登记它的 layout spec，无需修改本 Pass。
+
+**前置要求**：
+
+- 在 `FlattenTileNdTo2D` 之后运行（假定 tile op 已为 2-D）。
+- 函数必须是 `InCore`；Orchestration / Group 函数被跳过。
+- 必须通过 `BackendConfig::Set(...)` 配置后端，否则本 Pass 为 no-op。
+
+**何时使用**：作为 `Default` tile-PTO pipeline 的一部分，在改变 layout 的若干 Pass（`FlattenTileNdTo2D`、`InferTileMemorySpace`、`ResolveTransposeLayout`）之后、`NormalizeStmtStructure` 之前运行。Pass manager 已经把它放在了正确的位置。
+
+## API
+
+| C++ | Python | 层级 |
+| --- | ------ | ---- |
+| `pass::ResolveBackendOpLayouts()` | `passes.resolve_backend_op_layouts()` | Function 级 |
+
+**Python 用法**：
+
+```python
+from pypto.pypto_core import passes
+
+repair = passes.resolve_backend_op_layouts()
+program = repair(program)
+```
+
+## 算法
+
+```text
+对程序中的每个函数：
+  若函数不是 InCore：跳过。
+  若未配置后端：跳过。
+
+  使用 IRMutator 遍历 body。对每个 RHS 是 Call 的
+  AssignStmt / EvalStmt：
+    spec = backend.GetTileLayoutSpec(call.op.name)
+    若 spec 为空：跳过
+    若没有输入违反 spec.input_layouts（仅 [N,1] col-major 输入针对
+       row_major 槽位时是可修复的）：跳过
+
+    对每个违反约束的输入 i：
+      reshape_var = 新临时变量（名字基于结果 + "row_major" + "arg<i>"）
+      发射  reshape_var = tile.reshape(arg_i, [1, N])
+      把 reshape_var 替换 call 中对应的实参
+
+    repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
+
+    若原始结果是 [N, 1] col-major（仅 AssignStmt）：
+      tmp = 新的 row-major 临时变量
+      发射  tmp = repaired
+      发射  result_var = tile.reshape(tmp, [N, 1])
+    否则：
+      发射  result_var = repaired   （或 EvalStmt 中以 repaired 替换）
+```
+
+已经满足要求的输入、非 tile 输入（标量、shape）、以及对应槽位 `required_layout` 为 `nullopt` 的输入都不会被改写。如果出现既非 row-major 也非 `[N, 1]` col-major 的输入，则该 call 被视为不可修复，整条语句保持不动。
+
+## 示例
+
+（改编自 `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py::test_rewrites_column_vector_add_through_row_major_reshape`，启用 Ascend910B 后端）
+
+**Before**：
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.InCore)
+    def repro(
+        self,
+        data: pl.Tensor[[16, 256], pl.FP32],
+        out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    ) -> pl.Tensor[[16, 1], pl.FP32]:
+        acc_0: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+            [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        acc_1: pl.Tile[[16, 1], pl.FP32] = pl.tile.muls(acc_0, 0.0)
+        chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+            [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        partial: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)
+        updated: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(acc_1, partial)
+        stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+        return stored
+```
+
+**After**：
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.InCore)
+    def repro(
+        self,
+        data: pl.Tensor[[16, 256], pl.FP32],
+        out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+    ) -> pl.Tensor[[16, 1], pl.FP32]:
+        acc_0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+            [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        acc_0_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_0, [1, 16])
+        acc_1_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.muls(acc_0_rm, 0.0)
+        acc_1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_1_rm, [16, 1])
+        chunk: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.load(data, [0, 0], [16, 256])
+        tmp: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+            [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        partial: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.row_sum(chunk, tmp)
+        acc_1_rm2: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(acc_1, [1, 16])
+        partial_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(partial, [1, 16])
+        updated_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(acc_1_rm2, partial_rm)
+        updated: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(updated_rm, [16, 1])
+        stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(updated, [0, 0], out)
+        return stored
+```
+
+`tile.muls`、`tile.add` 等 elementwise PTO op 要求输入和输出均为 `row_major`。每一个被约束的 call 都会被包裹：`[16, 1]` 操作数在 call 之前 reshape 为 `[1, 16]`，call 在 row-major 形式下执行，结果再 reshape 回 `[16, 1]`，使下游代码（`tile.store`、返回类型）继续看到用户可见的形状。`tile.row_sum` 不带约束，其输入和输出保持原样。
+
+## 实现
+
+| 文件 | 角色 |
+| ---- | ---- |
+| `include/pypto/ir/transforms/passes.h`（`ResolveBackendOpLayouts`） | 公共 C++ 工厂 |
+| `src/ir/transforms/resolve_backend_op_layouts_pass.cpp` | Mutator 与 Pass 主体 |
+| `include/pypto/ir/transforms/pass_properties.h`（`kResolveBackendOpLayoutsProperties`） | Pass 属性 |
+| `python/bindings/modules/passes.cpp`（`resolve_backend_op_layouts`） | Python 绑定 |
+| `python/pypto/pypto_core/passes.pyi`（`resolve_backend_op_layouts`） | 类型存根 |
+| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | 单元测试（`[N, 1]` 向量上的 binary、unary、tile×scalar） |
+
+Layout 约束通过 `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` 在 `src/backend/common/pto_ops_common.cpp` 中按 op 注册（如 `RequiresRowMajorLayout` 列表中的 row-major elementwise op、`tile.rsqrt`、`tile.cmps`、`tile.sort32`、`tile.mscatter` 等）。
+
+Pass 源文件中的关键 helper：
+
+- `IsRepairableCall` —— 当且仅当至少有一个 tile 输入违反 `row_major` 要求、且每个违反约束的输入都是 `[N, 1]` col-major tile 时返回 true。
+- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` —— 发射 call 前的 reshape、重建 call，并在结果是 col-major 列向量的情况下（仅 `AssignStmt`）发射 call 后的 reshape。
+- `RewriteFunction` —— 跳过非 `InCore` 函数和未配置后端的情况，再调用 mutator。
+
+## Pass 属性
+
+| 属性 | 取值 |
+| ---- | ---- |
+| Required | SSAForm、IncoreTileOps、SplitIncoreOrch、TileOps2D |
+| Produced | SSAForm、IncoreTileOps、SplitIncoreOrch、TileOps2D |
+| Invalidated | NormalizedStmtStructure |
+
+`NormalizedStmtStructure` 被 invalidate 是因为每次修复都会把原本一条语句的 op 包裹成多条 `tile.reshape` 赋值，破坏了规范化的语句结构。默认 pipeline 在本 Pass 之后立刻重新跑 `NormalizeStmtStructure` 以恢复该不变量。
+
+## 设计取舍
+
+| 决策 | 理由 |
+| ---- | ---- |
+| 通过 `Backend::GetTileLayoutSpec` 获取 layout 要求，而不是在 Pass 中硬编码 op 列表 | 各后端在自己的 codegen 注册旁边声明约束。Pass 保持后端无关（参见 `pass-context-config.md`）；新增被约束的 op 只需要一次 `set_input_layout` 调用，不必改 Pass。 |
+| 通过两次 `tile.reshape` 修复，而不是直接拒绝程序 | `[N, 1]` col-major 与 `[1, N]` row-major 的扁平内存布局相同；局部 reshape 既保留了用户可见的形状，又满足后端 ISA，不必让用户重写 kernel。 |
+| 只修复 `[N, 1]` col-major 输入（不处理任意 layout 不匹配） | 这是当前 PTO row-major elementwise op 唯一观测到的不匹配模式。处理更一般情形需要真正的 layout 转换 Pass，本 Pass 不在该范围内；其他模式下 `IsRepairableCall` 返回 false，语句保持不变。 |
+| 未配置后端时直接 bypass | 大量测试在未选择后端的情况下构造 IR；no-op fast path 让这些测试仍然通过，避免无意义的改写。 |
+| 跳过非 `InCore` 函数 | Layout 约束作用于每个核内的 elementwise 执行；Orchestration、Group 函数仅承载对低层 kernel 的调用，没有需要修复的内容。 |


### PR DESCRIPTION
## Summary

- Add `docs/en/dev/passes/16-resolve_backend_op_layouts.md` covering the pass's purpose, backend-driven layout-repair algorithm, the `[N, 1]` col-major → `[1, N]` row-major reshape pattern, pass properties, implementation files, and design rationale.
- Mirror the new doc at `docs/zh-cn/dev/passes/16-resolve_backend_op_layouts.md` (English code blocks, file paths, and identifiers preserved).
- Cross-link the new doc from `00-pass_manager.md` (EN + ZH) where the strategy list and the `ResolveBackendOpLayouts` paragraph already mention the pass.
- Mark slot **16** in `.claude/rules/pass-doc-ordering.md` as documented.

## Test plan

- [x] `pre-commit` (markdownlint, header check, english-only, EOF/whitespace) passes
- [x] Code-review skill confirms doc faithfulness to `src/ir/transforms/resolve_backend_op_layouts_pass.cpp`
- [x] Pass properties table matches `kResolveBackendOpLayoutsProperties`
- [x] Before/After example matches `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py::test_rewrites_column_vector_add_through_row_major_reshape`
- [x] Both new docs ≤ 167 lines (well under the 500-line docs limit)

## Related Issues

Fixes #1166 (parent #1161)