### PR TITLE
fix(codegen): support index casts to unsigned PTO types

### DIFF
--- a/src/codegen/codegen_base.cpp
+++ b/src/codegen/codegen_base.cpp
@@ -123,6 +123,8 @@ std::string CodegenBase::GetRuntimeDataTypeString(const DataType& dtype) const {
   if (dtype == DataType::INT16) return "DataType::INT16";
   if (dtype == DataType::INT8) return "DataType::INT8";
   if (dtype == DataType::UINT8) return "DataType::UINT8";
+  if (dtype == DataType::UINT16) return "DataType::UINT16";
+  if (dtype == DataType::UINT32) return "DataType::UINT32";
   if (dtype == DataType::BF16) return "DataType::BFLOAT16";
   // INDEX is a semantic type in the IR; the runtime represents it as INT64
   if (dtype == DataType::INDEX) return "DataType::INT64";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1191,6 +1191,11 @@ std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {
     // annotation matches the declared dtype directly.
     return GetTypeString(const_int->dtype());
   }
+  // Fallback: derive annotation from any ScalarType expression (e.g. Cast results,
+  // arith expression results). Their SSA value carries the declared dtype.
+  if (auto scalar_type = As<ScalarType>(expr->GetType())) {
+    return GetTypeString(scalar_type->dtype_);
+  }
   return "";
 }
 

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -234,6 +234,28 @@ void PTOCodegen::VisitExpr_(const ir::CastPtr& op) {
     return;
   } else if (src_is_index || dst_is_index) {
     CHECK(!src_is_float && !dst_is_float) << "Cast between float and index types is not supported";
+    // arith.index_cast requires signless integer types. For unsigned source/destination,
+    // bridge via builtin.unrealized_conversion_cast (mirrors GetOrEmitConstant in pto_codegen.cpp).
+    if (dst_is_uint) {
+      // index -> uiN : arith.index_cast index -> iN, then bridge iN -> uiN
+      std::string signless_dst = dst_type.substr(1);  // "ui32" -> "i32"
+      std::string signless_tmp = NewTemp();
+      Emit(signless_tmp + " = arith.index_cast " + src + " : " + src_type + " to " + signless_dst);
+      Emit(result + " = builtin.unrealized_conversion_cast " + signless_tmp + " : " + signless_dst + " to " +
+           dst_type);
+      fs_.current_expr_value = result;
+      return;
+    }
+    if (src_is_uint) {
+      // uiN -> index : bridge uiN -> iN, then arith.index_cast iN -> index
+      std::string signless_src = src_type.substr(1);  // "ui32" -> "i32"
+      std::string signless_tmp = NewTemp();
+      Emit(signless_tmp + " = builtin.unrealized_conversion_cast " + src + " : " + src_type + " to " +
+           signless_src);
+      Emit(result + " = arith.index_cast " + signless_tmp + " : " + signless_src + " to " + dst_type);
+      fs_.current_expr_value = result;
+      return;
+    }
     mlir_op = "arith.index_cast";
   } else if (src_is_float && dst_is_float) {
     mlir_op = (dst_dtype.GetBit() > src_dtype.GetBit()) ? "arith.extf" : "arith.truncf";

--- a/tests/st/runtime/test_ci.py
+++ b/tests/st/runtime/test_ci.py
@@ -219,6 +219,33 @@ class TopLevelArangeProgram:
 
 
 @pl.program
+class ArangeRepro:
+    """Repro for ptoas 'expected \':\'' bug with dynamic arange start + sort32."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def repro_kernel(
+        self,
+        scores: pl.Tensor[[1, 32768], pl.FP32],
+        out: pl.Out[pl.Tensor[[4, 16384], pl.FP32]],
+    ) -> pl.Tensor[[4, 16384], pl.FP32]:
+        for part in pl.parallel(4):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                offset = part * 8192
+                score_slice = pl.slice(scores, [1, 8192], [0, offset])
+
+                idx_init = pl.tensor.arange(
+                    pl.cast(offset, pl.UINT32),
+                    [1, 8192],
+                    dtype=pl.UINT32,
+                )
+
+                sorted_t = pl.tensor.sort32(score_slice, idx_init)
+                out = pl.assemble(out, sorted_t, [part, 0])
+
+        return out
+
+
+@pl.program
 class CiUint32AscendProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def kernel(
@@ -411,6 +438,40 @@ class TopLevelArangeTestCase(_CiBaseTestCase):
         tensors["output"][:] = torch.arange(0, N, dtype=torch.int32).reshape(ROWS, COLS)
 
 
+class ArangeReproTestCase(_CiBaseTestCase):
+    """Dynamic arange start (via parallel loop var) + sort32 repro."""
+
+    def get_name(self) -> str:
+        return "arange_repro"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("scores", [1, 32768], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [4, 16384], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return ArangeRepro
+
+    def compute_expected(self, tensors, params=None):
+        scores = tensors["scores"]
+        out = torch.zeros(4, 16384, dtype=torch.float32)
+        for part in range(4):
+            offset = part * 8192
+            slice_vals = scores[:, offset : offset + 8192]
+            idx = torch.arange(offset, offset + 8192, dtype=torch.int32).unsqueeze(0)
+            for block in range(256):
+                start = block * 32
+                end = start + 32
+                block_vals = slice_vals[:, start:end].flatten()
+                block_idx = idx[:, start:end].flatten()
+                sorted_vals, order = torch.sort(block_vals, descending=True)
+                sorted_idx = block_idx[order]
+                out[part : part + 1, start * 2 : end * 2 : 2] = sorted_vals
+                out[part : part + 1, start * 2 + 1 : end * 2 + 1 : 2] = sorted_idx.view(torch.float32)
+        tensors["out"][:] = out
+
+
 class CiUint32AscendTestCase(_CiBaseTestCase):
     def get_name(self) -> str:
         return "ci_uint32_ascend"
@@ -483,6 +544,10 @@ class TestCi:
 
     def test_top_level_arange(self, test_runner):
         result = test_runner.run(TopLevelArangeTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_arange_repro(self, test_runner):
+        result = test_runner.run(ArangeReproTestCase())
         assert result.passed, f"Test failed: {result.error}"
 
     def test_ci_uint32_ascend(self, test_runner):


### PR DESCRIPTION
## Summary
- Support PTO lowering for `pl.cast` between `index` and unsigned integer types by bridging through signless integers around `arith.index_cast`.
- Preserve scalar expression type annotations for cast and arithmetic results so generated PTO IR keeps the expected unsigned type syntax.
- Add runtime dtype string mappings for `UINT16` and `UINT32`.
- Add a system regression case for dynamic `arange` start values feeding `sort32`, covering the issue #1181 repro path.

## Testing
- `python -m py_compile tests/st/runtime/test_ci.py`
- Not run: full runtime system test, because it requires the device/runtime environment.

## Related Issues
Fixes #1181
