### PR TITLE
fix(parser): Include source location in frontend diagnostics

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2013,6 +2013,7 @@ class ASTParser:
         if len(call.args) > 2:
             raise ParserSyntaxError(
                 f"pl.at() takes at most 2 positional arguments, got {len(call.args)}",
+                span=self.span_tracker.get_span(call),
                 hint="Use pl.at(level) or pl.at(level, role)",
             )
 
@@ -2028,6 +2029,7 @@ class ASTParser:
         if state.level is None:
             raise ParserSyntaxError(
                 "pl.at() requires a level argument",
+                span=self.span_tracker.get_span(call),
                 hint="Use pl.at(pl.Level.HOST) or pl.at(level=pl.Level.HOST)",
             )
 
@@ -2038,11 +2040,17 @@ class ASTParser:
         """Dispatch a single pl.at() keyword argument and update state."""
         if kw.arg == "level":
             if state.level is not None:
-                raise ParserSyntaxError("pl.at() got multiple values for argument 'level'")
+                raise ParserSyntaxError(
+                    "pl.at() got multiple values for argument 'level'",
+                    span=self.span_tracker.get_span(kw.value),
+                )
             state.level = extract_enum_value(kw.value, LEVEL_MAP, "Level", "pl.Level")
         elif kw.arg == "role":
             if state.role is not None:
-                raise ParserSyntaxError("pl.at() got multiple values for argument 'role'")
+                raise ParserSyntaxError(
+                    "pl.at() got multiple values for argument 'role'",
+                    span=self.span_tracker.get_span(kw.value),
+                )
             state.role = extract_enum_value(kw.value, ROLE_MAP, "Role", "pl.Role")
         elif kw.arg == "optimizations":
             self._handle_at_optimizations_kw(kw, state)
@@ -2055,11 +2063,13 @@ class ASTParser:
         elif kw.arg is None:
             raise ParserSyntaxError(
                 "Unsupported **kwargs in pl.at()",
+                span=self.span_tracker.get_span(kw.value),
                 hint="Use pl.at(level=pl.Level.HOST, role=pl.Role.Worker)",
             )
         else:
             raise ParserSyntaxError(
                 f"Unknown keyword argument '{kw.arg}' in pl.at()",
+                span=self.span_tracker.get_span(kw.value),
                 hint="Supported arguments: level, role, optimizations, name_hint",
             )
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2042,14 +2042,14 @@ class ASTParser:
             if state.level is not None:
                 raise ParserSyntaxError(
                     "pl.at() got multiple values for argument 'level'",
-                    span=self.span_tracker.get_span(kw.value),
+                    span=self.span_tracker.get_span(kw),
                 )
             state.level = extract_enum_value(kw.value, LEVEL_MAP, "Level", "pl.Level")
         elif kw.arg == "role":
             if state.role is not None:
                 raise ParserSyntaxError(
                     "pl.at() got multiple values for argument 'role'",
-                    span=self.span_tracker.get_span(kw.value),
+                    span=self.span_tracker.get_span(kw),
                 )
             state.role = extract_enum_value(kw.value, ROLE_MAP, "Role", "pl.Role")
         elif kw.arg == "optimizations":
@@ -2063,13 +2063,13 @@ class ASTParser:
         elif kw.arg is None:
             raise ParserSyntaxError(
                 "Unsupported **kwargs in pl.at()",
-                span=self.span_tracker.get_span(kw.value),
+                span=self.span_tracker.get_span(kw),
                 hint="Use pl.at(level=pl.Level.HOST, role=pl.Role.Worker)",
             )
         else:
             raise ParserSyntaxError(
                 f"Unknown keyword argument '{kw.arg}' in pl.at()",
-                span=self.span_tracker.get_span(kw.value),
+                span=self.span_tracker.get_span(kw),
                 hint="Supported arguments: level, role, optimizations, name_hint",
             )
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -196,6 +196,7 @@ class TypeResolver:
         if isinstance(resolved, list):
             raise ParserTypeError(
                 "Parameter type cannot be a tuple",
+                span=self._get_span(type_node),
                 hint="Tuple types are only supported as return types",
             )
 
@@ -203,6 +204,7 @@ class TypeResolver:
         if direction == ir.ParamDirection.InOut and isinstance(resolved, ir.ScalarType):
             raise ParserTypeError(
                 "Scalar parameters cannot have InOut direction",
+                span=self._get_span(type_node),
                 hint="Only Tensor and Tile parameters support InOut direction",
             )
 
