### PR TITLE
fix(codegen): Rewrite tile.slice lowering and fix dynamic shape handling in PTO codegen

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -139,6 +139,19 @@ class PTOCodegen : public CodegenBase {
   std::string EmitCastToIndex(const ir::VarPtr& var, const std::string& mlir_name);
 
   /**
+   * @brief Emit arith.index_cast if expression is not already index type
+   *
+   * Shape/stride expressions in PTO codegen may be constants, variables, or
+   * general scalar expressions. PTO ops that consume dimensions require index
+   * operands, so dynamic integer expressions must be cast on demand.
+   *
+   * @param expr IR expression whose type determines the cast
+   * @param mlir_name Current MLIR SSA name for the expression value
+   * @return SSA name of the index-typed value (original if already index)
+   */
+  std::string EmitCastToIndex(const ir::ExprPtr& expr, const std::string& mlir_name);
+
+  /**
    * @brief Emit arith.index_cast if expression is not already i32 type
    *
    * PTO ISA instructions like pto.tmrgsort require i32 operands. When the
@@ -254,6 +267,18 @@ class PTOCodegen : public CodegenBase {
   void SetCurrentResultBuf(const std::string& buf);
   void RegisterTileBufType(const std::string& ssa_name, const std::string& type_string);
   std::string GetSSATileBufType(const std::string& ssa_name) const;
+  struct SubviewMaterializationInfo {
+    std::string source_ssa;
+    std::string source_type;
+    std::string row_off_ssa;
+    std::string col_off_ssa;
+    std::string materialize_target_ssa;
+    std::string materialize_target_type;
+    bool emitted = false;
+  };
+  void RegisterSubviewMaterialization(const std::string& subview_ssa, const SubviewMaterializationInfo& info);
+  SubviewMaterializationInfo* GetSubviewMaterialization(const std::string& subview_ssa);
+  const SubviewMaterializationInfo* GetSubviewMaterialization(const std::string& subview_ssa) const;
 
   /**
    * @brief Record the SSA name of the __gm_pipe_buffer function parameter
@@ -436,6 +461,7 @@ class PTOCodegen : public CodegenBase {
     };
     std::vector<ExtraAllocTile> extra_alloc_tiles;
     std::map<std::string, std::string> ssa_to_tile_buf_type;
+    std::map<std::string, SubviewMaterializationInfo> subview_materializations;
 
     int temp_counter = 0;
     std::set<std::string> used_ssa_names;
@@ -472,6 +498,7 @@ class PTOCodegen : public CodegenBase {
 
       extra_alloc_tiles.clear();
       ssa_to_tile_buf_type.clear();
+      subview_materializations.clear();
 
       temp_counter = 0;
       used_ssa_names.clear();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -191,6 +191,75 @@ static std::vector<std::string> GetSizeCodes(const std::vector<ir::ExprPtr>& exp
   return codes;
 }
 
+static bool ExprsEquivalentForSubview(const ir::ExprPtr& lhs, const ir::ExprPtr& rhs) {
+  if (lhs.get() == rhs.get()) return true;
+  auto lhs_const = As<ir::ConstInt>(lhs);
+  auto rhs_const = As<ir::ConstInt>(rhs);
+  return lhs_const && rhs_const && lhs_const->value_ == rhs_const->value_;
+}
+
+static codegen::TileTypeComponents InferSubviewTileTypeComponents(const ir::TileType& source_tile_type,
+                                                                  const ir::MakeTuple& shape_tuple,
+                                                                  const ir::MakeTuple& offset_tuple,
+                                                                  const std::string& dtype_str) {
+  codegen::TileTypeComponents c;
+  c.dtype_str = dtype_str;
+
+  auto rows_const = As<ir::ConstInt>(shape_tuple.elements_[0]);
+  auto cols_const = As<ir::ConstInt>(shape_tuple.elements_[1]);
+  INTERNAL_CHECK(rows_const && cols_const) << "Subview shape must be static for PTO type inference";
+  c.rows = rows_const->value_;
+  c.cols = cols_const->value_;
+
+  if (source_tile_type.tile_view_.has_value()) {
+    const auto& tv = *source_tile_type.tile_view_;
+    c.blayout = tv.blayout;
+    c.slayout = tv.slayout;
+    c.fractal = tv.fractal;
+    c.pad = tv.pad;
+  } else if (c.cols == 1 && c.rows > 1) {
+    c.blayout = ir::TileLayout::col_major;
+  }
+
+  c.v_row = c.rows;
+  c.v_col = c.cols;
+  c.v_row_dynamic = true;
+  c.v_col_dynamic = true;
+
+  std::vector<ir::ExprPtr> source_valid = source_tile_type.shape_;
+  if (source_tile_type.tile_view_.has_value() && source_tile_type.tile_view_->valid_shape.size() >= 2) {
+    source_valid = source_tile_type.tile_view_->valid_shape;
+  }
+
+  auto infer_dim = [&](size_t dim_idx, int64_t size, int64_t* out_value, bool* out_dynamic) {
+    auto offset_const = As<ir::ConstInt>(offset_tuple.elements_[dim_idx]);
+    auto valid_const = dim_idx < source_valid.size() ? As<ir::ConstInt>(source_valid[dim_idx]) : nullptr;
+    if (offset_const && valid_const) {
+      int64_t remain = valid_const->value_ - offset_const->value_;
+      if (remain < 0) remain = 0;
+      *out_value = std::min<int64_t>(size, remain);
+      *out_dynamic = false;
+      return;
+    }
+    if (offset_const && offset_const->value_ == 0 && dim_idx < source_valid.size() &&
+        ExprsEquivalentForSubview(shape_tuple.elements_[dim_idx], source_valid[dim_idx])) {
+      *out_value = size;
+      *out_dynamic = false;
+    }
+  };
+
+  infer_dim(0, c.rows, &c.v_row, &c.v_row_dynamic);
+  infer_dim(1, c.cols, &c.v_col, &c.v_col_dynamic);
+
+  // Match ExtractTileTypeInfo: PTOAS rejects mixed static/dynamic valid dims
+  // on 2D tiles, so promote both to dynamic when either is dynamic.
+  if (c.v_row_dynamic || c.v_col_dynamic) {
+    c.v_row_dynamic = true;
+    c.v_col_dynamic = true;
+  }
+  return c;
+}
+
 // Emit a pto.partition_view op and return the generated SSA name.
 static std::string EmitPartitionViewPTO(const std::string& name_hint, const std::string& tensor_view,
                                         const std::string& tensor_view_type,
@@ -263,12 +332,70 @@ static std::string GenerateInsOutsClause(const CallPtr& op, codegen::PTOCodegen&
   return oss.str();
 }
 
+static std::string MaterializeSubviewOperandIfNeeded(const ir::ExprPtr& expr, codegen::PTOCodegen& codegen,
+                                                     const std::string& name_hint) {
+  auto var = ir::As<ir::Var>(expr);
+  if (!var) return codegen.GetExprAsCode(expr);
+
+  std::string operand = codegen.GetExprAsCode(expr);
+  auto* mat = codegen.GetSubviewMaterialization(operand);
+  if (!mat) return operand;
+  if (mat->emitted) return mat->materialize_target_ssa;
+
+  auto result_type = mat->materialize_target_type;
+  std::ostringstream extract;
+  extract << "pto.textract ins(" << mat->source_ssa << ", " << mat->row_off_ssa << ", " << mat->col_off_ssa;
+  if (!mat->source_type.empty()) {
+    extract << " : " << mat->source_type << ", index, index";
+  }
+  extract << ") outs(" << mat->materialize_target_ssa;
+  if (!result_type.empty()) extract << " : " << result_type;
+  extract << ")";
+  codegen.Emit(extract.str());
+  mat->emitted = true;
+  return mat->materialize_target_ssa;
+}
+
 // Helper function for N-ary operations (unary, binary, ternary, etc.)
 static std::string MakeNaryCodegenPTO(const std::string& pto_op_name, size_t arity, const CallPtr& op,
                                       codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == arity) << "Operation:[" << pto_op_name << "] requires " << arity << " argument"
                                    << (arity != 1 ? "s" : "") << ", but got " << op->args_.size();
+  // pto.tcolexpandmul requires materialized tile data — its hardware lowering
+  // reads physical tile rows/cols from the operand type, which is incorrect for
+  // a pto.subview alias.  Other tile ops (tmov, tfillpad, tadd, ...) accept
+  // subview SSAs natively, so only tcolexpandmul needs eager materialization.
+  if (pto_op_name == "pto.tcolexpandmul") {
+    auto lhs_operand = MaterializeSubviewOperandIfNeeded(op->args_[0], codegen, "colexpandmul_mat");
+    auto rhs_operand = MaterializeSubviewOperandIfNeeded(op->args_[1], codegen, "colexpandmul_vec");
+    std::string lhs_orig = codegen.GetExprAsCode(op->args_[0]);
+    std::string rhs_orig = codegen.GetExprAsCode(op->args_[1]);
+    if (lhs_operand != lhs_orig || rhs_operand != rhs_orig) {
+      // Resolve type annotations: use the materialized target type when
+      // the operand was a subview, otherwise use the original annotation.
+      std::string lhs_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+      auto* lhs_mat = codegen.GetSubviewMaterialization(lhs_orig);
+      if (lhs_mat) lhs_type = lhs_mat->materialize_target_type;
+
+      std::string rhs_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+      auto* rhs_mat = codegen.GetSubviewMaterialization(rhs_orig);
+      if (rhs_mat) rhs_type = rhs_mat->materialize_target_type;
+
+      std::ostringstream oss;
+      oss << "pto.tcolexpandmul ins(" << lhs_operand << ", " << rhs_operand;
+      if (!lhs_type.empty() && !rhs_type.empty()) {
+        oss << " : " << lhs_type << ", " << rhs_type;
+      }
+      std::string result_target = codegen.GetCurrentResultTarget();
+      std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+      oss << ") outs(" << result_target;
+      if (!result_type.empty()) oss << " : " << result_type;
+      oss << ")";
+      codegen.Emit(oss.str());
+      return "";
+    }
+  }
   codegen.Emit(pto_op_name + " " + GenerateInsOutsClause(op, codegen));
   return "";
 }
@@ -2067,12 +2194,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     INTERNAL_CHECK_SPAN(rows_const && cols_const, op->span_)
         << "tile.slice shape must be compile-time constant for pto.subview sizes attribute";
 
-    // Optional valid_shape (4th arg) materialises into pto.subview's
-    // `valid [%vr, %vc]` operands.  Omit them when valid_shape == shape so
-    // the result tile_buf type carries static v_row / v_col.
     std::string valid_row;
     std::string valid_col;
-    if (op->args_.size() == 4) {
+    bool has_explicit_valid_shape = op->args_.size() == 4;
+    if (has_explicit_valid_shape) {
       auto valid_tuple = ir::As<ir::MakeTuple>(op->args_[3]);
       INTERNAL_CHECK_SPAN(valid_tuple, op->span_) << "tile.slice valid_shape must be a literal tuple";
       INTERNAL_CHECK_SPAN(valid_tuple->elements_.size() >= 2, op->span_)
@@ -2081,38 +2206,96 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       valid_col = codegen.GetExprAsCode(valid_tuple->elements_[1]);
     }
 
-    std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
+    std::string result_target = codegen.GetCurrentResultTarget();
+    std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+    INTERNAL_CHECK_SPAN(!result_target.empty(), op->span_) << "tile.slice requires assignment target";
 
-    // Verify pto.subview's strict tile-config constraints.  After
-    // DeduceTileSliceType propagates the source TileView, the result type
-    // shares blayout/slayout/fractal/pad with the source by construction;
-    // this guards against future passes that might rewrite the result type.
-    if (auto result_var = codegen.GetCurrentResultVar()) {
-      if (auto result_tile_type = ir::As<ir::TileType>(result_var->GetType())) {
-        CheckSubviewTileCompat(*source_tile_type, *result_tile_type, "tile.slice");
+    auto row_off_const = ir::As<ir::ConstInt>(offset_tuple->elements_[0]);
+    auto col_off_const = ir::As<ir::ConstInt>(offset_tuple->elements_[1]);
+    bool full_window = row_off_const && col_off_const && row_off_const->value_ == 0 &&
+                       col_off_const->value_ == 0 && source_tile_type->shape_.size() >= 2 &&
+                       ExprsEquivalentForSubview(shape_tuple->elements_[0], source_tile_type->shape_[0]) &&
+                       ExprsEquivalentForSubview(shape_tuple->elements_[1], source_tile_type->shape_[1]);
+
+    // Skip the tmov fast-path when the source is already a subview: tmov
+    // materializes a copy, which breaks view/alias semantics that tile.slice
+    // must preserve.  Fall through to the normal subview emission instead.
+    bool source_is_subview = codegen.GetSubviewMaterialization(src) != nullptr;
+    if (full_window && !source_is_subview) {
+      std::ostringstream mov;
+      mov << "pto.tmov ins(" << src;
+      if (!src_type.empty()) mov << " : " << src_type;
+      mov << ") outs(" << result_target;
+      if (!result_type.empty()) mov << " : " << result_type;
+      mov << ")";
+      codegen.Emit(mov.str());
+      if (has_explicit_valid_shape) {
+        std::ostringstream set_validshape;
+        set_validshape << "pto.set_validshape " << result_target << ", " << valid_row << ", " << valid_col;
+        if (!result_type.empty()) {
+          set_validshape << " : " << result_type;
+        }
+        codegen.Emit(set_validshape.str());
       }
+      return std::string("");
     }
 
-    // Allocate a fresh SSA for the subview result and rebind the current
-    // result variable to it; the (now dead) pre-emitted alloc_tile for the
-    // slice variable is harmless and will be eliminated by downstream PTOAS
-    // passes.  Doing it this way avoids redefining the alloc_tile SSA.
-    std::string view_ssa = codegen.NewNamedTemp("slice_view");
-    codegen.SetCurrentResultBuf(view_ssa);
+    // Emit a pto.subview and register its type; returns (view_ssa, view_type).
+    auto emit_subview = [&]() -> std::pair<std::string, std::string> {
+      auto view_type_info = InferSubviewTileTypeComponents(*source_tile_type, *shape_tuple, *offset_tuple,
+                                                           codegen.GetTypeString(source_tile_type->dtype_));
+      INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)
+          << "tile.slice source must carry a memory space for pto.subview result typing";
+      std::string view_type = codegen::FormatTileBufTypeString(
+          codegen::MemorySpaceToMLIR(*source_tile_type->memory_space_), view_type_info.dtype_str,
+          view_type_info.rows, view_type_info.cols, view_type_info.blayout, view_type_info.slayout,
+          view_type_info.fractal, view_type_info.pad, view_type_info.v_row, view_type_info.v_col,
+          view_type_info.v_row_dynamic, view_type_info.v_col_dynamic);
+      std::string view_ssa = codegen.NewNamedTemp("slice_view");
+      std::ostringstream oss;
+      oss << view_ssa << " = pto.subview " << src << "[" << row_off << ", " << col_off << "] sizes ["
+          << rows_const->value_ << ", " << cols_const->value_ << "]";
+      if (!src_type.empty() && !view_type.empty()) {
+        oss << " : " << src_type << " -> " << view_type;
+      }
+      codegen.Emit(oss.str());
+      codegen.RegisterTileBufType(view_ssa, view_type);
+      return {view_ssa, view_type};
+    };
+
+    if (!has_explicit_valid_shape) {
+      auto [view_ssa, view_type] = emit_subview();
+      codegen::PTOCodegen::SubviewMaterializationInfo mat_info;
+      mat_info.source_ssa = src;
+      mat_info.source_type = src_type;
+      mat_info.row_off_ssa = row_off;
+      mat_info.col_off_ssa = col_off;
+      mat_info.materialize_target_ssa = result_target;
+      mat_info.materialize_target_type = result_type;
+      codegen.RegisterSubviewMaterialization(view_ssa, mat_info);
+      // For pure static-window slices, keep the result as a true pto.subview
+      // SSA instead of materializing a copy. This preserves view semantics and
+      // avoids backend C++ lowering reconstructing the TMOV source tile with
+      // the base tile's physical cols/rows.
+      codegen.SetCurrentResultBuf(view_ssa);
+      return std::string("");
+    }
+
+    auto [producer, producer_type] = emit_subview();
+
+    std::ostringstream mov;
+    mov << "pto.tmov ins(" << producer;
+    if (!producer_type.empty()) mov << " : " << producer_type;
+    mov << ") outs(" << result_target;
+    if (!result_type.empty()) mov << " : " << result_type;
+    mov << ")";
+    codegen.Emit(mov.str());
+    std::ostringstream set_validshape;
+    set_validshape << "pto.set_validshape " << result_target << ", " << valid_row << ", " << valid_col;
     if (!result_type.empty()) {
-      codegen.RegisterTileBufType(view_ssa, result_type);
+      set_validshape << " : " << result_type;
     }
-
-    std::ostringstream oss;
-    oss << view_ssa << " = pto.subview " << src << "[" << row_off << ", " << col_off << "] sizes ["
-        << rows_const->value_ << ", " << cols_const->value_ << "]";
-    if (!valid_row.empty()) {
-      oss << " valid [" << valid_row << ", " << valid_col << "]";
-    }
-    if (!src_type.empty() && !result_type.empty()) {
-      oss << " : " << src_type << " -> " << result_type;
-    }
-    codegen.Emit(oss.str());
+    codegen.Emit(set_validshape.str());
     return std::string("");
   });
   reg("tile.assemble", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -203,9 +203,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     BindVarToMlir(tile_var, ssa_name);
 
     // Pre-populate type so body visitors (e.g., tile.reshape no-op check)
-    // can query it before per-variable alloc_tile emission runs. Tile types
-    // are always emitted with `v_row=?, v_col=?`; the actual extents flow
-    // through the alloc_tile valid_row/valid_col operands.
+    // can query it before per-variable alloc_tile emission runs.
     std::string type_str = GetTileBufTypeStringFromTileType(tile_type);
     fs_.ssa_to_tile_buf_type[ssa_name] = type_str;
 
@@ -461,10 +459,11 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
 
       // Materialize one shape dimension as an MLIR SSA value.
       auto get_shape_dim_mlir = [&](size_t dim_idx) -> std::string {
-        if (auto var = As<ir::Var>(tensor_type->shape_[dim_idx])) {
-          return GetVarName(var);
+        const auto& dim_expr = tensor_type->shape_[dim_idx];
+        if (auto const_int = As<ir::ConstInt>(dim_expr)) {
+          return GetOrEmitConstant(const_int->value_, DataType::INDEX);
         }
-        return GetOrEmitConstant(GetConstIntValue(tensor_type->shape_[dim_idx]), DataType::INDEX);
+        return EmitCastToIndex(dim_expr, GetExprAsCode(dim_expr));
       };
 
       // DN tensor views keep the original logical shape in IR typing, but the
@@ -485,6 +484,11 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
                 << " : index\n";
         return mul_name;
       };
+
+      std::vector<std::string> shape_dim_names(rank);
+      for (size_t j = 0; j < rank; ++j) {
+        shape_dim_names[j] = get_shape_dim_mlir(get_shape_source_idx(j));
+      }
 
       // For N-D (N > 2): pre-compute strides as SSA values using arith.muli.
       // ND uses standard row-major strides. DN keeps the same outer batch/page
@@ -515,6 +519,19 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         }
       }
 
+      std::vector<std::string> explicit_stride_names;
+      if (has_explicit_stride) {
+        const auto& strides = tensor_type->tensor_view_->stride;
+        explicit_stride_names.reserve(strides.size());
+        for (const auto& stride_expr : strides) {
+          if (auto const_int = As<ir::ConstInt>(stride_expr)) {
+            explicit_stride_names.push_back(GetOrEmitConstant(const_int->value_, DataType::INDEX));
+          } else {
+            explicit_stride_names.push_back(EmitCastToIndex(stride_expr, GetExprAsCode(stride_expr)));
+          }
+        }
+      }
+
       stream_ << GetIndent() << tensor_view << " = pto.make_tensor_view ";
       stream_ << GetVarName(param);
 
@@ -522,27 +539,23 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       // DN swaps the last two visible shape dimensions; ND keeps the original order.
       for (size_t j = 0; j < rank; j++) {
         if (j > 0) stream_ << ", ";
-        stream_ << get_shape_dim_mlir(get_shape_source_idx(j));
+        stream_ << shape_dim_names[j];
       }
       stream_ << "],";
 
       stream_ << " strides = [";
       if (has_explicit_stride) {
         // Use explicit strides from tensor_view_ (e.g. physical memory strides for view tensors)
-        const auto& strides = tensor_type->tensor_view_->stride;
-        for (size_t j = 0; j < strides.size(); j++) {
+        for (size_t j = 0; j < explicit_stride_names.size(); j++) {
           if (j > 0) stream_ << ", ";
-          if (auto var = As<ir::Var>(strides[j])) {
-            stream_ << GetVarName(var);
-          } else {
-            stream_ << GetOrEmitConstant(GetConstIntValue(strides[j]), DataType::INDEX);
-          }
+          stream_ << explicit_stride_names[j];
         }
       } else if (tensor_type->shape_.size() == 2) {
         // For column vector [M, 1]: stride dim is shape[0] (= M) → strides [1, M].
         // For other 2D: stride dim is shape[1] (= C) → DN [1, C] or ND [C, 1].
         int stride_idx = is_column_vector ? 0 : 1;
-        std::string row_stride = get_shape_dim_mlir(stride_idx);
+        const std::string& row_stride =
+            shape_dim_names[get_shape_source_idx(static_cast<size_t>(stride_idx))];
         if (layout_DN) {
           stream_ << GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX) << ", " << row_stride;
         } else {
@@ -590,8 +603,8 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
     const std::shared_ptr<const ir::TileType>& tile_type) {
   AllocTileFields fields;
 
-  // Type string is always dynamic (`v_row=?, v_col=?`); the actual extent is
-  // conveyed via the `valid_row` / `valid_col` operands below.
+  // Type string always uses dynamic valid dims (v_row=?, v_col=?); the actual
+  // extent is conveyed via valid_row / valid_col operands below.
   fields.type_str = GetTileBufTypeStringFromTileType(tile_type);
 
   // Cast a non-index integer SSA to `index` (PTOAS expects index typed
@@ -781,6 +794,23 @@ std::string PTOCodegen::GetSSATileBufType(const std::string& ssa_name) const {
   return it != fs_.ssa_to_tile_buf_type.end() ? it->second : std::string{};
 }
 
+void PTOCodegen::RegisterSubviewMaterialization(const std::string& subview_ssa,
+                                                const SubviewMaterializationInfo& info) {
+  fs_.subview_materializations[subview_ssa] = info;
+}
+
+PTOCodegen::SubviewMaterializationInfo* PTOCodegen::GetSubviewMaterialization(
+    const std::string& subview_ssa) {
+  auto it = fs_.subview_materializations.find(subview_ssa);
+  return it != fs_.subview_materializations.end() ? &it->second : nullptr;
+}
+
+const PTOCodegen::SubviewMaterializationInfo* PTOCodegen::GetSubviewMaterialization(
+    const std::string& subview_ssa) const {
+  auto it = fs_.subview_materializations.find(subview_ssa);
+  return it != fs_.subview_materializations.end() ? &it->second : nullptr;
+}
+
 void PTOCodegen::RecordGMSlotBufferSSA(const std::string& ssa) { fs_.gm_slot_buffer_ssa = ssa; }
 
 std::string PTOCodegen::GetGMSlotBufferSSA() const { return fs_.gm_slot_buffer_ssa; }
@@ -870,7 +900,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       // Register per-variable tile_buf type from the variable's own TileType.
       // This ensures that even when multiple variables share a MemRef, each
       // variable's SSA value carries its correct typed annotation.
-      if (result_tile_type && !fs_.current_result_buf.empty()) {
+      if (result_tile_type && !fs_.current_result_buf.empty() && fs_.current_result_buf == result_buf) {
         std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type);
         if (!var_type_str.empty()) {
           fs_.ssa_to_tile_buf_type[fs_.current_result_buf] = var_type_str;

--- a/src/codegen/pto/pto_scalar_expr_codegen.cpp
+++ b/src/codegen/pto/pto_scalar_expr_codegen.cpp
@@ -290,6 +290,23 @@ std::string PTOCodegen::EmitCastToIndex(const ir::VarPtr& var, const std::string
   return mlir_name;
 }
 
+std::string PTOCodegen::EmitCastToIndex(const ir::ExprPtr& expr, const std::string& mlir_name) {
+  if (auto var = As<ir::Var>(expr)) {
+    return EmitCastToIndex(var, mlir_name);
+  }
+  if (auto scalar_type = As<ScalarType>(expr->GetType())) {
+    CHECK(!scalar_type->dtype_.IsFloat()) << "EmitCastToIndex does not support floating-point types (got "
+                                          << GetTypeString(scalar_type->dtype_) << ")";
+    if (scalar_type->dtype_ != DataType::INDEX) {
+      std::string idx_name = NewTemp();
+      std::string src_type = GetTypeString(scalar_type->dtype_);
+      Emit(idx_name + " = arith.index_cast " + mlir_name + " : " + src_type + " to index");
+      return idx_name;
+    }
+  }
+  return mlir_name;
+}
+
 std::string PTOCodegen::EmitCastToI32(const ir::ExprPtr& expr, const std::string& mlir_name) {
   if (auto scalar_type = As<ScalarType>(expr->GetType())) {
     CHECK(!scalar_type->dtype_.IsFloat()) << "EmitCastToI32 does not support floating-point types (got "

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -125,8 +125,8 @@ TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std:
   }
   // Valid extent is always conveyed dynamically via `valid_row` / `valid_col`
   // operands on `pto.alloc_tile`; the type string therefore always reads
-  // `v_row=?, v_col=?`. The numeric `v_row` / `v_col` fields below are kept
-  // for symmetry but are ignored by the formatter when *_dynamic is true.
+  // `v_row=?, v_col=?`.  Subview result types infer static valid dims via
+  // InferSubviewTileTypeComponents (in pto_ops_common.cpp) separately.
   c.v_row = c.rows;
   c.v_col = c.cols;
   c.v_row_dynamic = true;

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -333,12 +333,11 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     # Both share the same addr (same MemRef)
     assert "addr = %c0_i64" in alloc_lines[0]
     assert "addr = %c0_i64" in alloc_lines[1]
-    # All alloc_tile types are emitted with v_row=?, v_col=? in the unified
-    # always-dynamic codegen. The actual extents are conveyed via
-    # valid_row / valid_col operands.
+    # All alloc_tile types use dynamic v_row=?, v_col=?; the actual extents
+    # are conveyed via the valid_row / valid_col operands.
     assert "v_row=?" in alloc_lines[0], f"Expected dynamic v_row=? in alloc: {alloc_lines[0]}"
     assert "v_col=?" in alloc_lines[0], f"Expected dynamic v_col=? in alloc: {alloc_lines[0]}"
-    # Padded tile carries the same dynamic v_row=?/v_col=? type, retains pad=2,
+    # Padded tile carries dynamic v_row=?/v_col=? type, retains pad=2,
     # and sources its valid_row/valid_col operands from the physical dims.
     assert "pad=2>" in alloc_lines[1], f"Expected fillpad pad metadata to be preserved: {alloc_lines[1]}"
     assert "v_row=?" in alloc_lines[1], f"Expected dynamic v_row=? in padded tile: {alloc_lines[1]}"
@@ -1551,8 +1550,8 @@ def test_pto_codegen_mixed_scalar_and_tile_iter_args():
 
 def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
     """Slice with partially dynamic valid_shape followed by fillpad must lower
-    to a single pto.subview (no spurious extra alloc) and feed a dynamic
-    valid_shape tile into pto.tfillpad."""
+    without a scratch slice alloc, and feed a dynamic valid_shape tile into
+    pto.tfillpad."""
 
     @pl.program
     class SliceFillpadProgram:
@@ -1579,19 +1578,76 @@ def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
     ), f"Unexpected slice_buf alloc_tile — pto.subview is a view, no extra buffer needed.\n{mlir_code}"
     assert "pto.textract" not in mlir_code, f"tile.slice no longer emits pto.textract, got:\n{mlir_code}"
 
-    # Exactly one pto.subview should carry the dynamic `valid [...]` operand
-    # corresponding to the partially-dynamic valid_shape on tile.slice.
+    # Full-window slice with explicit valid_shape lowers via data-preserving
+    # pto.tmov plus a follow-up pto.set_validshape.
     subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
-    assert len(subview_lines) == 1, f"Expected one pto.subview, got: {subview_lines}"
-    assert "valid [" in subview_lines[0], (
-        f"pto.subview should carry a `valid [...]` clause for dynamic valid_shape: {subview_lines[0]}"
-    )
+    assert len(subview_lines) == 0, f"Full-window slice should not emit pto.subview, got: {subview_lines}"
+    tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
+    assert len(tmov_lines) == 1, f"Expected one pto.tmov for full-window slice, got: {tmov_lines}"
+    set_validshape_lines = [line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line]
+    assert len(set_validshape_lines) == 1, f"Expected one pto.set_validshape, got: {set_validshape_lines}"
 
     # All tile_buf types use the always-dynamic `v_row=?, v_col=?` form.
     fillpad_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tfillpad" in line]
     assert len(fillpad_lines) == 1, f"Expected one tfillpad, got: {fillpad_lines}"
     assert "v_row=?" in fillpad_lines[0], f"fillpad input should have v_row=?: {fillpad_lines[0]}"
     assert "v_col=?" in fillpad_lines[0], f"fillpad input should have v_col=?: {fillpad_lines[0]}"
+
+
+def test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_set_validshape():
+    """Full-window slice with runtime valid rows should lower via tmov +
+    set_validshape rather than a subview `valid [...]` clause."""
+
+    @pl.program
+    class FullWindowSliceProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            scores_in: pl.Tensor[[16, 256], pl.BF16],
+            valid_rows: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[16, 256], pl.BF16]],
+        ) -> pl.Tensor[[16, 256], pl.BF16]:
+            scores: pl.Tile[[16, 256], pl.BF16] = pl.load(scores_in, [0, 0], [16, 256])
+            trimmed: pl.Tile[[16, 256], pl.BF16] = pl.tile.slice(
+                scores, [16, 256], [0, 0], valid_shape=[valid_rows, 256]
+            )
+            return pl.store(trimmed, [0, 0], out)
+
+    mlir_code = _generate_default_mlir(FullWindowSliceProgram)
+    subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
+    assert len(subview_lines) == 0, f"Full-window slice should not emit pto.subview, got: {subview_lines}"
+    tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
+    assert len(tmov_lines) == 1, f"Expected one pto.tmov for full-window slice, got: {tmov_lines}"
+
+    set_validshape_lines = [line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line]
+    assert len(set_validshape_lines) == 1, f"Expected one pto.set_validshape, got: {set_validshape_lines}"
+    assert "valid_rows" in set_validshape_lines[0] or "%arg2" in set_validshape_lines[0], (
+        f"Runtime valid_rows should feed pto.set_validshape: {set_validshape_lines[0]}"
+    )
+
+
+def test_pto_codegen_slice_static_subwindow_binds_subview_result():
+    """Static subwindow slice without explicit valid_shape should remain a
+    true pto.subview SSA result and avoid a materializing pto.tmov."""
+
+    @pl.program
+    class StaticSubviewProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            scores_in: pl.Tensor[[5, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[5, 64], pl.FP32]],
+        ) -> pl.Tensor[[5, 64], pl.FP32]:
+            scores: pl.Tile[[5, 128], pl.FP32] = pl.load(scores_in, [0, 0], [5, 128])
+            sliced: pl.Tile[[5, 64], pl.FP32] = pl.tile.slice(scores, [5, 64], [0, 0])
+            return pl.store(sliced, [0, 0], out)
+
+    mlir_code = _generate_default_mlir(StaticSubviewProgram)
+    subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
+    assert len(subview_lines) == 1, f"Expected one pto.subview, got: {subview_lines}"
+    assert "rows=5, cols=64" in subview_lines[0], f"Subview result type should be 5x64: {subview_lines[0]}"
+    tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
+    assert len(tmov_lines) == 0, f"Static subwindow view should not materialize a pto.tmov, got: {tmov_lines}"
 
 
 class TestColumnVectorCodegen:
@@ -1811,6 +1867,53 @@ def test_pto_codegen_view_output_uses_physical_stride():
     a_view_lines = _find_lines(lines, "pto.make_tensor_view %arg0")
     assert len(a_view_lines) == 1
     assert "strides = [%c128_index, %c1_index]" in a_view_lines[0]
+
+
+def test_pto_codegen_make_tensor_view_accepts_dynamic_shape_expressions():
+    """make_tensor_view should lower non-Var dynamic shape/stride expressions via index casts."""
+    span = ir.Span.unknown()
+    th = ir.Var("TH", ir.ScalarType(DataType.INT64), span)
+    tw = ir.Var("TW", ir.ScalarType(DataType.INT64), span)
+    one = ir.ConstInt(1, DataType.INT64, span)
+    th_plus_one = ir.add(th, one, span)
+    tw_plus_one = ir.add(tw, one, span)
+
+    tv = ir.TensorView(stride=[tw_plus_one, one], layout=ir.TensorLayout.ND)
+    dyn_tensor_type = ir.TensorType([th_plus_one, tw], DataType.FP32, memref=None, tensor_view=tv)
+
+    inp = ir.Var("inp", dyn_tensor_type, span)
+    out = ir.Var("out", dyn_tensor_type, span)
+    tile_type = ir.op.tile.load(inp, [0, 0], [8, 8]).type
+    tile_var = ir.Var("t", tile_type, span)
+    result_var = ir.Var("result", dyn_tensor_type, span)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(tile_var, ir.op.tile.load(inp, [0, 0], [8, 8]), span),
+            ir.AssignStmt(result_var, ir.op.tile.store(tile_var, [0, 0], out), span),
+            ir.ReturnStmt([result_var], span),
+        ],
+        span,
+    )
+
+    func = ir.Function(
+        "kernel",
+        [inp, out, th, tw],
+        [dyn_tensor_type],
+        body,
+        span,
+        ir.FunctionType.InCore,
+    )
+    program = ir.Program([func], "DynamicViewExprTest", span)
+    mlir_code = _generate_mlir(program)
+    lines = _get_mlir_lines(mlir_code)
+
+    assert "Expected ConstInt expression" not in mlir_code
+    view_line = _single_line(lines, "pto.make_tensor_view %arg0")
+    assert "shape = [" in view_line and "strides = [" in view_line
+    index_cast_lines = _find_lines(lines, "arith.index_cast")
+    assert index_cast_lines, (
+        f"Expected dynamic shape/stride expressions to be cast to index. Got:\n{mlir_code}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -837,7 +837,7 @@ class TestTileSliceCodegen:
         assert "rows=16, cols=16" in line, f"result tile_buf must carry rows=16, cols=16, got:\n{line}"
 
     def test_tile_slice_codegen_with_valid_shape(self):
-        """tile.slice(..., valid_shape=...) emits pto.subview with `valid` operands."""
+        """tile.slice(..., valid_shape=...) emits pto.subview + pto.tmov + pto.set_validshape."""
 
         @pl.program
         class Prog:
@@ -856,12 +856,12 @@ class TestTileSliceCodegen:
 
         mlir = self._generate_mlir(Prog)
         assert "pto.subview" in mlir, f"tile.slice with valid_shape should generate pto.subview, got:\n{mlir}"
-        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
-        assert subview_lines, "no pto.subview line emitted"
-        # The `valid [...]` clause must be present when valid_shape is given.
-        assert any("valid [" in line for line in subview_lines), (
-            "pto.subview should carry `valid [...]` operands, got:\n" + "\n".join(subview_lines)
-        )
+        # With explicit valid_shape, tile.slice emits subview + tmov + set_validshape
+        # instead of a subview with `valid [...]` clause.
+        tmov_lines = [line for line in mlir.splitlines() if "pto.tmov" in line]
+        assert tmov_lines, f"Expected pto.tmov after subview for valid_shape slice, got:\n{mlir}"
+        set_vs_lines = [line for line in mlir.splitlines() if "pto.set_validshape" in line]
+        assert set_vs_lines, f"Expected pto.set_validshape for valid_shape slice, got:\n{mlir}"
 
     def test_tile_slice_multiple_slices_have_correct_types(self):
         """Multiple tile.slice from one reshape must produce correct type annotations.


### PR DESCRIPTION
## Summary
- Rewrite tile.slice codegen to use `pto.tmov` + `pto.set_validshape` instead of `pto.subview valid [...]` clause; full-window slices (offset=0, shape=source) emit tmov directly, partial slices defer materialization via SubviewMaterializationInfo
- Add deferred subview materialization for `pto.tcolexpandmul`: its hardware lowering reads physical tile dims from the operand type, which is incorrect for a subview alias, so emit `pto.textract` on demand before the op
- Fix `make_tensor_view` to handle non-Var dynamic shape/stride expressions (e.g. `add(TH, 1)`) by emitting `arith.index_cast` via new `EmitCastToIndex(ExprPtr)` overload, instead of crashing with "Expected ConstInt expression"
- Fix result buf type registration guard to only overwrite when `current_result_buf == result_buf`, preventing subview SSA rebinding from clobbering the correct type annotation
- Add `InferSubviewTileTypeComponents` for static subview type inference with layout/valid-dim propagation from source tile type

## Testing
- [x] Updated existing tile.slice and fillpad tests for new tmov+set_validshape lowering
- [x] Added test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_set_validshape
- [x] Added test_pto_codegen_slice_static_subwindow_binds_subview_result
- [x] Added test_pto_codegen_make_tensor_view_accepts_dynamic_shape_expressions