### PR TITLE
fix(ir): Correct tile.cmp/cmps to return packed predicate mask

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -169,13 +169,15 @@ Transfer data between memory hierarchy levels.
 
 ## Comparison / Selection (`pl.tile.*`)
 
-Compare types: `EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5`
+Compare types: `EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5`. `cmp` and `cmps` return
+a target-packed predicate mask; use `sel` with an explicit `UINT8 [1, 32]`
+scratch tile to materialize numeric results on A2/A3.
 
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
 | `cmp` | `(lhs: Tile, rhs: Tile, cmp_type: int = 0) -> Tile` | Compare two tiles |
 | `cmps` | `(lhs: Tile, rhs: int \| float \| Scalar, cmp_type: int = 0) -> Tile` | Compare tile with scalar |
-| `sel` | `(mask: Tile, lhs: Tile, rhs: Tile) -> Tile` | Select: `lhs if mask else rhs` |
+| `sel` | `(mask: Tile, lhs: Tile, rhs: Tile, tmp: Tile) -> Tile` | Select: `lhs if mask else rhs`; `tmp` is TSEL scratch |
 | `sels` | `(lhs: Tile, rhs: Tile, select_mode: int \| float \| Scalar) -> Tile` | Select by scalar mode |
 
 ## Bitwise (`pl.tile.*`)

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -164,13 +164,15 @@
 
 ## 比较/选择（`pl.tile.*`）
 
-比较类型：`EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5`
+比较类型：`EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5`。`cmp` 和 `cmps` 返回目标相关的
+packed predicate mask；A2/A3 上如需得到数值结果，请配合 `sel` 和显式
+`UINT8 [1, 32]` scratch tile 使用。
 
 | 名称 | 签名 | 说明 |
 | ---- | ---- | ---- |
 | `cmp` | `(lhs: Tile, rhs: Tile, cmp_type: int = 0) -> Tile` | 比较两个 tile |
 | `cmps` | `(lhs: Tile, rhs: int \| float \| Scalar, cmp_type: int = 0) -> Tile` | tile 与标量比较 |
-| `sel` | `(mask: Tile, lhs: Tile, rhs: Tile) -> Tile` | 选择：`mask 为真取 lhs，否则取 rhs` |
+| `sel` | `(mask: Tile, lhs: Tile, rhs: Tile, tmp: Tile) -> Tile` | 选择：`mask 为真取 lhs，否则取 rhs`；`tmp` 是 TSEL scratch |
 | `sels` | `(lhs: Tile, rhs: Tile, select_mode: int \| float \| Scalar) -> Tile` | 按标量模式选择 |
 
 ## 位运算（`pl.tile.*`）

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -999,7 +999,7 @@ def lrelu(tile: Expr, slope: int | float | Expr, span: Span | None = None) -> Ca
     return _ir_core.create_op_call("tile.lrelu", [tile, slope_expr], {}, actual_span)
 
 
