### PR TITLE
feat(gather): extend lowering to rank-3 and arbitrary gather dim and bump PTOAS to v0.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
       - name: Install project and dependencies
         run: |
           python -m pip install --upgrade pip
+          rm -rf ./build ./_skbuild
+          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
           pip install --no-build-isolation .[dev]
 
       - name: Install ptoas (local cache)
@@ -151,6 +153,7 @@ jobs:
       - name: Install simpler
         run: |
           rm -rf ./runtime/build
+          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
           pip install --no-build-isolation ./runtime
 
       - name: Show ccache stats (after)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.30
-      PTOAS_SHA256: 83cd91f1bbe3c1b5bc7b01462adeb73603fb22b1b56d8b39bd90644b373ba2a1
+      PTOAS_VERSION: v0.31
+      PTOAS_SHA256: ca184d071cef3af989ff3f98e7ce4c7262ba1e07405738b65e9900c43065ada5
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -158,19 +158,19 @@ jobs:
 
       - name: Test system tests
         timeout-minutes: 15
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=2c607938
 
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.30
-      PTOAS_SHA256: 9a918aa5e8e17e3a194db8aa6af2f945a6c177d5bc0813494c30ff5d15ca2740
+      PTOAS_VERSION: v0.31
+      PTOAS_SHA256: cd9121b768f7383f5bda702c89507dd160f539c28bbdf57a0585be9473081d07
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:
@@ -208,13 +208,13 @@ jobs:
           pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=2c607938
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=2c607938
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=5779238f2461460c1b2e87d0a6741bf10dfe4352
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=2c607938
 
   fuzz-tests-sim:
     runs-on: ubuntu-latest

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -270,6 +270,59 @@ static std::string MakeNaryCodegenPTO(const std::string& pto_op_name, size_t ari
   return "";
 }
 
+// pto.ttrans requires ins(%src, %tmp : tile_type, tile_type) where %tmp is a scratch
+// workspace tile (same type/shape as %src).
+//
+// Two IR forms are supported:
+//   3-arg form: tile.transpose(src, axis0, axis1)   -- axis ints; tmp allocated via AllocNewTileBuf
+//   4-arg form: tile.transpose(src, tmp, axis0, axis1) -- tmp pre-allocated in IR (preferred;
+//               ensures pto.alloc_tile receives a hardware address at --pto-level=level3).
+//
+// The 4-arg form is used by gather lowering (op_conversion_registry.cpp) so that the memory
+// allocator assigns a proper UB address to the tmp tile before codegen.
+// The 3-arg form is kept for FlattenTileNdTo2D which filters it out via batch_matmul_only_vars
+// before reaching the backend (so the AllocNewTileBuf fallback is rarely reached in practice).
+static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 3 || op->args_.size() == 4)
+      << "tile.transpose requires 3 or 4 arguments, got " << op->args_.size();
+
+  std::string src_ssa = codegen.GetExprAsCode(op->args_[0]);
+  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+
+  std::string tmp_ssa;
+  if (op->args_.size() == 4) {
+    // 4-arg form: args_[1] is the pre-allocated tmp tile with a proper hardware address.
+    tmp_ssa = codegen.GetExprAsCode(op->args_[1]);
+    // tmp was created by tile.create (same shape as src) and has a MemRef, so its type
+    // annotation is always available.  Use it as fallback when src_type is empty (e.g. when
+    // src is a ForStmt result var or a tile.reshape view that lacks a MemRef in codegen).
+    if (src_type.empty()) {
+      src_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+    }
+  } else {
+    // 3-arg form fallback: allocate tmp via extra_alloc_tiles (no hardware addr; only safe if
+    // this code path is not reached at --pto-level=level3).
+    tmp_ssa = codegen.AllocNewTileBuf(src_type, "ttrans_tmp");
+  }
+
+  std::string result_target = codegen.GetCurrentResultTarget();
+  std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream oss;
+  oss << "pto.ttrans ins(" << src_ssa << ", " << tmp_ssa;
+  if (!src_type.empty()) {
+    oss << " : " << src_type << ", " << src_type;
+  }
+  oss << ") outs(" << result_target;
+  if (!result_type.empty()) {
+    oss << " : " << result_type;
+  }
+  oss << ")";
+  codegen.Emit(oss.str());
+  return std::string("");
+}
+
 // pto.tcolexpand takes only the column vector in ins(); output shape comes from outs().
 // IR tile.col_expand(target, col_vec) keeps target for shape/type inference only.
 static std::string MakeColExpandCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
@@ -1465,7 +1518,9 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.concat",          "pto.tconcat",          2},
     {"tile.move",            "pto.tmov",             1},
     {"tile.move_fp",         "pto.tmov.fp",          2},
-    {"tile.transpose",       "pto.ttrans",           3},
+    // tile.transpose has custom codegen (MakeTileTransposeCodegenPTO): pto.ttrans needs
+    // ins(%src, %tmp : tile_type, tile_type) where %tmp is a scratch workspace tile, NOT
+    // the axis-index integers that tile.transpose(src, axis0, axis1) carries in the IR.
     {"tile.extract",         "pto.textract",         3},
     // Gather/scatter operations
     {"tile.gather",          "pto.tgather",          3},
@@ -1539,6 +1594,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.store", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileStoreCodegenPTO(op, codegen);
+  });
+  reg("tile.transpose", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeTileTransposeCodegenPTO(op, codegen);
   });
   // tile.mscatter: src and idx must be row_major (MTE3 DMA reads UB linearly)
   if (exclude_ops.count("tile.mscatter") == 0) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -303,6 +303,9 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   } else {
     // 3-arg form fallback: allocate tmp via extra_alloc_tiles (no hardware addr; only safe if
     // this code path is not reached at --pto-level=level3).
+    CHECK(!src_type.empty()) << "tile.transpose 3-arg form requires src to have a tile-buf type annotation; "
+                             << "use the 4-arg form (with pre-allocated tmp) when src is a ForStmt result or "
+                             << "tile.reshape view";
     tmp_ssa = codegen.AllocNewTileBuf(src_type, "ttrans_tmp");
   }
 

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -13,8 +13,8 @@
  * @file gather.cpp
  * @brief Tensor-level gather operator.
  *
- * MVP scope: rank == 2 and dim == -1 (last axis). Lowered to a per-row
- * tile.gather loop by ConvertTensorToTileOps.
+ * Supports rank >= 2 and any dim (including negative). Lowered to a sequence
+ * of tile.transpose + tile.reshape + tile.gather by ConvertTensorToTileOps.
  */
 
 #include <any>
@@ -32,7 +32,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
-#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -59,8 +58,7 @@ TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
       << index_type->dtype_.ToString();
 
   const int64_t rank = static_cast<int64_t>(input_type->shape_.size());
-  CHECK(rank == 2) << "The operator " << op_name << " currently supports only 2D input (MVP), but got rank "
-                   << rank;
+  CHECK(rank >= 2) << "The operator " << op_name << " requires rank >= 2, but got rank " << rank;
   CHECK(static_cast<int64_t>(index_type->shape_.size()) == rank)
       << "The operator " << op_name << " requires index rank (" << index_type->shape_.size()
       << ") to match input rank (" << rank << ")";
@@ -75,14 +73,24 @@ TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
     }
   }
   CHECK(dim_seen) << "The operator " << op_name << " requires a 'dim' keyword argument";
-  CHECK(dim_val == -1 || dim_val == rank - 1)
-      << "The operator " << op_name
-      << " currently supports only dim=-1 or dim=rank-1 (MVP), but got dim=" << dim_val;
 
-  // Non-dim axis (axis 0 for 2D) must match between input and index.
-  CHECK(DimensionsEqual(input_type->shape_[0], index_type->shape_[0]))
-      << "The operator " << op_name
-      << " requires index.shape[0] to equal input.shape[0] on the non-gather axis";
+  // Normalize negative dim.
+  int norm_dim = dim_val < 0 ? dim_val + static_cast<int>(rank) : dim_val;
+  CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
+      << "The operator " << op_name << " requires dim in [" << -rank << ", " << rank - 1
+      << "], but got dim=" << dim_val;
+
+  // For non-gather axes: index.shape[i] <= input.shape[i] (static check when both are ConstInt).
+  for (int64_t i = 0; i < rank; ++i) {
+    if (i == static_cast<int64_t>(norm_dim)) continue;
+    auto idx_const = As<ConstInt>(index_type->shape_[i]);
+    auto inp_const = As<ConstInt>(input_type->shape_[i]);
+    if (idx_const && inp_const) {
+      CHECK(idx_const->value_ <= inp_const->value_)
+          << "The operator " << op_name << " requires index.shape[" << i << "] (" << idx_const->value_
+          << ") <= input.shape[" << i << "] (" << inp_const->value_ << ") on non-gather axes";
+    }
+  }
 
   return std::make_shared<TensorType>(index_type->shape_, input_type->dtype_);
 }
