### PR TITLE
refactor(codegen): Read addr dtype from IR ConstInt, declare INT64 for byte_offset

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -366,12 +366,14 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   indent_level_++;
   fs_.constants_indent = GetIndent();
 
-  // Pre-emit i64 address constants now that indent_level_ is set
+  // Pre-emit address constants now that indent_level_ is set. The dtype
+  // is whatever the IR ConstInt declares — codegen is a 1:1 mapping over
+  // the IR's type, never an override.
   for (const auto& [tile_var, tile_type] : fs_.tile_var_allocs) {
     if (fs_.tpop_result_vars.count(tile_var.get()) > 0) continue;
     auto memref = ir::GetDefinedMemRef(tile_type);
-    if (memref && As<ir::ConstInt>(memref->byte_offset_)) {
-      GetOrEmitConstant(As<ir::ConstInt>(memref->byte_offset_)->value_, DataType::INT64);
+    if (auto const_offset = memref ? As<ir::ConstInt>(memref->byte_offset_) : nullptr) {
+      GetOrEmitConstant(const_offset->value_, const_offset->dtype());
     }
   }
 
@@ -714,7 +716,7 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
   auto memref = ir::GetDefinedMemRef(tile_type);
   if (memref) {
     if (auto const_offset = As<ir::ConstInt>(memref->byte_offset_)) {
-      fields.addr_ssa = GetOrEmitConstant(const_offset->value_, DataType::INT64);
+      fields.addr_ssa = GetOrEmitConstant(const_offset->value_, const_offset->dtype());
     }
   }
   return fields;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -366,9 +366,10 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   indent_level_++;
   fs_.constants_indent = GetIndent();
 
-  // Pre-emit address constants now that indent_level_ is set. The dtype
-  // is whatever the IR ConstInt declares — codegen is a 1:1 mapping over
-  // the IR's type, never an override.
+  // Pre-emit alloc_tile address constants now that indent_level_ is set.
+  // For addr constants specifically, codegen preserves the IR ConstInt
+  // dtype 1:1 (other operands like valid_row/valid_col adapt to the
+  // consumer's type via cast_to_index — see ComputeAllocTileFields).
   for (const auto& [tile_var, tile_type] : fs_.tile_var_allocs) {
     if (fs_.tpop_result_vars.count(tile_var.get()) > 0) continue;
     auto memref = ir::GetDefinedMemRef(tile_type);

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -67,7 +67,10 @@ MemRef::MemRef(VarPtr base, ExprPtr byte_offset, uint64_t size, Span span)
       size_(size) {}
 
 MemRef::MemRef(VarPtr base, int64_t byte_offset, uint64_t size, Span span)
-    : MemRef(std::move(base), std::make_shared<ConstInt>(byte_offset, DataType::INDEX, Span::unknown()), size,
+    // INT64 dtype matches AllocateMemoryAddrPass (which materializes the final
+    // concrete address) and the PTOAS dialect's `i64` requirement on the
+    // alloc_tile addr operand. Codegen reads dtype from the ConstInt 1:1.
+    : MemRef(std::move(base), std::make_shared<ConstInt>(byte_offset, DataType::INT64, Span::unknown()), size,
              std::move(span)) {}
 
 MemRef::MemRef(std::string name, VarPtr base, ExprPtr byte_offset, uint64_t size, Span span)

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -330,8 +330,12 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       // result MemRef offset, so collapsing all members onto base_addr is safe
       // (and matches the existing post-pass invariant that byte_offset_ is a
       // ConstInt the verifier can read).
+      //
+      // INT64 dtype is required by the PTOAS dialect's `pto.alloc_tile` addr
+      // operand. PTO codegen reads this dtype from the ConstInt 1:1 — no
+      // codegen-side override.
       auto base_addr_expr =
-          std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INDEX, Span::unknown());
+          std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INT64, Span::unknown());
       for (const auto& old_memref : group) {
         auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_, base_addr_expr,
                                                    old_memref->size_, old_memref->span_);

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -286,12 +286,15 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     span = ir.Span.unknown()
     zero = ir.ConstInt(0, DataType.INDEX, span)
     size = ir.ConstInt(128, DataType.INDEX, span)
+    # MemRef byte_offset must be INT64 (PTOAS addr operand requires i64) — see
+    # MemRef(VarPtr, int64_t, ...) ctor and AllocateMemoryAddrPass.
+    byte_offset_zero = ir.ConstInt(0, DataType.INT64, span)
 
     input_tensor = ir.Var("a", ir.TensorType([128, 128], DataType.FP32), span)
     output_tensor = ir.Var("output", ir.TensorType([128, 128], DataType.FP32), span)
     m_var = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
     n_var = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
-    shared_memref = ir.MemRef(ir.MemorySpace.Vec, zero, 128 * 128 * 4, 0)
+    shared_memref = ir.MemRef(ir.MemorySpace.Vec, byte_offset_zero, 128 * 128 * 4, 0)
 
     load_view = ir.TileView(valid_shape=[m_var, n_var])
     load_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, load_view, ir.MemorySpace.Vec)
