### PR TITLE
Unify pl.while_ and pl.range output convention (RFC #1246)

### DIFF
--- a/.claude/rules/ir-kind-traits.md
+++ b/.claude/rules/ir-kind-traits.md
@@ -1,0 +1,61 @@
+# IR Kind-Trait Downcasting
+
+## Core Rule
+
+**`As<T>()` matches the exact `ObjectKind` only, NOT subclasses.** When you want to treat a base type and its subclass(es) uniformly, use the corresponding `*Like` helper, not `As<Base>()`.
+
+## Why
+
+PyPTO's IR uses a single `ObjectKind` enum for runtime-type dispatch (see `include/pypto/ir/kind_traits.h`). `As<T>(node)` checks `node->GetKind() == ObjectKind::T` — exact match.
+
+C++ inheritance doesn't help here: `IterArg` is a subclass of `Var`, but `IterArg` has its own `ObjectKind::IterArg`. So `As<Var>(iter_arg_ptr)` returns **null**, even though `iter_arg` IS-A Var.
+
+## The cases that bite
+
+| Have | Want | Correct API | Wrong API |
+| ---- | ---- | ----------- | --------- |
+| `ExprPtr` that may be `Var` or `IterArg` | Treat both as `Var` | `AsVarLike(expr)` (returns `VarPtr`) | `As<Var>(expr)` — misses `IterArg` |
+| Visitor override for both `Var` and `IterArg` | Single handler for both | Override `VisitVarLike_` | Override `VisitExpr_(VarPtr)` only — `IterArg` dispatches separately |
+
+`MemRef` is intentionally **excluded** from `AsVarLike` — `MemRef` has scope/storage semantics that don't fit the Var-bound-name model. Use `As<MemRef>()` directly.
+
+## Examples
+
+```cpp
+// ❌ WRONG — As<Var> won't match IterArg
+for (const auto& yield_value : yields) {
+  if (As<Var>(yield_value)) {     // returns null for IterArg!
+    // skip materialization
+  }
+  // ... materialization runs even for IterArg
+}
+
+// ✅ CORRECT — AsVarLike matches Var AND IterArg
+for (const auto& yield_value : yields) {
+  if (AsVarLike(yield_value)) {   // matches both
+    // skip materialization for any already-bound Var
+  }
+}
+```
+
+```cpp
+// ❌ WRONG — only catches Var, IterArgs go through default
+class MyVisitor : public IRVisitor {
+  void VisitExpr_(const VarPtr& op) override { /* ... */ }
+};
+
+// ✅ CORRECT — VisitVarLike_ handles both Var and IterArg
+class MyVisitor : public IRVisitor {
+  void VisitVarLike_(const VarPtr& op) override { /* ... */ }
+};
+```
+
+## Decision rule
+
+Before writing `As<T>(...)`, ask:
+
+1. Does `T` have subclasses with their own `ObjectKind` values? Check `include/pypto/ir/kind_traits.h` and the class hierarchy.
+2. If yes: is there an `As<T>Like()` helper? If yes, use it.
+3. If no `*Like` helper exists and you genuinely need union semantics: write one in `kind_traits.h` rather than re-rolling `dynamic_pointer_cast<...>` at the call site.
+
+When in doubt: grep for `AsVarLike` / `VisitVarLike_` in the codebase to confirm the pattern, then mirror it.

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -268,7 +268,7 @@ while_stmt = ir.WhileStmt(condition, [x_iter], body, [x_final], span)
 **Properties:** `condition_` evaluated each iteration; supports SSA iter_args/return_vars; DSL uses `pl.cond()` as first statement.
 
 - Natural syntax without iter_args is converted to SSA by ConvertToSSA pass
-- Body must end with YieldStmt when iter_args are present
+- Body must end with YieldStmt when iter_args are present, AND no YieldStmt may appear before the trailing position — the yield is the scope's terminator. The same rule applies to ForStmt/IfStmt with non-empty `return_vars_`. Enforced in SSA form by the `SSAVerify` verifier (see `99-verifier.md`, error code `MISPLACED_YIELD`).
 
 ### ScopeStmt Details
 

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -258,6 +258,35 @@ for i in pl.unroll(12, chunk=4):
 
 **Key points:** `chunk=C` splits the loop into an outer sequential loop and an inner loop of `C` iterations. The inner loop preserves the original kind (Sequential/Parallel/Unroll). `init_values` is supported with chunked loops (iter_args thread through the generated outer/inner/remainder loops). `chunk=` loops are only valid inside a `with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):` — outside that scope the parser rejects them with an error. See [SplitChunkedLoops Pass](../passes/06-split_chunked_loops.md).
 
+### While Loop (SSA-style with iter_args)
+
+```python
+# Natural while: condition is the for-header expression
+i: pl.Scalar[pl.INT64] = 0
+while i < n:
+    i = i + 1
+
+# SSA form with init_values: header tuple = iter_args, first stmt is pl.cond().
+# yield-LHS supplies the post-loop binding name (mirrors pl.range).
+x_init: pl.Scalar[pl.INT64] = 0
+for (x,) in pl.while_(init_values=(x_init,)):
+    pl.cond(x < n)
+    x_next = pl.yield_(x + 1)
+# `x_next` is bound here (from the yield-LHS); `x` is loop-scoped only.
+
+# Pre-SSA: no pl.yield_ at all; ConvertToSSA synthesizes it later.
+for (x,) in pl.while_(init_values=(x_init,)):
+    pl.cond(x < n)
+    x = x + 1
+
+# ❌ Bare pl.yield_(...) with non-empty init_values is rejected at parse time:
+#    for (x,) in pl.while_(init_values=(x_init,)):
+#        pl.cond(x < n)
+#        pl.yield_(x + 1)             # ParserSyntaxError: requires assignment-form pl.yield_
+```
+
+**Key points:** `pl.while_(init_values=(...,))` reuses the `for ... in` header for SSA-style loops; the first body statement must be `pl.cond(<bool>)`. The post-loop binding name comes from the **yield-LHS** (`x_next` above), not the header tuple — header-tuple names are scoped to the loop body only. This convention is **uniform with `pl.range`**: assignment-form yield is required whenever `init_values` is non-empty AND the body contains a `pl.yield_(...)` call. Pre-SSA loops with no yield at all are still valid (last form above).
+
 ### Scope Context Managers
 
 | Form | Scope Kind | Notes |

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -261,7 +261,7 @@ for i in pl.unroll(12, chunk=4):
 ### While Loop (SSA-style with iter_args)
 
 ```python
-# Natural while: condition is the for-header expression
+# Natural while: condition is the while-header expression
 i: pl.Scalar[pl.INT64] = 0
 while i < n:
     i = i + 1

--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -88,6 +88,7 @@ The `run_verifier()` utility creates a standalone `Pass` for ad-hoc use in custo
 | 4 | `ITER_ARGS_RETURN_VARS_MISMATCH` | iter_args count != return_vars count in ForStmt/WhileStmt |
 | 5 | `YIELD_COUNT_MISMATCH` | YieldStmt value count != iter_args/return_vars count |
 | 6 | `SCOPE_VIOLATION` | Variable used outside its defining scope |
+| 7 | `MISPLACED_YIELD` | YieldStmt appears before the trailing position in its scope |
 
 ### TypeCheck
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -235,7 +235,7 @@ while_stmt = ir.WhileStmt(condition, [x_iter], body, [x_final], span)
 **属性：** `condition_` 每次迭代都会求值；支持 SSA iter_args/return_vars；DSL 使用 `pl.cond()` 作为第一条语句。
 
 - 不带 iter_args 的自然语法通过 ConvertToSSA Pass 转换为 SSA
-- 存在 iter_args 时，循环体必须以 YieldStmt 结尾
+- 存在 iter_args 时，循环体必须以 YieldStmt 结尾，并且尾部之前的位置不允许再出现 YieldStmt——yield 是作用域的终结语句。同一规则同样适用于 `return_vars_` 非空的 ForStmt / IfStmt。在 SSA 形式下由 `SSAVerify` 强制（参见 `99-verifier.md`，错误码 `MISPLACED_YIELD`）。
 
 ### ScopeStmt 详细说明
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -257,6 +257,35 @@ for i in pl.unroll(12, chunk=4):
 
 **要点:** `chunk=C` 将循环拆分为外层顺序循环和 `C` 次迭代的内层循环。内层循环保留原始类型 (Sequential/Parallel/Unroll)。`chunk=` 循环支持与 `init_values` 一起使用（iter_args 会贯穿生成的外层/内层/余数循环）。`chunk=` 循环只能出现在 `with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):` 内；在该作用域外，parser 会直接报错。参见 [SplitChunkedLoops Pass](../passes/06-split_chunked_loops.md)。
 
+### While 循环 (带 iter_args 的 SSA 风格)
+
+```python
+# 自然 while：条件作为 for 头部表达式
+i: pl.Scalar[pl.INT64] = 0
+while i < n:
+    i = i + 1
+
+# 带 init_values 的 SSA 形式：头部元组 = iter_args，第一条语句是 pl.cond()。
+# yield-LHS 名字成为循环外的绑定名（与 pl.range 一致）。
+x_init: pl.Scalar[pl.INT64] = 0
+for (x,) in pl.while_(init_values=(x_init,)):
+    pl.cond(x < n)
+    x_next = pl.yield_(x + 1)
+# 此处 `x_next` 已由 yield-LHS 绑定；`x` 仅在循环 body 内可见。
+
+# Pre-SSA：body 中完全没有 pl.yield_，由 ConvertToSSA 后续补出。
+for (x,) in pl.while_(init_values=(x_init,)):
+    pl.cond(x < n)
+    x = x + 1
+
+# ❌ init_values 非空时不允许裸 pl.yield_(...)，parser 直接报错：
+#    for (x,) in pl.while_(init_values=(x_init,)):
+#        pl.cond(x < n)
+#        pl.yield_(x + 1)             # ParserSyntaxError: requires assignment-form pl.yield_
+```
+
+**要点:** `pl.while_(init_values=(...,))` 复用 `for ... in` 头部，用于 SSA 风格循环；body 的第一条语句必须是 `pl.cond(<bool>)`。循环外的绑定名来自 **yield-LHS**（上面的 `x_next`），而不是头部元组——头部元组中的名字只在循环 body 内可见。这一约定与 `pl.range` **保持一致**：当 `init_values` 非空且 body 中确实出现 `pl.yield_(...)` 调用时，必须使用 assignment 形式。Pre-SSA 形式的循环（body 中完全没有 yield，如最后一种写法）仍然合法。
+
 ### 作用域上下文管理器 (Scope Context Managers)
 
 | 形式 | Scope 类型 | 说明 |

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -260,7 +260,7 @@ for i in pl.unroll(12, chunk=4):
 ### While 循环 (带 iter_args 的 SSA 风格)
 
 ```python
