### PR TITLE
docs(passes): Document DeriveCallDirections pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -40,7 +40,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 25 | *(no doc yet)* | 25th pass (`LegalizePTOBufferReuse`) |
 | 26 | `26-allocate_memory_addr.md` | 26th pass |
 | 27 | *(no doc yet)* | 27th pass (`FuseCreateAssembleToSlice`) |
-| 28 | *(no doc yet)* | 28th pass (`DeriveCallDirections`) |
+| 28 | `28-derive_call_directions.md` | 28th pass |
 | 91 | `91-utility_passes.md` | Not in Default strategy |
 | 99 | `99-verifier.md` | Infrastructure (not a pipeline pass) |
 

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -368,15 +368,18 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 4. [`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md)
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
-7. `SplitVectorKernel`
-8. `NormalizeReturnOrder`
-9. `InitMemRef`
-10. `MemoryReuse`
-11. `LegalizePTOBufferReuse`
-12. `AllocateMemoryAddr`
-13. `FuseCreateAssembleToSlice`
-14. [`DeriveCallDirections`](28-derive_call_directions.md)
-15. `Simplify`
+7. [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md)
+8. `SplitVectorKernel`
+9. `NormalizeReturnOrder`
+10. [`LowerPipelineLoops`](21-lower_pipeline_loops.md)
+11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)
+12. `InitMemRef`
+13. `MemoryReuse`
+14. `LegalizePTOBufferReuse`
+15. `AllocateMemoryAddr`
+16. `FuseCreateAssembleToSlice`
+17. [`DeriveCallDirections`](28-derive_call_directions.md)
+18. `Simplify`
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
 | FuseCreateAssembleToSlice | — | — | — |
+| DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | Simplify | — | — | — |
 
 > **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
@@ -374,7 +375,8 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 11. `LegalizePTOBufferReuse`
 12. `AllocateMemoryAddr`
 13. `FuseCreateAssembleToSlice`
-14. `Simplify`
+14. [`DeriveCallDirections`](28-derive_call_directions.md)
+15. `Simplify`
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/en/dev/passes/28-derive_call_directions.md
+++ b/docs/en/dev/passes/28-derive_call_directions.md
@@ -9,11 +9,11 @@ PyPTO uses a **two-layer direction model** (introduced in commit `c53dac0d`):
 - `ParamDirection` (`In` / `Out` / `InOut`) lives on the callee `Function` and describes the function-signature contract — *"I read/write this parameter."*
 - `ArgDirection` (`Input` / `Output` / `InOut` / `OutputExisting` / `NoDep` / `Scalar`) lives on each `Call` site and describes the runtime task-submission semantics — *"this submission establishes these dependencies and uses this memory ownership model."*
 
-The two layers must agree but are not identical: a callee `Out` parameter may legitimately become either `Output`, `OutputExisting`, or `InOut` at the call site depending on whether the destination was allocated locally and whether other writers have already touched the same buffer.
+The two layers must agree but are not identical: under `DeriveCallDirections`, a callee `Out` parameter may become either `OutputExisting` or `InOut` at the call site depending on whether other writers have already touched the same buffer. `ArgDirection::Output` is reserved for explicitly populated call sites where the runtime should allocate a fresh output buffer; this pass never infers it.
 
 `DeriveCallDirections` is the pass that bridges the two layers. It walks every non-builtin `Call` in every `Function` body and writes the resolved per-argument vector to `Call.attrs["arg_directions"]` (the reserved key `kAttrArgDirections`, value type `std::vector<ArgDirection>`). Downstream consumers — orchestration codegen and the runtime task-submission layer — read this vector instead of recomputing it from raw param directions.
 
-**When to use**: Run after the tile pipeline has stabilized (`SplitIncoreOrch` is required) and before any consumer that observes `Call.attrs["arg_directions"]`. In the `Default` strategy it sits between `FuseCreateAssembleToSlice` and the final `Simplify` (entry 28 in `python/pypto/ir/pass_manager.py`).
+**When to use**: Run after the tile pipeline has stabilized (`SplitIncoreOrch` is required) and before any consumer that observes `Call.attrs["arg_directions"]`. In the `Default` strategy it sits between `FuseCreateAssembleToSlice` and the final `Simplify` (doc slot 28 — the 28th pipeline pass excluding utility passes; see `.claude/rules/pass-doc-ordering.md` for the numbering scheme).
 
 ## Properties
 
@@ -21,7 +21,7 @@ The two layers must agree but are not identical: a callee `Out` parameter may le
 | -------- | -------- | ----------- |
 | `SplitIncoreOrch` | `CallDirectionsResolved` | — |
 
-The `CallDirectionsResolved` property is verified by the registered `CallDirectionsResolvedPropertyVerifier` (`src/ir/verifier/verify_call_directions.cpp`), so the pipeline auto-checks the integrity of the produced `arg_directions` after this pass runs — no separate verify pass exists. See [Verifier](99-verifier.md).
+The `CallDirectionsResolved` property is verified by the registered `CallDirectionsResolved` property verifier (factory `CreateCallDirectionsResolvedPropertyVerifier()` in `src/ir/verifier/verify_call_directions.cpp`), so the pipeline auto-checks the integrity of the produced `arg_directions` after this pass runs — no separate verify pass exists. See [Verifier](99-verifier.md).
 
 ## API
 
@@ -77,9 +77,9 @@ For each positional argument the mutator picks a direction by this table:
 
 **R-seq** keeps cross-iteration write-after-write chains correct inside sequential loops: the same buffer slot is written once per iteration, so the runtime must serialize iterations on it. **R-prior** preserves the cross-sibling WAW dependency when an earlier writer-unit in the same scope already touched the same root.
 
-A pre-populated `Call.attrs["arg_directions"]` is treated as authoritative and left untouched (the `Call` constructor's `ValidateArgDirectionsAttr` enforces length compatibility, and some directions like `NoDep` are not derivable structurally).
+A pre-populated `Call.attrs["arg_directions"]` is treated as authoritative and left untouched (some directions like `NoDep` are not derivable structurally). The `Call` constructor's `ValidateArgDirectionsAttr` only enforces arity when the vector is non-empty; an empty vector can still be attached and will later be rejected by the `CallDirectionsResolved` verifier.
 
-**Idempotency**: when the freshly computed direction vector equals the call's existing one, the mutator skips the rewrite. Running the pass twice therefore produces structurally identical IR (regression-tested by `TestDeriveIdempotent::test_idempotent`).
+**Idempotency**: the mutator skips any call that already has `attrs["arg_directions"]` (`HasArgDirections()`), so a second run leaves resolved calls untouched. Running the pass twice therefore produces structurally identical IR (regression-tested by `TestDeriveIdempotent::test_idempotent`).
 
 ## Example
 

--- a/docs/en/dev/passes/28-derive_call_directions.md
+++ b/docs/en/dev/passes/28-derive_call_directions.md
@@ -1,0 +1,161 @@
+# DeriveCallDirections Pass
+
+Derives per-argument `ArgDirection` for every cross-function `Call` based on callee `ParamDirection` and buffer lineage.
+
+## Overview
+
+PyPTO uses a **two-layer direction model** (introduced in commit `c53dac0d`):
+
+- `ParamDirection` (`In` / `Out` / `InOut`) lives on the callee `Function` and describes the function-signature contract — *"I read/write this parameter."*
+- `ArgDirection` (`Input` / `Output` / `InOut` / `OutputExisting` / `NoDep` / `Scalar`) lives on each `Call` site and describes the runtime task-submission semantics — *"this submission establishes these dependencies and uses this memory ownership model."*
+
+The two layers must agree but are not identical: a callee `Out` parameter may legitimately become either `Output`, `OutputExisting`, or `InOut` at the call site depending on whether the destination was allocated locally and whether other writers have already touched the same buffer.
+
+`DeriveCallDirections` is the pass that bridges the two layers. It walks every non-builtin `Call` in every `Function` body and writes the resolved per-argument vector to `Call.attrs["arg_directions"]` (the reserved key `kAttrArgDirections`, value type `std::vector<ArgDirection>`). Downstream consumers — orchestration codegen and the runtime task-submission layer — read this vector instead of recomputing it from raw param directions.
+
+**When to use**: Run after the tile pipeline has stabilized (`SplitIncoreOrch` is required) and before any consumer that observes `Call.attrs["arg_directions"]`. In the `Default` strategy it sits between `FuseCreateAssembleToSlice` and the final `Simplify` (entry 28 in `python/pypto/ir/pass_manager.py`).
+
+## Properties
+
+| Required | Produced | Invalidated |
+| -------- | -------- | ----------- |
+| `SplitIncoreOrch` | `CallDirectionsResolved` | — |
+
+The `CallDirectionsResolved` property is verified by the registered `CallDirectionsResolvedPropertyVerifier` (`src/ir/verifier/verify_call_directions.cpp`), so the pipeline auto-checks the integrity of the produced `arg_directions` after this pass runs — no separate verify pass exists. See [Verifier](99-verifier.md).
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::DeriveCallDirections()` | `passes.derive_call_directions()` | Program-level |
+
+**Factory function**:
+
+```cpp
+Pass DeriveCallDirections();
+```
+
+**Python usage**:
+
+```python
+from pypto.pypto_core import passes
+
+derive_pass = passes.derive_call_directions()
+program_with_dirs = derive_pass(program)
+```
+
+## Algorithm
+
+The pass is a `ProgramPass` that runs three phases per `Function` body.
+
+### 1. Buffer-root collection
+
+`BufferRootCollector` (defined in `include/pypto/codegen/orchestration/orchestration_analysis.h`) walks the function body and maps every `Var*` to the `Var*` that owns its underlying buffer, propagating root identity through assignments, loops, and call outputs. The pass also builds a `param_vars` set from the function's formal parameters for fast *"rooted at a function param?"* lookups.
+
+### 2. Prior-writer analysis
+
+`PriorWriterCollector` decides, per `(Call, local-root)`, whether the call is the *first writer* of that root within its enclosing scope. It runs in two phases:
+
+1. **Bottom-up cache** (`PrecomputeWrittenRoots`): for every subtree, cache the union of locally allocated roots written by any non-builtin `Call` inside it. The result becomes the *writer footprint* of that subtree when it appears as a sibling in an outer scope.
+2. **Top-down scan** (`AnalyzeScope`): walk the IR maintaining a `seen_roots` set of roots already written by prior siblings. For each `Call`, every callee-`Out` argument whose root is *not* in `seen_roots` is recorded as a first writer. Every `ForStmt` (regardless of `ForKind`) / `WhileStmt` / `IfStmt` is entered with a *snapshot copy* of `seen_roots` (so writes inside the unit do not leak into sibling tracking) and treated as an opaque writer-unit; `ScopeStmt` and `SeqStmts` share the same `seen_roots`.
+
+### 3. Direction rewrite
+
+`CallDirectionMutator` walks every non-builtin `Call`. For Group/Spmd callees the effective per-position directions are recovered via `ComputeGroupEffectiveDirections` (`orchestration_analysis.h`); other callees use their declared `param_directions_`. A `sequential_depth_` counter is incremented on non-`Parallel` `For` and on `While`, driving the *R-seq* promotion below.
+
+For each positional argument the mutator picks a direction by this table:
+
+| Callee `ParamDirection` | Argument origin | `sequential_depth > 0`? | Prior writer in scope? | Result |
+| ----------------------- | --------------- | ----------------------- | ---------------------- | ------ |
+| any | non-tensor | — | — | `Scalar` |
+| `In` | tensor | — | — | `Input` |
+| `InOut` | tensor | — | — | `InOut` |
+| `Out` | rooted at param | — | — | `OutputExisting` |
+| `Out` | local buffer | yes (R-seq) | — | `InOut` |
+| `Out` | local buffer | no | yes (R-prior) | `InOut` |
+| `Out` | local buffer | no | no | `OutputExisting` |
+
+**R-seq** keeps cross-iteration write-after-write chains correct inside sequential loops: the same buffer slot is written once per iteration, so the runtime must serialize iterations on it. **R-prior** preserves the cross-sibling WAW dependency when an earlier writer-unit in the same scope already touched the same root.
+
+A pre-populated `Call.attrs["arg_directions"]` is treated as authoritative and left untouched (the `Call` constructor's `ValidateArgDirectionsAttr` enforces length compatibility, and some directions like `NoDep` are not derivable structurally).
+
+**Idempotency**: when the freshly computed direction vector equals the call's existing one, the mutator skips the rewrite. Running the pass twice therefore produces structurally identical IR (regression-tested by `TestDeriveIdempotent::test_idempotent`).
+
+## Example
+
+Two consecutive calls writing the same locally allocated buffer at top level. The first is the only writer-unit so it stays `OutputExisting`; the second hits R-prior and is promoted to `InOut` so the runtime preserves the cross-call WAW dependency on `local`.
+
+### Before
+
+```python
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+        local = self.kernel(x, local)   # arg_directions = []  (pre-pass)
+        local = self.kernel(x, local)   # arg_directions = []  (pre-pass)
+        return local
+```
+
+### After
+
+```python
+# Same IR shape; only Call.attrs["arg_directions"] changes:
+local = self.kernel(x, local)   # arg_directions = [Input, OutputExisting]
+local = self.kernel(x, local)   # arg_directions = [Input, InOut]
+```
+
+The `kernel` callee declares `Out` for parameter `out`. Because `local` is locally allocated (rooted at `pl.create_tensor`, not at a `main` parameter), the first call gets `OutputExisting` (no sequential ancestor, no prior writer-unit) while the second sees a prior writer in the same scope and is promoted to `InOut`.
+
+## Implementation
+
+**Header**: `include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass DeriveCallDirections();
+```
+
+**Properties**: `include/pypto/ir/transforms/pass_properties.h`
+
+```cpp
+inline const PassProperties kDeriveCallDirectionsProperties{
+    .required = {IRProperty::SplitIncoreOrch},
+    .produced = {IRProperty::CallDirectionsResolved}};
+```
+
+**Implementation**: `src/ir/transforms/derive_call_directions_pass.cpp`
+
+- `PriorWriterCollector` — per-scope first-writer analysis (bottom-up cache + top-down scan)
+- `CallDirectionMutator` — `IRMutator` that rewrites every non-builtin `Call` with the resolved `arg_directions` vector
+- Reuses `BufferRootCollector` and `ComputeGroupEffectiveDirections` from `include/pypto/codegen/orchestration/orchestration_analysis.h`
+
+**Property verifier**: `src/ir/verifier/verify_call_directions.cpp` (factory in `include/pypto/ir/verifier/verifier.h`)
+
+**Python binding**: `python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("derive_call_directions", &pass::DeriveCallDirections,
+           "Derive Call attrs['arg_directions'] from callee param directions and buffer lineage. ...");
+```
+
+**Type stub**: `python/pypto/pypto_core/passes.pyi`
+
+**Hand-written-IR helper**: `python/pypto/ir/directions.py` (`make_call`, lowercase aliases) — for tests and hand-built IR fragments that want to attach explicit directions before the pass runs.
+
+**Tests**: `tests/ut/ir/transforms/test_derive_call_directions.py`
+
+- `TestDeriveDirectionMatrix` — one test per cell of the (callee_dir, origin) → ArgDirection mapping table, including R-seq (`pl.range`, `while`) and R-prior (top-level + branch / parallel-after-top-level) edge cases
+- `TestDeriveIdempotent` — running the pass twice yields structurally equal IR
+- `TestDerivePreservesExplicit` — pre-populated `arg_directions` is not overwritten
+- `TestVerifyPositive` / `TestVerifyNegative` — the `CallDirectionsResolved` property verifier accepts the pass output and rejects ill-formed `arg_directions` assignments

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -368,15 +368,18 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 4. [`ResolveBackendOpLayouts`](16-resolve_backend_op_layouts.md)
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
-7. `SplitVectorKernel`
-8. `NormalizeReturnOrder`
-9. `InitMemRef`
-10. `MemoryReuse`
-11. `LegalizePTOBufferReuse`
-12. `AllocateMemoryAddr`
-13. `FuseCreateAssembleToSlice`
-14. [`DeriveCallDirections`](28-derive_call_directions.md)
-15. `Simplify`
+7. [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md)
+8. `SplitVectorKernel`
+9. `NormalizeReturnOrder`
+10. [`LowerPipelineLoops`](21-lower_pipeline_loops.md)
+11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)
+12. `InitMemRef`
+13. `MemoryReuse`
+14. `LegalizePTOBufferReuse`
+15. `AllocateMemoryAddr`
+16. `FuseCreateAssembleToSlice`
+17. [`DeriveCallDirections`](28-derive_call_directions.md)
+18. `Simplify`
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -76,6 +76,7 @@ struct PassProperties {
 | MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
 | AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
 | FuseCreateAssembleToSlice | — | — | — |
+| DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | Simplify | — | — | — |
 
 > **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
@@ -374,7 +375,8 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 11. `LegalizePTOBufferReuse`
 12. `AllocateMemoryAddr`
 13. `FuseCreateAssembleToSlice`
-14. `Simplify`
+14. [`DeriveCallDirections`](28-derive_call_directions.md)
+15. `Simplify`
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/docs/zh-cn/dev/passes/28-derive_call_directions.md
+++ b/docs/zh-cn/dev/passes/28-derive_call_directions.md
@@ -1,0 +1,161 @@
+# DeriveCallDirections Pass
+
+基于被调用方的 `ParamDirection` 和缓冲区血缘，为每个跨函数 `Call` 推导每个参数的 `ArgDirection`。
+
+## 概述
+
+PyPTO 采用**两层方向模型**（在提交 `c53dac0d` 中引入）：
+
+- `ParamDirection`（`In` / `Out` / `InOut`）位于被调用方 `Function` 上，描述函数签名约定——*"我读取/写入这个参数"*。
+- `ArgDirection`（`Input` / `Output` / `InOut` / `OutputExisting` / `NoDep` / `Scalar`）位于每个 `Call` 调用点上，描述运行时任务提交语义——*"本次提交建立这些依赖关系并采用这种内存所有权模型"*。
+
+两层必须保持一致，但并不完全相同：被调用方的 `Out` 参数在调用点上可能合理地变为 `Output`、`OutputExisting` 或 `InOut`，取决于目的地是否在本地分配以及是否已有其他写入者触及同一缓冲区。
+
+`DeriveCallDirections` 就是连接两层的 pass。它遍历每个 `Function` body 中的所有非 builtin `Call`，并将解析后的每参数向量写入 `Call.attrs["arg_directions"]`（保留键 `kAttrArgDirections`，值类型为 `std::vector<ArgDirection>`）。下游消费者——orchestration 代码生成和运行时任务提交层——直接读取该向量，而不是从原始参数方向重新计算。
+
+**何时使用**：在 tile 流水线稳定后（要求满足 `SplitIncoreOrch`）、并在任何观察 `Call.attrs["arg_directions"]` 的消费者之前运行。在 `Default` 策略中，它位于 `FuseCreateAssembleToSlice` 与最终 `Simplify` 之间（`python/pypto/ir/pass_manager.py` 的第 28 项）。
+
+## 属性
+
+| Required | Produced | Invalidated |
+| -------- | -------- | ----------- |
+| `SplitIncoreOrch` | `CallDirectionsResolved` | — |
+
+`CallDirectionsResolved` 属性由已注册的 `CallDirectionsResolvedPropertyVerifier`（`src/ir/verifier/verify_call_directions.cpp`）验证，因此 pass 运行后流水线会自动检查所产生的 `arg_directions` 完整性——不存在独立的 verify pass。参见[验证器](99-verifier.md)。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::DeriveCallDirections()` | `passes.derive_call_directions()` | Program 级 |
+
+**工厂函数**：
+
+```cpp
+Pass DeriveCallDirections();
+```
+
+**Python 用法**：
+
+```python
+from pypto.pypto_core import passes
+
+derive_pass = passes.derive_call_directions()
+program_with_dirs = derive_pass(program)
+```
+
+## 算法
+
+该 pass 是一个 `ProgramPass`，对每个 `Function` body 运行三个阶段。
+
+### 1. 缓冲区根收集
+
+`BufferRootCollector`（定义在 `include/pypto/codegen/orchestration/orchestration_analysis.h`）遍历函数 body，将每个 `Var*` 映射到拥有其底层缓冲区的 `Var*`，并在赋值、循环和函数调用输出之间传播根标识。pass 还从函数形式参数构建一个 `param_vars` 集合，用于快速判断*"是否根植于函数参数？"*。
+
+### 2. 先前写入者分析
+
+`PriorWriterCollector` 针对每个 `(Call, local-root)` 组合判断该调用是否是其所在作用域内对该 root 的*第一个写入者*。它分两阶段：
+
+1. **自底向上缓存**（`PrecomputeWrittenRoots`）：为每个子树缓存其内部所有非 builtin `Call` 写入的本地分配 root 的并集。该结果在该子树作为外层作用域的兄弟节点出现时，作为它的*写入者足迹*。
+2. **自顶向下扫描**（`AnalyzeScope`）：遍历 IR，并维护一个 `seen_roots` 集合，记录已被前置兄弟节点写入的 root。对于每个 `Call`，若其某个被调用方为 `Out` 的实参对应的 root *不在* `seen_roots` 中，则将其记录为第一个写入者。每个 `ForStmt`（不论 `ForKind`）/ `WhileStmt` / `IfStmt` 在进入时使用 `seen_roots` 的*快照副本*（这样单元内部的写入不会泄漏到兄弟跟踪中），并被视为不透明的写入单元；`ScopeStmt` 与 `SeqStmts` 共享同一个 `seen_roots`。
+
+### 3. 方向重写
+
+`CallDirectionMutator` 遍历每个非 builtin `Call`。对于 Group/Spmd 被调用方，通过 `ComputeGroupEffectiveDirections`（`orchestration_analysis.h`）恢复每位置的有效方向；其他被调用方使用其声明的 `param_directions_`。`sequential_depth_` 计数器在非 `Parallel` 的 `For` 和 `While` 上递增，用于驱动下面的 *R-seq* 提升。
+
+对于每个位置参数，mutator 按下表选择方向：
+
+| Callee `ParamDirection` | 实参来源 | `sequential_depth > 0`？ | 作用域内有先前写入者？ | Result |
+| ----------------------- | -------- | ------------------------ | ---------------------- | ------ |
+| any | 非 tensor | — | — | `Scalar` |
+| `In` | tensor | — | — | `Input` |
+| `InOut` | tensor | — | — | `InOut` |
+| `Out` | 根植于函数参数 | — | — | `OutputExisting` |
+| `Out` | 本地缓冲区 | 是 (R-seq) | — | `InOut` |
+| `Out` | 本地缓冲区 | 否 | 是 (R-prior) | `InOut` |
+| `Out` | 本地缓冲区 | 否 | 否 | `OutputExisting` |
+
+**R-seq** 在顺序循环内保持跨迭代的 write-after-write 链：同一缓冲区槽每次迭代都会被写入一次，因此运行时必须在该槽上序列化迭代。**R-prior** 当同一作用域中较早的写入单元已经触及同一 root 时，保留跨兄弟的 WAW 依赖关系。
+
+预先填充的 `Call.attrs["arg_directions"]` 被视为权威信息并保持不变（`Call` 构造函数中的 `ValidateArgDirectionsAttr` 强制长度匹配，且像 `NoDep` 这类方向无法从结构上推导得出）。
+
+**幂等性**：当新计算的方向向量与调用现有方向向量相等时，mutator 会跳过重写。因此连续运行该 pass 两次会产生结构上完全相同的 IR（由 `TestDeriveIdempotent::test_idempotent` 回归测试验证）。
+
+## 示例
+
+两个连续调用写入同一本地分配缓冲区。第一个是该作用域内唯一的写入单元，因此保持 `OutputExisting`；第二个触发 R-prior 并被提升为 `InOut`，从而让运行时在 `local` 上保留跨调用的 WAW 依赖关系。
+
+### 之前
+
+```python
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        local: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+        local = self.kernel(x, local)   # arg_directions = []  （pass 之前）
+        local = self.kernel(x, local)   # arg_directions = []  （pass 之前）
+        return local
+```
+
+### 之后
+
+```python
+# IR 结构相同；仅 Call.attrs["arg_directions"] 发生变化：
+local = self.kernel(x, local)   # arg_directions = [Input, OutputExisting]
+local = self.kernel(x, local)   # arg_directions = [Input, InOut]
+```
+
+被调用方 `kernel` 为参数 `out` 声明了 `Out`。由于 `local` 是本地分配的（根植于 `pl.create_tensor`，而非 `main` 的某个参数），第一个调用得到 `OutputExisting`（无顺序祖先、无先前写入单元），而第二个调用看到同作用域内已有先前写入者，因此被提升为 `InOut`。
+
+## 实现
+
+**头文件**：`include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass DeriveCallDirections();
+```
+
+**属性**：`include/pypto/ir/transforms/pass_properties.h`
+
+```cpp
+inline const PassProperties kDeriveCallDirectionsProperties{
+    .required = {IRProperty::SplitIncoreOrch},
+    .produced = {IRProperty::CallDirectionsResolved}};
+```
+
+**实现**：`src/ir/transforms/derive_call_directions_pass.cpp`
+
+- `PriorWriterCollector` —— 每作用域的第一写入者分析（自底向上缓存 + 自顶向下扫描）
+- `CallDirectionMutator` —— 一个 `IRMutator`，用解析后的 `arg_directions` 向量重写每个非 builtin `Call`
+- 复用 `include/pypto/codegen/orchestration/orchestration_analysis.h` 中的 `BufferRootCollector` 与 `ComputeGroupEffectiveDirections`
+
+**属性验证器**：`src/ir/verifier/verify_call_directions.cpp`（工厂函数声明在 `include/pypto/ir/verifier/verifier.h`）
+
+**Python 绑定**：`python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("derive_call_directions", &pass::DeriveCallDirections,
+           "Derive Call attrs['arg_directions'] from callee param directions and buffer lineage. ...");
+```
+
+**类型存根**：`python/pypto/pypto_core/passes.pyi`
+
+**手写 IR 辅助**：`python/pypto/ir/directions.py`（`make_call`、小写别名）—— 用于在 pass 运行前为 IR 片段附加显式方向的测试和手写 IR 代码。
+
+**测试**：`tests/ut/ir/transforms/test_derive_call_directions.py`
+
+- `TestDeriveDirectionMatrix` —— 为 (callee_dir, origin) → ArgDirection 映射表的每个单元各设一个测试，包含 R-seq（`pl.range`、`while`）与 R-prior（顶层 + 分支 / 顶层后跟 parallel）等边界情况
+- `TestDeriveIdempotent` —— 两次运行该 pass 产生结构相等的 IR
+- `TestDerivePreservesExplicit` —— 预先填充的 `arg_directions` 不会被覆盖
+- `TestVerifyPositive` / `TestVerifyNegative` —— `CallDirectionsResolved` 属性验证器接受 pass 输出，并拒绝格式错误的 `arg_directions` 赋值

--- a/docs/zh-cn/dev/passes/28-derive_call_directions.md
+++ b/docs/zh-cn/dev/passes/28-derive_call_directions.md
@@ -9,11 +9,11 @@ PyPTO 采用**两层方向模型**（在提交 `c53dac0d` 中引入）：
 - `ParamDirection`（`In` / `Out` / `InOut`）位于被调用方 `Function` 上，描述函数签名约定——*"我读取/写入这个参数"*。
 - `ArgDirection`（`Input` / `Output` / `InOut` / `OutputExisting` / `NoDep` / `Scalar`）位于每个 `Call` 调用点上，描述运行时任务提交语义——*"本次提交建立这些依赖关系并采用这种内存所有权模型"*。
 
-两层必须保持一致，但并不完全相同：被调用方的 `Out` 参数在调用点上可能合理地变为 `Output`、`OutputExisting` 或 `InOut`，取决于目的地是否在本地分配以及是否已有其他写入者触及同一缓冲区。
+两层必须保持一致，但并不完全相同：就当前 `DeriveCallDirections` 的推导规则而言，被调用方的 `Out` 参数在调用点上会变为 `OutputExisting` 或 `InOut`，取决于该缓冲区是否已被其他写入者触及。`ArgDirection::Output` 仅用于显式填写方向时表达"运行时分配输出缓冲区"的语义，本 pass 不会自动推导出该方向。
 
 `DeriveCallDirections` 就是连接两层的 pass。它遍历每个 `Function` body 中的所有非 builtin `Call`，并将解析后的每参数向量写入 `Call.attrs["arg_directions"]`（保留键 `kAttrArgDirections`，值类型为 `std::vector<ArgDirection>`）。下游消费者——orchestration 代码生成和运行时任务提交层——直接读取该向量，而不是从原始参数方向重新计算。
 
-**何时使用**：在 tile 流水线稳定后（要求满足 `SplitIncoreOrch`）、并在任何观察 `Call.attrs["arg_directions"]` 的消费者之前运行。在 `Default` 策略中，它位于 `FuseCreateAssembleToSlice` 与最终 `Simplify` 之间（`python/pypto/ir/pass_manager.py` 的第 28 项）。
+**何时使用**：在 tile 流水线稳定后（要求满足 `SplitIncoreOrch`）、并在任何观察 `Call.attrs["arg_directions"]` 的消费者之前运行。在 `Default` 策略中，它位于 `FuseCreateAssembleToSlice` 与最终 `Simplify` 之间（文档编号 28，即排除 utility pass 后的第 28 个 pipeline pass；编号规则见 `.claude/rules/pass-doc-ordering.md`）。
 
 ## 属性
 
@@ -21,7 +21,7 @@ PyPTO 采用**两层方向模型**（在提交 `c53dac0d` 中引入）：
 | -------- | -------- | ----------- |
 | `SplitIncoreOrch` | `CallDirectionsResolved` | — |
 
-`CallDirectionsResolved` 属性由已注册的 `CallDirectionsResolvedPropertyVerifier`（`src/ir/verifier/verify_call_directions.cpp`）验证，因此 pass 运行后流水线会自动检查所产生的 `arg_directions` 完整性——不存在独立的 verify pass。参见[验证器](99-verifier.md)。
+`CallDirectionsResolved` 属性由 `src/ir/verifier/verify_call_directions.cpp` 中通过 `CreateCallDirectionsResolvedPropertyVerifier()` 注册/创建的 `CallDirectionsResolved` 属性验证器进行验证，因此 pass 运行后流水线会自动检查所产生的 `arg_directions` 完整性——不存在独立的 verify pass。参见[验证器](99-verifier.md)。
 
 ## API
 
@@ -77,9 +77,9 @@ program_with_dirs = derive_pass(program)
 
 **R-seq** 在顺序循环内保持跨迭代的 write-after-write 链：同一缓冲区槽每次迭代都会被写入一次，因此运行时必须在该槽上序列化迭代。**R-prior** 当同一作用域中较早的写入单元已经触及同一 root 时，保留跨兄弟的 WAW 依赖关系。
 
-预先填充的 `Call.attrs["arg_directions"]` 被视为权威信息并保持不变（`Call` 构造函数中的 `ValidateArgDirectionsAttr` 强制长度匹配，且像 `NoDep` 这类方向无法从结构上推导得出）。
+预先填充的 `Call.attrs["arg_directions"]` 被视为权威信息并保持不变（像 `NoDep` 这类方向也无法仅从结构上推导得出）。需要注意的是，`Call` 构造函数中的 `ValidateArgDirectionsAttr` 只会在向量非空时检查其长度是否与参数个数匹配；空向量仍可被构造，但随后不会通过 `CallDirectionsResolved` 的属性验证。
 
-**幂等性**：当新计算的方向向量与调用现有方向向量相等时，mutator 会跳过重写。因此连续运行该 pass 两次会产生结构上完全相同的 IR（由 `TestDeriveIdempotent::test_idempotent` 回归测试验证）。
+**幂等性**：mutator 一旦发现 `attrs["arg_directions"]` 已存在（`HasArgDirections()`）即直接保留原 `Call`，所以第二次运行时已解析的调用不会被改写。因此连续运行该 pass 两次会产生结构上完全相同的 IR（由 `TestDeriveIdempotent::test_idempotent` 回归测试验证）。
 
 ## 示例
 


### PR DESCRIPTION
## Summary

Adds the per-pass documentation for `DeriveCallDirections`, the late-pipeline pass (entry 28 in the `Default` strategy) that writes `Call.attrs[\"arg_directions\"]` and produces the `CallDirectionsResolved` IR property.

- New `docs/en/dev/passes/28-derive_call_directions.md` (mirrored at `docs/zh-cn/dev/passes/28-derive_call_directions.md`) covers the two-layer `ParamDirection` vs `ArgDirection` model introduced in c53dac0d, the pass's required/produced properties, the buffer-root + prior-writer + R-seq/R-prior promotion algorithm with a per-row mapping table, idempotency, and a before/after IR example.
- Updates `docs/en/dev/passes/00-pass_manager.md` and the zh-cn mirror — adds `DeriveCallDirections` to the property table and to the tile-stage strategy list (between `FuseCreateAssembleToSlice` and the final `Simplify`).
- Updates `.claude/rules/pass-doc-ordering.md` to point slot 28 at the new file.

Documentation only — no code, bindings, or tests changed.

## Testing

- [x] markdownlint passes (`pre-commit` ran on commit)
- [x] Doc files within the 500-line limit (161 lines each)
- [x] Cross-references verified via grep against the index files
- [ ] N/A — no code changed, so no build/test signal

## Related Issues

Fixes #1171