### PR TITLE
refactor(codegen): lower tile.slice/assemble to pto.subview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.31
-      PTOAS_SHA256: ca184d071cef3af989ff3f98e7ce4c7262ba1e07405738b65e9900c43065ada5
+      PTOAS_VERSION: v0.32
+      PTOAS_SHA256: 325198dff677d7d163e16ce0aed27aa08c119764a4f50a60092b0edcd2e0784b
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -135,7 +135,7 @@ jobs:
             echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
             mkdir -p "$PTOAS_CACHE_DIR"
             curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
               -o "$CACHE_ARCHIVE.tmp"
             echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
             mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
@@ -172,8 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.31
-      PTOAS_SHA256: cd9121b768f7383f5bda702c89507dd160f539c28bbdf57a0585be9473081d07
+      PTOAS_VERSION: v0.32
+      PTOAS_SHA256: 631b19f9112e5533da3585b4ac422a0ab24ba7ac53b7d251c085390335946950
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:
@@ -197,7 +197,7 @@ jobs:
         if: steps.cache-ptoas.outputs.cache-hit != 'true'
         run: |
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-x86_64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-x86_64.tar.gz \
              -o /tmp/ptoas-bin-x86_64.tar.gz
           echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -132,9 +132,32 @@ print(pto_code)
 | --------------- | ----------------- |
 | `tile.load(tensor, [row, col], [h, w])` | `pto.partition_view` + `pto.tload` |
 | `tile.store(tile, [row, col], tensor)` | `pto.partition_view` + `pto.tstore` |
+| `tile.slice(tile, [h, w], [row, col][, valid_shape=...])` | `pto.subview` (zero-copy view; `valid [...]` clause emitted only when `valid_shape` is supplied) |
+| `tile.assemble(target, source, [row, col])` | (optional) `pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (3-operand add) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (tile + scalar) |
+
+**`tile.slice` / `tile.assemble` lowering details.**  Both ops are lowered
+through `pto.subview`, which is a pure view alias of the source tile (no
+data movement, no extra `pto.alloc_tile`).  `pto.subview` requires the
+result `tile_buf` to share `dtype`, `memory_space`, `blayout`, `slayout`,
+`fractal`, and `pad` with the source — `DeduceTileSliceType` propagates
+those four `TileView` fields from the source so the produced `TileType`
+satisfies the constraints by construction.  Backend codegen also runs a
+`CheckSubviewTileCompat` guard at lowering time:
+
+- Source and result must both carry an explicit `TileView`.
+- `dtype`, `blayout`, `slayout`, `fractal`, and `pad` must match exactly.
+- `pad` must be `PadValue::null` — `pto.subview` is a view, not a fillpad,
+  so use `tile.fillpad` on the slice result if zero/min/max padding is
+  required.
+
+For `tile.assemble`, the leading `pto.tmov target → dst` is only emitted
+when buffer reuse did not collapse `target` and the destination buffer; in
+that case it preserves any data outside the insertion window.  The
+trailing `pto.tmov src → dst_view` is the actual data write into the
+sub-window carved out by `pto.subview`.
 
 ### Cross-Core Operations → PTO Instructions
 

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -132,9 +132,29 @@ print(pto_code)
 | ---------- | -------------- |
 | `tile.load(tensor, [row, col], [h, w])` | `pto.partition_view` + `pto.tload` |
 | `tile.store(tile, [row, col], tensor)` | `pto.partition_view` + `pto.tstore` |
+| `tile.slice(tile, [h, w], [row, col][, valid_shape=...])` | `pto.subview`（零拷贝视图；仅在传入 `valid_shape` 时输出 `valid [...]` 子句） |
+| `tile.assemble(target, source, [row, col])` | （可选）`pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (三操作数加法) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (Tile + 标量) |
+
+**`tile.slice` / `tile.assemble` 下沉细节。** 两个 op 都通过 `pto.subview`
+下沉，它是源 tile 的纯视图别名（不搬数据，也不会额外发 `pto.alloc_tile`）。
+`pto.subview` 要求结果 `tile_buf` 与源 `tile_buf` 在 `dtype`、`memory_space`、
+`blayout`、`slayout`、`fractal` 和 `pad` 上完全一致，因此
+`DeduceTileSliceType` 会将源 `TileView` 的这四个字段透传到结果，使新生成的
+`TileType` 天然满足约束。后端 codegen 还会在下沉时执行 `CheckSubviewTileCompat`
+做兜底校验：
+
+- 源和结果都必须显式携带 `TileView`。
+- `dtype`、`blayout`、`slayout`、`fractal` 与 `pad` 必须严格相等。
+- `pad` 必须为 `PadValue::null`——`pto.subview` 是视图而不是 fillpad；如果
+  需要 zero/min/max 填充，请在切出来的子 tile 上再调用 `tile.fillpad`。
+
+对 `tile.assemble`，前置的 `pto.tmov target → dst` 仅在缓冲复用未把
+`target` 与目标缓冲合并时才会发出，用于保留写入窗口外的数据；末尾的
+`pto.tmov src → dst_view` 才是真正写入由 `pto.subview` 切出的子窗口的数据
+搬运。
 
 ### 跨核操作到 PTO 指令
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -446,14 +446,55 @@ static std::string MakeCmpsCodegenPTO(const std::string& pto_op_name, const Call
   return "";
 }
 