-# 自然 while：条件作为 for 头部表达式
+# 自然 while：条件作为 while 头部表达式
 i: pl.Scalar[pl.INT64] = 0
 while i < n:
     i = i + 1

--- a/docs/zh-cn/dev/passes/99-verifier.md
+++ b/docs/zh-cn/dev/passes/99-verifier.md
@@ -88,6 +88,7 @@
 | 4 | `ITER_ARGS_RETURN_VARS_MISMATCH` | ForStmt/WhileStmt 中 iter_args 数量 != return_vars 数量 |
 | 5 | `YIELD_COUNT_MISMATCH` | YieldStmt 值数量 != iter_args/return_vars 数量 |
 | 6 | `SCOPE_VIOLATION` | 变量在其定义作用域之外被使用 |
+| 7 | `MISPLACED_YIELD` | YieldStmt 出现在作用域中尾部以外的位置 |
 
 ### TypeCheck
 

--- a/include/pypto/ir/verifier/verification_error.h
+++ b/include/pypto/ir/verifier/verification_error.h
@@ -31,7 +31,8 @@ enum class ErrorType : int {
   MISSING_YIELD = 3,                   // ForStmt or IfStmt missing required YieldStmt
   ITER_ARGS_RETURN_VARS_MISMATCH = 4,  // iter_args.size() != return_vars.size()
   YIELD_COUNT_MISMATCH = 5,            // YieldStmt value count != iter_args/return_vars count
-  SCOPE_VIOLATION = 6                  // Variable used outside its defining scope
+  SCOPE_VIOLATION = 6,                 // Variable used outside its defining scope
+  MISPLACED_YIELD = 7                  // YieldStmt appears before the trailing position in its scope
 };
 
 /**

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1867,15 +1867,20 @@ class ASTParser:
     def _find_first_bare_yield(cls, stmts: list[ast.stmt]) -> ast.Expr | None:
         """First bare `pl.yield_(...)` expression-statement in `stmts`, or None.
 
-        Recurses into `if/else` branches at the same scope. Does NOT descend
-        into nested For/While bodies — yields inside an inner loop bind to
-        that inner loop's return_vars, not the outer one.
+        Recurses into `if/else` branches and `with` bodies at the same scope
+        (e.g. `with pl.at(...): pl.yield_(...)` inside a loop body). Does NOT
+        descend into nested For/While bodies — yields inside an inner loop
+        bind to that inner loop's return_vars, not the outer one.
         """
         for s in stmts:
             if isinstance(s, ast.Expr) and cls._is_dsl_call(s, "yield_"):
                 return s
             if isinstance(s, ast.If):
                 found = cls._find_first_bare_yield(s.body) or cls._find_first_bare_yield(s.orelse)
+                if found is not None:
+                    return found
+            elif isinstance(s, ast.With):
+                found = cls._find_first_bare_yield(s.body)
                 if found is not None:
                     return found
         return None

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1343,6 +1343,8 @@ class ASTParser:
                 hint="Use: for i, (var1,) in pl.range(n, init_values=(val1,)) to include iter_args",
             )
 
+        self._require_yield_lhs_for_init_values(stmt, bool(range_args["init_values"]))
+
         # For pl.unroll(), require compile-time constant integer bounds
         # and reject step=0. Fail early with clear parser errors instead of
         # later generic failures in the UnrollLoops C++ pass.
@@ -1470,13 +1472,12 @@ class ASTParser:
                 assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
                 loop_output_vars = self._current_yield_vars[:]
 
-            # Create return_vars using yield LHS names (or fallback to _out names)
+            # Yield-LHS names if present; else synthetic `_out` names (pre-SSA).
             if not is_simple_for and range_args["init_values"]:
                 if loop_output_vars:
                     for rv_name in loop_output_vars:
                         loop.return_var(rv_name)
                 else:
-                    # Fallback: no yield vars found, use auto-generated names
                     assert iter_args_node is not None
                     assert isinstance(iter_args_node, ast.Tuple)
                     for iter_arg_node in iter_args_node.elts:
@@ -1695,20 +1696,17 @@ class ASTParser:
         return self.parse_expression(call.args[0])
 
     @staticmethod
-    def _is_dsl_call(stmt: ast.Expr, func_name: str) -> bool:
-        """Check if statement is a call to a named DSL function (e.g. pl.func_name() or func_name()).
-
-        Args:
-            stmt: AST Expr node
-            func_name: The function name to match (e.g. "static_print")
-
-        Returns:
-            True if statement is a call to the named function
+    def _is_dsl_call(node: ast.AST, func_name: str) -> bool:
+        """Check if `node` is a call to a named DSL function (`pl.func_name(...)`
+        or bare `func_name(...)`). Accepts either an `ast.Expr` statement (the
+        body-stmt form, e.g. a bare `pl.cond(...)` line) or an expression node
+        directly (e.g. the RHS of an `ast.Assign`).
         """
-        call = stmt.value
-        if not isinstance(call, ast.Call):
+        if isinstance(node, ast.Expr):
+            node = node.value
+        if not isinstance(node, ast.Call):
             return False
-        func = call.func
+        func = node.func
         if isinstance(func, ast.Attribute):
             return func.attr == func_name
         if isinstance(func, ast.Name):
@@ -1865,6 +1863,50 @@ class ASTParser:
 
         return init_values
 
+    @classmethod
+    def _find_first_bare_yield(cls, stmts: list[ast.stmt]) -> ast.Expr | None:
+        """First bare `pl.yield_(...)` expression-statement in `stmts`, or None.
+
+        Recurses into `if/else` branches at the same scope. Does NOT descend
+        into nested For/While bodies — yields inside an inner loop bind to
+        that inner loop's return_vars, not the outer one.
+        """
+        for s in stmts:
+            if isinstance(s, ast.Expr) and cls._is_dsl_call(s, "yield_"):
+                return s
+            if isinstance(s, ast.If):
+                found = cls._find_first_bare_yield(s.body) or cls._find_first_bare_yield(s.orelse)
+                if found is not None:
+                    return found
+        return None
+
+    def _require_yield_lhs_for_init_values(self, stmt: ast.For, init_values_present: bool) -> None:
+        """Reject bare `pl.yield_(...)` when init_values is non-empty.
+
+        Valid body shapes for an init-values loop:
+          1. Assignment-form yield: `x_next = pl.yield_(updated)` — the LHS
+             supplies the return_var name and the post-loop binding.
+          2. No yield at all (pre-SSA): body mutates iter_args via AssignStmt;
+             ConvertToSSA later synthesizes the yield. Synthetic `_out`
+             return_var names are used.
+
+        Bare `pl.yield_(...)` mixed with init_values is rejected: it would
+        leave the post-loop binding nameless, and the user gets a downstream
+        arity mismatch from the IR builder instead of a clear parser error.
+        """
+        if not init_values_present:
+            return
+        first_bare = self._find_first_bare_yield(stmt.body)
+        if first_bare is None:
+            return
+        raise ParserSyntaxError(
+            "Loop with init_values requires an assignment-form pl.yield_(...) "
+            "— the LHS supplies the post-loop binding name. Bare pl.yield_(...) "
+            "is rejected here.",
+            span=self.span_tracker.get_span(first_bare),
+            hint="Use yield-LHS form: `x_next = pl.yield_(updated)`. Then refer to `x_next` after the loop.",
+        )
+
     def _validate_while_body(self, stmt: ast.For) -> None:
         """Validate pl.while_() body structure."""
         if not stmt.body:
@@ -1932,20 +1974,14 @@ class ASTParser:
             assert self._current_yield_vars is not None  # Guaranteed by _yield_tracking_scope
             return self._current_yield_vars[:]
 
-    def _register_while_outputs(
-        self, loop: Any, iter_args_node: ast.Tuple, loop_output_vars: list[str]
-    ) -> None:
-        """Register output variables from pl.while_() loop."""
+    def _register_while_outputs(self, loop: Any, loop_output_vars: list[str]) -> None:
+        """Register output variables from pl.while_() loop.
+
+        Mirrors `parse_for_loop`: the post-loop binding name is the yield-LHS,
+        not the header tuple. Header-tuple names are loop-scoped only.
+        """
         loop_result = loop.get_result()
         if hasattr(loop_result, "return_vars") and loop_result.return_vars and loop_output_vars:
-            for i, iter_arg_node in enumerate(iter_args_node.elts):
-                if i >= len(loop_result.return_vars):
-                    break
-                if isinstance(iter_arg_node, ast.Name):
-                    self.scope_manager.define_var(
-                        iter_arg_node.id, loop_result.return_vars[i], allow_redef=True
-                    )
-
             for i, var_name in enumerate(loop_output_vars):
                 if i < len(loop_result.return_vars):
                     self.scope_manager.define_var(var_name, loop_result.return_vars[i], allow_redef=True)
@@ -1966,6 +2002,9 @@ class ASTParser:
         init_values = self._parse_while_init_values(while_call)
         self._validate_while_body(stmt)
         iter_args_node = self._validate_while_target(stmt, init_values)
+
+        # init_values is always non-empty for pl.while_ (enforced earlier).
+        self._require_yield_lhs_for_init_values(stmt, True)
 
         span = self.span_tracker.get_span(stmt)
         placeholder_condition = ir.ConstBool(True, span)
@@ -1995,15 +2034,14 @@ class ASTParser:
             # Parse body statements first to get actual output variable names
             loop_output_vars = self._parse_while_body_statements(stmt)
 
-            # Add return_vars using actual output variable names from body
-            if not loop_output_vars:
-                raise ParserSyntaxError(
-                    "pl.while_() with init_values requires a pl.yield_(...) in the body",
-                    span=self.span_tracker.get_span(stmt),
-                    hint="Yield the updated loop-carried values before the end of the body",
-                )
-            for var_name in loop_output_vars:
-                loop.return_var(var_name)
+            # Yield-LHS names if present; else synthetic `_out` names (pre-SSA).
+            if loop_output_vars:
+                for var_name in loop_output_vars:
+                    loop.return_var(var_name)
+            else:
+                for iter_arg_node in iter_args_node.elts:
+                    assert isinstance(iter_arg_node, ast.Name)
+                    loop.return_var(f"{iter_arg_node.id}_out")
 
             # Enforce Bool-typed condition after iter_args and return_vars are both
             # set up, so that the while_loop context manager's __exit__ validation
@@ -2017,7 +2055,7 @@ class ASTParser:
             self.current_loop_builder = prev_loop_builder
 
         # Register output variables
-        self._register_while_outputs(loop, iter_args_node, loop_output_vars)
+        self._register_while_outputs(loop, loop_output_vars)
 
     def parse_while_loop(self, stmt: ast.While) -> None:
         """Parse natural while loop syntax.
@@ -3406,25 +3444,10 @@ class ASTParser:
         # Emit yield statement
         self.builder.emit(ir.YieldStmt(yield_exprs, span))
 
-        # Bare top-level loop/while yields carry the loop output vars directly.
-        # Record their names so pl.while_()/init_values and similar printed forms
-        # can be parsed back into return_vars without requiring assignment-form
-        # yields.
-        if (
-            self._current_yield_vars is not None
-            and not self.in_if_stmt
-            and (self.in_for_loop or self.in_while_loop)
-        ):
-            for expr in yield_exprs:
-                if isinstance(expr, ir.Var):
-                    self._track_yield_var(expr.name_hint, [expr])
-
-        # Track yielded variables for if statement processing
-        # This is for single assignment like: var = pl.yield_(expr)
-        # We'll return a placeholder that gets resolved when if statement completes
-
-        # Return first expression as the "value" of the yield
-        # This handles: var = pl.yield_(expr)
+        # Return first expression as the "value" of the yield, so an
+        # assignment-form yield like `var = pl.yield_(expr)` binds `var` to
+        # `expr` for the body's purposes. The IR builder resolves the actual
+        # return_var once the enclosing scope closes.
         if len(yield_exprs) == 0:
             # Bare pl.yield_() with no arguments — return None (used as bare stmt)
             return None  # type: ignore[return-value]

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -723,15 +723,20 @@ class CtrlFlowTransformMutator : public IRMutator {
     auto processed =
         ProcessBodyForBreakAndContinue(decomposed, op->iter_args_, break_var, also_has_continue, span);
 
-    // Build final body with loop advancement guarded by if (!__break)
-    if (!processed.yield_values.empty() || decomposed.had_yield) {
-      processed.stmts.push_back(std::make_shared<YieldStmt>(std::move(processed.yield_values), span));
-    }
-
+    // Counter advancement happens BEFORE the YieldStmt so the yield terminates
+    // its scope — required by the SSA-form invariant that any For/While/If
+    // with non-empty return_vars_ ends with a YieldStmt. ProcessBodyForBreak
+    // resolves yield values to let-bound Vars (phi return_vars and iter_args),
+    // never the loop_var directly, so reordering does not change yielded
+    // values.
     auto iter_adv = std::make_shared<AssignStmt>(loop_var, MakeAdd(loop_var, op->step_, span), span);
     auto guarded_adv = std::make_shared<IfStmt>(MakeNot(break_var, span), iter_adv, std::nullopt,
                                                 std::vector<VarPtr>{}, span);
     processed.stmts.push_back(guarded_adv);
+
+    if (!processed.yield_values.empty() || decomposed.had_yield) {
+      processed.stmts.push_back(std::make_shared<YieldStmt>(std::move(processed.yield_values), span));
+    }
 
     auto final_body = MakeSeq(std::move(processed.stmts), span);
 

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -723,19 +723,38 @@ class CtrlFlowTransformMutator : public IRMutator {
     auto processed =
         ProcessBodyForBreakAndContinue(decomposed, op->iter_args_, break_var, also_has_continue, span);
 
-    // Counter advancement happens BEFORE the YieldStmt so the yield terminates
-    // its scope — required by the SSA-form invariant that any For/While/If
-    // with non-empty return_vars_ ends with a YieldStmt. ProcessBodyForBreak
-    // resolves yield values to let-bound Vars (phi return_vars and iter_args),
-    // never the loop_var directly, so reordering does not change yielded
-    // values.
+    // The YieldStmt must terminate the loop body (SSA-form invariant: any
+    // For/While/If with non-empty return_vars_ ends with a YieldStmt). The
+    // counter-advance must happen BEFORE the yield. To keep the yield reading
+    // pre-increment values regardless of whether yielded expressions reference
+    // the loop counter (e.g. `pl.yield_(acc + i)` where `i` is the loop var),
+    // we materialize any non-Var yielded expression into a temp BEFORE the
+    // increment, then yield the temp. Already-bound Var/IterArg references
+    // need no materialization — their value is fixed at the binding site.
+    std::vector<ExprPtr> trailing_yield_values;
+    if (!processed.yield_values.empty()) {
+      trailing_yield_values.reserve(processed.yield_values.size());
+      for (auto& yield_value : processed.yield_values) {
+        // AsVarLike (not As<Var>) so IterArg — a Var subclass — also
+        // short-circuits: its value is fixed at the binding site.
+        if (AsVarLike(yield_value)) {
+          trailing_yield_values.push_back(yield_value);
+          continue;
+        }
+        auto yield_tmp =
+            std::make_shared<Var>(FreshInternalName("yield", "tmp"), yield_value->GetType(), span);
+        processed.stmts.push_back(std::make_shared<AssignStmt>(yield_tmp, yield_value, span));
+        trailing_yield_values.push_back(yield_tmp);
+      }
+    }
+
     auto iter_adv = std::make_shared<AssignStmt>(loop_var, MakeAdd(loop_var, op->step_, span), span);
     auto guarded_adv = std::make_shared<IfStmt>(MakeNot(break_var, span), iter_adv, std::nullopt,
                                                 std::vector<VarPtr>{}, span);
     processed.stmts.push_back(guarded_adv);
 
-    if (!processed.yield_values.empty() || decomposed.had_yield) {
-      processed.stmts.push_back(std::make_shared<YieldStmt>(std::move(processed.yield_values), span));
+    if (!trailing_yield_values.empty() || decomposed.had_yield) {
+      processed.stmts.push_back(std::make_shared<YieldStmt>(std::move(trailing_yield_values), span));
     }
 
     auto final_body = MakeSeq(std::move(processed.stmts), span);

--- a/src/ir/transforms/ctrl_flow_transform_pass.cpp
+++ b/src/ir/transforms/ctrl_flow_transform_pass.cpp
@@ -23,6 +23,7 @@
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1344,39 +1344,6 @@ std::string IRPythonPrinter::GetVarName(const Var* var) const {
   return var->name_hint_;
 }
 
-namespace {
-
-/// Collects (return_var, iter_arg) pointer pairs from WhileStmts whose
-/// position-i bindings share name_hint_. Scoped to WhileStmt because only
-/// `pl.while_` parser-side auto-binds the header tuple name to the
-/// outer-scope return_var (`ast_parser.py::_register_while_outputs`);
-/// `pl.range` derives the post-loop binding from the yield-LHS and so does
-/// not need this pinning. The default IRVisitor traverses ForStmt/IfStmt/etc.
-/// bodies for us, so nested WhileStmts inside a ForStmt are still reached.
-///
-/// DISCUSSABLE: if the `pl.while_` DSL is unified with `pl.range` to derive
-/// return_var bindings from yield-LHS only (see RFC #1246), this collector
-/// and the harmonization step below can be deleted — lenient-mode
-/// disambiguation alone would suffice.
-class IterArgReturnVarPairCollector : public IRVisitor {
- public:
-  std::vector<std::pair<const Var*, const Var*>> pairs;  // (return_var, iter_arg)
-
- protected:
-  void VisitStmt_(const WhileStmtPtr& op) override {
-    const size_t n = std::min(op->return_vars_.size(), op->iter_args_.size());
-    for (size_t i = 0; i < n; ++i) {
-      if (!op->return_vars_[i] || !op->iter_args_[i]) continue;
-      if (op->return_vars_[i]->name_hint_ == op->iter_args_[i]->name_hint_) {
-        pairs.emplace_back(op->return_vars_[i].get(), op->iter_args_[i].get());
-      }
-    }
-    VisitStmt(op->body_);
-  }
-};
-
-}  // namespace
-
 void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body) {
   // Collect Var/IterArg pointers in DFS pre-order: params, then body defs,
   // then body uses. Defs precede uses so a pointer appearing as both keeps
@@ -1387,7 +1354,6 @@ void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const
   ordered_refs.reserve(params.size());
   for (const auto& p : params) ordered_refs.push_back(p.get());
   body_defined_vars_.clear();
-  IterArgReturnVarPairCollector pair_collector;
   if (body) {
     var_collectors::VarDefUseCollector body_collector;
     body_collector.VisitStmt(body);
@@ -1396,7 +1362,6 @@ void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const
     ordered_refs.insert(ordered_refs.end(), body_collector.var_uses_ordered.begin(),
                         body_collector.var_uses_ordered.end());
     body_defined_vars_ = std::move(body_collector.var_defs);
-    pair_collector.VisitStmt(body);
   }
   // Drop program-level dynamic dim vars: they are already disambiguated
   // globally in dyn_var_rename_map_, and re-registering them here would
@@ -1407,16 +1372,6 @@ void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const
                        ordered_refs.end());
   }
   auto_name::BuildRenameMapForDefs(ordered_refs, var_rename_map_);
-
-  // Harmonize iter_arg / return_var names where they share name_hint_. Both
-  // pointers are colliding def-sites, so BuildRenameMapForDefs has registered
-  // each under a distinct suffix; route the iter_arg to the return_var's name.
-  for (const auto& [rv, ia] : pair_collector.pairs) {
-    auto rv_it = var_rename_map_.find(rv);
-    INTERNAL_CHECK(rv_it != var_rename_map_.end())
-        << "Internal error: return_var with colliding name_hint must be in var_rename_map_";
-    var_rename_map_[ia] = rv_it->second;
-  }
 }
 
 void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {

--- a/src/ir/verifier/verify_ssa_pass.cpp
+++ b/src/ir/verifier/verify_ssa_pass.cpp
@@ -49,6 +49,8 @@ std::string ErrorTypeToString(ErrorType type) {
       return "YIELD_COUNT_MISMATCH";
     case ErrorType::SCOPE_VIOLATION:
       return "SCOPE_VIOLATION";
+    case ErrorType::MISPLACED_YIELD:
+      return "MISPLACED_YIELD";
     default:
       return "UNKNOWN";
   }
@@ -176,6 +178,13 @@ class SSAVerifier : public IRVisitor {
   StmtPtr GetLastStmt(const StmtPtr& stmt);
 
   /**
+   * @brief Record a SCOPE_VIOLATION if any YieldStmt appears in `body` other
+   * than as the trailing statement. Caller is responsible for the trailing
+   * check; this helper covers the "no mid-body yield" half.
+   */
+  void CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body, const Span& span);
+
+  /**
    * @brief Verify iter_args/return_vars cardinality and yield constraints for a loop statement.
    *
    * Shared logic for ForStmt and WhileStmt verification.
@@ -241,6 +250,21 @@ StmtPtr SSAVerifier::GetLastStmt(const StmtPtr& stmt) {
   return stmt;
 }
 
+void SSAVerifier::CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body, const Span& span) {
+  auto seq = As<SeqStmts>(body);
+  if (!seq) return;
+  for (size_t i = 0; i + 1 < seq->stmts_.size(); ++i) {
+    if (As<YieldStmt>(seq->stmts_[i])) {
+      RecordError(ssa::ErrorType::MISPLACED_YIELD,
+                  scope_kind +
+                      " body has YieldStmt before the terminating position; "
+                      "YieldStmt must be the last statement in its scope",
+                  span);
+      return;
+    }
+  }
+}
+
 void SSAVerifier::VerifyLoopIterArgsAndYield(const std::string& stmt_kind, size_t iter_args_size,
                                              size_t return_vars_size, const StmtPtr& body, const Span& span) {
   // Cardinality check: iter_args.size() == return_vars.size()
@@ -251,7 +275,10 @@ void SSAVerifier::VerifyLoopIterArgsAndYield(const std::string& stmt_kind, size_
     RecordError(ssa::ErrorType::ITER_ARGS_RETURN_VARS_MISMATCH, msg.str(), span);
   }
 
-  // Check: If iter_args is not empty, body must end with YieldStmt
+  // Check: If iter_args is not empty, body must end with YieldStmt and no
+  // YieldStmt may appear mid-body (the trailing yield is the scope's
+  // terminator). When iter_args is empty the scope produces no values, so
+  // the mid-body check does not apply (matches the pre-SSA bare-yield case).
   if (iter_args_size > 0) {
     StmtPtr last_stmt = GetLastStmt(body);
     if (!last_stmt || !As<YieldStmt>(last_stmt)) {
@@ -264,6 +291,10 @@ void SSAVerifier::VerifyLoopIterArgsAndYield(const std::string& stmt_kind, size_
         msg << stmt_kind << " YieldStmt value count (" << yield->value_.size() << ") != iter_args count ("
             << iter_args_size << ")";
         RecordError(ssa::ErrorType::YIELD_COUNT_MISMATCH, msg.str(), span);
+      } else {
+        // Trailing yield is sound; check no earlier yield sits mid-body.
+        // Skipping when trailing already failed avoids cascading errors.
+        CheckNoMidBodyYield(stmt_kind, body, span);
       }
     }
   }
@@ -299,6 +330,11 @@ void SSAVerifier::VerifyIfStmt(const IfStmtPtr& if_stmt) {
     msg << "IfStmt then-branch YieldStmt value count (" << then_yield->value_.size()
         << ") != return_vars count (" << if_stmt->return_vars_.size() << ")";
     RecordError(ssa::ErrorType::YIELD_COUNT_MISMATCH, msg.str(), if_stmt->span_);
+  } else {
+    // Trailing yield is sound; check no earlier yield sits mid-body. Skipping
+    // when trailing already failed avoids cascading errors with redundant
+    // function dumps.
+    CheckNoMidBodyYield("IfStmt then-branch", if_stmt->then_body_, if_stmt->span_);
   }
 
   if (!else_yield) {
@@ -309,6 +345,8 @@ void SSAVerifier::VerifyIfStmt(const IfStmtPtr& if_stmt) {
     msg << "IfStmt else-branch YieldStmt value count (" << else_yield->value_.size()
         << ") != return_vars count (" << if_stmt->return_vars_.size() << ")";
     RecordError(ssa::ErrorType::YIELD_COUNT_MISMATCH, msg.str(), if_stmt->span_);
+  } else {
+    CheckNoMidBodyYield("IfStmt else-branch", if_stmt->else_body_.value(), if_stmt->span_);
   }
 }
 

--- a/src/ir/verifier/verify_ssa_pass.cpp
+++ b/src/ir/verifier/verify_ssa_pass.cpp
@@ -178,11 +178,12 @@ class SSAVerifier : public IRVisitor {
   StmtPtr GetLastStmt(const StmtPtr& stmt);
 
   /**
-   * @brief Record a SCOPE_VIOLATION if any YieldStmt appears in `body` other
-   * than as the trailing statement. Caller is responsible for the trailing
-   * check; this helper covers the "no mid-body yield" half.
+   * @brief Record a MISPLACED_YIELD if any YieldStmt appears in `body` other
+   * than as the trailing statement. The diagnostic span points at the
+   * offending YieldStmt itself. Caller is responsible for the trailing check;
+   * this helper covers the "no mid-body yield" half.
    */
