### PR TITLE
fix(codegen): hoist host_orch tensor.create to pre-init alloc fn

### DIFF
--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "pypto/codegen/code_emitter.h"
@@ -98,6 +99,15 @@ class DistributedCodegen : public CodegenBase {
   void EmitTreeReduce(const ir::CallPtr& call);
   void EmitTensorCreate(const ir::CallPtr& call);
 
+  // Pre-init allocation hoisting for HOST orchestrator. tensor.create
+  // statements at the top level of the HOST orchestrator body are emitted
+  // into a separate `_alloc_intermediates(tensors)` Python function so the
+  // simpler runtime can populate shared-memory tensors *before* w.init()
+  // forks subworker / chip-worker child processes. Allocations made after
+  // fork are not visible to inherited children.
+  void CollectHostOrchHoistableAllocs(const ir::FunctionPtr& host_orch);
+  void EmitAllocIntermediatesFunction(const ir::FunctionPtr& host_orch);
+
   // Helpers
   [[nodiscard]] std::string ParamDirectionToTensorArgType(ir::ParamDirection dir) const;
   [[nodiscard]] std::vector<ir::FunctionPtr> SortFunctionsByRoleAndLevel() const;
@@ -124,6 +134,13 @@ class DistributedCodegen : public CodegenBase {
   std::set<std::string> declared_vars_;
   bool is_worker_context_{false};
   int task_args_counter_{0};  // Counter for generating unique TaskArgs variable names
+
+  // HOST orchestrator alloc-hoisting state. Populated by
+  // CollectHostOrchHoistableAllocs() before EmitFunction() runs on the HOST
+  // orchestrator; consulted by VisitStmt_(AssignStmt) to skip tensor.create
+  // assignments that have already been emitted in _alloc_intermediates.
+  std::unordered_set<const ir::AssignStmt*> hoisted_allocs_;
+  bool host_orch_body_after_hoist_{false};
 };
 
 }  // namespace codegen

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -167,6 +167,14 @@ def execute_distributed(  # noqa: PLR0912
             arg.share_memory_()
         tensors[info.name] = arg
 
+    # 3b. Pre-fork: allocate HOST-level intermediate tensors so the POSIX
+    # shared-memory mappings exist before w.init() forks subworker /
+    # chip-worker child processes. Mappings created after fork are not
+    # visible to inherited children.
+    alloc_fn = getattr(orch_module, "_alloc_intermediates", None)
+    if alloc_fn is not None:
+        alloc_fn(tensors)
+
     # 4. Load SubWorker callables from sub_workers/*.py files
     sub_worker_fns: dict[str, Any] = {}
     sub_workers_dir = output_dir / "sub_workers"

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -47,6 +47,8 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
   entry_func_ = nullptr;
   all_funcs_.clear();
   used_levels_.clear();
+  hoisted_allocs_.clear();
+  host_orch_body_after_hoist_ = false;
 
   ClassifyFunctions();
   CHECK(!workers_.empty() || !orchestrators_.empty())
@@ -70,7 +72,22 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
         }
       }
     }
-    EmitFunction(best_orch);
+    // HOST-or-above orchestrator (Linqu level >= 3): split tensor.create
+    // allocations into a pre-init `_alloc_intermediates(tensors)` function so
+    // the simpler runtime can establish POSIX shared memory before fork.
+    const bool is_host_orch =
+        best_orch->level_.has_value() &&
+        ir::LevelToLinquLevel(*best_orch->level_) >= 3;  // NOLINT(bugprone-unchecked-optional-access)
+    if (is_host_orch) {
+      CollectHostOrchHoistableAllocs(best_orch);
+      EmitAllocIntermediatesFunction(best_orch);
+      host_orch_body_after_hoist_ = true;
+      EmitFunction(best_orch);
+      host_orch_body_after_hoist_ = false;
+      hoisted_allocs_.clear();
+    } else {
+      EmitFunction(best_orch);
+    }
   } else if (entry_func_) {
     EmitEntryFunction();
   }
