### PR TITLE
refactor(debug): Remove dead visit_scope_stmt from torch_codegen

### DIFF
--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1357,10 +1357,6 @@ class TorchCodegen(_ir.IRVisitor):
         for s in op.stmts:
             self.visit_stmt(s)
 
-    def visit_scope_stmt(self, op: _ir.ScopeStmt) -> None:
-        # Scopes are transparent - just emit the body
-        self.visit_stmt(op.body)
-
     def visit_break_stmt(self, _op: _ir.BreakStmt) -> None:
         self._emit("break")
 


### PR DESCRIPTION
## Summary

Removes a dead `visit_scope_stmt` override on `TorchCodegen(_ir.IRVisitor)` in `python/pypto/debug/torch_codegen.py`.

After the `ScopeStmt` hierarchy split, the `IRVisitor` dispatcher routes scope statements only through the per-kind methods (`visit_in_core_scope_stmt`, `visit_auto_in_core_scope_stmt`, `visit_cluster_scope_stmt`, `visit_hierarchy_scope_stmt`, `visit_spmd_scope_stmt`). There is no `visit_scope_stmt` slot on the dispatcher, so the override was never invoked. The C++ `IRVisitor` defaults for those five per-kind methods already do exactly the intended "transparent — visit body" behavior (`src/ir/transforms/visitor.cpp:216-241`), so simply deleting the dead method is sufficient and any future scope kind is handled automatically.

## Test plan

- [x] Code review (PASS)
- [x] Full unit-test suite (4247 passed, 0 failed, 30 skipped)
- [x] Pre-commit hooks (ruff, pyright, header/whitespace checks) all pass