### PR TITLE
fix(ir): Rewrite lane1 replay loop state

### DIFF
--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -811,6 +811,74 @@ NoSplitSharedPrefix SplitNoSplitSharedPipeSetupPrefix(const std::vector<StmtPtr>
   return result;
 }
 
+TypePtr Lane1LoopVarType(const TypePtr& original_type, const ExprPtr& init_value) {
+  if (!std::dynamic_pointer_cast<const TileType>(original_type) || !init_value) {
+    return original_type;
+  }
+  auto init_type = init_value->GetType();
+  if (std::dynamic_pointer_cast<const TileType>(init_type)) {
+    return init_type;
+  }
+  return original_type;
+}
+
+std::vector<IterArgPtr> RebuildLane1LoopIterArgs(const std::vector<IterArgPtr>& iter_args,
+                                                 const ExprReplacementMap& entry_replacements,
+                                                 ExprReplacementMap& scoped_replacements) {
+  std::vector<IterArgPtr> new_iter_args;
+  new_iter_args.reserve(iter_args.size());
+
+  for (const auto& iter_arg : iter_args) {
+    auto new_init = SubstituteExprIfNeeded(iter_arg->initValue_, entry_replacements);
+    auto new_type = Lane1LoopVarType(iter_arg->GetType(), new_init);
+    if (new_init != iter_arg->initValue_ || new_type != iter_arg->GetType()) {
+      auto new_iter_arg =
+          std::make_shared<IterArg>(iter_arg->name_hint_, new_type, new_init, iter_arg->span_);
+      scoped_replacements[iter_arg.get()] = new_iter_arg;
+      new_iter_args.push_back(new_iter_arg);
+    } else {
+      new_iter_args.push_back(iter_arg);
+    }
+  }
+
+  return new_iter_args;
+}
+
+std::vector<VarPtr> RebuildLane1LoopReturnVars(const std::vector<VarPtr>& return_vars,
+                                               const std::vector<IterArgPtr>& iter_args,
+                                               ExprReplacementMap& replacements) {
+  INTERNAL_CHECK(return_vars.size() == iter_args.size())
+      << "Internal error: return_vars and iter_args sizes must match";
+
+  std::vector<VarPtr> new_return_vars;
+  new_return_vars.reserve(return_vars.size());
+
+  for (size_t i = 0; i < return_vars.size(); ++i) {
+    const auto& return_var = return_vars[i];
+    auto new_type = return_var->GetType();
+    if (i < iter_args.size()) {
+      new_type = Lane1LoopVarType(return_var->GetType(), iter_args[i]);
+    }
+    if (new_type != return_var->GetType()) {
+      auto new_return_var = std::make_shared<Var>(return_var->name_hint_, new_type, return_var->span_);
+      replacements[return_var.get()] = new_return_var;
+      new_return_vars.push_back(new_return_var);
+    } else {
+      new_return_vars.push_back(return_var);
+    }
+  }
+
+  return new_return_vars;
+}
+
+std::optional<ChunkConfig> SubstituteChunkConfigIfNeeded(const std::optional<ChunkConfig>& chunk_config,
+                                                         const ExprReplacementMap& replacements) {
+  if (!chunk_config.has_value()) return std::nullopt;
+  auto new_size = SubstituteExprIfNeeded(chunk_config->size, replacements);
+  if (new_size == chunk_config->size) return chunk_config;
+  return ChunkConfig{new_size, chunk_config->policy};
+}
+
 // Lane 1 still needs to replay cross-core handshakes so Ascend910B GM-backed
 // pipes stay balanced. Tile-producing replay work is forced to static
 // valid_shape=0, letting PTO ops run as empty tiles while preserving the tpush /
@@ -868,21 +936,34 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
 
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
       auto loop_replacements = replacements;
+      auto new_iter_args = RebuildLane1LoopIterArgs(for_stmt->iter_args_, replacements, loop_replacements);
+      auto new_return_vars = RebuildLane1LoopReturnVars(for_stmt->return_vars_, new_iter_args, replacements);
       auto new_body_stmts =
           BuildNoSplitLane1ReplayStmts(transform_utils::FlattenToStmts(for_stmt->body_), loop_replacements);
       auto new_for = MutableCopy(for_stmt);
+      new_for->start_ = SubstituteExprIfNeeded(for_stmt->start_, replacements);
+      new_for->stop_ = SubstituteExprIfNeeded(for_stmt->stop_, replacements);
+      new_for->step_ = SubstituteExprIfNeeded(for_stmt->step_, replacements);
+      new_for->iter_args_ = std::move(new_iter_args);
       new_for->body_ = loop_repair::MakeBody(new_body_stmts, for_stmt->span_);
