### PR TITLE
feat(language): Support pl.add/sub/mul/div on scalar arguments

### DIFF
--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -97,7 +97,13 @@ def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
 # --- add ---
 
 
-def add(lhs: T, rhs: T | int | float | Scalar) -> T:
+@overload
+def add(lhs: Tensor, rhs: Tensor | int | float | Scalar) -> Tensor: ...
+@overload
+def add(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
+@overload
+def add(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
+def add(lhs, rhs):
     """Element-wise addition, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.add(lhs, rhs)
@@ -105,13 +111,21 @@ def add(lhs: T, rhs: T | int | float | Scalar) -> T:
         return _tile.add(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
         return _tile.adds(lhs, rhs)
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+        return lhs + rhs
     _raise_type_dispatch_error("add", lhs, rhs)
 
 
 # --- sub ---
 
 
-def sub(lhs: T, rhs: T | int | float | Scalar) -> T:
+@overload
+def sub(lhs: Tensor, rhs: Tensor | int | float | Scalar) -> Tensor: ...
+@overload
+def sub(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
+@overload
+def sub(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
+def sub(lhs, rhs):
     """Element-wise subtraction, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.sub(lhs, rhs)
@@ -119,13 +133,21 @@ def sub(lhs: T, rhs: T | int | float | Scalar) -> T:
         return _tile.sub(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
         return _tile.subs(lhs, rhs)
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+        return lhs - rhs
     _raise_type_dispatch_error("sub", lhs, rhs)
 
 
 # --- mul ---
 
 
-def mul(lhs: T, rhs: T | int | float | Scalar) -> T:
+@overload
+def mul(lhs: Tensor, rhs: Tensor | int | float | Scalar) -> Tensor: ...
+@overload
+def mul(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
+@overload
+def mul(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
+def mul(lhs, rhs):
     """Element-wise multiplication, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.mul(lhs, rhs)
@@ -133,13 +155,21 @@ def mul(lhs: T, rhs: T | int | float | Scalar) -> T:
         return _tile.mul(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
         return _tile.muls(lhs, rhs)
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+        return lhs * rhs
     _raise_type_dispatch_error("mul", lhs, rhs)
 
 
 # --- div ---
 
 
-def div(lhs: T, rhs: T | int | float | Scalar) -> T:
+@overload
+def div(lhs: Tensor, rhs: Tensor | int | float | Scalar) -> Tensor: ...
+@overload
+def div(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
+@overload
+def div(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
+def div(lhs, rhs):
     """Element-wise division, dispatched by input type."""
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
         return _tensor.div(lhs, rhs)
@@ -147,6 +177,8 @@ def div(lhs: T, rhs: T | int | float | Scalar) -> T:
         return _tile.div(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
         return _tile.divs(lhs, rhs)
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+        return lhs / rhs
     _raise_type_dispatch_error("div", lhs, rhs)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4267,7 +4267,7 @@ class ASTParser:
             hint=(
                 f"Supported scalar ops: {', '.join(supported)}. "
                 "For other arithmetic / bitwise / comparison ops, use Python operators "
-                "directly on scalars (e.g. `s1 + s2`, `s1 % s2`, `s1 << 1`, `s1 == s2`)."
+                "directly on scalars (e.g. `s1 % s2`, `s1 << 1`, `s1 | s2`, `s1 == s2`)."
             ),
         )
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4048,7 +4048,15 @@ class ASTParser:
     }
 
     # Maps unified op names to ir scalar expression functions.
+    # Arithmetic ops (add/sub/mul/div) mirror the `+`/`-`/`*`/`/` operators
+    # so `pl.<op>(scalar, scalar)` behaves like `scalar <op> scalar`. `div`
+    # maps to `truediv`, matching `pl.tile.div` semantics; users who want
+    # integer floor division can use the `//` operator.
     _SCALAR_BINARY_OPS: dict[str, str] = {
+        "add": "add",
+        "sub": "sub",
+        "mul": "mul",
+        "div": "truediv",
         "min": "min_",
         "max": "max_",
     }
@@ -4256,7 +4264,11 @@ class ASTParser:
         raise InvalidOperationError(
             f"Operation '{op_name}' is not supported for scalar arguments",
             span=call_span,
-            hint=f"Supported scalar ops: {', '.join(supported)}",
+            hint=(
+                f"Supported scalar ops: {', '.join(supported)}. "
+                "For other arithmetic / bitwise / comparison ops, use Python operators "
+                "directly on scalars (e.g. `s1 + s2`, `s1 % s2`, `s1 << 1`, `s1 == s2`)."
+            ),
         )
 
     def parse_attribute(self, attr: ast.Attribute) -> ir.Expr:

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -15,6 +15,7 @@ when called with scalar arguments.
 
 import pypto.language as pl
 import pytest
+from pypto.language.parser.diagnostics.exceptions import InvalidOperationError
 from pypto.pypto_core import ir
 
 
@@ -339,7 +340,7 @@ class TestScalarUnsupportedOpHint:
     def test_unsupported_op_hint_mentions_python_operators(self):
         # `pl.exp` is a unified op (tile/tensor) with no scalar dispatch — hits
         # the catch-all path that surfaces the improved hint.
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(InvalidOperationError, match=r"Operation 'exp' is not supported") as exc_info:
 
             @pl.program
             class Bad:

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -230,7 +230,7 @@ class TestScalarArithmetic:
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
                 b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
-                c: pl.Scalar[pl.INT64] = pl.add(a, b)  # pyright: ignore[reportArgumentType]
+                c: pl.Scalar[pl.INT64] = pl.add(a, b)
                 _ = c + 1
                 return out
 
@@ -250,7 +250,7 @@ class TestScalarArithmetic:
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
                 b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
-                c: pl.Scalar[pl.INT64] = pl.sub(a, b)  # pyright: ignore[reportArgumentType]
+                c: pl.Scalar[pl.INT64] = pl.sub(a, b)
                 _ = c + 1
                 return out
 
@@ -270,7 +270,7 @@ class TestScalarArithmetic:
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
                 b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
-                c: pl.Scalar[pl.INT64] = pl.mul(a, b)  # pyright: ignore[reportArgumentType]
+                c: pl.Scalar[pl.INT64] = pl.mul(a, b)
                 _ = c + 1
                 return out
 
@@ -290,7 +290,7 @@ class TestScalarArithmetic:
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
                 b: pl.Scalar[pl.FP32] = pl.tensor.read(config, [1])
-                c: pl.Scalar[pl.FP32] = pl.div(a, b)  # pyright: ignore[reportArgumentType]
+                c: pl.Scalar[pl.FP32] = pl.div(a, b)
                 _ = c
                 return out
 
@@ -312,7 +312,7 @@ class TestScalarArithmetic:
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
                 b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
-                c: pl.Scalar[pl.INT64] = pl.add(a, b)  # pyright: ignore[reportArgumentType]
+                c: pl.Scalar[pl.INT64] = pl.add(a, b)
                 _ = c
                 return out
 

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -216,5 +216,149 @@ class TestScalarNot:
         ir.assert_structural_equal(Before, pl.parse_program(printed))
 
 
+class TestScalarArithmetic:
+    """Tests for pl.add/sub/mul/div dispatching on scalar arguments."""
+
+    def test_scalar_add(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = pl.add(a, b)  # pyright: ignore[reportArgumentType]
+                _ = c + 1
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a + b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_sub(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = pl.sub(a, b)  # pyright: ignore[reportArgumentType]
+                _ = c + 1
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a - b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_mul(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = pl.mul(a, b)  # pyright: ignore[reportArgumentType]
+                _ = c + 1
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a * b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_div(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.FP32],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.FP32] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.FP32] = pl.div(a, b)  # pyright: ignore[reportArgumentType]
+                _ = c
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a / b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_add_matches_plus_operator(self):
+        """`pl.add(a, b)` must produce the same IR as `a + b`."""
+
+        @pl.program
+        class WithCall:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = pl.add(a, b)  # pyright: ignore[reportArgumentType]
+                _ = c
+                return out
+
+        @pl.program
+        class WithOperator:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = a + b
+                _ = c
+                return out
+
+        ir.assert_structural_equal(WithCall, WithOperator)
+
+
+class TestScalarUnsupportedOpHint:
+    """Verify the catch-all error message points users at Python operators."""
+
+    def test_unsupported_op_hint_mentions_python_operators(self):
+        # `pl.exp` is a unified op (tile/tensor) with no scalar dispatch — hits
+        # the catch-all path that surfaces the improved hint.
+        with pytest.raises(Exception) as exc_info:
+
+            @pl.program
+            class Bad:
+                @pl.function
+                def main(
+                    self,
+                    config: pl.Tensor[[1], pl.FP32],
+                    out: pl.Tensor[[2, 16, 128], pl.FP32],
+                ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                    a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                    _ = pl.exp(a)  # pyright: ignore[reportArgumentType]
+                    return out
+
+            assert Bad is not None  # silence "unused" warnings if reached
+
+        err = exc_info.value
+        assert "exp" in err.message  # type: ignore[attr-defined]
+        assert "Python operators" in err.hint  # type: ignore[attr-defined]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The DSL parser intercepts `pl.<op>(...)` calls and dispatches by first-arg type. For `ScalarType` arguments it consulted `_SCALAR_BINARY_OPS`, which only listed `min`/`max` — so `pl.add(s1, s2)` raised `InvalidOperationError` even though native `+` worked fine on the same scalars. The hint was also misleading, pointing users at `cast, max, min` (none of which compute arithmetic).

This PR closes that asymmetry: `pl.<op>` now works as the unified operator across Tensor / Tile / Scalar.

- Extend `_SCALAR_BINARY_OPS` (`python/pypto/language/parser/ast_parser.py:4023`) with `add`/`sub`/`mul`/`div`. `div` maps to `ir.truediv` to match `pl.tile.div` semantics; users wanting integer floor div continue to use `//`.
- Reword the catch-all hint to point users at Python operators (`+`/`-`/`*`/`/`/`==`/`<<` ...) for arithmetic / bitwise / comparison ops, replacing the misleading `cast, max, min` list.

The C++ IR already supported scalar `Add`/`Sub`/`Mul`/`Div` (that's what `s1 + s2` lowers to). This is a pure frontend allowlist gap — no IR, codegen, or pass changes.

**Out of scope**: `unified_ops.add`/`sub`/`mul`/`div` (used in builder mode, not DSL parsing) still don't admit `Scalar+Scalar` because their `TypeVar("T", Tensor, Tile)` excludes Scalar. Adding that would require overloads + a runtime branch — a separate change.

## Testing

- [x] 6 new tests in `tests/ut/language/parser/test_scalar_dispatch.py`:
    - `TestScalarArithmetic`: round-trip for each of `pl.add`/`sub`/`mul`/`div`, plus a structural-equality test confirming `pl.add(a, b) ≡ a + b`.
    - `TestScalarUnsupportedOpHint`: exercises the improved hint via `pl.exp(scalar)` (a unified op with no scalar dispatch).
- [x] Full language test suite: 757 passed, 0 regressions.
- [x] Pre-commit hooks: ruff, pyright, header / English-only / large-file checks — all pass.