### PR TITLE
chore(claude): Improve fix-pr skill and known-issues entry quality

### DIFF
--- a/.claude/rules/problem-handling.md
+++ b/.claude/rules/problem-handling.md
@@ -53,19 +53,35 @@ Examples: build failure preventing testing, ambiguous requirements, API behaving
 
 - **Date**: YYYY-MM-DD
 - **Found during**: [brief context of what task you were working on]
-- **Description**: [clear description of the problem]
+- **Description**: [actual behaviour, expected behaviour, why it matters]
+- **Example / Repro**: [smallest artefact that surfaces the issue — see "Entry Quality" below; use `N/A` only for purely descriptive issues]
 - **Location**: [file path(s) and line number(s) if applicable]
 - **Severity**: low | medium | high
 
 ---
 ```
 
+### Entry Quality
+
+Each entry must be **self-contained** — a future reader (you in two months, or the user filing it as a GitHub issue) should understand the problem without re-deriving it from memory.
+
+- **Description**: name the actual vs. expected behaviour and the consequence. ✅ "ConvertSeq doesn't guard mid-body yields, so malformed SeqStmts survive SSA conversion when verification is off" beats ❌ "ConvertSeq has a bug".
+- **Example / Repro**: include the smallest concrete artefact that surfaces the issue. Pick whichever fits:
+  - A failing test name + the bottom of the traceback for runtime bugs
+  - A short code snippet (DSL / IR / C++) showing the wrong output for codegen / printer / pass issues
+  - The exact CLI command + error message for build or tooling issues
+  - A grep query + counts for inventory-style observations (e.g. `grep -rE 'INTERNAL_CHECK\(' src/ir | wc -l   # 91`)
+
+**Note on `N/A`:** Mark as `N/A` only when the issue is purely descriptive (doc gap, naming concern) — that signals "considered, not forgotten" rather than "skipped".
+
+If you cannot produce a concrete example, treat that as a signal the issue may not yet be well-understood — flag it to the user before logging.
+
 ### How to Log
 
 1. Determine the main repo root (`git worktree list` — first entry)
 2. Read `KNOWN_ISSUES.md` (create if it doesn't exist)
 3. Check the issue is not already logged (avoid duplicates)
-4. Append the new issue using the format above
+4. Append the new issue using the format above — verify it meets the "Entry Quality" bar before saving
 5. Continue with the current task (do not fix the logged issue now)
 
 ## On Task Completion

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -65,6 +65,16 @@ grep -o '"isResolved":[[:space:]]*false' /tmp/threads.json | wc -l
 
 # Paginate: if hasNextPage is true, re-run with -F cursor="<endCursor>" until done
 
+# Also fetch CodeRabbit "outside diff range" findings — they live in review BODIES, not threads
+gh api "repos/$OWNER/$NAME/pulls/<NUMBER>/reviews" > /tmp/reviews.json
+# Markers in body: "Outside diff range comments" or "Some comments are outside the diff".
+# After stripping the leading "> " (the [!CAUTION] callout makes everything a blockquote),
+# the structure is nested <details>:
+#   <summary>⚠️ Outside diff range comments (N)</summary><blockquote>
+#     <summary>PATH (N)</summary><blockquote>
+#       `LINE-RANGE`: severity-tags **Title** ... body ...
+# Use Python (re + json) to walk the tree; surface (path, line_range, body) as pseudo-threads.
+
 # Check CI status
 gh pr checks <NUMBER>
 ```
@@ -75,7 +85,7 @@ gh pr checks <NUMBER>
 - Do NOT use `gh api graphql --jq` with `$` in filter expressions — `gh`'s jq processor interprets `$` as a jq variable sign, causing `Expected VAR_SIGN` errors even when shell quoting is correct
 - Use `grep -c` for simple counts; save to a temp file first if complex parsing is needed
 
-Present: "**Iteration N** — Found X unresolved comments and Y failed/pending checks."
+Present: "**Iteration N** — Found X unresolved comments (A inline + B outside-diff) and Y failed/pending checks."
 
 **Exit:** All checks green AND no unresolved comments → done. Pending checks do NOT count as clean.
 
@@ -90,6 +100,8 @@ Present: "**Iteration N** — Found X unresolved comments and Y failed/pending c
 | **C: Informational** | Resolve without changes | Acknowledgments, "optional" suggestions |
 
 Treat bot reviewers (CodeRabbit, Copilot, Gemini) same as human — classify by content.
+
+**Out-of-diff findings** (from `/tmp/reviews.json`) — present alongside inline threads as pseudo-threads (path + line range + body). They have NO thread ID, so Step 6's `resolveReviewThread` mutation cannot apply; address by fixing the code and noting the commit in your push message.
 
 **CI failures:**
 
@@ -137,6 +149,8 @@ Ask which to address/skip. Recommend A + CI items. On subsequent iterations, reu
 Reply with `gh api repos/:owner/:repo/pulls/<number>/comments/<comment_id>/replies -f body="..."` then resolve with GraphQL `resolveReviewThread` mutation.
 
 Templates: Fixed → "Fixed in `<commit>` - description" | Skip → "Follows `.claude/rules/<file>`" | Ack → "Acknowledged!"
+
+**Out-of-diff findings** (no thread ID): nothing to resolve via GraphQL — note the fix in the commit message; CodeRabbit re-scans on the next push and won't re-emit fixed findings.
 
 ### Step 7: Wait and Re-check
 

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -65,8 +65,9 @@ grep -o '"isResolved":[[:space:]]*false' /tmp/threads.json | wc -l
 
 # Paginate: if hasNextPage is true, re-run with -F cursor="<endCursor>" until done
 
-# Also fetch CodeRabbit "outside diff range" findings — they live in review BODIES, not threads
-gh api "repos/$OWNER/$NAME/pulls/<NUMBER>/reviews" > /tmp/reviews.json
+# Also fetch CodeRabbit "outside diff range" findings — they live in review BODIES, not threads.
+# Use --paginate so PRs with many reviews don't drop the latest CodeRabbit body.
+gh api --paginate "repos/$OWNER/$NAME/pulls/<NUMBER>/reviews" > /tmp/reviews.json
 # Markers in body: "Outside diff range comments" or "Some comments are outside the diff".
 # After stripping the leading "> " (the [!CAUTION] callout makes everything a blockquote),
 # the structure is nested <details>:
@@ -101,7 +102,7 @@ Present: "**Iteration N** — Found X unresolved comments (A inline + B outside-
 
 Treat bot reviewers (CodeRabbit, Copilot, Gemini) same as human — classify by content.
 
-**Out-of-diff findings** (from `/tmp/reviews.json`) — present alongside inline threads as pseudo-threads (path + line range + body). They have NO thread ID, so Step 6's `resolveReviewThread` mutation cannot apply; address by fixing the code and noting the commit in your push message.
+**Out-of-diff findings** (from `/tmp/reviews.json`) — present alongside inline threads as pseudo-threads (path + line range + body). They have NO thread ID, so Step 6's `resolveReviewThread` mutation cannot apply; address by fixing the code and noting the fix in the next commit message.
 
 **CI failures:**
 


### PR DESCRIPTION
## Summary

Two AI-tooling improvements, both surfaced while working through PR #1251 review feedback:

### 1. `fix-pr` skill: handle CodeRabbit out-of-diff comments

Previously, `.claude/skills/fix-pr/SKILL.md` Step 2 only fetched inline review *threads* via the `reviewThreads` GraphQL query. CodeRabbit posts findings for code outside the diff range as a section of its top-level review *body*, wrapped in a `[!CAUTION]` callout and a nested `<details><blockquote>` tree. Those never appear in `reviewThreads` and were silently dropped — on PR #1251 a real `ConvertSeq`-not-guarded finding nearly slipped through.

The skill now:

- Fetches `gh api repos/<owner>/<repo>/pulls/<n>/reviews` in parallel with `reviewThreads`
- Documents the markers (`Outside diff range comments` / `Some comments are outside the diff`) and the nested-`<details>` structure (with the `> ` blockquote prefix from the `[!CAUTION]` callout)
- Surfaces findings as pseudo-threads (path + line range + body) presented alongside inline threads
- Flags in Step 6 that out-of-diff findings have no thread ID and so cannot be resolved via `resolveReviewThread` — fix the code and note in the commit message instead

### 2. `problem-handling` rule: require concrete examples in `KNOWN_ISSUES.md`

`.claude/rules/problem-handling.md` now requires an **Example / Repro** field on every entry. The new "Entry Quality" section enumerates the four artefact shapes:

- Failing test name + bottom of the traceback (runtime bugs)
- Short code snippet (codegen / printer / pass issues)
- Exact CLI command + error message (build / tooling)
- Grep query + counts (inventory observations)

`N/A` is reserved for purely descriptive issues (doc gap, naming concern). The Description-field guidance is also tightened to require actual-vs-expected behaviour (with a ✅/❌ contrast example).

This makes future entries self-contained — a future reader (or `/create-issue`) can act on them without re-deriving the context.

## File Changes

- `.claude/skills/fix-pr/SKILL.md` (+15/-1)
- `.claude/rules/problem-handling.md` (+18/-2)

## Testing

- [x] Code review completed (via `/code-review` skill — passed with one minor markdown nit applied before commit)
- [x] No code/test/clang-tidy hooks needed (docs/rules only — pre-commit hooks confirmed)
- [x] Both files within the 200-line limit per `.claude/rules/documentation-length.md` (problem-handling at 103, fix-pr at 193)