### PR TITLE
fix(parser): Accept arbitrary expressions in TileView fields

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -284,6 +284,7 @@ class ASTParser:
             scope_lookup=self.scope_manager.lookup_var,
             span_tracker=self.span_tracker,
             dyn_var_cache=dyn_var_cache,
+            parse_expression=self.parse_expression,
         )
         self.builder = IRBuilder()
         self.global_vars = global_vars or {}  # Track GlobalVars for cross-function calls

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -73,6 +73,18 @@ def _try_get_static_dim(dim: ir.Expr) -> int | None:
     return None
 
 
+def _is_index_expr_type(t: "ir.Type | None") -> bool:
+    """Whether ``t`` is admissible for a TileView/TensorView field expression.
+
+    Mirrors the C++ contract: TileView fields are integer/index scalars
+    (constants, dyn vars, and arithmetic over them). Excludes tile, tensor,
+    tuple, float, and bool types.
+    """
+    if not isinstance(t, ir.ScalarType):
+        return False
+    return t.dtype == DataType.INDEX or t.dtype.is_int()
+
+
 _TYPE_KIND_NAMES: dict[type, str] = {
     ir.TensorType: "Tensor",
     ir.TileType: "Tile",
@@ -1299,11 +1311,26 @@ class TypeResolver:
                 self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), self._get_span(node))
             return self._dyn_var_cache[name]
         if self._parse_expression is not None:
-            return self._parse_expression(node)
+            result = self._parse_expression(node)
+            # Reject non-Expr returns (e.g. bare `pl.yield_()` returns None and emits a
+            # YieldStmt to the builder) and non-index expression types (e.g. `pl.tile.create(...)`
+            # returns a Tile). The C++ TileView contract is index expressions only.
+            if not isinstance(result, ir.Expr) or not _is_index_expr_type(result.type):
+                got = type(result).__name__ if not isinstance(result, ir.Expr) else type(result.type).__name__
+                raise ParserTypeError(
+                    f"TileView field must be an index expression, got {got}: {ast.unparse(node)}",
+                    span=self._get_span(node),
+                    hint=(
+                        "Use integer literals, dynamic variables, or arithmetic over them "
+                        "(pl.max, pl.min, +, -, *, ...)"
+                    ),
+                )
+            return result
         raise ParserTypeError(
-            f"TileView expression must be a parsable index expression, got: {ast.unparse(node)}",
+            f"TileView expression must be an integer constant or bare variable, got: {ast.unparse(node)}",
             span=self._get_span(node),
-            hint="Use an integer literal, a dynamic variable, or any pl.* index expression",
+            hint="Standalone TypeResolver only handles integer literals and bare names; "
+            "richer expressions require the resolver to be wired into an ASTParser.",
         )
 
     def _resolve_tilelayout(self, node: ast.expr) -> "ir.TileLayout":

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -85,6 +85,21 @@ def _is_index_expr_type(t: "ir.Type | None") -> bool:
     return t.dtype == DataType.INDEX or t.dtype.is_int()
 
 
