### PR TITLE
feat(parser): Support assemble write syntax dst[slices] = src

### DIFF
--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -156,6 +156,14 @@ elem = A[i, j]         # equivalent to pl.tensor.read(A, [i, j]) / pl.tile.read(
 block = A[0:16, 0:32]  # equivalent to pl.slice(A, [16, 32], [0, 0])
 ```
 
+The symmetric write form `dst[<slices...>] = src` is sugar for `pl.assemble`:
+
+```python
+out[i:i+16, j:j+32] = src   # equivalent to out = pl.assemble(out, src, [i, j])
+```
+
+This sugar is only available before SSA conversion — it rebinds `dst`, which is incompatible with strict SSA. Under `@pl.function(strict_ssa=True)` (or any post-SSA context), use the explicit `pl.assemble(...)` call instead.
+
 Use `pl.tile.*` for tile-specific operations (memory transfers, broadcast, bitwise, etc.).
 
 ## Variable Assignment and SSA

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -45,7 +45,7 @@ Operate on `Tensor` objects (DDR memory).
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | Slice. Sugar: `A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | Reshape |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | Swap two axes |
-| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | Write source into target at offset |
+| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | Write source into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | Update rows of `input` at sparse positions given by `index` with values from `src`. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise add |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise subtract |
@@ -72,7 +72,7 @@ Transfer data between memory hierarchy levels.
 | ---- | --------- | ----------- |
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat). Both `offsets` and `shapes` use the source tensor's coordinate system. |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
-| `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset |
+| `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices. Sugar: `A[i, j]` |
 | `write` | `(tile: Tile, indices: IntLike \| Sequence[IntLike], value: Scalar) -> None` | Write scalar at indices. Sugar: `A[i, j] = v` |

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -156,6 +156,14 @@ elem = A[i, j]         # 等价于 pl.tensor.read(A, [i, j]) / pl.tile.read(A, [
 block = A[0:16, 0:32]  # 等价于 pl.slice(A, [16, 32], [0, 0])
 ```
 
+对称的写入形式 `dst[<slices...>] = src` 是 `pl.assemble` 的语法糖：
+
+```python
+out[i:i+16, j:j+32] = src   # 等价于 out = pl.assemble(out, src, [i, j])
+```
+
+该语法糖仅在 SSA 转换前可用——它会重新绑定 `dst`，与严格 SSA 不兼容。在 `@pl.function(strict_ssa=True)` 或任何 SSA 后的上下文中，请显式调用 `pl.assemble(...)`。
+
 需要 tile 特定操作（内存搬运、广播、位运算等）时使用 `pl.tile.*`。
 
 ## 变量赋值与 SSA

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -42,7 +42,7 @@
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | 切片。语法糖：`A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | 变形 |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | 交换两个轴 |
-| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | 将 source 写入 target 的指定偏移 |
+| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | 将 source 写入 target 的指定偏移。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | 按 `index` 指定的稀疏行位置，将 `src` 的行数据写入 `input`。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素加法 |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素减法 |
@@ -69,7 +69,7 @@
 | ---- | ---- | ---- |
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat）。`offsets` 和 `shapes` 均使用源 tensor 的坐标系。 |
 | `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
-| `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处 |
+| `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1039,11 +1039,146 @@ class ASTParser:
 
                 return
 
+            # Handle subscript-write: dst[i:i+64, j:j+64] = src
+            if isinstance(target, ast.Subscript):
+                self._parse_subscript_assignment(target, stmt.value)
+                return
+
         raise ParserSyntaxError(
             f"Unsupported assignment: {ast.unparse(stmt)}",
             span=self.span_tracker.get_span(stmt),
             hint="Use simple variable assignments or tuple unpacking with pl.yield_()",
         )
+
+    def _parse_subscript_assignment(self, target: ast.Subscript, value_node: ast.expr) -> None:
+        """Desugar ``dst[<slices...>] = src`` to ``dst = pl.assemble(dst, src, offsets)``.
+
+        This sugar is parser-time only and therefore only meaningful before
+        ConvertToSSA: the rewrite rebinds ``dst``, which strict-SSA forbids.
+        """
+        span = self.span_tracker.get_span(target)
+
+        if self.scope_manager.strict_ssa:
+            raise UnsupportedFeatureError(
+                "Subscript-write syntax 'dst[...] = src' is only supported before SSA conversion",
+                span=span,
+                hint="Rewrite as an explicit pl.assemble(...) call, or remove strict_ssa=True",
+            )
+
+        if not isinstance(target.value, ast.Name):
+            raise ParserSyntaxError(
+                f"Subscript-write target must be a variable name, got {ast.unparse(target.value)}",
+                span=span,
+                hint="Assign through a named Tensor/Tile, e.g. 'dst[...] = src'",
+            )
+
+        var_name = target.value.id
+        base_expr = self.parse_expression(target.value)
+        base_type = base_expr.type
+
+        if isinstance(base_type, ir.TensorType):
+            kind_name = "tensor"
+            assemble_op = ir_op.tensor.assemble
+        elif isinstance(base_type, ir.TileType):
+            kind_name = "tile"
+            assemble_op = ir_op.tile.assemble
+        else:
+            raise ParserTypeError(
+                f"Subscript-write requires a Tensor or Tile target, got {type(base_type).__name__}",
+                span=span,
+                hint="Subscript-write 'dst[...] = src' is only supported for Tensor and Tile",
+            )
+
+        indices = self._normalize_subscript_indices(target, span)
+        offsets, extents = self._build_assemble_offsets_and_extents(indices, base_type.shape, span, kind_name)
+
+        source_expr = self.parse_expression(value_node)
+        source_type = source_expr.type
+        if not isinstance(source_type, type(base_type)):
+            raise ParserTypeError(
+                f"Subscript-write source must also be a {kind_name}, got {type(source_type).__name__}",
+                span=span,
+                hint=f"The rhs of 'dst[...] = src' must be a {kind_name} of matching shape",
+            )
+
+        if len(source_type.shape) != len(base_type.shape):
+            raise ParserTypeError(
+                f"Subscript-write source must be {len(base_type.shape)}D to match "
+                f"the {kind_name} target, got {len(source_type.shape)}D",
+                span=span,
+                hint="The lhs and rhs of 'dst[...] = src' must have the same rank",
+            )
+
+        for dim_idx, (requested, src_extent) in enumerate(zip(extents, source_type.shape)):
+            requested_const = _fold_const_slice_extent(requested, 0)
+            source_const = _fold_const_slice_extent(src_extent, 0)
+            if requested_const is not None and source_const is not None and requested_const != source_const:
+                raise ParserTypeError(
+                    f"Subscript-write shape mismatch on axis {dim_idx}: "
+                    f"slice expects {requested_const} elements, source has {source_const}",
+                    span=span,
+                    hint=f"Make the source's axis-{dim_idx} extent match the slice extent, "
+                    f"or adjust the slice bounds",
+                )
+
+        assemble_call = assemble_op(base_expr, source_expr, offsets, span=span)
+        var = self._assign_or_let(var_name, assemble_call, span)
+        self.scope_manager.define_var(var_name, var, span=span)
+
+    def _build_assemble_offsets_and_extents(
+        self,
+        indices: list[ast.expr],
+        target_shape: Sequence[ir.Expr],
+        span: ir.Span,
+        kind_name: str,
+    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr]]:
+        """Parse a subscript-write index list once into per-axis offsets and extents.
+
+        For ``a[lower:upper]`` the offset is ``lower`` (defaulting to 0) and the
+        extent is ``upper - lower`` (defaulting to the full target axis when
+        ``upper`` is omitted). For ``a[i]`` the offset is ``i`` and the extent
+        is 1. Extents are folded through the arithmetic simplifier so symbolic
+        bounds like ``i:i+16`` collapse to a constant when possible — this is
+        the same path used by the slice-read sugar.
+
+        All-integer indexing is rejected (no element-write op wiring today),
+        as is ``step``.
+        """
+        if len(indices) != len(target_shape):
+            raise ParserTypeError(
+                f"{kind_name.capitalize()} subscript-write requires {len(target_shape)} indices, "
+                f"got {len(indices)}",
+                span=span,
+                hint=f"Provide exactly {len(target_shape)} indices for a {len(target_shape)}D {kind_name}",
+            )
+
+        if not any(isinstance(idx, ast.Slice) for idx in indices):
+            raise UnsupportedFeatureError(
+                f"Element-write 'dst[i, j] = scalar' is not supported for {kind_name} targets",
+                span=span,
+                hint="Use slice indices, e.g. 'dst[i:i+1, j:j+1] = tile_1x1'",
+            )
+
+        offsets: list[int | ir.Expr] = []
+        extents: list[int | ir.Expr] = []
+        for dim_idx, idx in enumerate(indices):
+            if not isinstance(idx, ast.Slice):
+                offsets.append(self.parse_expression(idx))
+                extents.append(1)
+                continue
+            if idx.step is not None:
+                raise UnsupportedFeatureError(
+                    f"Slice step is not supported in {kind_name} subscript-write",
+                    span=span,
+                    hint="Use 'dst[start:stop] = src' without step",
+                )
+            lower: int | ir.Expr = 0 if idx.lower is None else self.parse_expression(idx.lower)
+            upper: int | ir.Expr = (
+                target_shape[dim_idx] if idx.upper is None else self.parse_expression(idx.upper)
+            )
+            offsets.append(lower)
+            extents.append(self._build_slice_shape_expr(upper, lower))
+        return offsets, extents
 
     def parse_yield_assignment(self, target: ast.Tuple, value: ast.Call) -> None:
         """Parse yield assignment: (a, b) = pl.yield_(x, y).

--- a/python/pypto/language/typing/tensor.py
+++ b/python/pypto/language/typing/tensor.py
@@ -235,6 +235,10 @@ class Tensor(metaclass=TensorMeta):
         """Subscript syntax for tensor slicing/reading (only valid inside @pl.function)."""
         raise NotImplementedError("Tensor subscript syntax is only available inside @pl.function")
 
+    def __setitem__(self, indices: Any, value: Any) -> None:
+        """Subscript-write sugar for tensor.assemble (only valid inside @pl.function, pre-SSA)."""
+        raise NotImplementedError("Tensor subscript-write syntax is only available inside @pl.function")
+
     def __repr__(self) -> str:
         """String representation."""
         if self._expr is not None:

--- a/python/pypto/language/typing/tile.py
+++ b/python/pypto/language/typing/tile.py
@@ -205,6 +205,10 @@ class Tile(metaclass=TileMeta):
         """Subscript syntax for tile slicing (only valid inside @pl.function)."""
         raise NotImplementedError("Tile subscript syntax is only available inside @pl.function")
 
+    def __setitem__(self, indices: Any, value: Any) -> None:
+        """Subscript-write sugar for tile.assemble (only valid inside @pl.function, pre-SSA)."""
+        raise NotImplementedError("Tile subscript-write syntax is only available inside @pl.function")
+
     def __repr__(self) -> str:
         """String representation."""
         if self._expr is not None:

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -352,5 +352,238 @@ class TestTupleSubscript:
         assert isinstance(tuple_access, ir.Function)
 
 
+class TestTensorSubscriptWrite:
+    """Tests for tensor subscript-write syntax: A[i:i+H, j:j+W] = src."""
+
+    def test_tensor_assemble_via_subscript_write(self):
+        """A[i:i+16, j:j+32] = src on Tensor -> tensor.assemble (rebinds A)."""
+
+        @pl.function
+        def write_slice(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 32], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            out[i : i + 16, j : j + 32] = src
+            return out
+
+        assert isinstance(write_slice, ir.Function)
+        printed = write_slice.as_python()
+        assert "tensor.assemble" in printed
+
+    def test_tensor_subscript_write_constant_offsets(self):
+        """A[0:16, 0:32] = src lowers to tensor.assemble with literal offsets [0, 0]."""
+
+        @pl.function
+        def write_const(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 32], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            out[0:16, 0:32] = src
+            return out
+
+        assert isinstance(write_const, ir.Function)
+        assert isinstance(write_const.body, ir.SeqStmts)
+
+        assemble_stmt = write_const.body.stmts[0]
+        assert isinstance(assemble_stmt, ir.AssignStmt)
+        assert isinstance(assemble_stmt.value, ir.Call)
+        assert assemble_stmt.value.op.name == "tensor.assemble"
+
+        offset_tuple = assemble_stmt.value.args[2]
+        assert isinstance(offset_tuple, ir.MakeTuple)
+        assert [cast(ir.ConstInt, e).value for e in offset_tuple.elements] == [0, 0]
+
+    def test_tensor_subscript_write_open_lower(self):
+        """A[:16, :32] = src treats omitted lower bound as 0."""
+
+        @pl.function
+        def write_open(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 32], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            out[:16, :32] = src
+            return out
+
+        assert isinstance(write_open.body, ir.SeqStmts)
+        assemble_stmt = write_open.body.stmts[0]
+        assert isinstance(assemble_stmt, ir.AssignStmt)
+        assert isinstance(assemble_stmt.value, ir.Call)
+        offset_tuple = assemble_stmt.value.args[2]
+        assert isinstance(offset_tuple, ir.MakeTuple)
+        assert [cast(ir.ConstInt, e).value for e in offset_tuple.elements] == [0, 0]
+
+    def test_tensor_subscript_write_step_error(self):
+        """A[0:16:2, :] = src must reject slice steps."""
+
+        with pytest.raises(UnsupportedFeatureError, match="step"):
+
+            @pl.function
+            def bad_step(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[8, 128], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[0:16:2, :] = src
+                return out
+
+    def test_tensor_subscript_write_wrong_rank(self):
+        """A[0:16] = src on a 2D tensor must reject (rank mismatch)."""
+
+        with pytest.raises(ParserTypeError, match="2 indices"):
+
+            @pl.function
+            def bad_rank(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[16, 128], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[0:16] = src
+                return out
+
+    def test_tensor_subscript_write_element_form_unsupported(self):
+        """A[i, j] = scalar must be rejected for now (no element-write op wiring)."""
+
+        with pytest.raises(UnsupportedFeatureError, match="Element-write"):
+
+            @pl.function
+            def bad_elem(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                v: pl.Scalar[pl.FP32],
+                i: pl.Scalar[pl.INDEX],
+                j: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[i, j] = v
+                return out
+
+    def test_tensor_subscript_write_strict_ssa_rejected(self):
+        """Subscript-write must be rejected under strict_ssa=True."""
+
+        with pytest.raises(UnsupportedFeatureError, match="before SSA conversion"):
+
+            @pl.function(strict_ssa=True)
+            def bad_ssa(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[0:16, 0:32] = src
+                return out
+
+    def test_tensor_subscript_write_shape_mismatch_static(self):
+        """Static shape mismatch on a slice axis must be reported with axis + extents."""
+
+        with pytest.raises(ParserTypeError, match="shape mismatch on axis 0"):
+
+            @pl.function
+            def bad_shape(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[8, 32], pl.FP32],  # axis 0 should be 16
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[0:16, 0:32] = src
+                return out
+
+    def test_tensor_subscript_write_full_axis_shape_mismatch(self):
+        """`out[:, :] = src` requires src to fill the target shape exactly."""
+
+        with pytest.raises(ParserTypeError, match="shape mismatch on axis 1"):
+
+            @pl.function
+            def bad_full(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[64, 32], pl.FP32],  # axis 1 should be 128
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[:, :] = src
+                return out
+
+    def test_tensor_subscript_write_rank_mismatch(self):
+        """A 1D source on a 2D target must be rejected with a rank-mismatch error."""
+
+        with pytest.raises(ParserTypeError, match="must be 2D"):
+
+            @pl.function
+            def bad_rank_src(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[32], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[0:1, 0:32] = src
+                return out
+
+    def test_tensor_subscript_write_symbolic_extent_simplifies_match(self):
+        """``out[i:i+16, j:j+32] = src`` simplifies (i+16)-i=16 etc. and matches src."""
+
+        @pl.function
+        def symbolic_match(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 32], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            out[i : i + 16, j : j + 32] = src
+            return out
+
+        assert isinstance(symbolic_match, ir.Function)
+        assert "tensor.assemble" in symbolic_match.as_python()
+
+    def test_tensor_subscript_write_symbolic_extent_simplifies_mismatch(self):
+        """``out[i:i+8, ...] = src`` simplifies to 8 — must reject when src has 16."""
+
+        with pytest.raises(ParserTypeError, match="shape mismatch on axis 0"):
+
+            @pl.function
+            def bad_symbolic(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[16, 32], pl.FP32],  # axis 0 should be 8
+                i: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                out[i : i + 8, 0:32] = src
+                return out
+
+    def test_tensor_subscript_write_unfoldable_extent_skipped(self):
+        """Genuinely-symbolic extents (``out[:, :k] = src`` with runtime k) are trusted."""
+
+        @pl.function
+        def truly_symbolic(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[64, 128], pl.FP32],
+            k: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            # Upper bound `k` cannot be statically reduced — the parser cannot
+            # prove a mismatch, so it accepts the write.
+            out[:, :k] = src
+            return out
+
+        assert isinstance(truly_symbolic, ir.Function)
+        assert "tensor.assemble" in truly_symbolic.as_python()
+
+
+class TestTileSubscriptWrite:
+    """Tests for tile subscript-write syntax on Tile types."""
+
+    def test_tile_assemble_via_subscript_write(self):
+        """t[0:16, 0:32] = src on Tile -> tile.assemble."""
+
+        @pl.function
+        def write_tile(
+            x: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tile[[16, 32], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128])
+            t[0:16, 0:32] = src
+            return pl.store(t, [0, 0], x)
+
+        assert isinstance(write_tile, ir.Function)
+        printed = write_tile.as_python()
+        assert "tile.assemble" in printed
+
+        assert isinstance(write_tile.body, ir.SeqStmts)
+        assemble_stmt = write_tile.body.stmts[1]
+        assert isinstance(assemble_stmt, ir.AssignStmt)
+        assert isinstance(assemble_stmt.value, ir.Call)
+        assert assemble_stmt.value.op.name == "tile.assemble"
+
+        offset_tuple = assemble_stmt.value.args[2]
+        assert isinstance(offset_tuple, ir.MakeTuple)
+        assert [cast(ir.ConstInt, e).value for e in offset_tuple.elements] == [0, 0]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds the symmetric subscript-write sugar `dst[i:i+H, j:j+W] = src` as a parse-time desugaring to `pl.assemble(dst, src, [i, j])`, mirroring the existing slice-read sugar `tile = src[i:i+H, j:j+W]`.
- Sugar is **pre-SSA only** — the desugaring rebinds `dst`, which strict SSA forbids. `@pl.function(strict_ssa=True)` rejects the syntax up front with a clear `UnsupportedFeatureError`.
- Parser performs a static shape-mismatch check using the same arithmetic simplifier as the slice-read path: `out[i:i+16, j:j+32] = src` folds `(i+16)-i → 16` and verifies it against `src.shape[0]`. Truly-symbolic extents like `out[:, :k] = src` (runtime `k`) are trusted.
- Element-write `dst[i, j] = scalar` is rejected for now since no element-write op is wired to the parser yet (separate concern).
- Adds `__setitem__` stubs on `Tensor` / `Tile` so static type checkers (pyright) accept the new syntax.
- Updates EN + zh-CN language guide and operation reference docs to document the sugar and its SSA constraint.

## Testing

- [x] 14 new tests in `tests/ut/language/parser/test_subscript_syntax.py` covering happy paths, every error case, and arith-simplifier matching/mismatching behavior
- [x] Full language test suite (746 tests) passes
- [x] Full IR + language sweep (3581 tests) passes
- [x] Parser sweep (630 tests) passes
- [x] Pyright passes
- [x] Ruff format / check passes

## Related Issues

Fixes #1201