@@ -91,7 +99,8 @@ REGISTER_OP("tensor.gather")
     .set_op_category("TensorOp")
     .set_description(
         "Gather elements of input along the specified dimension using the index tensor "
-        "(tensor-level). MVP: rank==2 and dim==-1; lowered to a per-row tile.gather loop.")
+        "(tensor-level). Supports rank>=2 and any dim; lowered via tile.transpose + "
+        "tile.reshape + tile.gather by ConvertTensorToTileOps.")
     .add_argument("input", "Input tensor (TensorType; FP16, FP32, INT16, or INT32)")
     .add_argument("index", "Index tensor (TensorType, INT32, same shape as output)")
     .set_attr<int>("dim")

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -261,15 +261,9 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.transpose supports two forms:
-  //   3-arg: (src, axis1, axis2)         -- legacy form used by FlattenTileNdTo2D
-  //   4-arg: (src, tmp, axis1, axis2)    -- form used by gather lowering; tmp is a pre-allocated
-  //                                         scratch TileType with same shape/dtype as src, so
-  //                                         pto.ttrans can receive a hardware-addressed tmp buffer.
-  CHECK(args.size() == 3 || args.size() == 4)
-      << "tile.transpose requires 3 arguments (src, axis1, axis2) or "
-         "4 arguments (src, tmp, axis1, axis2), but got "
-      << args.size();
+  // tile.transpose requires exactly 3 arguments: input tile, axis1, axis2
+  CHECK(args.size() == 3) << "tile.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
+                          << args.size();
 
   // First argument must be TileType
   auto tile_type = As<TileType>(args[0]->GetType());
@@ -281,15 +275,13 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
 
   CHECK(ndim >= 2) << "tile.transpose requires at least 2 dimensions, but got " << ndim;
 
-  // Axis args: positions 1,2 in 3-arg form; positions 2,3 in 4-arg form.
-  size_t axis1_idx = (args.size() == 4) ? 2 : 1;
-  size_t axis2_idx = (args.size() == 4) ? 3 : 2;
+  // Second argument is axis1 (ConstInt)
+  auto axis1_const = As<ConstInt>(args[1]);
+  CHECK(axis1_const) << "tile.transpose requires second argument (axis1) to be a ConstInt";
 
-  auto axis1_const = As<ConstInt>(args[axis1_idx]);
-  CHECK(axis1_const) << "tile.transpose requires axis1 to be a ConstInt";
-
-  auto axis2_const = As<ConstInt>(args[axis2_idx]);
-  CHECK(axis2_const) << "tile.transpose requires axis2 to be a ConstInt";
+  // Third argument is axis2 (ConstInt)
+  auto axis2_const = As<ConstInt>(args[2]);
+  CHECK(axis2_const) << "tile.transpose requires third argument (axis2) to be a ConstInt";
 
   int axis1 = NormalizeAxis(static_cast<int>(axis1_const->value_), ndim);
   int axis2 = NormalizeAxis(static_cast<int>(axis2_const->value_), ndim);

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -261,9 +261,15 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.transpose requires exactly 3 arguments: input tile, axis1, axis2
-  CHECK(args.size() == 3) << "tile.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
-                          << args.size();
+  // tile.transpose supports two forms:
+  //   3-arg: (src, axis1, axis2)         -- legacy form used by FlattenTileNdTo2D
+  //   4-arg: (src, tmp, axis1, axis2)    -- form used by gather lowering; tmp is a pre-allocated
+  //                                         scratch TileType with same shape/dtype as src, so
+  //                                         pto.ttrans can receive a hardware-addressed tmp buffer.
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tile.transpose requires 3 arguments (src, axis1, axis2) or "
+         "4 arguments (src, tmp, axis1, axis2), but got "
+      << args.size();
 
   // First argument must be TileType
   auto tile_type = As<TileType>(args[0]->GetType());
@@ -275,15 +281,16 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
 
   CHECK(ndim >= 2) << "tile.transpose requires at least 2 dimensions, but got " << ndim;
 
-  // Second argument is axis1 (ConstInt)
-  auto axis1_const = As<ConstInt>(args[1]);
-  CHECK(axis1_const) << "tile.transpose requires second argument (axis1) to be a ConstInt";
+  // Axis args: positions 1,2 in 3-arg form; positions 2,3 in 4-arg form.
+  size_t axis1_idx = (args.size() == 4) ? 2 : 1;
+  size_t axis2_idx = (args.size() == 4) ? 3 : 2;
 
-  // Third argument is axis2 (ConstInt)
-  auto axis2_const = As<ConstInt>(args[2]);
-  CHECK(axis2_const) << "tile.transpose requires third argument (axis2) to be a ConstInt";
+  auto axis1_const = As<ConstInt>(args[axis1_idx]);
+  CHECK(axis1_const) << "tile.transpose requires axis1 to be a ConstInt";
 
-  // Normalize axes (handle negative indexing)
+  auto axis2_const = As<ConstInt>(args[axis2_idx]);
+  CHECK(axis2_const) << "tile.transpose requires axis2 to be a ConstInt";
+
   int axis1 = NormalizeAxis(static_cast<int>(axis1_const->value_), ndim);
   int axis2 = NormalizeAxis(static_cast<int>(axis2_const->value_), ndim);
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -14,6 +14,7 @@
 #include <any>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -908,20 +909,18 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& index = args[1];
 
         auto input_tensor_type = As<TensorType>(input->GetType());
-        CHECK(input_tensor_type)
-            << "tensor.gather conversion: input must be TensorType, got "
-            << input->GetType()->TypeName();
+        CHECK(input_tensor_type) << "tensor.gather conversion: input must be TensorType, got "
+                                 << input->GetType()->TypeName();
         auto index_tensor_type = As<TensorType>(index->GetType());
-        CHECK(index_tensor_type)
-            << "tensor.gather conversion: index must be TensorType, got "
-            << index->GetType()->TypeName();
+        CHECK(index_tensor_type) << "tensor.gather conversion: index must be TensorType, got "
+                                 << index->GetType()->TypeName();
 
         const auto& input_shape = input_tensor_type->shape_;
         const auto& index_shape = index_tensor_type->shape_;
         const int64_t rank = static_cast<int64_t>(input_shape.size());
         CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 
-        int dim_val  = GetKwargOr<int>(kwargs, "dim", -1);
+        int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
         int norm_dim = dim_val < 0 ? dim_val + static_cast<int>(rank) : dim_val;
         CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
             << "tensor.gather conversion: dim out of range, got " << dim_val;
@@ -935,7 +934,7 @@ void OpConversionRegistry::RegisterGatherOps() {
           return std::make_shared<ConstInt>(value, DataType::INT32, span);
         };
         auto zero = make_idx(0);
-        auto one  = make_idx(1);
+        auto one = make_idx(1);
 
         std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
                                                                      {"transpose", false}};
@@ -974,23 +973,22 @@ void OpConversionRegistry::RegisterGatherOps() {
                                      const VarPtr& idx_row, int64_t idx_cols,
                                      const std::string& name) -> VarPtr {
           auto tmp_sh = MakeShapeTuple({one, make_idx(idx_cols)}, span);
-          auto tmp    = emit_to(stmts, "tile.create", {tmp_sh}, tmp_create_kwargs, name + "_tmp");
+          auto tmp = emit_to(stmts, "tile.create", {tmp_sh}, tmp_create_kwargs, name + "_tmp");
           return emit_to(stmts, "tile.gather", {src_row, idx_row, tmp}, {}, name);
         };
 
         // Build a ForStmt that accumulates [1, acc_cols] rows into [acc_rows, acc_cols].
         // body_builder receives (loop_var, iter_arg, body_stmts) and returns a [1, acc_cols] tile.
         auto make_loop =
