### PR TITLE
docs(passes): Document ResolveTransposeLayout pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -27,7 +27,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 12 | `12-optimize_orch_tensors.md` | 12th pass |
 | 13 | `13-flatten_tile_nd_to_2d.md` | 13th pass |
 | 14 | `14-infer_tile_memory_space.md` | 14th pass |
-| 15 | *(no doc yet)* | 15th pass (`ResolveTransposeLayout`) |
+| 15 | `15-resolve_transpose_layout.md` | 15th pass |
 | 16 | `16-resolve_backend_op_layouts.md` | 16th pass |
 | 17 | `17-expand_mixed_kernel.md` | 17th pass |
 | 18 | `18-inject_gm_pipe_buffer.md` | Runs immediately after `ExpandMixedKernel` (backend-gated, Ascend910B) |

--- a/docs/en/dev/passes/15-resolve_transpose_layout.md
+++ b/docs/en/dev/passes/15-resolve_transpose_layout.md
@@ -1,0 +1,153 @@
+# ResolveTransposeLayout Pass
+
+Annotates InCore tensor parameters that source `tile.load(..., transpose=True)` with the `DN` (column-major) layout.
+
+## Overview
+
+When a `tile.load` is issued with `transpose=True`, PTO codegen needs the source tensor to be materialized in column-major (`DN`) layout — the transpose is realized by the layout choice rather than by reshaping data. This pass propagates that layout requirement back from the load site to the function parameter type, so that downstream passes and codegen can rely on the parameter's `TensorType` as the single source of truth for layout.
+
+The pass annotates the parameter only — **shape is preserved**. `DN` is a layout/codegen hint; the logical tensor dimensions are not swapped. (This is the invariant enforced by the regression test for #606: a partial transpose load on `[128, 128]` must keep the parameter shape at `[128, 128]`, not the load-window shape.)
+
+**Requirements**:
+
+- Input IR must be in SSA form
+- InCore functions must already be split out (`SplitIncoreOrch`)
+- Tile ops must be present and 2D (`IncoreTileOps`, `TileOps2D`)
+- Annotated tensor parameters must have rank ≥ 2
+
+**When to use**: Run as the 15th pass in the `Default` strategy, after `InferTileMemorySpace` and before `ResolveBackendOpLayouts`. The 2D shape produced by `FlattenTileNdTo2D` is a precondition.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::ResolveTransposeLayout()` | `passes.resolve_transpose_layout()` | Program-level |
+
+**Python usage**:
+
+```python
+from pypto.pypto_core import passes
+
+resolve_pass = passes.resolve_transpose_layout()
+program_dn = resolve_pass(program)
+```
+
+## Algorithm
+
+For each function in the program:
+
+1. **Skip non-InCore functions**: Orchestration and Opaque functions are returned unchanged. Only InCore-type functions (InCore, AIC, AIV) are processed.
+2. **Scan body for transposed loads**: walk the function body and collect, for each `tile.load` call whose kwarg `transpose=True` and whose first argument is one of the function's parameters, the index of that parameter. Duplicates across multiple load sites are deduplicated.
+3. **Rewrite parameters**: for each collected parameter:
+   - **Skip if already DN**: if the parameter's `TensorType` already carries `TensorView{layout=DN}`, no rewrite is needed (idempotent).
+   - **Require rank ≥ 2**: a 1D tensor cannot meaningfully be column-major; the pass aborts with a `CHECK` if it sees one.
+   - Build a new `Var` with the same `name_hint`, span, and shape, but with a new `TensorType` whose `tensor_view_` is `TensorView({}, TensorLayout::DN)`.
+4. **Substitute**: rewrite all uses of the old `Var` inside the function body via `Substitute`, then rebuild the function via `MutableCopy` with the new parameter list and body.
+
+No Orchestration-side rewrite happens. Downstream passes and codegen consume the InCore signature as the layout source of truth.
+
+| Behavior | Trigger |
+| -------- | ------- |
+| Annotate param with `DN` | InCore function param is the source of `tile.load(..., transpose=True)` |
+| Skip param | Already `DN`, or no transposed load reaches it |
+| Skip whole function | Function is Orchestration or Opaque |
+| `CHECK` failure | Annotated param is not a `TensorType`, or rank < 2 |
+
+## Example
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_incore(
+        self,
+        a: pl.Tensor[[64, 128], pl.FP32],
+        b: pl.Tensor[[32, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+        tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+        tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+        tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        c_store = pl.store(tile_c, [0, 0], c)
+        return c_store
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+        c_result = self.matmul_incore(a, b, c)
+        return c_result
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_incore(
+        self,
+        a: pl.Tensor[[64, 128], pl.FP32],
+        b: pl.Tensor[[32, 128], pl.FP32, pl.DN],
+        c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+        tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+        tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+        tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        c_store = pl.store(tile_c, [0, 0], c)
+        return c_store
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+        c_result = self.matmul_incore(a, b, c)
+        return c_result
+```
+
+`b` is the source of a `tile.load` with `transpose=True`, so the InCore parameter type gains the `pl.DN` layout annotation. The shape `[32, 128]` is unchanged. `a` is loaded without transpose, so it is left alone. The Orchestration `orchestrator` signature is **not** rewritten.
+
+## Implementation
+
+**Header**: `include/pypto/ir/transforms/passes.h`
+
+**Implementation**: `src/ir/transforms/resolve_transpose_layout_pass.cpp`
+
+**Python binding**: `python/bindings/modules/passes.cpp`
+
+**Tests**: `tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py`
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| Produced | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| Invalidated | — |
+
+The pass preserves all input properties: it only rewrites tensor parameter type annotations, not statement structure or SSA form.
+
+## Scope
+
+| Function type | Action |
+| ------------- | ------ |
+| InCore (InCore, AIC, AIV) | Scanned and possibly rewritten |
+| Orchestration | Unchanged |
+| Opaque | Unchanged |
+
+| Parameter state | Action |
+| --------------- | ------ |
+| Sourced by `tile.load(..., transpose=True)`, layout != DN, rank ≥ 2 | Rewritten to add `DN` |
+| Sourced by `tile.load(..., transpose=True)`, layout already DN | Unchanged (idempotent) |
+| Not sourced by any transposed load | Unchanged |
+| Rank < 2 candidate | `CHECK` failure |
+
+The pass is a no-op when no InCore function contains a `tile.load(..., transpose=True)` whose source is a parameter (verified by the `TestResolveTransposeLayoutNoOp` test class).

--- a/docs/zh-cn/dev/passes/15-resolve_transpose_layout.md
+++ b/docs/zh-cn/dev/passes/15-resolve_transpose_layout.md
@@ -1,0 +1,153 @@
+# ResolveTransposeLayout Pass
+
+为作为 `tile.load(..., transpose=True)` 源张量的 InCore 函数参数标注 `DN`（列主序）布局。
+
+## 概述
+
+当 `tile.load` 使用 `transpose=True` 发起时，PTO codegen 需要源张量以列主序（`DN`）布局物化 —— 转置通过布局选择来实现，而不是通过对数据进行 reshape。该 Pass 把这一布局需求从 load 站点回传到函数参数类型，让下游 Pass 与 codegen 把参数的 `TensorType` 视为布局的唯一权威。
+
+该 Pass 只标注参数 —— **形状保持不变**。`DN` 是布局/codegen 提示；逻辑张量维度不会被交换。（这正是 #606 的回归测试所保护的不变量：在 `[128, 128]` 上做窗口转置加载时，参数形状必须保持 `[128, 128]`，而不是 load 窗口的形状。）
+
+**前置条件**：
+
+- 输入 IR 必须为 SSA 形式
+- InCore 函数已完成拆分（`SplitIncoreOrch`）
+- Tile 操作已存在且为 2D（`IncoreTileOps`、`TileOps2D`）
+- 待标注的张量参数必须 rank ≥ 2
+
+**使用时机**：在 `Default` 策略中作为第 15 个 Pass 运行，位于 `InferTileMemorySpace` 之后、`ResolveBackendOpLayouts` 之前。`FlattenTileNdTo2D` 产生的 2D 形状是其前置条件。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::ResolveTransposeLayout()` | `passes.resolve_transpose_layout()` | Program 级 |
+
+**Python 用法**：
+
+```python
+from pypto.pypto_core import passes
+
+resolve_pass = passes.resolve_transpose_layout()
+program_dn = resolve_pass(program)
+```
+
+## 算法
+
+对程序中每个函数：
+
+1. **跳过非 InCore 函数**：Orchestration 与 Opaque 函数原样返回。仅处理 InCore 类函数（InCore、AIC、AIV）。
+2. **扫描 body 中的转置 load**：遍历函数体，对每个 kwarg `transpose=True` 且第一个参数是该函数某个 parameter 的 `tile.load` 调用，记录该 parameter 的索引。多次出现的同一参数会去重。
+3. **重写参数**：对每个被收集到的参数：
+   - **若已是 DN 则跳过**：参数的 `TensorType` 已携带 `TensorView{layout=DN}` 时无需重写（幂等）。
+   - **要求 rank ≥ 2**：1D 张量谈不上列主序；遇到时通过 `CHECK` 终止。
+   - 构造一个新的 `Var`，沿用原有的 `name_hint`、span 与形状，但其 `TensorType` 的 `tensor_view_` 为 `TensorView({}, TensorLayout::DN)`。
+4. **替换**：通过 `Substitute` 把函数体内对旧 `Var` 的所有引用替换为新 `Var`，再用 `MutableCopy` 以新参数列表与新 body 重建函数。
+
+不会对 Orchestration 端做任何改写。下游 Pass 与 codegen 把 InCore 签名视为布局的唯一权威。
+
+| 行为 | 触发条件 |
+| ---- | -------- |
+| 给参数加 `DN` | InCore 函数参数是 `tile.load(..., transpose=True)` 的源 |
+| 跳过该参数 | 已是 `DN`，或没有任何转置 load 命中它 |
+| 跳过整个函数 | 函数为 Orchestration 或 Opaque |
+| `CHECK` 失败 | 待标注参数不是 `TensorType`，或 rank < 2 |
+
+## 示例
+
+**之前**：
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_incore(
+        self,
+        a: pl.Tensor[[64, 128], pl.FP32],
+        b: pl.Tensor[[32, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+        tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+        tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+        tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        c_store = pl.store(tile_c, [0, 0], c)
+        return c_store
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+        c_result = self.matmul_incore(a, b, c)
+        return c_result
+```
+
+**之后**：
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.InCore)
+    def matmul_incore(
+        self,
+        a: pl.Tensor[[64, 128], pl.FP32],
+        b: pl.Tensor[[32, 128], pl.FP32, pl.DN],
+        c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+        tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+        tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+        tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+        c_store = pl.store(tile_c, [0, 0], c)
+        return c_store
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+    ) -> pl.Tensor[[64, 32], pl.FP32]:
+        c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+        c_result = self.matmul_incore(a, b, c)
+        return c_result
+```
+
+`b` 是带 `transpose=True` 的 `tile.load` 的源，因此 InCore 参数类型获得 `pl.DN` 布局标注。形状 `[32, 128]` 不变。`a` 没有转置 load，保持原样。Orchestration `orchestrator` 的签名**不会**被改写。
+
+## 实现
+
+**头文件**：`include/pypto/ir/transforms/passes.h`
+
+**实现文件**：`src/ir/transforms/resolve_transpose_layout_pass.cpp`
+
+**Python 绑定**：`python/bindings/modules/passes.cpp`
+
+**测试**：`tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py`
+
+## Pass 属性
+
+| 属性 | 值 |
+| ---- | -- |
+| 所需 | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| 产生 | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D |
+| 失效 | — |
+
+该 Pass 保留所有输入属性：仅重写张量参数的类型标注，不改变语句结构或 SSA 形式。
+
+## 作用范围
+
+| 函数类型 | 处理方式 |
+| -------- | -------- |
+| InCore（InCore、AIC、AIV） | 扫描并可能改写 |
+| Orchestration | 原样保留 |
+| Opaque | 原样保留 |
+
+| 参数状态 | 处理方式 |
+| -------- | -------- |
+| 是 `tile.load(..., transpose=True)` 的源、布局非 DN、rank ≥ 2 | 改写并加上 `DN` |
+| 是 `tile.load(..., transpose=True)` 的源、布局已是 DN | 原样保留（幂等） |
+| 不是任何转置 load 的源 | 原样保留 |
+| 候选参数 rank < 2 | `CHECK` 失败 |
+
+如果没有任何 InCore 函数包含以参数为源的 `tile.load(..., transpose=True)`，整个 Pass 是 no-op（由 `TestResolveTransposeLayoutNoOp` 测试类验证）。

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -359,10 +359,10 @@ Pass InferTileMemorySpace();
 /**
  * @brief Resolve transpose layout for tile.load with transpose=True
  *
- * Detects tile.load(..., transpose=True) in InCore functions and transforms
- * the source tensor parameter type from its physical shape (e.g. [N, K]) to
- * the logical transposed shape with DN layout (e.g. [K, N] + DN).
- * Propagates the type change to corresponding Orchestration function parameters.
+ * For each InCore function, detects tile.load(..., transpose=True) whose source
+ * is a function parameter and annotates that parameter's TensorType with the DN
+ * (column-major) layout. The shape is preserved -- DN is a codegen hint only.
+ * Orchestration and Opaque functions are returned unchanged.
  *
  * Requirements:
  * - Input IR must have tile ops (run ConvertTensorToTileOps first)

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -364,9 +364,10 @@ void BindPass(nb::module_& m) {
              "Create a pass that infers memory_space for TileType variables in InCore functions");
   passes.def("resolve_transpose_layout", &pass::ResolveTransposeLayout,
              "Create a pass that resolves transpose layout for tile.load with transpose=True\n\n"
-             "Detects tile.load(..., transpose=True) in InCore functions and transforms\n"
-             "the source tensor parameter type to the logical transposed shape with DN layout.\n"
-             "Propagates the type change to corresponding Orchestration function parameters.");
+             "For each InCore function, detects tile.load(..., transpose=True) whose source\n"
+             "is a function parameter and annotates that parameter's TensorType with the DN\n"
+             "(column-major) layout. The shape is preserved -- DN is a codegen hint only.\n"
+             "Orchestration and Opaque functions are returned unchanged.");
   passes.def("resolve_backend_op_layouts", &pass::ResolveBackendOpLayouts,
              "Create a pass that repairs backend-required layouts for constrained elementwise tile ops\n\n"
              "Repairs `[N,1]` col-major vector inputs at constrained use-sites by reshaping them\n"


### PR DESCRIPTION
## Summary

- Add per-pass documentation for `ResolveTransposeLayout` at slot 15 of the `Default` strategy under `docs/en/dev/passes/15-resolve_transpose_layout.md` and the Chinese mirror `docs/zh-cn/dev/passes/15-resolve_transpose_layout.md`. Style and sectioning follow the existing per-pass docs (purpose, requirements, API table, algorithm, before/after example, implementation files, pass properties, scope).
- Mark slot 15 as documented in `.claude/rules/pass-doc-ordering.md`.
- Fix a stale claim in the Python binding docstring for `resolve_transpose_layout` in `python/bindings/modules/passes.cpp`. The old text said the pass "transforms the source tensor parameter type to the logical transposed shape" and "propagates the type change to corresponding Orchestration function parameters". The implementation does neither — it preserves the shape and only annotates InCore-type parameters with the `DN` layout hint, leaving Orchestration and Opaque functions untouched. The new docstring matches the documented behavior.

## Test plan

- [x] Build (`cmake --build build --parallel`) succeeds with the binding docstring change.
- [x] Targeted tests pass: `pytest tests/ut/ir/transforms/test_resolve_transpose_layout_pass.py -v` (12/12 green).
- [x] Pass manager tests pass: `pytest tests/ut/ir/transforms/test_pass_manager.py -v` (12/12 green).
- [x] Pre-commit hooks (markdownlint, cpplint, clang-format, header check, English-only check) all pass.
- [x] Doc length compliance: each new doc is 153 lines (well under the 500-line cap).

## Related issues

Fixes #1165
Parent tracker: #1161