### PR TITLE
fix(printer): Disambiguate distinct Var/IterArg pointers in dumps

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -466,7 +466,7 @@ void IRPythonPrinter::DecreaseIndent() {
 // Expression visitors - reuse precedence logic from base printer
 void IRPythonPrinter::VisitExpr_(const VarPtr& op) { stream_ << GetVarName(op.get()); }
 
-void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << op->name_hint_; }
+void IRPythonPrinter::VisitExpr_(const IterArgPtr& op) { stream_ << GetVarName(op.get()); }
 
 void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << op->name_hint_; }
 
@@ -894,7 +894,7 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
     stream_ << ", (";
     for (size_t i = 0; i < op->iter_args_.size(); ++i) {
       if (i > 0) stream_ << ", ";
-      stream_ << op->iter_args_[i]->name_hint_;
+      stream_ << GetVarName(op->iter_args_[i].get());
     }
     // Add trailing comma for single-element tuples to distinguish from parenthesized expression
     if (op->iter_args_.size() == 1) {
@@ -1058,7 +1058,7 @@ void IRPythonPrinter::VisitStmt_(const WhileStmtPtr& op) {
     stream_ << "for (";
     for (size_t i = 0; i < op->iter_args_.size(); ++i) {
       if (i > 0) stream_ << ", ";
-      stream_ << op->iter_args_[i]->name_hint_;
+      stream_ << GetVarName(op->iter_args_[i].get());
     }
     // Add trailing comma for single-element tuples
     if (op->iter_args_.size() == 1) {
@@ -1337,18 +1337,78 @@ std::string IRPythonPrinter::GetVarName(const Var* var) const {
   return var->name_hint_;
 }
 
+namespace {
+
+/// Collects (return_var, iter_arg) pointer pairs from WhileStmts whose
+/// position-i bindings share name_hint_. Scoped to WhileStmt because only
+/// `pl.while_` parser-side auto-binds the header tuple name to the
+/// outer-scope return_var (`ast_parser.py::_register_while_outputs`);
+/// `pl.range` derives the post-loop binding from the yield-LHS and so does
+/// not need this pinning. The default IRVisitor traverses ForStmt/IfStmt/etc.
+/// bodies for us, so nested WhileStmts inside a ForStmt are still reached.
+///
+/// DISCUSSABLE: if the `pl.while_` DSL is unified with `pl.range` to derive
+/// return_var bindings from yield-LHS only (see RFC #1246), this collector
+/// and the harmonization step below can be deleted — lenient-mode
+/// disambiguation alone would suffice.
+class IterArgReturnVarPairCollector : public IRVisitor {
+ public:
+  std::vector<std::pair<const Var*, const Var*>> pairs;  // (return_var, iter_arg)
+
+ protected:
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    const size_t n = std::min(op->return_vars_.size(), op->iter_args_.size());
+    for (size_t i = 0; i < n; ++i) {
+      if (!op->return_vars_[i] || !op->iter_args_[i]) continue;
+      if (op->return_vars_[i]->name_hint_ == op->iter_args_[i]->name_hint_) {
+        pairs.emplace_back(op->return_vars_[i].get(), op->iter_args_[i].get());
+      }
+    }
+    VisitStmt(op->body_);
+  }
+};
+
+}  // namespace
+
 void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
-  // Collect all Var def-sites in DFS pre-order: params first, then body.
-  std::vector<const Var*> defs;
-  for (auto& p : func->params_) defs.push_back(p.get());
+  // Collect Var/IterArg pointers in DFS pre-order: params, then body defs,
+  // then body uses. Defs precede uses so a pointer appearing as both keeps
+  // its def-site canonical name; pointers appearing only as uses (e.g. a
+  // dangling reference from a buggy transform, or a sibling-scope iter_arg
+  // sharing a name_hint) still get their own suffix. (#1244)
+  std::vector<const Var*> ordered_refs;
+  for (auto& p : func->params_) ordered_refs.push_back(p.get());
   body_defined_vars_.clear();
+  IterArgReturnVarPairCollector pair_collector;
   if (func->body_) {
     var_collectors::VarDefUseCollector body_collector;
     body_collector.VisitStmt(func->body_);
-    defs.insert(defs.end(), body_collector.var_defs_ordered.begin(), body_collector.var_defs_ordered.end());
+    ordered_refs.insert(ordered_refs.end(), body_collector.var_defs_ordered.begin(),
+                        body_collector.var_defs_ordered.end());
+    ordered_refs.insert(ordered_refs.end(), body_collector.var_uses_ordered.begin(),
+                        body_collector.var_uses_ordered.end());
     body_defined_vars_ = std::move(body_collector.var_defs);
+    pair_collector.VisitStmt(func->body_);
   }
-  auto_name::BuildRenameMapForDefs(defs, var_rename_map_);
+  // Drop program-level dynamic dim vars: they are already disambiguated
+  // globally in dyn_var_rename_map_, and re-registering them here would
+  // shadow that map in GetVarName's two-tier lookup.
+  if (!dyn_var_rename_map_.empty()) {
+    ordered_refs.erase(std::remove_if(ordered_refs.begin(), ordered_refs.end(),
+                                      [this](const Var* v) { return dyn_var_rename_map_.count(v) > 0; }),
+                       ordered_refs.end());
+  }
+  auto_name::BuildRenameMapForDefs(ordered_refs, var_rename_map_);
+
+  // Harmonize iter_arg / return_var names where they share name_hint_. Both
+  // pointers are colliding def-sites, so BuildRenameMapForDefs has registered
+  // each under a distinct suffix; route the iter_arg to the return_var's name.
+  for (const auto& [rv, ia] : pair_collector.pairs) {
+    auto rv_it = var_rename_map_.find(rv);
+    INTERNAL_CHECK(rv_it != var_rename_map_.end())
+        << "Internal error: return_var with colliding name_hint must be in var_rename_map_";
+    var_rename_map_[ia] = rv_it->second;
+  }
 }
 
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -284,9 +284,12 @@ class IRPythonPrinter : public IRVisitor {
   // Return the printed name for a Var, using rename map if SSA name shadowing occurred.
   std::string GetVarName(const Var* var) const;
 
-  // Build var_rename_map_ for a function by scanning all Var def-sites in DFS pre-order.
+  // Build var_rename_map_ from a body stmt (and optional params).
   // Assigns unique suffixed names (e.g., "i", "i_1") when two distinct Vars share a name.
-  void BuildVarRenameMap(const FunctionPtr& func);
+  // Called from VisitFunction (with params) and from Print() for bare Stmt roots
+  // (no params) so that standalone stmt.as_python() also gets disambiguation.
+  void BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body);
+  void BuildVarRenameMap(const FunctionPtr& func) { BuildVarRenameMap(func->params_, func->body_); }
 
   // Print a statement block at current indent level.
   // SeqStmts is a transparent container - recursed into without extra indent.
@@ -350,6 +353,10 @@ std::string IRPythonPrinter::Print(const IRNodePtr& node) {
   } else if (auto func = As<Function>(node)) {
     VisitFunction(func);
   } else if (auto stmt = As<Stmt>(node)) {
+    // Bare-stmt roots (e.g. for_stmt.as_python(), seq.as_python()) need the
+    // same disambiguation a function body gets — without this, two distinct
+    // Var*/IterArg* sharing a name_hint collapse to one printed identifier.
+    BuildVarRenameMap({}, stmt);
     VisitStmt(stmt);
   } else if (auto expr = As<Expr>(node)) {
     VisitExpr(expr);
@@ -1370,25 +1377,26 @@ class IterArgReturnVarPairCollector : public IRVisitor {
 
 }  // namespace
 
-void IRPythonPrinter::BuildVarRenameMap(const FunctionPtr& func) {
+void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body) {
   // Collect Var/IterArg pointers in DFS pre-order: params, then body defs,
   // then body uses. Defs precede uses so a pointer appearing as both keeps
   // its def-site canonical name; pointers appearing only as uses (e.g. a
   // dangling reference from a buggy transform, or a sibling-scope iter_arg
   // sharing a name_hint) still get their own suffix. (#1244)
   std::vector<const Var*> ordered_refs;
-  for (auto& p : func->params_) ordered_refs.push_back(p.get());
+  ordered_refs.reserve(params.size());
+  for (const auto& p : params) ordered_refs.push_back(p.get());
   body_defined_vars_.clear();
   IterArgReturnVarPairCollector pair_collector;
-  if (func->body_) {
+  if (body) {
     var_collectors::VarDefUseCollector body_collector;
-    body_collector.VisitStmt(func->body_);
+    body_collector.VisitStmt(body);
     ordered_refs.insert(ordered_refs.end(), body_collector.var_defs_ordered.begin(),
                         body_collector.var_defs_ordered.end());
     ordered_refs.insert(ordered_refs.end(), body_collector.var_uses_ordered.begin(),
                         body_collector.var_uses_ordered.end());
     body_defined_vars_ = std::move(body_collector.var_defs);
-    pair_collector.VisitStmt(func->body_);
+    pair_collector.VisitStmt(body);
   }
   // Drop program-level dynamic dim vars: they are already disambiguated
   // globally in dyn_var_rename_map_, and re-registering them here would

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1146,6 +1146,43 @@ def test_python_print_distinct_iter_args_same_name_hint_disambiguated():
     assert text.count("(acc_1,)") == 1
 
 
+def test_python_print_distinct_iter_args_disambiguated_at_stmt_root():
+    """Bare `seq.as_python()` (no enclosing Function) must still disambiguate
+    distinct IterArg* sharing a name_hint.
+
+    Regression for the gap CodeRabbit flagged on PR #1247: BuildVarRenameMap
+    used to run only from VisitFunction, so standalone stmt printing hit an
+    empty rename map and collapsed colliding pointers back together.
+    """
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    scalar_ty = ir.ScalarType(dtype)
+    one = ir.ConstInt(1, dtype, span)
+    n = ir.ConstInt(8, dtype, span)
+
+    def make_loop(loop_name: str, rv_name: str) -> ir.ForStmt:
+        acc = ir.IterArg("acc", scalar_ty, ir.ConstInt(0, dtype, span), span)
+        loop_var = ir.Var(loop_name, scalar_ty, span)
+        rv = ir.Var(rv_name, scalar_ty, span)
+        body = ir.YieldStmt([ir.Add(acc, one, dtype, span)], span)
+        return ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, dtype, span),
+            n,
+            ir.ConstInt(1, dtype, span),
+            [acc],
+            body,
+            [rv],
+            span,
+        )
+
+    seq = ir.SeqStmts([make_loop("i", "rv_a"), make_loop("j", "rv_b")], span)
+    text = seq.as_python()
+
+    assert "(acc,)" in text
+    assert "(acc_1,)" in text
+
+
 def test_python_print_dangling_iter_arg_use_disambiguated():
     """A body that references an IterArg pointer not present in any enclosing
     iter_args_ field must still print as a unique identifier — never collapsed

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1101,5 +1101,91 @@ def test_python_print_default_is_verbose():
     assert "x:" in result or "x :" in result
 
 
+def test_python_print_distinct_iter_args_same_name_hint_disambiguated():
+    """Two sibling ForStmts whose iter_args share name_hint must print as distinct identifiers.
+
+    Regression test for #1244: the printer used to emit `op->name_hint_` directly
+    for IterArgs (and only registered defs in the rename map), so two distinct
+    IterArg pointers with name_hint_="acc" collapsed to a single `acc` token in
+    headers and bodies, hiding pointer-identity bugs in post-pass dumps.
+    """
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    scalar_ty = ir.ScalarType(dtype)
+    one = ir.ConstInt(1, dtype, span)
+    n = ir.ConstInt(8, dtype, span)
+
+    def make_loop(loop_name: str, rv_name: str) -> tuple[ir.IterArg, ir.ForStmt]:
+        acc = ir.IterArg("acc", scalar_ty, ir.ConstInt(0, dtype, span), span)
+        loop_var = ir.Var(loop_name, scalar_ty, span)
+        rv = ir.Var(rv_name, scalar_ty, span)
+        body = ir.YieldStmt([ir.Add(acc, one, dtype, span)], span)
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, dtype, span),
+            n,
+            ir.ConstInt(1, dtype, span),
+            [acc],
+            body,
+            [rv],
+            span,
+        )
+        return acc, for_stmt
+
+    _, for_outer = make_loop("i", "acc_final_i")
+    _, for_inner = make_loop("j", "acc_final_j")
+
+    func_body = ir.SeqStmts([for_outer, for_inner], span)
+    func = ir.Function("f", [], [], func_body, span)
+    text = func.as_python()
+
+    # Both header tuples must appear, and the second one must be suffix-disambiguated.
+    assert "(acc,)" in text
+    assert "(acc_1,)" in text
+    assert text.count("(acc,)") == 1
+    assert text.count("(acc_1,)") == 1
+
+
+def test_python_print_dangling_iter_arg_use_disambiguated():
+    """A body that references an IterArg pointer not present in any enclosing
+    iter_args_ field must still print as a unique identifier — never collapsed
+    onto an unrelated in-scope IterArg sharing the same name_hint.
+
+    Mirrors the malformed-IR symptom from #1243 that motivated #1244: a
+    transform drops pointer identity and the printed dump masks the divergence.
+    """
+    span = ir.Span.unknown()
+    dtype = DataType.INT64
+    scalar_ty = ir.ScalarType(dtype)
+    one = ir.ConstInt(1, dtype, span)
+
+    in_scope_acc = ir.IterArg("acc", scalar_ty, ir.ConstInt(0, dtype, span), span)
+    stale_acc = ir.IterArg("acc", scalar_ty, ir.ConstInt(0, dtype, span), span)
+    assert stale_acc is not in_scope_acc
+
+    # Body uses `stale_acc`, but only `in_scope_acc` is in iter_args_ — a
+    # pointer-identity bug surfaced as a dangling use.
+    loop_var = ir.Var("i", scalar_ty, span)
+    rv = ir.Var("acc_final", scalar_ty, span)
+    body = ir.YieldStmt([ir.Add(stale_acc, one, dtype, span)], span)
+    for_stmt = ir.ForStmt(
+        loop_var,
+        ir.ConstInt(0, dtype, span),
+        ir.ConstInt(8, dtype, span),
+        ir.ConstInt(1, dtype, span),
+        [in_scope_acc],
+        body,
+        [rv],
+        span,
+    )
+    func = ir.Function("f", [], [], for_stmt, span)
+    text = func.as_python()
+
+    # The in-scope iter_arg keeps "acc"; the dangling use must take a suffix
+    # so the two distinct pointers are visibly different in the dump.
+    assert "(acc,)" in text
+    assert "acc_1" in text
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the Python IR printer's pointer-identity bug from #1244: two distinct `Var*`/`IterArg*` pointers sharing the same `name_hint_` could collapse to one identifier in pass dumps, masking malformed-IR symptoms (the literal cause of #1243's undiagnosable post-pass dump).

- `BuildVarRenameMap` now collects both defs and uses (was defs-only). Defs precede uses, so a pointer that appears as both keeps its def-site canonical name; pointers appearing only as uses (sibling-scope iter_args, dangling references) get their own suffix.
- `IterArg` printing routes through `GetVarName` at all three sites (expression visitor, `ForStmt` header tuple, `WhileStmt` header tuple) — was emitting raw `name_hint_`, which bypassed the rename map entirely.
- Program-level dynamic dim vars are filtered out of the function-local map so `GetVarName`'s two-tier lookup (`var_rename_map_` → `dyn_var_rename_map_`) stays intact.
- A `WhileStmt`-scoped `IterArgReturnVarPairCollector` pins iter_args[i] and return_vars[i] to the same printed name when their `name_hint_` matches by design (e.g. `CtrlFlowTransform` `break` lowering output). This preserves the parser's `_register_while_outputs` header-tuple auto-binding for round-trip; marked `DISCUSSABLE` pending RFC #1246.

## Test plan

- [x] Two regression tests added in `tests/ut/ir/printing/test_python_printer.py`:
  - `test_python_print_distinct_iter_args_same_name_hint_disambiguated` — sibling for-loops with iter_args sharing `"acc"` print as `acc` and `acc_1`.
  - `test_python_print_dangling_iter_arg_use_disambiguated` — a body that references an `IterArg` pointer not in any enclosing `iter_args_` surfaces as a unique identifier with no `=` line above it.
- [x] Full unit suite: `python -m pytest tests/ut/ -n auto --maxprocesses 8` — 4214 passed, 30 skipped.
- [x] Print/parse round-trip suite: `tests/ut/ir/printing/` + `tests/ut/ir/parser/` — 129 passed.
- [x] `tests/ut/ir/transforms/test_ctrl_flow_transform.py` — 48 passed (this was the regression surface during fix iteration; the `WhileStmt` harmonization is what closes it).
- [x] `clang-tidy` clean.

## Related issues

Fixes #1244.

Originating context: surfaced while diagnosing #1243 (`MemoryReuse` `RetypeApplier` losing iter_arg pointer identity), where the printer collapsed both a stale and an in-scope `IterArg` to `acc__tile_l0_c`, requiring `fprintf("%p")` instrumentation to recover ground truth.

Follow-up: RFC #1246 (*Unify pl.while_ output convention with pl.range — drop header-tuple auto-binding*) — landing the RFC would let the `WhileStmt` harmonization step in this PR be deleted.