-            [&](std::vector<StmtPtr>& outer_stmts, const std::string& lname,
-                const ExprPtr& loop_stop, int64_t acc_rows, int64_t acc_cols, DataType acc_dtype,
-                const std::function<VarPtr(VarPtr, IterArgPtr, std::vector<StmtPtr>&)>& body_builder)
-            -> VarPtr {
+            [&](std::vector<StmtPtr>& outer_stmts, const std::string& lname, const ExprPtr& loop_stop,
+                int64_t acc_rows, int64_t acc_cols, DataType acc_dtype,
+                const std::function<VarPtr(const VarPtr&, const IterArgPtr&, std::vector<StmtPtr>&)>&
+                    body_builder) -> VarPtr {
           std::vector<std::pair<std::string, std::any>> acc_kwargs = {{"dtype", acc_dtype},
                                                                       {"target_memory", MemorySpace::Vec}};
-          auto acc_init = emit_to(
-              outer_stmts, "tile.create",
-              {MakeShapeTuple({make_idx(acc_rows), make_idx(acc_cols)}, span)}, acc_kwargs,
-              lname + "_acc_init");
+          auto acc_init = emit_to(outer_stmts, "tile.create",
+                                  {MakeShapeTuple({make_idx(acc_rows), make_idx(acc_cols)}, span)},
+                                  acc_kwargs, lname + "_acc_init");
           auto acc_type = acc_init->GetType();
           auto lv = std::make_shared<Var>(lname + "_lv", std::make_shared<ScalarType>(DataType::INDEX), span);
           auto ia = std::make_shared<IterArg>(lname + "_ia", acc_type, acc_init, span);
@@ -998,13 +996,12 @@ void OpConversionRegistry::RegisterGatherOps() {
 
           std::vector<StmtPtr> body_stmts;
           auto row_result = body_builder(lv, ia, body_stmts);
-          auto ofs   = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
+          auto ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
           auto asmbl = emit_to(body_stmts, "tile.assemble", {ia, row_result, ofs}, {}, lname + "_asmbl");
           body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{asmbl}, span));
           auto body = SeqStmts::Flatten(std::move(body_stmts), span);
-          outer_stmts.push_back(std::make_shared<ForStmt>(lv, zero, loop_stop, one,
-                                                           std::vector<IterArgPtr>{ia}, body,
-                                                           std::vector<VarPtr>{rv}, span));
+          outer_stmts.push_back(std::make_shared<ForStmt>(
+              lv, zero, loop_stop, one, std::vector<IterArgPtr>{ia}, body, std::vector<VarPtr>{rv}, span));
           return rv;
         };
 
@@ -1021,18 +1018,18 @@ void OpConversionRegistry::RegisterGatherOps() {
         if (rank == 2 && norm_dim == 1) {
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");
           int64_t S1 = get_const(input_shape[1], "input.shape[1]");
-          int64_t K  = get_const(index_shape[1], "index.shape[1]");
+          int64_t K = get_const(index_shape[1], "index.shape[1]");
 
           auto result = make_loop(
               prologue, "gather", index_shape[0], I0, K, input_dtype,
-              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+              [&](const VarPtr& lv, const IterArgPtr& /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
                 auto row_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
-                auto inp_sh  = MakeShapeTuple({one, make_idx(S1)}, span);
-                auto inp_row = emit_to(bs, "tile.load", {input, row_ofs, inp_sh, inp_sh},
-                                       load_kwargs, "gather_inp_row");
-                auto idx_sh  = MakeShapeTuple({one, make_idx(K)}, span);
-                auto idx_row = emit_to(bs, "tile.load", {index, row_ofs, idx_sh, idx_sh},
-                                       load_kwargs, "gather_idx_row");
+                auto inp_sh = MakeShapeTuple({one, make_idx(S1)}, span);
+                auto inp_row =
+                    emit_to(bs, "tile.load", {input, row_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_row");
+                auto idx_sh = MakeShapeTuple({one, make_idx(K)}, span);
+                auto idx_row =
+                    emit_to(bs, "tile.load", {index, row_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_row");
                 return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
               });
           return ConversionResult{std::move(prologue), result};
@@ -1045,33 +1042,34 @@ void OpConversionRegistry::RegisterGatherOps() {
         // partition_shape [1, I0*I1, K] which covers all elements correctly.
         // ================================================================
         if (rank == 3 && norm_dim == 2) {
-          int64_t I0  = get_const(index_shape[0], "index.shape[0]");
-          int64_t I1  = get_const(index_shape[1], "index.shape[1]");
-          int64_t S2  = get_const(input_shape[2], "input.shape[2]");
-          int64_t K   = get_const(index_shape[2], "index.shape[2]");
+          int64_t I0 = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1 = get_const(index_shape[1], "index.shape[1]");
+          int64_t S2 = get_const(input_shape[2], "input.shape[2]");
+          int64_t K = get_const(index_shape[2], "index.shape[2]");
           int64_t I1K = I1 * K;
 
           // Outer loop: i0=0..I0-1, accumulates [I0, I1*K].
           auto outer_result = make_loop(
               prologue, "gather_outer", index_shape[0], I0, I1K, input_dtype,
-              [&](VarPtr outer_lv, IterArgPtr /*oia*/, std::vector<StmtPtr>& ob) -> VarPtr {
+              [&](const VarPtr& outer_lv, const IterArgPtr& /*oia*/, std::vector<StmtPtr>& ob) -> VarPtr {
                 // Inner loop: i1=0..I1-1, accumulates [I1, K].
-                auto inner_result = make_loop(
-                    ob, "gather_inner", index_shape[1], I1, K, input_dtype,
-                    [&](VarPtr inner_lv, IterArgPtr /*iia*/, std::vector<StmtPtr>& bs) -> VarPtr {
-                      auto ofs = std::make_shared<MakeTuple>(
-                          std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
-                      // Load with 3D shape → 3D tile type; immediately reshape to 2D.
-                      auto inp_sh  = MakeShapeTuple({one, one, make_idx(S2)}, span);
-                      auto inp_raw = emit_to(bs, "tile.load", {input, ofs, inp_sh, inp_sh},
-                                             load_kwargs, "gather_inp_raw");
-                      auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
-                      auto idx_sh  = MakeShapeTuple({one, one, make_idx(K)}, span);
-                      auto idx_raw = emit_to(bs, "tile.load", {index, ofs, idx_sh, idx_sh},
-                                             load_kwargs, "gather_idx_raw");
-                      auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
-                      return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
-                    });
+                auto inner_result =
+                    make_loop(ob, "gather_inner", index_shape[1], I1, K, input_dtype,
+                              [&](const VarPtr& inner_lv, const IterArgPtr& /*iia*/,
+                                  std::vector<StmtPtr>& bs) -> VarPtr {
+                                auto ofs = std::make_shared<MakeTuple>(
+                                    std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
+                                // Load with 3D shape → 3D tile type; immediately reshape to 2D.
+                                auto inp_sh = MakeShapeTuple({one, one, make_idx(S2)}, span);
+                                auto inp_raw = emit_to(bs, "tile.load", {input, ofs, inp_sh, inp_sh},
+                                                       load_kwargs, "gather_inp_raw");
+                                auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
+                                auto idx_sh = MakeShapeTuple({one, one, make_idx(K)}, span);
+                                auto idx_raw = emit_to(bs, "tile.load", {index, ofs, idx_sh, idx_sh},
+                                                       load_kwargs, "gather_idx_raw");
+                                auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
+                                return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+                              });
                 // Reshape [I1, K] → [1, I1*K] for outer assemble.
                 return reshape_to(ob, inner_result, {one, make_idx(I1K)}, "gather_inner_flat");
               });
@@ -1089,49 +1087,50 @@ void OpConversionRegistry::RegisterGatherOps() {
         // Uses flat-index gather to avoid intermediate tiles with I0 (potentially
         // non-8-aligned) columns, which would violate hardware 32-byte row alignment.
         // For each output row r = i0*I1+i1:
-        //   inp_flat = inp[:, i1, :].flatten()  → [1, S0*I2]
+        //   inp_flat = inp[:, i1, :].flatten()  → [1, S0*S2]
         //   idx_row  = idx[i0, i1, :]           → [1, I2]
-        //   flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+        //   flat_idx = idx_row * S2 + [0..I2-1] → [1, I2]
         //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
         // ================================================================
         if (rank == 3 && norm_dim == 0) {
-          int64_t S0   = get_const(input_shape[0], "input.shape[0]");
-          int64_t I0   = get_const(index_shape[0], "index.shape[0]");
-          int64_t I1   = get_const(index_shape[1], "index.shape[1]");
-          int64_t I2   = get_const(index_shape[2], "index.shape[2]");
+          int64_t S0 = get_const(input_shape[0], "input.shape[0]");
+          int64_t S2 = get_const(input_shape[2], "input.shape[2]");
+          int64_t I0 = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1 = get_const(index_shape[1], "index.shape[1]");
+          int64_t I2 = get_const(index_shape[2], "index.shape[2]");
           int64_t I0I1 = I0 * I1;
-          int64_t S0I2 = S0 * I2;
+          int64_t S0S2 = S0 * S2;
 
           // Precompute constant range tile [0, 1, ..., I2-1] (shared across all loop iterations).
           std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", DataType(DataType::INT32)}};
-          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)},
-                               ci_kw, "gather_range");
+          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)}, ci_kw,
+                               "gather_range");
 
           // Outer loop: r=0..I0*I1-1, accumulating [I0*I1, I2].
           auto result = make_loop(
               prologue, "gather_main", make_idx(I0I1), I0I1, I2, input_dtype,
-              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+              [&](const VarPtr& lv, const IterArgPtr& /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
                 // Load inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
                 auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, i1_expr, zero}, span);
-                auto inp_sh  = MakeShapeTuple({input_shape[0], one, input_shape[2]}, span);
-                auto inp_raw = emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh},
-                                       load_kwargs, "gather_inp_raw");
-                auto inp_2d   = reshape_to(bs, inp_raw, {input_shape[0], input_shape[2]}, "gather_inp_2d");
-                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S0I2)}, "gather_inp_flat");
+                auto inp_sh = MakeShapeTuple({input_shape[0], one, input_shape[2]}, span);
+                auto inp_raw =
+                    emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_raw");
+                auto inp_2d = reshape_to(bs, inp_raw, {input_shape[0], input_shape[2]}, "gather_inp_2d");
+                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S0S2)}, "gather_inp_flat");
 
                 // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
