### PR TITLE
fix(codegen): preserve tpush valid_shape after set_validshape

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -177,7 +177,15 @@ sub-window carved out by `pto.subview`.
 **Notes:**
 
 - Push ops use an `ins()` clause with a typed tile buffer; frontend pop ops produce an SSA result with a `-> !pto.tile_buf<...>` result type
+- If the pushed tile was allocated with dynamic `valid_row` / `valid_col` operands or updated by
+  `tile.set_validshape`, `tpush` emits the same tile handle after its runtime valid shape has been
+  updated. For split `tpush`, codegen temporarily uses a full non-split transport dimension (`cols`
+  for up/down, `rows` for left/right), then restores the producer tile's logical valid shape;
+  consumer-side dynamic tpop operands carry the logical extents used by compute and store.
 - When a tpop result `TileView.valid_shape` contains dynamic expressions, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. The tile type keeps `?` for the dynamic valid shape while the operands carry runtime extents.
+- For split consumers, `SplitVectorKernel` localizes those dynamic tpop
+  valid-shape operands per subblock (for example global `[8, 16]` becomes
+  `[8, 16]` then `[0, 16]` under up/down split of a `[16, 16]` tile).
 - `system.tfree_*` derives `split` from its tile argument, so the frontend must free the exact SSA value produced by `tile.tpop_*`, even though the PTO instruction itself does not take the tile as an explicit operand
 - `ExpandMixedKernel` now auto-generates consumer-side `system.tfree_*` after split-generated `tile.tpop_*`, preserving `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` and `import_reserved_buffer` return `i32` SSA values; `initialize_pipe` references them as operands

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -174,7 +174,15 @@ print(pto_code)
 **说明：**
 
 - Push 操作使用带类型 tile buffer 的 `ins()` 子句；前端 Pop 操作生成 SSA 结果，并带 `-> !pto.tile_buf<...>` 结果类型
+- 如果被 push 的 tile 通过动态 `valid_row` / `valid_col` operand 分配，或经
+  `tile.set_validshape` 更新，`tpush` 会发射已经更新运行时 valid shape 的同一个
+  tile handle。对于 split `tpush`，codegen 会临时使用完整的非切分传输维度（上下
+  切分使用完整 `cols`，左右切分使用完整 `rows`），随后恢复 producer tile 的逻辑
+  valid shape；消费侧动态 tpop operand 仍携带后续计算和 store 使用的逻辑范围。
 - 当 tpop 结果的 `TileView.valid_shape` 包含动态表达式时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。tile 类型中动态 valid shape 仍保留为 `?`，运行时范围由操作数传递。
+- 对于 split consumer，`SplitVectorKernel` 会按 subblock 本地化这些动态
+  tpop valid-shape operand（例如 `[16, 16]` tile 做上下切分时，全局
+  `[8, 16]` 会变成 `[8, 16]` 和 `[0, 16]`）。
 - `system.tfree_*` 的 `split` 来自其 tile 参数，因此前端必须释放由 `tile.tpop_*` 产生的那个确切 SSA 值，即使 PTO 指令本身并不显式接收该 tile 作为操作数
 - `ExpandMixedKernel` 现在会在 split 生成的消费侧 `tile.tpop_*` 之后自动补 `system.tfree_*`，保持 `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` 和 `import_reserved_buffer` 返回 `i32` SSA 值；`initialize_pipe` 以操作数引用这些值

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -41,6 +41,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -49,6 +50,7 @@ namespace backend {
 using ir::As;
 using ir::AsVarLike;
 using ir::CallPtr;
+using ir::ExprPtr;
 using ir::ScalarType;
 using ir::TensorType;
 using ir::Var;
@@ -544,7 +546,8 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   ir::ExprPtr valid_row_expr = src_shape[0];
   ir::ExprPtr valid_col_expr = src_shape[1];
   if (source_tile_type->tile_view_.has_value()) {
-    const auto& src_valid = source_tile_type->tile_view_->valid_shape;
+    const auto tile_view = source_tile_type->tile_view_.value_or(ir::TileView{});
+    const auto& src_valid = tile_view.valid_shape;
     if (src_valid.size() >= 1 && src_valid[0]) valid_row_expr = src_valid[0];
     if (src_valid.size() >= 2 && src_valid[1]) valid_col_expr = src_valid[1];
   }
@@ -560,6 +563,7 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
 
   INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)
       << "tile.assemble source must carry a memory space for pto.subview result typing";
