### PR TITLE
docs(passes): Document SplitVectorKernel pass

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -31,7 +31,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 16 | `16-resolve_backend_op_layouts.md` | 16th pass |
 | 17 | `17-expand_mixed_kernel.md` | 17th pass |
 | 18 | `18-inject_gm_pipe_buffer.md` | Runs immediately after `ExpandMixedKernel` (backend-gated, Ascend910B) |
-| 19 | *(no doc yet)* | 19th pass (`SplitVectorKernel`) |
+| 19 | `19-split_vector_kernel.md` | 19th pass |
 | 20 | `20-normalize_return_order.md` | 20th pass |
 | 21 | `21-lower_pipeline_loops.md` | 21st pass |
 | 22 | `22-canonicalize_io_order.md` | 22nd pass |

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -369,7 +369,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
 7. [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md)
-8. `SplitVectorKernel`
+8. [`SplitVectorKernel`](19-split_vector_kernel.md)
 9. `NormalizeReturnOrder`
 10. [`LowerPipelineLoops`](21-lower_pipeline_loops.md)
 11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)

--- a/docs/en/dev/passes/19-split_vector_kernel.md
+++ b/docs/en/dev/passes/19-split_vector_kernel.md
@@ -6,7 +6,7 @@ work, halving the per-lane tile shapes and rewriting `tile.load`,
 Ascend910B, the same pass also handles the **no-split dual-AIV dispatch**
 path: when `ExpandMixedKernel` decides a mixed kernel cannot be split, it
 tags the AIV function with `dual_aiv_dispatch=True` and this pass wraps
-the body in a per-lane `if subblock_idx == 0 / else` so AIC↔AIV cross-core
+the body in a per-lane `if subblock_idx == 0 ... else` so AIC↔AIV cross-core
 handshakes stay balanced even though only lane 0 does real compute.
 
 ## Overview
@@ -229,7 +229,7 @@ class Before:
         y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
         y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
         z_tile = pl.matmul(x_left, y_right)
-        pl.tpush_to_aiv(z_tile, split=0)        # split kwarg unset
+        pl.tpush_to_aiv(z_tile, split=0)        # split=0 is the "None" sentinel
 
     @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
     def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):