+def _is_pl_yield_call(node: ast.expr) -> bool:
+    """Detect ``pl.yield_(...)`` / bare ``yield_(...)`` call nodes.
+
+    ``parse_yield_call`` emits an ``ir.YieldStmt`` to the builder as a side
+    effect — incompatible with the pure-expression contract type-annotation
+    parsing assumes.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "yield_":
+        return True
+    return isinstance(func, ast.Name) and func.id == "yield_"
+
+
 _TYPE_KIND_NAMES: dict[type, str] = {
     ir.TensorType: "Tensor",
     ir.TileType: "Tile",
@@ -1311,10 +1326,21 @@ class TypeResolver:
                 self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), self._get_span(node))
             return self._dyn_var_cache[name]
         if self._parse_expression is not None:
+            # Pre-flight: pl.yield_() emits an ir.YieldStmt to the builder as a side
+            # effect during parsing. Type-annotation parsing must stay pure, so reject
+            # the call before delegation rather than after — otherwise the spurious
+            # YieldStmt is already in the builder when we throw.
+            if _is_pl_yield_call(node):
+                raise ParserTypeError(
+                    "TileView field cannot contain pl.yield_() — it would emit a "
+                    "YieldStmt as a side effect of type annotation parsing.",
+                    span=self._get_span(node),
+                    hint="Use a pure index expression (constants, vars, arithmetic, pl.max/pl.min, ...).",
+                )
             result = self._parse_expression(node)
-            # Reject non-Expr returns (e.g. bare `pl.yield_()` returns None and emits a
-            # YieldStmt to the builder) and non-index expression types (e.g. `pl.tile.create(...)`
-            # returns a Tile). The C++ TileView contract is index expressions only.
+            # Backstop: the delegated parser may still return non-Expr (e.g. None)
+            # or non-index expressions (e.g. pl.tile.create(...) returns a Tile).
+            # The C++ TileView contract is index expressions only.
             if not isinstance(result, ir.Expr) or not _is_index_expr_type(result.type):
                 got = type(result).__name__ if not isinstance(result, ir.Expr) else type(result.type).__name__
                 raise ParserTypeError(

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -150,6 +150,7 @@ class TypeResolver:
         scope_lookup: Callable[[str], Any | None] | None = None,
         span_tracker: "SpanTracker | None" = None,
         dyn_var_cache: dict[str, ir.Var] | None = None,
+        parse_expression: Callable[[ast.expr], "ir.Expr"] | None = None,
     ):
         """Initialize type resolver.
 
@@ -162,11 +163,17 @@ class TypeResolver:
                 objects. When provided, multiple TypeResolvers share the same cache,
                 ensuring the same DynVar produces the same ir.Var across functions
                 in a program.
+            parse_expression: Optional callback to the enclosing parser's full
+                expression parser. When set, TileView/TensorView fields accept any
+                index expression the DSL itself can parse (matching what the C++
+                ``ir.TileView`` constructor accepts), not just integer constants
+                and bare names.
         """
         self.expr_evaluator = expr_evaluator
         self.scope_lookup = scope_lookup
         self.span_tracker = span_tracker
         self._dyn_var_cache: dict[str, ir.Var] = dyn_var_cache if dyn_var_cache is not None else {}
+        self._parse_expression = parse_expression
 
     def resolve_param_type(self, type_node: ast.expr) -> "tuple[ir.Type, ir.ParamDirection]":
         """Resolve AST type annotation to (ir.Type, ParamDirection) for function parameters.
@@ -1247,7 +1254,14 @@ class TypeResolver:
         return [self._parse_tileview_expr(elt) for elt in node.elts]
 
     def _parse_tileview_expr(self, node: ast.expr) -> "ir.Expr":
-        """Parse a single expression for a TileView field."""
+        """Parse a single expression for a TileView field.
+
+        TileView fields admit arbitrary index expressions, matching what the
+        C++ ``ir.TileView`` constructor accepts. Integer constants and bare
+        names use fast paths here; richer expressions (calls, arithmetic,
+        attribute access, etc.) fall through to the same expression parser
+        that the DSL uses everywhere else.
+        """
         val = self._try_resolve_int(node)
         if val is not None:
             return ir.ConstInt(val, DataType.INDEX, self._get_span(node))
@@ -1284,10 +1298,12 @@ class TypeResolver:
             if name not in self._dyn_var_cache:
                 self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), self._get_span(node))
             return self._dyn_var_cache[name]
+        if self._parse_expression is not None:
+            return self._parse_expression(node)
         raise ParserTypeError(
-            f"TileView expression must be an integer constant, got: {ast.unparse(node)}",
+            f"TileView expression must be a parsable index expression, got: {ast.unparse(node)}",
             span=self._get_span(node),
-            hint="Use an integer literal for TileView fields",
+            hint="Use an integer literal, a dynamic variable, or any pl.* index expression",
         )
 
     def _resolve_tilelayout(self, node: ast.expr) -> "ir.TileLayout":

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -28,13 +28,33 @@ def _setup_backend():
 
 
 def _run_split_vector_kernel(program):
