### PR TITLE
fix(pass): Repair matrix layout for row-major ops

### DIFF
--- a/docs/en/dev/passes/18-resolve_backend_op_layouts.md
+++ b/docs/en/dev/passes/18-resolve_backend_op_layouts.md
@@ -1,14 +1,16 @@
 # ResolveBackendOpLayouts Pass
 
-Repairs backend-required tile layouts for elementwise ops by reshaping `[N, 1]` col-major vector inputs into `[1, N]` row-major views and reshaping the result back. Runs in the tile-PTO stage between `ResolveTransposeLayout` and the trailing `NormalizeStmtStructure`.
+Repairs backend-required tile layouts for elementwise ops. `[N, 1]` col-major vectors are reshaped into `[1, N]` row-major views, while general non-row-major tiles are coerced through `tile.move(..., blayout=row_major)`. Runs in the tile-PTO stage between `ResolveTransposeLayout` and the trailing `NormalizeStmtStructure`.
 
 ## Overview
 
-After `FlattenTileNdTo2D` and `ResolveTransposeLayout`, every tile op is in 2-D form with a known layout. Several PTO elementwise ops (registered in `src/backend/common/pto_ops_common.cpp`) require their tile operands and result to be `row_major`. A column vector of shape `[N, 1]` has the same memory layout as a row vector of shape `[1, N]`, so this pass repairs the violation locally:
+After `FlattenTileNdTo2D` and `ResolveTransposeLayout`, every tile op is in 2-D form with a known layout. Several PTO elementwise ops (registered in `src/backend/common/pto_ops_common.cpp`) require their tile operands and result to be `row_major`. This pass repairs those local violations at the consumer:
 
 1. For each `AssignStmt` / `EvalStmt` whose RHS is a `Call`, query `Backend::GetTileLayoutSpec(op_name)`.
-2. Skip if no spec is registered, or if no `[N, 1]` col-major input violates a `row_major` requirement.
-3. Otherwise insert `tile.reshape(arg, [1, N])` before the call, substitute the reshaped value into the call, and — for `AssignStmt` results, unless the result type is already a `[1, N]` row-major tile — append `tile.reshape(tmp, original_shape)` to restore the user-visible shape.
+2. Skip if no spec is registered, or if all constrained tile inputs and output already use `row_major`.
+3. For `[N, 1]` col-major inputs, insert `tile.reshape(arg, [1, N])` before the call. This is a metadata-only view repair because `[N, 1]` col-major and `[1, N]` row-major have the same flat memory order.
+4. For other non-row-major tile inputs, insert `tile.move(arg, target_memory=<same>, blayout=row_major, slayout=none_box)` before the call.
+5. For `AssignStmt` results whose original result type is not row-major, assign the repaired call to a row-major temporary, then restore the original result layout with either `tile.reshape` for column vectors or `tile.move` for general matrix tiles.
 
 The pass is **backend-driven**: the set of constrained ops and their per-input requirements come from each op's `BackendOpRegistryEntry` (see `set_input_layout` / `set_output_layout` in `pto_ops_common.cpp`). The pass code itself stays backend-agnostic — adding a new constrained op only requires registering its layout spec, not editing this pass.
 
@@ -46,29 +48,36 @@ For each function in the program:
   RHS is a Call:
     spec = backend.GetTileLayoutSpec(call.op.name)
     if spec is None: continue
-    if no input violates spec.input_layouts (only [N,1] col-major inputs
-       targeting a row_major slot are repairable): continue
+    if no constrained input/output needs row_major repair: continue
 
     For each input i targeting a row_major slot:
-      Skip if the input is non-tile, or [1, N] row-major, or not [N, 1].
+      Skip if the input is non-tile or already row-major.
       reshape_var = fresh temp
         (AssignStmt: name derived from the result variable.
          EvalStmt:  name derived from the literal "layout_fix".
          Both forms add "row_major" + "arg<i>" qualifiers.)
-      emit  reshape_var = tile.reshape(arg_i, [1, N])
+      If input is [N, 1] col-major:
+        emit  reshape_var = tile.reshape(arg_i, [1, N])
+      Else:
+        emit  reshape_var = tile.move(arg_i, target_memory=<same>,
+                                      blayout=row_major, slayout=none_box)
       substitute reshape_var into the call
 
     repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
 
-    If statement is AssignStmt and result_type is not [1, N] row-major:
+    If statement is AssignStmt and result_type is constrained but not row-major:
       tmp = fresh row-major temp ("row_major" qualifier on the result name)
       emit  tmp = repaired