+  const auto source_memory_space = source_tile_type->memory_space_.value_or(ir::MemorySpace::DDR);
   auto view_type_info =
       codegen::ExtractTileTypeInfo(*source_tile_type, codegen.GetTypeString(source_tile_type->dtype_));
   if (valid_row_const) {
@@ -571,10 +575,10 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
     view_type_info.v_col_dynamic = false;
   }
   std::string view_type = codegen::FormatTileBufTypeString(
-      codegen::MemorySpaceToMLIR(*source_tile_type->memory_space_), view_type_info.dtype_str,
-      view_type_info.rows, view_type_info.cols, view_type_info.blayout, view_type_info.slayout,
-      view_type_info.fractal, view_type_info.pad, view_type_info.v_row, view_type_info.v_col,
-      view_type_info.v_row_dynamic, view_type_info.v_col_dynamic);
+      codegen::MemorySpaceToMLIR(source_memory_space), view_type_info.dtype_str, view_type_info.rows,
+      view_type_info.cols, view_type_info.blayout, view_type_info.slayout, view_type_info.fractal,
+      view_type_info.pad, view_type_info.v_row, view_type_info.v_col, view_type_info.v_row_dynamic,
+      view_type_info.v_col_dynamic);
 
   std::string dst_view = codegen.NewNamedTemp("assemble_view");
   std::ostringstream sv;
@@ -858,8 +862,8 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
 
-  bool is_dn =
-      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
+  const auto tensor_view_value = tensor_type->tensor_view_.value_or(ir::TensorView{});
+  bool is_dn = tensor_type->tensor_view_.has_value() && tensor_view_value.layout == ir::TensorLayout::DN;
 
   // Use valid_shapes (op arg 3) for partition_view sizes so the DMA copy size
   // matches the logical valid region. When valid_shapes equals the physical
@@ -909,7 +913,8 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   INTERNAL_CHECK_SPAN(tile_type, op->span_) << "tile.store first argument must have TileType";
   INTERNAL_CHECK_SPAN(tile_type->tile_view_.has_value(), op->span_)
       << "tile.store tile must have TileView with valid_shape";
-  auto& valid_shape = tile_type->tile_view_->valid_shape;
+  const auto tile_view = tile_type->tile_view_.value_or(ir::TileView{});
+  const auto& valid_shape = tile_view.valid_shape;
   INTERNAL_CHECK_SPAN(valid_shape.size() == 2, op->span_) << "tile.store tile valid_shape must be 2D";
 
   auto height_code = codegen.GetExprAsCode(valid_shape[0]);
@@ -932,8 +937,8 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   std::string partition_type;
   const size_t tensor_rank = tensor_type->shape_.size();
 
-  bool is_dn =
-      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == ir::TensorLayout::DN;
+  const auto tensor_view_value = tensor_type->tensor_view_.value_or(ir::TensorView{});
+  bool is_dn = tensor_type->tensor_view_.has_value() && tensor_view_value.layout == ir::TensorLayout::DN;
 
   // Check if FlattenTileNdTo2D injected an explicit shapes tuple as args[3].
   ir::MakeTuplePtr shapes_tuple;