-    """Run convert_to_ssa then split_vector_kernel (without verification)."""
+    """Run convert_to_ssa then split_vector_kernel.
+
+    Verification is disabled because these tests hand-construct minimal IR that
+    targets ``SplitVectorKernel`` in isolation; that IR doesn't satisfy
+    properties produced earlier in the real pipeline (``MixedKernelExpanded``,
+    pipe initialization, etc.). Roundtrip correctness is exercised explicitly
+    in tests that need it (see ``_assert_parses``).
+    """
     ssa = passes.convert_to_ssa()(program)
     pipeline = passes.PassPipeline()
     pipeline.add_pass(passes.split_vector_kernel())
     ctx = passes.PassContext([], passes.VerificationLevel.NONE)
     with ctx:
         return pipeline.run(ssa)
+
+
+def _assert_parses(program, printed: str | None = None):
+    """Print (if not already provided) and reparse, asserting the parser accepts the printed text.
+
+    This is the half of roundtrip the parser owns: any IR a producer can
+    construct must be printable and reparseable. (Full structural_equal
+    additionally requires the producer not to clone Vars, which is a
+    separate concern outside parser scope.) Tests that cover passes
+    producing non-trivial IR shapes (e.g. TileView fields with dynamic
+    expressions) call this to gate the parser side.
+    """
+    pl.parse_program(printed if printed is not None else python_print(program))
 
 
 def _assert_split_matches_expected(before_program, expected_program):
@@ -165,6 +185,9 @@ class TestSplitVectorKernelUpDown:
         assert re.search(r"pl\.tile\.tpop_from_aic\(\s*split=1\s*\)", printed)
         assert "pl.max(pl.min(valid_rows__ssa_v0 - subblock_idx * 8, 8), 0)" in printed
         assert "valid_rows__ssa_v0 // 2" not in printed
+        # The TileView's localized valid_shape carries a non-constant expression;
+        # the parser must accept the same shapes the printer emits.
+        _assert_parses(actual, printed=printed)
 
     def test_load_shape_halved_and_offset_adjusted(self):
         """tile.load in AIV: shape halved, offset adjusted in split dim (includes add of halved tiles)."""

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -54,7 +54,7 @@ def _assert_parses(program, printed: str | None = None):
     producing non-trivial IR shapes (e.g. TileView fields with dynamic
     expressions) call this to gate the parser side.
     """
-    pl.parse_program(printed if printed is not None else python_print(program))
+    pl.parse(printed if printed is not None else python_print(program))
 
 
 def _assert_split_matches_expected(before_program, expected_program):

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -272,35 +272,44 @@ class TestTypeResolver:
         with pytest.raises(ParserTypeError, match="integer constant or bare variable"):
             resolver.resolve_type(ast.parse(annotation, mode="eval").body)
 
-    def test_tileview_field_rejects_non_index_typed_callback_result(self):
-        """The delegated parser may return non-Expr or non-index expressions.
+    def test_tileview_field_rejects_pl_yield_pre_flight(self):
+        """``pl.yield_()`` is rejected before the delegated parser is even called.
 
-        Bare ``pl.yield_()`` returns ``None`` while emitting a YieldStmt to the
-        builder; ``pl.tile.create(...)`` returns a Tile-typed Expr. Both are
-        invalid for a TileView field — the validator must reject them with a
-        clear error rather than letting downstream code consume malformed IR.
+        ``parse_yield_call`` emits an ``ir.YieldStmt`` to the builder as a side
+        effect of expression parsing. Type-annotation parsing must stay pure,
+        so the AST shape is checked up front and rejected before delegation.
         """
-        # Non-Expr result (e.g. None from bare pl.yield_())
+        sentinel_expr = ir.ConstInt(0, DataType.INDEX, ir.Span.unknown())
+
+        def fake_parse_expression(_node: ast.expr) -> ir.Expr:
+            # Returning a valid Expr makes any leak through pre-flight visible
+            # as a missing-error test failure rather than a swallowed exception.
+            return sentinel_expr
+
         ev = ExprEvaluator(closure_vars={})
-        resolver = TypeResolver(expr_evaluator=ev, parse_expression=lambda _node: None)  # type: ignore[arg-type,return-value]
+        resolver = TypeResolver(expr_evaluator=ev, parse_expression=fake_parse_expression)
         annotation = "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[pl.yield_()])]"