-                auto idx_ofs = std::make_shared<MakeTuple>(
-                    std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
-                auto idx_sh  = MakeShapeTuple({one, one, index_shape[2]}, span);
-                auto idx_raw = emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh},
-                                       load_kwargs, "gather_idx_raw");
+                auto idx_ofs =
+                    std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
+                auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
+                auto idx_raw =
+                    emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
-                // flat_idx[k] = idx_row[k] * I2 + k  →  selects inp_flat[flat_idx[k]].
-                auto idx_sc   = emit_to(bs, "tile.muls", {idx_row, make_i32(I2)}, {}, "gather_idx_s");
+                // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
+                auto idx_sc = emit_to(bs, "tile.muls", {idx_row, make_i32(S2)}, {}, "gather_idx_s");
                 auto flat_idx = emit_to(bs, "tile.add", {idx_sc, range_1d}, {}, "gather_fidx");
 
                 return single_row_gather(bs, inp_flat, flat_idx, I2, "gather_row");
@@ -1147,54 +1146,53 @@ void OpConversionRegistry::RegisterGatherOps() {
         // Uses flat-index gather to avoid intermediate tiles with I1 (potentially
         // non-8-aligned) columns, which would violate hardware 32-byte row alignment.
         // For each output row r = i0*I1+i1:
-        //   inp_flat = inp[i0, :, :].flatten()  → [1, S1*I2]
+        //   inp_flat = inp[i0, :, :].flatten()  → [1, S1*S2]
         //   idx_row  = idx[i0, i1, :]           → [1, I2]
-        //   flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+        //   flat_idx = idx_row * S2 + [0..I2-1] → [1, I2]
         //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
         // ================================================================
-        CHECK(rank == 3 && norm_dim == 1)
-            << "tensor.gather: only rank==3 with dim in {0,1,2} is supported, "
-            << "got rank=" << rank << " norm_dim=" << norm_dim;
+        CHECK(rank == 3 && norm_dim == 1) << "tensor.gather: unsupported (rank, dim) combination, "
+                                          << "got rank=" << rank << " norm_dim=" << norm_dim;
 
         {
-          int64_t I0   = get_const(index_shape[0], "index.shape[0]");
-          int64_t I1   = get_const(index_shape[1], "index.shape[1]");
-          int64_t I2   = get_const(index_shape[2], "index.shape[2]");
-          int64_t S1   = get_const(input_shape[1], "input.shape[1]");
+          int64_t I0 = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1 = get_const(index_shape[1], "index.shape[1]");
+          int64_t I2 = get_const(index_shape[2], "index.shape[2]");
+          int64_t S1 = get_const(input_shape[1], "input.shape[1]");
+          int64_t S2 = get_const(input_shape[2], "input.shape[2]");
           int64_t I0I1 = I0 * I1;
-          int64_t S1I2 = S1 * I2;
+          int64_t S1S2 = S1 * S2;
 
           // Precompute constant range tile [0, 1, ..., I2-1] (shared across all loop iterations).
           std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", DataType(DataType::INT32)}};
-          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)},
-                               ci_kw, "gather_range");
+          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)}, ci_kw,
+                               "gather_range");
 
           // Outer loop: r=0..I0*I1-1, accumulating [I0*I1, I2].
           auto result = make_loop(
               prologue, "gather_main", make_idx(I0I1), I0I1, I2, input_dtype,
-              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+              [&](const VarPtr& lv, const IterArgPtr& /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
                 // Load inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
-                auto inp_ofs = std::make_shared<MakeTuple>(
-                    std::vector<ExprPtr>{i0_expr, zero, zero}, span);
-                auto inp_sh  = MakeShapeTuple({one, input_shape[1], input_shape[2]}, span);
-                auto inp_raw = emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh},
-                                       load_kwargs, "gather_inp_raw");
-                auto inp_2d   = reshape_to(bs, inp_raw, {input_shape[1], input_shape[2]}, "gather_inp_2d");
-                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S1I2)}, "gather_inp_flat");
+                auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, zero, zero}, span);
+                auto inp_sh = MakeShapeTuple({one, input_shape[1], input_shape[2]}, span);
+                auto inp_raw =
+                    emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_raw");
+                auto inp_2d = reshape_to(bs, inp_raw, {input_shape[1], input_shape[2]}, "gather_inp_2d");
+                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S1S2)}, "gather_inp_flat");
 
                 // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
-                auto idx_ofs = std::make_shared<MakeTuple>(
-                    std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
-                auto idx_sh  = MakeShapeTuple({one, one, index_shape[2]}, span);
-                auto idx_raw = emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh},
-                                       load_kwargs, "gather_idx_raw");
+                auto idx_ofs =
+                    std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
+                auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
+                auto idx_raw =
+                    emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
-                // flat_idx[k] = idx_row[k] * I2 + k  →  selects inp_flat[flat_idx[k]].
-                auto idx_sc   = emit_to(bs, "tile.muls", {idx_row, make_i32(I2)}, {}, "gather_idx_s");
+                // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
+                auto idx_sc = emit_to(bs, "tile.muls", {idx_row, make_i32(S2)}, {}, "gather_idx_s");
                 auto flat_idx = emit_to(bs, "tile.add", {idx_sc, range_1d}, {}, "gather_fidx");
 
                 return single_row_gather(bs, inp_flat, flat_idx, I2, "gather_row");

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1135,7 +1135,9 @@ void OpConversionRegistry::RegisterGatherOps() {
 
                 return single_row_gather(bs, inp_flat, flat_idx, I2, "gather_row");
               });
