### PR TITLE
fix(codegen): Scale GM pipe buffer for SPMD and shard unpack in wrapper

### DIFF
--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -130,6 +130,20 @@ class CodegenBase : public ir::IRVisitor {
   }
 
   /**
+   * @brief Optional scale expression applied to tensor.create shape
+   *
+   * Used by orchestration codegen to adjust backend allocation size without
+   * mutating IR (e.g. GM pipe workspace expansion for SPMD launch core_num).
+   *
+   * @param result_var Emitted result variable name of tensor.create
+   * @return C++ scalar expression string; empty means no scaling
+   */
+  [[nodiscard]] virtual std::string GetTensorCreateScaleExpr(const std::string& result_var) const {
+    (void)result_var;
+    return "";
+  }
+
+  /**
    * @brief Get the runtime DataType enum string for generated code
    *
    * Returns the fully qualified DataType enum name as used by the runtime

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -255,7 +255,7 @@ def _preprocess_ptoas_output(content: str) -> str:
     return result
 
 
-def _generate_arg_unpacking(func: _ir_core.Function) -> tuple[str, list[str]]:
+def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False) -> tuple[str, list[str]]:
     """Generate C++ code to unpack ``int64_t* args`` into typed locals.
 
     Args[] are dispatched in tensors-first order (all tensors, then scalars),
@@ -291,11 +291,31 @@ def _generate_arg_unpacking(func: _ir_core.Function) -> tuple[str, list[str]]:
         c_type = param.type.dtype.to_c_type_string()
         lines.append(f"    // Unpack tensor: {param_name}")
         lines.append(f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);")
-        lines.append(
-            f"    __gm__ {c_type}* {param_name} = "
-            f"reinterpret_cast<__gm__ {c_type}*>("
-            f"{param_name}_tensor->buffer.addr) + {param_name}_tensor->start_offset;"
-        )
+        if param_name == "__gm_pipe_buffer" and uses_spmd:
+            lines.append("    // SPMD: shard GM pipe workspace by logical block_idx to avoid overlap.")
+            lines.append("    int64_t __pypto_gm_block_num = static_cast<int64_t>(__pypto_spmd_block_num);")
+            lines.append("    if (__pypto_gm_block_num <= 0) __pypto_gm_block_num = 1;")
+            lines.append(
+                f"    int64_t __pypto_gm_total_elems = static_cast<int64_t>({param_name}_tensor->shapes[0]);"
+            )
+            lines.append(
+                "    int64_t __pypto_gm_elems_per_block = __pypto_gm_total_elems / __pypto_gm_block_num;"
+            )
+            lines.append(
+                "    int64_t __pypto_gm_block_offset = static_cast<int64_t>(__pypto_spmd_block_idx) * "
+                "__pypto_gm_elems_per_block;"
+            )
+            lines.append(
+                f"    __gm__ {c_type}* {param_name} = "
+                f"reinterpret_cast<__gm__ {c_type}*>({param_name}_tensor->buffer.addr) + "
+                f"{param_name}_tensor->start_offset + __pypto_gm_block_offset;"
+            )
+        else:
+            lines.append(
+                f"    __gm__ {c_type}* {param_name} = "
+                f"reinterpret_cast<__gm__ {c_type}*>("
+                f"{param_name}_tensor->buffer.addr) + {param_name}_tensor->start_offset;"
+            )
         lines.append("")
         var_names.append(param_name)
 
@@ -501,9 +521,10 @@ def _generate_kernel_wrapper(
     2. Preprocessed ptoas code (static, no duplicate includes)
     3. ``kernel_entry`` wrapper with arg unpacking and forward call
     """
-    header = _generate_kernel_header(func, uses_spmd=group_uses_spmd or _uses_spmd_block_ops(func))
+    uses_spmd = group_uses_spmd or _uses_spmd_block_ops(func)
+    header = _generate_kernel_header(func, uses_spmd=uses_spmd)
     ptoas_body = _preprocess_ptoas_output(ptoas_code)
-    unpacking_code, var_names = _generate_arg_unpacking(func)
+    unpacking_code, var_names = _generate_arg_unpacking(func, uses_spmd=uses_spmd)
     call_args = ", ".join(var_names)
     runtime_subblock_setup = ""
     if _needs_runtime_subblock_bridge(func):
@@ -515,7 +536,7 @@ def _generate_kernel_wrapper(
         )
 
     spmd_args_setup = ""
-    if _uses_spmd_block_ops(func):
+    if uses_spmd:
         # Use undef/redefine dance: temporarily remove our macros so we can call
         # the intrinsic.h functions that take args, then restore the macros.
         # Runs under both NPU and SIM — in SIM, intrinsic.h::get_block_idx(args)

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -233,6 +233,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return "(int64_t)" + name + ".shapes[" + std::to_string(axis) + "]";
   }
 
+  [[nodiscard]] std::string GetTensorCreateScaleExpr(const std::string& result_var) const override {
+    auto it = tensor_create_scale_expr_by_emit_name_.find(result_var);
+    if (it == tensor_create_scale_expr_by_emit_name_.end()) {
+      return "";
+    }
+    return it->second;
+  }
+
   void VisitStmt_(const ForStmtPtr& for_stmt) override {
     if (for_stmt->kind_ == ForKind::Unroll) {
       LOG_WARN << "ForKind::Unroll loop was not expanded before codegen; "
@@ -658,8 +666,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
 
       auto it = wrapper_param_to_outer_idx.find(inner_arg_var.get());
-      INTERNAL_CHECK_SPAN(it != wrapper_param_to_outer_idx.end(), inner_call->span_)
-          << "Internal error: inner call arg " << inner_idx << " does not map to any wrapper parameter";
+      if (it == wrapper_param_to_outer_idx.end()) {
+        // Some wrapper-expansion paths can leave inner-call scalar ivs that are
+        // not part of the user-visible wrapper signature. They should not be
+        // forwarded as orchestration args.
+        if (As<ScalarType>(inner_arg->GetType()) != nullptr) {
+          continue;
+        }
+        INTERNAL_CHECK_SPAN(false, inner_call->span_)
+            << "Internal error: inner call arg " << inner_idx << " does not map to any wrapper parameter";
+      }
 
       size_t outer_idx = it->second;
       const auto& outer_arg = outer_call->args_[outer_idx];
@@ -739,6 +755,54 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   static constexpr size_t kMaxAllocTensorsArgs = 16;
 
+  static bool IsInjectedGMPipeCreateVar(const VarPtr& var) {
+    return var && var->name_hint_.rfind("gm_pipe_buffer_", 0) == 0;
+  }
+
+  [[nodiscard]] std::string ResolveLaunchCoreNumForCreate(const std::vector<StmtPtr>& stmts,
+                                                          size_t create_stmt_idx,
+                                                          const VarPtr& create_var) const {
+    if (!create_var) return "";
+
+    for (size_t i = create_stmt_idx + 1; i < stmts.size(); ++i) {
+      auto assign = As<AssignStmt>(stmts[i]);
+      if (assign && assign->var_ && assign->var_.get() == create_var.get()) {
+        break;
+      }
+
+      CallPtr call;
+      if (assign) {
+        call = As<Call>(assign->value_);
+      } else if (auto eval = As<EvalStmt>(stmts[i])) {
+        call = As<Call>(eval->expr_);
+      }
+      if (!call) continue;
+
+      bool uses_create_var = false;
+      for (const auto& arg : call->args_) {
+        auto arg_var = AsVarLike(arg);
+        if (arg_var && arg_var.get() == create_var.get()) {
+          uses_create_var = true;
+          break;
+        }
+      }
+      if (!uses_create_var) continue;
+
+      auto gv = As<GlobalVar>(call->op_);
+      if (!gv) return "";
+      auto callee_func = program_->GetFunction(gv->name_);
+      if (!callee_func) return "";
+      if (callee_func->func_type_ != FunctionType::Spmd && callee_func->func_type_ != FunctionType::Group) {
+        return "";
+      }
+
+      auto core_num_expr = callee_func->GetAttr<ExprPtr>("core_num", nullptr);
+      if (!core_num_expr) return "";
+      return RenderLaunchCoreNum(core_num_expr);
+    }
+    return "";
+  }
+
   static bool ExprRefsAnyOf(const ExprPtr& expr, const std::unordered_set<const Var*>& vars) {
     if (!expr) {
       return false;
@@ -798,7 +862,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     std::unordered_set<const Var*> locally_defined;
 
-    for (const auto& stmt : stmts) {
+    for (size_t stmt_idx = 0; stmt_idx < stmts.size(); ++stmt_idx) {
+      const auto& stmt = stmts[stmt_idx];
       auto assign = As<AssignStmt>(stmt);
       if (!assign) {
         continue;
@@ -818,6 +883,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
       declared_var_ptrs_.insert(assign->var_.get());
       std::string emit_var = ReserveVarEmitName(assign->var_.get());
+      if (IsInjectedGMPipeCreateVar(assign->var_)) {
+        std::string core_num_expr = ResolveLaunchCoreNumForCreate(stmts, stmt_idx, assign->var_);
+        if (!core_num_expr.empty()) {
+          tensor_create_scale_expr_by_emit_name_[emit_var] = core_num_expr;
+        }
+      }
       creates.push_back({emit_var, call});
       batched_create_stmts_.insert(stmt.get());
     }
@@ -1071,12 +1142,39 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
+    int max_tuple_index = -1;
     for (const auto& elem : elements_it->second) {
-      INTERNAL_CHECK_SPAN(elem.index >= 0 && static_cast<size_t>(elem.index) < out_indices.size(),
-                          call->span_)
-          << "Internal error: tuple element index " << elem.index << " out of range for " << call->op_->name_
-          << " (has " << out_indices.size() << " Out/InOut params)";
-      size_t param_idx = out_indices[static_cast<size_t>(elem.index)];
+      max_tuple_index = std::max(max_tuple_index, elem.index);
+    }
+    size_t tuple_arity = max_tuple_index >= 0 ? static_cast<size_t>(max_tuple_index + 1) : 0;
+    size_t tuple_out_base = tuple_arity >= out_indices.size() ? (tuple_arity - out_indices.size()) : 0;
+
+    for (const auto& elem : elements_it->second) {
+      // Some wrappers (notably SPMD helpers) return auxiliary scalars before
+      // Out/InOut tensors, e.g. (idx, out_tensor). Map tuple tail elements to
+      // Out/InOut params and ignore leading non-output tuple elements.
+      if (elem.index < 0) {
+        continue;
+      }
+      size_t elem_pos = static_cast<size_t>(elem.index);
+      if (elem_pos < tuple_out_base) {
+        // Leading tuple elements are auxiliary values (e.g. loop iv from
+        // SPMD wrappers). They are not returned by runtime task submission.
+        // If such scalar is referenced later, materialize a safe default to
+        // keep generated orchestration compilable.
+        if (effective_uses_.count(elem.var)) {
+          std::string elem_name = ReserveVarEmitName(elem.var);
+          if (auto st = As<ScalarType>(elem.var->GetType())) {
+            code_ << Indent() << st->dtype_.ToCTypeString() << " " << elem_name << " = 0;\n";
+          }
+        }
+        continue;
+      }
+      size_t out_pos = elem_pos - tuple_out_base;
+      if (out_pos >= out_indices.size()) {
+        continue;
+      }
+      size_t param_idx = out_indices[out_pos];
       INTERNAL_CHECK_SPAN(param_idx < call->args_.size(), call->span_)
           << "Internal error: resolved param_idx " << param_idx << " out of range for " << call->op_->name_
           << " (has " << call->args_.size() << " args)";
@@ -1154,6 +1252,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
   std::unordered_set<const Var*> effective_uses_;
+  std::unordered_map<std::string, std::string> tensor_create_scale_expr_by_emit_name_;
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -75,12 +75,19 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
 
   std::string result_var = codegen.GetCurrentResultTarget();
   size_t ndim = result_type->shape_.size();
+  const std::string create_scale_expr = codegen.GetTensorCreateScaleExpr(result_var);
 
   std::ostringstream oss;
   oss << "uint32_t " << result_var << "_ci_shapes[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
-    oss << EmitAsUint32(result_type->shape_[i], codegen);
+    std::string dim_expr = EmitAsUint32(result_type->shape_[i], codegen);
+    // Backend-side allocation expansion for injected GM pipe buffers in SPMD:
+    // keep IR shape unchanged, scale host allocation at codegen.
+    if (!create_scale_expr.empty() && ndim == 1 && i == 0) {
+      dim_expr = "static_cast<uint32_t>((" + dim_expr + ") * (" + create_scale_expr + "))";
+    }
+    oss << dim_expr;
   }
   oss << "};\n";
 

--- a/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
+++ b/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
@@ -394,7 +394,6 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
   int64_t gm_buffer_bytes = ComputeGMBufferSizeFromPipeOps(functions);
   INTERNAL_CHECK(gm_buffer_bytes > 0) << "Internal error: cross-core pipe functions found but no "
                                          "initialize_pipe ops to determine buffer size";
-  int64_t gm_buffer_elems = (gm_buffer_bytes + 3) / 4;
 
   // Propagate upward, stopping at Orchestration boundaries (they materialize
   // the buffer locally instead of taking it as a parameter).
@@ -416,6 +415,8 @@ void InjectGMSlotBufferInPlace(std::vector<FunctionPtr>& functions) {
       }
     }
   }
+
+  int64_t gm_buffer_elems = (gm_buffer_bytes + 3) / 4;
 
   for (auto& func : functions) {
     if (needs_gm_param.count(func->name_) && !HasGMPipeBufferParam(func)) {

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -165,6 +165,27 @@ std::vector<int> ComputeReturnPermutation(const FunctionPtr& func) {
     if (permutation[i] != i) needs_reorder = true;
   }
 
+  // Guard against non-bijective permutations (duplicate targets or holes).
+  // A malformed permutation can later create ReturnStmt entries with null values.
+  std::vector<bool> seen(permutation.size(), false);
+  for (int i = 0; i < static_cast<int>(permutation.size()); ++i) {
+    int target = permutation[i];
+    if (target < 0 || target >= static_cast<int>(permutation.size())) {
+      return {};
+    }
+    if (seen[target]) {
+      // Collision: two old indices map to the same new index.
+      return {};
+    }
+    seen[target] = true;
+  }
+  for (bool v : seen) {
+    if (!v) {
+      // Hole: at least one new index has no source.
+      return {};
+    }
+  }
+
   if (!needs_reorder) return {};
   return permutation;
 }

--- a/tests/st/runtime/test_spmd.py
+++ b/tests/st/runtime/test_spmd.py
@@ -364,6 +364,45 @@ class SPMDSyncStartMixedProgram:
         return out
 
 
+@pl.program
+class SPMDGMPipeBufferProgram:
+    # No UP_DOWN split: runtime shards __gm_pipe_buffer by SPMD block_idx only; dual-AIV
+    # split would run two lanes per block on the same slice and corrupt the pipe workspace.
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[128, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        bias: pl.Tensor[[128, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[128, 16], pl.FP32]],
+    ) -> pl.Tensor[[128, 16], pl.FP32]:
+        block_idx = pl.tile.get_block_idx()
+        row_offset = block_idx * 64
+
+        tile_a_l1 = pl.load(a, [row_offset, 0], [64, 16], target_memory=pl.MemorySpace.Mat)
+        tile_b_l1 = pl.load(b, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+        tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+        tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+        tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+
+        tile_bias = pl.load(bias, [row_offset, 0], [64, 16])
+        tile_out = pl.add(tile_mm, tile_bias)
+        out = pl.store(tile_out, [row_offset, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[128, 16], pl.FP32],
+        b: pl.Tensor[[16, 16], pl.FP32],
+        bias: pl.Tensor[[128, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[128, 16], pl.FP32]],
+    ) -> pl.Tensor[[128, 16], pl.FP32]:
+        with pl.spmd(2, name_hint="gm_pipe_spmd"):
+            out = self.kernel(a, b, bias, out)
+        return out
+
+
 # --- Test Cases ---
 
 
@@ -529,6 +568,27 @@ class SPMDSyncStartMixedTestCase(_BaseSPMDTestCase):
         tensors["out"][:] = tensors["a"] + tensors["b"]
 
 
+class SPMDGMPipeBufferTestCase(_BaseSPMDTestCase):
+    """SPMD mixed-kernel down-proj residual golden test for gm_pipe_buffer path."""
+
+    def get_name(self) -> str:
+        return "spmd_gm_pipe_buffer_128x16"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [128, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [16, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("bias", [128, 16], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [128, 16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDGMPipeBufferProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
+
+
 # --- Tests ---
 
 
@@ -577,6 +637,11 @@ class TestSPMDOperations:
     def test_spmd_sync_start_mixed(self, test_runner, platform):
         """4 submissions: T0 baseline + T1/T2/T3 with sync_start=True, mirroring the sync_start test."""
         self._run_case(test_runner, SPMDSyncStartMixedTestCase(platform=platform))
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_spmd_gm_pipe_buffer_golden(self, test_runner, platform):
+        """SPMD gm_pipe_buffer runtime path should pass golden on all platforms."""
+        self._run_case(test_runner, SPMDGMPipeBufferTestCase(platform=platform))
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2280,6 +2280,53 @@ class TestTensorReadWriteOffsetCodegen:
             f"SPMD tuple outputs must remain OutputExisting at call site. Generated code:\n{code}"
         )
 
+    def test_spmd_gm_pipe_buffer_tensor_create_scales_with_core_num(self):
+        """SPMD gm_pipe_buffer allocation should scale by launch core_num in orchestration codegen."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdGMPipeProgram:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_bias = pl.load(bias, [0, 0], [64, 64])
+                tile_out = pl.add(tile_mm, tile_bias)
+                out = pl.store(tile_out, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, b, bias, out)
+                return out
+
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SpmdGMPipeProgram)
+
+        code = _generate_orch_code(transformed)
+        assert "params_t0.launch_spec.set_block_num(4);" in code
+        assert re.search(
+            r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{static_cast<uint32_t>\(\(\d+\) \* \(4\)\)\};",
+            code,
+        ), f"Expected gm_pipe_buffer tensor.create shape to scale by core_num. Generated code:\n{code}"
+
 
 class TestUnregisteredOpError:
     """Test that unregistered/misplaced ops in Orchestration functions raise errors."""


### PR DESCRIPTION
- Add GetTensorCreateScaleExpr; orchestration scales injected gm_pipe_buffer
  tensor.create by launch core_num; pto_backend shards __gm_pipe_buffer by block_idx.
- Compute gm_buffer_elems after upward propagation in inject_gm_pipe_buffer.
- Orchestration: skip inner scalar IVs absent from wrapper signature; map tuple
  outputs when SPMD wrappers prefix auxiliary tuple fields.
- Reject non-bijective return permutations in normalize_return_order.
- Add ST golden and UT coverage for SPMD gm_pipe_buffer path.