@@ -249,6 +266,14 @@ void DistributedCodegen::VisitStmt_(const ir::AssignStmtPtr& op) {
   INTERNAL_CHECK(op != nullptr) << "Internal error: null AssignStmt";
 
   std::string var_name = SanitizeName(op->var_->name_hint_);
+
+  // If this AssignStmt was hoisted to _alloc_intermediates(tensors), the
+  // value has already been emitted in the alloc function. Register the SSA
+  // name for downstream tensors[...] references but emit nothing here.
+  if (host_orch_body_after_hoist_ && hoisted_allocs_.count(op.get())) {
+    declared_vars_.insert(var_name);
+    return;
+  }
 
   current_target_var_ = var_name;
   current_expr_value_ = "";
@@ -582,6 +607,95 @@ void DistributedCodegen::EmitTensorCreate(const ir::CallPtr& call) {
 
   declared_vars_.insert(target);
   current_expr_value_ = "";
+}
+
+// ========================================================================
+// HOST orchestrator alloc hoisting
+// ========================================================================
+
+namespace {
+
+// Returns true iff @p stmt is an AssignStmt whose value is a Call to op
+// `tensor.create`. Used to detect hoistable allocations.
+bool IsTensorCreateAssign(const ir::StmtPtr& stmt) {
+  auto assign = std::dynamic_pointer_cast<const ir::AssignStmt>(stmt);
+  if (!assign) return false;
+  auto call = std::dynamic_pointer_cast<const ir::Call>(assign->value_);
+  if (!call || !call->op_) return false;
+  return call->op_->name_ == "tensor.create";
+}
+
+// Recursively reject any `tensor.create` reachable through @p stmt — pre-init
+// hoisting requires unconditional, top-level allocations, so a tensor.create
+// nested inside control flow (if/for/scope) is unsupported. @p container
+// labels the enclosing construct for the error message.
+void RejectNestedTensorCreate(const ir::StmtPtr& stmt, const std::string& container) {
+  if (!stmt) return;
+  CHECK(!IsTensorCreateAssign(stmt)) << "pl.create_tensor in HOST orchestrator must be a top-level "
+                                        "statement (not nested inside "
+                                     << container
+                                     << "). Pre-init hoisting requires static, unconditional allocation.";
+  if (auto if_stmt = std::dynamic_pointer_cast<const ir::IfStmt>(stmt)) {
+    RejectNestedTensorCreate(if_stmt->then_body_, "if-then");
+    if (if_stmt->else_body_.has_value()) {
+      RejectNestedTensorCreate(*if_stmt->else_body_,  // NOLINT(bugprone-unchecked-optional-access)
+                               "if-else");
+    }
+  } else if (auto for_stmt = std::dynamic_pointer_cast<const ir::ForStmt>(stmt)) {
+    RejectNestedTensorCreate(for_stmt->body_, "for-loop");
+  } else if (auto seq = std::dynamic_pointer_cast<const ir::SeqStmts>(stmt)) {
+    for (const auto& s : seq->stmts_) RejectNestedTensorCreate(s, container);
+  }
+}
+
+// Returns the immediate top-level statements of a function body. The HOST
+// orchestrator body is a SeqStmts in practice; the single-stmt case is
+// handled for safety.
+std::vector<ir::StmtPtr> TopLevelStmts(const ir::StmtPtr& body) {
+  if (auto seq = std::dynamic_pointer_cast<const ir::SeqStmts>(body)) {
+    return {seq->stmts_.begin(), seq->stmts_.end()};
+  }
+  return {body};
+}
+
+}  // namespace
+
+void DistributedCodegen::CollectHostOrchHoistableAllocs(const ir::FunctionPtr& host_orch) {
+  hoisted_allocs_.clear();
+  if (!host_orch->body_) return;
+
+  for (const auto& stmt : TopLevelStmts(host_orch->body_)) {
+    if (IsTensorCreateAssign(stmt)) {
+      auto assign = std::dynamic_pointer_cast<const ir::AssignStmt>(stmt);
+      hoisted_allocs_.insert(assign.get());
+    } else {
+      // Any tensor.create reached from a non-top-level statement is an error.
+      RejectNestedTensorCreate(stmt, "control flow");
+    }
+  }
+}
+
+void DistributedCodegen::EmitAllocIntermediatesFunction(const ir::FunctionPtr& host_orch) {
+  emitter_.EmitLine("def _alloc_intermediates(tensors):");
+  emitter_.IncreaseIndent();
+  if (hoisted_allocs_.empty()) {
+    emitter_.EmitLine("pass");
+  } else {
+    // Walk top-level statements in original order; emit only hoisted allocs.
+    // Falls through the normal AssignStmt → Call → EmitTensorCreate path.
+    // host_orch_body_after_hoist_ is FALSE here so EmitTensorCreate runs
+    // unchanged. The subsequent EmitFunction(host_orch) call resets visitor
+    // state (declared_vars_, current_func_, ...), so no save/restore needed.
+    current_func_ = host_orch;
+    for (const auto& stmt : TopLevelStmts(host_orch->body_)) {
+      auto assign = std::dynamic_pointer_cast<const ir::AssignStmt>(stmt);
+      if (assign && hoisted_allocs_.count(assign.get())) {
+        VisitStmt(stmt);
+      }
+    }
+  }
+  emitter_.DecreaseIndent();
+  emitter_.EmitLine("");
 }
 
 std::string DistributedCodegen::DataTypeToPythonDType(const DataType& dtype) {

--- a/tests/st/distributed/test_l3_parallel_reduce.py
+++ b/tests/st/distributed/test_l3_parallel_reduce.py
@@ -108,10 +108,6 @@ class L3ParallelReduceProgram:
 class TestL3ParallelReduce:
     """L3 distributed runtime: two independent chip tasks + SubWorker reduce."""
 
-    @pytest.mark.skip(
-        reason="Multiple submit_next_level calls with different chip callables segfaults "
-        "in _chip_process_loop — runtime support pending"
-    )
     def test_execute(self, test_config):
         """End-to-end: compile + execute, verify f = (a+b) + (a-b) = 2a."""
         compiled = ir.compile(

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -9,6 +9,8 @@
 
 """Unit tests for distributed Python code generation."""
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import codegen, ir, passes
@@ -378,6 +380,107 @@ class TestDistributedCodegen:
         # Parameter tensors still use make_tensor_arg(tensors[...])
         assert 'make_tensor_arg(tensors["a' in code
         assert 'make_tensor_arg(tensors["b' in code
+
+    def test_host_orch_create_tensor_hoisted_to_alloc_intermediates(self):
+        """HOST-orch tensor.create lifts to _alloc_intermediates(tensors).
+
+        The simpler L3 runtime forks subworker / chip-worker child processes
+        inside w.init(); POSIX shared memory created after fork is invisible
+        to inherited children. Intermediate tensors created via
+        pl.create_tensor in the HOST orchestrator body must therefore be
+        allocated *before* w.init() — codegen splits them into a separate
+        _alloc_intermediates(tensors) function that the runtime invokes
+        pre-init.
+        """
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.SubWorker)
+            def chip_worker(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                buf: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(a, a)
+                return y
+
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                buf: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = self.chip_worker(a, buf)
+                return result
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                buf: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                result: pl.Tensor[[64], pl.FP32] = self.chip_orch(a, buf)
+                return result
+
+        program = passes.convert_to_ssa()(Input)
+        cg = codegen.DistributedCodegen()
+        code = cg.generate(program)
+
+        alloc_idx = code.find("def _alloc_intermediates(tensors):")
+        host_idx = code.find("def host_orch(")
+        assert alloc_idx >= 0, f"Missing _alloc_intermediates in:\n{code}"
+        assert host_idx >= 0, f"Missing host_orch in:\n{code}"
+        assert alloc_idx < host_idx, "_alloc_intermediates must precede host_orch"
+
+        alloc_block = code[alloc_idx:host_idx]
+        host_block = code[host_idx:]
+
+        # Allocation lives in _alloc_intermediates only. SSA renames the local
+        # so match by structure rather than the literal source name.
+        assert "torch.zeros((64,), dtype=torch.float32).share_memory_()" in alloc_block
+        match = re.search(r'tensors\["([^"]+)"\] = torch\.zeros\(', alloc_block)
+        assert match is not None, f"No tensors[...] = torch.zeros(...) in:\n{alloc_block}"
+        hoisted_name = match.group(1)
+
+        # host_orch must NOT re-allocate the hoisted tensor — but it must
+        # still pass it via `tensors["<name>"]` to the chip orchestrator.
+        assert "torch.zeros(" not in host_block
+        assert f'tensors["{hoisted_name}"]' in host_block
+
+    def test_alloc_intermediates_emitted_when_no_creates(self):
+        """HOST orchestrator without tensor.create still gets an empty alloc fn.
+
+        Keeping the symbol present simplifies the runtime contract: it can
+        unconditionally call _alloc_intermediates(tensors) before w.init().
+        """
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.SubWorker)
+            def chip_worker(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.chip_worker(x)
+                return y
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.chip_orch(x)
+                return y
+
+        program = passes.convert_to_ssa()(Input)
+        cg = codegen.DistributedCodegen()
+        code = cg.generate(program)
+
+        assert "def _alloc_intermediates(tensors):" in code
+        # Body is just `pass` since there are no allocations to hoist.
+        alloc_idx = code.find("def _alloc_intermediates(tensors):")
+        host_idx = code.find("def host_orch(")
+        alloc_block = code[alloc_idx:host_idx]
+        assert "    pass" in alloc_block
 
 
 class TestSubWorkerSourceGeneration:


### PR DESCRIPTION
## Summary

The simpler L3 distributed runtime forks subworker / chip-worker child processes inside `w.init()`. POSIX shared memory established **after** fork is not visible to inherited children — they have no fd, no mmap, and a different VA mapping.

Until now, `pl.create_tensor` calls in the HOST orchestrator body were emitted as `tensors["X"] = torch.zeros(...).share_memory_()` lines **inside** `host_orch`, which runs after `w.init()`. Children would dereference an un-mapped pointer when accessing those intermediate tensors.

This PR splits the HOST orchestrator into two generated functions:

- `_alloc_intermediates(tensors)` — pre-init function holding the `torch.zeros(...).share_memory_()` lines.
- `host_orch(orch, ..., tensors, ...)` — dispatch logic only; the `tensor.create` lines have been hoisted out.

`distributed_runner.py` now invokes `_alloc_intermediates(tensors)` before `w.init()`, so the shared-memory mappings exist at fork time and are inherited by every child process.

### Generated output (before → after)

```python
# Before — sum_ab / diff_ab allocated post-fork; children can't see them
def host_orch(orch, _args, config, *, tensors, callables, sub_ids, _keep):
    tensors["sum_ab"]  = torch.zeros((128,128), dtype=torch.float32).share_memory_()
    tensors["diff_ab"] = torch.zeros((128,128), dtype=torch.float32).share_memory_()
    _ta_0 = TaskArgs(); ...

# After — allocations live in a pre-init fn
def _alloc_intermediates(tensors):
    tensors["sum_ab"]  = torch.zeros((128,128), dtype=torch.float32).share_memory_()
    tensors["diff_ab"] = torch.zeros((128,128), dtype=torch.float32).share_memory_()

def host_orch(orch, _args, config, *, tensors, callables, sub_ids, _keep):
    _ta_0 = TaskArgs(); ...
```

### Constraints

`tensor.create` is rejected (with a `CHECK` message) when nested inside `if` / `for` / scope statements in the HOST orchestrator. Pre-init hoisting requires unconditional, top-level allocation; conditional or loop-bound allocations would need a different mechanism.

### Out of scope (logged to KNOWN_ISSUES.md)

`EmitCallToWorker` has a fallback at `src/codegen/distributed/distributed_codegen.cpp:489-491` that allocates a return tensor at host_orch run time when the callee has a return type but no `Out` param. This has the same fork-visibility bug. None of the current L3 tests exercise this path (every chip orchestrator declares an `Out` param), so the fix is deferred.

## Files changed

| File | Change |
| ---- | ------ |
| `include/pypto/codegen/distributed/distributed_codegen.h` | New `hoisted_allocs_` set, `host_orch_body_after_hoist_` flag, two helper declarations |
| `src/codegen/distributed/distributed_codegen.cpp` | `Generate()` splits HOST orchestrator into alloc + run; `VisitStmt_(AssignStmt)` skips hoisted statements; rejects nested `tensor.create` |
| `python/pypto/runtime/distributed_runner.py` | Invokes `_alloc_intermediates(tensors)` before `w.init()` |
| `tests/ut/codegen/test_distributed_codegen.py` | Two new tests: hoisting populates alloc fn / strips host_orch body; empty alloc fn emitted when no allocations |
| `tests/st/distributed/test_l3_parallel_reduce.py` | Removed the `@pytest.mark.skip` decorator — the test exercises the bug this PR fixes |

## Test plan

- [x] `tests/ut/codegen/test_distributed_codegen.py` — 15/15 pass (2 new tests)
- [x] Full codegen UT suite — 217 pass, 3 unrelated skips
- [x] Full project test suite — 4162 pass, 30 unrelated skips, 0 fail
- [x] clang-tidy — no new warnings on changed lines (pre-existing whole-file warnings unaffected)
- [x]  `test_l3_parallel_reduce.py` pass

## Related

Builds on #1193 (L3 hierarchical codegen). The runtime contract — HOST orchestrators emit `_alloc_intermediates(tensors)` and the runner calls it pre-init — should be documented in `docs/en/dev/codegen/01-orchestration_codegen.md` in a follow-up.