-// Helper function for tile.assemble → pto.tinsert
-// Inserts source tile into target tile at a given row/col offset (DPS pattern).
-// pto.tinsert semantics: dst[i+row, j+col] = src[i, j]
+// Verify that two TileTypes share the strict "same tile config" required by
+// pto.subview: identical dtype, identical TileView (blayout, slayout, fractal,
+// pad), and pad must be null since pto.subview is a pure view and does not
+// pad.  Memory-space equality is enforced separately (via memory_inherit
+// rules on the op definition); this helper checks the tile_view fields that
+// must be byte-for-byte compatible for a subview to be legal.
+static void CheckSubviewTileCompat(const ir::TileType& source, const ir::TileType& result,
+                                   const std::string& op_name) {
+  CHECK(source.tile_view_.has_value())
+      << op_name << ": source tile must carry an explicit TileView to be sliced via pto.subview";
+  CHECK(result.tile_view_.has_value())
+      << op_name << ": result tile must carry an explicit TileView to be emitted as pto.subview";
+  CHECK(source.dtype_ == result.dtype_) << op_name << ": source and result must share dtype, got "
+                                        << source.dtype_.ToString() << " vs " << result.dtype_.ToString();
+
+  const auto& src_v = *source.tile_view_;
+  const auto& res_v = *result.tile_view_;
+  CHECK(src_v.blayout == res_v.blayout)
+      << op_name
+      << ": blayout mismatch between source and result; pto.subview requires identical block layout";
+  CHECK(src_v.slayout == res_v.slayout)
+      << op_name
+      << ": slayout mismatch between source and result; pto.subview requires identical scatter layout";
+  CHECK(src_v.fractal == res_v.fractal) << op_name << ": fractal mismatch (" << src_v.fractal << " vs "
+                                        << res_v.fractal << "); pto.subview requires identical fractal";
+  CHECK(src_v.pad == res_v.pad)
+      << op_name << ": pad mismatch between source and result; pto.subview requires identical pad mode";
+  CHECK(src_v.pad == ir::PadValue::null)
+      << op_name << ": pto.subview does not support pad_value (" << static_cast<int>(src_v.pad)
+      << "); apply tile.fillpad on the result tile instead of carrying a pad on the slice/assemble window";
+}
+
+// Helper function for tile.assemble → pto.subview + pto.tmov
+// Writes source tile into target tile at a given row/col offset.  Lowering:
+//   1. (optional) pto.tmov target → dst when buffer reuse did not merge them
+//      (preserves any data outside the insertion window).
+//   2. %dst_view = pto.subview %dst[row, col] sizes [src.rows, src.cols] : ... -> ...
+//   3. pto.tmov ins(%src) outs(%dst_view)
 // Arguments: args[0] = target (destination base), args[1] = source, args[2] = offset MakeTuple
 static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 3) << "tile.assemble requires 3 arguments (target, source, offset), got "
                                << op->args_.size();
