### PR TITLE
fix(ir): Guard against mid-body YieldStmt in ConvertToSSA and structural verifier

### DIFF
--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -913,7 +913,24 @@ class SSAConverter {
     return nullptr;
   }
 
+  // Invariant: a YieldStmt may appear only as the trailing statement of its
+  // scope. Both helpers below only inspect / pop the last stmt, so a mid-body
+  // YieldStmt would silently survive ReplaceOrAppendYield and produce a
+  // SeqStmts with two yields. Assert at the source rather than letting the
+  // structural verifier blame the resulting shape.
+  static void AssertNoMidBodyYield(const StmtPtr& s) {
+    auto seq = As<SeqStmts>(s);
+    if (!seq) return;
+    for (size_t i = 0; i + 1 < seq->stmts_.size(); ++i) {
+      INTERNAL_CHECK(!As<YieldStmt>(seq->stmts_[i]))
+          << "ConvertToSSA: body has a YieldStmt at position " << i << " of " << seq->stmts_.size()
+          << "; YieldStmt must be the trailing statement of its scope. "
+          << "A producing pass emitted malformed IR.";
+    }
+  }
+
   static YieldStmtPtr ExtractYield(const StmtPtr& s) {
+    AssertNoMidBodyYield(s);
     if (auto y = As<YieldStmt>(s)) {
       return y;
     }
@@ -926,6 +943,7 @@ class SSAConverter {
   }
 
   static StmtPtr ReplaceOrAppendYield(const StmtPtr& s, const std::vector<ExprPtr>& vals, const Span& span) {
+    AssertNoMidBodyYield(s);
     auto yield = std::make_shared<YieldStmt>(vals, span);
     if (auto seq = As<SeqStmts>(s)) {
       std::vector<StmtPtr> stmts = seq->stmts_;

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -398,6 +398,7 @@ class SSAConverter {
   // ── SeqStmts — computes future uses per-statement for escaping detection
 
   StmtPtr ConvertSeq(const SeqStmtsPtr& op) {
+    AssertNoMidBodyYield(op);
     size_t n = op->stmts_.size();
 
     // Precompute suffix_needs[i] = variables needed from the outer scope by stmts[i..N-1].
@@ -914,15 +915,16 @@ class SSAConverter {
   }
 
   // Invariant: a YieldStmt may appear only as the trailing statement of its
-  // scope. Both helpers below only inspect / pop the last stmt, so a mid-body
-  // YieldStmt would silently survive ReplaceOrAppendYield and produce a
-  // SeqStmts with two yields. Assert at the source rather than letting the
-  // structural verifier blame the resulting shape.
+  // scope. ConvertSeq and the loop/if helpers below only inspect / pop the
+  // last stmt, so a mid-body YieldStmt would silently survive
+  // ReplaceOrAppendYield and produce a SeqStmts with two yields. Assert at the
+  // source rather than letting the structural verifier blame the resulting
+  // shape.
   static void AssertNoMidBodyYield(const StmtPtr& s) {
     auto seq = As<SeqStmts>(s);
     if (!seq) return;
     for (size_t i = 0; i + 1 < seq->stmts_.size(); ++i) {
-      INTERNAL_CHECK(!As<YieldStmt>(seq->stmts_[i]))
+      INTERNAL_CHECK_SPAN(!As<YieldStmt>(seq->stmts_[i]), seq->stmts_[i]->span_)
           << "ConvertToSSA: body has a YieldStmt at position " << i << " of " << seq->stmts_.size()
           << "; YieldStmt must be the trailing statement of its scope. "
           << "A producing pass emitted malformed IR.";

--- a/src/ir/transforms/normalize_stmt_structure_pass.cpp
+++ b/src/ir/transforms/normalize_stmt_structure_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
@@ -34,9 +35,13 @@ namespace ir {
 namespace {
 
 /**
- * @brief Checks that no SeqStmts has a single child (should be
- * unwrapped) and no SeqStmts contains a nested instance of itself
- * (should be flattened).
+ * @brief Checks structural invariants of SeqStmts:
+ *   - no single-child SeqStmts (should be unwrapped),
+ *   - no nested SeqStmts inside another SeqStmts (should be flattened),
+ *   - no YieldStmt anywhere except as the trailing statement (YieldStmt is
+ *     the scope-exit terminator; mid-body yields are unreachable code and
+ *     break passes that assume the yield is at the tail — see
+ *     ConvertToSSA::ExtractYield/ReplaceOrAppendYield).
  */
 class NoRedundantBlocksVerifier : public IRVisitor {
  public:
@@ -50,10 +55,17 @@ class NoRedundantBlocksVerifier : public IRVisitor {
       diagnostics_.emplace_back(DiagnosticSeverity::Error, rule_name_, 0,
                                 "SeqStmts with single child should be unwrapped", op->span_);
     }
-    for (const auto& stmt : op->stmts_) {
+    for (size_t i = 0; i < op->stmts_.size(); ++i) {
+      const auto& stmt = op->stmts_[i];
       if (As<SeqStmts>(stmt)) {
         diagnostics_.emplace_back(DiagnosticSeverity::Error, rule_name_, 0,
                                   "SeqStmts contains nested SeqStmts", stmt->span_);
+      }
+      if (i + 1 < op->stmts_.size() && As<YieldStmt>(stmt)) {
+        diagnostics_.emplace_back(DiagnosticSeverity::Error, rule_name_, 0,
+                                  "YieldStmt before the terminating position; "
+                                  "YieldStmt must be the trailing statement of its scope",
+                                  stmt->span_);
       }
     }
     IRVisitor::VisitStmt_(op);

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1553,5 +1553,54 @@ class TestEscapingVariables:
         )
 
 
+class TestMidBodyYieldGuard:
+    """ConvertToSSA rejects a body whose SeqStmts contains a YieldStmt before
+    the trailing position via INTERNAL_CHECK in ExtractYield/ReplaceOrAppendYield.
+
+    Structural pre-verification (NoRedundantBlocks) normally intercepts this
+    shape before ConvertToSSA runs, so the test wraps the call in a
+    VerificationLevel.NONE PassContext to exercise the in-pass assertion.
+    """
+
+    def test_for_body_with_mid_body_yield_rejected(self):
+        """ForStmt body shaped as [YieldStmt, AssignStmt] trips
+        AssertNoMidBodyYield. Constructed directly because the DSL parser
+        cannot produce this shape; iter_args ensure the loop-handler path
+        that calls the helpers is exercised.
+        """
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        loop_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        iter_arg = ir.IterArg("acc", ir.ScalarType(DataType.INT64), a, span)
+
+        mid_yield = ir.YieldStmt([iter_arg], span)
+        trailing_assign = ir.AssignStmt(ir.Var("dummy", ir.ScalarType(DataType.INT64), span), loop_var, span)
+        body = ir.SeqStmts([mid_yield, trailing_assign], span)
+
+        rv = ir.Var("result", ir.ScalarType(DataType.INT64), span)
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(10, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [iter_arg],
+            body,
+            [rv],
+            span,
+        )
+
+        func_body = ir.SeqStmts([for_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("main", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
+        with ctx, pytest.raises(Exception, match="YieldStmt at position"):
+            passes.convert_to_ssa()(program)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1601,6 +1601,29 @@ class TestMidBodyYieldGuard:
         with ctx, pytest.raises(Exception, match="YieldStmt at position"):
             passes.convert_to_ssa()(program)
 
+    def test_function_body_with_mid_body_yield_rejected(self):
+        """Function-body SeqStmts with a mid-body YieldStmt trips
+        AssertNoMidBodyYield via ConvertSeq — the path that bypasses the
+        loop/if scope handlers.
+        """
+        span = ir.Span.unknown()
+
+        a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+        params: list[ir.Var] = [a]
+        return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+        dummy_var = ir.Var("dummy", ir.ScalarType(DataType.INT64), span)
+        assign = ir.AssignStmt(dummy_var, a, span)
+        mid_yield = ir.YieldStmt([a], span)
+        ret = ir.ReturnStmt([a], span)
+        func_body = ir.SeqStmts([assign, mid_yield, ret], span)
+        func = ir.Function("main", params, return_types, func_body, span)
+        program = ir.Program([func], "test_program", span)
+
+        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
+        with ctx, pytest.raises(Exception, match="YieldStmt at position"):
+            passes.convert_to_ssa()(program)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -236,5 +236,29 @@ def test_idempotence():
     ir.assert_structural_equal(After2, Expected)
 
 
+def test_no_redundant_blocks_rejects_mid_body_yield():
+    """NoRedundantBlocks rejects a YieldStmt at a non-trailing position of a
+    SeqStmts. Function body has no iter_args context, so SSAVerify's
+    CheckNoMidBodyYield does not apply — only the structural verifier catches it.
+    """
+    span = ir.Span.unknown()
+
+    a = ir.Var("a", ir.ScalarType(DataType.INT64), span)
+    params: list[ir.Var] = [a]
+    return_types: list[ir.Type] = [ir.ScalarType(DataType.INT64)]
+
+    dummy_var = ir.Var("dummy", ir.ScalarType(DataType.INT64), span)
+    assign = ir.AssignStmt(dummy_var, a, span)
+    mid_yield = ir.YieldStmt([a], span)
+    ret = ir.ReturnStmt([a], span)
+    func_body = ir.SeqStmts([assign, mid_yield, ret], span)
+    func = ir.Function("main", params, return_types, func_body, span)
+    program = ir.Program([func], "test_program", span)
+
+    verify_pass = passes.run_verifier()
+    with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+        verify_pass(program)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_verify_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_verify_ssa_pass.py
@@ -494,14 +494,11 @@ class TestCardinalityChecks:
             verify_pass(program)
 
     # The next four tests construct IR directly via `ir.ForStmt` / `ir.WhileStmt`
-    # / `ir.IfStmt` rather than via @pl.program. The DSL parser cannot produce
-    # the shape these tests check: it rejects two yield-LHS bindings to the
-    # same names (SSA), and a body with two yields that have matching value
-    # counts on both yields requires either re-binding LHS names (rejected) or
-    # mismatched counts (caught by the structural verifier before SSAVerify
-    # runs). The MISPLACED_YIELD check exists as a backstop for IR producers
-    # (passes, transforms, IRBuilder users), so direct IR construction is the
-    # only way to test it.
+    # / `ir.IfStmt` because the DSL parser cannot produce a body with a
+    # mid-body yield. The structural NoRedundantBlocks verifier intercepts the
+    # shape before SSAVerify, so the diagnostic surfaces as a NoRedundantBlocks
+    # error; SSAVerify's check remains as a backstop for flows that bypass
+    # structural pre-verification.
 
     def test_for_mid_body_yield(self):
         """ForStmt body with a YieldStmt followed by another stmt is rejected,
@@ -565,7 +562,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="WhileStmt.*YieldStmt before the terminating position"):
+        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
     def test_if_then_mid_body_yield(self):
@@ -592,7 +589,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="IfStmt then-branch.*YieldStmt before the terminating position"):
+        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
     def test_if_else_mid_body_yield(self):
@@ -619,7 +616,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="IfStmt else-branch.*YieldStmt before the terminating position"):
+        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
 


### PR DESCRIPTION
## Summary

`ConvertToSSA`'s `ExtractYield`/`ReplaceOrAppendYield` only inspected the trailing stmt of a `SeqStmts` body. A mid-body `YieldStmt` followed by other stmts would silently survive `ReplaceOrAppendYield` and produce IR with two `YieldStmt`s in the same scope. The only known producer (`LowerForWithBreak`) was already fixed under RFC #1246, but the helpers themselves remained a latent foot-gun for future passes.

This PR adds two layers of defense:

- **`AssertNoMidBodyYield` (in-pass)** — a static helper called from both `ExtractYield` and `ReplaceOrAppendYield` in `convert_to_ssa_pass.cpp`. A malformed body now trips an `INTERNAL_CHECK` pinned to the producing pass rather than surfacing as a downstream verification error.
- **`NoRedundantBlocksVerifier` (structural)** — extended to reject the same shape as part of the `NoRedundantBlocks` / `NormalizedStmtStructure` properties. The check runs at every pre-pass structural verification boundary, so any IR producer is caught regardless of whether the enclosing scope is in SSA form.

The mid-body-yield tests in `test_verify_ssa_pass.py` are updated: the structural verifier now intercepts before `SSAVerify`, so the diagnostic is the structural one.

## Test plan

- [x] `pytest tests/ut/ir/transforms/test_convert_to_ssa_pass.py tests/ut/ir/transforms/test_verify_ssa_pass.py tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py` — 80 passed
- [x] Full `pytest tests/ut -n auto --maxprocesses 8` — 4246 passed, 30 skipped
- [x] `clang-tidy` — clean
- [x] New regression test `TestMidBodyYieldGuard::test_for_body_with_mid_body_yield_rejected` exercises the in-pass `INTERNAL_CHECK` (wraps in `VerificationLevel.NONE` to bypass the structural pre-check that would otherwise intercept first).
- [x] New regression test `test_no_redundant_blocks_rejects_mid_body_yield` exercises the structural verifier on a function-body `SeqStmts` with no enclosing `iter_args`, where SSA-form's `CheckNoMidBodyYield` does not apply.