### PR TITLE
feat(runtime): Add Worker context manager for device init/close reuse

### DIFF
--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,6 +26,7 @@ Example::
 
 from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
 from .tensor_spec import ScalarSpec, TensorSpec
+from .worker import Worker
 
 __all__ = [
     "run",
@@ -35,4 +36,5 @@ __all__ = [
     "RunResult",
     "ScalarSpec",
     "TensorSpec",
+    "Worker",
 ]

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -495,6 +495,11 @@ def execute_on_device(
         aicpu_thread_num: Number of AICPU threads.
         enable_profiling: Enable runtime profiling.
         runtime_env: Optional per-example environment variable overrides.
+            Applied around the device ``run`` call. When an active
+            :class:`pypto.runtime.Worker` is reused, ``init()`` has already
+            executed before this call, so env vars that influence device
+            initialization will not take effect on the reuse path — pass
+            those at ``Worker(...)`` construction instead.
     """
     if level != 2:
         raise ValueError(

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -466,6 +466,7 @@ def execute_on_device(
     runtime_name: str,
     device_id: int,
     *,
+    level: int = 2,
     block_dim: int = 24,
     aicpu_thread_num: int = 4,
     enable_profiling: bool = False,
@@ -473,19 +474,35 @@ def execute_on_device(
 ) -> None:
     """Execute *chip_callable* on device via Simpler's unified ``Worker``.
 
+    If a :class:`pypto.runtime.Worker` is currently active (the call site is
+    inside a ``with Worker(...):`` block) and matches the
+    ``(level, platform, device_id, runtime_name)`` binding, that Worker is
+    reused — its already-initialized device context dispatches the run
+    without re-running ``init`` / ``close``. Otherwise a fresh one-shot
+    Worker is constructed exactly as before.
+
     Args:
         chip_callable: Assembled callable (orchestration + kernels).
         orch_args: Tensor/scalar arguments.
         platform: Target execution platform (e.g. ``"a2a3sim"``).
         runtime_name: Runtime implementation name (e.g. ``"tensormap_and_ringbuffer"``).
         device_id: NPU device index.
+        level: Hierarchy level. Only ``2`` (single-chip) is currently
+            supported; passing any other value raises ``ValueError``. The
+            parameter exists so callers can plumb level through ahead of L3
+            user-API support.
         block_dim: Block dimension for execution.
         aicpu_thread_num: Number of AICPU threads.
         enable_profiling: Enable runtime profiling.
         runtime_env: Optional per-example environment variable overrides.
     """
-    worker = Worker(level=2, device_id=device_id, platform=platform, runtime=runtime_name)
-    worker.init()
+    if level != 2:
+        raise ValueError(
+            f"execute_on_device currently only supports level=2; got level={level}. "
+            f"L3 execution is not yet exposed at the pypto user-API layer."
+        )
+
+    from .worker import Worker as _PyptoWorker  # noqa: PLC0415
 
     cfg = ChipCallConfig()
     cfg.block_dim = block_dim
@@ -493,10 +510,15 @@ def execute_on_device(
     cfg.enable_l2_swimlane = enable_profiling
 
     env = runtime_env or {}
+    active = _PyptoWorker.current(level=level, platform=platform, device_id=device_id, runtime=runtime_name)
     with _temporary_env(env):
+        if active is not None:
+            active._run_chip(chip_callable, orch_args, cfg)
+            return
+        worker = Worker(level=level, device_id=device_id, platform=platform, runtime=runtime_name)
+        worker.init()
         worker.run(chip_callable, orch_args, cfg)
-
-    worker.close()
+        worker.close()
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -599,6 +599,7 @@ def execute_compiled(
     device_id: int,
     pto_isa_commit: str | None = None,
     runtime_profiling: bool = False,
+    level: int = 2,
 ) -> None:
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
@@ -617,6 +618,8 @@ def execute_compiled(
         pto_isa_commit: Optional git commit to pin pto-isa clone.
         runtime_profiling: If ``True``, enable runtime profiling and
             generate swimlane JSON after execution.
+        level: Hierarchy level. Forwarded to :func:`execute_on_device`,
+            which currently only supports ``2``.
     """
     work_dir = Path(work_dir)
 
@@ -665,6 +668,7 @@ def execute_compiled(
         platform,
         runtime_name,
         device_id,
+        level=level,
         enable_profiling=runtime_profiling,
     )
 

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -30,9 +30,26 @@ import contextvars
 from typing import Any
 
 from .runner import RunConfig
-from .task_interface import (
-    Worker as _SimplerWorker,  # pyright: ignore[reportAttributeAccessIssue]
-)
+
+# ``simpler`` is loaded lazily on first ``Worker(...)`` instantiation, matching
+# the pattern used by ``device_runner.py`` (imported via lazy ``from .device_runner
+# import ...`` inside function bodies). Eager loading would make ``simpler`` a
+# hard import-time dependency of ``pypto.runtime`` and break unit-test
+# environments that do not install simpler.
+_SimplerWorker: type | None = None
+
+
+def _get_simpler_worker_cls() -> type:
+    global _SimplerWorker  # noqa: PLW0603 - module-level cache that tests patch directly
+    if _SimplerWorker is None:
+        from .task_interface import (  # noqa: PLC0415
+            Worker as _W,  # pyright: ignore[reportAttributeAccessIssue]
+        )
+
+        _SimplerWorker = _W
+    assert _SimplerWorker is not None
+    return _SimplerWorker
+
 
 # Stack of active workers (most-recent last). ContextVar gives correct
 # scoping under nested ``with`` blocks and ``asyncio`` tasks.
@@ -92,7 +109,7 @@ class Worker:
         self._runtime = runtime
         self._token: contextvars.Token | None = None
 
-        self._impl = _SimplerWorker(
+        self._impl = _get_simpler_worker_cls()(
             level=level,
             device_id=self._config.device_id,
             platform=self._config.platform,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -1,0 +1,204 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""User-facing :class:`Worker` that amortizes init/close across multiple runs.
+
+Inside a ``with Worker(...) as _:`` block, calls to ``CompiledProgram(...)``
+(and :func:`pypto.runtime.run`) reuse the active Worker instead of creating a
+fresh one. Outside such a block, behavior is unchanged from one-shot
+construction in :func:`pypto.runtime.device_runner.execute_on_device`.
+
+Example::
+
+    from pypto.runtime import Worker, RunConfig
+
+    with Worker(config=RunConfig(platform="a2a3")):
+        out1 = Add(*tensors1)   # uses active Worker
+        out2 = Mul(*tensors2)   # reuses same Worker
+    # close() runs once on exit
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Any
+
+from .runner import RunConfig
+from .task_interface import (
+    Worker as _SimplerWorker,  # pyright: ignore[reportAttributeAccessIssue]
+)
+
+# Stack of active workers (most-recent last). ContextVar gives correct
+# scoping under nested ``with`` blocks and ``asyncio`` tasks.
+_ACTIVE_WORKERS: contextvars.ContextVar[tuple[Worker, ...]] = contextvars.ContextVar(
+    "_pypto_active_workers", default=()
+)
+
+# Default runtime name — matches ``compile_and_assemble``'s fallback in
+# ``device_runner.py`` and the most common user-program runtime.
+_DEFAULT_RUNTIME = "host_build_graph"
+
+
+class Worker:
+    """Reusable execution Worker bound to one ``(level, platform, device_id, runtime)``.
+
+    A ``Worker`` constructed with ``level=2`` auto-initializes device state in
+    ``__init__`` so that an immediate ``with worker:`` block can dispatch runs
+    without further setup. Construction without entering a ``with`` block also
+    works — call ``close()`` manually when done, or re-enter via ``with`` later.
+
+    Inside a ``with`` block, ``CompiledProgram.__call__`` and
+    :func:`pypto.runtime.run` find this Worker via a ``ContextVar`` and reuse
+    its initialized device context instead of creating a fresh Worker per call.
+    Reuse only happens when all four binding fields match — otherwise the
+    caller falls through to the one-shot path.
+
+    Args:
+        config: Run configuration providing ``platform`` and ``device_id``.
+            Defaults to :class:`RunConfig` defaults.
+        level: Hierarchy level. Only ``2`` (single-chip) is currently
+            supported at the pypto user-API layer.
+        runtime: Runtime implementation name. Must match the runtime the
+            program is compiled against; otherwise reuse silently falls
+            through to the one-shot path. Defaults to ``"host_build_graph"``.
+        auto_init: If ``True``, call :meth:`init` from ``__init__``. Default
+            is ``True`` for ``level=2`` and ``False`` otherwise (level 3+
+            requires ``register()`` calls before ``init()``, but is not
+            currently supported anyway).
+    """
+
+    def __init__(
+        self,
+        config: RunConfig | None = None,
+        *,
+        level: int = 2,
+        runtime: str = _DEFAULT_RUNTIME,
+        auto_init: bool | None = None,
+    ) -> None:
+        if level != 2:
+            raise ValueError(
+                f"pypto.runtime.Worker currently only supports level=2; got level={level}. "
+                f"L3 (multi-chip / DistWorker) is not yet exposed at the pypto user-API layer."
+            )
+
+        self._config = config or RunConfig()
+        self._level = level
+        self._runtime = runtime
+        self._token: contextvars.Token | None = None
+
+        self._impl = _SimplerWorker(
+            level=level,
+            device_id=self._config.device_id,
+            platform=self._config.platform,
+            runtime=runtime,
+        )
+        self._initialized = False
+
+        if auto_init is None:
+            auto_init = level == 2
+        if auto_init:
+            self.init()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def init(self) -> None:
+        """Initialize device state. Idempotent — a second call is a no-op."""
+        if self._initialized:
+            return
+        self._impl.init()
+        self._initialized = True
+
+    def close(self) -> None:
+        """Release device state. Idempotent. The Worker may be re-``init()``'d."""
+        if not self._initialized:
+            return
+        self._impl.close()
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Binding accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def level(self) -> int:
+        return self._level
+
+    @property
+    def platform(self) -> str:
+        return self._config.platform
+
+    @property
+    def device_id(self) -> int:
+        return self._config.device_id
+
+    @property
+    def runtime(self) -> str:
+        return self._runtime
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def _binding(self) -> tuple[int, str, int, str]:
+        return (self._level, self._config.platform, self._config.device_id, self._runtime)
+
+    # ------------------------------------------------------------------
+    # Active-Worker discovery (mirrors PassContext.Current pattern)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def current(cls, *, level: int, platform: str, device_id: int, runtime: str) -> Worker | None:
+        """Return the topmost active Worker matching the binding, or ``None``.
+
+        Used by :func:`pypto.runtime.device_runner.execute_on_device` to
+        decide whether to reuse a user-published Worker or fall through to
+        constructing a fresh one-shot Worker.
+        """
+        target = (level, platform, device_id, runtime)
+        for w in reversed(_ACTIVE_WORKERS.get()):
+            if w._binding == target:
+                return w
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal hook for the runner reuse path
+    # ------------------------------------------------------------------
+
+    def _run_chip(self, chip_callable: Any, orch_args: Any, cfg: Any) -> None:
+        if not self._initialized:
+            raise RuntimeError("Worker is not initialized; call init() or use `with worker:`")
+        self._impl.run(chip_callable, orch_args, cfg)
+
+    # ------------------------------------------------------------------
+    # Context manager — publishes ``self`` on the active stack
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> Worker:
+        stack = _ACTIVE_WORKERS.get()
+        if any(w._binding == self._binding for w in stack):
+            level, platform, device_id, runtime = self._binding
+            raise ValueError(
+                f"A Worker for (level={level}, platform={platform!r}, "
+                f"device_id={device_id}, runtime={runtime!r}) is already "
+                f"active in an enclosing scope. Reuse the outer Worker instead of nesting "
+                f"a second one with identical binding."
+            )
+        if not self._initialized:
+            self.init()
+        self._token = _ACTIVE_WORKERS.set(stack + (self,))
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        assert self._token is not None
+        _ACTIVE_WORKERS.reset(self._token)
+        self._token = None
+        self.close()

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -1,0 +1,194 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``pypto.runtime.Worker`` reuse logic.
+
+Patches the ``_SimplerWorker`` alias in :mod:`pypto.runtime.worker` so tests
+run without a device. The reuse path is observed by counting ``init`` /
+``run`` / ``close`` calls on the mock.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypto.runtime import RunConfig, Worker
+from pypto.runtime.device_runner import execute_on_device
+
+
+@pytest.fixture
+def fake_simpler_worker():
+    """Patch ``simpler.worker.Worker`` so Worker construction does not touch a device."""
+    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+        instance = MagicMock()
+        cls.return_value = instance
+        yield instance
+
+
+class TestLevelGuard:
+    def test_level_3_rejected(self, fake_simpler_worker):
+        with pytest.raises(ValueError, match="only supports level=2"):
+            Worker(config=RunConfig(platform="a2a3sim"), level=3)
+
+    def test_level_2_accepted(self, fake_simpler_worker):
+        w = Worker(config=RunConfig(platform="a2a3sim"))
+        assert w.level == 2
+        w.close()
+
+
+class TestLifecycleIdempotency:
+    def test_auto_init_on_construction(self, fake_simpler_worker):
+        Worker(config=RunConfig(platform="a2a3sim"))
+        fake_simpler_worker.init.assert_called_once()
+
+    def test_init_idempotent(self, fake_simpler_worker):
+        w = Worker(config=RunConfig(platform="a2a3sim"))  # first init
+        w.init()  # must not raise, must not double-init
+        assert fake_simpler_worker.init.call_count == 1
+
+    def test_close_idempotent(self, fake_simpler_worker):
+        w = Worker(config=RunConfig(platform="a2a3sim"))
+        w.close()
+        w.close()  # second close is a no-op
+        assert fake_simpler_worker.close.call_count == 1
+
+    def test_close_then_reinit(self, fake_simpler_worker):
+        w = Worker(config=RunConfig(platform="a2a3sim"))
+        w.close()
+        w.init()  # the wrapper supports re-init after close
+        assert fake_simpler_worker.init.call_count == 2
+        assert fake_simpler_worker.close.call_count == 1
+        w.close()
+
+
+class TestActiveWorkerLookup:
+    def test_no_active_worker_outside_with_block(self, fake_simpler_worker):
+        Worker(config=RunConfig(platform="a2a3sim"))  # constructed but not entered
+        assert Worker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph") is None
+
+    def test_with_block_publishes_worker(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim")) as w:
+            found = Worker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph")
+            assert found is w
+
+    def test_exit_unpublishes(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim")):
+            pass
+        assert Worker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph") is None
+
+    def test_device_mismatch_returns_none(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim", device_id=0)):
+            assert (
+                Worker.current(level=2, platform="a2a3sim", device_id=1, runtime="host_build_graph") is None
+            )
+
+    def test_runtime_mismatch_returns_none(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim"), runtime="host_build_graph"):
+            assert (
+                Worker.current(
+                    level=2,
+                    platform="a2a3sim",
+                    device_id=0,
+                    runtime="tensormap_and_ringbuffer",
+                )
+                is None
+            )
+
+    def test_nested_distinct_binding_picks_topmost(self, fake_simpler_worker):
+        # Distinct device_id — both Workers can coexist on the stack.
+        with Worker(config=RunConfig(platform="a2a3sim", device_id=0)) as outer:
+            with Worker(config=RunConfig(platform="a2a3sim", device_id=1)) as inner:
+                # Lookup for device_id=1 finds inner.
+                assert (
+                    Worker.current(level=2, platform="a2a3sim", device_id=1, runtime="host_build_graph")
+                    is inner
+                )
+                # Lookup for device_id=0 still finds the outer Worker — the
+                # filter walks the whole stack, not just the topmost entry.
+                assert (
+                    Worker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph")
+                    is outer
+                )
+
+    def test_nested_same_binding_rejected(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim", device_id=0)):
+            with pytest.raises(ValueError, match="already active in an enclosing scope"):
+                with Worker(config=RunConfig(platform="a2a3sim", device_id=0)):
+                    pass
+
+    def test_with_block_closes_on_exit(self, fake_simpler_worker):
+        with Worker(config=RunConfig(platform="a2a3sim")):
+            pass
+        fake_simpler_worker.close.assert_called_once()
+
+
+class TestExecuteOnDeviceReuse:
+    """Verify ``execute_on_device`` reuses an active Worker rather than constructing a new one."""
+
+    def test_reuse_skips_init_and_close(self, fake_simpler_worker):
+        chip_callable = MagicMock(name="chip_callable")
+        orch_args = MagicMock(name="orch_args")
+
+        with Worker(config=RunConfig(platform="a2a3sim")):
+            # Reset call counters after the with-block's auto-init.
+            fake_simpler_worker.init.reset_mock()
+            fake_simpler_worker.close.reset_mock()
+            fake_simpler_worker.run.reset_mock()
+
+            with patch("pypto.runtime.device_runner.ChipCallConfig", MagicMock):
+                execute_on_device(
+                    chip_callable,
+                    orch_args,
+                    platform="a2a3sim",
+                    runtime_name="host_build_graph",
+                    device_id=0,
+                )
+
+            # Reuse path: the active Worker's run was invoked, no new init/close.
+            assert fake_simpler_worker.run.call_count == 1
+            assert fake_simpler_worker.init.call_count == 0
+            assert fake_simpler_worker.close.call_count == 0
+
+    def test_no_active_worker_uses_one_shot_path(self, fake_simpler_worker):
+        chip_callable = MagicMock(name="chip_callable")
+        orch_args = MagicMock(name="orch_args")
+
+        # No `with` block — execute_on_device must construct its own Worker
+        # (one init + one run + one close on the underlying simpler.Worker).
+        # The one-shot path imports simpler.Worker directly into device_runner,
+        # so patch that name in addition to the wrapper's _SimplerWorker.
+        one_shot = MagicMock()
+        with (
+            patch("pypto.runtime.device_runner.ChipCallConfig", MagicMock),
+            patch("pypto.runtime.device_runner.Worker", return_value=one_shot),
+        ):
+            execute_on_device(
+                chip_callable,
+                orch_args,
+                platform="a2a3sim",
+                runtime_name="host_build_graph",
+                device_id=0,
+            )
+        assert one_shot.init.call_count == 1
+        assert one_shot.run.call_count == 1
+        assert one_shot.close.call_count == 1
+
+    def test_level_mismatch_rejected(self, fake_simpler_worker):
+        with pytest.raises(ValueError, match="only supports level=2"):
+            execute_on_device(
+                MagicMock(),
+                MagicMock(),
+                platform="a2a3sim",
+                runtime_name="host_build_graph",
+                device_id=0,
+                level=3,
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -131,6 +131,21 @@ class TestActiveWorkerLookup:
         fake_simpler_worker.close.assert_called_once()
 
 
+# ``execute_on_device`` lives in ``device_runner`` which eagerly imports the
+# ``simpler`` package. The Worker-only tests above mock just the
+# ``simpler.Worker`` class via ``_SimplerWorker`` and do not need
+# ``device_runner`` loaded — but the tests in this class invoke
+# ``execute_on_device`` directly, so they are skipped when ``simpler`` is not
+# installed (e.g. unit-tests CI).
+try:
+    import simpler  # noqa: F401  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _has_simpler = False
+else:
+    _has_simpler = True
+
+
+@pytest.mark.skipif(not _has_simpler, reason="execute_on_device requires the simpler package")
 class TestExecuteOnDeviceReuse:
     """Verify ``execute_on_device`` reuses an active Worker rather than constructing a new one."""
 

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -18,7 +18,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pypto.runtime import RunConfig, Worker
-from pypto.runtime.device_runner import execute_on_device
+
+# ``execute_on_device`` is imported lazily inside individual tests to keep
+# this module importable in environments where the underlying ``simpler``
+# package is not installed (e.g. unit-tests CI). ``device_runner`` eagerly
+# imports ``simpler.task_interface`` at module load.
 
 
 @pytest.fixture
@@ -131,6 +135,8 @@ class TestExecuteOnDeviceReuse:
     """Verify ``execute_on_device`` reuses an active Worker rather than constructing a new one."""
 
     def test_reuse_skips_init_and_close(self, fake_simpler_worker):
+        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
         chip_callable = MagicMock(name="chip_callable")
         orch_args = MagicMock(name="orch_args")
 
@@ -155,6 +161,8 @@ class TestExecuteOnDeviceReuse:
             assert fake_simpler_worker.close.call_count == 0
 
     def test_no_active_worker_uses_one_shot_path(self, fake_simpler_worker):
+        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
         chip_callable = MagicMock(name="chip_callable")
         orch_args = MagicMock(name="orch_args")
 
@@ -179,6 +187,8 @@ class TestExecuteOnDeviceReuse:
         assert one_shot.close.call_count == 1
 
     def test_level_mismatch_rejected(self, fake_simpler_worker):
+        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
         with pytest.raises(ValueError, match="only supports level=2"):
             execute_on_device(
                 MagicMock(),


### PR DESCRIPTION
## Summary

Introduces a user-facing `pypto.runtime.Worker` context manager so that the device init / runtime-binary load / AICPU bring-up cost is paid once per `with` block instead of per `CompiledProgram(...)` call. Outside the `with` block, behavior is unchanged — `execute_on_device` still constructs a one-shot Worker per call.

```python
from pypto.runtime import Worker, RunConfig

with Worker(config=RunConfig(platform="a2a3")):
    out1 = Add(*tensors1)   # uses active Worker
    out2 = Mul(*tensors2)   # reuses same Worker
# close() runs once on exit
```

### Key design choices

- A `Worker` is bound to the four-tuple `(level, platform, device_id, runtime)`. `execute_on_device` consults `Worker.current(...)` and falls through to the one-shot path when no active Worker matches the binding — existing call sites keep working without changes.
- `Worker.current(...)` mirrors the existing `PassContext.Current()` pattern; the active stack lives in a `ContextVar` for nested-`with` and `asyncio` correctness.
- Nesting two Workers with **identical** binding raises `ValueError` — silent shadowing would double-init the same physical device. Distinct bindings (different `device_id` / `platform` / `runtime`) coexist on the stack and the lookup picks the topmost match per binding.
- `level` is plumbed through `execute_on_device` and `execute_compiled` keyword-only with default `2`; passing anything else raises a clear `ValueError` until L3 is exposed.

### Files

- `python/pypto/runtime/worker.py` (new) — the `Worker` wrapper with `init`/`close` idempotency, `_binding` tuple, `current(...)` classmethod, same-binding nest rejection
- `python/pypto/runtime/__init__.py` — re-exports `Worker`
- `python/pypto/runtime/device_runner.py` — `execute_on_device` reuse-or-fallthrough; `runtime_env` is hoisted around both branches so it applies on the reuse path too
- `python/pypto/runtime/runner.py` — `execute_compiled` plumbs `level` through
- `tests/ut/runtime/test_worker_reuse.py` (new) — 17 unit tests, mocked simpler Worker

## Test plan

- [x] `pytest tests/ut/runtime/test_worker_reuse.py` — 17/17 pass
- [x] `pytest tests/ut/runtime/` — 28/28 pass (no regression in `test_run_config`, `test_env_manager`)
- [x] Pre-commit: ruff-check, ruff-format, pyright all pass