+
+  auto target_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
+  auto source_tile_type = ir::As<ir::TileType>(op->args_[1]->GetType());
+  INTERNAL_CHECK_SPAN(target_tile_type && source_tile_type, op->span_)
+      << "tile.assemble target and source must both be TileType";
+  CheckSubviewTileCompat(*source_tile_type, *target_tile_type, "tile.assemble");
 
   std::string target = codegen.GetExprAsCode(op->args_[0]);
   std::string src = codegen.GetExprAsCode(op->args_[1]);
@@ -469,9 +510,10 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
   std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
 
-  // pto.tinsert writes src into dst at (row, col) in place — dst must already
-  // contain target's data.  When target and dst are different buffers (i.e.
-  // memory reuse did not merge them), copy target → dst first.
+  // pto.subview is a view, so writing into the dst_view only affects the
+  // [row, col]+sizes window.  Data outside that window must already be present
+  // in dst — when target and dst are different buffers (memory reuse did not
+  // merge them), copy target → dst first to preserve target's outer data.
   if (target != dst) {
     std::string target_type = codegen.GetExprTypeAnnotation(op->args_[0]);
     std::ostringstream mov;
@@ -483,16 +525,39 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
     codegen.Emit(mov.str());
   }
 
-  // Emit pto.tinsert ins(src, row, col) outs(dst)
-  std::ostringstream oss;
-  oss << "pto.tinsert ins(" << src << ", " << row_off << ", " << col_off;
-  if (!src_type.empty()) {
-    oss << " : " << src_type << ", index, index";
+  // Build %dst_view = pto.subview %dst[%row, %col] sizes [R, C] : <dst_type> -> <view_type>
+  // The subview "sizes" attribute is the source tile's shape; its result
+  // tile_buf type matches the source's tile_buf type (same dtype, layout,
+  // fractal, pad — verified above — and same logical shape).  Reusing src_type
+  // as the view type is always sound under the strict subview constraints.
+  const auto& src_shape = source_tile_type->shape_;
+  INTERNAL_CHECK_SPAN(src_shape.size() >= 2, op->span_)
+      << "tile.assemble source must have at least 2 dimensions for pto.subview";
+  auto rows_const = ir::As<ir::ConstInt>(src_shape[0]);
+  auto cols_const = ir::As<ir::ConstInt>(src_shape[1]);
+  INTERNAL_CHECK_SPAN(rows_const && cols_const, op->span_)
+      << "tile.assemble source shape must be compile-time constant for pto.subview sizes attribute";
+
+  std::string dst_view = codegen.NewNamedTemp("assemble_view");
+  std::ostringstream sv;
+  sv << dst_view << " = pto.subview " << dst << "[" << row_off << ", " << col_off << "] sizes ["
+     << rows_const->value_ << ", " << cols_const->value_ << "]";
+  if (!dst_type.empty() && !src_type.empty()) {
+    sv << " : " << dst_type << " -> " << src_type;
   }
-  oss << ") outs(" << dst;
-  if (!dst_type.empty()) oss << " : " << dst_type;
-  oss << ")";
-  codegen.Emit(oss.str());
+  codegen.Emit(sv.str());
+  if (!src_type.empty()) {
+    codegen.RegisterTileBufType(dst_view, src_type);
+  }
+
+  // Emit pto.tmov ins(%src) outs(%dst_view) — the actual data transfer.
+  std::ostringstream tmov;
+  tmov << "pto.tmov ins(" << src;
+  if (!src_type.empty()) tmov << " : " << src_type;
+  tmov << ") outs(" << dst_view;
+  if (!src_type.empty()) tmov << " : " << src_type;
+  tmov << ")";
+  codegen.Emit(tmov.str());
   return "";
 }
 
@@ -1839,6 +1904,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
         << "Operation:[tile.slice] requires 3 or 4 arguments (tile, shape, offset[, valid_shape]), but got "
         << op->args_.size();
 
+    auto source_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
+    INTERNAL_CHECK_SPAN(source_tile_type, op->span_) << "tile.slice source must be TileType";
+
     std::string src = codegen.GetExprAsCode(op->args_[0]);
     std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
 
@@ -1850,29 +1918,60 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
     std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
 