-        with pytest.raises(ParserTypeError, match="must be an index expression"):
+        with pytest.raises(ParserTypeError, match="cannot contain pl.yield_"):
             resolver.resolve_type(ast.parse(annotation, mode="eval").body)
 
-        # Non-index Expr result (e.g. a Tile from pl.tile.create(...))
-        tile_typed = ir.Var(
-            "t",
-            ir.TileType(
-                [ir.ConstInt(16, DataType.INDEX, ir.Span.unknown())], DataType.FP32, None, None, None
-            ),
-            ir.Span.unknown(),
-        )
-        resolver_tile = TypeResolver(expr_evaluator=ev, parse_expression=lambda _node: tile_typed)
+    def test_tileview_field_rejects_non_index_typed_callback_result(self):
+        """Backstop: callback returning a non-index expression is rejected.
+
+        ``pl.tile.create(...)`` returns a Tile-typed expression; downstream
+        code relies on TileView fields being integer/index scalars. The
+        validator catches the type mismatch with a clear error rather than
+        letting malformed IR slip through.
+        """
+        span = ir.Span.unknown()
+        tile_type = ir.TileType([ir.ConstInt(16, DataType.INDEX, span)], DataType.FP32, None, None, None)
+        tile_typed = ir.Var("t", tile_type, span)
+        ev = ExprEvaluator(closure_vars={})
+        resolver = TypeResolver(expr_evaluator=ev, parse_expression=lambda _node: tile_typed)
         annotation = (
             "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[pl.tile.create([16], pl.FP32)])]"
         )
         with pytest.raises(ParserTypeError, match="must be an index expression"):
-            resolver_tile.resolve_type(ast.parse(annotation, mode="eval").body)
+            resolver.resolve_type(ast.parse(annotation, mode="eval").body)
 
 
 class TestTupleTypeResolver:

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -226,6 +226,52 @@ class TestTypeResolver:
 
         assert ir.python_print_type(reparsed) == printed
 
+    def test_tileview_field_accepts_arbitrary_expression(self):
+        """TileView fields must accept the same expressions ir.TileView accepts in C++.
+
+        Passes such as SplitVectorKernel produce TileViews whose ``valid_shape`` is
+        a non-constant expression (e.g. ``pl.max(pl.min(rows - i * 8, 8), 0)``).
+        The printer emits the expression verbatim, so the parser must round-trip
+        it. The TypeResolver delegates richer index expressions to the enclosing
+        parser's ``parse_expression``; here we stub that callback to confirm the
+        delegation happens.
+        """
+        sentinel = ir.ConstInt(99, DataType.INDEX, ir.Span.unknown())
+
+        def fake_parse_expression(_node: ast.expr) -> ir.Expr:
+            return sentinel
+
+        ev = ExprEvaluator(closure_vars={})
+        resolver = TypeResolver(expr_evaluator=ev, parse_expression=fake_parse_expression)
+
+        annotation = (
+            "pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec, "
+            "pl.TileView(valid_shape=[pl.max(pl.min(rows - i * 8, 8), 0), 128])]"
+        )
+        resolved = resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+
+        assert isinstance(resolved, ir.TileType)
+        assert resolved.tile_view is not None
+        valid_shape = resolved.tile_view.valid_shape
+        assert len(valid_shape) == 2
+        # First element is the complex expression — delegated to the callback.
+        assert valid_shape[0] is sentinel
+        # Second element is a plain int constant — handled by the fast path.
+        assert isinstance(valid_shape[1], ir.ConstInt)
+        assert valid_shape[1].value == 128
+
+    def test_tileview_field_rejects_complex_expr_without_callback(self):
+        """Standalone TypeResolver still surfaces a clear error for non-trivial fields.
+
+        Without a ``parse_expression`` callback (e.g. unit-test or tooling usage),
+        TypeResolver cannot parse arbitrary index expressions and must report so.
+        """
+        resolver = _make_resolver()  # no parse_expression callback
+
+        annotation = "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[i + 1])]"
+        with pytest.raises(ParserTypeError, match="parsable index expression"):
+            resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+
 
 class TestTupleTypeResolver:
     """Tests for tuple[T1, T2, ...] return type resolution."""

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -269,8 +269,38 @@ class TestTypeResolver:
         resolver = _make_resolver()  # no parse_expression callback
 
         annotation = "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[i + 1])]"