-      emit  result_var = tile.reshape(tmp, original_result_shape)
+      If original result is a column vector:
+        emit  result_var = tile.reshape(tmp, original_result_shape)
+      Else:
+        emit  result_var = tile.move(tmp, target_memory=<same>,
+                                     blayout=<original>, slayout=<original>)
     Else:
       emit  result_var = repaired   (or EvalStmt with repaired)
 ```
 
-Non-tile inputs (scalars, shapes) and inputs whose required layout is `nullopt` are left untouched. For tile inputs targeting a `row_major` slot, the per-input rewrite loop reshapes any `[N, 1]` operand (col-major *or* row-major) once the call has been classified as repairable; only `[1, N]` row-major and non-`[N, 1]` shapes are skipped. The call is classified as repairable (`IsRepairableCall`) only when at least one input violates `row_major` and every violating input is `[N, 1]` col-major — if any violating input falls outside that pattern, the statement is left alone.
+Non-tile inputs (scalars, shapes) and inputs whose required layout is `nullopt` are left untouched. The repair is local to the constrained op: downstream code still sees the original variable type and layout because `AssignStmt` results are restored after the row-major operation.
 
 ## Example
 
@@ -140,14 +149,15 @@ class After:
 | `include/pypto/ir/transforms/pass_properties.h` (`kResolveBackendOpLayoutsProperties`) | Pass properties |
 | `python/bindings/modules/passes.cpp` (`resolve_backend_op_layouts`) | Python binding |
 | `python/pypto/pypto_core/passes.pyi` (`resolve_backend_op_layouts`) | Type stub |
-| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | Unit tests (binary, unary, scalar-binary on `[N, 1]` vectors) |
+| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | Unit tests (binary, unary, scalar-binary on `[N, 1]` vectors, plus matrix layout coercion through `tile.move`) |
 
 Layout constraints are registered per op via `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` in `src/backend/common/pto_ops_common.cpp` (e.g. row-major elementwise ops listed in `RequiresRowMajorLayout`, `tile.rsqrt`, `tile.cmps`, `tile.sort32`, `tile.mscatter`, ...).
 
 Key helpers in the pass source:
 
-- `IsRepairableCall` — true iff at least one tile input violates a `row_major` requirement and every violating input is a `[N, 1]` col-major tile.
-- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` — emit the pre-call reshape(s), rebuild the call, and (for `AssignStmt`) emit the post-call reshape when the result was a col-major column vector.
+- `NeedsInputRepair` / `NeedsOutputRepair` — detect constrained `row_major` slots whose current tile layout is not row-major.
+- `CreateLayoutMoveCall` — emits the `tile.move` used for general matrix layout coercion and result restoration.
+- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` — emit the pre-call reshape/move repairs, rebuild the call, and (for `AssignStmt`) emit the post-call reshape/move restoration when needed.
 - `RewriteFunction` — bypasses non-`InCore` functions and the unconfigured-backend case before invoking the mutator.
 
 ## Pass Properties
@@ -165,7 +175,7 @@ Key helpers in the pass source:
 | Decision | Rationale |
 | -------- | --------- |
 | Drive layout requirements from `Backend::GetTileLayoutSpec` rather than hard-coded op lists in the pass | Each backend declares its own constraints next to its codegen registration. The pass stays backend-agnostic per `pass-context-config.md`; new constrained ops cost one `set_input_layout` call, not a pass edit. |
-| Repair via two `tile.reshape` ops instead of rejecting the program | `[N, 1]` col-major and `[1, N]` row-major share the same flat memory; a local reshape preserves user-visible shapes while satisfying the backend ISA without forcing kernel rewrites. |
-| Only repair `[N, 1]` col-major inputs (not arbitrary layout mismatches) | This is the only mismatch class observed for current PTO row-major elementwise ops. Broader cases would require a real layout-conversion pass and are out of scope; if one is found, `IsRepairableCall` returns false and the statement is left alone. |
+| Prefer `tile.reshape` for `[N, 1]` vectors | `[N, 1]` col-major and `[1, N]` row-major share the same flat memory, so reshape is cheaper and preserves the existing vector repair behavior. |
+| Use `tile.move` for general matrix layout coercion | Full tiles such as `[16, 256]` cannot be repaired by a shape-only vector reshape. A same-memory `tile.move` materializes a row-major view before row-major PTO ops such as `tile.exp`, then restores the original layout when needed. |
 | Bypass when no backend is configured | Many tests build IR without selecting a backend. A no-op fast path keeps those green and avoids spurious mutations. |
 | Skip non-`InCore` functions | Layout constraints apply to per-core elementwise execution; Orchestration and Group functions only contain calls to lower-level kernels and have nothing to repair. |

--- a/docs/zh-cn/dev/passes/18-resolve_backend_op_layouts.md
+++ b/docs/zh-cn/dev/passes/18-resolve_backend_op_layouts.md
@@ -1,14 +1,16 @@
 # ResolveBackendOpLayouts Pass
 
-为后端有 layout 约束的 elementwise tile op 修复 layout：把 `[N, 1]` 的 col-major 向量输入 reshape 成 `[1, N]` 的 row-major 视图，必要时再把结果 reshape 回来。该 Pass 在 tile-PTO 阶段运行，位于 `ResolveTransposeLayout` 之后、收尾的 `NormalizeStmtStructure` 之前。
+为后端有 layout 约束的 elementwise tile op 修复 layout：把 `[N, 1]` 的 col-major 向量 reshape 成 `[1, N]` 的 row-major 视图，并通过 `tile.move(..., blayout=row_major)` 修复一般非 row-major tile。该 Pass 在 tile-PTO 阶段运行，位于 `ResolveTransposeLayout` 之后、收尾的 `NormalizeStmtStructure` 之前。
 
 ## 概述
 
-经过 `FlattenTileNdTo2D` 和 `ResolveTransposeLayout` 之后，所有 tile op 都已是 2-D 形式且带有明确的 layout。多个 PTO elementwise op（在 `src/backend/common/pto_ops_common.cpp` 中注册）要求其 tile 操作数与结果均为 `row_major`。`[N, 1]` 列向量与 `[1, N]` 行向量在内存中的排布完全相同，因此本 Pass 在使用点局部修复约束违反：
+经过 `FlattenTileNdTo2D` 和 `ResolveTransposeLayout` 之后，所有 tile op 都已是 2-D 形式且带有明确的 layout。多个 PTO elementwise op（在 `src/backend/common/pto_ops_common.cpp` 中注册）要求其 tile 操作数与结果均为 `row_major`。本 Pass 在使用点局部修复这些约束违反：
 
 1. 对每个 RHS 是 `Call` 的 `AssignStmt` / `EvalStmt`，调用 `Backend::GetTileLayoutSpec(op_name)` 查询约束。
-2. 若没有注册约束，或者没有 `[N, 1]` col-major 输入违反 `row_major` 要求，则跳过。
-3. 否则在 call 前插入 `tile.reshape(arg, [1, N])`，把 reshape 后的值代入 call；对 `AssignStmt`，只要结果类型不是 `[1, N]` row-major tile，就再追加 `tile.reshape(tmp, original_shape)` 把结果 reshape 回用户可见的形状。
+2. 若没有注册约束，或者所有受约束的 tile 输入与输出都已经是 `row_major`，则跳过。
+3. 对 `[N, 1]` col-major 输入，在 call 前插入 `tile.reshape(arg, [1, N])`。这是仅改变元数据的视图修复，因为 `[N, 1]` col-major 与 `[1, N]` row-major 的扁平内存顺序相同。
+4. 对其他非 row-major tile 输入，在 call 前插入 `tile.move(arg, target_memory=<same>, blayout=row_major, slayout=none_box)`。
+5. 对原始结果类型不是 row-major 的 `AssignStmt`，先把修复后的 call 赋给一个 row-major 临时变量，再用 `tile.reshape`（列向量）或 `tile.move`（一般矩阵 tile）恢复原始结果 layout。
 
 本 Pass 是 **后端驱动** 的：被约束的 op 集合及其逐输入要求来自每个 op 的 `BackendOpRegistryEntry`（参见 `pto_ops_common.cpp` 中的 `set_input_layout` / `set_output_layout`）。Pass 自身保持后端无关——新增一个被约束的 op 只需登记它的 layout spec，无需修改本 Pass。
 
@@ -46,29 +48,36 @@ program = repair(program)
   AssignStmt / EvalStmt：
     spec = backend.GetTileLayoutSpec(call.op.name)
     若 spec 为空：跳过
-    若没有输入违反 spec.input_layouts（仅 [N,1] col-major 输入针对
-       row_major 槽位时是可修复的）：跳过
+    若没有受约束输入/输出需要 row_major 修复：跳过
 
     对每个 row_major 槽位上的输入 i：
-      若输入非 tile、为 [1, N] row-major、或非 [N, 1]：跳过。
+      若输入非 tile 或已经是 row-major：跳过。
       reshape_var = 新临时变量
         （AssignStmt：名字基于结果变量；
           EvalStmt：名字基于字面量 "layout_fix"。
           两种形式都附加 "row_major" + "arg<i>" 限定符。）
-      发射  reshape_var = tile.reshape(arg_i, [1, N])
+      若输入是 [N, 1] col-major：
+        发射  reshape_var = tile.reshape(arg_i, [1, N])
+      否则：
+        发射  reshape_var = tile.move(arg_i, target_memory=<same>,
+                                      blayout=row_major, slayout=none_box)
       把 reshape_var 替换 call 中对应的实参
 
     repaired = OpRegistry.Create(call.op.name, new_args, call.kwargs)
 
-    若语句是 AssignStmt 且 result_type 不是 [1, N] row-major：
+    若语句是 AssignStmt 且 result_type 受约束但不是 row-major：
       tmp = 新的 row-major 临时变量（结果名字加 "row_major" 限定符）
       发射  tmp = repaired
-      发射  result_var = tile.reshape(tmp, original_result_shape)
+      若原始结果是列向量：
+        发射  result_var = tile.reshape(tmp, original_result_shape)
+      否则：
+        发射  result_var = tile.move(tmp, target_memory=<same>,
+                                     blayout=<original>, slayout=<original>)
     否则：
       发射  result_var = repaired   （或 EvalStmt 中以 repaired 替换）
 ```
 