-    std::string result_target = codegen.GetCurrentResultTarget();
+    auto shape_tuple = ir::As<ir::MakeTuple>(op->args_[1]);
+    INTERNAL_CHECK_SPAN(shape_tuple, op->span_) << "tile.slice shape must be a literal tuple";
+    INTERNAL_CHECK_SPAN(shape_tuple->elements_.size() >= 2, op->span_)
+        << "tile.slice shape must have at least 2 elements (rows, cols)";
+    auto rows_const = ir::As<ir::ConstInt>(shape_tuple->elements_[0]);
+    auto cols_const = ir::As<ir::ConstInt>(shape_tuple->elements_[1]);
+    INTERNAL_CHECK_SPAN(rows_const && cols_const, op->span_)
+        << "tile.slice shape must be compile-time constant for pto.subview sizes attribute";
+
+    // Optional valid_shape (4th arg) materialises into pto.subview's
+    // `valid [%vr, %vc]` operands.  Omit them when valid_shape == shape so
+    // the result tile_buf type carries static v_row / v_col.
+    std::string valid_row;
+    std::string valid_col;
+    if (op->args_.size() == 4) {
+      auto valid_tuple = ir::As<ir::MakeTuple>(op->args_[3]);
+      INTERNAL_CHECK_SPAN(valid_tuple, op->span_) << "tile.slice valid_shape must be a literal tuple";
+      INTERNAL_CHECK_SPAN(valid_tuple->elements_.size() >= 2, op->span_)
+          << "tile.slice valid_shape must have at least 2 elements";
+      valid_row = codegen.GetExprAsCode(valid_tuple->elements_[0]);
+      valid_col = codegen.GetExprAsCode(valid_tuple->elements_[1]);
+    }
+
     std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
 
-    // With per-var alloc model, prefer the pre-declared alloc SSA if its type
-    // matches the slice result type
-    auto existing_type = codegen.GetSSATileBufType(result_target);
-    if (!result_type.empty() && existing_type != result_type) {
-      result_target = codegen.AllocNewTileBuf(result_type, "slice_buf");
-      codegen.SetCurrentResultBuf(result_target);
-    } else if (!result_type.empty()) {
-      codegen.RegisterTileBufType(result_target, result_type);
+    // Verify pto.subview's strict tile-config constraints.  After
+    // DeduceTileSliceType propagates the source TileView, the result type
+    // shares blayout/slayout/fractal/pad with the source by construction;
+    // this guards against future passes that might rewrite the result type.
+    if (auto result_var = codegen.GetCurrentResultVar()) {
+      if (auto result_tile_type = ir::As<ir::TileType>(result_var->GetType())) {
+        CheckSubviewTileCompat(*source_tile_type, *result_tile_type, "tile.slice");
+      }
+    }
+
+    // Allocate a fresh SSA for the subview result and rebind the current
+    // result variable to it; the (now dead) pre-emitted alloc_tile for the
+    // slice variable is harmless and will be eliminated by downstream PTOAS
+    // passes.  Doing it this way avoids redefining the alloc_tile SSA.
+    std::string view_ssa = codegen.NewNamedTemp("slice_view");
+    codegen.SetCurrentResultBuf(view_ssa);
+    if (!result_type.empty()) {
+      codegen.RegisterTileBufType(view_ssa, result_type);
     }
 
     std::ostringstream oss;
-    oss << "pto.textract ins(" << src << ", " << row_off << ", " << col_off;
-    if (!src_type.empty()) {
-      oss << " : " << src_type << ", index, index";
+    oss << view_ssa << " = pto.subview " << src << "[" << row_off << ", " << col_off << "] sizes ["
+        << rows_const->value_ << ", " << cols_const->value_ << "]";
+    if (!valid_row.empty()) {
+      oss << " valid [" << valid_row << ", " << valid_col << "]";
     }
-    oss << ") outs(" << result_target;
-    if (!result_type.empty()) {
-      oss << " : " << result_type;
+    if (!src_type.empty() && !result_type.empty()) {
+      oss << " : " << src_type << " -> " << result_type;
     }
-    oss << ")";
     codegen.Emit(oss.str());
     return std::string("");
   });

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -182,13 +182,31 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
     }
   }
 
