### PR TITLE
refactor(ir/serialization): Remove legacy ScopeStmt deserializer

### DIFF
--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -275,28 +275,6 @@ inline std::string ScopeKindToString(ScopeKind kind) {
 }
 
 /**
- * @brief Convert string to ScopeKind
- * @param str String representation
- * @return ScopeKind enum value
- * @throws pypto::TypeError if string is not recognized
- */
-inline ScopeKind StringToScopeKind(const std::string& str) {
-  if (str == "InCore") {
-    return ScopeKind::InCore;
-  } else if (str == "AutoInCore") {
-    return ScopeKind::AutoInCore;
-  } else if (str == "Cluster") {
-    return ScopeKind::Cluster;
-  } else if (str == "Hierarchy") {
-    return ScopeKind::Hierarchy;
-  } else if (str == "Spmd") {
-    return ScopeKind::Spmd;
-  } else {
-    throw pypto::TypeError("Unknown ScopeKind: " + str);
-  }
-}
-
-/**
  * @brief Base class for all statements in the IR
  *
  * Statements represent operations that perform side effects or control flow.

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -723,30 +723,6 @@ static IRNodePtr DeserializeSpmdScopeStmt(const msgpack::object& fields_obj, msg
                                          DeserializeLeadingComments(fields_obj));
 }
 
-// Backward-compatibility: route legacy "ScopeStmt" type tags (written before the
-// per-kind subclass split, issue #1047) to the matching derived deserializer by
-// reading the legacy "scope_kind" field.
-static IRNodePtr DeserializeLegacyScopeStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
-                                            DeserializerContext& ctx) {
-  auto kind_obj = GET_FIELD_OBJ("scope_kind");
-  CHECK(kind_obj.type == msgpack::type::STR)
-      << "Legacy ScopeStmt scope_kind must be a string, got msgpack type " << static_cast<int>(kind_obj.type);
-  auto kind = StringToScopeKind(kind_obj.as<std::string>());
-  switch (kind) {
-    case ScopeKind::InCore:
-      return DeserializeInCoreScopeStmt(fields_obj, zone, ctx);
-    case ScopeKind::AutoInCore:
-      return DeserializeAutoInCoreScopeStmt(fields_obj, zone, ctx);
-    case ScopeKind::Cluster:
-      return DeserializeClusterScopeStmt(fields_obj, zone, ctx);
-    case ScopeKind::Hierarchy:
-      return DeserializeHierarchyScopeStmt(fields_obj, zone, ctx);
-    case ScopeKind::Spmd:
-      return DeserializeSpmdScopeStmt(fields_obj, zone, ctx);
-  }
-  throw pypto::TypeError("Unknown legacy ScopeKind during deserialization");
-}
-
 // Deserialize SeqStmts
 static IRNodePtr DeserializeSeqStmts(const msgpack::object& fields_obj, msgpack::zone& zone,
                                      DeserializerContext& ctx) {
@@ -997,8 +973,6 @@ static TypeRegistrar _auto_in_core_scope_stmt_registrar("AutoInCoreScopeStmt",
 static TypeRegistrar _cluster_scope_stmt_registrar("ClusterScopeStmt", DeserializeClusterScopeStmt);
 static TypeRegistrar _hierarchy_scope_stmt_registrar("HierarchyScopeStmt", DeserializeHierarchyScopeStmt);
 static TypeRegistrar _spmd_scope_stmt_registrar("SpmdScopeStmt", DeserializeSpmdScopeStmt);
-// Backward compatibility for IR serialized before issue #1047 split ScopeStmt into per-kind subclasses.
-static TypeRegistrar _legacy_scope_stmt_registrar("ScopeStmt", DeserializeLegacyScopeStmt);
 static TypeRegistrar _seq_stmts_registrar("SeqStmts", DeserializeSeqStmts);
 static TypeRegistrar _eval_stmt_registrar("EvalStmt", DeserializeEvalStmt);
 static TypeRegistrar _break_stmt_registrar("BreakStmt", DeserializeBreakStmt);


### PR DESCRIPTION
## Summary

- Drop `DeserializeLegacyScopeStmt` and the `"ScopeStmt"` `TypeRegistrar` entry in `src/ir/serialization/type_deserializers.cpp`. They were a backward-compatibility shim that routed pre-#1049 `.msgpack` blobs (single `ScopeStmt` + `scope_kind` field) to the matching per-kind deserializer after the class was split into `InCoreScopeStmt`/`AutoInCoreScopeStmt`/`ClusterScopeStmt`/`HierarchyScopeStmt`/`SpmdScopeStmt`.
- Drop `StringToScopeKind` in `include/pypto/ir/stmt.h` — it had no other callers. `ScopeKindToString` stays (still used by `structural_equal.cpp` for diagnostics).
- The shim was untested (tracked in `KNOWN_ISSUES.md`), and no production code path persists IR across versions — `ir.serialize`/`ir.deserialize` is exposed publicly but not used internally to load older blobs.

## Breaking change

`.msgpack` blobs produced by PyPTO before PR #1049 will no longer deserialize. Re-serialize with the current toolchain to migrate. The serialization format has no version field, so backward-compat has been best-effort; if we want a stronger guarantee long-term, the right move is a top-level format-version field rather than per-class shims.

## Test plan

- [x] Clean build from worktree (`cmake --build build --parallel`)
- [x] Full unit-test suite (`pytest tests/ut/ -n auto --maxprocesses 8`) — 4244 passed, 30 skipped
- [x] Targeted serialization/scope-stmt tests pass
- [x] Code review (project skill) — clean
- [x] Verified no remaining call sites for `DeserializeLegacyScopeStmt`, `_legacy_scope_stmt_registrar`, or `StringToScopeKind` anywhere in the tree