--- a/docs/en/dev/passes/19-split_vector_kernel.md
+++ b/docs/en/dev/passes/19-split_vector_kernel.md
@@ -1,0 +1,397 @@
+# SplitVectorKernel Pass
+
+Splits a vector kernel along one tile axis so that two AIV lanes share the
+work, halving the per-lane tile shapes and rewriting `tile.load`,
+`tile.store`, and `tile.tpop_from_aic` to address each lane's half. On
+Ascend910B, the same pass also handles the **no-split dual-AIV dispatch**
+path: when `ExpandMixedKernel` decides a mixed kernel cannot be split, it
+tags the AIV function with `dual_aiv_dispatch=True` and this pass wraps
+the body in a per-lane `if subblock_idx == 0 / else` so AIC↔AIV cross-core
+handshakes stay balanced even though only lane 0 does real compute.
+
+## Overview
+
+Two distinct rewrites share one pass because both depend on
+`subblock_idx` and on cross-core `tpush`/`tpop` accounting:
+
+1. **Split mode** — driven by either `Function::attrs["split"]`
+   (`SplitMode::UpDown` or `SplitMode::LeftRight`) or a `split=` kwarg on
+   any `tile.tpush_*` / `tile.tpop_*` call inside the function. The AIC
+   side only needs the `split=` value synced across its cross-core ops;
+   the AIV side gets a real shape rewrite — its tiles are halved on the
+   split axis, `tile.load` / `tile.store` offsets are bumped by
+   `subblock_idx * half_dim` so each lane addresses its own half, and
+   `tile.tpop_from_aic` results are halved on the split axis.
+
+2. **No-split dual-AIV dispatch** — only fires on backends whose
+   `BackendHandler::RequiresNoSplitDualAivDispatch()` returns `true`
+   (Ascend910B today) and only on AIV functions tagged
+   `dual_aiv_dispatch=True` by `ExpandMixedKernel` (see
+   [`ExpandMixedKernel`](17-expand_mixed_kernel.md), the "no function
+   split mode" paragraph). The pass injects `subblock_idx`, hoists shared
+   pipe-setup calls (`reserve_buffer`, `import_peer_buffer`,
+   `aic_initialize_pipe`, `aiv_initialize_pipe`) above the lane branch,
+   and emits an `IfStmt` whose then-branch is the original body and
+   whose else-branch is a "replay" that keeps every cross-core
+   `tpush`/`tpop`/`tfree` but forces tile-producing replays to
+   `valid_shape=[0, 0]` and drops user-visible `tile.store` writes.
+
+`ResolveSplitMode` decides which mode to use:
+
+- If `attrs["split"]` is set and non-`None`, that wins (cross-core
+  `split=` kwargs in the body must agree, otherwise `ValueError`).
+- Otherwise the body is scanned by `CrossCoreSplitCollector` and the
+  unique non-zero `split=` kwarg becomes the inferred mode.
+- Conflicting cross-core `split=` values raise `ValueError`.
+- If the function is AIV with `dual_aiv_dispatch=True` *and* the
+  resolved split mode is `None`, the no-split dual-dispatch rewrite
+  applies instead.
+
+### Split-axis dispatch
+
+| `SplitMode` (int) | Split axis | Halved | Offset adjust on `tile.load` / `tile.store` |
+| ----------------- | ---------- | ------ | ------------------------------------------- |
+| `None` (0) | — | — | pass is a no-op for that function |
+| `UpDown` (1) | dim 0 (height) | rows | `[orig + subblock_idx * H/2, orig]` |
+| `LeftRight` (2) | dim 1 (width) | cols | `[orig, orig + subblock_idx * W/2]` |
+
+`subblock_idx` is materialized by `pl.tile.get_subblock_idx()`, injected
+as the first stmt of the rewritten AIV body via `InjectSubblockIdx`.
+Name collisions with existing params/locals are avoided by
+`auto_name::GenerateFreshNameLike`.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::SplitVectorKernel()` | `passes.split_vector_kernel()` | Program-level |
+
+```python
+from pypto import passes
+result = passes.split_vector_kernel()(program)
+```
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | `SSAForm`, `MixedKernelExpanded` |
+| Produced | `SSAForm`, `VectorKernelSplit`, `NormalizedStmtStructure` |
+| Invalidated | — |
+
+`MixedKernelExpanded` is the upstream contract that no `FunctionType::InCore`
+function still mixes Cube and Vector ops, and that AIC↔AIV cross-core
+ops are already in place. `VectorKernelSplit` advertises that AIV
+functions whose `attrs["split"]` is non-`None` have had their tile shapes,
+`tile.tpop_from_aic` results, and `tile.load`/`tile.store` offsets
+adjusted to per-lane form. Source: `include/pypto/ir/transforms/pass_properties.h`,
+`include/pypto/ir/transforms/ir_property.h`.
+
+## Algorithm — split-mode
+
+`ProcessFunction` rewrites a single AIC or AIV function whose
+`ResolveSplitMode` resolves to `UpDown` or `LeftRight`:
+
+```text
+1. Resolve split mode and split dim:
+   split_dim = (mode == UpDown) ? 0 : 1
+2. Clone params (preserving names and types) into var_replacements so the
+   rewritten body still sees the same parameter identity.
+3. (AIV only) InjectSubblockIdx prepends:
+       subblock_idx = tile.get_subblock_idx()
+   to the body, picking a fresh name if 'subblock_idx' is already taken.
+4. Walk every statement via ProcessStmt:
+
+   tile.tpush_to_aiv / tile.tpush_to_aic / tile.tpop_from_aiv:
+     RebuildCallWithSplit — sync the `split=` kwarg only. AIC keeps the
+     full operand tile (cube still consumes the whole matmul output).
+
+   tile.tpop_from_aic (AIV only):
+     RebuildTpopWithHalvedShape — halve the result shape on split_dim,
+     localize TileView.valid_shape per subblock, and sync `split=`.
+
+   tile.load (AIV only, ≥4-arg form):
+     If the result tile's split-axis dim is singleton (e.g. [1, 128]
+     under UpDown), keep the load as-is.
+     If the tile is rank-deficient (rank < split_dim+1), keep as-is.
+     Otherwise: halve result shape, halve the static shape arg, localize
+     valid_shape, and add `subblock_idx * H/2` to the split-axis offset.
+
+   tile.store (AIV only, ≥3-arg form):
+     If the source tile is tracked in tile_vars (i.e. it was halved
+     earlier), bump its split-axis offset by `subblock_idx * H/2`.
+
+   any other tile.* op producing a TileType (AIV only):
+     Halve the result shape on split_dim. For tile.full / tile.create the
+     static shape arg is also halved. Reduce ops on the split axis raise
+     ValueError via IsReduceOnSplitAxis (partial reduction would be
+     incorrect).
+
+   ForStmt:
+     Rebuild iter_args whose initValue is a tracked halved tile so they
+     carry the halved type. Rebuild return_vars to inherit the halved
+     type from their iter_args. Recurse into the body. Loop-carried
+     state is repaired by loop_repair::RebuildForStmt.
+
+   IfStmt / SeqStmts:
+     Recurse into branches and stmt sequences.
+
+5. After rewriting, transform_utils::Substitute applies var_replacements
+   so every reference (param, iter_arg, return_var, tpop result) sees the
+   rewritten Var node.
+6. DeepClone is applied to detach from any shared IR sub-trees.
+7. WithSplitAttr stamps the resolved SplitMode onto Function::attrs
+   (overwriting any prior `split` entry).
+```
+
+`tile_vars` is the per-pass map that tracks which `Var`s carry halved
+tiles (with their `half_dim_size`). It is the mechanism that lets a
+`tile.store` issued *outside* the loop still recognize that its source
+tile was halved by a `tile.load` *inside* the loop.
+
+## Algorithm — no-split dual-AIV dispatch
+
+`ProcessNoSplitDualAivFunction` only fires when
+`RequiresNoSplitDualAivSync(func)` is true — that is, the backend is
+Ascend910B (or any backend whose `BackendHandler::RequiresNoSplitDualAivDispatch()`
+returns true), the function is AIV, and `attrs["dual_aiv_dispatch"]` is
+true. It runs *instead of* `ProcessFunction` (a function never enters
+both paths).
+
+```text
+1. Clone params into param_replacements (same as split-mode).
+2. InjectSubblockIdx — prepend `subblock_idx = tile.get_subblock_idx()`.
+3. Strip the leading subblock_idx assign from the body, then split off
+   the shared pipe-setup prefix:
+     SplitNoSplitSharedPipeSetupPrefix takes the maximal prefix of
+     reserve_buffer / import_peer_buffer / aic_initialize_pipe /
+     aiv_initialize_pipe stmts (see IsNoSplitSharedPipeSetupCall) so
+     they run on both lanes from the original location.
+4. Lane 0 body = the original branch stmts (unchanged).
+5. Lane 1 body = BuildNoSplitLane1ReplayStmts(branch stmts):
+     - tile.store: drop EvalStmt forms entirely; for AssignStmt forms
+       passthrough the third arg (the destination tensor) so SSA users
+       still see a value, but no write happens.
+     - any other call producing a TileType: rewrite via
+       RebuildLane1CallWithZeroValidShape — `tile.load` becomes
+       `tile.create` whose result type carries `valid_shape=[0, 0]`;
+       `tile.slice` and `tile.set_validshape` get their valid_shape args
+       zeroed; everything else has its result type's `valid_shape`
+       cleared.
+     - cross-core tile.tpush_* / tile.tpop_* / system.tfree_* are kept
+       so the AIC↔AIV handshake stays balanced.
+     - For/While/If recurse with a forked replacements map so SSA
+       renames inside a branch do not leak across siblings.
+6. Wrap lane 0 and lane 1 in:
+       if subblock_idx == 0:
+           <lane 0>
+       else:
+           <lane 1>
+7. New body =
+     subblock_idx assign
+     <hoisted shared pipe-setup>
+     <branch IfStmt>
+8. Substitute / DeepClone, attrs unchanged (dual_aiv_dispatch=True
+   stays — downstream lowering reads it).
+```
+
+## Constraints
+
+| Constraint | Why |
+| ---------- | --- |
+| Even split-axis dim (or dynamic dim with `// 2`) | `ComputeHalfDimSize` raises if a `ConstInt` split dim is odd; dynamic dims emit `MakeFloorDiv(dim, 2)` |
+| Conflicting function-level vs cross-core split modes | `ResolveSplitMode` raises `ValueError` |
+| Conflicting cross-core split kwargs in one body | `CrossCoreSplitCollector` raises `ValueError` |
+| Reduce on the split axis is rejected | `IsReduceOnSplitAxis` raises — partial reduction in a single subblock is semantically incorrect |
+| Singleton split-axis dim preserved as-is | broadcast tiles like `[1, 128]` under `UpDown` or `[16, 1]` under `LeftRight` still carry the full tile |
+| Rank-deficient tiles bypass split rewrites | rank-1 `tile.load` under `LeftRight` (split dim 1) is left untouched |
+| AIC keeps full `tile.tpop_from_aiv` shape | cube still consumes the whole matmul operand; only `split=` is synced |
+| No-split lane 1 must produce no visible writes | `tile.store` writes are dropped; tile producers are forced to `valid_shape=[0, 0]` so PTO ops run as empty tiles |
+
+## Examples
+
+### Example 1 — UpDown: tpop halved + store offset adjusted
+
+Distilled from `test_tpop_shape_halved_and_store_offset_adjusted` in
+`tests/ut/ir/transforms/test_split_vector_kernel.py`. AIC body keeps
+its operand tiles intact and only syncs `split=`; AIV gets the full
+halve-and-shift treatment.
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+        x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+        x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+        y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+        y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+        z_tile = pl.matmul(x_left, y_right)
+        pl.tpush_to_aiv(z_tile, split=0)        # split kwarg unset
+
+    @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):
+        z_vec: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
+        return pl.store(z_vec, [0, 0], out_0)
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aic(self, x, y):
+        # ... cube ops unchanged ...
+        pl.tpush_to_aiv(z_tile, split=1)        # only split kwarg synced
+
+    @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aiv(self, out_0):
+        subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+        z_vec: pl.Tile[[8, 128], pl.FP32, pl.Mem.Vec] = pl.tpop_from_aic(split=1)
+        return pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
+```
+
+### Example 2 — LeftRight: width halved, dim-1 offset adjusted
+
+Distilled from `test_load_shape_halved_left_right`. AIV does both a
+real `tile.load` and a `tpop_from_aic`; both end up on the right half
+of the source via `subblock_idx * 64`.
+
+**Before**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+def main_aiv(self, data: pl.Tensor[[16, 128], pl.FP32],
+             out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):
+    prev = pl.load(data, [0, 0], [16, 128], target_memory=pl.Mem.Vec)
+    pop_tile: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
+    result = pl.add(prev, pop_tile)
+    return pl.store(result, [0, 0], out_0)
+```
+
+**After**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+def main_aiv(self, data, out_0):
+    subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+    prev: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.load(
+        data, [0, 0 + subblock_idx * 64], [16, 64], target_memory=pl.Mem.Vec)
+    pop_tile: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tpop_from_aic(split=2)
+    result: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.add(prev, pop_tile)
+    return pl.store(result, [0, 0 + subblock_idx * 64], out_0)
+```
+
+### Example 3 — Ascend910B no-split dual-AIV dispatch
+
+Distilled from
+`test_no_split_dual_dispatch_producer_replays_compute_and_tpush_on_lane1`.
+The AIV function carries `dual_aiv_dispatch=True` (set by
+`ExpandMixedKernel` for a no-split mixed kernel) and no `split` attr.
+The pass keeps lane 0 doing real work and rebuilds lane 1 as an
+empty-tile replay so the `tpush_to_aic` handshake still happens twice.
+
+**Before**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+def main_aiv(self, a, b, out):
+    slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+    pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
+    a_tile = pl.load(a, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+    b_tile = pl.load(b, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+    summed = pl.add(a_tile, b_tile)
+    pl.tpush_to_aic(summed, split=0)
+    return out
+```
+
+**After** (shape-preserving — lane 1 carries empty tiles via
+`valid_shape=[0, 0]`):
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+def main_aiv(self, a, b, out):
+    subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+    slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+    pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
+    if subblock_idx == 0:
+        a_tile = pl.load(a, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+        b_tile = pl.load(b, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+        summed = pl.add(a_tile, b_tile)
+        pl.tpush_to_aic(summed, split=0)
+    else:
+        # tile.load -> tile.create with valid_shape=[0, 0]
+        a_tile: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+        b_tile: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+        summed: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.add(a_tile, b_tile)
+        pl.tpush_to_aic(summed, split=0)        # handshake still fires
+    return out
+```
+
+`reserve_buffer` and `aiv_initialize_pipe` are hoisted above the
+`if`/`else` so both lanes share the same buffer state.
+
+## Implementation
+
+**Header**: `include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass SplitVectorKernel();
+```
+
+**Implementation**: `src/ir/transforms/split_vector_kernel_pass.cpp`
+
+- `ResolveSplitMode` — picks function-level vs body-derived split mode.
+- `ProcessFunction` / `ProcessStmt` / `ProcessStmts` — split-mode rewrite.
+- `RebuildCallWithSplit` / `RebuildTpopWithHalvedShape` — cross-core
+  call rewriters.
+- `HalveTileShape` / `ApplyTrackedTileShape` /
+  `LocalizeValidDimForSplit` — tile type rewriters.
+- `AdjustOffsets` — split-axis offset shift on `tile.load`/`tile.store`.
+- `IsReduceOnSplitAxis` — guard for partial-reduction errors.
+- `RequiresNoSplitDualAivSync` / `ProcessNoSplitDualAivFunction` /
+  `BuildNoSplitLane1ReplayStmts` / `RebuildLane1CallWithZeroValidShape` /
+  `IsNoSplitSharedPipeSetupCall` — Ascend910B no-split path.
+
+**Properties**: `include/pypto/ir/transforms/pass_properties.h`
+
+```cpp
+inline const PassProperties kSplitVectorKernelProperties{
+    .required = {IRProperty::SSAForm, IRProperty::MixedKernelExpanded},
+    .produced = {IRProperty::SSAForm, IRProperty::VectorKernelSplit,
+                 IRProperty::NormalizedStmtStructure}};
+```
+
+**Python binding**: `python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("split_vector_kernel", &pass::SplitVectorKernel,
+           "Create a pass that splits vector kernels based on SplitMode "
+           "(adjusts tpush/tpop split, halves tpop shapes, adjusts store offsets)");
+```
+
+**Type stub**: `python/pypto/pypto_core/passes.pyi`
+
+```python
+def split_vector_kernel() -> Pass:
+    """Create a pass that splits vector kernels based on SplitMode."""
+```
+
+**Tests**: `tests/ut/ir/transforms/test_split_vector_kernel.py`
+(`TestSplitVectorKernelUpDown`, `TestSplitVectorKernelLeftRight`, and
+`TestSplitVectorKernelNoSplitA2A3`).
+
+## Related
+
+- [`ExpandMixedKernel`](17-expand_mixed_kernel.md) — upstream producer of
+  AIC/AIV functions and of the `dual_aiv_dispatch` marker.
+- [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md) — runs immediately
+  before; backend-gated GM pipe buffer wiring this pass relies on.
+- [`NormalizeReturnOrder`](20-normalize_return_order.md) — runs immediately
+  after; sees the per-lane tile shapes produced here.

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -369,7 +369,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 5. `NormalizeStmtStructure`
 6. `ExpandMixedKernel`
 7. [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md)
-8. `SplitVectorKernel`
+8. [`SplitVectorKernel`](19-split_vector_kernel.md)
 9. `NormalizeReturnOrder`
 10. [`LowerPipelineLoops`](21-lower_pipeline_loops.md)
 11. [`CanonicalizeIOOrder`](22-canonicalize_io_order.md)

--- a/docs/zh-cn/dev/passes/19-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/19-split_vector_kernel.md
@@ -1,0 +1,388 @@
+# SplitVectorKernel Pass
+
+将 vector kernel 沿一个 tile 轴拆分，使两个 AIV lane 各自承担一半工作；该
+Pass 会把 per-lane 的 tile 形状减半，并重写 `tile.load`、`tile.store`、
+`tile.tpop_from_aic` 以指向各自的那一半。在 Ascend910B 上，本 Pass 还
+负责 **no-split 双 AIV 派发** 路径：当 `ExpandMixedKernel` 判断混合
+kernel 不可拆分时，会给 AIV 函数打上 `dual_aiv_dispatch=True` 标记，本
+Pass 据此把函数体包装为 `if subblock_idx == 0 / else`，让 AIC↔AIV 跨核
+握手在两条 lane 上仍然对称（即使只有 lane 0 做真实计算）。
+
+## 概述
+
+这两类重写共用一个 Pass，因为它们都依赖 `subblock_idx`，并且都需要维
+护跨核 `tpush`/`tpop` 的对称性：
+
+1. **拆分模式（split mode）** —— 由
+   `Function::attrs["split"]`（`SplitMode::UpDown` 或
+   `SplitMode::LeftRight`）或函数体内任意
+   `tile.tpush_*` / `tile.tpop_*` 调用上的 `split=` kwarg 触发。AIC 侧
+   只需要将所有跨核 op 上的 `split=` 同步；AIV 侧才会真正改写 shape：
+   tile 在 split 轴上减半，`tile.load` / `tile.store` 的偏移量加上
+   `subblock_idx * half_dim`，让每个 lane 取自己那一半，并把
+   `tile.tpop_from_aic` 结果在 split 轴上减半。
+
+2. **No-split 双 AIV 派发** —— 仅在后端
+   `BackendHandler::RequiresNoSplitDualAivDispatch()` 返回 `true`
+   （目前只有 Ascend910B）且 AIV 函数被
+   `ExpandMixedKernel` 打上 `dual_aiv_dispatch=True` 标记时启用，参见
+   [`ExpandMixedKernel`](17-expand_mixed_kernel.md) 中的「no function
+   split mode」段落。本 Pass 注入 `subblock_idx`，把
+   `reserve_buffer`、`import_peer_buffer`、`aic_initialize_pipe`、
+   `aiv_initialize_pipe` 这些共享 pipe-setup 调用从分支前缀中外提到分
+   支之外，并发出一个 `IfStmt`：then 分支保留原始函数体，else 分支
+   通过 replay 保留所有跨核 `tpush`/`tpop`/`tfree`，但让所有产生 tile
+   的 op 把结果 `valid_shape` 强制为 `[0, 0]`，并丢弃用户可见的
+   `tile.store` 写回。
+
+`ResolveSplitMode` 决定走哪一条：
+
+- 若 `attrs["split"]` 为非 `None`，以它为准（函数体中跨核 op 的
+  `split=` 必须一致，否则 `ValueError`）。
+- 否则由 `CrossCoreSplitCollector` 扫描函数体，使用唯一非零的
+  `split=` 作为推断模式。
+- 函数体内不同跨核 op 上的 `split=` 取值不一致时抛 `ValueError`。
+- 若函数为 AIV 且 `dual_aiv_dispatch=True`，且解析得到的拆分模式为
+  `None`，则改走 no-split 双 AIV 派发路径。
+
+### 拆分轴
+
+| `SplitMode`（int） | 拆分轴 | 减半维度 | `tile.load` / `tile.store` 偏移修正 |
+| ------------------ | ------ | -------- | ----------------------------------- |
+| `None`（0） | — | — | 该函数视为 no-op |
+| `UpDown`（1） | dim 0（高度） | 行数 | `[orig + subblock_idx * H/2, orig]` |
+| `LeftRight`（2） | dim 1（宽度） | 列数 | `[orig, orig + subblock_idx * W/2]` |
+
+`subblock_idx` 由 `pl.tile.get_subblock_idx()` 物化，由
+`InjectSubblockIdx` 注入为重写后 AIV 函数体的第一条语句。若
+`subblock_idx` 与已有 param/局部变量重名，由
+`auto_name::GenerateFreshNameLike` 生成新的名字以避免冲突。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::SplitVectorKernel()` | `passes.split_vector_kernel()` | 程序级 |
+
+```python
+from pypto import passes
+result = passes.split_vector_kernel()(program)
+```
+
+## Pass 属性
+
+| 属性 | 取值 |
+| ---- | ---- |
+| 前置（Required） | `SSAForm`、`MixedKernelExpanded` |
+| 产出（Produced） | `SSAForm`、`VectorKernelSplit`、`NormalizedStmtStructure` |
+| 失效（Invalidated） | — |
+
+`MixedKernelExpanded` 来自上游契约，保证不再有 `FunctionType::InCore`
+函数同时混合 Cube 和 Vector 操作，并且 AIC↔AIV 跨核 op 已就位。
+`VectorKernelSplit` 表示已对 `attrs["split"]` 非 `None` 的 AIV 函数完
+成 tile 形状、`tile.tpop_from_aic` 结果、`tile.load`/`tile.store` 偏
+移的 per-lane 调整。来源：`include/pypto/ir/transforms/pass_properties.h`、
+`include/pypto/ir/transforms/ir_property.h`。
+
+## 算法 —— 拆分模式
+
+`ProcessFunction` 重写 `ResolveSplitMode` 解析为
+`UpDown` 或 `LeftRight` 的单个 AIC 或 AIV 函数：
+
+```text
+1. 解析拆分模式与拆分轴：
+   split_dim = (mode == UpDown) ? 0 : 1
+2. 克隆 params（保持原 name 与 type），登记到 var_replacements，使重写
+   后的函数体仍持有同一份 param 身份。
+3. （仅 AIV）InjectSubblockIdx 在函数体头部插入：
+       subblock_idx = tile.get_subblock_idx()
+   若 'subblock_idx' 已被占用则改用一个新名字。
+4. 通过 ProcessStmt 遍历每条语句：
+
+   tile.tpush_to_aiv / tile.tpush_to_aic / tile.tpop_from_aiv：
+     RebuildCallWithSplit —— 仅同步 `split=` kwarg。AIC 保留完整操作
+     数 tile（cube 仍然消费整张 matmul 输出）。
+
+   tile.tpop_from_aic（仅 AIV）：
+     RebuildTpopWithHalvedShape —— 在 split_dim 上将结果 shape 减半，
+     按 subblock 局部化 TileView.valid_shape，并同步 `split=`。
+
+   tile.load（仅 AIV，≥4 个参数）：
+     若结果 tile 在 split 轴上是 singleton（如 UpDown 下的 [1, 128]）
+     保持原状；
+     若 tile 是低秩（rank < split_dim+1）保持原状；
+     否则减半结果 shape、减半静态 shape 参数、局部化 valid_shape，
+     并把 split 轴偏移加 `subblock_idx * H/2`。
+
+   tile.store（仅 AIV，≥3 个参数）：
+     若源 tile 在 tile_vars 中（早先被减半），把它的 split 轴偏移加
+     `subblock_idx * H/2`。
+
+   产生 TileType 的其他 tile.* op（仅 AIV）：
+     在 split_dim 上减半结果 shape；tile.full / tile.create 还会减半
+     静态 shape 参数。命中 split 轴的 reduce op 由 IsReduceOnSplitAxis
+     拦截抛 ValueError（单 subblock 内的部分 reduce 语义不正确）。
+
+   ForStmt：
+     若 iter_args 的 initValue 是被追踪的 halved tile，则重建 iter_arg
+     使其类型也减半；同时按 iter_arg 类型重建 return_vars。递归处理函
+     数体；loop-carried state 由 loop_repair::RebuildForStmt 修复。
+
+   IfStmt / SeqStmts：
+     递归处理分支与语句序列。
+
+5. 重写完成后，transform_utils::Substitute 应用 var_replacements，确
+   保所有引用（param、iter_arg、return_var、tpop 结果）看到的是重写
+   后的 Var。
+6. 调用 DeepClone，避免与共享 IR 子树纠缠。
+7. WithSplitAttr 把解析得到的 SplitMode 写回 Function::attrs（覆盖原
+   有 `split` 项）。
+```
+
+`tile_vars` 是 Pass 内部的映射，记录哪些 `Var` 携带 halved tile 以及
+对应的 `half_dim_size`。它让在循环外发出的 `tile.store` 也能识别到
+循环内 `tile.load` 已经把源 tile 减半这一事实。
+
+## 算法 —— No-split 双 AIV 派发
+
+`ProcessNoSplitDualAivFunction` 仅在
+`RequiresNoSplitDualAivSync(func)` 为 true 时触发，即后端为
+Ascend910B（或任意
+`BackendHandler::RequiresNoSplitDualAivDispatch()` 返回 true 的后端）、
+函数为 AIV、`attrs["dual_aiv_dispatch"]` 为 true。它**取代**
+`ProcessFunction`（同一函数永远不会同时走两条路径）。
+
+```text
+1. 克隆 params 到 param_replacements（与拆分模式一致）。
+2. InjectSubblockIdx —— 注入 `subblock_idx = tile.get_subblock_idx()`。
+3. 剥离 body 头部的 subblock_idx 赋值后，再切出共享 pipe-setup 前缀：
+     SplitNoSplitSharedPipeSetupPrefix 取最长前缀，仅包含
+     reserve_buffer / import_peer_buffer / aic_initialize_pipe /
+     aiv_initialize_pipe（参见 IsNoSplitSharedPipeSetupCall），让它们
+     在两条 lane 之外保持原位执行。
+4. Lane 0 = 剩余的分支语句（保持原状）。
+5. Lane 1 = BuildNoSplitLane1ReplayStmts(分支语句)：
+     - tile.store：EvalStmt 形式整体丢弃；AssignStmt 形式让 LHS 直
+       接 passthrough 第三个参数（目标 tensor），让 SSA 后续仍能看
+       到一个值，但不再发生写入。
+     - 任意产生 TileType 的 call：通过
+       RebuildLane1CallWithZeroValidShape 改写 —— `tile.load` →
+       `tile.create`，结果类型携带 `valid_shape=[0, 0]`；
+       `tile.slice`、`tile.set_validshape` 的 valid_shape 参数清零；
+       其他 op 的结果类型 `valid_shape` 全部清空。
+     - 跨核 tile.tpush_* / tile.tpop_* / system.tfree_* 全部保留，
+       使 AIC↔AIV 握手保持平衡。
+     - For/While/If 用 fork 后的 replacements 递归处理，避免分支内
+       的 SSA 重命名串到兄弟语句。
+6. 用以下结构包装 lane 0 与 lane 1：
+       if subblock_idx == 0:
+           <lane 0>
+       else:
+           <lane 1>
+7. 新 body =
+     subblock_idx 赋值
+     <外提的共享 pipe-setup>
+     <分支 IfStmt>
+8. Substitute / DeepClone；attrs 不变（`dual_aiv_dispatch=True` 仍然
+   保留 —— 后续 lowering 会读它）。
+```
+
+## 约束
+
+| 约束 | 原因 |
+| ---- | ---- |
+| 拆分轴必须是偶数（动态维度走 `// 2`） | `ComputeHalfDimSize`：`ConstInt` 为奇数时直接抛错；动态维度发出 `MakeFloorDiv(dim, 2)` |
+| 函数级与跨核 op `split=` 模式冲突 | `ResolveSplitMode` 抛 `ValueError` |
+| 函数体内多个跨核 op 的 `split=` 不一致 | `CrossCoreSplitCollector` 抛 `ValueError` |
+| split 轴上的 reduce 被禁止 | `IsReduceOnSplitAxis` 抛错 —— 单 subblock 内的部分 reduce 语义不正确 |
+| split 轴 singleton 维度保持原状 | UpDown 下的 `[1, 128]` 或 LeftRight 下的 `[16, 1]` 等广播 tile |
+| 低秩 tile 跳过拆分改写 | LeftRight（split dim=1）下的 rank-1 `tile.load` 保持原样 |
+| AIC 上的 `tile.tpop_from_aiv` 保持完整 shape | cube 仍需消费整张 matmul 操作数；只同步 `split=` |
+| No-split lane 1 不可产生可见写回 | `tile.store` 写入被丢弃；产生 tile 的 op 强制 `valid_shape=[0, 0]`，PTO op 以空 tile 形式执行 |
+
+## 示例
+
+### 示例 1 —— UpDown：tpop 减半 + store 偏移调整
+
+提炼自 `tests/ut/ir/transforms/test_split_vector_kernel.py` 中的
+`test_tpop_shape_halved_and_store_offset_adjusted`。AIC 函数体保持
+不变，仅同步 `split=`；AIV 完整经历减半与偏移修正。
+
+**Before**:
+
+```python
+@pl.program
+class Before:
+    @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+        x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+        x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+        y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+        y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+        z_tile = pl.matmul(x_left, y_right)
+        pl.tpush_to_aiv(z_tile, split=0)        # split kwarg 未设置
+
+    @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):
+        z_vec: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
+        return pl.store(z_vec, [0, 0], out_0)
+```
+
+**After**:
+
+```python
+@pl.program
+class After:
+    @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aic(self, x, y):
+        # ... cube ops 不变 ...
+        pl.tpush_to_aiv(z_tile, split=1)        # 仅同步 split kwarg
+
+    @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+    def main_aiv(self, out_0):
+        subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+        z_vec: pl.Tile[[8, 128], pl.FP32, pl.Mem.Vec] = pl.tpop_from_aic(split=1)
+        return pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
+```
+
+### 示例 2 —— LeftRight：宽度减半，dim-1 偏移调整
+
+提炼自 `test_load_shape_halved_left_right`。AIV 同时包含
+`tile.load` 与 `tile.tpop_from_aic`；两者最终都通过
+`subblock_idx * 64` 各自落到源数据的右半区域。
+
+**Before**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+def main_aiv(self, data: pl.Tensor[[16, 128], pl.FP32],
+             out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):
+    prev = pl.load(data, [0, 0], [16, 128], target_memory=pl.Mem.Vec)
+    pop_tile: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
+    result = pl.add(prev, pop_tile)
+    return pl.store(result, [0, 0], out_0)
+```
+
+**After**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+def main_aiv(self, data, out_0):
+    subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+    prev: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.load(
+        data, [0, 0 + subblock_idx * 64], [16, 64], target_memory=pl.Mem.Vec)
+    pop_tile: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tpop_from_aic(split=2)
+    result: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.add(prev, pop_tile)
+    return pl.store(result, [0, 0 + subblock_idx * 64], out_0)
+```
+
+### 示例 3 —— Ascend910B no-split 双 AIV 派发
+
+提炼自
+`test_no_split_dual_dispatch_producer_replays_compute_and_tpush_on_lane1`。
+AIV 函数携带 `dual_aiv_dispatch=True`（由 `ExpandMixedKernel` 为
+no-split 混合 kernel 打上），且无 `split` 属性。本 Pass 让 lane 0 做
+真正的工作，lane 1 重建为空 tile replay，使
+`tpush_to_aic` 握手仍然发生两次。
+
+**Before**:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+def main_aiv(self, a, b, out):
+    slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+    pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
+    a_tile = pl.load(a, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+    b_tile = pl.load(b, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+    summed = pl.add(a_tile, b_tile)
+    pl.tpush_to_aic(summed, split=0)
+    return out
+```
+
+**After**（保持 shape 不变 —— lane 1 通过 `valid_shape=[0, 0]` 携带空
+tile）:
+
+```python
+@pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+def main_aiv(self, a, b, out):
+    subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+    slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+    pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
+    if subblock_idx == 0:
+        a_tile = pl.load(a, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+        b_tile = pl.load(b, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+        summed = pl.add(a_tile, b_tile)
+        pl.tpush_to_aic(summed, split=0)
+    else:
+        # tile.load 改写为 tile.create，valid_shape=[0, 0]
+        a_tile: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+        b_tile: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+        summed: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[0, 0])] = \
+            pl.add(a_tile, b_tile)
+        pl.tpush_to_aic(summed, split=0)        # 握手仍然触发
+    return out
+```
+
+`reserve_buffer` 与 `aiv_initialize_pipe` 被外提到 `if`/`else` 之外，
+两条 lane 共享同一份 buffer 状态。
+
+## 实现
+
+**头文件**：`include/pypto/ir/transforms/passes.h`
+
+```cpp
+Pass SplitVectorKernel();
+```
+
+**实现**：`src/ir/transforms/split_vector_kernel_pass.cpp`
+
+- `ResolveSplitMode` —— 在函数级 attr 与函数体推断之间挑选拆分模式。
+- `ProcessFunction` / `ProcessStmt` / `ProcessStmts` —— 拆分模式重写。
+- `RebuildCallWithSplit` / `RebuildTpopWithHalvedShape` —— 跨核 call
+  改写器。
+- `HalveTileShape` / `ApplyTrackedTileShape` /
+  `LocalizeValidDimForSplit` —— TileType 改写器。
+- `AdjustOffsets` —— `tile.load`/`tile.store` 在 split 轴上的偏移修正。
+- `IsReduceOnSplitAxis` —— 部分 reduce 错误的守卫。
+- `RequiresNoSplitDualAivSync` / `ProcessNoSplitDualAivFunction` /
+  `BuildNoSplitLane1ReplayStmts` / `RebuildLane1CallWithZeroValidShape` /
+  `IsNoSplitSharedPipeSetupCall` —— Ascend910B no-split 路径。
+
+**Pass 属性**：`include/pypto/ir/transforms/pass_properties.h`
+
+```cpp
+inline const PassProperties kSplitVectorKernelProperties{
+    .required = {IRProperty::SSAForm, IRProperty::MixedKernelExpanded},
+    .produced = {IRProperty::SSAForm, IRProperty::VectorKernelSplit,
+                 IRProperty::NormalizedStmtStructure}};
+```
+
+**Python 绑定**：`python/bindings/modules/passes.cpp`
+
+```cpp
+passes.def("split_vector_kernel", &pass::SplitVectorKernel,
+           "Create a pass that splits vector kernels based on SplitMode "
+           "(adjusts tpush/tpop split, halves tpop shapes, adjusts store offsets)");
+```
+
+**类型 stub**：`python/pypto/pypto_core/passes.pyi`
+
+```python
+def split_vector_kernel() -> Pass:
+    """Create a pass that splits vector kernels based on SplitMode."""
+```
+
+**测试**：`tests/ut/ir/transforms/test_split_vector_kernel.py`
+（`TestSplitVectorKernelUpDown`、`TestSplitVectorKernelLeftRight`、
+`TestSplitVectorKernelNoSplitA2A3`）。
+
+## 相关文档
+
+- [`ExpandMixedKernel`](17-expand_mixed_kernel.md) —— 上游 Pass，产生
+  AIC/AIV 函数和 `dual_aiv_dispatch` 标记。
+- [`InjectGMPipeBuffer`](18-inject_gm_pipe_buffer.md) —— 紧邻上游；本
+  Pass 依赖它布置好的 backend-gated GM pipe buffer。
+- [`NormalizeReturnOrder`](20-normalize_return_order.md) —— 紧邻下游；
+  会观察到本 Pass 产出的 per-lane tile 形状。

--- a/docs/zh-cn/dev/passes/19-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/19-split_vector_kernel.md
@@ -5,7 +5,7 @@ Pass 会把 per-lane 的 tile 形状减半，并重写 `tile.load`、`tile.store
 `tile.tpop_from_aic` 以指向各自的那一半。在 Ascend910B 上，本 Pass 还
 负责 **no-split 双 AIV 派发** 路径：当 `ExpandMixedKernel` 判断混合
 kernel 不可拆分时，会给 AIV 函数打上 `dual_aiv_dispatch=True` 标记，本
-Pass 据此把函数体包装为 `if subblock_idx == 0 / else`，让 AIC↔AIV 跨核
+Pass 据此把函数体包装为 `if subblock_idx == 0 ... else`，让 AIC↔AIV 跨核
 握手在两条 lane 上仍然对称（即使只有 lane 0 做真实计算）。
 
 ## 概述
@@ -220,7 +220,7 @@ class Before:
         y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
         y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
         z_tile = pl.matmul(x_left, y_right)
-        pl.tpush_to_aiv(z_tile, split=0)        # split kwarg 未设置
+        pl.tpush_to_aiv(z_tile, split=0)        # split=0 表示 "None" 哨兵值
 
     @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
     def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]):


### PR DESCRIPTION
## Summary

- Add `19-split_vector_kernel.md` (English + Chinese mirror) covering the
  SplitVectorKernel pass at slot #19 of the `Default` strategy.
- Document both rewrite paths the pass implements: the SplitMode
  (UpDown/LeftRight) per-lane shape halving + offset shift, and the
  Ascend910B no-split dual-AIV dispatch that replays cross-core
  handshakes on lane 1 with `valid_shape=[0, 0]`.
- Wire the new doc into the index — link from `00-pass_manager.md`
  (slot 8 of the tile stage, en + zh-cn) and update the
  `pass-doc-ordering.md` rule table (slot 19 was previously marked
  *(no doc yet)*).

Each section follows the established per-pass doc structure: API,
Pass Properties, Algorithm narration for both modes, Constraints,
three before/after examples distilled from
`tests/ut/ir/transforms/test_split_vector_kernel.py`, Implementation
references, and Related links.

## Testing

- [x] markdownlint-cli2 passes on all modified `.md` files
- [x] `tests/lint/check_english_only.py` passes (no CJK in English doc)
- [x] All cross-references resolve (`17-expand_mixed_kernel.md`,
      `18-inject_gm_pipe_buffer.md`, `20-normalize_return_order.md`)
- [x] Code snippets verified against
      `include/pypto/ir/transforms/pass_properties.h`,
      `python/bindings/modules/passes.cpp`,
      `python/pypto/pypto_core/passes.pyi`
- [x] Docs are 397 / 388 lines, under the 500-line cap

## Related Issues

Fixes #1167
Tracked under #1161