-def sel(mask: Expr, lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+def sel(mask: Expr, lhs: Expr, rhs: Expr, tmp: Expr, span: Span | None = None) -> Call:
     """Per-element selection between two tiles using a predicate mask tile.
 
     For each element (i, j): dst[i,j] = lhs[i,j] if mask[i,j] is true, else rhs[i,j].
@@ -1009,13 +1009,14 @@ def sel(mask: Expr, lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
         mask: Predicate mask tile (TileType); encoding is target-defined
         lhs: Source tile 0, selected where mask is true (TileType)
         rhs: Source tile 1, selected where mask is false (TileType)
+        tmp: Scratch tile required by TSEL (TileType UINT8 [1, 32] on A2/A3)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for per-element tile selection
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.sel", [mask, lhs, rhs], {}, actual_span)
+    return _ir_core.create_op_call("tile.sel", [mask, lhs, rhs, tmp], {}, actual_span)
 
 
 def sels(lhs: Expr, rhs: Expr, select_mode: int | float | Expr, span: Span | None = None) -> Call:
@@ -1123,7 +1124,7 @@ def subs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
 
 
 def cmp(lhs: Expr, rhs: Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
-    """Element-wise comparison of two tiles (returns boolean tile).
+    """Element-wise comparison of two tiles (returns a packed predicate mask tile).
 
     Args:
         lhs: Left-hand side tile (TileType)
@@ -1134,7 +1135,8 @@ def cmp(lhs: Expr, rhs: Expr, cmp_type: int = 0, span: Span | None = None) -> Ca
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression for element-wise comparison
+        Call expression for a packed predicate mask tile.
+        Use tile.sel with an explicit tmp tile to materialize values.
 
     """
     actual_span = _get_span_or_capture(span)
@@ -1148,7 +1150,7 @@ def cmps(
     cmp_type: int = 0,
     span: Span | None = None,
 ) -> Call:
-    """Element-wise comparison of tile and scalar (returns boolean tile).
+    """Element-wise comparison of tile and scalar (returns a packed predicate mask tile).
 
     Args:
         lhs: Tile (TileType)
@@ -1159,7 +1161,8 @@ def cmps(
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
-        Call expression for element-wise comparison with scalar
+        Call expression for a packed predicate mask tile.
+        Use tile.sel with an explicit tmp tile to materialize values.
     """
     actual_span = _get_span_or_capture(span)
     rhs_expr = (

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1189,7 +1189,7 @@ def cmp(lhs: Tile, rhs: Tile, cmp_type: int = 0) -> Tile:
         cmp_type: Comparison type (EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5)
 
     Returns:
-        Tile wrapping the cmp operation
+        Tile wrapping a packed predicate mask. Use tile.sel with an explicit tmp tile to materialize values.
     """
     call_expr = _ir_ops.cmp(lhs.unwrap(), rhs.unwrap(), cmp_type)
     return Tile(expr=call_expr)
@@ -1204,7 +1204,7 @@ def cmps(lhs: Tile, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tile
         cmp_type: Comparison type (EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5)
 
     Returns:
-        Tile wrapping the cmps operation
+        Tile wrapping a packed predicate mask. Use tile.sel with an explicit tmp tile to materialize values.
     """
     rhs_expr = rhs.unwrap() if isinstance(rhs, Scalar) else rhs
     call_expr = _ir_ops.cmps(lhs.unwrap(), rhs_expr, cmp_type)
@@ -1758,7 +1758,7 @@ def lrelu(tile: Tile, slope: int | float | Expr | Scalar) -> Tile:
     return Tile(expr=call_expr)
 
 
-def sel(mask: Tile, lhs: Tile, rhs: Tile) -> Tile:
+def sel(mask: Tile, lhs: Tile, rhs: Tile, tmp: Tile) -> Tile:
     """Per-element selection between two tiles using a predicate mask tile.
 
     For each element (i, j): dst[i,j] = lhs[i,j] if mask[i,j] is true, else rhs[i,j].
@@ -1768,11 +1768,12 @@ def sel(mask: Tile, lhs: Tile, rhs: Tile) -> Tile:
         mask: Predicate mask tile; encoding is target-defined
         lhs: Source tile 0, selected where mask is true
         rhs: Source tile 1, selected where mask is false
+        tmp: Scratch tile required by TSEL (UINT8 [1, 32] on A2/A3)
 
     Returns:
         Tile wrapping the sel operation
     """
-    call_expr = _ir_ops.sel(mask.unwrap(), lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.sel(mask.unwrap(), lhs.unwrap(), rhs.unwrap(), tmp.unwrap())
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -305,7 +305,7 @@ static std::string GenerateInsOutsClause(const CallPtr& op, codegen::PTOCodegen&
   }
 
   if (!config_attr.empty()) {
-    oss << config_attr;
+    oss << " " << config_attr;
   }
 
   // Add type annotations after colon
@@ -397,6 +397,33 @@ static std::string MakeNaryCodegenPTO(const std::string& pto_op_name, size_t ari
     }
   }
   codegen.Emit(pto_op_name + " " + GenerateInsOutsClause(op, codegen));
+  return "";
+}
+
+static std::string MakeTileSelCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 4) << "Operation:[pto.tsel] requires 4 arguments, but got " << op->args_.size();
+
+  std::string mask = codegen.GetExprAsCode(op->args_[0]);
+  std::string src0 = codegen.GetExprAsCode(op->args_[1]);
+  std::string src1 = codegen.GetExprAsCode(op->args_[2]);
+  std::string tmp = codegen.GetExprAsCode(op->args_[3]);
+  std::string mask_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string src0_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+  std::string src1_type = codegen.GetExprTypeAnnotation(op->args_[2]);
+  std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[3]);
+  std::string dst = codegen.GetCurrentResultTarget();
+  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream oss;
+  oss << "pto.tsel ins(" << mask << ", " << src0 << ", " << src1 << ", " << tmp;
+  if (!mask_type.empty() && !src0_type.empty() && !src1_type.empty() && !tmp_type.empty()) {
+    oss << " : " << mask_type << ", " << src0_type << ", " << src1_type << ", " << tmp_type;
+  }
+  oss << ") outs(" << dst;
+  if (!dst_type.empty()) oss << " : " << dst_type;
+  oss << ")";
+  codegen.Emit(oss.str());
   return "";
 }
 
@@ -523,7 +550,7 @@ static std::string MakeTileCmpCodegenPTO(const std::string& pto_op_name, const C
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments, but got "
                                << op->args_.size();
-  int mode = op->GetKwarg<int>("mode");
+  int mode = op->GetKwarg<int>("cmp_type");
   CHECK(mode >= 0 && mode < static_cast<int>(cmp_modes.size())) << "Tile cmp mode out of range: " << mode;
   std::string config_attr = "{cmpMode = #pto<cmp " + cmp_modes.at(mode) + ">}";
   codegen.Emit(pto_op_name + " " + GenerateInsOutsClause(op, codegen, config_attr));
@@ -569,7 +596,7 @@ static std::string MakeCmpsCodegenPTO(const std::string& pto_op_name, const Call
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name << "] requires 2 arguments, but got "
                                << op->args_.size();
-  int mode = op->GetKwarg<int>("mode");
+  int mode = op->GetKwarg<int>("cmp_type");
   CHECK(mode >= 0 && mode < static_cast<int>(cmp_modes.size())) << "Tile cmp mode out of range: " << mode;
   std::string config_attr = "{cmpMode = #pto<cmp " + cmp_modes.at(mode) + ">}";
   codegen.Emit(pto_op_name + " " + GenerateInsOutsClause(op, codegen, config_attr));
@@ -1790,7 +1817,6 @@ static const SimpleOpEntry kSimpleOps[] = {
     // Ternary operations (tile x tile + carry/select)
     {"tile.addc",            "pto.taddc",            3},
     {"tile.subc",            "pto.tsubc",            3},
-    {"tile.sel",             "pto.tsel",             3},
     // Tile x Scalar operations
     {"tile.adds",            "pto.tadds",            2},
     {"tile.subs",            "pto.tsubs",            2},
@@ -1919,6 +1945,17 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.transpose", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileTransposeCodegenPTO(op, codegen);
   });
+  if (exclude_ops.count("tile.sel") == 0) {
+    backend.RegisterOp("tile.sel")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          return MakeTileSelCodegenPTO(op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_input_layout(1, ir::TileLayout::row_major)
+        .set_input_layout(2, ir::TileLayout::row_major)
+        .set_input_layout(3, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
   // tile.mscatter: src and idx must be row_major (MTE3 DMA reads UB linearly)
   if (exclude_ops.count("tile.mscatter") == 0) {
     backend.RegisterOp("tile.mscatter")

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -403,27 +403,7 @@ static std::string MakeNaryCodegenPTO(const std::string& pto_op_name, size_t ari
 static std::string MakeTileSelCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 4) << "Operation:[pto.tsel] requires 4 arguments, but got " << op->args_.size();
-
-  std::string mask = codegen.GetExprAsCode(op->args_[0]);
-  std::string src0 = codegen.GetExprAsCode(op->args_[1]);
-  std::string src1 = codegen.GetExprAsCode(op->args_[2]);
-  std::string tmp = codegen.GetExprAsCode(op->args_[3]);
-  std::string mask_type = codegen.GetExprTypeAnnotation(op->args_[0]);
-  std::string src0_type = codegen.GetExprTypeAnnotation(op->args_[1]);
-  std::string src1_type = codegen.GetExprTypeAnnotation(op->args_[2]);
-  std::string tmp_type = codegen.GetExprTypeAnnotation(op->args_[3]);
-  std::string dst = codegen.GetCurrentResultTarget();
-  std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
-
-  std::ostringstream oss;
-  oss << "pto.tsel ins(" << mask << ", " << src0 << ", " << src1 << ", " << tmp;
-  if (!mask_type.empty() && !src0_type.empty() && !src1_type.empty() && !tmp_type.empty()) {
-    oss << " : " << mask_type << ", " << src0_type << ", " << src1_type << ", " << tmp_type;
-  }
-  oss << ") outs(" << dst;
-  if (!dst_type.empty()) oss << " : " << dst_type;
-  oss << ")";
-  codegen.Emit(oss.str());
+  codegen.Emit("pto.tsel " + GenerateInsOutsClause(op, codegen));
   return "";
 }
 

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -21,17 +21,20 @@
  */
 
 #include <any>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -68,20 +71,22 @@ static ExprPtr MakeRoundUpIndex(const ExprPtr& value, int64_t alignment) {
 
 static std::shared_ptr<TileType> MakePackedPredicateTileType(
     const std::vector<ExprPtr>& logical_shape, const std::shared_ptr<const TileType>& source_tile_type) {
-  INTERNAL_CHECK(logical_shape.size() >= 2)
-      << "tile.cmp/tile.cmps currently require a 2D tile shape for packed predicate mask inference";
+  INTERNAL_CHECK(!logical_shape.empty())
+      << "tile.cmp/tile.cmps require a non-empty tile shape for packed predicate mask inference";
 
   constexpr int64_t kA2A3PredicateBitsPerByte = 8;
   constexpr int64_t kA2A3PredicateColAlignment = 32;
 
+  const size_t col_axis = logical_shape.size() - 1;
   std::vector<ExprPtr> mask_shape = logical_shape;
-  mask_shape[1] = MakeRoundUpIndex(MakeCeilDivIndex(logical_shape[1], kA2A3PredicateBitsPerByte),
-                                   kA2A3PredicateColAlignment);
+  mask_shape[col_axis] = MakeRoundUpIndex(
+      MakeCeilDivIndex(logical_shape[col_axis], kA2A3PredicateBitsPerByte), kA2A3PredicateColAlignment);
 
   auto logical_valid_shape = GetValidShape(source_tile_type);
   TileView tile_view;
   tile_view.valid_shape = logical_valid_shape;
-  tile_view.valid_shape[1] = MakeCeilDivIndex(logical_valid_shape[1], kA2A3PredicateBitsPerByte);
+  tile_view.valid_shape[col_axis] =
+      MakeCeilDivIndex(logical_valid_shape[col_axis], kA2A3PredicateBitsPerByte);
   InheritTileViewLayout(tile_view, source_tile_type);
   return std::make_shared<TileType>(mask_shape, DataType::UINT8, std::nullopt, tile_view);
 }

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -43,6 +44,46 @@ static std::vector<ExprPtr> GetValidShape(const std::shared_ptr<const TileType>&
     return tile_type->tile_view_->valid_shape;
   }
   return tile_type->shape_;
+}
+
+static ExprPtr MakeIndexConst(int64_t value, const Span& span = Span::unknown()) {
+  return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+}
+
+static ExprPtr MakeCeilDivIndex(const ExprPtr& value, int64_t divisor) {
+  if (auto const_value = As<ConstInt>(value)) {
+    return MakeIndexConst((const_value->value_ + divisor - 1) / divisor, value->span_);
+  }
+  return MakeFloorDiv(MakeAdd(value, MakeIndexConst(divisor - 1, value->span_), value->span_),
+                      MakeIndexConst(divisor, value->span_), value->span_);
+}
+
+static ExprPtr MakeRoundUpIndex(const ExprPtr& value, int64_t alignment) {
+  if (auto const_value = As<ConstInt>(value)) {
+    const int64_t rounded = ((const_value->value_ + alignment - 1) / alignment) * alignment;
+    return MakeIndexConst(rounded, value->span_);
+  }
+  return MakeMul(MakeCeilDivIndex(value, alignment), MakeIndexConst(alignment, value->span_), value->span_);
+}
+
+static std::shared_ptr<TileType> MakePackedPredicateTileType(
+    const std::vector<ExprPtr>& logical_shape, const std::shared_ptr<const TileType>& source_tile_type) {
+  INTERNAL_CHECK(logical_shape.size() >= 2)
+      << "tile.cmp/tile.cmps currently require a 2D tile shape for packed predicate mask inference";
+
+  constexpr int64_t kA2A3PredicateBitsPerByte = 8;
+  constexpr int64_t kA2A3PredicateColAlignment = 32;
+
+  std::vector<ExprPtr> mask_shape = logical_shape;
+  mask_shape[1] = MakeRoundUpIndex(MakeCeilDivIndex(logical_shape[1], kA2A3PredicateBitsPerByte),
+                                   kA2A3PredicateColAlignment);
+
+  auto logical_valid_shape = GetValidShape(source_tile_type);
+  TileView tile_view;
+  tile_view.valid_shape = logical_valid_shape;
+  tile_view.valid_shape[1] = MakeCeilDivIndex(logical_valid_shape[1], kA2A3PredicateBitsPerByte);
+  InheritTileViewLayout(tile_view, source_tile_type);
+  return std::make_shared<TileType>(mask_shape, DataType::UINT8, std::nullopt, tile_view);
 }
 
 TypePtr DeduceTileOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
@@ -712,13 +753,13 @@ REGISTER_OP("tile.lrelu")
       return DeduceTileOpScalarBinaryType(args, kwargs, "tile.lrelu");
     });
 
-// Type deduction for tile.sel (MaskTile x Tile x Tile -> Tile)
+// Type deduction for tile.sel (MaskTile x Tile x Tile x TmpTile -> Tile)
 // The mask tile encodes per-element predicates in a target-defined layout; its dtype/shape
 // do not influence the output type.  Output type is derived from lhs and rhs only.
 TypePtr DeduceTileSelType(const std::vector<ExprPtr>& args,
                           const std::vector<std::pair<std::string, std::any>>& kwargs,
                           const std::string& op_name) {
-  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
+  CHECK(args.size() == 4) << "The operator " << op_name << " requires exactly 4 arguments, but got "
                           << args.size();
 
   CHECK(As<TileType>(args[0]->GetType()))
@@ -733,6 +774,9 @@ TypePtr DeduceTileSelType(const std::vector<ExprPtr>& args,
   CHECK(tile_type2) << "The operator " << op_name
                     << " requires third argument (rhs) to be a TileType, but got "
                     << args[2]->GetType()->TypeName();
+  CHECK(As<TileType>(args[3]->GetType()))
+      << "The operator " << op_name << " requires fourth argument (tmp) to be a TileType, but got "
+      << args[3]->GetType()->TypeName();
 
   auto result_dtype = PromoteDataTypes(tile_type1->dtype_, tile_type2->dtype_);
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
@@ -759,9 +803,11 @@ REGISTER_OP("tile.sel")
     .add_argument("mask", "Predicate mask tile; encoding is target-defined (TileType)")
     .add_argument("lhs", "Source tile 0, selected where mask is true (TileType)")
     .add_argument("rhs", "Source tile 1, selected where mask is false (TileType)")
+    .add_argument("tmp", "Scratch tile required by TSEL (TileType UINT8 [1, 32])")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
+    .set_input_memory(3, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -848,43 +894,25 @@ TypePtr DeduceTileCmpType(const std::vector<ExprPtr>& args,
                        << " requires second argument to be a ScalarType, but got "
                        << args[1]->GetType()->TypeName();
 
-    // Result has same shape as tile, with promoted dtype
-    auto result_dtype = PromoteDataTypes(tile_type1->dtype_, scalar_type->dtype_);
-    CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                        << tile_type1->dtype_.ToString() << " and " << scalar_type->dtype_.ToString();
-
-    TileView tile_view;
-    tile_view.valid_shape = GetValidShape(tile_type1);
-    InheritTileViewLayout(tile_view, tile_type1);
-    return std::make_shared<TileType>(tile_type1->shape_, *result_dtype, std::nullopt, tile_view);
+    return MakePackedPredicateTileType(tile_type1->shape_, tile_type1);
   } else {
     // Second argument must be TileType
     auto tile_type2 = As<TileType>(args[1]->GetType());
     CHECK(tile_type2) << "The operator " << op_name << " requires second argument to be a TileType, but got "
                       << args[1]->GetType()->TypeName();
 
-    // Use broadcasting
-    auto result_dtype = PromoteDataTypes(tile_type1->dtype_, tile_type2->dtype_);
-    CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                        << args[0]->GetType()->TypeName() << " and " << args[1]->GetType()->TypeName();
-
     auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
     CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes, but got "
                                     << FormatShape(tile_type1->shape_) << " and "
                                     << FormatShape(tile_type2->shape_);
 
-    // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-    // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-    TileView tile_view;
-    tile_view.valid_shape = GetValidShape(tile_type1);
-    InheritTileViewLayout(tile_view, tile_type1);
-    return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
+    return MakePackedPredicateTileType(broadcast_result.shape, tile_type1);
   }
 }
 
 REGISTER_OP("tile.cmp")
     .set_op_category("TileOp")
-    .set_description("Element-wise comparison of two tiles (returns boolean tile)")
+    .set_description("Element-wise comparison of two tiles (returns a packed predicate mask tile)")
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .set_attr<int>("cmp_type")
@@ -898,7 +926,7 @@ REGISTER_OP("tile.cmp")
 
 REGISTER_OP("tile.cmps")
     .set_op_category("TileOp")
-    .set_description("Element-wise comparison of tile and scalar (returns boolean tile)")
+    .set_description("Element-wise comparison of tile and scalar (returns a packed predicate mask tile)")
     .add_argument("lhs", "Tile (TileType)")
     .add_argument("rhs", "Scalar (ScalarType)")
     .set_attr<int>("cmp_type")

--- a/tests/st/runtime/test_cmp.py
+++ b/tests/st/runtime/test_cmp.py
@@ -1,0 +1,239 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime tests for tile comparison operations."""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import ONBOARD_PLATFORMS, DataType, PTOTestCase, TensorSpec
+
+M = 16
+N = 16
+
+_OUTPUT_NAMES = ("eq", "ne", "lt", "le", "gt", "ge")
+
+
+def _cmp_lhs() -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.float32).reshape(M, N)
+    return values.remainder(9) - 4
+
+
+def _cmp_rhs() -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.float32).reshape(M, N)
+    return values.remainder(7) - 3
+
+
+def _write_expected_outputs(outputs: dict[str, torch.Tensor], lhs: torch.Tensor, rhs: torch.Tensor) -> None:
+    comparisons = {
+        "eq": lhs == rhs,
+        "ne": lhs != rhs,
+        "lt": lhs < rhs,
+        "le": lhs <= rhs,
+        "gt": lhs > rhs,
+        "ge": lhs >= rhs,
+    }
+    for name, result in comparisons.items():
+        outputs[name][:] = result.to(outputs[name].dtype)
+
+
+@pl.program
+class TileCmpProgram:
+    """Tile-to-tile comparison for all cmp_type modes."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        rhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N])
+        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N])
+        one_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.full([M, N], dtype=pl.FP32, value=1.0)
+        zero_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.full([M, N], dtype=pl.FP32, value=0.0)
+        tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+        eq_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=0)
+        ne_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=1)
+        lt_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=2)
+        le_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=3)
+        gt_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=4)
+        ge_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile, cmp_type=5)
+        eq = pl.store(pl.tile.sel(eq_mask, one_tile, zero_tile, tmp), [0, 0], eq)
+        ne = pl.store(pl.tile.sel(ne_mask, one_tile, zero_tile, tmp), [0, 0], ne)
+        lt = pl.store(pl.tile.sel(lt_mask, one_tile, zero_tile, tmp), [0, 0], lt)
+        le = pl.store(pl.tile.sel(le_mask, one_tile, zero_tile, tmp), [0, 0], le)
+        gt = pl.store(pl.tile.sel(gt_mask, one_tile, zero_tile, tmp), [0, 0], gt)
+        ge = pl.store(pl.tile.sel(ge_mask, one_tile, zero_tile, tmp), [0, 0], ge)
+        return eq, ne, lt, le, gt, ge
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        rhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        eq, ne, lt, le, gt, ge = self.kernel(lhs, rhs, eq, ne, lt, le, gt, ge)
+        return eq, ne, lt, le, gt, ge
+
+
+@pl.program
+class TileCmpsProgram:
+    """Tile-to-scalar comparison for all cmp_type modes."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N])
+        one_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.full([M, N], dtype=pl.FP32, value=1.0)
+        zero_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.full([M, N], dtype=pl.FP32, value=0.0)
+        tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+        eq_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=0)
+        ne_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=1)
+        lt_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=2)
+        le_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=3)
+        gt_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=4)
+        ge_mask: pl.Tile[[M, 32], pl.UINT8] = pl.tile.cmps(lhs_tile, 0.0, cmp_type=5)
+        eq = pl.store(pl.tile.sel(eq_mask, one_tile, zero_tile, tmp), [0, 0], eq)
+        ne = pl.store(pl.tile.sel(ne_mask, one_tile, zero_tile, tmp), [0, 0], ne)
+        lt = pl.store(pl.tile.sel(lt_mask, one_tile, zero_tile, tmp), [0, 0], lt)
+        le = pl.store(pl.tile.sel(le_mask, one_tile, zero_tile, tmp), [0, 0], le)
+        gt = pl.store(pl.tile.sel(gt_mask, one_tile, zero_tile, tmp), [0, 0], gt)
+        ge = pl.store(pl.tile.sel(ge_mask, one_tile, zero_tile, tmp), [0, 0], ge)
+        return eq, ne, lt, le, gt, ge
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        eq, ne, lt, le, gt, ge = self.kernel(lhs, eq, ne, lt, le, gt, ge)
+        return eq, ne, lt, le, gt, ge
+
+
+class TileCmpTestCase(PTOTestCase):
+    """Tile cmp: compare two FP32 tiles."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "tile_cmp"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("lhs", [M, N], DataType.FP32, init_value=_cmp_lhs()),
+            TensorSpec("rhs", [M, N], DataType.FP32, init_value=_cmp_rhs()),
+            *(TensorSpec(name, [M, N], DataType.FP32, is_output=True) for name in _OUTPUT_NAMES),
+        ]
+
+    def get_program(self) -> Any:
+        return TileCmpProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        _write_expected_outputs(tensors, tensors["lhs"], tensors["rhs"])
+
+
+class TileCmpsTestCase(PTOTestCase):
+    """Tile cmps: compare an FP32 tile with scalar zero."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "tile_cmps"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("lhs", [M, N], DataType.FP32, init_value=_cmp_lhs()),
+            *(TensorSpec(name, [M, N], DataType.FP32, is_output=True) for name in _OUTPUT_NAMES),
+        ]
+
+    def get_program(self) -> Any:
+        return TileCmpsProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        _write_expected_outputs(tensors, tensors["lhs"], torch.tensor(0.0, dtype=tensors["lhs"].dtype))
+
+
+class TestTileCmpOperations:
+    """Test tile comparison operations across supported platforms."""
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_tile_cmp(self, test_runner, platform):
+        result = test_runner.run(TileCmpTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_tile_cmps(self, test_runner, platform):
+        result = test_runner.run(TileCmpsTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -430,8 +430,12 @@ class BlockOperationsTest:
         """Element-wise comparison: output = cmp(lhs, rhs)."""
         lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, 0], [16, 16])
         rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [0, 0], [16, 16])
