### PR TITLE
feat(ir): Add tile.extract op (ISA TEXTRACT Variant 1)

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -255,7 +255,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations |
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape and optional dynamic valid_shape |
-| - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right/Scale, Acc→Mat) |
+| - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |
 | - | `tile.reshape` | Reshape tile to new dimensions (element count must match) |
 | - | `tile.transpose` | Swap two axes of a tile |
 | - | `tile.set_validshape` | Update valid-shape metadata without data movement |

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -255,6 +255,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations |
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape and optional dynamic valid_shape |
+| - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right/Scale, Acc→Mat) |
 | - | `tile.reshape` | Reshape tile to new dimensions (element count must match) |
 | - | `tile.transpose` | Swap two axes of a tile |
 | - | `tile.set_validshape` | Update valid-shape metadata without data movement |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -252,6 +252,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
+| - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right/Scale，Acc→Mat） |
 | - | `tile.reshape` | 重塑 tile 维度（元素总数须一致） |
 | - | `tile.transpose` | 交换 tile 的两个轴 |
 | - | `tile.set_validshape` | 更新 valid_shape 元数据，不搬移数据 |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -252,7 +252,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
-| - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right/Scale，Acc→Mat） |
+| - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat） |
 | - | `tile.reshape` | 重塑 tile 维度（元素总数须一致） |
 | - | `tile.transpose` | 交换 tile 的两个轴 |
 | - | `tile.set_validshape` | 更新 valid_shape 元数据，不搬移数据 |

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2019,6 +2019,43 @@ def slice(
     return _ir_core.create_op_call("tile.slice", args, kwargs, actual_span)
 
 
+def extract(
+    src: Expr,
+    index_row: int | Expr,
+    index_col: int | Expr,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
+    *,
+    target_memory: MemorySpace,
+    span: Span | None = None,
+) -> Call:
+    """Extract a sub-tile from src at (index_row, index_col).
+
+    Maps to ISA TEXTRACT Variant 1 (Standard Extract). The result tile has the
+    given static ``shape`` and lives in ``target_memory``.
+
+    Args:
+        src: Source tile expression (TileType, 2D)
+        index_row: Starting row offset (int or Expr)
+        index_col: Starting col offset (int or Expr)
+        shape: Static destination shape (2-element sequence or MakeTuple of ConstInt)
+        target_memory: Destination memory space (Left/Right/Scale/ScaleLeft/ScaleRight/Mat)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression with TileType[shape, src.dtype] in target_memory
+    """
+    actual_span = _get_span_or_capture(span)
+    shape_tuple = _to_make_tuple(shape, actual_span)
+    row_expr = _normalize_expr(index_row, actual_span, int_dtype=DataType.INDEX)
+    col_expr = _normalize_expr(index_col, actual_span, int_dtype=DataType.INDEX)
+    return _ir_core.create_op_call(
+        "tile.extract",
+        [src, row_expr, col_expr, shape_tuple],
+        {"target_memory": target_memory},
+        actual_span,
+    )
+
+
 def reshape(
     tile: Expr,
     shape: Sequence[int | Expr] | _ir_core.MakeTuple,

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2038,7 +2038,7 @@ def extract(
         index_row: Starting row offset (int or Expr)
         index_col: Starting col offset (int or Expr)
         shape: Static destination shape (2-element sequence or MakeTuple of ConstInt)
-        target_memory: Destination memory space (Left/Right/Scale/ScaleLeft/ScaleRight/Mat)
+        target_memory: Destination memory space (Left/Right for Mat sources, Mat for Acc sources)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -350,7 +350,7 @@ def extract(
     src: Tile,
     index_row: IntLike,
     index_col: IntLike,
-    shape: Sequence[int],
+    shape: Sequence[IntLike],
     *,
     target_memory: MemorySpace,
 ) -> Tile:
@@ -361,8 +361,8 @@ def extract(
         index_row: Starting row offset
         index_col: Starting col offset
         shape: Static 2D shape of the extracted sub-tile
-        target_memory: Destination memory space
-            (``Left`` / ``Right`` / ``Scale`` / ``ScaleLeft`` / ``ScaleRight`` / ``Mat``)
+        target_memory: Destination memory space —
+            ``Left`` / ``Right`` for Mat sources, ``Mat`` for Acc sources
 
     Returns:
         Tile of the requested shape in ``target_memory``

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -29,6 +29,7 @@ __all__ = [
     "load",
     "store",
     "assemble",
+    "extract",
     "scatter_update",
     "concat",
     "move",
@@ -342,6 +343,38 @@ def assemble(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile:
         Tile wrapping the assemble operation
     """
     call_expr = _ir_ops.assemble(target.unwrap(), source.unwrap(), _normalize_intlike(offset))
+    return Tile(expr=call_expr)
+
+
+def extract(
+    src: Tile,
+    index_row: IntLike,
+    index_col: IntLike,
+    shape: Sequence[int],
+    *,
+    target_memory: MemorySpace,
+) -> Tile:
+    """Extract a sub-tile from ``src`` at ``(index_row, index_col)`` — ISA TEXTRACT.
+
+    Args:
+        src: Source tile (typically in Mat or Acc memory)
+        index_row: Starting row offset
+        index_col: Starting col offset
+        shape: Static 2D shape of the extracted sub-tile
+        target_memory: Destination memory space
+            (``Left`` / ``Right`` / ``Scale`` / ``ScaleLeft`` / ``ScaleRight`` / ``Mat``)
+
+    Returns:
+        Tile of the requested shape in ``target_memory``
+    """
+    [row, col] = _normalize_intlike([index_row, index_col])
+    call_expr = _ir_ops.extract(
+        src.unwrap(),
+        row,
+        col,
+        shape=_normalize_intlike(shape),
+        target_memory=target_memory,
+    )
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2130,6 +2130,12 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
     std::string row_off = codegen.GetExprAsCode(op->args_[1]);
     std::string col_off = codegen.GetExprAsCode(op->args_[2]);
+    // Use the actual offset SSA dtype (`index` / `i64` / `i32` ...) — the IR
+    // type-check accepts any IndexLike scalar, so don't hardcode `index`.
+    std::string row_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+    std::string col_type = codegen.GetExprTypeAnnotation(op->args_[2]);
+    if (row_type.empty()) row_type = "index";
+    if (col_type.empty()) col_type = "index";
     // args_[3] is the shape tuple: type-deduction only, no PTO operand.
 
     std::string result_target = codegen.GetCurrentResultTarget();
@@ -2146,7 +2152,7 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     std::ostringstream oss;
     oss << "pto.textract ins(" << src << ", " << row_off << ", " << col_off;
     if (!src_type.empty()) {
-      oss << " : " << src_type << ", index, index";
+      oss << " : " << src_type << ", " << row_type << ", " << col_type;
     }
     oss << ") outs(" << result_target;
     if (!result_type.empty()) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1713,7 +1713,9 @@ static const SimpleOpEntry kSimpleOps[] = {
     // tile.transpose has custom codegen (MakeTileTransposeCodegenPTO): pto.ttrans needs
     // ins(%src, %tmp : tile_type, tile_type) where %tmp is a scratch workspace tile, NOT
     // the axis-index integers that tile.transpose(src, axis0, axis1) carries in the IR.
-    {"tile.extract",         "pto.textract",         3},
+    // tile.extract has custom codegen (see reg("tile.extract") below): the IR carries the
+    // shape tuple as args_[3] purely for type deduction, so the generic N-ary lowering
+    // would emit the tuple as a PTO operand — not what pto.textract expects.
     // Gather/scatter operations
     {"tile.gather",          "pto.tgather",          3},
     {"tile.gatherb",         "pto.tgatherb",         2},
@@ -2117,6 +2119,42 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.assemble", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileAssembleCodegenPTO(op, codegen);
+  });
+  reg("tile.extract", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 4)
+        << "tile.extract requires 4 arguments (src, index_row, index_col, shape), but got "
+        << op->args_.size();
+
+    std::string src = codegen.GetExprAsCode(op->args_[0]);
+    std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+    std::string row_off = codegen.GetExprAsCode(op->args_[1]);
+    std::string col_off = codegen.GetExprAsCode(op->args_[2]);
+    // args_[3] is the shape tuple: type-deduction only, no PTO operand.
+
+    std::string result_target = codegen.GetCurrentResultTarget();
+    std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
+
+    auto existing_type = codegen.GetSSATileBufType(result_target);
+    if (!result_type.empty() && existing_type != result_type) {
+      result_target = codegen.AllocNewTileBuf(result_type, "extract_buf");
+      codegen.SetCurrentResultBuf(result_target);
+    } else if (!result_type.empty()) {
+      codegen.RegisterTileBufType(result_target, result_type);
+    }
+
+    std::ostringstream oss;
+    oss << "pto.textract ins(" << src << ", " << row_off << ", " << col_off;
+    if (!src_type.empty()) {
+      oss << " : " << src_type << ", index, index";
+    }
+    oss << ") outs(" << result_target;
+    if (!result_type.empty()) {
+      oss << " : " << result_type;
+    }
+    oss << ")";
+    codegen.Emit(oss.str());
+    return std::string("");
   });
   reg("tile.reshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -410,6 +410,82 @@ REGISTER_OP("tile.assemble")
       return DeduceTileAssembleType(args, kwargs);
     });
 
+TypePtr DeduceTileExtractType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.extract(src, index_row, index_col, shape) — ISA TEXTRACT Variant 1.
+  // shape carries the static destination shape (2D MakeTuple of ConstInt).
+  // target_memory kwarg drives the destination memory space.
+  CHECK(args.size() == 4) << "tile.extract requires exactly 4 arguments "
+                          << "(src, index_row, index_col, shape), but got " << args.size();
+
+  auto src_type = As<TileType>(args[0]->GetType());
+  CHECK(src_type) << "tile.extract requires src to be a TileType, but got " << args[0]->GetType()->TypeName();
+  CHECK(src_type->shape_.size() == 2)
+      << "tile.extract requires a 2D source tile, but got rank " << src_type->shape_.size();
+
+  for (size_t i = 1; i <= 2; ++i) {
+    auto idx_type = As<ScalarType>(args[i]->GetType());
+    const char* name = (i == 1) ? "index_row" : "index_col";
+    CHECK(idx_type) << "tile.extract " << name << " must be ScalarType, but got "
+                    << args[i]->GetType()->TypeName();
+    CHECK(idx_type->dtype_.IsIndexLike())
+        << "tile.extract " << name << " must have INT64/UINT64/INDEX dtype, but got "
+        << idx_type->dtype_.ToString();
+  }
+
+  auto shape_tuple_type = As<TupleType>(args[3]->GetType());
+  CHECK(shape_tuple_type) << "tile.extract shape must be TupleType, but got "
+                          << args[3]->GetType()->TypeName();
+  ValidateIndexTupleElements(shape_tuple_type, "tile.extract", "shape");
+
+  auto shape_tuple = As<MakeTuple>(args[3]);
+  CHECK(shape_tuple) << "tile.extract shape must be a literal MakeTuple of ConstInt";
+  CHECK(shape_tuple->elements_.size() == 2)
+      << "tile.extract shape must be 2D, got rank " << shape_tuple->elements_.size();
+
+  std::vector<ExprPtr> dst_shape;
+  dst_shape.reserve(2);
+  for (size_t i = 0; i < 2; ++i) {
+    auto c = As<ConstInt>(shape_tuple->elements_[i]);
+    CHECK(c) << "tile.extract shape[" << i << "] must be a compile-time ConstInt";
+    CHECK(c->value_ > 0) << "tile.extract shape[" << i << "] must be positive, got " << c->value_;
+    dst_shape.push_back(shape_tuple->elements_[i]);
+  }
+
+  // Static-bounds check when both src dim and dst dim are constants.
+  auto src_r = As<ConstInt>(src_type->shape_[0]);
+  auto dst_r = As<ConstInt>(dst_shape[0]);
+  if (src_r && dst_r) {
+    CHECK(dst_r->value_ <= src_r->value_)
+        << "tile.extract shape[0]=" << dst_r->value_ << " exceeds src rows " << src_r->value_;
+  }
+  auto src_c = As<ConstInt>(src_type->shape_[1]);
+  auto dst_c = As<ConstInt>(dst_shape[1]);
+  if (src_c && dst_c) {
+    CHECK(dst_c->value_ <= src_c->value_)
+        << "tile.extract shape[1]=" << dst_c->value_ << " exceeds src cols " << src_c->value_;
+  }
+
+  TileView tile_view;
+  tile_view.valid_shape = dst_shape;
+  tile_view.blayout = InferTileLayoutFromShape(dst_shape);
+  return std::make_shared<TileType>(dst_shape, src_type->dtype_, std::nullopt, tile_view);
+}
+
+REGISTER_OP("tile.extract")
+    .set_op_category("TileOp")
+    .set_description("Extract a sub-tile from src at (index_row, index_col) — ISA TEXTRACT Variant 1")
+    .add_argument("src", "Source tile (TileType, 2D; typically Mat or Acc memory)")
+    .add_argument("index_row", "Starting row offset (ScalarType INT64/UINT64/INDEX)")
+    .add_argument("index_col", "Starting col offset (ScalarType INT64/UINT64/INDEX)")
+    .add_argument("shape", "Static destination shape (TupleType, 2D MakeTuple of ConstInt)")
+    .set_attr<MemorySpace>("target_memory")
+    .set_output_memory_from_kwarg("target_memory", MemorySpace::Vec)
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileExtractType(args, kwargs);
+    });
+
 TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
                                     const std::vector<std::pair<std::string, std::any>>& kwargs) {
   // tile.scatter_update(input, index, src) -> TileType same as input

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -452,19 +452,23 @@ TypePtr DeduceTileExtractType(const std::vector<ExprPtr>& args,
     dst_shape.push_back(shape_tuple->elements_[i]);
   }
 
-  // Static-bounds check when both src dim and dst dim are constants.
-  auto src_r = As<ConstInt>(src_type->shape_[0]);
-  auto dst_r = As<ConstInt>(dst_shape[0]);
-  if (src_r && dst_r) {
-    CHECK(dst_r->value_ <= src_r->value_)
-        << "tile.extract shape[0]=" << dst_r->value_ << " exceeds src rows " << src_r->value_;
-  }
-  auto src_c = As<ConstInt>(src_type->shape_[1]);
-  auto dst_c = As<ConstInt>(dst_shape[1]);
-  if (src_c && dst_c) {
-    CHECK(dst_c->value_ <= src_c->value_)
-        << "tile.extract shape[1]=" << dst_c->value_ << " exceeds src cols " << src_c->value_;
-  }
+  // Static-bounds check: when src dim, dst dim, and offset are all constants,
+  // verify offset + dst_shape <= src_shape per ISA TEXTRACT bounds rule.
+  auto check_axis = [&](size_t axis, const char* axis_name, const ExprPtr& offset_arg) {
+    auto src_dim = As<ConstInt>(src_type->shape_[axis]);
+    auto dst_dim = As<ConstInt>(dst_shape[axis]);
+    if (!src_dim || !dst_dim) return;
+    CHECK(dst_dim->value_ <= src_dim->value_) << "tile.extract shape[" << axis << "]=" << dst_dim->value_
+                                              << " exceeds src " << axis_name << " " << src_dim->value_;
+    auto off = As<ConstInt>(offset_arg);
+    if (!off) return;
+    CHECK(off->value_ >= 0) << "tile.extract index_" << axis_name << " must be >= 0, got " << off->value_;
+    CHECK(off->value_ + dst_dim->value_ <= src_dim->value_)
+        << "tile.extract index_" << axis_name << "=" << off->value_ << " + shape[" << axis
+        << "]=" << dst_dim->value_ << " exceeds src " << axis_name << " " << src_dim->value_;
+  };
+  check_axis(0, "row", args[1]);
+  check_axis(1, "col", args[2]);
 
   TileView tile_view;
   tile_view.valid_shape = dst_shape;

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1320,5 +1320,60 @@ class TestColReductionCodegen:
         assert "pto.tcolmin" in mlir, f"Expected pto.tcolmin in codegen output:\n{mlir}"
 
 
+class TestTileExtractCodegen:
+    """Tests for tile.extract PTO code generation (pto.textract)."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        # ExpandMixedKernel may wrap the kernel in a Group function plus AIC/AIV
+        # variants. PTOCodegen rejects Group; pick the first InCore-variant func.
+        target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
+        single = ir.Program([target], target.name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_extract_acc_to_mat_emits_pto_textract(self):
+        """tile.extract from an Acc-source tile to Mat lowers to pto.textract."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[32, 128], pl.BF16],
+                y: pl.Tensor[[128, 32], pl.BF16],
+                dst: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                x_mat = pl.load(x, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+                y_mat = pl.load(y, [0, 0], [128, 32], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                acc: pl.Tile[[32, 32], pl.FP32] = pl.matmul(x_left, y_right)
+                sub: pl.Tile[[16, 16], pl.FP32] = pl.tile.extract(
+                    acc, 0, 0, shape=[16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                vec = pl.move(sub, target_memory=pl.MemorySpace.Vec)
+                return pl.store(vec, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.textract" in mlir, f"Expected pto.textract in:\n{mlir}"
+
+        textract_lines = [line.strip() for line in mlir.splitlines() if "pto.textract" in line]
+        assert textract_lines, "no pto.textract line emitted"
+        line = textract_lines[0]
+        assert "ins(" in line and "outs(" in line, f"DPS form expected, got: {line}"
+        ins_clause = line.split("ins(", 1)[1].split(")", 1)[0]
+        operand_count = ins_clause.split(":", 1)[0].count(",") + 1
+        assert operand_count == 3, (
+            f"pto.textract should have 3 ins operands (src, row, col), got {operand_count}: {line}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2182,11 +2182,17 @@ class TestTileExtractOp:
     """Tests for tile.extract operator (ISA TEXTRACT Variant 1)."""
 
     @staticmethod
-    def _make_src_var(rows: int = 64, cols: int = 256, dtype: DataType = DataType.FP16) -> ir.Var:
+    def _make_src_var(
+        rows: int = 64,
+        cols: int = 256,
+        dtype: DataType = DataType.FP16,
+        memory_space: ir.MemorySpace | None = None,
+    ) -> ir.Var:
         span = ir.Span.unknown()
         r = ir.ConstInt(rows, DataType.INT32, span)
         c = ir.ConstInt(cols, DataType.INT32, span)
-        return ir.Var("src", ir.TileType([r, c], dtype), span)
+        tile_type = ir.TileType([r, c], dtype, memory_space=memory_space)
+        return ir.Var("src", tile_type, span)
 
     def test_tile_extract_basic(self):
         """tile.extract returns a TileType with the requested shape and src dtype."""
@@ -2205,8 +2211,11 @@ class TestTileExtractOp:
         assert isinstance(cols, ir.ConstInt) and cols.value == 64
 
     def test_tile_extract_acc_to_mat(self):
-        """Acc-source → Mat-target dtype is preserved."""
-        src_var = self._make_src_var(64, 64, DataType.FP32)
+        """Acc source → Mat target: src lives in Acc, dtype preserved."""
+        src_var = self._make_src_var(64, 64, DataType.FP32, memory_space=ir.MemorySpace.Acc)
+        src_tile_type = src_var.type
+        assert isinstance(src_tile_type, ir.TileType)
+        assert src_tile_type.memory_space == ir.MemorySpace.Acc
 
         call = tile.extract(src_var, 0, 0, shape=[32, 32], target_memory=ir.MemorySpace.Mat)
 
@@ -2240,6 +2249,21 @@ class TestTileExtractOp:
 
         with pytest.raises(ValueError, match="exceeds src"):
             tile.extract(src_var, 0, 0, shape=[128, 128], target_memory=ir.MemorySpace.Left)
+
+    def test_tile_extract_offset_plus_shape_exceeds_src_static(self):
+        """Constant offset + shape that walks past src is rejected at deduction."""
+        src_var = self._make_src_var(64, 64)
+
+        # offset 60 + shape 16 = 76 > 64 rows
+        with pytest.raises(ValueError, match="exceeds src row"):
+            tile.extract(src_var, 60, 0, shape=[16, 16], target_memory=ir.MemorySpace.Left)
+
+    def test_tile_extract_negative_offset_static(self):
+        """Constant negative offset is rejected at deduction."""
+        src_var = self._make_src_var(64, 64)
+
+        with pytest.raises(ValueError, match="must be >= 0"):
+            tile.extract(src_var, -1, 0, shape=[16, 16], target_memory=ir.MemorySpace.Left)
 
     def test_tile_extract_rejects_non_index_offset(self):
         """index_row/col must be INT64/UINT64/INDEX."""

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2178,6 +2178,95 @@ class TestTileAssembleOp:
             tile.assemble(target_var, source_var, [0, 0])
 
 
+class TestTileExtractOp:
+    """Tests for tile.extract operator (ISA TEXTRACT Variant 1)."""
+
+    @staticmethod
+    def _make_src_var(rows: int = 64, cols: int = 256, dtype: DataType = DataType.FP16) -> ir.Var:
+        span = ir.Span.unknown()
+        r = ir.ConstInt(rows, DataType.INT32, span)
+        c = ir.ConstInt(cols, DataType.INT32, span)
+        return ir.Var("src", ir.TileType([r, c], dtype), span)
+
+    def test_tile_extract_basic(self):
+        """tile.extract returns a TileType with the requested shape and src dtype."""
+        src_var = self._make_src_var()
+
+        call = tile.extract(src_var, 0, 0, shape=[64, 64], target_memory=ir.MemorySpace.Left)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.extract"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP16
+        assert len(result_type.shape) == 2
+        rows, cols = result_type.shape
+        assert isinstance(rows, ir.ConstInt) and rows.value == 64
+        assert isinstance(cols, ir.ConstInt) and cols.value == 64
+
+    def test_tile_extract_acc_to_mat(self):
+        """Acc-source → Mat-target dtype is preserved."""
+        src_var = self._make_src_var(64, 64, DataType.FP32)
+
+        call = tile.extract(src_var, 0, 0, shape=[32, 32], target_memory=ir.MemorySpace.Mat)
+
+        assert call.op.name == "tile.extract"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP32
+        rows, cols = result_type.shape
+        assert isinstance(rows, ir.ConstInt) and rows.value == 32
+        assert isinstance(cols, ir.ConstInt) and cols.value == 32
+
+    def test_tile_extract_dynamic_offset(self):
+        """Runtime symbolic offsets are accepted (no compile-time bounds check fires)."""
+        span = ir.Span.unknown()
+        src_var = self._make_src_var()
+        row = ir.Var("row", ir.ScalarType(DataType.INDEX), span)
+        col = ir.Var("col", ir.ScalarType(DataType.INDEX), span)
+
+        call = tile.extract(src_var, row, col, shape=[16, 16], target_memory=ir.MemorySpace.Left)
+
+        assert call.op.name == "tile.extract"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        rows, cols = result_type.shape
+        assert isinstance(rows, ir.ConstInt) and rows.value == 16
+        assert isinstance(cols, ir.ConstInt) and cols.value == 16
+
+    def test_tile_extract_shape_exceeds_src_static(self):
+        """Static shape larger than src is rejected at deduction time."""
+        src_var = self._make_src_var(64, 64)
+
+        with pytest.raises(ValueError, match="exceeds src"):
+            tile.extract(src_var, 0, 0, shape=[128, 128], target_memory=ir.MemorySpace.Left)
+
+    def test_tile_extract_rejects_non_index_offset(self):
+        """index_row/col must be INT64/UINT64/INDEX."""
+        span = ir.Span.unknown()
+        src_var = self._make_src_var()
+        bad = ir.Var("bad", ir.ScalarType(DataType.FP32), span)
+
+        with pytest.raises(ValueError, match="INT64/UINT64/INDEX"):
+            tile.extract(src_var, bad, 0, shape=[16, 16], target_memory=ir.MemorySpace.Left)
+
+    def test_tile_extract_rejects_dynamic_shape(self):
+        """shape elements must be compile-time ConstInt for storage allocation."""
+        span = ir.Span.unknown()
+        src_var = self._make_src_var()
+        dyn = ir.Var("dyn", ir.ScalarType(DataType.INDEX), span)
+
+        with pytest.raises(ValueError, match="compile-time ConstInt"):
+            tile.extract(src_var, 0, 0, shape=[dyn, 16], target_memory=ir.MemorySpace.Left)
+
+    def test_tile_extract_rejects_non_2d_shape(self):
+        """shape must be 2D."""
+        src_var = self._make_src_var()
+
+        with pytest.raises(ValueError, match="2D"):
+            tile.extract(src_var, 0, 0, shape=[16, 16, 16], target_memory=ir.MemorySpace.Left)
+
+
 class TestTileScatterUpdateOps:
     """Test suite for tile.scatter_update operation."""
 


### PR DESCRIPTION
## Summary

Adds `tile.extract(src, index_row, index_col, shape, *, target_memory)` — the SSA-form counterpart to `tile.assemble` (TINSERT). Lowers to `pto.textract`, exposing ISA TEXTRACT Standard Extract semantics for sub-tile extraction across architectural memory transitions:

- Mat → Left / Right / Scale / ScaleLeft / ScaleRight (MX block-format extraction)
- Acc → Mat (accumulator readout)

The `kSimpleOps` reservation for `tile.extract` was previously unwired (no `REGISTER_OP` registration existed). This PR adds the IR-level registration plus a custom codegen handler that drops the type-deduction-only shape `MakeTuple` from the emitted PTO operands.

### Example

```python
sub: pl.Tile[[16, 16], pl.FP32] = pl.tile.extract(
    acc, 0, 0, shape=(16, 16), target_memory=pl.MemorySpace.Mat
)
```

## Files Changed

| Layer | File |
|-------|------|
| IR registration | `src/ir/op/tile_ops/transform.cpp` |
| PTO codegen | `src/backend/common/pto_ops_common.cpp` |
| Python IR wrapper | `python/pypto/ir/op/tile_ops.py` |
| Python DSL wrapper | `python/pypto/language/op/tile_ops.py` |
| Unit tests (7) | `tests/ut/ir/operators/test_tile_ops.py` |
| Codegen test | `tests/ut/codegen/test_pto_codegen_ops.py` |
| Operator docs (en + zh-cn) | `docs/{en,zh-cn}/dev/ir/05-operators.md` |

## Design Notes

- **`shape` is positional, `target_memory` is kwarg.** `set_attr<T>` whitelist excludes `ExprPtr`/`MakeTuple`, so `shape` rides as the 4th positional `MakeTuple` arg. The custom codegen consumes only the first three operands and ignores `args[3]` — same idea as `tile.slice`'s custom codegen.
- **Variants 2-4 (ReLU, Scalar-Quant, Fix-Pipe) deferred.** Each adds operands or attrs (ReluPreMode, preQuantScalar, fp tile) and is best done as a follow-up — sibling ops or kwargs.
- **No tensor-level analog.** `tile.extract` is a hardware-specific tile primitive tied to MX block formats and accumulator readout; it has no clean tensor-level form.

## Test Plan

- [x] 7 new unit tests in `TestTileExtractOp` (basic, Acc→Mat, dynamic offset, OOB-static, non-index dtype, dynamic shape, non-2D shape) — pass
- [x] 1 new codegen test verifying `pto.textract` DPS-form emission — pass
- [x] Full `tests/ut/ir/` + `tests/ut/codegen/` — 3058 passed, 5 skipped (unrelated)
- [x] `tile.slice` codegen tests still pass (no regression on the shared `pto.textract` path)
- [x] clang-tidy clean on changed C++
- [x] pyright + ruff + clang-format + cpplint + markdownlint clean (pre-commit)