+      new_for->return_vars_ = std::move(new_return_vars);
+      new_for->chunk_config_ = SubstituteChunkConfigIfNeeded(for_stmt->chunk_config_, replacements);
       result.push_back(new_for);
       continue;
     }
 
     if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       auto loop_replacements = replacements;
+      auto new_iter_args = RebuildLane1LoopIterArgs(while_stmt->iter_args_, replacements, loop_replacements);
+      auto new_return_vars =
+          RebuildLane1LoopReturnVars(while_stmt->return_vars_, new_iter_args, replacements);
       auto new_body_stmts =
           BuildNoSplitLane1ReplayStmts(transform_utils::FlattenToStmts(while_stmt->body_), loop_replacements);
       auto new_while = MutableCopy(while_stmt);
-      new_while->condition_ = SubstituteExprIfNeeded(while_stmt->condition_, replacements);
+      new_while->condition_ = SubstituteExprIfNeeded(while_stmt->condition_, loop_replacements);
+      new_while->iter_args_ = std::move(new_iter_args);
       new_while->body_ = loop_repair::MakeBody(new_body_stmts, while_stmt->span_);
+      new_while->return_vars_ = std::move(new_return_vars);
       result.push_back(new_while);
       continue;
     }

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -893,3 +893,100 @@ class TestSplitVectorKernelNoSplitA2A3:
             r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
             printed,
         )
+
+    def test_no_split_dual_dispatch_lane1_loop_init_uses_empty_accumulator(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                    [16, 16], dtype=pl.FP32, value=0.0
+                )
+                for kb, (acc_iter,) in pl.range(4, init_values=(acc,)):
+                    z_vec: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                        split=0
+                    )
+                    next_acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_iter, z_vec)
+                    pl.tfree_to_aic(z_vec)
+                    acc_final: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.yield_(next_acc)
+                incremented: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_final, 1.0)
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
+                return updated
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        lane1 = printed.split("else:", 1)[1]
+
+        assert re.search(
+            r"acc__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
+            r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.full",
+            lane1,
+        )
+        assert re.search(r"pl.range\(4, init_values=\(acc__ssa_v0_\d+,\)\)", lane1)
+        assert "pl.range(4, init_values=(acc__ssa_v0,))" not in lane1
+        assert re.search(
+            r"incremented__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
+            r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
+            lane1,
+        )
+
+    def test_no_split_dual_dispatch_lane1_while_init_uses_empty_accumulator(self):
+        """Cover lane1 replay for while-loop tile/scalar carried state."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                    [16, 16], dtype=pl.FP32, value=0.0
+                )
+                count: pl.Scalar[pl.INDEX] = 0
+                for acc_iter, count_iter in pl.while_(init_values=(acc, count)):
+                    pl.cond(count_iter < 4)
+                    z_vec: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                        split=0
+                    )
+                    next_acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_iter, z_vec)
+                    next_count: pl.Scalar[pl.INDEX] = count_iter + 1
+                    pl.tfree_to_aic(z_vec)
+                    acc_final, count_final = pl.yield_(next_acc, next_count)
+                incremented: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_final, 1.0)
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
+                return updated
+
+        actual = _run_split_vector_kernel(Before)
+        printed = python_print(actual)
+        lane1 = printed.split("else:", 1)[1]
+
+        assert re.search(
+            r"acc__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
+            r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.full",
+            lane1,
+        )
+        assert re.search(
+            r"for acc_iter_\d+, count_iter_\d+ in pl.while_"
+            r"\(init_values=\(acc__ssa_v0_\d+, count__ssa_v0_\d+\)\)",
+            lane1,
+        )
+        assert "pl.while_(init_values=(acc__ssa_v0, count__ssa_v0))" not in lane1
+        assert re.search(r"pl.cond\(count_iter_\d+ < 4\)", lane1)
+        assert re.search(
+            r"incremented__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
+            r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
+            lane1,
+        )


### PR DESCRIPTION
  ## Summary

  Fix no-split dual-AIV lane1 replay so loop-carried tile state uses the zero-valid replay tiles instead of stale lane0 variables.

  Add regression coverage for lane1 replay loops with accumulator init values.

  ## Testing

  - cmake --build build --parallel
  - pytest tests/ut/ir/transforms/test_split_vector_kernel.py -v
  - ruff check/format --check
  - DeepSeek v3_2 representative compile repros on a2a3sim, a2a3, and a5