-        result_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.cmp(lhs_tile, rhs_tile)
-        updated_output: pl.Tensor[[16, 16], pl.FP32] = pl.store(result_tile, [0, 0], output)
+        result_tile: pl.Tile[[16, 32], pl.UINT8] = pl.tile.cmp(lhs_tile, rhs_tile)
+        one_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.full([16, 16], dtype=pl.FP32, value=1.0)
+        zero_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.full([16, 16], dtype=pl.FP32, value=0.0)
+        tmp_tile: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+        selected_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.sel(result_tile, one_tile, zero_tile, tmp_tile)
+        updated_output: pl.Tensor[[16, 16], pl.FP32] = pl.store(selected_tile, [0, 0], output)
         return updated_output
 
     @pl.function(type=pl.FunctionType.InCore)

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -164,8 +164,12 @@ class TestTileElementwiseOps:
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
                 tile_b: pl.Tile[[32, 32], pl.FP32] = pl.load(b, [0, 0], [32, 32])
-                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.cmp(tile_a, tile_b, cmp_type=0)
-                result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                tile_c: pl.Tile[[32, 32], pl.UINT8] = pl.cmp(tile_a, tile_b, cmp_type=0)
+                one_tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.full([32, 32], dtype=pl.FP32, value=1.0)
+                zero_tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.full([32, 32], dtype=pl.FP32, value=0.0)
+                tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+                selected: pl.Tile[[32, 32], pl.FP32] = pl.sel(tile_c, one_tile, zero_tile, tmp)
+                result: pl.Tensor[[128, 128], pl.FP32] = pl.store(selected, [0, 0], output)
                 return result
 
         ir_str = str(Program)