@@ -1287,6 +1292,94 @@ static std::string MakeTensorDimCodegenPTO(const CallPtr& op, codegen::CodegenBa
 // Cross-Core Communication Operations (TPUSH/TPOP)
 // ============================================================================
 
+static std::string EmitIndexOperand(codegen::PTOCodegen& codegen, const ExprPtr& expr,
+                                    std::string_view context) {
+  INTERNAL_CHECK(expr) << "Internal error: " << context << " requires a non-null index operand";
+  if (auto const_int = As<ir::ConstInt>(expr)) {
+    return codegen.GetOrEmitConstant(const_int->value_, DataType::INDEX);
+  }
+
+  std::string ssa = codegen.GetExprAsCode(expr);
+  if (auto scalar_type = As<ScalarType>(expr->GetType())) {
+    if (scalar_type->dtype_ == DataType::INDEX) {
+      return ssa;
+    }
+    CHECK(scalar_type->dtype_.IsInt()) << context << " operand must be integer or index type, got "
+                                       << codegen.GetTypeString(scalar_type->dtype_);
+    std::string idx = codegen.NewTemp();
+    codegen.Emit(idx + " = arith.index_cast " + ssa + " : " + codegen.GetTypeString(scalar_type->dtype_) +
+                 " to index");
+    return idx;
+  }
+  return ssa;
+}
+
+static bool IsSameDimExpr(const ExprPtr& lhs, const ExprPtr& rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  auto lhs_const = As<ir::ConstInt>(lhs);
+  auto rhs_const = As<ir::ConstInt>(rhs);
+  return lhs_const && rhs_const && lhs_const->value_ == rhs_const->value_;
+}
+
+static std::shared_ptr<const ir::TileType> GetTpushTileType(const ExprPtr& tile_expr) {
+  if (auto tile_type = ir::GetTileTypeWithMemRef(tile_expr->GetType())) {
+    return tile_type;
+  }
+  return As<ir::TileType>(tile_expr->GetType());
+}
+
+static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCodegen& codegen,
+                                              const std::string& tile_buf, const std::string& tile_type,
+                                              int split) {
+  if (split == 0 || tile_buf.empty() || tile_type.empty()) {
+    return false;
+  }
+
+  auto source_tile_type = GetTpushTileType(op->args_[0]);
+  if (!source_tile_type || source_tile_type->shape_.size() < 2 || !source_tile_type->tile_view_.has_value()) {
+    return false;
+  }
+  const auto tile_view = source_tile_type->tile_view_.value_or(ir::TileView{});
+  if (tile_view.valid_shape.size() < 2) {
+    return false;
+  }
+
+  const auto& shape = source_tile_type->shape_;
+  const auto& valid_shape = tile_view.valid_shape;
+  ExprPtr transport_row = valid_shape[0];
+  ExprPtr transport_col = valid_shape[1];
+  if (split == 1) {
+    transport_col = shape[1];
+  } else if (split == 2) {
+    transport_row = shape[0];
+  }
+
+  if (IsSameDimExpr(transport_row, valid_shape[0]) && IsSameDimExpr(transport_col, valid_shape[1])) {
+    return false;
+  }
+
+  std::string row = EmitIndexOperand(codegen, transport_row, "tpush transport valid_row");
+  std::string col = EmitIndexOperand(codegen, transport_col, "tpush transport valid_col");
+  codegen.Emit("pto.set_validshape " + tile_buf + ", " + row + ", " + col + " : " + tile_type);
+  return true;
+}
+
+static void EmitLogicalTpushValidShapeRestore(const CallPtr& op, codegen::PTOCodegen& codegen,
+                                              const std::string& tile_buf, const std::string& tile_type) {
+  auto source_tile_type = GetTpushTileType(op->args_[0]);
+  INTERNAL_CHECK(source_tile_type && source_tile_type->tile_view_.has_value())
+      << "Internal error: tpush validShape restore requires a rank-2 source TileView";
+  const auto tile_view = source_tile_type->tile_view_.value_or(ir::TileView{});
+  INTERNAL_CHECK(tile_view.valid_shape.size() >= 2)
+      << "Internal error: tpush validShape restore requires rank-2 validShape";
+  const auto& valid_shape = tile_view.valid_shape;
+  std::string row = EmitIndexOperand(codegen, valid_shape[0], "tpush logical valid_row");
+  std::string col = EmitIndexOperand(codegen, valid_shape[1], "tpush logical valid_col");
+  codegen.Emit("pto.set_validshape " + tile_buf + ", " + row + ", " + col + " : " + tile_type);
+}
+
 // tile.tpush_to_aiv: Push tile from Cube to Vector
 static std::string MakeTpushToAivCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -1299,8 +1392,9 @@ static std::string MakeTpushToAivCodegenPTO(const CallPtr& op, codegen::CodegenB
   CHECK(split >= 0 && split <= 2)
       << "tpush_to_aiv requires 'split' attribute (0=none, 1=up-down, 2=left-right), got " << split;
 
-  std::string tile_buf = codegen.GetVarName(tile);
+  std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  const bool restore_valid_shape = EmitSplitTpushTransportValidShape(op, codegen, tile_buf, tile_type, split);
 
   std::ostringstream oss;
   oss << "pto.tpush_to_aiv(" << tile_buf;
@@ -1309,6 +1403,9 @@ static std::string MakeTpushToAivCodegenPTO(const CallPtr& op, codegen::CodegenB
   }
   oss << ") {split = " << split << "}";
   codegen.Emit(oss.str());
+  if (restore_valid_shape) {
+    EmitLogicalTpushValidShapeRestore(op, codegen, tile_buf, tile_type);
+  }
 
   return "";
 }
@@ -1325,8 +1422,9 @@ static std::string MakeTpushToAicCodegenPTO(const CallPtr& op, codegen::CodegenB
   CHECK(split >= 0 && split <= 2)
       << "tpush_to_aic requires 'split' attribute (0=none, 1=up-down, 2=left-right), got " << split;
 
-  std::string tile_buf = codegen.GetVarName(tile);
+  std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  const bool restore_valid_shape = EmitSplitTpushTransportValidShape(op, codegen, tile_buf, tile_type, split);
 
   std::ostringstream oss;
   oss << "pto.tpush_to_aic(" << tile_buf;
@@ -1335,6 +1433,9 @@ static std::string MakeTpushToAicCodegenPTO(const CallPtr& op, codegen::CodegenB
   }
   oss << ") {split = " << split << "}";
   codegen.Emit(oss.str());
+  if (restore_valid_shape) {
+    EmitLogicalTpushValidShapeRestore(op, codegen, tile_buf, tile_type);
+  }
 
   return "";
 }