-非 tile 输入（标量、shape）以及对应槽位 `required_layout` 为 `nullopt` 的输入不会被改写。对 `row_major` 槽位上的 tile 输入，一旦 call 被判定为可修复，逐输入改写循环就会 reshape 任何 `[N, 1]` 操作数（无论 col-major 还是 row-major）；只有 `[1, N]` row-major 和非 `[N, 1]` 形状会被跳过。call 是否可修复由 `IsRepairableCall` 决定：仅当至少有一个输入违反 `row_major` 要求、且每个违反约束的输入都是 `[N, 1]` col-major 时才返回 true；若有违反约束的输入不属于该模式，整条语句保持不动。
+非 tile 输入（标量、shape）以及对应槽位 `required_layout` 为 `nullopt` 的输入不会被改写。修复局限在受约束 op 附近：下游代码仍然看到原始变量类型和 layout，因为 `AssignStmt` 结果会在 row-major op 之后恢复。
 
 ## 示例
 
@@ -140,14 +149,15 @@ class After:
 | `include/pypto/ir/transforms/pass_properties.h`（`kResolveBackendOpLayoutsProperties`） | Pass 属性 |
 | `python/bindings/modules/passes.cpp`（`resolve_backend_op_layouts`） | Python 绑定 |
 | `python/pypto/pypto_core/passes.pyi`（`resolve_backend_op_layouts`） | 类型存根 |
-| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | 单元测试（`[N, 1]` 向量上的 binary、unary、tile×scalar） |
+| `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | 单元测试（`[N, 1]` 向量上的 binary、unary、tile×scalar，以及通过 `tile.move` 进行矩阵 layout 修复） |
 
 Layout 约束通过 `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` 在 `src/backend/common/pto_ops_common.cpp` 中按 op 注册（如 `RequiresRowMajorLayout` 列表中的 row-major elementwise op、`tile.rsqrt`、`tile.cmps`、`tile.sort32`、`tile.mscatter` 等）。
 
 Pass 源文件中的关键 helper：
 
-- `IsRepairableCall` —— 当且仅当至少有一个 tile 输入违反 `row_major` 要求、且每个违反约束的输入都是 `[N, 1]` col-major tile 时返回 true。
-- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` —— 发射 call 前的 reshape、重建 call，并在结果是 col-major 列向量的情况下（仅 `AssignStmt`）发射 call 后的 reshape。
+- `NeedsInputRepair` / `NeedsOutputRepair` —— 检测受约束的 `row_major` 槽位中当前 tile layout 不是 row-major 的情况。
+- `CreateLayoutMoveCall` —— 发射用于一般矩阵 layout 修复和结果恢复的 `tile.move`。
+- `BackendLayoutRepairMutator::VisitStmt_(const AssignStmtPtr&)` / `VisitStmt_(const EvalStmtPtr&)` —— 发射 call 前的 reshape/move，重建 call，并在 `AssignStmt` 需要时发射 call 后的 reshape/move。
 - `RewriteFunction` —— 跳过非 `InCore` 函数和未配置后端的情况，再调用 mutator。
 
 ## Pass 属性