@@ -183,8 +187,12 @@ class TestTileElementwiseOps:
                 output: pl.Tensor[[128, 128], pl.FP32],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
-                tile_c: pl.Tile[[32, 32], pl.FP32] = pl.cmps(tile_a, 0.0, cmp_type=0)
-                result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
+                tile_c: pl.Tile[[32, 32], pl.UINT8] = pl.cmps(tile_a, 0.0, cmp_type=0)
+                one_tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.full([32, 32], dtype=pl.FP32, value=1.0)
+                zero_tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.full([32, 32], dtype=pl.FP32, value=0.0)
+                tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+                selected: pl.Tile[[32, 32], pl.FP32] = pl.sel(tile_c, one_tile, zero_tile, tmp)
+                result: pl.Tensor[[128, 128], pl.FP32] = pl.store(selected, [0, 0], output)
                 return result
 
         ir_str = str(Program)
@@ -2064,7 +2072,8 @@ class TestTileBitwiseArithmeticOps:
                 tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
                 tile_b: pl.Tile[[32, 32], pl.FP32] = pl.load(b, [0, 0], [32, 32])
                 tile_m: pl.Tile[[32, 32], pl.FP32] = pl.load(m, [0, 0], [32, 32])
-                tile_out: pl.Tile[[32, 32], pl.FP32] = pl.sel(tile_m, tile_a, tile_b)
+                tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+                tile_out: pl.Tile[[32, 32], pl.FP32] = pl.sel(tile_m, tile_a, tile_b, tmp)
                 result: pl.Tensor[[128, 128], pl.FP32] = pl.store(tile_out, [0, 0], output)
                 return result
 