@@ -268,11 +270,13 @@ class TypeResolver:
         if isinstance(type_node, ast.Attribute):
             raise ParserTypeError(
                 f"Incomplete type annotation: {ast.unparse(type_node)}",
+                span=self._get_span(type_node),
                 hint="Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]",
             )
 
         raise ParserTypeError(
             f"Unsupported type annotation: {ast.unparse(type_node)}",
+            span=self._get_span(type_node),
             hint="Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]",
         )
 
@@ -304,6 +308,7 @@ class TypeResolver:
         if type_name is None:
             raise ParserTypeError(
                 f"Unknown type in subscript: {ast.unparse(value)}",
+                span=self._get_span(value),
                 hint="Use pl.Tensor for tensor types, pl.Tile for tile types, or pl.Scalar for scalar types",
             )
 
@@ -344,7 +349,7 @@ class TypeResolver:
                     f"pl.{type_name}[[shape], dtype, pl.MemRef(...), pl.Mem.Vec], "
                     f"or pl.{type_name}[[shape], dtype, pl.MemRef(...), pl.Mem.Vec, pl.TileView(...)]"
                 )
-            raise ParserTypeError(message, hint=hint)
+            raise ParserTypeError(message, span=self._get_span(slice_value), hint=hint)
 
         shape_node = slice_value.elts[0]
         dtype_node = slice_value.elts[1]
@@ -387,6 +392,7 @@ class TypeResolver:
         if not self._is_memref_node(memref_node):
             raise ParserTypeError(
                 "Tensor 4th argument must be pl.MemRef(...)",
+                span=self._get_span(memref_node),
                 hint="Use pl.Tensor[[shape], dtype, layout, pl.MemRef(...)]",
             )
         memref = self.resolve_memref(memref_node)
@@ -415,6 +421,7 @@ class TypeResolver:
                 if memref_node is not None:
                     raise ParserTypeError(
                         "Tile annotation can contain at most one memref argument",
+                        span=self._get_span(node),
                         hint="Remove the duplicate pl.MemRef(...) or MemRefType variable argument",
                     )
                 memref_node = node
@@ -424,6 +431,7 @@ class TypeResolver:
                 if tile_view_node is not None:
                     raise ParserTypeError(
                         "Tile annotation can contain at most one pl.TileView(...)",
+                        span=self._get_span(node),
                         hint="Remove the duplicate pl.TileView(...) argument",
                     )
                 tile_view_node = node
@@ -433,6 +441,7 @@ class TypeResolver:
                 if memory_space_node is not None:
                     raise ParserTypeError(
                         "Tile annotation can contain at most one memory-space argument",
+                        span=self._get_span(node),
                         hint="Remove the duplicate pl.Mem.<space> argument",
                     )
                 memory_space_node = node
@@ -441,17 +450,20 @@ class TypeResolver:
             if self._is_layout_node(node):
                 raise ParserTypeError(
                     f"Tile does not accept layouts like {ast.unparse(node)}",
+                    span=self._get_span(node),
                     hint="Use pl.TileView(...) for tile views, or use pl.Tensor[...] for layout annotations",
                 )
 
             raise ParserTypeError(
                 f"Unsupported Tile annotation argument: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use pl.TileView(...), pl.Mem.<space>, pl.MemRef(...), and/or a MemRefType variable",
             )
 
         if memref_node is not None and memory_space_node is None:
             raise ParserTypeError(
                 "Tile annotation with a memref argument must also specify explicit memory space",
+                span=self._get_span(memref_node),
                 hint="Use pl.Tile[[shape], dtype, pl.MemRef(base, offset, size), pl.Mem.Vec] or "
                 "pl.Tile[[shape], dtype, memref_var, pl.Mem.Vec]",
             )
@@ -510,6 +522,7 @@ class TypeResolver:
             if isinstance(resolved, list):
                 raise ParserTypeError(
                     "Nested tuple types are not supported",
+                    span=self._get_span(elt),
                     hint="Use a flat tuple like tuple[pl.Tensor[...], pl.Tensor[...]]",
                 )
             types.append(resolved)
@@ -542,6 +555,7 @@ class TypeResolver:
 
         raise ParserTypeError(
             f"Unknown type constructor: {ast.unparse(func)}",
+            span=self._get_span(call_node),
             hint="Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]",
         )
 