-          return ConversionResult{std::move(prologue), result};
+          // Reshape [I0*I1, I2] is already the correct 2D layout; prevents Phase 3 optimization.
+          auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(I2)}, "gather_out");
+          return ConversionResult{std::move(prologue), out_2d};
         }
 
         // ================================================================

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -879,21 +879,20 @@ void OpConversionRegistry::RegisterSortOps() {
 //   Final reshape [I0,I1*K]→[I0*I1,K]; tile.store at [0,0,0].
 //
 // Case 3  rank==3, dim==0 (first):
-//   Phase A – loop a over S0: load [1,I1,I2]→reshape[1,I1*I2] → src_tile[S0,I1*I2].
-//   Transpose src_tile → src_t[I1*I2,S0].
-//   Load idx [I0,I1,I2] (type at construction [I0,I1,I2]; after flatten [I0*I1,I2])
-//     → reshape[I0,I1*I2] → transpose idx_t[I1*I2,I0].
-//   Phase B – loop r over I1*I2: slice src_t[r]→[1,S0], idx_t[r]→[1,I0],
-//     gather → [1,I0]; inner_acc[I1*I2,I0].
-//   Transpose inner_acc→[I0,I1*I2]; reshape→[I0*I1,I2]; tile.store at [0,0,0].
+//   Flat-index gather: for each output row r = i0*I1+i1:
+//     inp_flat = inp[:, i1, :].flatten()  → [1, S0*I2]
+//     idx_row  = idx[i0, i1, :]           → [1, I2]
+//     flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+//     out_row  = gather(inp_flat, flat_idx) → [1, I2]
+//   Accumulator [I0*I1, I2]; reshape→[I0*I1,I2]; tile.store at [0,0,0].
 //
 // Case 4  rank==3, dim==1 (middle):
-//   Outer loop over I0: load [1,S1,I2]→reshape[S1,I2]→transpose[I2,S1];
-//     load [1,I1,I2]→reshape[I1,I2]→transpose[I2,I1].
-//   Inner loop over I2: slice inp_at[c]→[1,S1], idx_at[c]→[1,I1];
-//     gather→[1,I1]; inner_acc[I2,I1].
-//   Transpose[I1,I2]; reshape→[1,I1*I2]; outer acc [I0,I1*I2].
-//   Final reshape [I0,I1*I2]→[I0*I1,I2]; tile.store at [0,0,0].
+//   Flat-index gather: for each output row r = i0*I1+i1:
+//     inp_flat = inp[i0, :, :].flatten()  → [1, S1*I2]
+//     idx_row  = idx[i0, i1, :]           → [1, I2]
+//     flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+//     out_row  = gather(inp_flat, flat_idx) → [1, I2]
+//   Accumulator [I0*I1, I2]; reshape→[I0*I1,I2]; tile.store at [0,0,0].
 // ============================================================================
 
 void OpConversionRegistry::RegisterGatherOps() {

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -846,17 +846,54 @@ void OpConversionRegistry::RegisterSortOps() {
 }
 
 // ============================================================================
-// Gather op: tensor.gather -> per-row tile.load + tile.gather + tile.assemble
-// loop over the outer (non-gather) dimension.
+// Generalized gather lowering.
 //
-// MVP supports 2D input with dim == -1 (last axis). Semantics:
-//     out[b, k] = input[b, index[b, k]]
+// Hardware constraint: pto.tgather only works correctly when the source tile
+// has exactly 1 row (rows=1).  Therefore all lowering paths use ForStmt loops
+// to decompose the gather into single-row pto.tgather calls.
 //
-// The loop yields a TileType accumulator built via tile.assemble; Phase 3 of
-// ConvertTensorToTileOps then rewrites the loop to write directly into an
-// added Out tensor parameter via tile.store (see RewriteReturnedAssembleLoop-
-// ToStore). Using per-row slicing avoids materialising a `b * N` base offset
-// tile, which would otherwise require an arange/iota op PyPTO currently lacks.
+// FlattenTileNdTo2D constraint: tile.load, tile.store, tile.reshape may
+// produce/consume >2D tiles; all other tile ops must be 2D.
+// tile.load with an N-D shape is automatically flattened to 2D by merging
+// all leading dims: [d0,...,d_{n-1}] → [d0*…*d_{n-2}, d_{n-1}].
+// Because of this, we explicitly tile.reshape every N-D tile.load result to
+// 2D before passing it to any other op.
+//
+// Storage for rank-3 output: we return a 2D tile [I0*I1, I2] (where I2 is
+// the tensor's last dim).  FlattenTileNdTo2D injects partition_shape
+// [1, I0*I1, I2] for the resulting tile.store, so element [0,j,k] maps to
+// physical j*I2+k — covering all I0*I1*I2 elements without overlap.
+// We always add a trailing tile.reshape so Phase 3 (RewriteReturnedAssemble-
+// LoopToStore) does not fire; we want the full-tile store path instead.
+//
+// Four cases (by rank and norm_dim):
+//
+// Case 1  rank==2, dim==1 (last):
+//   Loop over I0 rows: load [1,S1] and [1,K], single-row gather.
+//   Accumulator [I0, K].  Phase 3 rewrites the loop to per-row tile.store.
+//
+// Case 2  rank==3, dim==2 (last):
+//   Nested loop: outer I0 × inner I1.
+//   Load [1,1,S2]→reshape[1,S2]; Load [1,1,K]→reshape[1,K]; gather [1,K].
+//   Inner acc [I1,K]; reshape→[1,I1*K]; outer acc [I0,I1*K].
+//   Final reshape [I0,I1*K]→[I0*I1,K]; tile.store at [0,0,0].
+//
+// Case 3  rank==3, dim==0 (first):
+//   Phase A – loop a over S0: load [1,I1,I2]→reshape[1,I1*I2] → src_tile[S0,I1*I2].
+//   Transpose src_tile → src_t[I1*I2,S0].
+//   Load idx [I0,I1,I2] (type at construction [I0,I1,I2]; after flatten [I0*I1,I2])
+//     → reshape[I0,I1*I2] → transpose idx_t[I1*I2,I0].
+//   Phase B – loop r over I1*I2: slice src_t[r]→[1,S0], idx_t[r]→[1,I0],
+//     gather → [1,I0]; inner_acc[I1*I2,I0].
+//   Transpose inner_acc→[I0,I1*I2]; reshape→[I0*I1,I2]; tile.store at [0,0,0].
+//
+// Case 4  rank==3, dim==1 (middle):
+//   Outer loop over I0: load [1,S1,I2]→reshape[S1,I2]→transpose[I2,S1];
+//     load [1,I1,I2]→reshape[I1,I2]→transpose[I2,I1].
+//   Inner loop over I2: slice inp_at[c]→[1,S1], idx_at[c]→[1,I1];
+//     gather→[1,I1]; inner_acc[I2,I1].
+//   Transpose[I1,I2]; reshape→[1,I1*I2]; outer acc [I0,I1*I2].
+//   Final reshape [I0,I1*I2]→[I0*I1,I2]; tile.store at [0,0,0].
 // ============================================================================
 
 void OpConversionRegistry::RegisterGatherOps() {
@@ -872,101 +909,302 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& index = args[1];
 
         auto input_tensor_type = As<TensorType>(input->GetType());
-        auto input_tile_type = As<TileType>(input->GetType());
-        CHECK(input_tensor_type || input_tile_type)
-            << "tensor.gather conversion: input must be TensorType or TileType, got "
+        CHECK(input_tensor_type)
+            << "tensor.gather conversion: input must be TensorType, got "
             << input->GetType()->TypeName();
         auto index_tensor_type = As<TensorType>(index->GetType());
-        auto index_tile_type = As<TileType>(index->GetType());
-        CHECK(index_tensor_type || index_tile_type)
-            << "tensor.gather conversion: index must be TensorType or TileType, got "
+        CHECK(index_tensor_type)
+            << "tensor.gather conversion: index must be TensorType, got "
             << index->GetType()->TypeName();
-        const auto& input_shape = input_tensor_type ? input_tensor_type->shape_ : input_tile_type->shape_;
-        const auto& index_shape = index_tensor_type ? index_tensor_type->shape_ : index_tile_type->shape_;
-        CHECK(input_shape.size() == 2 && index_shape.size() == 2)
-            << "tensor.gather conversion (MVP): only rank-2 inputs supported";
 
-        int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
+        const auto& input_shape = input_tensor_type->shape_;
+        const auto& index_shape = index_tensor_type->shape_;
         const int64_t rank = static_cast<int64_t>(input_shape.size());
-        CHECK(dim_val == -1 || dim_val == rank - 1)
-            << "tensor.gather conversion (MVP): only dim=-1 supported, got " << dim_val;
+        CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 
-        DataType input_dtype = input_tensor_type ? input_tensor_type->dtype_ : input_tile_type->dtype_;
+        int dim_val  = GetKwargOr<int>(kwargs, "dim", -1);
+        int norm_dim = dim_val < 0 ? dim_val + static_cast<int>(rank) : dim_val;
+        CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
+            << "tensor.gather conversion: dim out of range, got " << dim_val;
 
-        auto make_index_const = [&](int64_t value) -> ExprPtr {
+        DataType input_dtype = input_tensor_type->dtype_;
+
+        auto make_idx = [&](int64_t value) -> ExprPtr {
           return std::make_shared<ConstInt>(value, DataType::INDEX, span);
         };
-        ExprPtr zero = make_index_const(0);
-        ExprPtr one = make_index_const(1);
-
-        std::vector<StmtPtr> prologue;
-
-        // Accumulator tile, shape equal to the output tensor; Phase 3 later
-        // rewrites this init to the added Out tensor parameter.
-        auto acc_shape_tuple = MakeShapeTuple(index_shape, span);
-        std::vector<std::pair<std::string, std::any>> acc_create_kwargs = {
-            {"dtype", input_dtype}, {"target_memory", MemorySpace::Vec}};
-        auto acc_create_call = op_reg.Create("tile.create", {acc_shape_tuple}, acc_create_kwargs, span);
-        auto acc_init_var = std::make_shared<Var>("gather_out_init", acc_create_call->GetType(), span);
-        prologue.push_back(std::make_shared<AssignStmt>(acc_init_var, acc_create_call, span));
-
-        auto acc_tile_type = acc_create_call->GetType();
-        auto loop_var = std::make_shared<Var>("b", std::make_shared<ScalarType>(DataType::INDEX), span);
-        auto iter_arg = std::make_shared<IterArg>("gather_acc", acc_tile_type, acc_init_var, span);
-        auto return_var = std::make_shared<Var>("gather_result", acc_tile_type, span);
-
-        auto row_offsets = std::make_shared<MakeTuple>(std::vector<ExprPtr>{loop_var, zero}, span);
-        std::vector<ExprPtr> src_row_shape = {one, input_shape[1]};
-        std::vector<ExprPtr> idx_row_shape = {one, index_shape[1]};
-        auto src_shape_tuple = MakeShapeTuple(src_row_shape, span);
-        auto idx_shape_tuple = MakeShapeTuple(idx_row_shape, span);
+        auto make_i32 = [&](int64_t value) -> ExprPtr {
+          return std::make_shared<ConstInt>(value, DataType::INT32, span);
+        };
+        auto zero = make_idx(0);
+        auto one  = make_idx(1);
 
         std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
                                                                      {"transpose", false}};
-
-        auto make_row = [&](const ExprPtr& tensor_or_tile, bool is_tensor,
-                            const ExprPtr& row_shape_tuple) -> CallPtr {
-          if (is_tensor) {
-            return op_reg.Create("tile.load", {tensor_or_tile, row_offsets, row_shape_tuple, row_shape_tuple},
-                                 load_kwargs, span);
-          }
-          return op_reg.Create("tile.slice", {tensor_or_tile, row_shape_tuple, row_offsets, row_shape_tuple},
-                               span);
-        };
-
-        std::vector<StmtPtr> body_stmts;
-        auto src_load = make_row(input, input_tensor_type != nullptr, src_shape_tuple);
-        auto src_tile_var = std::make_shared<Var>("gather_src_row", src_load->GetType(), span);
-        body_stmts.push_back(std::make_shared<AssignStmt>(src_tile_var, src_load, span));
-
-        auto idx_load = make_row(index, index_tensor_type != nullptr, idx_shape_tuple);
-        auto idx_tile_var = std::make_shared<Var>("gather_idx_row", idx_load->GetType(), span);
-        body_stmts.push_back(std::make_shared<AssignStmt>(idx_tile_var, idx_load, span));
-
-        // Scratch workspace tile required by tile.gather (same shape as idx row, INT32).
         std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
             {"dtype", DataType(DataType::INT32)}, {"target_memory", MemorySpace::Vec}};
-        auto tmp_create_call = op_reg.Create("tile.create", {idx_shape_tuple}, tmp_create_kwargs, span);
-        auto tmp_tile_var = std::make_shared<Var>("gather_tmp", tmp_create_call->GetType(), span);
-        body_stmts.push_back(std::make_shared<AssignStmt>(tmp_tile_var, tmp_create_call, span));
 
-        auto gather_call = op_reg.Create("tile.gather", {src_tile_var, idx_tile_var, tmp_tile_var}, span);
-        auto gather_row_var = std::make_shared<Var>("gather_row", gather_call->GetType(), span);
-        body_stmts.push_back(std::make_shared<AssignStmt>(gather_row_var, gather_call, span));
+        std::vector<StmtPtr> prologue;
 
-        // Assemble the per-row result into the accumulator; Phase 3 rewrites
-        // this tile.assemble into tile.store once the Out param is added.
-        auto assemble_call = op_reg.Create("tile.assemble", {iter_arg, gather_row_var, row_offsets}, span);
-        auto assemble_var = std::make_shared<Var>("gather_assemble", assemble_call->GetType(), span);
-        body_stmts.push_back(std::make_shared<AssignStmt>(assemble_var, assemble_call, span));
-        body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{assemble_var}, span));
+        // --- Low-level helpers ---
 
