### PR TITLE
docs(passes): Document LegalizePTOBufferReuse pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -37,7 +37,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 22 | `22-canonicalize_io_order.md` | 22nd pass |
 | 23 | `23-init_memref.md` | 23rd pass |
 | 24 | `24-memory_reuse.md` | 24th pass |
-| 25 | *(no doc yet)* | 25th pass (`LegalizePTOBufferReuse`) |
+| 25 | `25-legalize_pto_buffer_reuse.md` | 25th pass |
 | 26 | `26-allocate_memory_addr.md` | 26th pass |
 | 27 | `27-fuse_create_assemble_to_slice.md` | 27th pass |
 | 28 | `28-derive_call_directions.md` | 28th pass |

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -375,7 +375,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)
 12. `InitMemRef`
 13. `MemoryReuse`
-14. `LegalizePTOBufferReuse`
+14. [`LegalizePTOBufferReuse`](25-legalize_pto_buffer_reuse.md)
 15. `AllocateMemoryAddr`
 16. `FuseCreateAssembleToSlice`
 17. [`DeriveCallDirections`](28-derive_call_directions.md)

--- a/docs/en/dev/passes/25-legalize_pto_buffer_reuse.md
+++ b/docs/en/dev/passes/25-legalize_pto_buffer_reuse.md
@@ -1,10 +1,10 @@
 # LegalizePTOBufferReuse Pass
 
-Splits MemRefs left over by `MemoryReuse` whose shared writers cannot be expressed as a single PTO `alloc_tile` plus existing view ops.
+Splits MemRefs left over by `MemoryReuse` whose shared writers cannot be expressed as PTO-compatible `alloc_tile` / view combinations.
 
 ## Overview
 
-Generic `MemoryReuse` decides reuse on lifetime, memory space, dtype, shape, and (for 2D tiles) `valid_shape` differences. PTO codegen is stricter: every non-view writer that shares a MemRef must produce the **same typed `alloc_tile` signature**, since each MemRef becomes exactly one `alloc_tile` declaration on the target. Differences that PTO cannot express on a single allocation must be split into distinct allocations before address assignment.
+Generic `MemoryReuse` decides reuse on lifetime, memory space, dtype, shape, and (for 2D tiles) `valid_shape` differences. PTO codegen is stricter: multiple tile SSA values may lower to distinct `pto.alloc_tile` ops that alias the same MemRef address / byte offset, but sharing is only legal when the non-view writers have **identical `TileBufSignature`s** or any differences are materializable by existing PTO view ops. If a shared MemRef would require incompatible writer signatures that PTO cannot materialize via views, it must be split into distinct allocations before address assignment.
 
 This pass detects illegal cross-type sharing and rebinds the offending writer (and its transitive view chain) onto a fresh MemRef.
 
@@ -56,7 +56,7 @@ The pass only rebinds variables and inserts new `tile.alloc` statements; it does
 The transform runs in four phases over each `Function`:
 
 1. **Collect (`MemRefUsageCollector`)** — visit every `AssignStmt` that defines a tile-typed variable. For each MemRef base pointer, record:
-   - **Writers**: non-view producers (e.g. `tile.load`, `tile.add`, `tile.tpop_from_aic`) plus the `TileBufSignature` extracted from the LHS type and the input `Var`s of the RHS call.
+   - **Writers**: non-view producers (e.g. `tile.load`, `tile.add`, `tile.tpop_from_aic`) plus the `TileBufSignature` extracted from the LHS `TileType` (`TileBufSignature::FromTileType`); the input `Var`s of the RHS call are collected separately and used downstream (e.g. for the Ascend910B `load + tpop_from_aic` hazard detection), not as part of the signature.
    - **View users**: assignments whose RHS is a legal-view op and whose source argument lives in the same MemRef. The pass also records the source→user edge in `view_edges` so transitive views can be redirected later.
    - **`tile.tpop_from_aic` set**: tracked separately for the Ascend910B hazard described below.
 