-  // Slice preserves dtype but uses static shape for allocation and valid_shape for logical extent.
+  // Slice produces a window over the source tile.  PTO's pto.subview semantics
+  // require the result tile_buf to share dtype, memory space, and the four
+  // tile-config fields (blayout, slayout, fractal, pad) with the source.
+  // Inherit only those fields from the source TileView; recompute the
+  // window-specific fields (valid_shape and physical stride/start_offset are
+  // inherent to the slice itself, not the parent buffer).  Tiles without an
+  // explicit TileView fall back to inferring layout from shape (covers
+  // intermediate IR built before backend-level allocation).
   TileView tile_view;
+  if (tile_type->tile_view_.has_value()) {
+    const auto& src_v = *tile_type->tile_view_;
+    tile_view.blayout = src_v.blayout;
+    tile_view.slayout = src_v.slayout;
+    tile_view.fractal = src_v.fractal;
+    tile_view.pad = src_v.pad;
+  } else {
+    tile_view.blayout = InferTileLayoutFromShape(new_shape);
+  }
   tile_view.valid_shape = valid_shape;
 
-  tile_view.blayout = InferTileLayoutFromShape(new_shape);
-
-  // Read optional pad_value kwarg (default PadValue::null = no padding).
+  // Optional pad_value kwarg overrides the inherited pad mode.  When the user
+  // explicitly requests padding on a slice, codegen will reject it via
+  // CheckSubviewTileCompat (pto.subview is a pure view and cannot pad) and
+  // direct callers to use tile.fillpad on the slice result.
+  bool pad_value_specified = false;
   PadValue pad_value = PadValue::null;
   for (const auto& [k, v] : kwargs) {
     if (k != "pad_value") continue;
@@ -198,9 +216,12 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
     CHECK(pad_value == PadValue::null || pad_value == PadValue::zero || pad_value == PadValue::max ||
           pad_value == PadValue::min)
         << "tile.slice pad_value has invalid enum value: " << static_cast<int>(pad_value);
+    pad_value_specified = true;
     break;
   }
-  tile_view.pad = pad_value;
+  if (pad_value_specified) {
+    tile_view.pad = pad_value;
+  }
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1550,7 +1550,9 @@ def test_pto_codegen_mixed_scalar_and_tile_iter_args():
 
 
 def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
-    """Slice with partially dynamic valid_shape followed by fillpad must not create spurious slice_buf."""
+    """Slice with partially dynamic valid_shape followed by fillpad must lower
+    to a single pto.subview (no spurious extra alloc) and feed a dynamic
+    valid_shape tile into pto.tfillpad."""
 
     @pl.program
     class SliceFillpadProgram:
@@ -1570,16 +1572,19 @@ def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
 
     mlir_code = _generate_default_mlir(SliceFillpadProgram)
 
-    # No spurious slice_buf should be allocated — slice reuses its pre-allocated buffer
-    assert "slice_buf" not in mlir_code, (
-        f"Unexpected slice_buf allocation — tile.slice should reuse the pre-allocated buffer.\n{mlir_code}"
-    )
+    # tile.slice now lowers to a pto.subview view rather than a textract
+    # data-movement op; no slice_buf scratch allocation should appear.
+    assert "= pto.alloc_tile" not in "\n".join(
+        line for line in mlir_code.splitlines() if "slice_buf" in line
+    ), f"Unexpected slice_buf alloc_tile — pto.subview is a view, no extra buffer needed.\n{mlir_code}"
+    assert "pto.textract" not in mlir_code, f"tile.slice no longer emits pto.textract, got:\n{mlir_code}"
 