@@ -2064,6 +2165,12 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
 
     std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
     std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+    if (tile_buf.empty()) {
+      tile_buf = codegen.GetCurrentResultTarget();
+    }
+    if (tile_buf_type.empty()) {
+      tile_buf_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
+    }
 
     auto emit_index_arg = [&](const ir::ExprPtr& arg) -> std::string {
       if (auto var = ir::As<ir::Var>(arg)) {
@@ -2088,6 +2195,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     std::string vr = emit_index_arg(op->args_[1]);
     std::string vc = emit_index_arg(op->args_[2]);
 
+    codegen.RegisterTileBufType(tile_buf, tile_buf_type);
+    codegen.SetCurrentResultBuf(tile_buf);
     codegen.Emit("pto.set_validshape " + tile_buf + ", " + vr + ", " + vc + " : " + tile_buf_type);
     return std::string("");
   });

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -826,13 +826,16 @@ void PTOCodegen::EmitExtraAllocTiles() {
 // ========================================================================
 
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
+  auto call = As<ir::Call>(op->value_);
+  const bool is_set_validshape = call && call->op_->name_ == "tile.set_validshape";
+
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-    if (fs_.tpop_result_vars.count(op->var_.get()) == 0) {
+    if (!is_set_validshape && fs_.tpop_result_vars.count(op->var_.get()) == 0) {
       EmitAllocTileForVar(op->var_, tile_type);
     }
   }
 
-  if (auto call = As<ir::Call>(op->value_)) {
+  if (call) {
     if (backend_ != nullptr && backend_->GetOpInfo(call->op_->name_) != nullptr) {
       std::string result_buf =
           op->var_->name_hint_;  // Seed for readable MLIR names when no tile buffer exists.
@@ -861,7 +864,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       VisitExpr(op->value_);
       // If codegen changed the result buffer (e.g., reshape allocated a new tile),
       // update variable mapping so subsequent references use the new buffer
-      if (!fs_.current_result_buf.empty() && fs_.current_result_buf != result_buf) {
+      if (!fs_.current_result_buf.empty() && (is_set_validshape || fs_.current_result_buf != result_buf)) {
         BindVarToMlir(op->var_, fs_.current_result_buf);
       }
       // Register per-variable tile_buf type from the variable's own TileType.

--- a/tests/st/runtime/test_cross_core_dynamic_valid_shape.py
+++ b/tests/st/runtime/test_cross_core_dynamic_valid_shape.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Runtime test for C2V tpop with dynamic valid_shape operands."""
+"""Runtime tests for cross-core dynamic valid_shape on tpush/tpop paths."""
 
 import sys
 from typing import Any
@@ -154,6 +154,140 @@ class C2VDynamicTpopValidShapeTestCase(PTOTestCase):
         tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
 
 
+class C2VDynamicTpushValidShapeTestCase(PTOTestCase):
+    """Cube narrows valid_shape before tpush; vector tpop consumes the narrowed tile."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        platform: str | None = None,
+        config: RunConfig | None = None,
+    ):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"cross_core_c2v_dynamic_tpush_valid_shape_{VALID_ROWS}x{VALID_COLS}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec(
+                "valid_shape",
+                [2],
+                DataType.INT64,
+                init_value=torch.tensor([VALID_ROWS, VALID_COLS], dtype=torch.int64),
+            ),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class C2VDynamicTpushValidShapeProgram:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def cube_producer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ):
+                c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+                pl.aic_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_peer,
+                )
+
+                a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                    a_mat, target_memory=pl.MemorySpace.Left
+                )
+                b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                    b_mat, target_memory=pl.MemorySpace.Right
+                )
+                acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+                narrowed: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Acc,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+                pl.tpush_to_aiv(narrowed, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def vector_consumer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                c2v_buf = pl.reserve_buffer(
+                    name="c2v_slot_buffer",
+                    size=BUFFER_SIZE_BYTES,
+                    base=0x2000,
+                )
+                pl.aiv_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_buf,
+                )
+
+                popped: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tpop_from_aic(split=1)
+                incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+                pl.tfree_to_aic(popped)
+                return pl.store(incremented, [0, 0], output)
+
+            @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+            def group_func(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                self.cube_producer(a, b, output, valid_rows, valid_cols)
+                result = self.vector_consumer(a, b, output, valid_rows, valid_cols)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                valid_shape: pl.Tensor[[2], pl.INDEX],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                valid_rows: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [0])
+                valid_cols: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [1])
+                result = self.group_func(a, b, output, valid_rows, valid_cols)
+                return result
+
+        return C2VDynamicTpushValidShapeProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        valid_rows = int(tensors["valid_shape"][0])
+        valid_cols = int(tensors["valid_shape"][1])
+        matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
+
+
 class TestCrossCoreDynamicValidShape:
     """Cross-core dynamic valid_shape runtime tests."""
 
@@ -162,6 +296,12 @@ class TestCrossCoreDynamicValidShape:
         """C2V tpop passes runtime valid_shape to vector-core compute and store."""
         result = test_runner.run(C2VDynamicTpopValidShapeTestCase(platform=platform))
         assert result.passed, f"C2V dynamic valid_shape tpop failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_c2v_tpush_dynamic_valid_shape(self, test_runner, platform):