@@ -71,7 +71,7 @@ The transform runs in four phases over each `Function`:
 
 3. **Mutate (`MemRefSplitMutator`)** — clone every affected `Var` / `IterArg` with a new `TileType` whose `MemRef` is the split target; all references to the old `Var` are remapped through `var_remap_` so SSA users follow the rebinding.
 
-4. **Insert allocs (`InsertNewAllocStatements`)** — for each unique new base pointer, prepend a `tile.alloc` `AssignStmt` to the function body using `CreateAllocStatement(memref, memory_space)`. The body is wrapped in a flattened `SeqStmts`, so the new allocs appear before any user of the new MemRef.
+4. **Insert allocs (`InsertNewAllocStatements`)** — for each unique new base pointer, build a `tile.alloc` `AssignStmt` via `CreateAllocStatement(memref, memory_space)`. When the function body is already a non-empty `SeqStmts`, the pass prepends the new allocs to that sequence so they appear before any user of the new MemRef; otherwise the body is returned unchanged. In the `Default` pipeline this precondition holds because upstream passes establish the `NormalizedStmtStructure` property required by `MemoryReuse`.
 
 ### Ascend910B split-AIV `load + tpop_from_aic` hazard
 

--- a/docs/en/dev/passes/25-legalize_pto_buffer_reuse.md
+++ b/docs/en/dev/passes/25-legalize_pto_buffer_reuse.md
@@ -1,0 +1,184 @@
+# LegalizePTOBufferReuse Pass
+
+Splits MemRefs left over by `MemoryReuse` whose shared writers cannot be expressed as a single PTO `alloc_tile` plus existing view ops.
+
+## Overview
+
+Generic `MemoryReuse` decides reuse on lifetime, memory space, dtype, shape, and (for 2D tiles) `valid_shape` differences. PTO codegen is stricter: every non-view writer that shares a MemRef must produce the **same typed `alloc_tile` signature**, since each MemRef becomes exactly one `alloc_tile` declaration on the target. Differences that PTO cannot express on a single allocation must be split into distinct allocations before address assignment.
+
+This pass detects illegal cross-type sharing and rebinds the offending writer (and its transitive view chain) onto a fresh MemRef.
+
+**"Legal" cross-type sharing** is defined by `TileBufSignature::IsPTOMaterializable` (`include/pypto/codegen/pto/tile_buf_signature.h`) — differences that an existing PTO view op can materialise:
+
+- `tile.reshape` — same `memory_space` / `dtype` / layout / fractal, equal element count
+- `tile.extract`, `tile.slice`, `tensor.slice` — view-only consumers (no new storage)
+- `tile.fillpad`, `tile.fillpad_inplace` — `pad`-only differences
+- Load-with-padding / dynamic `valid_shape` — `valid_shape`-only differences
+- `[1, N]` row-major ↔ `[N, 1]` col-major (zero-cost reshape between physically identical layouts)
+
+All other differences are illegal and trigger a MemRef split.
+
+**When to use**: between `MemoryReuse` and `AllocateMemoryAddr`. Idempotent on legal IR.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::LegalizePTOBufferReuse()` | `passes.legalize_pto_buffer_reuse()` | Function-level |
+
+**Factory function**:
+
+```cpp
+Pass LegalizePTOBufferReuse();
+```
+
+**Python usage**:
+
+```python
+from pypto.pypto_core import passes
+
+legalize_pass = passes.legalize_pto_buffer_reuse()
+program_legal = legalize_pass(program)
+```
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | `SplitIncoreOrch`, `IncoreTileOps`, `HasMemRefs`, `TileOps2D` |
+| Produced | — |
+| Invalidated | — |
+
+The pass only rebinds variables and inserts new `tile.alloc` statements; it does not change control-flow shape, SSA form, or normalised structure.
+
+## Algorithm
+
+The transform runs in four phases over each `Function`:
+
+1. **Collect (`MemRefUsageCollector`)** — visit every `AssignStmt` that defines a tile-typed variable. For each MemRef base pointer, record:
+   - **Writers**: non-view producers (e.g. `tile.load`, `tile.add`, `tile.tpop_from_aic`) plus the `TileBufSignature` extracted from the LHS type and the input `Var`s of the RHS call.
+   - **View users**: assignments whose RHS is a legal-view op and whose source argument lives in the same MemRef. The pass also records the source→user edge in `view_edges` so transitive views can be redirected later.
+   - **`tile.tpop_from_aic` set**: tracked separately for the Ascend910B hazard described below.
+
+2. **Plan (`PlanMemRefSplits`)** — for each MemRef with more than one writer:
+
+   1. Take writer 0's signature as the reference.
+   2. Group remaining writers by `IsPTOMaterializable` against an existing group representative; group 0 keeps the original MemRef, group `g ≥ 1` gets a fresh MemRef.
+   3. **Force-split** any writer hitting the Ascend910B split-AIV `load + tpop_from_aic` hazard (see below) into its own group.
+   4. For every non-zero group, allocate a fresh base `Var` named via `BuildBasePtrName(memory_space, next_id++)`, build a new `MemRef` with the maximum observed allocation size, and call `PropagateSplitToViewUsers` to walk `view_edges` and redirect every transitive view user onto the new MemRef.
+
+   `next_id` is seeded by `MaxMemRefIdCollector`, which extracts the highest existing `mem_<space>_<n>` counter so generated names never collide.
+
+3. **Mutate (`MemRefSplitMutator`)** — clone every affected `Var` / `IterArg` with a new `TileType` whose `MemRef` is the split target; all references to the old `Var` are remapped through `var_remap_` so SSA users follow the rebinding.
+
+4. **Insert allocs (`InsertNewAllocStatements`)** — for each unique new base pointer, prepend a `tile.alloc` `AssignStmt` to the function body using `CreateAllocStatement(memref, memory_space)`. The body is wrapped in a flattened `SeqStmts`, so the new allocs appear before any user of the new MemRef.
+
+### Ascend910B split-AIV `load + tpop_from_aic` hazard
+
+On Ascend910B AIV functions whose `SplitMode` is non-`None`, sharing a MemRef between (a) the output of `tile.load` (or any of its view descendants) and (b) the input of an op that also consumes a `tile.tpop_from_aic` value produces a hardware hazard. `BackendHandler::RequiresSplitLoadTpopWorkaround()` returns true for this backend; when active, `CollectForcedSplitWriterIndices` flags every offending writer for force-split into its own group, regardless of signature compatibility.
+
+This is the only place in the pass where backend dispatch leaks in, and it goes through `PassContext::Current()->GetBackendHandler()` per `.claude/rules/pass-context-config.md`.
+
+## Examples
+
+### Different shapes → split
+
+Two writers sharing `mem_vec_0` with different physical shapes (`[128, 128]` vs `[64, 64]`) are not PTO-materializable from each other, so the second writer gets a fresh `mem_vec_1`.
+
+**Before** (after `MemoryReuse`):
+
+```python
+# SeqStmts [
+mem_vec_0: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+result: Tensor[[128, 128], FP32] = tile.store(t2, [0, 0], b)
+# ]
+```
+
+**After**:
+
+```python
+# SeqStmts [
+mem_vec_0: pl.Ptr = tile.alloc(Vec, 65536)
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)  # fresh MemRef for t2
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+result: Tensor[[128, 128], FP32] = tile.store(t2, [0, 0], b)
+# ]
+```
+
+See `tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py::TestIllegalSharingSplit::test_different_shape_same_memref_splits`.
+
+### View chain follows the split
+
+A `tile.fillpad` view of a split writer must rebind to the new MemRef so the view's storage matches its source.
+
+**Before**:
+
+```python
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t3: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec, view(pad=max)]
+   = tile.fillpad(t2, pad_value=max)
+```
+
+**After** (`t2` and its view `t3` both move to `mem_vec_1`):
+
+```python
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+t3: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec, view(pad=max)]
+   = tile.fillpad(t2, pad_value=max)
+```
+
+See `TestIllegalSharingSplit::test_split_propagates_through_view_chain`.
+
+### Legal sharing preserved
+
+Two writers with the **same** `TileBufSignature` (or differences materializable by `tile.fillpad` / `tile.reshape` / `valid_shape`) keep their shared MemRef untouched. See `TestLegalSharingPreserved`.
+
+## Implementation
+
+**Header**: `include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass LegalizePTOBufferReuse();
+```
+
+**Implementation**: `src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp`
+
+- `IsLegalViewOp` — string allowlist of view op names (`tile.reshape`, `tile.extract`, `tile.slice`, `tile.fillpad`, `tile.fillpad_inplace`, `tensor.slice`)
+- `MemRefUsageCollector` — Phase 1: per-MemRef writer / view-user / `tile.tpop_from_aic` index
+- `CollectLoadFamilyVars` / `CollectForcedSplitWriterIndices` — Ascend910B split-AIV hazard detection
+- `PlanMemRefSplits` — Phase 2: signature grouping and fresh MemRef allocation
+- `PropagateSplitToViewUsers` — Phase 2 helper: BFS over `view_edges` to redirect transitive views
+- `MemRefSplitMutator` — Phase 3: rewrite `Var` / `IterArg` types with the new MemRef
+- `InsertNewAllocStatements` — Phase 4: prepend `tile.alloc` for each fresh MemRef
+- `MaxMemRefIdCollector` — seeds fresh-id counter from existing names
+
+**Backend dispatch**: `BackendHandler::RequiresSplitLoadTpopWorkaround()` accessed via `PassContext::Current()->GetBackendHandler()` (per `.claude/rules/pass-context-config.md`).
+
+**Python binding**: `python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("legalize_pto_buffer_reuse", &pass::LegalizePTOBufferReuse,
+           "Create a PTO buffer reuse legalisation pass\n\n"
+           "After generic MemoryReuse, detects illegal cross-type MemRef sharing\n"
+           "that PTO codegen cannot express and splits such MemRefs.");
+```
+
+**Type stub**: `python/pypto/pypto_core/passes.pyi`
+
+```python
+def legalize_pto_buffer_reuse() -> Pass:
+    """Create a PTO buffer reuse legalisation pass."""
+```
+
+**Tests**: `tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py`
+
+- `TestLegalSharingPreserved` — same-signature and `tile.fillpad`-view sharing kept intact
+- `TestAscend910BSplitLoadTpopHazard` — split-AIV hazard force-split on 910B; no force-split on Ascend950
+- `TestIllegalSharingSplit` — different-shape split and view-chain propagation
+- `TestLegalizeWithCodegen` — end-to-end alloc count / address checks via PTO codegen

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -375,7 +375,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)
 12. `InitMemRef`
 13. `MemoryReuse`
-14. `LegalizePTOBufferReuse`
+14. [`LegalizePTOBufferReuse`](25-legalize_pto_buffer_reuse.md)
 15. `AllocateMemoryAddr`
 16. `FuseCreateAssembleToSlice`
 17. [`DeriveCallDirections`](28-derive_call_directions.md)

--- a/docs/zh-cn/dev/passes/25-legalize_pto_buffer_reuse.md
+++ b/docs/zh-cn/dev/passes/25-legalize_pto_buffer_reuse.md
@@ -1,10 +1,10 @@
 # LegalizePTOBufferReuse Pass
 
-拆分 `MemoryReuse` 留下的、其共享 writer 无法用单个 PTO `alloc_tile` 加既有 view op 表达的 MemRef。
+拆分 `MemoryReuse` 留下的、其共享 writer 无法用 PTO 兼容的 `alloc_tile` 与 view op 组合表达的 MemRef。
 
 ## 概述
 
-通用的 `MemoryReuse` 基于生命周期、内存空间、dtype、shape，以及（对 2D tile 的）`valid_shape` 差异判定复用。PTO codegen 更严格：每一个共享同一 MemRef 的非 view writer 必须产生**相同的 `alloc_tile` 类型签名 (signature)**，因为每个 MemRef 在目标侧仅对应一条 `alloc_tile` 声明。无法在单一分配上表达的差异必须在地址分配前被拆分到不同的分配中。
+通用的 `MemoryReuse` 基于生命周期、内存空间、dtype、shape，以及（对 2D tile 的）`valid_shape` 差异判定复用。PTO codegen 更严格：同一 MemRef 上多个 tile SSA 值可以下放为多条共享同一 MemRef 地址 / 字节偏移的 `pto.alloc_tile`，但只有当这些非 view writer 拥有**完全相同的 `TileBufSignature`**，或它们之间的差异可由既有 PTO view op materialize 时，共享才合法。否则，必须在地址分配前将该 MemRef 拆分到不同的分配中。
 
 本 Pass 检测非法的跨类型共享，并将冒犯的 writer（及其 view 链上的传递使用者）改绑到新的 MemRef。
 
@@ -56,7 +56,7 @@ program_legal = legalize_pass(program)
 变换以四个阶段在每个 `Function` 上执行：
 
 1. **收集 (`MemRefUsageCollector`)** —— 访问每个定义 tile 类型变量的 `AssignStmt`。对每个 MemRef base 指针记录：
-   - **Writers**：非 view 的产生者（如 `tile.load`、`tile.add`、`tile.tpop_from_aic`），以及从 LHS 类型与 RHS call 的输入 `Var` 列表中提取的 `TileBufSignature`。
+   - **Writers**：非 view 的产生者（如 `tile.load`、`tile.add`、`tile.tpop_from_aic`），其 `TileBufSignature` 仅由 LHS 的 `TileType` 提取（`TileBufSignature::FromTileType`）；RHS call 的输入 `Var` 列表则单独收集，用于下游分析（例如 Ascend910B `load + tpop_from_aic` hazard 检测），并不计入签名本身。
    - **View users**：RHS 是合法 view op 且其源参数与目标位于同一 MemRef 的赋值。Pass 还在 `view_edges` 中记录 source→user 的边，以便后续传递性地转向。
    - **`tile.tpop_from_aic` 集合**：单独追踪，用于下文的 Ascend910B 硬件 hazard。
 
@@ -71,7 +71,7 @@ program_legal = legalize_pass(program)
 
 3. **变换 (`MemRefSplitMutator`)** —— 克隆所有受影响的 `Var` / `IterArg`，使其新 `TileType` 指向拆分后的 `MemRef`。所有对旧 `Var` 的引用都通过 `var_remap_` 重映射，使 SSA 用户跟随这次改绑。
 
-4. **插入 alloc (`InsertNewAllocStatements`)** —— 对每个唯一的新 base 指针，使用 `CreateAllocStatement(memref, memory_space)` 在函数体前部插入一条 `tile.alloc` `AssignStmt`。函数体被包入扁平化后的 `SeqStmts`，确保新 alloc 出现在使用新 MemRef 的任何用户之前。
+4. **插入 alloc (`InsertNewAllocStatements`)** —— 对每个唯一的新 base 指针，使用 `CreateAllocStatement(memref, memory_space)` 构造一条 `tile.alloc` `AssignStmt`。当函数体本身已经是非空的 `SeqStmts` 时，Pass 会将这些新 alloc 前插到该 `SeqStmts` 开头，确保它们出现在使用新 MemRef 的任何用户之前；否则直接返回原 body 不作改动。在 `Default` 流水线中，这一前提由上游建立 `MemoryReuse` 所要求的 `NormalizedStmtStructure` 属性的 pass 保证。
 
 ### Ascend910B split-AIV `load + tpop_from_aic` hazard
 

--- a/docs/zh-cn/dev/passes/25-legalize_pto_buffer_reuse.md
+++ b/docs/zh-cn/dev/passes/25-legalize_pto_buffer_reuse.md
@@ -1,0 +1,184 @@
+# LegalizePTOBufferReuse Pass
+
+拆分 `MemoryReuse` 留下的、其共享 writer 无法用单个 PTO `alloc_tile` 加既有 view op 表达的 MemRef。
+
+## 概述
+
+通用的 `MemoryReuse` 基于生命周期、内存空间、dtype、shape，以及（对 2D tile 的）`valid_shape` 差异判定复用。PTO codegen 更严格：每一个共享同一 MemRef 的非 view writer 必须产生**相同的 `alloc_tile` 类型签名 (signature)**，因为每个 MemRef 在目标侧仅对应一条 `alloc_tile` 声明。无法在单一分配上表达的差异必须在地址分配前被拆分到不同的分配中。
+
+本 Pass 检测非法的跨类型共享，并将冒犯的 writer（及其 view 链上的传递使用者）改绑到新的 MemRef。
+
+**"合法"的跨类型共享** 由 `TileBufSignature::IsPTOMaterializable`（`include/pypto/codegen/pto/tile_buf_signature.h`）定义——即既有 PTO view op 能够表达的差异：
+
+- `tile.reshape` —— 相同 `memory_space` / `dtype` / 布局 (layout) / fractal，元素总数相等
+- `tile.extract`、`tile.slice`、`tensor.slice` —— 仅 view 的消费者 (consumer)（不引入新存储）
+- `tile.fillpad`、`tile.fillpad_inplace` —— 仅 `pad` 的差异
+- 带 padding 的 load / 动态 `valid_shape` —— 仅 `valid_shape` 的差异
+- `[1, N]` row-major ↔ `[N, 1]` col-major（物理布局相同的零开销 reshape）
+
+其他差异均视为非法，触发 MemRef 拆分。
+
+**使用时机**：在 `MemoryReuse` 与 `AllocateMemoryAddr` 之间运行。对合法 IR 幂等。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::LegalizePTOBufferReuse()` | `passes.legalize_pto_buffer_reuse()` | 函数级 |
+
+**工厂函数**：
+
+```cpp
+Pass LegalizePTOBufferReuse();
+```
+
+**Python 用法**：
+
+```python
+from pypto.pypto_core import passes
+
+legalize_pass = passes.legalize_pto_buffer_reuse()
+program_legal = legalize_pass(program)
+```
+
+## Pass Properties
+
+| 属性 | 取值 |
+| ---- | ---- |
+| Required | `SplitIncoreOrch`、`IncoreTileOps`、`HasMemRefs`、`TileOps2D` |
+| Produced | — |
+| Invalidated | — |
+
+本 Pass 只是改绑变量并插入新的 `tile.alloc` 语句，不会改变控制流形状、SSA form、或归一化结构。
+
+## 算法
+
+变换以四个阶段在每个 `Function` 上执行：
+
+1. **收集 (`MemRefUsageCollector`)** —— 访问每个定义 tile 类型变量的 `AssignStmt`。对每个 MemRef base 指针记录：
+   - **Writers**：非 view 的产生者（如 `tile.load`、`tile.add`、`tile.tpop_from_aic`），以及从 LHS 类型与 RHS call 的输入 `Var` 列表中提取的 `TileBufSignature`。
+   - **View users**：RHS 是合法 view op 且其源参数与目标位于同一 MemRef 的赋值。Pass 还在 `view_edges` 中记录 source→user 的边，以便后续传递性地转向。
+   - **`tile.tpop_from_aic` 集合**：单独追踪，用于下文的 Ascend910B 硬件 hazard。
+
+2. **规划 (`PlanMemRefSplits`)** —— 对每个 writer 数大于 1 的 MemRef：
+
+   1. 取 writer 0 的签名作为参考。
+   2. 将其余 writer 按 `IsPTOMaterializable` 与某个已存在组的代表 (representative) 进行兼容性分组：组 0 保留原 MemRef，组 `g ≥ 1` 各自获得新的 MemRef。
+   3. 命中 Ascend910B split-AIV `load + tpop_from_aic` hazard（详见下文）的 writer **强制拆分** 至独立组。
+   4. 对每个非 0 组，使用 `BuildBasePtrName(memory_space, next_id++)` 为新 base 指针 `Var` 命名，按已观察到的最大分配大小构造新 `MemRef`，并通过 `PropagateSplitToViewUsers` 沿 `view_edges` 将每一个传递性 view user 改绑到新 MemRef。
+
+   `next_id` 由 `MaxMemRefIdCollector` 提取已有 `mem_<space>_<n>` 计数的最大值后递增，避免新生成的名字冲突。
+
+3. **变换 (`MemRefSplitMutator`)** —— 克隆所有受影响的 `Var` / `IterArg`，使其新 `TileType` 指向拆分后的 `MemRef`。所有对旧 `Var` 的引用都通过 `var_remap_` 重映射，使 SSA 用户跟随这次改绑。
+
+4. **插入 alloc (`InsertNewAllocStatements`)** —— 对每个唯一的新 base 指针，使用 `CreateAllocStatement(memref, memory_space)` 在函数体前部插入一条 `tile.alloc` `AssignStmt`。函数体被包入扁平化后的 `SeqStmts`，确保新 alloc 出现在使用新 MemRef 的任何用户之前。
+
+### Ascend910B split-AIV `load + tpop_from_aic` hazard
+
+在 `SplitMode` 非 `None` 的 Ascend910B AIV 函数中，让 (a) `tile.load`（或其任何 view 后代）的输出与 (b) 同时消费 `tile.tpop_from_aic` 值的某个 op 的输入共享同一个 MemRef，会触发硬件 hazard。`BackendHandler::RequiresSplitLoadTpopWorkaround()` 在该后端返回 true；启用时，`CollectForcedSplitWriterIndices` 会标记每一个冒犯的 writer 强制拆分到独立组，无视签名兼容性。
+
+这是本 Pass 中唯一引入后端分派的位置，并且通过 `PassContext::Current()->GetBackendHandler()` 进行——遵循 `.claude/rules/pass-context-config.md`。
+
+## 示例
+
+### 形状不同 → 拆分
+
+两个共享 `mem_vec_0` 的 writer 物理 shape 不同（`[128, 128]` 与 `[64, 64]`），二者互相不可 PTO-materialize，因此第二个 writer 改绑到新的 `mem_vec_1`。
+
+**之前**（`MemoryReuse` 之后）：
+
+```python
+# SeqStmts [
+mem_vec_0: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+result: Tensor[[128, 128], FP32] = tile.store(t2, [0, 0], b)
+# ]
+```
+
+**之后**：
+
+```python
+# SeqStmts [
+mem_vec_0: pl.Ptr = tile.alloc(Vec, 65536)
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)  # 为 t2 新增
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+result: Tensor[[128, 128], FP32] = tile.store(t2, [0, 0], b)
+# ]
+```
+
+参见 `tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py::TestIllegalSharingSplit::test_different_shape_same_memref_splits`。
+
+### View 链跟随拆分
+
+被拆分 writer 的 `tile.fillpad` view 必须改绑到新 MemRef，使 view 的存储与其源一致。
+
+**之前**：
+
+```python
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t3: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec, view(pad=max)]
+   = tile.fillpad(t2, pad_value=max)
+```
+
+**之后**（`t2` 与其 view `t3` 一同迁移到 `mem_vec_1`）：
+
+```python
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+t3: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec, view(pad=max)]
+   = tile.fillpad(t2, pad_value=max)
+```
+
+参见 `TestIllegalSharingSplit::test_split_propagates_through_view_chain`。
+
+### 合法共享保留
+
+具有**相同** `TileBufSignature`（或仅在 `tile.fillpad` / `tile.reshape` / `valid_shape` 等可 view 实现的差异内不同）的两个 writer 保持原有 MemRef 共享不变。参见 `TestLegalSharingPreserved`。
+
+## 实现
+
+**头文件**：`include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass LegalizePTOBufferReuse();
+```
+
+**实现文件**：`src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp`
+
+- `IsLegalViewOp` —— view op 名称白名单（`tile.reshape`、`tile.extract`、`tile.slice`、`tile.fillpad`、`tile.fillpad_inplace`、`tensor.slice`）
+- `MemRefUsageCollector` —— 阶段 1：按 MemRef 收集 writer / view-user / `tile.tpop_from_aic` 索引
+- `CollectLoadFamilyVars` / `CollectForcedSplitWriterIndices` —— Ascend910B split-AIV hazard 检测
+- `PlanMemRefSplits` —— 阶段 2：签名分组与新 MemRef 分配
+- `PropagateSplitToViewUsers` —— 阶段 2 辅助：在 `view_edges` 上 BFS，传递性改绑 view
+- `MemRefSplitMutator` —— 阶段 3：用新 MemRef 重写 `Var` / `IterArg` 的类型
+- `InsertNewAllocStatements` —— 阶段 4：为每个新 MemRef 在函数体前部插入 `tile.alloc`
+- `MaxMemRefIdCollector` —— 由现有名字推断新 id 计数器起点
+
+**后端分派**：`BackendHandler::RequiresSplitLoadTpopWorkaround()`，通过 `PassContext::Current()->GetBackendHandler()` 访问（遵循 `.claude/rules/pass-context-config.md`）。
+
+**Python 绑定**：`python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("legalize_pto_buffer_reuse", &pass::LegalizePTOBufferReuse,
+           "Create a PTO buffer reuse legalisation pass\n\n"
+           "After generic MemoryReuse, detects illegal cross-type MemRef sharing\n"
+           "that PTO codegen cannot express and splits such MemRefs.");
+```
+
+**类型存根 (Type stub)**：`python/pypto/pypto_core/passes.pyi`
+
+```python
+def legalize_pto_buffer_reuse() -> Pass:
+    """Create a PTO buffer reuse legalisation pass."""
+```
+
+**测试**：`tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py`
+
+- `TestLegalSharingPreserved` —— 相同签名与 `tile.fillpad` view 共享被保留
+- `TestAscend910BSplitLoadTpopHazard` —— 910B 上 split-AIV hazard 触发强制拆分；Ascend950 上不强制
+- `TestIllegalSharingSplit` —— 不同 shape 拆分与 view 链传递
+- `TestLegalizeWithCodegen` —— 通过 PTO codegen 端到端校验 alloc 数量 / 地址