@@ -165,7 +175,7 @@ Pass 源文件中的关键 helper：
 | 决策 | 理由 |
 | ---- | ---- |
 | 通过 `Backend::GetTileLayoutSpec` 获取 layout 要求，而不是在 Pass 中硬编码 op 列表 | 各后端在自己的 codegen 注册旁边声明约束。Pass 保持后端无关（参见 `pass-context-config.md`）；新增被约束的 op 只需要一次 `set_input_layout` 调用，不必改 Pass。 |
-| 通过两次 `tile.reshape` 修复，而不是直接拒绝程序 | `[N, 1]` col-major 与 `[1, N]` row-major 的扁平内存布局相同；局部 reshape 既保留了用户可见的形状，又满足后端 ISA，不必让用户重写 kernel。 |
-| 只修复 `[N, 1]` col-major 输入（不处理任意 layout 不匹配） | 这是当前 PTO row-major elementwise op 唯一观测到的不匹配模式。处理更一般情形需要真正的 layout 转换 Pass，本 Pass 不在该范围内；其他模式下 `IsRepairableCall` 返回 false，语句保持不变。 |
+| 对 `[N, 1]` 向量优先使用 `tile.reshape` | `[N, 1]` col-major 与 `[1, N]` row-major 的扁平内存布局相同；reshape 成本更低，也保留了既有的向量修复行为。 |
+| 对一般矩阵 layout 修复使用 `tile.move` | `[16, 256]` 这类完整 tile 无法通过只改变形状的向量 reshape 修复。相同 memory space 内的 `tile.move` 会在 `tile.exp` 等 row-major PTO op 之前物化 row-major 视图，并在需要时恢复原 layout。 |
 | 未配置后端时直接 bypass | 大量测试在未选择后端的情况下构造 IR；no-op fast path 让这些测试仍然通过，避免无意义的改写。 |
 | 跳过非 `InCore` 函数 | Layout 约束作用于每个核内的 elementwise 执行；Orchestration、Group 函数仅承载对低层 kernel 的调用，没有需要修复的内容。 |

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <any>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -66,10 +67,11 @@ bool IsColumnVector(const TileTypePtr& tile_type) {
   return tile_type && tile_type->shape_.size() == 2 && IsConstOne(tile_type->shape_[1]);
 }
 
