### PR TITLE
refactor(parser): Move op type-checking to DSL wrappers

### DIFF
--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -10,24 +10,51 @@
 """Utility functions for IR construction."""
 
 import inspect
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
 
+# Span pinned by the DSL parser while invoking a wrapper. When set, IR
+# builders that fall back via ``_get_span_or_capture`` use this in preference
+# to frame-capture, so nodes constructed inside DSL wrappers carry the
+# call-site span rather than the wrapper file's own line.
+_PARSER_SPAN: ContextVar[_ir.Span | None] = ContextVar("_PARSER_SPAN", default=None)
+
+
+@contextmanager
+def use_parser_span(span: _ir.Span) -> Iterator[None]:
+    """Temporarily pin the parser span seen by ``_get_span_or_capture``."""
+    token = _PARSER_SPAN.set(span)
+    try:
+        yield
+    finally:
+        _PARSER_SPAN.reset(token)
+
 
 def _get_span_or_capture(span: _ir.Span | None = None, frame_offset: int = 1) -> _ir.Span:
-    """Get explicit span or capture from caller.
+    """Get explicit span, parser-pinned span, or captured frame span.
+
+    Resolution order:
+      1. Explicit ``span`` argument when provided.
+      2. ``_PARSER_SPAN`` contextvar (set by the DSL parser).
+      3. Frame capture from ``frame_offset`` levels up the Python stack.
 
     Args:
         span: Explicit span if provided
         frame_offset: Additional frames to skip beyond immediate caller
 
     Returns:
-        Provided span or captured span from call site
+        Provided span, parser-pinned span, or captured span from call site
     """
     if span is not None:
         return span
+
+    parser_span = _PARSER_SPAN.get()
+    if parser_span is not None:
+        return parser_span
 
     frame = inspect.currentframe()
     if frame is not None:
@@ -162,4 +189,5 @@ __all__ = [
     "_normalize_shape",
     "_to_make_tuple",
     "resolve_cast_mode",
+    "use_parser_span",
 ]

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -26,13 +26,29 @@ from . import system_ops as system
 from . import tensor_ops as tensor
 from . import tile_ops as tile
 
+# Promoted system ops (accessible as pl.tfree_to_aic, etc.)
+from .system_ops import (
+    aic_initialize_pipe,
+    aiv_initialize_pipe,
+    import_peer_buffer,
+    reserve_buffer,
+    tfree_to_aic,
+    tfree_to_aiv,
+    tpop_from_aic,
+    tpop_from_aiv,
+    tpush_to_aic,
+    tpush_to_aiv,
+)
+
 # Promoted tensor-only ops (accessible as pl.create_tensor, etc.)
-from .tensor_ops import assemble, dim, expand_clone, scatter_update
+from .tensor_ops import assemble, dim, expand_clone, full, scatter_update
+from .tensor_ops import ci as arange
 from .tensor_ops import create as create_tensor
 
-# Promoted tile-only ops (accessible as pl.load, etc.)
+# Promoted tile-only ops (accessible as pl.load, etc.). ``abs`` and
+# ``create_tile`` are re-exported below from ``unified_ops`` instead so
+# the unified Tensor/Tile dispatch wins.
 from .tile_ops import (
-    abs,
     addc,
     addsc,
     and_,
@@ -73,13 +89,15 @@ from .tile_ops import (
     xor,
     xors,
 )
-from .tile_ops import (
-    create as create_tile,
-)
 
-# Unified dispatch (overlapping ops)
+# Unified dispatch (overlapping ops). Imported AFTER tile_ops so the
+# unified versions override any same-named imports above (e.g. ``abs``,
+# ``create_tile``) — direct ``pl.abs(tensor)`` users get the unified
+# dispatch rather than the Tile-only path.
 from .unified_ops import (
+    abs,  # noqa: A004 (intentionally shadows builtin via DSL surface)
     add,
+    batch_matmul,
     cast,
     col_expand,
     col_expand_div,
@@ -88,6 +106,8 @@ from .unified_ops import (
     col_max,
     col_min,
     col_sum,
+    concat,
+    create_tile,
     div,
     exp,
     expands,
@@ -97,6 +117,7 @@ from .unified_ops import (
     maximum,
     mul,
     neg,
+    read,
     recip,
     reshape,
     row_expand,
@@ -112,6 +133,7 @@ from .unified_ops import (
     sqrt,
     sub,
     transpose,
+    write,
 )
 
 __all__ = [
@@ -154,7 +176,11 @@ __all__ = [
     "expand_clone",
     "expands",
     "neg",
+    "read",
     "recip",
+    "write",
+    "concat",
+    "batch_matmul",
     # Promoted tile-only
     "create_tile",
     "fillpad",
@@ -196,8 +222,22 @@ __all__ = [
     "sel",
     "sels",
     # Promoted tensor-only
+    "arange",
     "create_tensor",
     "assemble",
     "dim",
+    "expand_clone",
+    "full",
     "scatter_update",
+    # Promoted system ops
+    "aic_initialize_pipe",
+    "aiv_initialize_pipe",
+    "import_peer_buffer",
+    "reserve_buffer",
+    "tfree_to_aic",
+    "tfree_to_aiv",
+    "tpop_from_aic",
+    "tpop_from_aiv",
+    "tpush_to_aic",
+    "tpush_to_aiv",
 ]

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -74,6 +74,7 @@ __all__ = [
 
 from pypto.ir.op import tensor_ops as _ir_ops
 from pypto.pypto_core import DataType
+from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, TensorLayout
 
 from ..typing import IntLike, Scalar, Tensor
@@ -156,16 +157,19 @@ def write(tensor: Tensor, indices: IntLike | Sequence[IntLike], value: Scalar | 
     return _ir_ops.write(tensor.unwrap(), _normalize_intlike(indices_seq), value_expr)
 
 
-def dim(tensor: Tensor, axis: int) -> Scalar:
+def dim(tensor: Tensor, axis: int | _ir_core.ConstInt) -> Scalar:
     """Extract a shape dimension from a tensor as a scalar value.
 
     Args:
         tensor: Input tensor
-        axis: Dimension index (supports negative indexing)
+        axis: Dimension index (supports negative indexing). Accepts either
+            a Python ``int`` or a ``ConstInt`` (parser-shape).
 
     Returns:
         Scalar wrapping the dim operation (INT64)
     """
+    if isinstance(axis, _ir_core.ConstInt):
+        axis = int(axis.value)
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.dim(tensor_expr, axis)
     return Scalar(expr=call_expr)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -15,7 +15,7 @@ that accept and return Tensor types instead of raw Expr/Call objects.
 
 import warnings
 from collections.abc import Sequence
-from typing import overload
+from typing import Any, overload
 
 __all__ = [
     "create_tensor",
@@ -137,19 +137,23 @@ def read(tensor: Tensor, indices: IntLike | Sequence[IntLike]) -> Scalar:
     return Scalar(expr=call_expr)
 
 
-def write(tensor: Tensor, indices: IntLike | Sequence[IntLike], value: Scalar) -> None:
+def write(tensor: Tensor, indices: IntLike | Sequence[IntLike], value: Scalar | Expr) -> Expr:
     """Write a scalar value into a tensor at given indices.
 
     Args:
         tensor: Destination tensor
         indices: A single index expression (for 1-D flat access) or a list of
             index expressions (one per tensor dimension)
-        value: Scalar value to write
+        value: Scalar value to write (DSL Scalar or raw Expr)
+
+    Returns:
+        The underlying ``tensor.write`` call expression. Direct callers
+        typically ignore it; the DSL parser surfaces it as an ``EvalStmt``.
     """
     # Allow a bare IntLike as a flat 1-D index for backwards compatibility
     indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
-    call_expr = _ir_ops.write(tensor.unwrap(), _normalize_intlike(indices_seq), value.unwrap())
-    _ = call_expr  # result is the tensor itself; discarded here
+    value_expr = value.unwrap() if isinstance(value, Scalar) else value
+    return _ir_ops.write(tensor.unwrap(), _normalize_intlike(indices_seq), value_expr)
 
 
 def dim(tensor: Tensor, axis: int) -> Scalar:
@@ -344,7 +348,7 @@ def matmul_acc(
     return Tensor(expr=call_expr)
 
 
-def mul(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
+def mul(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr) -> Tensor:
     """Element-wise multiplication of tensor and tensor or scalar.
 
     Automatically selects between tensor.mul (tensor x tensor) and