### PR DESCRIPTION
## Original Problem

`tile.cmp` / `tile.cmps` were modeled in the IR as ordinary element-wise binary ops: the result type was `TileType(shape=lhs.shape, dtype=promote(lhs, rhs))`, i.e. a normal numeric tile with the same shape as the inputs.

But the underlying hardware instructions `TCMP` / `TCMPS` do not produce a numeric tile — they produce a **packed predicate mask**:

- dtype is **UINT8** (1 byte holds 8 mask bits)
- the **last (column) axis is packed**: `ceil(cols / 8)` bytes
- on A2/A3 the packed column dim is **padded to 32 bytes** for alignment
- the mask must be consumed by `TSEL`, which additionally requires a **scratch tile** of shape `[1, 32]` UINT8 to unpack the bits

This IR/hardware mismatch caused several concrete bugs:

1. **Storing the cmp result fails.** Code like `pl.store(pl.cmp(a, b), ...)` was accepted by the type checker but the layout was wrong — the IR's `[M, N] FP32` shape did not match the actual `[M, ceil(N/8) padded to 32] UINT8` produced by the hardware.
2. **`pto.tcmp/tcmps` codegen is broken.** The `cmp_type` kwarg was not used to emit `cmpMode`, and a missing space before the config attribute inside `ins(...)` produced `ptoas: expected ','` errors.
3. **`tile.sel` lowering crashes at `--pto-level=level3`.** The 3-arg form `sel(mask, lhs, rhs)` relied on the codegen implicitly allocating a scratch via `alloc_tile`, but this scratch never received a hardware address from the unified memory allocator, so `ptoas` rejected it.
4. **Users had no way to materialize a mask correctly.** Without a documented `sel` flow that surfaces the `tmp` requirement, users wrote `pl.cast(pl.cmp(...), FP32)` (which is meaningless on packed bytes) and silently produced wrong values.