-bool IsRowVectorRowMajor(const TileTypePtr& tile_type) {
-  return tile_type && tile_type->shape_.size() == 2 && IsConstOne(tile_type->shape_[0]) &&
-         GetTileLayout(tile_type) == TileLayout::row_major;
+bool RequiresRowMajor(const std::optional<TileLayout>& required_layout) {
+  return required_layout.has_value() && required_layout.value() == TileLayout::row_major;
 }
+
+bool IsRowMajor(const TileTypePtr& tile_type) { return GetTileLayout(tile_type) == TileLayout::row_major; }
 
 ExprPtr MakeShapeTuple(const std::vector<ExprPtr>& dims, const Span& span) {
   return std::make_shared<MakeTuple>(dims, span);
@@ -88,27 +90,55 @@ std::vector<ExprPtr> MakeRowVectorShape(const TileTypePtr& tile_type) {
   return {std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()), tile_type->shape_[0]};
 }
 
-bool IsRepairableCall(const CallPtr& call, const backend::BackendTileLayoutSpec& spec) {
-  bool has_repairable_input = false;
+MemorySpace GetRepairTargetMemory(const TileTypePtr& tile_type, MemorySpace fallback = MemorySpace::Vec) {
+  if (!tile_type) {
+    return fallback;
+  }
+  return tile_type->memory_space_.value_or(fallback);
+}
+
+std::vector<std::pair<std::string, std::any>> MakeLayoutMoveKwargs(MemorySpace target_memory,
+                                                                   TileLayout blayout, TileLayout slayout) {
+  return {
+      {"target_memory", std::any(target_memory)},
+      {"blayout", std::any(blayout)},
+      {"slayout", std::any(slayout)},
+  };
+}
+
+CallPtr CreateLayoutMoveCall(const ExprPtr& input, MemorySpace target_memory, TileLayout blayout,
+                             TileLayout slayout, const Span& span) {
+  auto expr = OpRegistry::GetInstance().Create("tile.move", {input},
+                                               MakeLayoutMoveKwargs(target_memory, blayout, slayout), span);
+  auto call = As<Call>(expr);
+  CHECK(call) << "ResolveBackendOpLayouts: tile.move must produce a Call";
+  return call;
+}
+
+bool NeedsInputRepair(const CallPtr& call, const backend::BackendTileLayoutSpec& spec) {
   for (size_t i = 0; i < spec.input_layouts.size() && i < call->args_.size(); ++i) {
     const auto& required_layout = spec.input_layouts[i];
-    if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+    if (!RequiresRowMajor(required_layout)) {
       continue;
     }
     auto tile_type = As<TileType>(call->args_[i]->GetType());
     if (!tile_type) {
       continue;  // Non-tile inputs (scalars, shapes) are not subject to layout repair
     }
-    if (GetTileLayout(tile_type) == TileLayout::row_major) {
-      continue;
+    if (!IsRowMajor(tile_type)) {
+      return true;
     }
-    if (IsColumnVectorColMajor(tile_type)) {
-      has_repairable_input = true;
-      continue;
-    }
-    return false;
   }
-  return has_repairable_input;
+  return false;
+}
+
+bool NeedsOutputRepair(const TileTypePtr& result_tile_type, const backend::BackendTileLayoutSpec& spec) {
+  return RequiresRowMajor(spec.output_layout) && result_tile_type && !IsRowMajor(result_tile_type);
+}
+
+bool NeedsRepair(const CallPtr& call, const TileTypePtr& result_tile_type,
+                 const backend::BackendTileLayoutSpec& spec) {
+  return NeedsInputRepair(call, spec) || NeedsOutputRepair(result_tile_type, spec);
 }
 
 class BackendLayoutRepairMutator : public IRMutator {
@@ -125,11 +155,11 @@ class BackendLayoutRepairMutator : public IRMutator {
     }
 
     auto* layout_spec = backend::GetBackend()->GetTileLayoutSpec(call->op_->name_);
-    if (!layout_spec || !IsRepairableCall(call, *layout_spec)) {
+    auto result_tile_type = As<TileType>(op->var_->GetType());
+    if (!layout_spec || !NeedsRepair(call, result_tile_type, *layout_spec)) {
       return IRMutator::VisitStmt_(op);
     }
 
-    auto result_tile_type = As<TileType>(op->var_->GetType());
     CHECK(result_tile_type)
         << "ResolveBackendOpLayouts expects constrained op assignment targets to be TileType";
 
@@ -138,21 +168,30 @@ class BackendLayoutRepairMutator : public IRMutator {
 
     for (size_t i = 0; i < layout_spec->input_layouts.size() && i < call->args_.size(); ++i) {
       const auto& required_layout = layout_spec->input_layouts[i];
-      if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+      if (!RequiresRowMajor(required_layout)) {
         continue;
       }
 
       auto tile_type = As<TileType>(call->args_[i]->GetType());
-      if (!IsColumnVector(tile_type) || IsRowVectorRowMajor(tile_type)) {
+      if (!tile_type || IsRowMajor(tile_type)) {
         continue;
       }
 
-      auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
-      auto reshape_var = std::make_shared<Var>(
-          NextTempName(op->var_->name_hint_, {auto_name::RowMajorQualifier(), auto_name::ArgQualifier(i)}),
-          reshape_call->GetType(), call->span_);
-      rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
-      new_args[i] = reshape_var;
+      auto repair_var_name =
+          NextTempName(op->var_->name_hint_, {auto_name::RowMajorQualifier(), auto_name::ArgQualifier(i)});
+      if (IsColumnVectorColMajor(tile_type)) {
+        auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
+        auto reshape_var = std::make_shared<Var>(repair_var_name, reshape_call->GetType(), call->span_);
+        rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
+        new_args[i] = reshape_var;
+        continue;
+      }
+
+      auto move_call = CreateLayoutMoveCall(call->args_[i], GetRepairTargetMemory(tile_type),
+                                            TileLayout::row_major, TileLayout::none_box, call->span_);
+      auto move_var = std::make_shared<Var>(repair_var_name, move_call->GetType(), call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(move_var, move_call, op->span_));
+      new_args[i] = move_var;
     }
 
     auto repaired_expr =
@@ -160,14 +199,21 @@ class BackendLayoutRepairMutator : public IRMutator {
     auto repaired_call = As<Call>(repaired_expr);
     CHECK(repaired_call) << "ResolveBackendOpLayouts: repaired consumer must remain a Call";
 
-    if (!IsRowVectorRowMajor(result_tile_type)) {
+    if (NeedsOutputRepair(result_tile_type, *layout_spec)) {
       auto row_major_var = std::make_shared<Var>(NextTempName(op->var_->name_hint_, {"row_major"}),
                                                  repaired_call->GetType(), call->span_);
       rewritten.push_back(std::make_shared<AssignStmt>(row_major_var, repaired_call, op->span_));
 
-      auto reshape_back = CreateReshapeCall(row_major_var, result_tile_type->shape_, call->span_);
+      CallPtr restore_call;
+      if (IsColumnVector(result_tile_type)) {
+        restore_call = CreateReshapeCall(row_major_var, result_tile_type->shape_, call->span_);
+      } else {
+        auto target_view = tile_view_semantics::GetEffectiveTileView(*result_tile_type);
+        restore_call = CreateLayoutMoveCall(row_major_var, GetRepairTargetMemory(result_tile_type),
+                                            target_view.blayout, target_view.slayout, call->span_);
+      }
       auto replacement = MutableCopy(op);
-      replacement->value_ = reshape_back;
+      replacement->value_ = restore_call;
       rewritten.push_back(std::move(replacement));
       return MakeSeqOrSingle(std::move(rewritten), op->span_);
     }
@@ -185,7 +231,7 @@ class BackendLayoutRepairMutator : public IRMutator {
     }
 
     auto* layout_spec = backend::GetBackend()->GetTileLayoutSpec(call->op_->name_);
-    if (!layout_spec || !IsRepairableCall(call, *layout_spec)) {
+    if (!layout_spec || !NeedsInputRepair(call, *layout_spec)) {
       return IRMutator::VisitStmt_(op);
     }
 
@@ -194,19 +240,27 @@ class BackendLayoutRepairMutator : public IRMutator {
 
     for (size_t i = 0; i < layout_spec->input_layouts.size() && i < call->args_.size(); ++i) {
       const auto& required_layout = layout_spec->input_layouts[i];
-      if (!required_layout.has_value() || required_layout.value() != TileLayout::row_major) {
+      if (!RequiresRowMajor(required_layout)) {
         continue;
       }
       auto tile_type = As<TileType>(call->args_[i]->GetType());
-      if (!IsColumnVector(tile_type) || IsRowVectorRowMajor(tile_type)) {
+      if (!tile_type || IsRowMajor(tile_type)) {
         continue;
       }
-      auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
-      auto reshape_var =
-          std::make_shared<Var>(NextTempName("layout_fix", {"row_major", "arg" + std::to_string(i)}),
-                                reshape_call->GetType(), call->span_);
-      rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
-      new_args[i] = reshape_var;
+      auto repair_var_name = NextTempName("layout_fix", {"row_major", "arg" + std::to_string(i)});
+      if (IsColumnVectorColMajor(tile_type)) {
+        auto reshape_call = CreateReshapeCall(call->args_[i], MakeRowVectorShape(tile_type), call->span_);
+        auto reshape_var = std::make_shared<Var>(repair_var_name, reshape_call->GetType(), call->span_);
+        rewritten.push_back(std::make_shared<AssignStmt>(reshape_var, reshape_call, op->span_));
+        new_args[i] = reshape_var;
+        continue;
+      }
+
+      auto move_call = CreateLayoutMoveCall(call->args_[i], GetRepairTargetMemory(tile_type),
+                                            TileLayout::row_major, TileLayout::none_box, call->span_);
+      auto move_var = std::make_shared<Var>(repair_var_name, move_call->GetType(), call->span_);
+      rewritten.push_back(std::make_shared<AssignStmt>(move_var, move_call, op->span_));
+      new_args[i] = move_var;
     }
 
     auto repaired_expr =

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -52,7 +52,9 @@ StmtPtr MakeSeqOrSingle(std::vector<StmtPtr> stmts, const Span& span) {
 }
 
 TileLayout GetTileLayout(const TileTypePtr& tile_type) {
-  if (!tile_type) return TileLayout::row_major;
+  if (!tile_type) {
+    return TileLayout::row_major;
+  }
   return tile_view_semantics::GetEffectiveTileView(*tile_type).blayout;
 }
 

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -92,11 +92,12 @@ std::vector<ExprPtr> MakeRowVectorShape(const TileTypePtr& tile_type) {
   return {std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()), tile_type->shape_[0]};
 }
 
-MemorySpace GetRepairTargetMemory(const TileTypePtr& tile_type, MemorySpace fallback = MemorySpace::Vec) {
-  if (!tile_type) {
-    return fallback;
-  }
-  return tile_type->memory_space_.value_or(fallback);
+MemorySpace GetRepairTargetMemory(const TileTypePtr& tile_type) {
+  CHECK(tile_type) << "ResolveBackendOpLayouts expects synthesized tile.move repairs to use tile inputs";
+  const auto& memory_space = tile_type->memory_space_;
+  CHECK(memory_space.has_value())
+      << "ResolveBackendOpLayouts expects synthesized tile.move repairs to preserve memory space";
+  return *memory_space;
 }
 
 std::vector<std::pair<std::string, std::any>> MakeLayoutMoveKwargs(MemorySpace target_memory,

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -178,6 +178,84 @@ class TestResolveBackendOpLayouts:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_rewrites_matrix_exp_through_row_major_move(self):
+        """`tile.exp` on a non-vector col_major tile should be repaired through `tile.move`."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
+            ) -> pl.Tensor[[16, 256], pl.FP32]:
+                src: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+                    [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                col_major: pl.Tile[
+                    [16, 256],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+                ] = pl.tile.move(
+                    src,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                result: pl.Tile[
+                    [16, 256],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+                ] = pl.tile.exp(col_major)
+                stored: pl.Tensor[[16, 256], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
+            ) -> pl.Tensor[[16, 256], pl.FP32]:
+                src: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+                    [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                col_major: pl.Tile[
+                    [16, 256],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+                ] = pl.tile.move(
+                    src,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                col_major_rm: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.move(
+                    col_major,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.row_major,
+                    slayout=pl.TileLayout.none_box,
+                )
+                result_rm: pl.Tile[[16, 256], pl.FP32, pl.MemorySpace.Vec] = pl.tile.exp(col_major_rm)
+                result: pl.Tile[
+                    [16, 256],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+                ] = pl.tile.move(
+                    result_rm,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                stored: pl.Tensor[[16, 256], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes hw-native-sys/pypto#1229.

`ResolveBackendOpLayouts` now repairs general non-row-major matrix tiles before backend ops that require `row_major` layout. Previously the pass only handled `[N, 1]` column-vector reshape repair, so full matrix tiles produced by paths such as `matmul/tpop -> Vec -> neg -> exp` could still reach `pto.texp` with `blayout=col_major`, causing `ptoas` to fail.

## Root Cause

The backend layout spec for ops like `tile.exp` requires row-major inputs and outputs. The old repair pass only rewrote `[N, 1]` col-major vectors into `[1, N]` row-major views via `tile.reshape`. It skipped general matrix tiles such as `[16, 256]` with `blayout=col_major, slayout=row_major`, so the generated PTO kept a non-row-major source for `pto.texp`.

## Changes

- Extend `ResolveBackendOpLayouts` to detect any constrained tile input/output that is not row-major.
- Preserve the existing `[N, 1]` vector reshape fast path.
- Insert same-memory `tile.move(..., blayout=row_major, slayout=none_box)` for general non-row-major matrix inputs.
- Restore original result layout after constrained ops using `tile.reshape` for column vectors or `tile.move` for general matrix tiles.
- Use `tile_view_semantics::GetEffectiveTileView()` when reading/restoring tile layouts so missing `TileView` annotations still follow the canonical effective-layout rules.
- Fail fast if a synthesized `tile.move` repair cannot determine the original tile memory space, instead of defaulting to `MemorySpace::Vec` and turning a layout repair into a memory migration.
- Add regression coverage for `tile.exp` on a col-major matrix tile.
- Update English and Chinese pass documentation.

## Validation

- `cmake --build build --parallel`
- `cmake --install build --prefix python/pypto`
- `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` (`4 passed`)
- `python tests/lint/clang_tidy.py --diff-base origin/main` (passes locally; local tool reports clang-tidy 18.1.8 vs expected 21.1.0)
- `pre-commit run --files src/ir/transforms/resolve_backend_op_layouts_pass.cpp`
- GitHub checks for PR #1231 are passing, including `system-tests`, `system-tests-a5sim`, `pre-commit`, `clang-tidy`, and unit tests.