-        auto body = SeqStmts::Flatten(std::move(body_stmts), span);
-        auto for_stmt =
-            std::make_shared<ForStmt>(loop_var, zero, input_shape[0], one, std::vector<IterArgPtr>{iter_arg},
-                                      body, std::vector<VarPtr>{return_var}, span);
-        prologue.push_back(for_stmt);
-        return ConversionResult{std::move(prologue), return_var};
+        auto emit_to = [&](std::vector<StmtPtr>& stmts, const std::string& op_name,
+                           const std::vector<ExprPtr>& op_args,
+                           const std::vector<std::pair<std::string, std::any>>& op_kwargs,
+                           const std::string& name) -> VarPtr {
+          auto call = op_kwargs.empty() ? op_reg.Create(op_name, op_args, span)
+                                        : op_reg.Create(op_name, op_args, op_kwargs, span);
+          auto var = std::make_shared<Var>(name, call->GetType(), span);
+          stmts.push_back(std::make_shared<AssignStmt>(var, call, span));
+          return var;
+        };
+
+        auto emit = [&](const std::string& op_name, const std::vector<ExprPtr>& op_args,
+                        const std::vector<std::pair<std::string, std::any>>& op_kwargs,
+                        const std::string& name) -> VarPtr {
+          return emit_to(prologue, op_name, op_args, op_kwargs, name);
+        };
+
+        // Emit tile.reshape.
+        auto reshape_to = [&](std::vector<StmtPtr>& stmts, const ExprPtr& src,
+                              const std::vector<ExprPtr>& new_shape, const std::string& name) -> VarPtr {
+          return emit_to(stmts, "tile.reshape", {src, MakeShapeTuple(new_shape, span)}, {}, name);
+        };
+
+        // Emit single-row tile.gather (with scratch tile); src_row and idx_row must be 2D.
+        auto single_row_gather = [&](std::vector<StmtPtr>& stmts, const VarPtr& src_row,
+                                     const VarPtr& idx_row, int64_t idx_cols,
+                                     const std::string& name) -> VarPtr {
+          auto tmp_sh = MakeShapeTuple({one, make_idx(idx_cols)}, span);
+          auto tmp    = emit_to(stmts, "tile.create", {tmp_sh}, tmp_create_kwargs, name + "_tmp");
+          return emit_to(stmts, "tile.gather", {src_row, idx_row, tmp}, {}, name);
+        };
+
+        // Build a ForStmt that accumulates [1, acc_cols] rows into [acc_rows, acc_cols].
+        // body_builder receives (loop_var, iter_arg, body_stmts) and returns a [1, acc_cols] tile.
+        auto make_loop =
+            [&](std::vector<StmtPtr>& outer_stmts, const std::string& lname,
+                const ExprPtr& loop_stop, int64_t acc_rows, int64_t acc_cols, DataType acc_dtype,
+                const std::function<VarPtr(VarPtr, IterArgPtr, std::vector<StmtPtr>&)>& body_builder)
+            -> VarPtr {
+          std::vector<std::pair<std::string, std::any>> acc_kwargs = {{"dtype", acc_dtype},
+                                                                      {"target_memory", MemorySpace::Vec}};
+          auto acc_init = emit_to(
+              outer_stmts, "tile.create",
+              {MakeShapeTuple({make_idx(acc_rows), make_idx(acc_cols)}, span)}, acc_kwargs,
+              lname + "_acc_init");
+          auto acc_type = acc_init->GetType();
+          auto lv = std::make_shared<Var>(lname + "_lv", std::make_shared<ScalarType>(DataType::INDEX), span);
+          auto ia = std::make_shared<IterArg>(lname + "_ia", acc_type, acc_init, span);
+          auto rv = std::make_shared<Var>(lname + "_rv", acc_type, span);
+
+          std::vector<StmtPtr> body_stmts;
+          auto row_result = body_builder(lv, ia, body_stmts);
+          auto ofs   = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
+          auto asmbl = emit_to(body_stmts, "tile.assemble", {ia, row_result, ofs}, {}, lname + "_asmbl");
+          body_stmts.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{asmbl}, span));
+          auto body = SeqStmts::Flatten(std::move(body_stmts), span);
+          outer_stmts.push_back(std::make_shared<ForStmt>(lv, zero, loop_stop, one,
+                                                           std::vector<IterArgPtr>{ia}, body,
+                                                           std::vector<VarPtr>{rv}, span));
+          return rv;
+        };
+
+        // Get ConstInt value from a shape expression.
+        auto get_const = [&](const ExprPtr& expr, const char* what) -> int64_t {
+          auto c = As<ConstInt>(expr);
+          CHECK(c) << "tensor.gather: " << what << " must be ConstInt for rank>2 lowering";
+          return c->value_;
+        };
+
+        // ================================================================
+        // Case 1  rank==2, dim==1 (last dim)
+        // ================================================================
+        if (rank == 2 && norm_dim == 1) {
+          int64_t I0 = get_const(index_shape[0], "index.shape[0]");
+          int64_t S1 = get_const(input_shape[1], "input.shape[1]");
+          int64_t K  = get_const(index_shape[1], "index.shape[1]");
+
+          auto result = make_loop(
+              prologue, "gather", index_shape[0], I0, K, input_dtype,
+              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+                auto row_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
+                auto inp_sh  = MakeShapeTuple({one, make_idx(S1)}, span);
+                auto inp_row = emit_to(bs, "tile.load", {input, row_ofs, inp_sh, inp_sh},
+                                       load_kwargs, "gather_inp_row");
+                auto idx_sh  = MakeShapeTuple({one, make_idx(K)}, span);
+                auto idx_row = emit_to(bs, "tile.load", {index, row_ofs, idx_sh, idx_sh},
+                                       load_kwargs, "gather_idx_row");
+                return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+              });
+          return ConversionResult{std::move(prologue), result};
+        }
+
+        // ================================================================
+        // Case 2  rank==3, dim==2 (last dim)
+        // Result tile: [I0*I1, K] where tile[i0*I1+i1, k] = output[i0, i1, k].
+        // Stored via tile.store at [0,0,0]; FlattenTileNdTo2D injects
+        // partition_shape [1, I0*I1, K] which covers all elements correctly.
+        // ================================================================
+        if (rank == 3 && norm_dim == 2) {
+          int64_t I0  = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1  = get_const(index_shape[1], "index.shape[1]");
+          int64_t S2  = get_const(input_shape[2], "input.shape[2]");
+          int64_t K   = get_const(index_shape[2], "index.shape[2]");
+          int64_t I1K = I1 * K;
+
+          // Outer loop: i0=0..I0-1, accumulates [I0, I1*K].
+          auto outer_result = make_loop(
+              prologue, "gather_outer", index_shape[0], I0, I1K, input_dtype,
+              [&](VarPtr outer_lv, IterArgPtr /*oia*/, std::vector<StmtPtr>& ob) -> VarPtr {
+                // Inner loop: i1=0..I1-1, accumulates [I1, K].
+                auto inner_result = make_loop(
+                    ob, "gather_inner", index_shape[1], I1, K, input_dtype,
+                    [&](VarPtr inner_lv, IterArgPtr /*iia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+                      auto ofs = std::make_shared<MakeTuple>(
+                          std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
+                      // Load with 3D shape → 3D tile type; immediately reshape to 2D.
+                      auto inp_sh  = MakeShapeTuple({one, one, make_idx(S2)}, span);
+                      auto inp_raw = emit_to(bs, "tile.load", {input, ofs, inp_sh, inp_sh},
+                                             load_kwargs, "gather_inp_raw");
+                      auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
+                      auto idx_sh  = MakeShapeTuple({one, one, make_idx(K)}, span);
+                      auto idx_raw = emit_to(bs, "tile.load", {index, ofs, idx_sh, idx_sh},
+                                             load_kwargs, "gather_idx_raw");
+                      auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
+                      return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+                    });
+                // Reshape [I1, K] → [1, I1*K] for outer assemble.
+                return reshape_to(ob, inner_result, {one, make_idx(I1K)}, "gather_inner_flat");
+              });
+          // Reshape [I0, I1*K] → [I0*I1, K].  Prevents Phase 3 and gives correct 2D layout.
+          int64_t I0I1 = I0 * I1;
+          auto out_2d = reshape_to(prologue, outer_result, {make_idx(I0I1), make_idx(K)}, "gather_out");
+          return ConversionResult{std::move(prologue), out_2d};
+        }
+
+        // ================================================================
+        // Case 3  rank==3, dim==0 (first dim)
+        // out[i0, i1, k] = inp[idx[i0, i1, k], i1, k]
+        // Result tile: [I0*I1, I2] where tile[i0*I1+i1, k] = output[i0, i1, k].
+        //
+        // Uses flat-index gather to avoid intermediate tiles with I0 (potentially
+        // non-8-aligned) columns, which would violate hardware 32-byte row alignment.
+        // For each output row r = i0*I1+i1:
+        //   inp_flat = inp[:, i1, :].flatten()  → [1, S0*I2]
+        //   idx_row  = idx[i0, i1, :]           → [1, I2]
+        //   flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+        //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
+        // ================================================================
+        if (rank == 3 && norm_dim == 0) {
+          int64_t S0   = get_const(input_shape[0], "input.shape[0]");
+          int64_t I0   = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1   = get_const(index_shape[1], "index.shape[1]");
+          int64_t I2   = get_const(index_shape[2], "index.shape[2]");
+          int64_t I0I1 = I0 * I1;
+          int64_t S0I2 = S0 * I2;
+
+          // Precompute constant range tile [0, 1, ..., I2-1] (shared across all loop iterations).
+          std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", DataType(DataType::INT32)}};
+          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)},
+                               ci_kw, "gather_range");
+
+          // Outer loop: r=0..I0*I1-1, accumulating [I0*I1, I2].
+          auto result = make_loop(
+              prologue, "gather_main", make_idx(I0I1), I0I1, I2, input_dtype,
+              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+                auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
+                auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
+
+                // Load inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
+                auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, i1_expr, zero}, span);
+                auto inp_sh  = MakeShapeTuple({input_shape[0], one, input_shape[2]}, span);
+                auto inp_raw = emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh},
+                                       load_kwargs, "gather_inp_raw");
+                auto inp_2d   = reshape_to(bs, inp_raw, {input_shape[0], input_shape[2]}, "gather_inp_2d");
+                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S0I2)}, "gather_inp_flat");
+
+                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                auto idx_ofs = std::make_shared<MakeTuple>(
+                    std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
+                auto idx_sh  = MakeShapeTuple({one, one, index_shape[2]}, span);
+                auto idx_raw = emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh},
+                                       load_kwargs, "gather_idx_raw");
+                auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
+
+                // flat_idx[k] = idx_row[k] * I2 + k  →  selects inp_flat[flat_idx[k]].
+                auto idx_sc   = emit_to(bs, "tile.muls", {idx_row, make_i32(I2)}, {}, "gather_idx_s");
+                auto flat_idx = emit_to(bs, "tile.add", {idx_sc, range_1d}, {}, "gather_fidx");
+
+                return single_row_gather(bs, inp_flat, flat_idx, I2, "gather_row");
+              });
+          return ConversionResult{std::move(prologue), result};
+        }
+
+        // ================================================================
+        // Case 4  rank==3, dim==1 (middle dim)
+        // out[i0, i1, k] = inp[i0, idx[i0, i1, k], k]
+        // Result tile: [I0*I1, I2] where tile[i0*I1+i1, k] = output[i0, i1, k].
+        //
+        // Uses flat-index gather to avoid intermediate tiles with I1 (potentially
+        // non-8-aligned) columns, which would violate hardware 32-byte row alignment.
+        // For each output row r = i0*I1+i1:
+        //   inp_flat = inp[i0, :, :].flatten()  → [1, S1*I2]
+        //   idx_row  = idx[i0, i1, :]           → [1, I2]
+        //   flat_idx = idx_row * I2 + [0..I2-1] → [1, I2]
+        //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
+        // ================================================================
+        CHECK(rank == 3 && norm_dim == 1)
+            << "tensor.gather: only rank==3 with dim in {0,1,2} is supported, "
+            << "got rank=" << rank << " norm_dim=" << norm_dim;
+
+        {
+          int64_t I0   = get_const(index_shape[0], "index.shape[0]");
+          int64_t I1   = get_const(index_shape[1], "index.shape[1]");
+          int64_t I2   = get_const(index_shape[2], "index.shape[2]");
+          int64_t S1   = get_const(input_shape[1], "input.shape[1]");
+          int64_t I0I1 = I0 * I1;
+          int64_t S1I2 = S1 * I2;
+
+          // Precompute constant range tile [0, 1, ..., I2-1] (shared across all loop iterations).
+          std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", DataType(DataType::INT32)}};
+          auto range_1d = emit("tile.ci", {make_i32(0), MakeShapeTuple({one, make_idx(I2)}, span)},
+                               ci_kw, "gather_range");
+
+          // Outer loop: r=0..I0*I1-1, accumulating [I0*I1, I2].
+          auto result = make_loop(
+              prologue, "gather_main", make_idx(I0I1), I0I1, I2, input_dtype,
+              [&](VarPtr lv, IterArgPtr /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+                auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
+                auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
+
+                // Load inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
+                auto inp_ofs = std::make_shared<MakeTuple>(
+                    std::vector<ExprPtr>{i0_expr, zero, zero}, span);
+                auto inp_sh  = MakeShapeTuple({one, input_shape[1], input_shape[2]}, span);
+                auto inp_raw = emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh},
+                                       load_kwargs, "gather_inp_raw");
+                auto inp_2d   = reshape_to(bs, inp_raw, {input_shape[1], input_shape[2]}, "gather_inp_2d");
+                auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S1I2)}, "gather_inp_flat");
+
+                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                auto idx_ofs = std::make_shared<MakeTuple>(
+                    std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
+                auto idx_sh  = MakeShapeTuple({one, one, index_shape[2]}, span);
+                auto idx_raw = emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh},
+                                       load_kwargs, "gather_idx_raw");
+                auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
+
+                // flat_idx[k] = idx_row[k] * I2 + k  →  selects inp_flat[flat_idx[k]].
+                auto idx_sc   = emit_to(bs, "tile.muls", {idx_row, make_i32(I2)}, {}, "gather_idx_s");
+                auto flat_idx = emit_to(bs, "tile.add", {idx_sc, range_1d}, {}, "gather_fidx");
+
+                return single_row_gather(bs, inp_flat, flat_idx, I2, "gather_row");
+              });
+
+          // Reshape [I0*I1, I2] is already the correct 2D layout; prevents Phase 3 optimization.
+          auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(I2)}, "gather_out");
+          return ConversionResult{std::move(prologue), out_2d};
+        }
       });
 }
 

--- a/tests/st/runtime/test_gather.py
+++ b/tests/st/runtime/test_gather.py
@@ -1,0 +1,317 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end tests for ``pl.tensor.gather`` (issue #676) — torch-style semantics.
+
+Covers the generalized contract beyond the original MVP (rank-2 + dim=-1):
+
+1. Rank-2 + dim=-1 (baseline / regression).
+2. Rank-2 + dim=-1 with ``index.shape[0] < input.shape[0]`` (smaller index leading).
+3. Rank-3 + dim=-1 (collapses leading dims via ``tile.reshape``).
+4. Rank-3 + dim=1 (middle axis — exercises the ``tile.transpose`` path).
+5. Rank-3 + dim=-3 (negative-dim normalization on the first axis).
+
+All cases are validated against a torch ``gather`` reference.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+
+# --- Shared init helpers ---
+
+
+def _rand_indices(low: int, high: int, shape: tuple[int, ...]) -> torch.Tensor:
+    """Random INT32 indices uniformly in [low, high)."""
+    return torch.randint(low, high, shape, dtype=torch.int32)
+
+
+# --- Programs ---
+
+
+@pl.program
+class GatherRank2LastDimProgram:
+    """Baseline rank-2 + dim=-1: ``out[b, k] = input[b, index[b, k]]``."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[4, 16], pl.FP32],
+        idx: pl.Tensor[[4, 8], pl.INT32],
+        output: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+    ) -> pl.Tensor[[4, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank2SmallerLeadingProgram:
+    """Rank-2 + dim=-1 with ``index.shape[0] (=2) < input.shape[0] (=4)``."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[4, 16], pl.FP32],
+        idx: pl.Tensor[[2, 8], pl.INT32],
+        output: pl.Out[pl.Tensor[[2, 8], pl.FP32]],
+    ) -> pl.Tensor[[2, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank3LastDimProgram:
+    """Rank-3 + dim=-1. Lowering collapses leading dims via ``tile.reshape``.
+
+    idx last-dim is 8 (8×4=32 bytes) to satisfy the hardware tile column
+    alignment requirement (Cols * sizeof(dtype) % 32 == 0).
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[2, 3, 16], pl.FP32],
+        idx: pl.Tensor[[2, 3, 8], pl.INT32],
+        output: pl.Out[pl.Tensor[[2, 3, 8], pl.FP32]],
+    ) -> pl.Tensor[[2, 3, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0, 0])
+        return output
+
+
+@pl.program
+class GatherRank3MiddleDimProgram:
+    """Rank-3 + dim=1 (middle axis) — exercises the ``tile.transpose`` path.
+
+    Last dim is 8 (8×4=32 bytes) to satisfy the hardware tile column
+    alignment requirement.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[2, 8, 8], pl.FP32],
+        idx: pl.Tensor[[2, 3, 8], pl.INT32],
+        output: pl.Out[pl.Tensor[[2, 3, 8], pl.FP32]],
+    ) -> pl.Tensor[[2, 3, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=1, index=idx)
+            output = pl.assemble(output, out, [0, 0, 0])
+        return output
+
+
+@pl.program
+class GatherRank3NegFirstDimProgram:
+    """Rank-3 + dim=-3 (== dim=0): negative-dim normalization on the first axis.
+
+    Last dim is 8 (8×4=32 bytes) to satisfy the hardware tile column
+    alignment requirement.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[8, 2, 8], pl.FP32],
+        idx: pl.Tensor[[3, 2, 8], pl.INT32],
+        output: pl.Out[pl.Tensor[[3, 2, 8], pl.FP32]],
+    ) -> pl.Tensor[[3, 2, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-3, index=idx)
+            output = pl.assemble(output, out, [0, 0, 0])
+        return output
+
+
+# --- Test cases ---
+
+
+class _GatherBaseTestCase(PTOTestCase):
+    __test__ = False
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+
+class GatherRank2LastDimTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_last_dim"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [4, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [4, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 16, (4, 8)),
+            ),
+            TensorSpec("output", [4, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2LastDimProgram
+
+    def compute_expected(self, tensors, params=None):
+        # torch.gather semantics: out[b, k] = inp[b, idx[b, k]]
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank2SmallerLeadingTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_smaller_leading"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [4, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [2, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 16, (2, 8)),
+            ),
+            TensorSpec("output", [2, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2SmallerLeadingProgram
+
+    def compute_expected(self, tensors, params=None):
+        # torch's index broadcast along the non-gather axis must match the
+        # PyPTO contract: rows of the input beyond index.shape[0] are unused.
+        inp = tensors["inp"][: tensors["idx"].shape[0]]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank3LastDimTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank3_last_dim"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [2, 3, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [2, 3, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 16, (2, 3, 8)),
+            ),
+            TensorSpec("output", [2, 3, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank3LastDimProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank3MiddleDimTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank3_middle_dim"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [2, 8, 8], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [2, 3, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 8, (2, 3, 8)),
+            ),
+            TensorSpec("output", [2, 3, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank3MiddleDimProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=1, index=idx)
+
+
+class GatherRank3NegFirstDimTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank3_neg_first_dim"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [8, 2, 8], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [3, 2, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 8, (3, 2, 8)),
+            ),
+            TensorSpec("output", [3, 2, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank3NegFirstDimProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        # dim=-3 normalizes to dim=0 on rank-3
+        tensors["output"][:] = torch.gather(inp, dim=0, index=idx)
+
+
+# --- Tests ---
+
+
+class TestGather:
+    """Verify ``pl.tensor.gather`` against a torch reference for the
+    generalized rank/dim contract introduced by issue #676."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_rank2_last_dim(self, test_runner, platform):
+        result = test_runner.run(GatherRank2LastDimTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_rank2_smaller_leading(self, test_runner, platform):
+        result = test_runner.run(GatherRank2SmallerLeadingTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_rank3_last_dim(self, test_runner, platform):
+        result = test_runner.run(GatherRank3LastDimTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_rank3_middle_dim(self, test_runner, platform):
+        result = test_runner.run(GatherRank3MiddleDimTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_rank3_neg_first_dim(self, test_runner, platform):
+        result = test_runner.run(GatherRank3NegFirstDimTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/test_gather.py
+++ b/tests/st/runtime/test_gather.py
@@ -14,7 +14,7 @@ Covers the generalized contract beyond the original MVP (rank-2 + dim=-1):
 1. Rank-2 + dim=-1 (baseline / regression).
 2. Rank-2 + dim=-1 with ``index.shape[0] < input.shape[0]`` (smaller index leading).
 3. Rank-3 + dim=-1 (collapses leading dims via ``tile.reshape``).
-4. Rank-3 + dim=1 (middle axis — exercises the ``tile.transpose`` path).
+4. Rank-3 + dim=1 (middle axis — flat-index gather).
 5. Rank-3 + dim=-3 (negative-dim normalization on the first axis).
 
 All cases are validated against a torch ``gather`` reference.
@@ -98,7 +98,7 @@ class GatherRank3LastDimProgram:
 
 @pl.program
 class GatherRank3MiddleDimProgram:
-    """Rank-3 + dim=1 (middle axis) — exercises the ``tile.transpose`` path.
+    """Rank-3 + dim=1 (middle axis) — flat-index gather.
 
     Last dim is 8 (8×4=32 bytes) to satisfy the hardware tile column
     alignment requirement.

--- a/tests/st/runtime/test_gather.py
+++ b/tests/st/runtime/test_gather.py
@@ -29,7 +29,6 @@ from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
-
 # --- Shared init helpers ---
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2133,8 +2133,9 @@ def test_tensor_gather_dim_last_axis_positive():
 
 def test_tensor_gather_rejects_bad_dim():
     inp, idx = _make_gather_inputs()
-    with pytest.raises(Exception, match=r"dim=-1 or dim=rank-1"):
-        ir.op.tensor.gather(inp, dim=0, index=idx)
+    # rank=2, valid dims are -2..1. dim=2 is out of range.
+    with pytest.raises(Exception, match=r"dim"):
+        ir.op.tensor.gather(inp, dim=2, index=idx)
 
 
 def test_tensor_gather_rejects_non_int32_index():
@@ -2168,7 +2169,7 @@ def test_tensor_gather_rejects_non_matching_outer_dim():
     K = ir.ConstInt(3, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([B, N], DataType.FP32), span)
     idx = ir.Var("idx", ir.TensorType([B2, K], DataType.INT32), span)
-    with pytest.raises(Exception, match=r"non-gather axis"):
+    with pytest.raises(Exception, match=r"non-gather axes"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 


### PR DESCRIPTION
## Summary
- Extend `tensor.gather` shape/type validation to rank>=2 with normalized gather dim
- Add generalized tile-level lowering and codegen paths for rank-3 inputs and arbitrary gather dims
- Add system tests covering the new runtime scenarios
- Bump PTOAS to v0.31
- Bump PTO-IAS to 6eecebc5

## Testing
- [x] All tests pass
- [x] Code review completed
- [x] Documentation updated