### PR DESCRIPTION
## Summary

- Adds per-pass doc `25-legalize_pto_buffer_reuse.md` (EN + zh-CN) covering purpose, Pass Properties, the four-phase algorithm, the Ascend910B `load + tpop_from_aic` hazard, and before/after IR examples drawn from existing tests.
- Links the new doc from `00-pass_manager.md` (EN + zh-CN) and reconciles the slot-25 row in `.claude/rules/pass-doc-ordering.md` (was `(no doc yet)`).
- Mirrors the structure of `24-memory_reuse.md` and the Pass Properties table style from `18-inject_gm_pipe_buffer.md`.

## Test plan

- [x] Cross-checked all referenced symbols (`MemRefUsageCollector`, `PlanMemRefSplits`, `PropagateSplitToViewUsers`, `MemRefSplitMutator`, `InsertNewAllocStatements`, `MaxMemRefIdCollector`, `IsLegalViewOp`, `BackendHandler::RequiresSplitLoadTpopWorkaround`) against the source.
- [x] Cross-checked all referenced test classes/methods (`TestLegalSharingPreserved`, `TestAscend910BSplitLoadTpopHazard`, `TestIllegalSharingSplit`, `TestLegalizeWithCodegen`, `test_different_shape_same_memref_splits`, `test_split_propagates_through_view_chain`).
- [x] Pass Properties (`SplitIncoreOrch`, `IncoreTileOps`, `HasMemRefs`, `TileOps2D`) match the C++ `kProps` declaration.
- [x] markdownlint, end-of-file, trailing-whitespace, header, and English-only pre-commit hooks all pass.

## Related Issues

Fixes #1169
Parent: #1161