@@ -579,6 +593,7 @@ class TypeResolver:
         if len(call_node.args) < 2:
             raise ParserTypeError(
                 f"{type_name} type requires shape and dtype arguments, got {len(call_node.args)}",
+                span=self._get_span(call_node),
                 hint=f"Use pl.{type_name}[[shape], dtype] format",
             )
 
@@ -601,6 +616,7 @@ class TypeResolver:
         if len(call_node.args) < 1:
             raise ParserTypeError(
                 f"Scalar type requires dtype argument, got {len(call_node.args)}",
+                span=self._get_span(call_node),
                 hint="Use pl.Scalar[dtype] format, e.g., pl.Scalar[pl.FP32]",
             )
 
@@ -627,6 +643,7 @@ class TypeResolver:
         if len(call_node.args) != 1 or not isinstance(call_node.args[0], ast.List):
             raise ParserTypeError(
                 f"Tuple type requires a list of types, got: {ast.unparse(call_node)}",
+                span=self._get_span(call_node),
                 hint="Use pl.Tuple[pl.Tensor[...], pl.Tile[...], ...] format",
             )
         return ir.TupleType(self._resolve_tuple_element_types(call_node.args[0].elts))
@@ -639,6 +656,7 @@ class TypeResolver:
             if isinstance(resolved, (list, ir.TupleType)):
                 raise ParserTypeError(
                     "Nested tuple types are not supported",
+                    span=self._get_span(elt),
                     hint="Use a flat pl.Tuple[pl.Tensor[...], pl.Tile[...], ...]",
                 )
             types.append(resolved)
@@ -683,6 +701,7 @@ class TypeResolver:
 
         raise ParserTypeError(
             f"Shape must be a list, tuple, or variable: {ast.unparse(shape_node)}",
+            span=self._get_span(shape_node),
             hint="Use a list like [64, 128] or a variable holding a list",
         )
 
@@ -776,6 +795,7 @@ class TypeResolver:
                     raise ParserTypeError(
                         f"Shape dimension must be int literal, variable, or evaluable expression: "
                         f"{ast.unparse(elt)}",
+                        span=self._get_span(elt),
                         hint="Use integer literals, variables, or expressions for shape dimensions",
                     )
         return dims
@@ -1079,11 +1099,13 @@ class TypeResolver:
         if not isinstance(node, ast.Call):
             raise ParserTypeError(
                 f"Expected pl.TensorView(...) call, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use pl.TensorView(valid_shape=[...], stride=[...], layout=pl.TensorLayout.NZ)",
             )
         if node.args:
             raise ParserTypeError(
                 f"pl.TensorView() does not accept positional arguments, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use keyword arguments: pl.TensorView(stride=[...], layout=pl.TensorLayout.NZ)",
             )
         tv = ir.TensorView()
@@ -1097,6 +1119,7 @@ class TypeResolver:
             else:
                 raise ParserTypeError(
                     f"Unknown TensorView keyword argument: {kw.arg!r}",
+                    span=self._get_span(kw.value),
                     hint="Supported: valid_shape, stride, layout",
                 )
         return tv
@@ -1137,11 +1160,13 @@ class TypeResolver:
         if not isinstance(node, ast.Call):
             raise ParserTypeError(
                 f"Expected pl.TileView(...) call, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use pl.TileView(valid_shape=[...], stride=[...], ...)",
             )
         if node.args:
             raise ParserTypeError(
                 f"pl.TileView() does not accept positional arguments, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use keyword arguments: pl.TileView(valid_shape=[...], stride=[...], ...)",
             )
         tv = ir.TileView()
@@ -1168,6 +1193,7 @@ class TypeResolver:
                 if val is None:
                     raise ParserTypeError(
                         f"TileView fractal must be an integer, got: {ast.unparse(kw.value)}",
+                        span=self._get_span(kw.value),
                     )
                 tv.fractal = val
                 has_explicit_fractal = True
@@ -1176,6 +1202,7 @@ class TypeResolver:
             else:
                 raise ParserTypeError(
                     f"Unknown TileView keyword argument: {kw.arg!r}",
+                    span=self._get_span(kw.value),
                     hint="Supported: valid_shape, stride, start_offset, blayout, slayout, fractal, pad",
                 )
         # If valid_shape was not explicitly given, inherit from tile_shape so roundtrip is stable
@@ -1211,6 +1238,7 @@ class TypeResolver:
         if not isinstance(node, ast.List):
             raise ParserTypeError(
                 f"Expected a list, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use a list like [64, 32]",
             )
         return [self._parse_tileview_expr(elt) for elt in node.elts]