-        with pytest.raises(ParserTypeError, match="parsable index expression"):
+        with pytest.raises(ParserTypeError, match="integer constant or bare variable"):
             resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+
+    def test_tileview_field_rejects_non_index_typed_callback_result(self):
+        """The delegated parser may return non-Expr or non-index expressions.
+
+        Bare ``pl.yield_()`` returns ``None`` while emitting a YieldStmt to the
+        builder; ``pl.tile.create(...)`` returns a Tile-typed Expr. Both are
+        invalid for a TileView field — the validator must reject them with a
+        clear error rather than letting downstream code consume malformed IR.
+        """
+        # Non-Expr result (e.g. None from bare pl.yield_())
+        ev = ExprEvaluator(closure_vars={})
+        resolver = TypeResolver(expr_evaluator=ev, parse_expression=lambda _node: None)  # type: ignore[arg-type,return-value]
+        annotation = "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[pl.yield_()])]"
+        with pytest.raises(ParserTypeError, match="must be an index expression"):
+            resolver.resolve_type(ast.parse(annotation, mode="eval").body)
+
+        # Non-index Expr result (e.g. a Tile from pl.tile.create(...))
+        tile_typed = ir.Var(
+            "t",
+            ir.TileType(
+                [ir.ConstInt(16, DataType.INDEX, ir.Span.unknown())], DataType.FP32, None, None, None
+            ),
+            ir.Span.unknown(),
+        )
+        resolver_tile = TypeResolver(expr_evaluator=ev, parse_expression=lambda _node: tile_typed)
+        annotation = (
+            "pl.Tile[[16], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[pl.tile.create([16], pl.FP32)])]"
+        )
+        with pytest.raises(ParserTypeError, match="must be an index expression"):
+            resolver_tile.resolve_type(ast.parse(annotation, mode="eval").body)
 
 
 class TestTupleTypeResolver:


### PR DESCRIPTION
## Summary

The text parser only accepted integer constants and bare names for `TileView`/`TensorView` fields, but the C++ `ir.TileView` constructor accepts arbitrary `ExprPtr`. Passes such as `SplitVectorKernel` exploit that freedom (e.g. localising a dynamic `valid_shape` per AIV subblock as `pl.max(pl.min(rows - i * 8, 8), 0)`), so the printer faithfully emitted expressions the parser then refused — breaking print → parse roundtrip.

This PR threads `ASTParser.parse_expression` into `TypeResolver` as an optional callback. Integer-constant and bare-name fast paths stay; everything else delegates to the same expression parser the assignment RHS uses — no new parsing logic, just reuse. `TypeResolver` remains constructible standalone (no callback) and surfaces a clearer error in that mode.

## Test plan

- [x] New unit tests in `tests/ut/language/parser/test_type_resolver.py`:
  - `test_tileview_field_accepts_arbitrary_expression` — sentinel callback verifies delegation
  - `test_tileview_field_rejects_complex_expr_without_callback` — standalone-resolver error path
- [x] `tests/ut/ir/transforms/test_split_vector_kernel.py::test_tpop_dynamic_valid_shape_is_localized_per_subblock` now asserts the parser accepts the printed pass output (regression for the issue)
- [x] Full `tests/ut/` sweep: 4256 passed, 30 skipped, 0 failed

## Follow-up (out of scope)

Full `assert_structural_equal` roundtrip after `SplitVectorKernel` is still blocked by a separate, systemic bug: `transform_utils::Substitute` (and `IRMutator` more generally) doesn't walk Var refs embedded in type annotations, so passes that swap out param Vars by substitution silently leave dangling refs inside `tile_view.valid_shape`, `MemRef.byte_offset`, etc. Diagnosed and tracked in local `KNOWN_ISSUES.md`; preferred fix is to extend `Substitute`/`IRMutator` to rewalk types. Once landed, the `VerificationLevel.NONE` wrapper in `_run_split_vector_kernel` and the `_assert_parses` helper here can both be replaced with a full structural-equal check.

Fixes #1260