-  void CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body, const Span& span);
+  void CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body);
 
   /**
    * @brief Verify iter_args/return_vars cardinality and yield constraints for a loop statement.
@@ -250,7 +251,7 @@ StmtPtr SSAVerifier::GetLastStmt(const StmtPtr& stmt) {
   return stmt;
 }
 
-void SSAVerifier::CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body, const Span& span) {
+void SSAVerifier::CheckNoMidBodyYield(const std::string& scope_kind, const StmtPtr& body) {
   auto seq = As<SeqStmts>(body);
   if (!seq) return;
   for (size_t i = 0; i + 1 < seq->stmts_.size(); ++i) {
@@ -259,7 +260,7 @@ void SSAVerifier::CheckNoMidBodyYield(const std::string& scope_kind, const StmtP
                   scope_kind +
                       " body has YieldStmt before the terminating position; "
                       "YieldStmt must be the last statement in its scope",
-                  span);
+                  seq->stmts_[i]->span_);
       return;
     }
   }
@@ -294,7 +295,7 @@ void SSAVerifier::VerifyLoopIterArgsAndYield(const std::string& stmt_kind, size_
       } else {
         // Trailing yield is sound; check no earlier yield sits mid-body.
         // Skipping when trailing already failed avoids cascading errors.
-        CheckNoMidBodyYield(stmt_kind, body, span);
+        CheckNoMidBodyYield(stmt_kind, body);
       }
     }
   }
@@ -334,7 +335,7 @@ void SSAVerifier::VerifyIfStmt(const IfStmtPtr& if_stmt) {
     // Trailing yield is sound; check no earlier yield sits mid-body. Skipping
     // when trailing already failed avoids cascading errors with redundant
     // function dumps.
-    CheckNoMidBodyYield("IfStmt then-branch", if_stmt->then_body_, if_stmt->span_);
+    CheckNoMidBodyYield("IfStmt then-branch", if_stmt->then_body_);
   }
 
   if (!else_yield) {
@@ -346,7 +347,7 @@ void SSAVerifier::VerifyIfStmt(const IfStmtPtr& if_stmt) {
         << ") != return_vars count (" << if_stmt->return_vars_.size() << ")";
     RecordError(ssa::ErrorType::YIELD_COUNT_MISMATCH, msg.str(), if_stmt->span_);
   } else {
-    CheckNoMidBodyYield("IfStmt else-branch", if_stmt->else_body_.value(), if_stmt->span_);
+    CheckNoMidBodyYield("IfStmt else-branch", if_stmt->else_body_.value());
   }
 }
 

--- a/tests/ut/ir/transforms/test_ctrl_flow_transform.py
+++ b/tests/ut/ir/transforms/test_ctrl_flow_transform.py
@@ -588,7 +588,7 @@ def test_continue_in_for():
     @pl.program
     class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
-        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
@@ -623,16 +623,16 @@ def test_break_in_for():
             i_idx: pl.Scalar[pl.INDEX] = 0
             brk: pl.Scalar[pl.BOOL] = False
             for (x_iter,) in pl.while_(init_values=(x_0,)):
-                pl.cond(i_idx < 10 and not brk)  # noqa: F841
+                pl.cond(i_idx < 10 and not brk)
                 if i_idx > 5:
                     brk: pl.Scalar[pl.BOOL] = True
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
                 else:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                x_iter = pl.yield_(phi)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -682,10 +682,10 @@ def _build_break_and_continue_expected() -> ir.Program:
                 phi2 = if_outer.output(0)
 
                 loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
                     ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
+                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
             ib.return_stmt(loop.output(0))
         prog.add_function(f.get_result())
@@ -756,8 +756,8 @@ def test_continue_multiple_iter_args():
             self,
             a_0: pl.Tensor[[64], pl.FP32],
             b_0: pl.Tensor[[64], pl.FP32],
-        ) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
-            for i, (a_iter, b_iter) in pl.range(10, init_values=(a_0, b_0)):  # noqa: F841
+        ) -> pl.Tensor[[64], pl.FP32]:
+            for i, (a_iter, b_iter) in pl.range(10, init_values=(a_0, b_0)):
                 if i < 5:
                     a_phi, b_phi = pl.yield_(a_iter, b_iter)
                 else:
@@ -788,8 +788,8 @@ def test_continue_with_pre_continue_assignment():
 
     @pl.program
     class Expected:
-        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)  # noqa: F841
-        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
                 if i < 5:
@@ -832,9 +832,9 @@ def test_break_negative_step():
                 else:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                x_iter = pl.yield_(phi)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + -1
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -844,7 +844,7 @@ def test_break_negative_step():
 def test_aic_function_type():
     """Pass processes AIC function type."""
 
-    @pl.program  # noqa: F841
+    @pl.program
     class Before:
         @pl.function(type=pl.FunctionType.AIC, strict_ssa=True)
         def aic_kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
@@ -873,9 +873,8 @@ def test_aic_function_type():
 
 
 def test_continue_no_iter_args():
-    """Continue in loop with no carried state."""  # noqa: F841
+    """Continue in loop with no carried state."""
 
-    # noqa: F841
     @pl.program
     class Before:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
@@ -894,7 +893,7 @@ def test_continue_no_iter_args():
                 if i < 5:
                     pass
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)  # noqa: F841
+                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
             return x_0
 
     After = passes.ctrl_flow_transform()(Before)
@@ -905,7 +904,7 @@ def test_break_no_iter_args():
     """Break in loop with no carried state."""
 
     @pl.program
-    class Before:  # noqa: F841
+    class Before:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i in pl.range(0, 10, 1):
@@ -925,7 +924,7 @@ def test_break_no_iter_args():
                     brk: pl.Scalar[pl.BOOL] = True
                     pl.yield_()
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)  # noqa: F841
+                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
                     pl.yield_()
                 if not brk:
                     i_idx = i_idx + 1
@@ -1036,10 +1035,10 @@ def _build_back_to_back_breaks_expected() -> ir.Program:
                 phi2 = if_outer.output(0)
 
                 loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
                     ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
+                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
             ib.return_stmt(loop.output(0))
         prog.add_function(f.get_result())
@@ -1068,8 +1067,7 @@ def test_back_to_back_breaks():
     ir.assert_structural_equal(After, Expected)
 
 
-# noqa: F841
-def _build_break_then_continue_expected() -> ir.Program:  # noqa: F841
+def _build_break_then_continue_expected() -> ir.Program:
     """Build Expected for test_break_then_continue."""
     ib = IRBuilder()
     tt = _tt()
@@ -1103,16 +1101,16 @@ def _build_break_then_continue_expected() -> ir.Program:  # noqa: F841
                         if_inner.else_()
                         z = ib.let("z", ir.Call(ir.Op("tensor.add"), [y, y], tt, _SPAN))
                         ib.emit(ir.YieldStmt([z], _SPAN))
-                    phi1 = if_inner.output(0)  # noqa: F841
+                    _phi1 = if_inner.output(0)
                     # NOTE: yields x_iter, not phi1
                     ib.emit(ir.YieldStmt([x_iter], _SPAN))
                 phi2 = if_outer.output(0)
 
                 loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
                     ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
+                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
             ib.return_stmt(loop.output(0))
         prog.add_function(f.get_result())
@@ -1125,8 +1123,8 @@ def test_break_then_continue():
 
     @pl.program
     class Before:
-        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)  # noqa: F841
-        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(0, 10, 1, init_values=(x_0,)):
                 if i > 8:
                     break
@@ -1180,9 +1178,9 @@ def test_multiple_iter_args_with_break():
                     a_new: pl.Tensor[[64], pl.FP32] = pl.add(a_iter, b_iter)
                     b_new: pl.Tensor[[64], pl.FP32] = pl.add(b_iter, a_iter)
                     a_phi, b_phi = pl.yield_(a_new, b_new)
-                a_iter, b_iter = pl.yield_(a_phi, b_phi)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                a_iter, b_iter = pl.yield_(a_phi, b_phi)
             return a_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -1192,7 +1190,6 @@ def test_multiple_iter_args_with_break():
 # ===========================================================================
 # Unconditional break/continue
 # ===========================================================================
-# noqa: F841
 
 
 def test_unconditional_break():
@@ -1216,16 +1213,13 @@ def test_unconditional_break():
             for (x_iter,) in pl.while_(init_values=(x_0,)):
                 pl.cond(i_idx < 10 and not brk)
                 brk: pl.Scalar[pl.BOOL] = True
-                x_iter = pl.yield_(x_iter)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                x_iter = pl.yield_(x_iter)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
     ir.assert_structural_equal(After, Expected)
-
-
-# noqa: F841
 
 
 def test_unconditional_continue():
@@ -1260,7 +1254,7 @@ def test_unconditional_continue():
 def test_nested_loops_only_inner():
     """Only inner loop with continue is transformed, outer loop unchanged."""
 
-    @pl.program  # noqa: F841
+    @pl.program
     class Before:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
@@ -1271,7 +1265,7 @@ def test_nested_loops_only_inner():
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
                     x_inner = pl.yield_(y)
                 x_outer = pl.yield_(x_inner)
-            return x_outer  # noqa: F841
+            return x_outer
 
     @pl.program
     class Expected:
@@ -1310,7 +1304,6 @@ def test_both_outer_and_inner_loop_have_break():
                 x_outer = pl.yield_(x_inner)
             return x_outer
 
-    # noqa: F841
     After = passes.ctrl_flow_transform()(Before)
 
     @pl.program
@@ -1331,17 +1324,17 @@ def test_both_outer_and_inner_loop_have_break():
                     else:
                         y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
                         x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)  # noqa: F841
                     if not brk_i:
                         j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
+                    _x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)
                 if i_idx > 2:
                     brk_o: pl.Scalar[pl.BOOL] = True
                     o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
                 else:
                     o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
-                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi)
                 if not brk_o:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi)
             return o_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1375,16 +1368,16 @@ def test_nested_continue_outer_break_inner():
                 j_idx: pl.Scalar[pl.INDEX] = 0
                 brk_i: pl.Scalar[pl.BOOL] = False
                 for (x_inner,) in pl.while_(init_values=(x_outer,)):
-                    pl.cond(j_idx < 8 and not brk_i)  # noqa: F841
+                    pl.cond(j_idx < 8 and not brk_i)
                     if j_idx > 3:
                         brk_i: pl.Scalar[pl.BOOL] = True
                         x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
                     else:
                         y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
                         x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)  # noqa: F841
                     if not brk_i:
                         j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
+                    _x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)
                 if i < 2:
                     o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
                 else:
@@ -1423,7 +1416,7 @@ def test_nested_continue_both_loops():
                 if i < 1:
                     x_outer_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
                 else:
-                    for j, (x_inner,) in pl.range(8, init_values=(x_outer,)):  # noqa: F841
+                    for j, (x_inner,) in pl.range(8, init_values=(x_outer,)):
                         if j < 2:
                             x_inner_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
                         else:
@@ -1469,16 +1462,16 @@ def test_nested_break_and_continue_inner():
                     if j_idx < 2:
                         x_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
                     else:
-                        if j_idx > 5:  # noqa: F841
+                        if j_idx > 5:
                             brk_i: pl.Scalar[pl.BOOL] = True
                             x_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
                         else:
                             y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
                             x_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
                         x_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi1)
-                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi2)
                     if not brk_i:
                         j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
+                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi2)
                 x_outer: pl.Tensor[[64], pl.FP32] = pl.yield_(x_rv)
             return x_outer
 
@@ -1525,7 +1518,7 @@ def test_nested_loop_both_have_break_and_continue():
                     for (x_inner,) in pl.while_(init_values=(x_outer,)):
                         pl.cond(j_idx < 8 and not brk_i)
                         if j_idx < 2:
-                            i_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)  # noqa: F841
+                            i_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
                         else:
                             if j_idx > 5:
                                 brk_i: pl.Scalar[pl.BOOL] = True
@@ -1534,18 +1527,18 @@ def test_nested_loop_both_have_break_and_continue():
                                 y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
                                 i_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
                             i_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(i_phi1)
-                        i_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(i_phi2)  # noqa: F841
                         if not brk_i:
                             j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
+                        _i_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(i_phi2)
                     if i_idx > 2:
                         brk_o: pl.Scalar[pl.BOOL] = True
                         o_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
                     else:
                         o_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
                     o_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi1)
-                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi2)
                 if not brk_o:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi2)
             return o_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1590,32 +1583,32 @@ def test_three_level_nesting_break_at_each():
                     k_idx: pl.Scalar[pl.INDEX] = 0
                     brk3: pl.Scalar[pl.BOOL] = False
                     for (x_l3,) in pl.while_(init_values=(x_l2,)):
-                        pl.cond(k_idx < 5 and not brk3)  # noqa: F841
+                        pl.cond(k_idx < 5 and not brk3)
                         if k_idx > 2:
-                            brk3: pl.Scalar[pl.BOOL] = True  # noqa: F841
+                            brk3: pl.Scalar[pl.BOOL] = True
                             l3_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l3)
                         else:
                             y: pl.Tensor[[64], pl.FP32] = pl.add(x_l3, x_l3)
                             l3_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                        l3_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l3_phi)  # noqa: F841
                         if not brk3:
                             k_idx: pl.Scalar[pl.INDEX] = k_idx + 1
-                    if j_idx > 1:  # noqa: F841
+                        _l3_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l3_phi)
+                    if j_idx > 1:
                         brk2: pl.Scalar[pl.BOOL] = True
                         l2_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l2)
                     else:
                         l2_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l2)
-                    l2_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l2_phi)  # noqa: F841
                     if not brk2:
                         j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
+                    _l2_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l2_phi)
                 if i_idx > 0:
                     brk1: pl.Scalar[pl.BOOL] = True
                     l1_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l1)
                 else:
                     l1_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l1)
-                l1_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l1_phi)
                 if not brk1:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                l1_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l1_phi)
             return l1_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1642,7 +1635,7 @@ def test_continue_in_else_branch():
             return x_iter
 
     @pl.program
-    class Expected:  # noqa: F841
+    class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
@@ -1677,7 +1670,7 @@ def test_break_in_else_branch():
     class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            i_idx: pl.Scalar[pl.INDEX] = 0  # noqa: F841
+            i_idx: pl.Scalar[pl.INDEX] = 0
             brk: pl.Scalar[pl.BOOL] = False
             for (x_iter,) in pl.while_(init_values=(x_0,)):
                 pl.cond(i_idx < 10 and not brk)
@@ -1687,9 +1680,9 @@ def test_break_in_else_branch():
                 else:
                     brk: pl.Scalar[pl.BOOL] = True
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
-                x_iter = pl.yield_(phi)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -1735,10 +1728,10 @@ def _build_if_else_continue_then_break_else_expected() -> ir.Program:
                 phi2 = if_outer.output(0)
 
                 loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
                     ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
+                ib.emit(ir.YieldStmt([phi2], _SPAN))
 
             ib.return_stmt(loop.output(0))
         prog.add_function(f.get_result())
@@ -1787,12 +1780,12 @@ def test_normal_if_else_before_continue():
     @pl.program
     class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
-        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_0)  # noqa: F841
+                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_0)
                 if i < 2:
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
                 else:
@@ -1912,22 +1905,22 @@ def _build_deeply_nested_break_expected() -> ir.Program:
                     ib.emit(ir.YieldStmt([phi3], _SPAN))
                     if_l1.else_()
                     ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                phi4 = if_l1.output(0)  # noqa: F841
+                phi4 = if_l1.output(0)
 
                 # if not brk: y = add(...); yield phi4; else: yield phi4
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)) as if_guard:
                     if_guard.return_var("phi5", tt)
-                    y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))  # noqa: F841
+                    _y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
                     ib.emit(ir.YieldStmt([phi4], _SPAN))
                     if_guard.else_()
                     ib.emit(ir.YieldStmt([phi4], _SPAN))
                 phi5 = if_guard.output(0)
 
                 loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi5], _SPAN))
 
                 with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
                     ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
+                ib.emit(ir.YieldStmt([phi5], _SPAN))
 
             ib.return_stmt(loop.output(0))
         prog.add_function(f.get_result())
@@ -1987,16 +1980,16 @@ def test_multi_function_program():
             i_idx: pl.Scalar[pl.INDEX] = 0
             brk: pl.Scalar[pl.BOOL] = False
             for (x_iter,) in pl.while_(init_values=(x_0,)):
-                pl.cond(i_idx < 10 and not brk)  # noqa: F841
+                pl.cond(i_idx < 10 and not brk)
                 if i_idx > 5:
                     brk: pl.Scalar[pl.BOOL] = True
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
                 else:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                x_iter = pl.yield_(phi)
                 if not brk:
                     i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                x_iter = pl.yield_(phi)
             return x_iter
 
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -2029,7 +2022,7 @@ def test_pipeline_integration():
     @pl.program
     class Expected:
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
-        def main_incore_0(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:  # noqa: F841
+        def main_incore_0(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
                     phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)

--- a/tests/ut/ir/transforms/test_verify_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_verify_ssa_pass.py
@@ -493,6 +493,135 @@ class TestCardinalityChecks:
         with pytest.raises(Exception, match=r"(YieldStmt value count.*return_vars count|size mismatch)"):
             verify_pass(program)
 
+    # The next four tests construct IR directly via `ir.ForStmt` / `ir.WhileStmt`
+    # / `ir.IfStmt` rather than via @pl.program. The DSL parser cannot produce
+    # the shape these tests check: it rejects two yield-LHS bindings to the
+    # same names (SSA), and a body with two yields that have matching value
+    # counts on both yields requires either re-binding LHS names (rejected) or
+    # mismatched counts (caught by the structural verifier before SSAVerify
+    # runs). The MISPLACED_YIELD check exists as a backstop for IR producers
+    # (passes, transforms, IRBuilder users), so direct IR construction is the
+    # only way to test it.
+
+    def test_for_mid_body_yield(self):
+        """ForStmt body with a YieldStmt followed by another stmt is rejected,
+        even when a second YieldStmt sits at the trailing position. The yield
+        must be the scope terminator."""
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        iter_arg = ir.IterArg("sum", ir.ScalarType(DataType.INT64), a, span)
+        mid_yield = ir.YieldStmt([iter_arg], span)
+        trailing_assign = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), loop_var, span)
+        final_yield = ir.YieldStmt([iter_arg], span)
+        body = ir.SeqStmts([mid_yield, trailing_assign, final_yield], span)
+
+        rv = ir.Var("result", ir.ScalarType(DataType.INT64), span)
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(10, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [iter_arg],
+            body,
+            [rv],
+            span,
+        )
+
+        func_body = ir.SeqStmts([for_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("test_for_mid_yield", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        verify_pass = passes.run_verifier()
+        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+            verify_pass(program)
+
+    def test_while_mid_body_yield(self):
+        """WhileStmt body with a YieldStmt followed by another stmt is rejected.
+        Mirrors the ForStmt case (both share VerifyLoopIterArgsAndYield)."""
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
+        condition = ir.Gt(iter_arg, ir.ConstInt(0, DataType.INT64, span), DataType.BOOL, span)
+
+        mid_yield = ir.YieldStmt([iter_arg], span)
+        trailing_assign = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), a, span)
+        final_yield = ir.YieldStmt([iter_arg], span)
+        body = ir.SeqStmts([mid_yield, trailing_assign, final_yield], span)
+
+        rv = ir.Var("result", ir.ScalarType(DataType.INT64), span)
+        while_stmt = ir.WhileStmt(condition, [iter_arg], body, [rv], span)
+
+        func_body = ir.SeqStmts([while_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("test_while_mid_yield", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        verify_pass = passes.run_verifier()
+        with pytest.raises(Exception, match="WhileStmt.*YieldStmt before the terminating position"):
+            verify_pass(program)
+
+    def test_if_then_mid_body_yield(self):
+        """IfStmt then-branch with a YieldStmt followed by another stmt is
+        rejected. Symmetric to the ForStmt case."""
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        condition = ir.Gt(a, ir.ConstInt(0, DataType.INT64, span), DataType.BOOL, span)
+        mid_yield = ir.YieldStmt([a], span)
+        trailing_assign = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), a, span)
+        final_yield = ir.YieldStmt([a], span)
+        then_body = ir.SeqStmts([mid_yield, trailing_assign, final_yield], span)
+        else_body = ir.YieldStmt([a], span)
+        rv = ir.Var("result", ir.ScalarType(DataType.INT64), span)
+
+        if_stmt = ir.IfStmt(condition, then_body, else_body, [rv], span)
+
+        func_body = ir.SeqStmts([if_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("test_if_then_mid_yield", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        verify_pass = passes.run_verifier()
+        with pytest.raises(Exception, match="IfStmt then-branch.*YieldStmt before the terminating position"):
+            verify_pass(program)
+
+    def test_if_else_mid_body_yield(self):
+        """IfStmt else-branch with a mid-body YieldStmt is rejected. Then-branch
+        is well-formed; only the else side fails."""
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        condition = ir.Gt(a, ir.ConstInt(0, DataType.INT64, span), DataType.BOOL, span)
+        then_body = ir.YieldStmt([a], span)
+        mid_yield = ir.YieldStmt([a], span)
+        trailing_assign = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), a, span)
+        final_yield = ir.YieldStmt([a], span)
+        else_body = ir.SeqStmts([mid_yield, trailing_assign, final_yield], span)
+        rv = ir.Var("result", ir.ScalarType(DataType.INT64), span)
+
+        if_stmt = ir.IfStmt(condition, then_body, else_body, [rv], span)
+
+        func_body = ir.SeqStmts([if_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("test_if_else_mid_yield", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        verify_pass = passes.run_verifier()
+        with pytest.raises(Exception, match="IfStmt else-branch.*YieldStmt before the terminating position"):
+            verify_pass(program)
+
 
 class TestValidScopePatterns:
     """Test that valid scope patterns pass verification."""

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -405,7 +405,7 @@ class TestYieldLHSRequired:
     post-loop binding name (uniform convention across both loop forms)."""
 
     def test_pl_range_bare_yield_with_init_values_rejected(self):
-        with pytest.raises(ParserSyntaxError, match="requires an assignment-form pl.yield_"):
+        with pytest.raises(ParserSyntaxError, match=r"requires an assignment-form pl\.yield_"):
 
             @pl.function
             def bad_range(x_0: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.INT64]:
@@ -414,7 +414,7 @@ class TestYieldLHSRequired:
                 return x_iter  # noqa: F821
 
     def test_pl_while_bare_yield_with_init_values_rejected(self):
-        with pytest.raises(ParserSyntaxError, match="requires an assignment-form pl.yield_"):
+        with pytest.raises(ParserSyntaxError, match=r"requires an assignment-form pl\.yield_"):
 
             @pl.function
             def bad_while(n: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.INT64]:

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -395,8 +395,34 @@ class TestConditionMustBeBool:
                 x: pl.Scalar[pl.INT64] = 0
                 for (x_iter,) in pl.while_(init_values=(x,)):
                     pl.cond(1)  # type: ignore  # non-bool
-                    y = pl.yield_(x_iter + 1)  # noqa: F841
+                    y = pl.yield_(x_iter + 1)
                 return y  # noqa: F821
+
+
+class TestYieldLHSRequired:
+    """`pl.range(init_values=...)` and `pl.while_(init_values=...)` both
+    require an assignment-form `pl.yield_(...)` so the LHS supplies the
+    post-loop binding name (uniform convention across both loop forms)."""
+
+    def test_pl_range_bare_yield_with_init_values_rejected(self):
+        with pytest.raises(ParserSyntaxError, match="requires an assignment-form pl.yield_"):
+
+            @pl.function
+            def bad_range(x_0: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.INT64]:
+                for _i, (x_iter,) in pl.range(10, init_values=(x_0,)):
+                    pl.yield_(x_iter + 1)  # bare — no LHS
+                return x_iter  # noqa: F821
+
+    def test_pl_while_bare_yield_with_init_values_rejected(self):
+        with pytest.raises(ParserSyntaxError, match="requires an assignment-form pl.yield_"):
+
+            @pl.function
+            def bad_while(n: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.INT64]:
+                x: pl.Scalar[pl.INT64] = 0
+                for (x_iter,) in pl.while_(init_values=(x,)):
+                    pl.cond(x_iter < n)
+                    pl.yield_(x_iter + 1)  # bare — no LHS
+                return x  # noqa: F821
 
 
 class TestSourceLocationPreservation:


### PR DESCRIPTION
## Summary

Implements [RFC #1246](https://github.com/hw-native-sys/pypto/issues/1246) — unifies `pl.while_` and `pl.range` on the same yield-LHS convention and codifies the underlying IR invariant.

**Before**: `pl.while_(init_values=...)` had an asymmetric binding rule — the header-tuple name auto-bound to the outer-scope return_var, while `pl.range` derived the post-loop binding from the yield-LHS only. To round-trip IR where `iter_arg.name_hint_` and `return_var.name_hint_` collide, the printer needed a `WhileStmt`-scoped harmonization step (added in #1247) to keep the two pointers printing as the same name.

**After**: both loop forms use the same convention — the yield-LHS supplies the post-loop binding name; header-tuple names are loop-scoped only. The printer harmonization is deletable; bare `pl.yield_(...)` with non-empty `init_values` is rejected up front with a clean parser diagnostic; the SSA-form invariant (YieldStmt is the scope terminator) is now enforced by the verifier.

```python
# Old pl.while_ shape (now rejected at parse time):
for (x,) in pl.while_(init_values=(x_0,)):
    pl.cond(x < n)
    pl.yield_(x + 1)        # bare yield
return x                    # implicit binding from header tuple

# New unified shape:
for (x,) in pl.while_(init_values=(x_0,)):
    pl.cond(x < n)
    x_next = pl.yield_(x + 1)   # yield-LHS supplies the binding
return x_next
```

### Commits

| | |
|-|-|
| `5547ec6` | `refactor(ir): emit YieldStmt as scope terminator in LowerForWithBreak` — moves the guarded counter-advancement before the trailing yield in the `break`-lowered WhileStmt body. Updates 13 Expected IR fixtures across `test_ctrl_flow_transform.py` to match. |
| `ff8affe` | `refactor(parser): unify pl.range and pl.while_ output convention` — drops the asymmetric header-tuple→outer-scope binding from `_register_while_outputs`, the bare-yield tracking from `parse_yield_call`, and adds a pre-flight `_require_yield_lhs_for_init_values` check that rejects bare `pl.yield_(...)` when `init_values` is non-empty. Pre-SSA loops with no yield at all still fall back to synthetic `<iter_arg>_out` return_var names — symmetric across both loop forms. |
| `f05aabe` | `refactor(printer): drop IterArgReturnVarPairCollector` — removes 45 lines of harmonization scaffolding from `python_printer.cpp`. The lenient-mode disambiguation from #1247 (`auto_name::BuildRenameMapForDefs`) is sufficient on its own once the parser is symmetric. |
| `d154ca2` | `feat(verifier): reject mid-body YieldStmt in SSA-form scopes` — extends `SSAVerify` so any For/While/IfStmt with non-empty `iter_args`/`return_vars` is rejected when its body contains a `YieldStmt` followed by other stmts. Adds `MISPLACED_YIELD` (error code 7) for the positional violation. |
| `b23ba6e` | `docs: document unified pl.while_/pl.range output convention` — new "While Loop" section in `00-python_syntax.md` (en + zh) showing the unified convention; `WhileStmt Details` in `01-hierarchy.md` (en + zh) cross-references the new verifier rule. |

### Why each piece

- **Pass restructuring (commit 1)** establishes the SSA-form invariant by example: `LowerForWithBreak` was the only IR producer that emitted a mid-body yield, and the fix is mechanical (yield values are let-bound Vars, never the loop counter, so reordering is semantically safe).
- **Parser unification (commit 2)** removes the asymmetry the original RFC called out. The pre-flight scan gives users a clean parser-level error instead of a confusing downstream IR-builder arity mismatch.
- **Printer cleanup (commit 3)** deletes the workaround that existed only because the parser was asymmetric.
- **Verifier (commit 4)** codifies the invariant so future passes can't silently regress it. The check is gated on SSA form (non-empty iter_args/return_vars), so pre-SSA shapes remain valid.
- **Docs (commit 5)** documents the unified rule for users and links the verifier diagnostic for IR producers.

## Migration

This is a breaking DSL change for `pl.while_`. Users on the header-tuple style:

```python
for (x,) in pl.while_(init_values=(x_0,)):
    pl.cond(x < n)
    pl.yield_(x + 1)
return x
```

migrate to yield-LHS form:

```python
for (x,) in pl.while_(init_values=(x_0,)):
    pl.cond(x < n)
    x_next = pl.yield_(x + 1)
return x_next
```

The parser now produces a clear error pointing at the bare `pl.yield_(...)` with a hint suggesting the assignment-form rewrite.

## Test plan

- [x] `tests/ut/ir/transforms/test_ctrl_flow_transform.py` — 48 tests pass; Expected IR updated to match new `LowerForWithBreak` emission shape.
- [x] `tests/ut/language/parser/test_error_cases.py::TestYieldLHSRequired` — 2 new tests cover bare-yield rejection for `pl.range` and `pl.while_`.
- [x] `tests/ut/ir/transforms/test_verify_ssa_pass.py::TestCardinalityChecks` — 4 new tests cover ForStmt, WhileStmt, IfStmt-then, IfStmt-else mid-body yield cases (constructed via direct IR; the DSL parser inherently prevents these shapes, so the verifier check is a backstop for IR producers).
- [x] Full `tests/ut/` — 4221 passed, 30 skipped, 0 failures.
- [x] clang-tidy clean on changed C++.
- [x] Pre-commit hooks (clang-format, cpplint, ruff, pyright, markdownlint) all pass.

Closes #1246.