@@ -1244,6 +1272,7 @@ class TypeResolver:
                     return ir.ConstInt(value, DataType.INDEX, self._get_span(node))
                 raise ParserTypeError(
                     f"TileView dimension {name!r} is bound to {type(value).__name__}, expected DynVar or int",
+                    span=self._get_span(node),
                     hint="Use pl.dynamic() or an integer for TileView dimension variables",
                 )
             # Auto-create a dynamic variable for unknown names to support roundtrip with dynamic shapes.
@@ -1254,6 +1283,7 @@ class TypeResolver:
             return self._dyn_var_cache[name]
         raise ParserTypeError(
             f"TileView expression must be an integer constant, got: {ast.unparse(node)}",
+            span=self._get_span(node),
             hint="Use an integer literal for TileView fields",
         )
 
@@ -1269,6 +1299,7 @@ class TypeResolver:
                 return _TILELAYOUT_MAP[node.attr]
         raise ParserTypeError(
             f"Unknown TileLayout value: {ast.unparse(node)}",
+            span=self._get_span(node),
             hint="Use pl.TileLayout.none_box, pl.TileLayout.row_major, or pl.TileLayout.col_major",
         )
 
@@ -1285,6 +1316,7 @@ class TypeResolver:
                 return _PADVALUE_MAP[node.attr]
         raise ParserTypeError(
             f"Unknown PadValue value: {ast.unparse(node)}",
+            span=self._get_span(node),
             hint="Use pl.PadValue.null, pl.PadValue.zero, pl.PadValue.max, or pl.PadValue.min",
         )
 
@@ -1334,6 +1366,7 @@ class TypeResolver:
         if not isinstance(node, ast.Call):
             raise ParserTypeError(
                 f"Expected pl.MemRef(...) call, got: {ast.unparse(node)}",
+                span=self._get_span(node),
                 hint="Use pl.MemRef(base_name, byte_offset, size)",
             )
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1119,7 +1119,7 @@ class TypeResolver:
             else:
                 raise ParserTypeError(
                     f"Unknown TensorView keyword argument: {kw.arg!r}",
-                    span=self._get_span(kw.value),
+                    span=self._get_span(kw),
                     hint="Supported: valid_shape, stride, layout",
                 )
         return tv
@@ -1202,7 +1202,7 @@ class TypeResolver:
             else:
                 raise ParserTypeError(
                     f"Unknown TileView keyword argument: {kw.arg!r}",
-                    span=self._get_span(kw.value),
+                    span=self._get_span(kw),
                     hint="Supported: valid_shape, stride, start_offset, blayout, slayout, fractal, pad",
                 )
         # If valid_shape was not explicitly given, inherit from tile_shape so roundtrip is stable

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -20,6 +20,7 @@ from pypto.language.parser.diagnostics import (
     UndefinedVariableError,
     UnsupportedFeatureError,
 )
+from pypto.language.parser.diagnostics.renderer import ErrorRenderer
 
 
 class TestErrorCases:
@@ -396,6 +397,91 @@ class TestConditionMustBeBool:
                     pl.cond(1)  # type: ignore  # non-bool
                     y = pl.yield_(x_iter + 1)  # noqa: F841
                 return y  # noqa: F821