## Summary

- **tile.cmp/cmps semantics** — output is now a packed predicate mask (`UINT8`, last axis = `ceil(cols/8)` rounded up to 32 on A2/A3), matching `TCMP/TCMPS`. Implementation: new `MakePackedPredicateTileType` helper in `src/ir/op/tile_ops/elementwise.cpp` that picks the innermost axis (works for 1D/ND), packs by 8 for the allocation shape, rounds to 32 for alignment, and packs the `valid_shape` by 8 (no rounding) so `TileView` reflects the real number of valid bytes. Inherits the source tile's layout so partition / stride information is preserved.
- **tile.sel takes an explicit 4-input form** `(mask, lhs, rhs, tmp)`, matching `TSEL`'s scratch requirement. The `tmp` must come from `tile.create` so the unified memory allocator assigns it an addr. The previous 3-arg form's implicit `alloc_tile` left the scratch without an addr at `--pto-level=level3` and tripped `ptoas`.
- **PTO codegen** — `pto.tcmp/tcmps` now emits `cmpMode` from the `cmp_type` kwarg, and the missing space before the `ins(...)` config attribute is fixed (resolves the `ptoas: expected ','` error). `MakeTileSelCodegenPTO` now reuses the shared `GenerateInsOutsClause` helper instead of hand-rolling the `ins/outs` clause (addresses Gemini review feedback).
- **Python API & docs** — `pl.tile.cmp/cmps` docstrings and operator-reference docs (en/zh-cn) explicitly state the result is a packed predicate mask, and `pl.tile.sel` documents the new `tmp` parameter and how to allocate it.