+        """C2V tpush preserves runtime valid_shape from cube producer to vector consumer."""
+        result = test_runner.run(C2VDynamicTpushValidShapeTestCase(platform=platform))
+        assert result.passed, f"C2V dynamic valid_shape tpush failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/test_cross_core_tpush_valid_shape.py
@@ -1,0 +1,166 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime regression for preserving producer-side validShape through tpush."""
+
+import sys
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+ROWS = 16
+COLS = 16
+VALID_ROWS = 8
+VALID_COLS = 16
+SLOT_SIZE_BYTES = ROWS * COLS * 4
+BUFFER_SIZE_BYTES = SLOT_SIZE_BYTES * 4
+
+
+class C2VTpushValidShapeTestCase(PTOTestCase):
+    """Cube sets validShape before tpush; vector pop observes the split valid region."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_c2v_tpush_valid_shape_updown_8x16"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec(
+                "valid_shape",
+                [2],
+                DataType.INT64,
+                init_value=torch.tensor([VALID_ROWS, VALID_COLS], dtype=torch.int64),
+            ),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class C2VTpushValidShapeProgram:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def cube_producer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ):
+                c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+                pl.aic_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_peer,
+                )
+
+                a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                    a_mat, target_memory=pl.MemorySpace.Left
+                )
+                b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                    b_mat, target_memory=pl.MemorySpace.Right
+                )
+                acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+                narrowed: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Acc,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+                pl.tpush_to_aiv(narrowed, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def vector_consumer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                c2v_buf = pl.reserve_buffer(
+                    name="c2v_slot_buffer",
+                    size=BUFFER_SIZE_BYTES,
+                    base=0x2000,
+                )
+                pl.aiv_initialize_pipe(
+                    dir_mask=1,
+                    slot_size=SLOT_SIZE_BYTES,
+                    c2v_consumer_buf=c2v_buf,
+                )
+
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                popped: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                ] = pl.tpop_from_aic(split=1)
+                incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+                pl.tfree_to_aic(popped)
+                return pl.store(incremented, [subblock_idx * VALID_ROWS, 0], output)
+
+            @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+            def group_func(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                self.cube_producer(a, b, output, valid_rows, valid_cols)
+                result = self.vector_consumer(a, b, output, valid_rows, valid_cols)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                valid_shape: pl.Tensor[[2], pl.INDEX],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                valid_rows: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [0])
+                valid_cols: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [1])
+                result = self.group_func(a, b, output, valid_rows, valid_cols)
+                return result
+
+        return C2VTpushValidShapeProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        valid_rows = int(tensors["valid_shape"][0])
+        valid_cols = int(tensors["valid_shape"][1])
+        matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
+
+
+class TestCrossCoreTpushValidShape:
+    """a2a3-only tpush validShape runtime test."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+    def test_c2v_tpush_preserves_producer_valid_shape(self, test_runner, platform):
+        result = test_runner.run(C2VTpushValidShapeTestCase(platform=platform))
+        assert result.passed, f"C2V tpush validShape failed: {result.error}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -394,6 +394,18 @@ class MrgSort2WayFP32Program:
 # Factory functions for init_value tensors (golden_writer requires callables for large tensors).
 
 
+def _make_unique_fp32_values(length: int) -> torch.Tensor:
+    """Deterministic unique FP32 values for sort tests that verify indices."""
+    positions = torch.arange(length, dtype=torch.int64)
+    permuted = (positions * 37 + 17) % length
+    return (permuted.to(torch.float32) - (length // 2)) / 64.0
+
+
+def _make_src_8x32():
+    """Deterministic [8, 32] FP32 source with unique values in each row."""
+    return _make_unique_fp32_values(8 * 32).reshape(8, 32).contiguous()
+
+
 def _make_idx_8x32():
     """[0, 1, 2, ..., 31] per row — logical indices for sort32 idx input."""
     return torch.arange(0, 32, dtype=torch.int32).unsqueeze(0).expand(8, -1).contiguous()
@@ -417,8 +429,8 @@ def _make_idx_1x128():
 
 
 def _make_src_1x128():
-    """Random [1, 128] FP32 source for mrgsort format1 test."""
-    return torch.randn(128).unsqueeze(0).contiguous()
+    """Deterministic [1, 128] FP32 source with unique values."""
+    return _make_unique_fp32_values(128).unsqueeze(0).contiguous()
 
 
 def _make_idx_1x2048():
@@ -427,8 +439,8 @@ def _make_idx_1x2048():
 
 
 def _make_src_1x2048():
-    """Random [1, 2048] FP32 source for mrgsort dynamic block_len test."""
-    return torch.randn(2048).unsqueeze(0).contiguous()
+    """Deterministic [1, 2048] FP32 source with unique values."""
+    return _make_unique_fp32_values(2048).unsqueeze(0).contiguous()
 
 
 def _make_idx_1x1024():
@@ -437,8 +449,8 @@ def _make_idx_1x1024():
 
 
 def _make_src_1x1024():
-    """Random [1, 1024] FP32 source for mrgsort 2-way format2 test."""
-    return torch.randn(1024).unsqueeze(0).contiguous()
+    """Deterministic [1, 1024] FP32 source with unique values."""
+    return _make_unique_fp32_values(1024).unsqueeze(0).contiguous()
 
 
 class MrgSort1FP32TestCase(PTOTestCase):
@@ -631,7 +643,7 @@ class Sort32FP32TestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=_make_src_8x32),
             TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
             TensorSpec("output", [8, 64], DataType.FP32, is_output=True),
         ]
@@ -671,7 +683,7 @@ class Sort32GatherFP32TestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=_make_src_8x32),
             TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
             TensorSpec("val_gather_idx", [8, 32], DataType.INT32, init_value=_make_val_gather_idx),
             TensorSpec("idx_gather_idx", [8, 32], DataType.INT32, init_value=_make_idx_gather_idx),
@@ -713,7 +725,7 @@ class Sort32GatherMaskFP32TestCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("src_tensor", [8, 32], DataType.FP32, init_value=_make_src_8x32),
             TensorSpec("idx_tensor", [8, 32], DataType.UINT32, init_value=_make_idx_8x32),
             TensorSpec("output", [8, 32], DataType.FP32, is_output=True),
         ]

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -380,6 +380,253 @@ class TestCrossCoreTpushTpopCodegen:
         with pytest.raises(Exception, match="tpop valid_shape operand must be integer or index type, got i1"):
             codegen.PTOCodegen().generate(ir.Program([func], "dynamic_tpop_bool_row_program", span))
 
+    @pytest.mark.parametrize(
+        ("tpush_op_name", "func_type", "memory_space"),
+        [
+            ("tile.tpush_to_aiv", ir.FunctionType.AIC, ir.MemorySpace.Acc),
+            ("tile.tpush_to_aic", ir.FunctionType.AIV, ir.MemorySpace.Vec),
+        ],
+    )
+    def test_tpush_uses_validshape_aliased_tile(self, tpush_op_name, func_type, memory_space):
+        """set_validshape + cross-core tpush should push the in-place validShape tile handle."""
+        span = ir.Span.unknown()
+
+        src = ir.Var("src", ir.TensorType([32, 32], pl.FP32), span)
+        valid_row = ir.Var("valid_row", ir.ScalarType(pl.INDEX), span)
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        shape_32 = ir.ConstInt(32, pl.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([shape_32, shape_32], span)
+
+        load_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 32 * 32 * 4, 0)
+        load_view = ir.TileView()
+        load_view.valid_shape = [shape_32, shape_32]
+        load_view.blayout = ir.TileLayout.col_major
+        load_view.slayout = ir.TileLayout.row_major
+        load_view.fractal = 1024
+        load_type = ir.TileType([32, 32], pl.FP32, load_memref, load_view, memory_space)
+        src_tile = ir.Var("src_tile", load_type, span)
+
+        narrowed_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 32 * 32 * 4, 0)
+        narrowed_view = ir.TileView()
+        narrowed_view.valid_shape = [valid_row, valid_col]
+        narrowed_view.blayout = ir.TileLayout.col_major
+        narrowed_view.slayout = ir.TileLayout.row_major
+        narrowed_view.fractal = 1024
+        narrowed_type = ir.TileType([32, 32], pl.FP32, narrowed_memref, narrowed_view, memory_space)
+        narrowed_tile = ir.Var("narrowed_tile", narrowed_type, span)
+
+        load_call = ir.Call(
+            ir.Op("tile.load"),
+            [src, offsets, shapes, shapes],
+            {"target_memory": memory_space},
+            load_type,
+            span,
+        )
+        set_validshape_call = ir.Call(
+            ir.Op("tile.set_validshape"),
+            [src_tile, valid_row, valid_col],
+            {},
+            narrowed_type,
+            span,
+        )
+        tpush_call = ir.Call(ir.Op(tpush_op_name), [narrowed_tile], {"split": 0}, ir.UnknownType(), span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(src_tile, load_call, span),
+                ir.AssignStmt(narrowed_tile, set_validshape_call, span),
+                ir.EvalStmt(tpush_call, span),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "narrow_then_push",
+            [
+                (src, ir.ParamDirection.In),
+                (valid_row, ir.ParamDirection.In),
+                (valid_col, ir.ParamDirection.In),
+            ],
+            [],
+            body,
+            span,
+            func_type,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "narrow_then_push_program", span))
+
+        narrowed_alloc_lines = [
+            line.strip()
+            for line in mlir_code.splitlines()
+            if "%narrowed_tile" in line and "pto.alloc_tile" in line
+        ]
+        set_validshape_line = next(
+            line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line
+        )
+        pto_tpush_op_name = tpush_op_name.replace("tile.", "pto.")
+        tpush_line = next(line.strip() for line in mlir_code.splitlines() if pto_tpush_op_name in line)
+
+        assert not narrowed_alloc_lines, (
+            "Expected set_validshape result to alias the payload tile without a second alloc_tile, got:\n"
+            + "\n".join(narrowed_alloc_lines)
+        )
+        assert "%src_tile" in set_validshape_line, (
+            f"Expected set_validshape to target source payload tile SSA, got:\n{set_validshape_line}"
+        )
+        assert "v_row=?" in set_validshape_line and "v_col=?" in set_validshape_line, (
+            f"Expected dynamic tile type on set_validshape, got:\n{set_validshape_line}"
+        )
+        assert "%src_tile" in tpush_line, (
+            f"Expected tpush to push the source tile after in-place set_validshape, got:\n{tpush_line}"
+        )
+        assert "%narrowed_tile" not in tpush_line, (
+            f"Expected tpush not to use a payload-less set_validshape alias alloc, got:\n{tpush_line}"
+        )
+        assert "v_row=?" in tpush_line and "v_col=?" in tpush_line, (
+            f"Expected tpush to follow main's always-dynamic alloc_tile type annotation, got:\n{tpush_line}"
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "tpush_op_name",
+            "func_type",
+            "memory_space",
+            "split",
+            "transport_valid_shape",
+        ),
+        [
+            (
+                "tile.tpush_to_aiv",
+                ir.FunctionType.AIC,
+                ir.MemorySpace.Acc,
+                1,
+                ", %arg1, %c16_index :",
+            ),
+            (
+                "tile.tpush_to_aic",
+                ir.FunctionType.AIV,
+                ir.MemorySpace.Vec,
+                2,
+                ", %c16_index, %arg2 :",
+            ),
+        ],
+    )
+    def test_split_tpush_uses_full_non_split_transport_dim(
+        self, tpush_op_name, func_type, memory_space, split, transport_valid_shape
+    ):
+        """Split tpush keeps logical validShape but transports a full non-split dimension."""
+        span = ir.Span.unknown()
+
+        src = ir.Var("src", ir.TensorType([16, 16], pl.FP32), span)
+        valid_row = ir.Var("valid_row", ir.ScalarType(pl.INDEX), span)
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        shape_16 = ir.ConstInt(16, pl.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([shape_16, shape_16], span)
+
+        src_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        src_view = ir.TileView()
+        src_view.valid_shape = [shape_16, shape_16]
+        src_view.blayout = ir.TileLayout.col_major
+        src_view.slayout = ir.TileLayout.row_major
+        src_view.fractal = 1024
+        src_type = ir.TileType([16, 16], pl.FP32, src_memref, src_view, memory_space)
+        src_tile = ir.Var("src_tile", src_type, span)
+
+        narrowed_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        narrowed_view = ir.TileView()
+        narrowed_view.valid_shape = [valid_row, valid_col]
+        narrowed_view.blayout = ir.TileLayout.col_major
+        narrowed_view.slayout = ir.TileLayout.row_major
+        narrowed_view.fractal = 1024
+        narrowed_type = ir.TileType([16, 16], pl.FP32, narrowed_memref, narrowed_view, memory_space)
+        narrowed_tile = ir.Var("narrowed_tile", narrowed_type, span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(
+                    src_tile,
+                    ir.Call(
+                        ir.Op("tile.load"),
+                        [src, offsets, shapes, shapes],
+                        {"target_memory": memory_space},
+                        src_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.AssignStmt(
+                    narrowed_tile,
+                    ir.Call(
+                        ir.Op("tile.set_validshape"),
+                        [src_tile, valid_row, valid_col],
+                        {},
+                        narrowed_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.EvalStmt(
+                    ir.Call(
+                        ir.Op(tpush_op_name),
+                        [narrowed_tile],
+                        {"split": split},
+                        ir.UnknownType(),
+                        span,
+                    ),
+                    span,
+                ),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "split_narrow_then_push",
+            [
+                (src, ir.ParamDirection.In),
+                (valid_row, ir.ParamDirection.In),
+                (valid_col, ir.ParamDirection.In),
+            ],
+            [],
+            body,
+            span,
+            func_type,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "split_narrow_then_push_program", span))
+
+        set_validshape_lines = [
+            line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line
+        ]
+        tpush_line = next(
+            line.strip() for line in mlir_code.splitlines() if tpush_op_name.replace("tile.", "pto.") in line
+        )
+
+        assert len(set_validshape_lines) == 3, (
+            "Expected logical set_validshape, transport normalization, and logical restore, got:\n"
+            + "\n".join(set_validshape_lines)
+        )
+        assert ", %arg1, %arg2 :" in set_validshape_lines[0], (
+            f"Expected the initial logical validShape update, got:\n{set_validshape_lines[0]}"
+        )
+        assert transport_valid_shape in set_validshape_lines[1], (
+            "Expected split tpush to normalize the non-split transport dimension, got:\n"
+            f"{set_validshape_lines[1]}"
+        )
+        assert ", %arg1, %arg2 :" in set_validshape_lines[2], (
+            f"Expected the logical validShape restore after tpush, got:\n{set_validshape_lines[2]}"
+        )
+        assert "%src_tile" in tpush_line and "%narrowed_tile" not in tpush_line, (
+            f"Expected tpush to use the aliased source tile, got:\n{tpush_line}"
+        )
+
     def test_tfree_stays_after_nested_control_flow_use(self):
         """Nested control-flow users of a tpop result must stay before tfree."""
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1029,9 +1029,6 @@ class TestSetValidShapeCodegen:
 
         mlir = self._generate_mlir(Prog)
 
-        # Locate the alloc_tile that produces the gather output (variable name
-        # 'gathered'). PTOCodegen names SSA values after the IR var's name_hint,
-        # so we can match by the SSA name prefix.
         gathered_alloc_lines = [
             line for line in mlir.splitlines() if "pto.alloc_tile" in line and "%gathered" in line
         ]
@@ -1053,8 +1050,6 @@ class TestSetValidShapeCodegen:
             f"got line:\n{gathered_line}\n\nfull MLIR:\n{mlir}"
         )
 
-        # The pto.set_validshape line's source tile_buf type annotation must be
-        # dynamic too; otherwise PTOAS rejects it.
         set_vs_lines = [line for line in mlir.splitlines() if "pto.set_validshape" in line]
         assert set_vs_lines, f"Expected pto.set_validshape in codegen output:\n{mlir}"
         for line in set_vs_lines:
@@ -1062,6 +1057,48 @@ class TestSetValidShapeCodegen:
                 f"pto.set_validshape source tile_buf type must be dynamic "
                 f"(v_row=?, v_col=?); got line:\n{line}\n\nfull MLIR:\n{mlir}"
             )
+
+    def test_set_validshape_updates_source_tile_and_aliases_result(self):
+        """tile.set_validshape should mutate the source tile handle and alias the result to it."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[32, 32], pl.FP32],
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+                dst: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                src_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(src, [0, 0], [32, 32])
+                narrowed: pl.Tile[[32, 32], pl.FP32] = pl.tile.set_validshape(
+                    src_tile, valid_rows, valid_cols
+                )
+                return pl.store(narrowed, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        set_validshape_line = next(line.strip() for line in mlir.splitlines() if "pto.set_validshape" in line)
+        narrowed_alloc_lines = [
+            line.strip() for line in mlir.splitlines() if "%narrowed" in line and "pto.alloc_tile" in line
+        ]
+        store_line = next(
+            line.strip() for line in mlir.splitlines() if "pto.tstore" in line and "%src_tile" in line
+        )
+
+        assert "%src_tile" in set_validshape_line, (
+            f"Expected pto.set_validshape to target the source tile SSA, got:\n{set_validshape_line}"
+        )
+        assert "v_row=?" in set_validshape_line and "v_col=?" in set_validshape_line, (
+            f"Expected dynamic source tile type on pto.set_validshape, got:\n{set_validshape_line}"
+        )
+        assert not narrowed_alloc_lines, (
+            "Expected set_validshape result to alias the source tile without a second alloc_tile, got:\n"
+            + "\n".join(narrowed_alloc_lines)
+        )
+        assert "%src_tile" in store_line, (
+            f"Expected subsequent narrowed uses to resolve to the source tile SSA, got:\n{store_line}"
+        )
 
 
 class TestMrgSortCodegen:


### PR DESCRIPTION
  ## Summary

  This PR preserves tile `validShape` metadata through `tpush` / `tpop` flows, including tiles whose valid shape is set after allocation via `tile.set_validshape`.

  It enables patterns such as:

  ```python
  tile = alloc_tile(addr, valid_row, valid_col)
  tpush(tile)
  ```

  and:

  ```python
  tile = alloc_tile(addr, r, c)
  tile = set_validshape(tile, valid_row, valid_col)
  tpush(tile)
  ```

  so the consumer side can tpop the pushed tile with the correct logical valid shape for compute and store.

  ## Changes

  - Lower tile.set_validshape as an in-place update on the underlying tile buffer handle, so later tpush carries the updated runtime valid shape.
  - Preserve dynamic valid-shape metadata across cross-core tpush / tpop codegen.
  - Handle split tpush transport correctly:
      - up/down split temporarily uses full physical columns for transport;
      - left/right split temporarily uses full physical rows for transport;
      - the producer tile's logical valid shape is restored after the push.
  - Add regression coverage for dynamic and post-allocation validShape tpush flows.
  - Add an a2a3 system test for C2V split tpush with dynamic valid shape.
  - Make sort ST inputs deterministic and unique where index order is checked, avoiding unstable equal-key tie behavior between hardware sort and PyTorch golden.
  - Update English and Chinese PTO codegen docs.