-    # The textract should reference the sliced tile's SSA (not a separate slice_buf)
-    textract_lines = [line.strip() for line in mlir_code.splitlines() if "pto.textract" in line]
-    assert len(textract_lines) == 1, f"Expected one textract, got: {textract_lines}"
-    assert "slice_buf" not in textract_lines[0], (
-        f"textract should not reference slice_buf: {textract_lines[0]}"
+    # Exactly one pto.subview should carry the dynamic `valid [...]` operand
+    # corresponding to the partially-dynamic valid_shape on tile.slice.
+    subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
+    assert len(subview_lines) == 1, f"Expected one pto.subview, got: {subview_lines}"
+    assert "valid [" in subview_lines[0], (
+        f"pto.subview should carry a `valid [...]` clause for dynamic valid_shape: {subview_lines[0]}"
     )
 
     # All tile_buf types use the always-dynamic `v_row=?, v_col=?` form.

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -740,10 +740,10 @@ class TestExpandMixedKernelCodegen:
 
         assert "main_incore_0_aic" in codes, "AIC function should be generated"
         aic_body = _extract_func_section(codes["main_incore_0_aic"], "main_incore_0_aic")
-        assert "pto.textract" in aic_body, "AIC should keep the tile.slice producer before C2V push"
+        assert "pto.subview" in aic_body, "AIC should keep the tile.slice producer before C2V push"
         assert "pto.tpush_to_aiv" in aic_body, "AIC should push the sliced row to AIV"
-        assert aic_body.index("pto.textract") < aic_body.index("pto.tpush_to_aiv"), (
-            "AIC should extract the row tile before pushing it across cores"
+        assert aic_body.index("pto.subview") < aic_body.index("pto.tpush_to_aiv"), (
+            "AIC should subview the row tile before pushing it across cores"
         )
 
         assert "main_incore_0_aiv" in codes, "AIV function should be generated"

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -789,7 +789,13 @@ class TestBroadcastOpsCodegen:
 
 
 class TestTileSliceCodegen:
-    """Tests for tile.slice PTO code generation (pto.textract)."""
+    """Tests for tile.slice PTO code generation (pto.subview).
+
+    tile.slice lowers to pto.subview — a pure view alias of the source tile —
+    rather than the historical pto.textract data-movement op.  The result tile
+    inherits the source's tile_buf configuration (loc/dtype/blayout/slayout/
+    fractal/pad) and only the shape/valid_shape change.
+    """
 
     def _generate_mlir(self, program_cls) -> str:
         """Run PassManager and PTOCodegen on the given program, return MLIR string."""
@@ -805,7 +811,7 @@ class TestTileSliceCodegen:
         return codegen_instance.generate(single)
 
     def test_tile_slice_codegen(self):
-        """tile.slice(tile[32,32], [16,16], [0,0]) should generate pto.textract."""
+        """tile.slice(tile[32,32], [16,16], [0,0]) should generate pto.subview."""
 
         @pl.program
         class Prog:
@@ -820,10 +826,18 @@ class TestTileSliceCodegen:
                 return pl.store(sliced, [0, 0], dst)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.textract" in mlir, f"tile.slice should generate pto.textract, got:\n{mlir}"
+        assert "pto.subview" in mlir, f"tile.slice should generate pto.subview, got:\n{mlir}"
+        assert "pto.textract" not in mlir, f"tile.slice no longer emits pto.textract, got:\n{mlir}"
+        # Subview line must carry both source and result tile_buf types and a
+        # static `sizes [R, C]` attribute matching the slice shape.
+        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
+        assert subview_lines, "no pto.subview line emitted"
+        line = subview_lines[0]
+        assert "sizes [16, 16]" in line, f"sizes attribute must be [16, 16], got:\n{line}"
+        assert "rows=16, cols=16" in line, f"result tile_buf must carry rows=16, cols=16, got:\n{line}"
 
     def test_tile_slice_codegen_with_valid_shape(self):
-        """tile.slice(..., valid_shape=...) should still generate pto.textract."""
+        """tile.slice(..., valid_shape=...) emits pto.subview with `valid` operands."""
 
         @pl.program
         class Prog:
@@ -841,8 +855,12 @@ class TestTileSliceCodegen:
                 return pl.store(sliced, [0, 0], dst)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.textract" in mlir, (
-            f"tile.slice with valid_shape should generate pto.textract, got:\n{mlir}"
+        assert "pto.subview" in mlir, f"tile.slice with valid_shape should generate pto.subview, got:\n{mlir}"
+        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
+        assert subview_lines, "no pto.subview line emitted"
+        # The `valid [...]` clause must be present when valid_shape is given.
+        assert any("valid [" in line for line in subview_lines), (
+            "pto.subview should carry `valid [...]` operands, got:\n" + "\n".join(subview_lines)
         )
 
     def test_tile_slice_multiple_slices_have_correct_types(self):
@@ -851,8 +869,8 @@ class TestTileSliceCodegen:
         Reproduces the Qwen3 decode pattern:
             load [1,512] → reshape [4,128] → slice [4,64]@[0,0] + slice [4,64]@[0,64]
         Both slices share the same MemRef and PTO buffer (sequential execution),
-        but their ins()/outs() type annotations must reflect the [4,64] slice
-        shape, not the [1,512] root alloc shape.
+        but their pto.subview result tile_buf types must reflect the [4,64]
+        slice shape, not the [1,512] root alloc shape.
         """
 
         @pl.program
@@ -872,15 +890,73 @@ class TestTileSliceCodegen:
 
         mlir = self._generate_mlir(Prog)
 
-        textract_lines = [line.strip() for line in mlir.splitlines() if "pto.textract" in line]
-        assert len(textract_lines) == 2, (
-            f"Expected 2 pto.textract (lo+hi slices), got {len(textract_lines)}:\n"
-            + "\n".join(textract_lines)
+        subview_lines = [line.strip() for line in mlir.splitlines() if "pto.subview" in line]
+        assert len(subview_lines) == 2, (
+            f"Expected 2 pto.subview (lo+hi slices), got {len(subview_lines)}:\n" + "\n".join(subview_lines)
         )
-        for line in textract_lines:
-            assert "rows=4" in line and "cols=64" in line, (
-                f"textract outs() type should be rows=4,cols=64 (slice shape), got:\n{line}"
+        # Both subviews must declare the [4, 64] sub-shape on their result type.
+        for line in subview_lines:
+            result_type = line.split("->", 1)[-1]
+            assert "rows=4" in result_type and "cols=64" in result_type, (
+                f"subview result type should be rows=4,cols=64 (slice shape), got:\n{line}"
             )
+
+
+class TestTileAssembleCodegen:
+    """Tests for tile.assemble PTO code generation (pto.subview + pto.tmov).
+
+    tile.assemble lowers to:
+      1. (optional) pto.tmov target → dst when buffer reuse did not merge them.
+      2. %dst_view = pto.subview %dst[row, col] sizes [...] : ... -> ...
+      3. pto.tmov ins(%src) outs(%dst_view)
+    The historical pto.tinsert copy op is no longer emitted.
+    """
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_assemble_codegen(self):
+        """tile.assemble lowers to pto.subview + pto.tmov, never pto.tinsert."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                target_in: pl.Tensor[[16, 128], pl.FP32],
+                source_in: pl.Tensor[[16, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                target: pl.Tile[[16, 128], pl.FP32] = pl.load(target_in, [0, 0], [16, 128])
+                source: pl.Tile[[16, 64], pl.FP32] = pl.load(source_in, [0, 0], [16, 64])
+                result: pl.Tile[[16, 128], pl.FP32] = pl.tile.assemble(target, source, [0, 64])
+                return pl.store(result, [0, 0], out)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tinsert" not in mlir, f"tile.assemble no longer emits pto.tinsert, got:\n{mlir}"
+        # Exactly one pto.subview should carve out the destination window.
+        subview_lines = [line.strip() for line in mlir.splitlines() if "pto.subview" in line]
+        assert len(subview_lines) == 1, (
+            f"Expected one pto.subview for tile.assemble, got {len(subview_lines)}:\n"
+            + "\n".join(subview_lines)
+        )
+        sv = subview_lines[0]
+        assert "sizes [16, 64]" in sv, f"subview sizes must equal source shape: {sv}"
+        # The actual data write is a pto.tmov from src into the subview SSA.
+        view_ssa = sv.split(" = ", 1)[0].strip()
+        assert any("pto.tmov" in line and f"outs({view_ssa}" in line for line in mlir.splitlines()), (
+            f"tile.assemble should pto.tmov into the subview SSA {view_ssa!r}, got:\n{mlir}"
+        )
 
 
 class TestSetValidShapeCodegen:

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -923,15 +923,21 @@ class TestInferTileMemorySpaceInheritOps:
                 x_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.load(
                     x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
                 )
-                sliced: pl.Tile[
+                # tile.slice now propagates the source TileView (Mat-implicit
+                # col_major / row_major) into the result so pto.subview is legal,
+                # which means the printer elides the implicit annotation here.
+                sliced: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Mat] = pl.tile.slice(
+                    x_tile, [16, 64], [0, 0]
+                )
+                # The move into Vec preserves the slice's Mat-style layout
+                # (col_major / row_major) on the destination buffer; the printer
+                # surfaces this because it differs from the Vec-implicit defaults.
+                sliced_V: pl.Tile[
                     [16, 64],
                     pl.BF16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.none_box),
-                ] = pl.tile.slice(x_tile, [16, 64], [0, 0])
-                sliced_V: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Vec] = pl.move(
-                    sliced, target_memory=pl.MemorySpace.Vec
-                )
+                    pl.MemorySpace.Vec,
+                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+                ] = pl.move(sliced, target_memory=pl.MemorySpace.Vec)
                 out_0: pl.Tensor[[16, 64], pl.BF16] = pl.store(sliced_V, [0, 0], out_0)
                 return out_0
 
@@ -980,12 +986,14 @@ class TestInferTileMemorySpaceInheritOps:
                 x_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.load(
                     x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
                 )
-                sliced: pl.Tile[
-                    [16, 64],
-                    pl.BF16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.none_box),
-                ] = pl.tile.slice(x_tile, [16, 64], [0, 0])
+                # tile.slice now inherits the Mat-implicit TileView from x_tile,
+                # so the printer elides the redundant annotation.
+                sliced: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Mat] = pl.tile.slice(
+                    x_tile, [16, 64], [0, 0]
+                )
+                # tile.reshape recomputes layout from the new shape, producing
+                # row_major / none_box which differs from Mat-implicit
+                # col_major / row_major and is therefore surfaced by the printer.
                 reshaped: pl.Tile[
                     [1024],
                     pl.BF16,


### PR DESCRIPTION
## Summary

Refactor PTO code generation for `tile.slice` and `tile.assemble` (incore) to lower onto PTOAS's zero-copy `pto.subview` instead of the historical `pto.textract` / `pto.tinsert` data-movement ops.  This removes redundant tile allocations and tile-to-tile copies on the AICore data path.

### Lowering

- `tile.slice(tile, [h, w], [row, col][, valid_shape=...])` → `pto.subview` (pure view alias; `valid [...]` operands are emitted only when `valid_shape` is supplied).
- `tile.assemble(target, source, [row, col])` →
  1. (optional) `pto.tmov target -> dst` when buffer reuse did not collapse the two buffers — preserves any data outside the insertion window.
  2. `pto.subview dst[row, col] sizes [src.rows, src.cols]` to carve out the destination window.
  3. `pto.tmov src -> dst_view` for the actual data write.

### Type propagation

- `DeduceTileSliceType` propagates the source's `blayout`, `slayout`, `fractal`, and `pad` so the slice result shares the four tile-config fields required by `pto.subview` by construction.
- An optional `pad_value` kwarg on `tile.slice` overrides the inherited pad — codegen then rejects it via the new `CheckSubviewTileCompat` guard with a clear hint to use `tile.fillpad` on the slice result.
- `CheckSubviewTileCompat` enforces the strict subview constraints (matching dtype / blayout / slayout / fractal / pad, and `pad == null`) at lowering time so any future regression in the type path is caught immediately.

### Docs

- `docs/en/dev/codegen/00-pto_codegen.md` and the matching Chinese doc record the new lowering, the strict subview constraints, and the conditional `target -> dst` pre-copy for `tile.assemble`.

## Testing

- [x] `cmake --build build --parallel`
- [x] `python3 -m pytest tests/ut -q` — 4101 passed, 4 skipped (full UT suite).
- [x] Codegen UTs updated to assert `pto.subview` / `pto.tmov` (and the absence of `pto.textract` / `pto.tinsert`) in `tests/ut/codegen/test_pto_codegen.py`, `test_pto_codegen_ops.py`, and `test_pto_codegen_cross_core.py`; new `TestTileAssembleCodegen::test_tile_assemble_codegen` covers the assemble path.
- [x] `TestInferTileMemorySpaceInheritOps` expectations refreshed to match the corrected Mat-implicit TileView propagation through `tile.slice`.
- [x] `pre-commit run --files <changed>` — all hooks pass.

Made with [Cursor](https://cursor.com)