@@ -377,7 +381,7 @@ def muls(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def add(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
+def add(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr) -> Tensor:
     """Element-wise addition of tensor and tensor or scalar.
 
     Automatically selects between tensor.add (tensor + tensor) and
@@ -410,7 +414,7 @@ def adds(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def sub(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
+def sub(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr) -> Tensor:
     """Element-wise subtraction of tensor and tensor or scalar.
 
     Automatically selects between tensor.sub (tensor - tensor) and
@@ -443,7 +447,7 @@ def subs(lhs: Tensor, rhs: int | float | Expr | Scalar) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def div(lhs: Tensor, rhs: int | float | Tensor | Scalar) -> Tensor:
+def div(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr) -> Tensor:
     """Element-wise division of tensor and tensor or scalar.
 
     Automatically selects between tensor.div (tensor / tensor) and
@@ -881,29 +885,26 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def scatter_update(
-    input: Tensor,
-    dim: int,
-    index: Tensor,
-    src: Tensor,
-) -> Tensor:
+def scatter_update(input: Tensor, *args: Any, **kwargs: Any) -> Tensor:
     """Update input tensor rows at positions specified by 2D index with values from src.
 
-    Supports two variants based on input/src rank:
-    - 2D: input [rows, d], src [b*s, d], index [b, s]
-    - 4D: input [blockNum, blockSize, 1, d], src [b, s, 1, d], index [b, s]
+    Accepts the same flexible call shapes as the IR builder
+    ``pypto.ir.op.tensor.scatter_update``:
 
-    Args:
-        input: Destination tensor (2D or 4D)
-        dim: Dimension to scatter along (currently only -2 is supported)
-        index: 2D index tensor [b, s] of integer dtype
-        src: Source tensor (2D [b*s, d] or 4D [b, s, 1, d])
+    - ``scatter_update(input, dim, index, src)``
+    - ``scatter_update(input, index, src, dim=-2)``
+    - ``scatter_update(input, dim, index=..., src=...)``
 
-    Returns:
-        Tensor wrapping the scatter_update operation
+    Tensor / Scalar wrappers are unwrapped before forwarding so the IR
+    builder receives raw ``Expr`` operands.
     """
-    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap())
-    return Tensor(expr=call_expr)
+
+    def _unwrap(v: Any) -> Any:
+        return v.unwrap() if isinstance(v, (Tensor, Scalar)) else v
+
+    fwd_args = tuple(_unwrap(a) for a in args)
+    fwd_kwargs = {k: _unwrap(v) for k, v in kwargs.items()}
+    return Tensor(expr=_ir_ops.scatter_update(input.unwrap(), *fwd_args, **fwd_kwargs))
 
 
 def sort32(src: Tensor, idx: Tensor) -> Tensor:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -128,6 +128,7 @@ __all__ = [
 ]
 
 from pypto.ir.op import tile_ops as _ir_ops
+from pypto.ir.utils import _get_span_or_capture
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, TileLayout
@@ -201,13 +202,39 @@ def _scalar_operand_to_expr(value: int | Scalar | Expr) -> Expr:
 
     Used by the scalar-pair branches of ``tile.min`` / ``tile.max``: ``Scalar``
     is unwrapped to its inner ``Expr``, raw ``Expr`` is forwarded as-is, and a
-    bare ``int`` is materialized as ``ConstInt(.., INT32)``.
+    bare ``int`` is materialized as ``ConstInt(.., INDEX)`` with the span
+    pinned by the parser if any (so error messages and dumps point at the
+    user's source line, not this wrapper). ``INDEX`` matches the dtype the
+    parser uses for plain int literals, so round-tripped programs don't
+    sprout spurious casts on otherwise-equivalent constants.
     """
     if isinstance(value, Scalar):
         return value.unwrap()
     if isinstance(value, Expr):
         return value
-    return _ir_core.ConstInt(value, DataType.INT32, _ir_core.Span.unknown())
+    return _ir_core.ConstInt(value, DataType.INDEX, _get_span_or_capture())
+
+
+def _axis_to_int(axis: int | Scalar | Expr) -> int:
+    """Coerce a compile-time axis argument to a Python ``int``.
+
+    The parser passes integer literals through as raw ``ConstInt`` (to
+    preserve dtype) — accept that shape and unwrap. Direct callers can
+    still pass a bare ``int``.
+    """
+    if isinstance(axis, bool):  # bool is an int subclass; reject explicitly
+        raise TypeError(f"axis must be int, got bool ({axis!r})")
+    if isinstance(axis, int):
+        return axis
+    if isinstance(axis, _ir_core.ConstInt):
+        return int(axis.value)
+    if isinstance(axis, Scalar):
+        inner = axis.unwrap()
+        if isinstance(inner, _ir_core.ConstInt):
+            return int(inner.value)
+    raise TypeError(
+        f"axis must be a compile-time int (or ConstInt/Scalar wrapping one), got {type(axis).__name__}"
+    )
 
 
 def create(
@@ -1241,7 +1268,7 @@ def sum(tile: Tile, axis: int, keepdim: bool = False) -> Tile:
     Returns:
         Tile wrapping the sum operation
     """
-    call_expr = _ir_ops.sum(tile.unwrap(), axis, keepdim)
+    call_expr = _ir_ops.sum(tile.unwrap(), _axis_to_int(axis), keepdim)
     return Tile(expr=call_expr)
 
 
@@ -1266,8 +1293,7 @@ def max(tile: Tile | Scalar, axis: int | Scalar | Expr = 0, keepdim: bool = Fals
     """
     if isinstance(tile, Scalar):
         return Scalar(expr=_ir_core.max_(tile.unwrap(), _scalar_operand_to_expr(axis)))
-    assert isinstance(axis, int)
-    call_expr = _ir_ops.max(tile.unwrap(), axis, keepdim)
+    call_expr = _ir_ops.max(tile.unwrap(), _axis_to_int(axis), keepdim)
     return Tile(expr=call_expr)
 
 
@@ -1302,8 +1328,7 @@ def min(
         lhs = _scalar_operand_to_expr(tile)
         rhs = _scalar_operand_to_expr(axis)
         return Scalar(expr=_ir_core.min_(lhs, rhs))
-    assert isinstance(axis, int)
-    call_expr = _ir_ops.min(tile.unwrap(), axis, keepdim)
+    call_expr = _ir_ops.min(tile.unwrap(), _axis_to_int(axis), keepdim)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -17,7 +17,7 @@ Accessed as ``pl.tile.*``
 
 import warnings
 from collections.abc import Sequence
-from typing import overload
+from typing import Any, overload
 
 __all__ = [
     "MemRefType",
@@ -196,6 +196,20 @@ def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
 
 
+def _scalar_operand_to_expr(value: int | Scalar | Expr) -> Expr:
+    """Coerce a scalar-binary operand to an ``Expr``.
+
+    Used by the scalar-pair branches of ``tile.min`` / ``tile.max``: ``Scalar``
+    is unwrapped to its inner ``Expr``, raw ``Expr`` is forwarded as-is, and a
+    bare ``int`` is materialized as ``ConstInt(.., INT32)``.
+    """
+    if isinstance(value, Scalar):
+        return value.unwrap()
+    if isinstance(value, Expr):
+        return value
+    return _ir_core.ConstInt(value, DataType.INT32, _ir_core.Span.unknown())
+
+
 def create(
     shape: Sequence[IntLike],
     dtype: DataType,
@@ -241,27 +255,31 @@ def read(tile: Tile, indices: IntLike | Sequence[IntLike]) -> Scalar:
     return Scalar(expr=call_expr)
 
 
-def write(tile: Tile, indices: IntLike | Sequence[IntLike], value: Scalar) -> None:
+def write(tile: Tile, indices: IntLike | Sequence[IntLike], value: Scalar | Expr) -> Expr:
     """Write a scalar value into a tile at given indices.
 
     Args:
         tile: Destination tile
         indices: A single index expression (for 1-D flat access) or a list of
             index expressions (one per tile dimension)
-        value: Scalar value to write
+        value: Scalar value to write (DSL Scalar or raw Expr)
+
+    Returns:
+        The underlying ``tile.write`` call expression. Direct callers
+        typically ignore it; the DSL parser surfaces it as an ``EvalStmt``.
     """
     # Allow a bare IntLike as a flat 1-D index for backwards compatibility
     indices_seq: Sequence[IntLike] = [indices] if not isinstance(indices, Sequence) else indices
-    call_expr = _ir_ops.write(tile.unwrap(), _normalize_intlike(indices_seq), value.unwrap())
-    _ = call_expr  # result is the tile itself; discarded here
+    value_expr = value.unwrap() if isinstance(value, Scalar) else value
+    return _ir_ops.write(tile.unwrap(), _normalize_intlike(indices_seq), value_expr)
 
 
 def load(
     tensor: Tensor,
     offsets: Sequence[IntLike],
     shapes: Sequence[IntLike],
-    target_memory: MemorySpace = MemorySpace.Vec,
     valid_shapes: Sequence[IntLike] | None = None,
+    target_memory: MemorySpace = MemorySpace.Vec,
     transpose: bool = False,
 ) -> Tile:
     """Copy data from tensor to unified buffer (tile).
@@ -379,27 +397,26 @@ def extract(
     return Tile(expr=call_expr)
 
 
-def scatter_update(
-    input: Tile,
-    dim: int,
-    index: Tile,
-    src: Tile,
-    scratch: Tile,
-) -> Tile:
+def scatter_update(input: Tile, *args: Any, **kwargs: Any) -> Tile:
     """Update tile rows at positions specified by 2D index tile with values from src.
 
-    Args:
-        input: Destination tile (2D or 4D)
-        dim: Dimension to scatter along (currently only -2 is supported)
-        index: 2D index tile [b, s] of integer dtype
-        src: Source tile (same rank as input)
-        scratch: [1, d] scratch row tile (Vec memory) used as the per-row staging buffer
+    Accepts the same flexible call shapes as the IR builder
+    ``pypto.ir.op.tile.scatter_update``:
 
-    Returns:
-        Tile wrapping the scatter_update operation
+    - ``scatter_update(input, dim, index, src, scratch)``
+    - ``scatter_update(input, index, src, scratch, dim=-2)``
+    - ``scatter_update(input, dim, index=..., src=..., scratch=...)``
+
+    Tile / Scalar wrappers are unwrapped before forwarding so the IR builder
+    receives raw ``Expr`` operands.
     """
-    call_expr = _ir_ops.scatter_update(input.unwrap(), dim, index.unwrap(), src.unwrap(), scratch.unwrap())
-    return Tile(expr=call_expr)
+
+    def _unwrap(v: Any) -> Any:
+        return v.unwrap() if isinstance(v, (Tile, Scalar)) else v
+
+    fwd_args = tuple(_unwrap(a) for a in args)
+    fwd_kwargs = {k: _unwrap(v) for k, v in kwargs.items()}
+    return Tile(expr=_ir_ops.scatter_update(input.unwrap(), *fwd_args, **fwd_kwargs))
 
 
 def concat(src0: Tile, src1: Tile) -> Tile:
@@ -566,7 +583,7 @@ def get_block_num() -> Scalar:
     return Scalar(expr=call_expr)
 
 
-def add(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+def add(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise addition of tile and tile or scalar.
 
     Args:
@@ -580,7 +597,7 @@ def add(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
     return Tile(expr=call_expr)
 
 
-def sub(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+def sub(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise subtraction of tile and tile or scalar.
 
     Args:
@@ -594,7 +611,7 @@ def sub(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
     return Tile(expr=call_expr)
 
 
-def mul(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+def mul(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise multiplication of tile and tile or scalar.
 
     Args:
@@ -608,7 +625,7 @@ def mul(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
     return Tile(expr=call_expr)
 
 
-def div(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile:
+def div(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise division of tile and tile or scalar.
 
     Args:
@@ -1236,7 +1253,7 @@ def max(tile: Tile, axis: int, keepdim: bool = False) -> Tile: ...
 def max(tile: Scalar, axis: Scalar | int, keepdim: bool = False) -> Scalar: ...
 
 
-def max(tile: Tile | Scalar, axis: int | Scalar = 0, keepdim: bool = False) -> Tile | Scalar:
+def max(tile: Tile | Scalar, axis: int | Scalar | Expr = 0, keepdim: bool = False) -> Tile | Scalar:
     """Max reduction along specified axis, or scalar max of two values.
 
     Args:
@@ -1248,12 +1265,7 @@ def max(tile: Tile | Scalar, axis: int | Scalar = 0, keepdim: bool = False) -> T
         Tile or Scalar wrapping the max operation
     """
     if isinstance(tile, Scalar):
-        rhs: Expr = (
-            axis.unwrap()
-            if isinstance(axis, Scalar)
-            else _ir_core.ConstInt(axis, DataType.INT32, _ir_core.Span.unknown())
-        )
-        return Scalar(expr=_ir_core.max_(tile.unwrap(), rhs))
+        return Scalar(expr=_ir_core.max_(tile.unwrap(), _scalar_operand_to_expr(axis)))
     assert isinstance(axis, int)
     call_expr = _ir_ops.max(tile.unwrap(), axis, keepdim)
     return Tile(expr=call_expr)
@@ -1271,7 +1283,11 @@ def min(tile: Scalar, axis: Scalar | int, keepdim: bool = False) -> Scalar: ...
 def min(tile: int, axis: Scalar | int, keepdim: bool = False) -> Scalar: ...
 
 
-def min(tile: Tile | Scalar | int, axis: int | Scalar = 0, keepdim: bool = False) -> Tile | Scalar:
+def min(
+    tile: Tile | Scalar | int | Expr,
+    axis: int | Scalar | Expr = 0,
+    keepdim: bool = False,
+) -> Tile | Scalar:
     """Min reduction along specified axis, or scalar min of two values.
 
     Args:
@@ -1282,17 +1298,9 @@ def min(tile: Tile | Scalar | int, axis: int | Scalar = 0, keepdim: bool = False
     Returns:
         Tile or Scalar wrapping the min operation
     """
-    if isinstance(tile, (Scalar, int)):
-        lhs: Expr = (
-            tile.unwrap()
-            if isinstance(tile, Scalar)
-            else _ir_core.ConstInt(tile, DataType.INT32, _ir_core.Span.unknown())
-        )
-        rhs: Expr = (
-            axis.unwrap()
-            if isinstance(axis, Scalar)
-            else _ir_core.ConstInt(axis, DataType.INT32, _ir_core.Span.unknown())
-        )
+    if isinstance(tile, (Scalar, int, Expr)):
+        lhs = _scalar_operand_to_expr(tile)
+        rhs = _scalar_operand_to_expr(axis)
         return Scalar(expr=_ir_core.min_(lhs, rhs))
     assert isinstance(axis, int)
     call_expr = _ir_ops.min(tile.unwrap(), axis, keepdim)

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -16,7 +16,7 @@ or ``pl.tile.add``.
 """
 
 from collections.abc import Sequence
-from typing import NoReturn, TypeVar, overload
+from typing import Any, NoReturn, TypeVar, overload
 
 __all__ = [
     "add",
@@ -60,7 +60,7 @@ __all__ = [
     "write",
 ]
 
-from pypto.ir.utils import resolve_cast_mode
+from pypto.ir.utils import _get_span_or_capture, resolve_cast_mode
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import MemorySpace, PadValue
@@ -96,6 +96,38 @@ def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
     raise TypeError(f"{qualified}: expected Tensor or Tile operands, got ({types})")
 
 
+def _is_scalar_like(v: object) -> bool:
+    """True for Scalar, Python int/float, or raw Expr with ScalarType.
+
+    Used by the unified arithmetic wrappers so parser-shaped operands
+    (raw ``ConstInt`` / ``ConstFloat`` literals, IR scalar Vars, etc.)
+    flow through the scalar branch alongside DSL ``Scalar`` and Python
+    literals.
+    """
+    if isinstance(v, (Scalar, int, float)):
+        return True
+    return isinstance(v, _ir_core.Expr) and isinstance(v.type, _ir_core.ScalarType)
+
+
+def _to_scalar_expr(v: Any) -> _ir_core.Expr:
+    """Coerce a scalar-like value to an ``Expr``.
+
+    Caller must have already passed :func:`_is_scalar_like`. ``Scalar`` is
+    unwrapped, raw ``Expr`` is returned as-is, and Python ``int`` / ``float``
+    are materialized as ``ConstInt`` / ``ConstFloat`` with the parser-pinned
+    span (or frame-captured fallback).
+    """
+    if isinstance(v, Scalar):
+        return v.unwrap()
+    if isinstance(v, _ir_core.Expr):
+        return v
+    if isinstance(v, bool):  # bool is an int subclass; reject explicitly
+        raise TypeError(f"scalar arithmetic does not accept bool, got {v!r}")
+    if isinstance(v, int):
+        return _ir_core.ConstInt(v, DataType.INDEX, _get_span_or_capture())
+    return _ir_core.ConstFloat(float(v), DataType.DEFAULT_CONST_FLOAT, _get_span_or_capture())
+
+
 # ---------------------------------------------------------------------------
 # Binary arithmetic with scalar auto-dispatch
 # ---------------------------------------------------------------------------
@@ -117,8 +149,8 @@ def add(lhs, rhs):
         return _tile.add(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.adds(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
-        return lhs + rhs
+    if _is_scalar_like(lhs) and _is_scalar_like(rhs):
+        return Scalar(expr=_to_scalar_expr(lhs) + _to_scalar_expr(rhs))
     _raise_type_dispatch_error("add", lhs, rhs)
 
 
@@ -139,8 +171,8 @@ def sub(lhs, rhs):
         return _tile.sub(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.subs(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
-        return lhs - rhs
+    if _is_scalar_like(lhs) and _is_scalar_like(rhs):
+        return Scalar(expr=_to_scalar_expr(lhs) - _to_scalar_expr(rhs))
     _raise_type_dispatch_error("sub", lhs, rhs)
 
 
@@ -161,8 +193,8 @@ def mul(lhs, rhs):
         return _tile.mul(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.muls(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
-        return lhs * rhs
+    if _is_scalar_like(lhs) and _is_scalar_like(rhs):
+        return Scalar(expr=_to_scalar_expr(lhs) * _to_scalar_expr(rhs))
     _raise_type_dispatch_error("mul", lhs, rhs)
 
 
@@ -183,8 +215,8 @@ def div(lhs, rhs):
         return _tile.div(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.divs(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
-        return lhs / rhs
+    if _is_scalar_like(lhs) and _is_scalar_like(rhs):
+        return Scalar(expr=_to_scalar_expr(lhs) / _to_scalar_expr(rhs))
     _raise_type_dispatch_error("div", lhs, rhs)
 
 
@@ -609,11 +641,11 @@ def cast(
         return _tensor.cast(input, target_type, mode)
     if isinstance(input, Tile):
         return _tile.cast(input, target_type, mode)
-    if isinstance(input, Scalar):
+    if _is_scalar_like(input):
         if resolve_cast_mode(mode) != 2:
             raise ValueError(f"cast: Scalar inputs do not support non-default mode, got mode={mode!r}")
         dtype = DataType(target_type) if isinstance(target_type, int) else target_type
-        return Scalar(expr=_ir_core.cast(input.unwrap(), dtype))
+        return Scalar(expr=_ir_core.cast(_to_scalar_expr(input), dtype))
     raise TypeError(f"pl.cast: expected Tensor, Tile, or Scalar, got {type(input).__name__}")
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -77,17 +77,23 @@ T = TypeVar("T", Tensor, Tile)
 
 
 def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
-    """Raise TypeError for mixed Tensor/Tile or unsupported argument types."""
+    """Raise TypeError for mixed Tensor/Tile or unsupported argument types.
+
+    Op-name prefix is auto-normalized to ``pl.<op>`` so the message reads
+    consistently whether the user invoked the wrapper directly or the DSL
+    parser surfaced the error.
+    """
+    qualified = op_name if op_name.startswith("pl.") else f"pl.{op_name}"
     has_tensor = any(isinstance(a, Tensor) for a in args)
     has_tile = any(isinstance(a, Tile) for a in args)
     types = ", ".join(type(a).__name__ for a in args)
     if has_tensor and has_tile:
         raise TypeError(
-            f"{op_name}: cannot mix Tensor and Tile arguments "
+            f"{qualified}: cannot mix Tensor and Tile arguments "
             f"({types}). All operands must be the same type "
             f"level — either all Tensor or all Tile"
         )
-    raise TypeError(f"{op_name}: expected Tensor or Tile operands, got ({types})")
+    raise TypeError(f"{qualified}: expected Tensor or Tile operands, got ({types})")
 
 
 # ---------------------------------------------------------------------------
@@ -105,13 +111,13 @@ def add(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
 def add(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
 def add(lhs, rhs):
     """Element-wise addition, dispatched by input type."""
-    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
+    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar, _ir_core.Expr)):
         return _tensor.add(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.add(lhs, rhs)
-    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
+    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.adds(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
         return lhs + rhs
     _raise_type_dispatch_error("add", lhs, rhs)
 
@@ -127,13 +133,13 @@ def sub(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
 def sub(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
 def sub(lhs, rhs):
     """Element-wise subtraction, dispatched by input type."""
-    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
+    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar, _ir_core.Expr)):
         return _tensor.sub(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.sub(lhs, rhs)
-    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
+    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.subs(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
         return lhs - rhs
     _raise_type_dispatch_error("sub", lhs, rhs)
 
@@ -149,13 +155,13 @@ def mul(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
 def mul(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
 def mul(lhs, rhs):
     """Element-wise multiplication, dispatched by input type."""
-    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
+    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar, _ir_core.Expr)):
         return _tensor.mul(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.mul(lhs, rhs)
-    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
+    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.muls(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
         return lhs * rhs
     _raise_type_dispatch_error("mul", lhs, rhs)
 
@@ -171,13 +177,13 @@ def div(lhs: Tile, rhs: Tile | int | float | Scalar) -> Tile: ...
 def div(lhs: Scalar, rhs: Scalar | int | float) -> Scalar: ...
 def div(lhs, rhs):
     """Element-wise division, dispatched by input type."""
-    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar)):
+    if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar, _ir_core.Expr)):
         return _tensor.div(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.div(lhs, rhs)
-    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar)):
+    if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         return _tile.divs(lhs, rhs)
-    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float)):
+    if isinstance(lhs, Scalar) and isinstance(rhs, (Scalar, int, float, _ir_core.Expr)):
         return lhs / rhs
     _raise_type_dispatch_error("div", lhs, rhs)
 
@@ -202,7 +208,7 @@ def exp(input: T) -> T:
         return _tensor.exp(input)
     if isinstance(input, Tile):
         return _tile.exp(input)
-    raise TypeError(f"exp: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.exp: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def neg(input: T) -> T:
@@ -211,7 +217,7 @@ def neg(input: T) -> T:
         return _tensor.neg(input)
     if isinstance(input, Tile):
         return _tile.neg(input)
-    raise TypeError(f"neg: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.neg: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def abs(input: T) -> T:
@@ -220,7 +226,7 @@ def abs(input: T) -> T:
         return _tensor.abs(input)
     if isinstance(input, Tile):
         return _tile.abs(input)
-    raise TypeError(f"abs: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.abs: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def recip(input: T) -> T:
@@ -229,7 +235,7 @@ def recip(input: T) -> T:
         return _tensor.recip(input)
     if isinstance(input, Tile):
         return _tile.recip(input)
-    raise TypeError(f"recip: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.recip: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def sqrt(input: T) -> T:
@@ -238,7 +244,7 @@ def sqrt(input: T) -> T:
         return _tensor.sqrt(input)
     if isinstance(input, Tile):
         return _tile.sqrt(input)
-    raise TypeError(f"sqrt: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.sqrt: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def rsqrt(input: T, high_precision: bool = False) -> T:
@@ -253,7 +259,7 @@ def rsqrt(input: T, high_precision: bool = False) -> T:
         return _tensor.rsqrt(input, high_precision=high_precision)
     if isinstance(input, Tile):
         return _tile.rsqrt(input)
-    raise TypeError(f"rsqrt: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.rsqrt: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def row_expand_mul(lhs: T, rhs: T) -> T:
@@ -343,7 +349,7 @@ def expands(target: Tensor | Tile, scalar: int | float | Scalar) -> Tensor | Til
         return _tensor.expands(target, scalar)
     if isinstance(target, Tile):
         return _tile.expands(target, scalar)
-    raise TypeError(f"expands: expected Tensor or Tile, got {type(target).__name__}")
+    raise TypeError(f"pl.expands: expected Tensor or Tile, got {type(target).__name__}")
 
 
 def reshape(input: T, shape: Sequence[IntLike]) -> T:
@@ -352,7 +358,7 @@ def reshape(input: T, shape: Sequence[IntLike]) -> T:
         return _tensor.reshape(input, shape)
     if isinstance(input, Tile):
         return _tile.reshape(input, shape)
-    raise TypeError(f"reshape: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.reshape: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def transpose(input: T, axis1: int, axis2: int) -> T:
@@ -361,7 +367,7 @@ def transpose(input: T, axis1: int, axis2: int) -> T:
         return _tensor.transpose(input, axis1, axis2)
     if isinstance(input, Tile):
         return _tile.transpose(input, axis1, axis2)
-    raise TypeError(f"transpose: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.transpose: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def concat(src0: T, src1: T) -> T:
@@ -384,7 +390,7 @@ def slice(
         return _tensor.slice(input, shape, offset, valid_shape)
     if isinstance(input, Tile):
         return _tile.slice(input, shape, offset, valid_shape)
-    raise TypeError(f"slice: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.slice: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def fillpad(value: T, pad_value: PadValue | int | float = PadValue.zero) -> T:
@@ -398,7 +404,7 @@ def fillpad(value: T, pad_value: PadValue | int | float = PadValue.zero) -> T:
         return _tensor.fillpad(value, pad_value)
     if isinstance(value, Tile):
         return _tile.fillpad(value, pad_value)
-    raise TypeError(f"fillpad: expected Tensor or Tile, got {type(value).__name__}")
+    raise TypeError(f"pl.fillpad: expected Tensor or Tile, got {type(value).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -511,7 +517,7 @@ def row_max(input: T, tmp_tile: Tile | None = None) -> T:
         if tmp_tile is None:
             raise ValueError("row_max on Tile requires tmp_tile argument")
         return _tile.row_max(input, tmp_tile)
-    raise TypeError(f"row_max: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.row_max: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def row_sum(input: T, tmp_tile: Tile | None = None) -> T:
@@ -526,7 +532,7 @@ def row_sum(input: T, tmp_tile: Tile | None = None) -> T:
         if tmp_tile is None:
             raise ValueError("row_sum on Tile requires tmp_tile argument")
         return _tile.row_sum(input, tmp_tile)
-    raise TypeError(f"row_sum: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.row_sum: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def row_min(input: T, tmp_tile: Tile | None = None) -> T:
@@ -541,7 +547,7 @@ def row_min(input: T, tmp_tile: Tile | None = None) -> T:
         if tmp_tile is None:
             raise ValueError("row_min on Tile requires tmp_tile argument")
         return _tile.row_min(input, tmp_tile)
-    raise TypeError(f"row_min: expected Tensor or Tile, got {type(input).__name__}")
+    raise TypeError(f"pl.row_min: expected Tensor or Tile, got {type(input).__name__}")
 
 
 def col_sum(input: T, tmp_tile: Tile | None = None) -> T:
@@ -608,7 +614,7 @@ def cast(
             raise ValueError(f"cast: Scalar inputs do not support non-default mode, got mode={mode!r}")
         dtype = DataType(target_type) if isinstance(target_type, int) else target_type
         return Scalar(expr=_ir_core.cast(input.unwrap(), dtype))
-    raise TypeError(f"cast: expected Tensor, Tile, or Scalar, got {type(input).__name__}")
+    raise TypeError(f"pl.cast: expected Tensor, Tile, or Scalar, got {type(input).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -641,10 +647,14 @@ def read(src: Tensor | Tile, offset: IntLike | Sequence[IntLike]) -> Scalar:
         return _tensor.read(src, offset)
     if isinstance(src, Tile):
         return _tile.read(src, offset)
-    raise TypeError(f"read: expected Tensor or Tile, got {type(src).__name__}")
+    raise TypeError(f"pl.read: expected Tensor or Tile, got {type(src).__name__}")
 
 
-def write(dst: Tensor | Tile, offset: IntLike | Sequence[IntLike], value: Scalar) -> None:
+def write(
+    dst: Tensor | Tile,
+    offset: IntLike | Sequence[IntLike],
+    value: Scalar,
+) -> _ir_core.Expr:
     """Write a scalar value to a tensor or tile at given indices.
 
     Args:
@@ -652,9 +662,13 @@ def write(dst: Tensor | Tile, offset: IntLike | Sequence[IntLike], value: Scalar
         offset: A single index expression (for 1-D flat access) or index list
             (one per dimension) into the destination
         value: Scalar value to write
+
+    Returns:
+        Underlying ``tensor.write`` / ``tile.write`` call expression. Direct
+        callers ignore it; the DSL parser surfaces it as an ``EvalStmt``.
     """
     if isinstance(dst, Tensor):
         return _tensor.write(dst, offset, value)
     if isinstance(dst, Tile):
         return _tile.write(dst, offset, value)
-    raise TypeError(f"write: expected Tensor or Tile, got {type(dst).__name__}")
+    raise TypeError(f"pl.write: expected Tensor or Tile, got {type(dst).__name__}")

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -654,8 +654,17 @@ def cast(
 # ---------------------------------------------------------------------------
 
 
-def create_tile(shape: list[int], dtype: DataType, target_memory: MemorySpace) -> Tile:
-    """Create a tile at specific memory space."""
+def create_tile(
+    shape: list[int],
+    dtype: DataType,
+    target_memory: MemorySpace = MemorySpace.Vec,
+) -> Tile:
+    """Create a tile at specific memory space.
+
+    ``target_memory`` defaults to ``Vec`` to match the underlying
+    ``tile.create`` wrapper — direct callers like
+    ``pl.create_tile(shape, dtype)`` (omitting target_memory) keep working.
+    """
     return _tile.create(shape, dtype, target_memory)
 
 

--- a/python/pypto/language/parser/_dsl_invoker.py
+++ b/python/pypto/language/parser/_dsl_invoker.py
@@ -1,0 +1,91 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Parse-time invocation of DSL op wrappers.
+
+Bridges the parser's ``ir.Expr`` arguments to the DSL wrappers, which expect
+DSL types (``Tensor`` / ``Tile`` / ``Scalar``). The parser:
+
+  1. Parses each AST argument to an ``ir.Expr``.
+  2. Calls :func:`invoke_dsl` with the wrapper, the parsed args, and the
+     call-site span. ``invoke_dsl`` wraps each ``ir.Expr`` to its matching
+     DSL type (by inspecting ``expr.type``), pins the span via the
+     ``_PARSER_SPAN`` contextvar so IR builders inside the wrapper pick it
+     up, calls the wrapper, and unwraps the returned DSL object back to an
+     ``ir.Expr``.
+
+This collapses the dispatch the parser used to do via hand-maintained tables
+into ordinary Python attribute lookup: ``pl.add`` is just
+``pypto.language.op.add``, and the wrapper itself owns the type-based
+dispatch logic that ``_TILE_SCALAR_OPS`` / ``_SCALAR_BINARY_OPS`` etc. used
+to duplicate.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from pypto.ir.utils import use_parser_span
+from pypto.language.typing import Scalar, Tensor, Tile
+from pypto.pypto_core import ir
+
+
+def _wrap_arg(arg: Any) -> Any:
+    """Wrap a parsed ``ir.Expr`` as the matching DSL type.
+
+    Rules:
+
+    - ``MakeTuple`` (the parser's representation of a Python list literal in
+      source) is unwrapped to a Python list of its elements so wrappers that
+      expect ``Sequence[IntLike]`` (e.g. shape / offset / indices) accept it.
+    - ``ConstInt`` / ``ConstFloat`` literals are kept raw. Wrapping them as
+      ``Scalar`` would defeat downstream ``isinstance(x, int)`` fast-paths
+      (see e.g. ``tile.max(t, 0, ...)``), and every wrapper that accepts a
+      ``Scalar`` already accepts a raw ``Expr`` too.
+    - ``ir.Expr`` whose ``type`` is ``TensorType`` / ``TileType`` /
+      ``ScalarType`` is wrapped in the matching DSL class so type-dispatch in
+      the wrapper sees the right ``isinstance`` answer.
+    - Anything else (non-Expr Python values, or Expr with no matching DSL
+      class) is returned unchanged.
+    """
+    if isinstance(arg, ir.MakeTuple):
+        return list(arg.elements)
+    if not isinstance(arg, ir.Expr) or isinstance(arg, (ir.ConstInt, ir.ConstFloat)):
+        return arg
+    t = arg.type
+    if isinstance(t, ir.TensorType):
+        return Tensor(expr=arg)
+    if isinstance(t, ir.TileType):
+        return Tile(expr=arg)
+    if isinstance(t, ir.ScalarType):
+        return Scalar(expr=arg)
+    return arg
+
+
+def _unwrap_result(value: Any) -> Any:
+    """Unwrap a DSL return value to an ``ir.Expr`` for the parser to consume."""
+    if isinstance(value, (Tensor, Tile, Scalar)):
+        return value.unwrap()
+    return value
+
+
+def invoke_dsl(
+    fn: Callable[..., Any],
+    args: list[Any],
+    kwargs: dict[str, Any],
+    span: ir.Span,
+) -> Any:
+    """Wrap parsed args, invoke a DSL wrapper under a pinned span, unwrap the result."""
+    wrapped_args = [_wrap_arg(a) for a in args]
+    wrapped_kwargs = {k: _wrap_arg(v) for k, v in kwargs.items()}
+    with use_parser_span(span):
+        result = fn(*wrapped_args, **wrapped_kwargs)
+    return _unwrap_result(result)
+
+
+__all__ = ["invoke_dsl"]

--- a/python/pypto/language/parser/_dsl_invoker.py
+++ b/python/pypto/language/parser/_dsl_invoker.py
@@ -43,19 +43,27 @@ def _wrap_arg(arg: Any) -> Any:
     - ``MakeTuple`` (the parser's representation of a Python list literal in
       source) is unwrapped to a Python list of its elements so wrappers that
       expect ``Sequence[IntLike]`` (e.g. shape / offset / indices) accept it.
-    - ``ConstInt`` / ``ConstFloat`` literals are kept raw. Wrapping them as
-      ``Scalar`` would defeat downstream ``isinstance(x, int)`` fast-paths
-      (see e.g. ``tile.max(t, 0, ...)``), and every wrapper that accepts a
-      ``Scalar`` already accepts a raw ``Expr`` too.
+    - ``ConstInt`` / ``ConstFloat`` literals stay as raw ``Expr``. They
+      carry the parser's chosen dtype (``INDEX`` for plain ``int`` literals,
+      ``FP32`` for plain ``float``, or whatever the user specified via
+      ``pl.const``) — extracting them to Python ``int`` / ``float`` would
+      lose that dtype and let downstream IR-builder defaults pick something
+      different (e.g. tensor.muls' rhs defaults to ``FP32``, which would
+      silently change the result dtype). Wrappers that need a Python
+      ``int`` (axis-style arguments) explicitly extract via the IR layer's
+      ``ConstInt.value`` field.
     - ``ir.Expr`` whose ``type`` is ``TensorType`` / ``TileType`` /
-      ``ScalarType`` is wrapped in the matching DSL class so type-dispatch in
-      the wrapper sees the right ``isinstance`` answer.
+      ``ScalarType`` (and which is not a ``Const*`` literal) is wrapped in
+      the matching DSL class so type-dispatch in the wrapper sees the right
+      ``isinstance`` answer.
     - Anything else (non-Expr Python values, or Expr with no matching DSL
       class) is returned unchanged.
     """
     if isinstance(arg, ir.MakeTuple):
         return list(arg.elements)
-    if not isinstance(arg, ir.Expr) or isinstance(arg, (ir.ConstInt, ir.ConstFloat)):
+    if not isinstance(arg, ir.Expr):
+        return arg
+    if isinstance(arg, (ir.ConstInt, ir.ConstFloat)):
         return arg
     t = arg.type
     if isinstance(t, ir.TensorType):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4130,24 +4130,26 @@ class ASTParser:
     def _parse_unified_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse a ``pl.<op>(...)`` call by delegating to the matching DSL wrapper.
 
-        Lookup mirrors how ``pl.<op>`` resolves at runtime: the top-level
-        ``pypto.language`` package is the authoritative source for ``pl.<op>``
-        symbols (it re-exports unified, promoted tensor-only, promoted
-        tile-only, and promoted system ops). The wrapper itself owns
-        type-checking and dispatch (e.g. ``unified_ops.add`` routes Tile+Scalar
-        to ``tile.adds``); the parser only forwards arguments and the
-        call-site span.
+        Lookup is restricted to ``pypto.language.op`` rather than the broader
+        ``pypto.language`` namespace. The op package re-exports only callable
+        ops (unified + promoted tensor/tile/system), so non-op DSL symbols
+        like ``pl.range``, ``pl.dynamic``, or ``pl.const`` cannot be invoked
+        here as ops — they're handled by their own parser entry points
+        upstream of this method. The wrapper itself owns type-checking and
+        dispatch (e.g. ``unified_ops.add`` routes Tile+Scalar to
+        ``tile.adds``); the parser only forwards arguments and the call-site
+        span.
         """
-        import pypto.language as _pl  # noqa: PLC0415 (circular import — `pypto.language` re-exports parser)
+        import pypto.language.op as _pl_op  # noqa: PLC0415 (circular import — `pypto.language` re-exports parser)
 
-        op_func = getattr(_pl, op_name, None)
+        op_func = getattr(_pl_op, op_name, None)
         if op_func is None or not callable(op_func):
             raise InvalidOperationError(
                 f"Unknown operation 'pl.{op_name}'",
                 span=self.span_tracker.get_span(call),
                 hint="Check spelling, or use pl.tensor.*/pl.tile.*/pl.system.* for explicit namespacing",
             )
-        return self._dispatch_op(_pl, "pl", op_name, call)
+        return self._dispatch_op(_pl_op, "pl", op_name, call)
 
     def _parse_typed_constant(self, call: ast.Call) -> ir.Expr:
         """Parse pl.const(value, dtype) → ConstInt or ConstFloat.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -20,9 +20,13 @@ from typing import TYPE_CHECKING, Any, cast
 from pypto.ir import IRBuilder
 from pypto.ir import op as ir_op
 from pypto.ir.printer import python_print
+from pypto.language.op import system_ops as _dsl_system
+from pypto.language.op import tensor_ops as _dsl_tensor
+from pypto.language.op import tile_ops as _dsl_tile
 from pypto.pypto_core import DataType, ir
 from pypto.pypto_core import arith as _arith
 
+from ._dsl_invoker import invoke_dsl
 from .diagnostics import (
     InvalidOperationError,
     ParserError,
@@ -3831,6 +3835,22 @@ class ASTParser:
 
         return return_expr
 
+    def _parse_op_positional_arg(self, arg: ast.expr) -> Any:
+        """Parse a positional op argument.
+
+        For ``ast.Attribute`` nodes (e.g. ``pl.INDEX``, ``pl.FP32``), try
+        dtype resolution first so wrappers receive a ``DataType`` for slots
+        like ``pl.cast(value, dtype)``. Falls through to ``parse_expression``
+        for everything else, which keeps Tensor/Tile/Scalar var lookups,
+        list literals, etc. on the existing path.
+        """
+        if isinstance(arg, ast.Attribute):
+            try:
+                return self.type_resolver.resolve_dtype(arg)
+            except ParserError:
+                pass
+        return self.parse_expression(arg)
+
     def _parse_op_kwargs(self, call: ast.Call) -> dict[str, Any]:
         """Parse keyword arguments for an operation call.
 
@@ -3949,16 +3969,22 @@ class ASTParser:
         return self.parse_list(value)
 
     def _dispatch_op(self, module: Any, module_name: str, op_name: str, call: ast.Call) -> ir.Expr:
-        """Dispatch an operation call to the given ir_op module.
+        """Dispatch an op call to a DSL wrapper module.
+
+        The wrapper owns type-checking and dispatch (e.g. ``tile.add`` already
+        routes scalar rhs to ``tile.adds``); the parser only parses args, wraps
+        them as DSL types via :func:`invoke_dsl`, pins the call-site span
+        through a contextvar, and unwraps the result.
 
         Args:
-            module: The ir_op sub-module (e.g., ir_op.tensor, ir_op.tile, ir_op.system)
-            module_name: Human-readable module name for error messages
-            op_name: Name of the operation to look up on the module
-            call: Call AST node
+            module: A DSL op submodule (``_dsl_tensor`` / ``_dsl_tile`` /
+                ``_dsl_system``) or the unified ``pypto.language.op`` namespace.
+            module_name: Human-readable module name for error messages.
+            op_name: Name of the operation to look up on the module.
+            call: Call AST node.
 
         Returns:
-            IR expression from the operation
+            IR expression from the operation.
         """
         if not hasattr(module, op_name):
             raise InvalidOperationError(
@@ -3966,30 +3992,94 @@ class ASTParser:
                 span=self.span_tracker.get_span(call),
                 hint=f"Check if '{op_name}' is a valid {module_name} operation",
             )
-        args = [self.parse_expression(arg) for arg in call.args]
+        args = [self._parse_op_positional_arg(arg) for arg in call.args]
         kwargs = self._parse_op_kwargs(call)
         op_func = getattr(module, op_name)
+        span = self.span_tracker.get_span(call)
         try:
-            return op_func(*args, **kwargs, span=self.span_tracker.get_span(call))
+            return invoke_dsl(op_func, args, kwargs, span)
         except ParserError:
             raise
+        except (TypeError, ValueError) as e:
+            # Wrapper may have prefixed its message (``pl.<op>:`` from
+            # ``_raise_type_dispatch_error`` or ``pl.<module>.<op>:``) or raised
+            # bare text from a deeper helper (e.g. ``ValueError("Invalid
+            # rounding mode ...")``). Make sure the surfaced error always names
+            # the op so users can locate the bad call. When any operand was a
+            # Scalar, append a hint pointing at Python operators.
+            msg = str(e)
+            if not msg.startswith(f"pl.{op_name}") and not msg.startswith(f"{module_name}.{op_name}"):
+                msg = f"{module_name} operation '{op_name}': {msg}"
+            hint = self._scalar_operand_hint(args, kwargs)
+            raise InvalidOperationError(msg, span=span, hint=hint) from e
         except Exception as e:
             raise InvalidOperationError(
                 f"Error in {module_name} operation '{op_name}': {concise_error_message(e)}",
-                span=self.span_tracker.get_span(call),
+                span=span,
             ) from e
+
+    @staticmethod
+    def _scalar_operand_hint(args: list[Any], kwargs: dict[str, Any]) -> str | None:
+        """Return the Python-operators hint when any operand has ScalarType.
+
+        Replaces a fragile ``"Scalar" in msg`` substring check; the parsed
+        operands carry their IR type explicitly, so we can decide based on
+        that rather than the wrapper's error wording.
+        """
+        for v in (*args, *kwargs.values()):
+            if isinstance(v, ir.Expr) and isinstance(v.type, ir.ScalarType):
+                return (
+                    "For scalar arithmetic / comparison, use Python operators directly "
+                    "(e.g. `s1 + s2`, `s1 % s2`, `s1 == s2`)."
+                )
+        return None
 
     def _parse_tensor_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tensor operation."""
         if op_name == "alloc":
             return self._parse_printed_alloc_call(call)
-        return self._dispatch_op(ir_op.tensor, "tensor", op_name, call)
+        # Prefer the DSL wrapper (owns type-checking + dispatch); fall back to
+        # the IR-builder layer for pass-internal ops like ``gather_mask``
+        # that are emitted by the printer but have no DSL wrapper.
+        if hasattr(_dsl_tensor, op_name):
+            return self._dispatch_op(_dsl_tensor, "pl.tensor", op_name, call)
+        return self._dispatch_ir_builder_op(ir_op.tensor, "pl.tensor", op_name, call)
 
     def _parse_tile_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tile operation."""
         if op_name == "alloc":
             return self._parse_printed_alloc_call(call)
-        return self._dispatch_op(ir_op.tile, "tile", op_name, call)
+        if hasattr(_dsl_tile, op_name):
+            return self._dispatch_op(_dsl_tile, "pl.tile", op_name, call)
+        return self._dispatch_ir_builder_op(ir_op.tile, "pl.tile", op_name, call)
+
+    def _dispatch_ir_builder_op(self, module: Any, module_name: str, op_name: str, call: ast.Call) -> ir.Expr:
+        """Dispatch to a raw IR-builder op (no DSL wrapping).
+
+        Used as a fallback when the DSL layer doesn't expose an op that the
+        printer emitted (e.g. pass-internal lowerings like ``tile.gather_mask``,
+        ``tile.mrgsort_format1``). IR builders take ``span=`` explicitly and
+        accept raw ``ir.Expr`` arguments — no DSL wrap/unwrap round-trip.
+        """
+        if not hasattr(module, op_name):
+            raise InvalidOperationError(
+                f"Unknown {module_name} operation: {op_name}",
+                span=self.span_tracker.get_span(call),
+                hint=f"Check if '{op_name}' is a valid {module_name} operation",
+            )
+        args = [self._parse_op_positional_arg(arg) for arg in call.args]
+        kwargs = self._parse_op_kwargs(call)
+        op_func = getattr(module, op_name)
+        span = self.span_tracker.get_span(call)
+        try:
+            return op_func(*args, **kwargs, span=span)
+        except ParserError:
+            raise
+        except Exception as e:
+            raise InvalidOperationError(
+                f"Error in {module_name} operation '{op_name}': {concise_error_message(e)}",
+                span=span,
+            ) from e
 
     @staticmethod
     def _is_printed_alloc_call(call: ast.Call) -> bool:
@@ -4027,7 +4117,7 @@ class ASTParser:
 
     def _parse_system_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse system operation."""
-        return self._dispatch_op(ir_op.system, "system", op_name, call)
+        return self._dispatch_op(_dsl_system, "pl.system", op_name, call)
 
     # Maps iterator type name to ForKind enum value.
     _ITERATOR_TO_KIND = {
@@ -4037,128 +4127,27 @@ class ASTParser:
         "pipeline": ir.ForKind.Pipeline,
     }
 
-    # Maps unified op names to the scalar variant for tile ops.
-    # Only binary arithmetic ops have scalar auto-dispatch.
-    _TILE_SCALAR_OPS: dict[str, str] = {
-        "add": "adds",
-        "sub": "subs",
-        "mul": "muls",
-        "div": "divs",
-    }
-
-    # Maps unified op names to ir scalar expression functions.
-    # Arithmetic ops (add/sub/mul/div) mirror the `+`/`-`/`*`/`/` operators
-    # so `pl.<op>(scalar, scalar)` behaves like `scalar <op> scalar`. `div`
-    # maps to `truediv`, matching `pl.tile.div` semantics; users who want
-    # integer floor division can use the `//` operator.
-    _SCALAR_BINARY_OPS: dict[str, str] = {
-        "add": "add",
-        "sub": "sub",
-        "mul": "mul",
-        "div": "truediv",
-        "min": "min_",
-        "max": "max_",
-    }
-
-    _SCALAR_UNARY_OPS: dict[str, str] = {}
-
-    # Maps unified op names to ir scalar functions that take (expr, dtype, span).
-    _SCALAR_DTYPE_OPS: dict[str, str] = {
-        "cast": "cast",
-    }
-
-    # Ops that exist only in one module (no dispatch needed).
-    _TENSOR_ONLY_OPS = {
-        "create_tensor",
-        "dim",
-        "assemble",
-        "full",
-        "arange",
-    }
-    _TILE_ONLY_OPS = {
-        "load",
-        "store",
-        "move",
-        "log",
-        "relu",
-        "minimum",
-        "cmp",
-        "cmps",
-        "sum",
-        "matmul_bias",
-        "gemv",
-        "gemv_acc",
-        "gemv_bias",
-        "create_tile",
-        "tpush_to_aiv",
-        "tpush_to_aic",
-        "tpop_from_aic",
-        "tpop_from_aiv",
-    }
-    _SYSTEM_OPS = {
-        "tfree_to_aic",
-        "tfree_to_aiv",
-        "aic_initialize_pipe",
-        "aiv_initialize_pipe",
-        "reserve_buffer",
-        "import_peer_buffer",
-    }
-
     def _parse_unified_op(self, op_name: str, call: ast.Call) -> ir.Expr:
-        """Parse unified operation call (pl.{op_name}).
+        """Parse a ``pl.<op>(...)`` call by delegating to the matching DSL wrapper.
 
-        Dispatches to tensor or tile IR op based on the first argument's type.
-
-        Args:
-            op_name: Name of the operation
-            call: Call AST node
-
-        Returns:
-            IR expression from the dispatched operation
+        Lookup mirrors how ``pl.<op>`` resolves at runtime: the top-level
+        ``pypto.language`` package is the authoritative source for ``pl.<op>``
+        symbols (it re-exports unified, promoted tensor-only, promoted
+        tile-only, and promoted system ops). The wrapper itself owns
+        type-checking and dispatch (e.g. ``unified_ops.add`` routes Tile+Scalar
+        to ``tile.adds``); the parser only forwards arguments and the
+        call-site span.
         """
-        # Short-circuit for ops that only exist in one module
-        if op_name in self._TENSOR_ONLY_OPS:
-            return self._parse_tensor_op(op_name, call)
-        if op_name in self._TILE_ONLY_OPS:
-            return self._parse_tile_op(op_name, call)
-        if op_name in self._SYSTEM_OPS:
-            return self._parse_system_op(op_name, call)
+        import pypto.language as _pl  # noqa: PLC0415 (circular import — `pypto.language` re-exports parser)
 
-        call_span = self.span_tracker.get_span(call)
-
-        if not call.args:
+        op_func = getattr(_pl, op_name, None)
+        if op_func is None or not callable(op_func):
             raise InvalidOperationError(
-                f"Unified operation '{op_name}' requires at least one argument for type dispatch",
-                span=call_span,
-                hint="Provide a Tensor or Tile as the first argument",
+                f"Unknown operation 'pl.{op_name}'",
+                span=self.span_tracker.get_span(call),
+                hint="Check spelling, or use pl.tensor.*/pl.tile.*/pl.system.* for explicit namespacing",
             )
-
-        # Parse only the first arg to determine dispatch target
-        first_arg = self.parse_expression(call.args[0])
-        first_type = first_arg.type
-
-        if isinstance(first_type, ir.TensorType):
-            return self._parse_tensor_op(op_name, call)
-
-        if isinstance(first_type, ir.TileType):
-            # For binary arithmetic ops, check if rhs is scalar → use scalar variant
-            scalar_op = self._TILE_SCALAR_OPS.get(op_name)
-            if scalar_op and len(call.args) >= 2:
-                rhs_arg = self.parse_expression(call.args[1])
-                if isinstance(rhs_arg.type, ir.ScalarType):
-                    return self._parse_tile_op(scalar_op, call)
-
-            return self._parse_tile_op(op_name, call)
-
-        if isinstance(first_type, ir.ScalarType):
-            return self._parse_scalar_op(op_name, call, call_span)
-
-        raise InvalidOperationError(
-            f"Cannot dispatch '{op_name}': first argument has type {type(first_type).__name__}, "
-            f"expected TensorType, TileType, or ScalarType",
-            span=call_span,
-            hint="Use pl.tensor.* or pl.tile.* for explicit dispatch",
-        )
+        return self._dispatch_op(_pl, "pl", op_name, call)
 
     def _parse_typed_constant(self, call: ast.Call) -> ir.Expr:
         """Parse pl.const(value, dtype) → ConstInt or ConstFloat.
@@ -4203,72 +4192,6 @@ class ASTParser:
             return ir.ConstFloat(value, dtype, span)
         else:
             return ir.ConstInt(value, dtype, span)
-
-    def _parse_scalar_op(self, op_name: str, call: ast.Call, call_span: ir.Span) -> ir.Expr:
-        """Parse scalar operation (e.g. pl.min(s1, s2) where s1, s2 are scalars).
-
-        Args:
-            op_name: Name of the operation
-            call: Call AST node
-            call_span: Source span for error reporting
-
-        Returns:
-            IR scalar expression
-        """
-        if call.keywords:
-            raise InvalidOperationError(
-                f"Scalar operation '{op_name}' does not accept keyword arguments",
-                span=call_span,
-            )
-
-        if op_name in self._SCALAR_DTYPE_OPS:
-            if len(call.args) != 2:
-                raise InvalidOperationError(
-                    f"Scalar operation '{op_name}' requires exactly 2 arguments (value, dtype), "
-                    f"got {len(call.args)}",
-                    span=call_span,
-                )
-            operand = self.parse_expression(call.args[0])
-            dtype = self.type_resolver.resolve_dtype(call.args[1])
-            ir_func_name = self._SCALAR_DTYPE_OPS[op_name]
-            ir_func = getattr(ir, ir_func_name)
-            return ir_func(operand, dtype, call_span)
-
-        if op_name in self._SCALAR_BINARY_OPS:
-            if len(call.args) != 2:
-                raise InvalidOperationError(
-                    f"Scalar binary operation '{op_name}' requires exactly 2 arguments, got {len(call.args)}",
-                    span=call_span,
-                )
-            lhs = self.parse_expression(call.args[0])
-            rhs = self.parse_expression(call.args[1])
-            ir_func_name = self._SCALAR_BINARY_OPS[op_name]
-            ir_func = getattr(ir, ir_func_name)
-            return ir_func(lhs, rhs, call_span)
-
-        if op_name in self._SCALAR_UNARY_OPS:
-            if len(call.args) != 1:
-                raise InvalidOperationError(
-                    f"Scalar unary operation '{op_name}' requires exactly 1 argument, got {len(call.args)}",
-                    span=call_span,
-                )
-            arg = self.parse_expression(call.args[0])
-            ir_func_name = self._SCALAR_UNARY_OPS[op_name]
-            ir_func = getattr(ir, ir_func_name)
-            return ir_func(arg, call_span)
-
-        supported = sorted(
-            set(self._SCALAR_BINARY_OPS) | set(self._SCALAR_UNARY_OPS) | set(self._SCALAR_DTYPE_OPS)
-        )
-        raise InvalidOperationError(
-            f"Operation '{op_name}' is not supported for scalar arguments",
-            span=call_span,
-            hint=(
-                f"Supported scalar ops: {', '.join(supported)}. "
-                "For other arithmetic / bitwise / comparison ops, use Python operators "
-                "directly on scalars (e.g. `s1 % s2`, `s1 << 1`, `s1 | s2`, `s1 == s2`)."
-            ),
-        )
 
     def parse_attribute(self, attr: ast.Attribute) -> ir.Expr:
         """Parse attribute access.

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -149,7 +149,7 @@ class ChunkedLoopProgram:
     def test_unknown_tensor_operation(self):
         """Test error on unknown tensor operation."""
 
-        with pytest.raises(InvalidOperationError, match="Unknown tensor operation"):
+        with pytest.raises(InvalidOperationError, match=r"Unknown operation 'pl\.nonexistent_op'"):
 
             @pl.function
             def unknown_op(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -90,7 +90,7 @@ class TestOpErrorWrapping:
 
     def test_parser_errors_not_double_wrapped(self):
         """ParserErrors from op dispatch are not re-wrapped."""
-        with pytest.raises(InvalidOperationError, match="Unknown tensor operation"):
+        with pytest.raises(InvalidOperationError, match=r"Unknown operation 'pl\.nonexistent_op'"):
 
             @pl.function
             def unknown(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:

--- a/tests/ut/language/parser/test_op_validation.py
+++ b/tests/ut/language/parser/test_op_validation.py
@@ -1,0 +1,201 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Coverage for the DSL-wrapper-based parser dispatch.
+
+After moving op type-checking from the parser into the DSL wrappers, the
+parser surfaces wrapper ``TypeError`` / ``ValueError`` as
+``InvalidOperationError`` with the call-site span. These tests pin the
+behavior we explicitly want from the new path: clean error messages, the
+parser-pinned span flowing into IR nodes constructed inside wrappers, and
+direct-Python wrapper calls staying functional.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.language.parser.diagnostics import InvalidOperationError
+from pypto.language.typing import Scalar
+from pypto.pypto_core import DataType
+from pypto.pypto_core import ir as _ir
+
+
+class TestWrapperErrorsThroughParser:
+    """Wrapper errors surface as InvalidOperationError with op name + span."""
+
+    def test_unknown_pl_op_clean_error(self):
+        with pytest.raises(InvalidOperationError, match=r"Unknown operation 'pl\.does_not_exist'"):
+
+            @pl.function
+            def main(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.does_not_exist(x)  # type: ignore[attr-defined]
+                return result
+
+    def test_pl_exp_on_scalar_emits_python_operators_hint(self):
+        with pytest.raises(InvalidOperationError) as exc_info:
+
+            @pl.function
+            def main(
+                config: pl.Tensor[[1], pl.FP32],
+                out: pl.Tensor[[1], pl.FP32],
+            ) -> pl.Tensor[[1], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                _ = pl.exp(a)  # pyright: ignore[reportArgumentType]
+                return out
+
+        msg = exc_info.value.message  # type: ignore[attr-defined]
+        assert "pl.exp" in msg
+        assert "Scalar" in msg
+        assert "Python operators" in (exc_info.value.hint or "")  # type: ignore[attr-defined]
+
+    def test_invalid_value_in_wrapper_names_op(self):
+        """A ValueError raised deep in a wrapper is rewrapped with the op name."""
+        with pytest.raises(
+            InvalidOperationError,
+            match=r"pl\.tensor operation 'cast'.*Invalid rounding mode",
+        ):
+
+            @pl.function
+            def main(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(
+                    x,
+                    target_type=pl.BF16,
+                    mode="bogus_mode",  # type: ignore[arg-type]
+                )
+                return result
+
+
+class TestSpanPropagatesIntoWrapperConstructedNodes:
+    """Span pinned by parser surfaces on IR nodes constructed inside wrappers."""
+
+    def test_call_span_matches_parse_site(self):
+        """``Call`` span must point at the user's source line, not the wrapper file."""
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.add(x, y)
+                return z
+
+        # Walk the IR: locate the pl.add Call and verify its span filename
+        # matches this test file (the parse site), not tile_ops.py /
+        # tensor_ops.py / unified_ops.py.
+        found_calls: list[ir.Call] = []
+
+        class _Collect(ir.IRVisitor):
+            def visit_call(self, op):
+                found_calls.append(op)
+                super().visit_call(op)
+
+        _Collect().visit_program(Prog)
+        add_calls = [c for c in found_calls if c.op.name in ("tensor.add", "tile.add")]
+        assert add_calls, "expected at least one tensor.add or tile.add Call in IR"
+
+        for call in add_calls:
+            span = call.span
+            # The call site lives in this test file; wrapper file paths
+            # would contain "tile_ops.py" or "unified_ops.py".
+            assert span is not None
+            assert "tile_ops.py" not in span.filename
+            assert "tensor_ops.py" not in span.filename
+            assert "unified_ops.py" not in span.filename
+
+
+class TestDirectWrapperCallsStillWork:
+    """Wrappers invoked outside the parser keep working — no contextvar set."""
+
+    def test_unified_add_scalar_scalar_via_python(self):
+        """Direct-Python ``pl.add(scalar, scalar)`` lowers via ``Scalar.__add__``."""
+        # Build minimal scalars from constants — exercises the lhs + rhs path
+        # in unified_ops.add without going through the parser.
+        s1 = Scalar(expr=_ir.ConstInt(3, DataType.INT32, _ir.Span.unknown()))
+        s2 = Scalar(expr=_ir.ConstInt(4, DataType.INT32, _ir.Span.unknown()))
+        result = pl.add(s1, s2)
+        assert isinstance(result, Scalar)
+
+
+class TestFullPythonCallingConvention:
+    """Parser delegates to DSL wrappers, so Python's full arg-binding works."""
+
+    def test_mixed_positional_and_keyword_styles_all_parse(self):
+        """All-positional, mixed, all-keyword, and unified-op-kwargs forms parse."""
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP16],
+            ) -> pl.Tensor[[16, 16], pl.FP16]:
+                # All positional
+                t_pos: pl.Tile[[16, 16], pl.FP16] = pl.tile.load(x, [0, 0], [16, 16])
+                # Mixed positional + keyword
+                t_mix: pl.Tile[[16, 16], pl.FP16] = pl.tile.load(x, [0, 0], shapes=[16, 16])
+                # All keyword
+                t_kw: pl.Tile[[16, 16], pl.FP16] = pl.tile.load(tensor=x, offsets=[0, 0], shapes=[16, 16])
+                # Unified-op kwargs
+                t_add: pl.Tile[[16, 16], pl.FP16] = pl.add(lhs=t_pos, rhs=t_mix)
+                # Suppress "unused" warnings while exercising every call site
+                _ = (t_kw, t_add)
+                return x
+
+        # Each pl.tile.load lowers to one tile.load Call; the program should
+        # contain exactly three of them regardless of how the source spelled
+        # the args.
+        load_calls: list[ir.Call] = []
+        add_calls: list[ir.Call] = []
+
+        class _Collect(ir.IRVisitor):
+            def visit_call(self, op):
+                if op.op.name == "tile.load":
+                    load_calls.append(op)
+                elif op.op.name == "tile.add":
+                    add_calls.append(op)
+                super().visit_call(op)
+
+        _Collect().visit_program(Prog)
+        assert len(load_calls) == 3, f"expected 3 tile.load calls, got {len(load_calls)}"
+        assert len(add_calls) == 1, f"expected 1 tile.add call, got {len(add_calls)}"
+
+    def test_dtype_attribute_works_positional_and_keyword(self):
+        """``pl.cast(x, pl.BF16)`` and ``pl.cast(x, target_type=pl.BF16)`` both parse."""
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.BF16]:
+                # Positional dtype attribute
+                a: pl.Tensor[[16, 16], pl.BF16] = pl.cast(x, pl.BF16)
+                # Keyword dtype attribute
+                b: pl.Tensor[[16, 16], pl.BF16] = pl.cast(x, target_type=pl.BF16)
+                _ = a
+                return b
+
+        cast_calls: list[ir.Call] = []
+
+        class _Collect(ir.IRVisitor):
+            def visit_call(self, op):
+                if op.op.name in ("tensor.cast", "tile.cast"):
+                    cast_calls.append(op)
+                super().visit_call(op)
+
+        _Collect().visit_program(Prog)
+        assert len(cast_calls) == 2, f"expected 2 cast calls, got {len(cast_calls)}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -340,7 +340,7 @@ class TestScalarUnsupportedOpHint:
     def test_unsupported_op_hint_mentions_python_operators(self):
         # `pl.exp` is a unified op (tile/tensor) with no scalar dispatch — hits
         # the catch-all path that surfaces the improved hint.
-        with pytest.raises(InvalidOperationError, match=r"Operation 'exp' is not supported") as exc_info:
+        with pytest.raises(InvalidOperationError, match=r"pl\.exp.*expected.*got Scalar") as exc_info:
 
             @pl.program
             class Bad:

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1005,8 +1005,12 @@ class TestUnifiedOpsTypeErrors:
             unified_ops.add("not_a_tensor", 1)  # type: ignore
 
     def test_mul_invalid_lhs(self):
+        # ``pl.mul(42, 2)`` is valid scalar arithmetic — both operands are
+        # ``int``, so it lowers via ``ir.mul(ConstInt(42), ConstInt(2))``
+        # and returns a ``Scalar``. Reject only when a non-scalar-like
+        # type slips in.
         with pytest.raises(TypeError, match="expected Tensor or Tile operands"):
-            unified_ops.mul(42, 2)  # type: ignore
+            unified_ops.mul("not_a_number", 2)  # type: ignore
 
     def test_exp_invalid_input(self):
         with pytest.raises(TypeError, match="expected Tensor or Tile"):


### PR DESCRIPTION
## Summary

Delete seven hand-maintained dispatch tables in \`ast_parser.py\` (\`_TILE_SCALAR_OPS\`, \`_SCALAR_BINARY_OPS\`/\`_UNARY_OPS\`/\`_DTYPE_OPS\`, \`_TENSOR_ONLY_OPS\`, \`_TILE_ONLY_OPS\`, \`_SYSTEM_OPS\`) and \`_parse_scalar_op\`. The DSL wrappers (\`unified_ops\`/\`tile_ops\`/\`tensor_ops\`/\`system_ops\`) already encode dispatch and type-checking for direct Python use; the parser now delegates to them via a new \`invoke_dsl\` helper, so those rules live in one place.

Resolves the \`KNOWN_ISSUES\` entry _"Parser-side \`_SCALAR_BINARY_OPS\` / \`_TILE_SCALAR_OPS\` / \`_TENSOR_ONLY_OPS\` / \`_TILE_ONLY_OPS\` duplicate metadata that already lives on the op definitions"_.

## Mechanism

- **Span ContextVar** in \`ir/utils.py\`: \`_get_span_or_capture\` consults a parser-pinned \`_PARSER_SPAN\` before frame-capture, so IR builders inside wrappers pick up the parser's call-site span without a \`span=\` kwarg.
- **\`_dsl_invoker.invoke_dsl\`**: wraps parsed \`ir.Expr\` args as DSL types (\`Tensor\`/\`Tile\`/\`Scalar\`) by inspecting \`expr.type\`, pins the span, calls the wrapper, unwraps the result. \`ConstInt\`/\`ConstFloat\` literals stay raw (preserves dtype + downstream \`isinstance(int)\` fast-paths); \`MakeTuple\` unwraps to a Python list for shape/offset/indices slots.
- **Parser collapses**: \`_parse_unified_op\` becomes \`getattr(pypto.language, op_name)\`; \`_parse_tensor_op\`/\`_parse_tile_op\` prefer the DSL wrapper and fall back to \`pypto.ir.op\` for printer-emitted internal ops (\`mrgsort_format1\`, \`gather_mask\`, ...) via a new \`_dispatch_ir_builder_op\`.
- **\`_parse_op_positional_arg\`**: resolves dtype attributes (\`pl.INDEX\`) for positional dtype slots, matching existing kwarg behavior.

## Wrapper alignment

- \`tensor_ops\`/\`tile_ops\` \`scatter_update\`: accept \`*args/**kwargs\` to mirror the IR-builder's flexible call shapes.
- \`tile_ops.load\`: swap \`valid_shapes\`/\`target_memory\` parameter order to match the IR-builder and printer emission.
- \`write\` returns the underlying \`Call\` expression (was \`None\`) so the parser surfaces it as an \`EvalStmt\`.
- Binary arith wrappers accept raw \`Expr\` alongside \`int\`/\`float\`/\`Scalar\` so parser-shaped args (raw \`ConstInt\`) flow through cleanly.
- \`unified_ops\` error messages prefix \`pl.<op>\` for a consistent surface.

## Test plan

- [x] Update three error-message regex assertions for the unified \`Unknown operation 'pl.<X>'\` wording.
- [x] Add \`tests/ut/language/parser/test_op_validation.py\` covering wrapper-error surfacing, span propagation into wrapper-constructed nodes, direct-Python invocation, mixed positional/keyword arg styles, and dtype-attribute positional/keyword.
- [x] Full unit test suite: **4251 passed, 30 skipped** locally (\`tests/ut/\`).

## Net diff

\`\`\`
 python/pypto/ir/utils.py                         |  34 ++-
 python/pypto/language/op/tensor_ops.py           |  55 ++--
 python/pypto/language/op/tile_ops.py             | 100 ++++----
 python/pypto/language/op/unified_ops.py          |  80 +++---
 python/pypto/language/parser/_dsl_invoker.py     |  91 +++++++
 python/pypto/language/parser/ast_parser.py       | 313 +++++++++--------------
 tests/ut/language/parser/test_error_cases.py     |   2 +-
 tests/ut/language/parser/test_error_wrapping.py  |   2 +-
 tests/ut/language/parser/test_op_validation.py   | 199 +++++++++++++++
 tests/ut/language/parser/test_scalar_dispatch.py |   2 +-
\`\`\`