## How to use cmp/sel correctly

```python
# Wrong — cast on packed bytes is meaningless:
# mask_fp32 = pl.cast(pl.tile.cmps(x, scalar, cmp_type=0), target_type=pl.FP32)

# Correct — materialize via tile.sel with an explicit tmp scratch:
one_tile  = pl.tile.full([M, N], dtype=pl.FP32, value=1.0)
zero_tile = pl.tile.full([M, N], dtype=pl.FP32, value=0.0)
tmp       = pl.tile.create([1, 32], dtype=pl.UINT8)        # required scratch
mask      = pl.tile.cmps(x, scalar, cmp_type=0)            # EQ
mask_fp32 = pl.tile.sel(mask, one_tile, zero_tile, tmp)
```

`cmp_type` values: `EQ=0, NE=1, LT=2, LE=3, GT=4, GE=5`.

## Testing

- New `tests/st/runtime/test_cmp.py` — end-to-end on-device tests for `tile.cmp` and `tile.cmps` covering EQ/NE/LT/LE/GT/GE, with results validated via `tile.sel(mask, one, zero, tmp)`.
- Updated `tests/ut/ir/operators/test_tile_ops.py` and `tests/ut/codegen/test_pto_codegen_ops.py` for the packed-mask result type, the 4-arg `tile.sel`, and the PTO codegen path.