+
+
+class TestSourceLocationPreservation:
+    """Regression tests for issue #1200: every frontend diagnostic must
+    include the user's source location so the error can be navigated to."""
+
+    @staticmethod
+    def _assert_span_populated(err: pl.parser.ParserError) -> None:
+        span = err.span
+        assert span is not None, "ParserError must carry a span for location preservation"
+        assert span["filename"], f"span filename must be non-empty, got {span['filename']!r}"
+        assert span["begin_line"] > 0, f"span begin_line must be > 0, got {span['begin_line']}"
+        assert span["begin_column"] >= 0, f"span begin_column must be >= 0, got {span['begin_column']}"
+
+    def test_unsupported_type_annotation_carries_span(self):
+        """The exact failure mode reported in issue #1200."""
+        with pytest.raises(ParserTypeError) as excinfo:
+
+            @pl.function
+            def bad(x: ([64, 128], pl.FP32)) -> pl.Tensor[[64], pl.FP32]:  # type: ignore
+                return x  # type: ignore
+
+        self._assert_span_populated(excinfo.value)
+
+    def test_incomplete_type_annotation_carries_span(self):
+        """Bare `pl.Tensor` (no subscript) — must report location."""
+        with pytest.raises(ParserTypeError) as excinfo:
+
+            @pl.function
+            def bad(x: pl.Tensor) -> pl.Tensor[[64], pl.FP32]:  # type: ignore
+                return x
+
+        self._assert_span_populated(excinfo.value)
+
+    def test_parameter_tuple_annotation_carries_span(self):
+        """A tuple-as-parameter-type annotation must be located.
+
+        ``resolve_param_type`` rejects list-typed (tuple) results because
+        parameters cannot be tuples. The error must include source location.
+        """
+        with pytest.raises(ParserTypeError) as excinfo:
+
+            @pl.function
+            def bad(  # type: ignore
+                x: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return x  # type: ignore
+
+        self._assert_span_populated(excinfo.value)
+
+    def test_rendered_error_includes_location_arrow(self):
+        """End-to-end pipeline (raise → attach source_lines → render) emits
+        the `--> file:line:col` arrow that issue #1200 reported as missing."""
+        with pytest.raises(ParserTypeError) as excinfo:
+
+            @pl.function
+            def bad(x: ([64, 128], pl.FP32)) -> pl.Tensor[[64], pl.FP32]:  # type: ignore
+                return x  # type: ignore
+
+        err = excinfo.value
+        # `@pl.function` attaches source_lines via its except handler before
+        # the exception escapes, so the renderer has everything it needs.
+        rendered = ErrorRenderer(use_color=False).render(err)
+        assert "-->" in rendered, f"rendered output missing location arrow:\n{rendered}"
+        # Must be a real line:col, not the unknown-span default of `:0:0`.
+        assert ":0:0" not in rendered, f"rendered output has unknown span:\n{rendered}"
+
+    def test_pl_at_unknown_kwarg_carries_span(self):
+        """Covers the ast_parser.py path: ParserSyntaxError from pl.at()
+        keyword dispatch must include the source location of the bad kwarg."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class P:
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(self, x: pl.Tensor[[16], pl.FP32]) -> pl.Tensor[[16], pl.FP32]:
+        with pl.at(level=pl.Level.HOST, not_a_real_arg=42):
+            pass
+        return x
+"""
+        with pytest.raises(ParserSyntaxError) as excinfo:
+            pl.parse_program(code)
+
+        self._assert_span_populated(excinfo.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Wire AST node locations into ~36 parser error sites that previously raised
`ParserTypeError` / `ParserSyntaxError` without `span=`. The renderer
already supported `--> file:line:col` arrows and source snippets — it just
had nothing to draw with at these sites.

## Repro (from the issue)

Before:

```
Error: Unsupported type annotation: ([cache_rows, head_dim], pl.BF16)
   = help: Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]
```

After:

```
Error: Unsupported type annotation: ([1024, 128], pl.BF16)
  --> /tmp/repro.py:6:13
  |
4 | def bad_qwen(
5 |     x: pl.Tensor[[64, 128], pl.FP16],
6 |     k_cache: ([1024, 128], pl.BF16),
  |              ^
   = help: Use pl.Tensor[[shape], dtype], pl.Tile[[shape], dtype], or pl.Scalar[dtype]
```

## Changes

- `python/pypto/language/parser/type_resolver.py` — ~30 raises now pass
  `span=self._get_span(<ast_node>)`, covering all type-annotation,
  shape, dtype, layout, MemRef, TileView, TensorView, and PadValue
  validation paths.
- `python/pypto/language/parser/ast_parser.py` — 6 raises in `pl.at()`
  kwarg parsing now pass `span=self.span_tracker.get_span(...)`.
- `tests/ut/language/parser/test_error_cases.py` — new
  `TestSourceLocationPreservation` class with 5 regression tests.

## Out of scope (follow-up)

The 12 remaining NOSPAN raises in `decorator.py` are decorator-metadata
errors raised before `SpanTracker` is constructed (e.g. malformed
`@pl.function(type=...)`). Plumbing the tracker through those helpers
needs its own PR.

## Test plan

- [x] `pytest tests/ut/language/parser/` — 626 passed
- [x] `pytest tests/ut/ir/` — 2835 passed, 2 skipped
- [x] `pytest tests/ut/language/parser/test_error_cases.py::TestSourceLocationPreservation -v` — 5 passed
- [x] Manual repro of the issue example confirms `-->` arrow + caret snippet

## Related Issues

Fixes #1200