@@ -352,7 +355,9 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     alloc_lines = _get_alloc_tile_lines(mlir_code)
 
     assert len(alloc_lines) == 2, f"Expected two alloc_tiles for per-var alloc model, got: {alloc_lines}"
-    # Both share the same addr (same MemRef)
+    # Both share the same addr (same MemRef). The PTOAS dialect requires `i64`
+    # for the alloc_tile addr operand, so AllocateMemoryAddrPass declares the
+    # final byte_offset_ ConstInt as INT64 and codegen emits it 1:1.
     assert "addr = %c0_i64" in alloc_lines[0]
     assert "addr = %c0_i64" in alloc_lines[1]
     # All alloc_tile types use dynamic v_row=?, v_col=?; the actual extents
@@ -377,12 +382,15 @@ def test_pto_codegen_fillpad_inplace():
     span = ir.Span.unknown()
     zero = ir.ConstInt(0, DataType.INDEX, span)
     size = ir.ConstInt(128, DataType.INDEX, span)
+    # MemRef byte_offset must be INT64 (PTOAS addr operand requires i64) — see
+    # MemRef(VarPtr, int64_t, ...) ctor and AllocateMemoryAddrPass.
+    byte_offset_zero = ir.ConstInt(0, DataType.INT64, span)
 
     input_tensor = ir.Var("a", ir.TensorType([128, 128], DataType.FP32), span)
     output_tensor = ir.Var("output", ir.TensorType([128, 128], DataType.FP32), span)
     m_var = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
     n_var = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
-    shared_memref = ir.MemRef(ir.MemorySpace.Vec, zero, 128 * 128 * 4, 0)
+    shared_memref = ir.MemRef(ir.MemorySpace.Vec, byte_offset_zero, 128 * 128 * 4, 0)
 
     load_view = ir.TileView(valid_shape=[m_var, n_var])
     load_tile_type = ir.TileType([128, 128], DataType.FP32, shared_memref, load_view, ir.MemorySpace.Vec)
@@ -440,7 +448,9 @@ def test_pto_codegen_fillpad_inplace():
     mlir_code = _generate_mlir(program)
     alloc_lines = _get_alloc_tile_lines(mlir_code)
 
-    # Both allocs share the same addr (same MemRef)
+    # Both allocs share the same addr (same MemRef). Address dtype tracks
+    # MemRef::byte_offset_ — declared INT64 by AllocateMemoryAddrPass so the
+    # codegen emits `i64` as required by the PTOAS dialect's addr operand.
     assert len(alloc_lines) == 2, f"Expected two alloc_tiles for per-var alloc model, got: {alloc_lines}"
     assert "addr = %c0_i64" in alloc_lines[0]
     assert "addr = %c0_i64" in alloc_lines[1]


### PR DESCRIPTION
## Summary

PTO codegen was hardcoding `DataType::INT64` for the `pto.alloc_tile` `addr` operand, overriding the dtype declared by `MemRef::byte_offset_` (`INDEX`). The PTOAS dialect strictly requires `i64` for that operand — emitting `index` causes ptoas to reject the `.pto` with:

```
error: use of value '%c0_index' expects different type than prior uses: 'i64' vs 'index'
```

This PR fixes the layering so codegen reflects IR dtype 1:1 and the IR carries the correct type.

## Changes

- **`src/codegen/pto/pto_codegen.cpp`** — read `const_offset->dtype()` from the IR `ConstInt` instead of hardcoding `INT64` (two sites: pre-emission of constants and `addr` operand emission).
- **`src/ir/transforms/allocate_memory_addr_pass.cpp`** — declare the materialized concrete-address `ConstInt` as `INT64` (matches PTOAS requirement). Comment explains the constraint.
- **`src/ir/memref.cpp`** — `MemRef(VarPtr, int64_t, ...)` convenience constructor wraps `byte_offset` as `INT64` to match.
- **`tests/ut/codegen/test_pto_codegen.py`** — two test fixtures that hand-build a `MemRef` with `ConstInt(0, INDEX)` now use a separate `INT64` `byte_offset_zero` (the existing `INDEX` `zero` is still reused for tile/slice offsets).

## Why this split

The intermediate symbolic byte-offset trees in `memref_utils.h` (`AddByteOffsets`, `MulByteOffsets`, `MakeZeroByteOffset`, `ComputeSliceByteOffset`) intentionally **keep `INDEX`** — they participate in arithmetic with `index`-typed loop vars, and `AllocateMemoryAddrPass` folds them into a single concrete `INT64` `ConstInt` before codegen runs.

So the dtype split is:
- Symbolic offset arithmetic (pre-AllocateMemoryAddr): `INDEX` (matches loop-var dtype)
- Materialized concrete address (post-AllocateMemoryAddr → codegen): `INT64` (matches PTOAS requirement)

## Test plan

- [x] All unit tests pass (4269+ tests, including 8 JIT tests that previously failed at PTOAS parse with the bad `.pto`)
- [x] clang-tidy clean
- [x] Pre-commit hooks all pass (clang-format, cpplint, ruff, pyright)
- [x] End-to-end PTOAS round-trip verified via `tests/ut/jit/test_decorator.py::TestJitCaching::test_returns_compiled_program` — the test that originally surfaced the PTOAS parse error now passes