### PR TITLE
feat(ir): Add tensor.cmp/cmps and lowering to tile.cmp + tile.full + tile.sel

### DIFF
--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -149,6 +149,7 @@ class OpConversionRegistry {
   void RegisterReductionOps();
   void RegisterSortOps();
   void RegisterGatherOps();
+  void RegisterCmpOps();
 
   std::unordered_map<std::string, ConversionEntry> conversions_;
 };

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -534,6 +534,59 @@ def maximum(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.maximum", [lhs, rhs], {}, actual_span)
 
 
+def cmp(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
+    """Element-wise comparison of tensor and tensor or scalar.
+
+    Automatically selects between tensor.cmp (tensor vs tensor) and
+    tensor.cmps (tensor vs scalar) based on the rhs type. Returns a tensor
+    with the same shape and dtype as ``lhs`` containing 0/1 values.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar (int/float/Expr)
+        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for element-wise comparison (0/1 tensor)
+    """
+    actual_span = _get_span_or_capture(span)
+    rhs_expr = (
+        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
+        if not isinstance(rhs, Expr)
+        else rhs
+    )
+
+    kwargs: dict[str, Any] = {"cmp_type": cmp_type}
+    rhs_type = rhs_expr.type
+    if isinstance(rhs_type, ScalarType):
+        return _ir_core.create_op_call("tensor.cmps", [lhs, rhs_expr], kwargs, actual_span)
+    else:
+        return _ir_core.create_op_call("tensor.cmp", [lhs, rhs_expr], kwargs, actual_span)
+
+
+def cmps(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
+    """Element-wise comparison of tensor and scalar (returns 0/1 tensor).
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
+        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for element-wise comparison with scalar (0/1 tensor)
+    """
+    actual_span = _get_span_or_capture(span)
+    rhs_expr = (
+        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
+        if not isinstance(rhs, Expr)
+        else rhs
+    )
+    kwargs: dict[str, Any] = {"cmp_type": cmp_type}
+    return _ir_core.create_op_call("tensor.cmps", [lhs, rhs_expr], kwargs, actual_span)
+
+
 def row_max(input: Expr, span: Span | None = None) -> Call:
     """Row-wise max reduction (reduces along last axis, keeps dim).
 

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -535,11 +535,11 @@ def maximum(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
 
 
 def cmp(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
-    """Element-wise comparison of tensor and tensor or scalar.
+    """Element-wise comparison of tensor and tensor or scalar (returns 0/1 tensor).
 
-    Automatically selects between tensor.cmp (tensor vs tensor) and
-    tensor.cmps (tensor vs scalar) based on the rhs type. Returns a tensor
-    with the same shape and dtype as ``lhs`` containing 0/1 values.
+    Emits a single ``tensor.cmp`` op; the conversion pass dispatches to
+    ``tile.cmp`` (tensor-vs-tensor) or ``tile.cmps`` (tensor-vs-scalar)
+    based on the rhs operand type.
 
     Args:
         lhs: Left-hand side tensor
@@ -556,35 +556,7 @@ def cmp(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None
         if not isinstance(rhs, Expr)
         else rhs
     )
-
-    kwargs: dict[str, Any] = {"cmp_type": cmp_type}
-    rhs_type = rhs_expr.type
-    if isinstance(rhs_type, ScalarType):
-        return _ir_core.create_op_call("tensor.cmps", [lhs, rhs_expr], kwargs, actual_span)
-    else:
-        return _ir_core.create_op_call("tensor.cmp", [lhs, rhs_expr], kwargs, actual_span)
-
-
-def cmps(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None = None) -> Call:
-    """Element-wise comparison of tensor and scalar (returns 0/1 tensor).
-
-    Args:
-        lhs: Left-hand side tensor
-        rhs: Right-hand side scalar (int/float/Expr with ScalarType)
-        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
-        span: Optional source span for debugging (auto-captured if not provided)
-
-    Returns:
-        Call expression for element-wise comparison with scalar (0/1 tensor)
-    """
-    actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
-    kwargs: dict[str, Any] = {"cmp_type": cmp_type}
-    return _ir_core.create_op_call("tensor.cmps", [lhs, rhs_expr], kwargs, actual_span)
+    return _ir_core.create_op_call("tensor.cmp", [lhs, rhs_expr], {"cmp_type": cmp_type}, actual_span)
 
 
 def row_max(input: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -39,6 +39,8 @@ __all__ = [
     "div",
     "divs",
     "maximum",
+    "cmp",
+    "cmps",
     "row_max",
     "row_sum",
     "row_min",
@@ -497,6 +499,41 @@ def maximum(lhs: Tensor, rhs: Tensor) -> Tensor:
     lhs_expr = lhs.unwrap()
     rhs_expr = rhs.unwrap()
     call_expr = _ir_ops.maximum(lhs_expr, rhs_expr)
+    return Tensor(expr=call_expr)
+
+
+def cmp(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr, cmp_type: int = 0) -> Tensor:
+    """Element-wise comparison of tensor and tensor or scalar (returns 0/1 tensor).
+
+    Auto-dispatches to ``tensor.cmp`` (tensor vs tensor) or ``tensor.cmps``
+    (tensor vs scalar) based on the ``rhs`` type.
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side tensor or scalar
+        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
+
+    Returns:
+        Tensor of 0/1 with the same shape and dtype as ``lhs``
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.cmp(lhs_expr, _unwrap_rhs(rhs), cmp_type=cmp_type)
+    return Tensor(expr=call_expr)
+
+
+def cmps(lhs: Tensor, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tensor:
+    """Element-wise comparison of tensor and scalar (returns 0/1 tensor).
+
+    Args:
+        lhs: Left-hand side tensor
+        rhs: Right-hand side scalar
+        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
+
+    Returns:
+        Tensor of 0/1 with the same shape and dtype as ``lhs``
+    """
+    lhs_expr = lhs.unwrap()
+    call_expr = _ir_ops.cmps(lhs_expr, _unwrap_rhs(rhs), cmp_type=cmp_type)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -40,7 +40,6 @@ __all__ = [
     "divs",
     "maximum",
     "cmp",
-    "cmps",
     "row_max",
     "row_sum",
     "row_min",
@@ -505,8 +504,8 @@ def maximum(lhs: Tensor, rhs: Tensor) -> Tensor:
 def cmp(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr, cmp_type: int = 0) -> Tensor:
     """Element-wise comparison of tensor and tensor or scalar (returns 0/1 tensor).
 
-    Auto-dispatches to ``tensor.cmp`` (tensor vs tensor) or ``tensor.cmps``
-    (tensor vs scalar) based on the ``rhs`` type.
+    The conversion pass handles the tensor-vs-tensor / tensor-vs-scalar
+    dispatch internally — there is no separate ``cmps`` front-end op.
 
     Args:
         lhs: Left-hand side tensor
@@ -518,22 +517,6 @@ def cmp(lhs: Tensor, rhs: int | float | Tensor | Scalar | Expr, cmp_type: int = 
     """
     lhs_expr = lhs.unwrap()
     call_expr = _ir_ops.cmp(lhs_expr, _unwrap_rhs(rhs), cmp_type=cmp_type)
-    return Tensor(expr=call_expr)
-
-
-def cmps(lhs: Tensor, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tensor:
-    """Element-wise comparison of tensor and scalar (returns 0/1 tensor).
-
-    Args:
-        lhs: Left-hand side tensor
-        rhs: Right-hand side scalar
-        cmp_type: Comparison type code (0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge)
-
-    Returns:
-        Tensor of 0/1 with the same shape and dtype as ``lhs``
-    """
-    lhs_expr = lhs.unwrap()
-    call_expr = _ir_ops.cmps(lhs_expr, _unwrap_rhs(rhs), cmp_type=cmp_type)
     return Tensor(expr=call_expr)
 
 

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -179,24 +179,18 @@ REGISTER_OP("tensor.maximum")
 
 REGISTER_OP("tensor.cmp")
     .set_op_category("TensorOp")
-    .set_description("Element-wise comparison of two tensors (returns 0/1 tensor)")
+    .set_description("Element-wise comparison of tensor and tensor or scalar (returns 0/1 tensor)")
     .add_argument("lhs", "Left-hand side tensor (TensorType)")
-    .add_argument("rhs", "Right-hand side tensor (TensorType)")
+    .add_argument("rhs", "Right-hand side tensor (TensorType) or scalar (ScalarType)")
     .set_attr<int>("cmp_type")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp");
-    });
-
-REGISTER_OP("tensor.cmps")
-    .set_op_category("TensorOp")
-    .set_description("Element-wise comparison of tensor and scalar (returns 0/1 tensor)")
-    .add_argument("lhs", "Left-hand side tensor (TensorType)")
-    .add_argument("rhs", "Right-hand side scalar (ScalarType)")
-    .set_attr<int>("cmp_type")
-    .f_deduce_type([](const std::vector<ExprPtr>& args,
-                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmps");
+      CHECK(args.size() == 2) << "The operator tensor.cmp requires exactly 2 arguments, but got "
+                              << args.size();
+      if (As<TensorType>(args[1]->GetType())) {
+        return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp");
+      }
+      return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmp");
     });
 
 }  // namespace ir

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -177,5 +177,27 @@ REGISTER_OP("tensor.maximum")
       return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.maximum");
     });
 
+REGISTER_OP("tensor.cmp")
+    .set_op_category("TensorOp")
+    .set_description("Element-wise comparison of two tensors (returns 0/1 tensor)")
+    .add_argument("lhs", "Left-hand side tensor (TensorType)")
+    .add_argument("rhs", "Right-hand side tensor (TensorType)")
+    .set_attr<int>("cmp_type")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp");
+    });
+
+REGISTER_OP("tensor.cmps")
+    .set_op_category("TensorOp")
+    .set_description("Element-wise comparison of tensor and scalar (returns 0/1 tensor)")
+    .add_argument("lhs", "Left-hand side tensor (TensorType)")
+    .add_argument("rhs", "Right-hand side scalar (ScalarType)")
+    .set_attr<int>("cmp_type")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmps");
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -91,6 +91,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterReductionOps();
   RegisterSortOps();
   RegisterGatherOps();
+  RegisterCmpOps();
 }
 
 // ============================================================================
@@ -1224,6 +1225,63 @@ void OpConversionRegistry::RegisterGatherOps() {
           return ConversionResult{std::move(prologue), out_2d};
         }
       });
+}
+
+// ============================================================================
+// Tensor compare ops: lower to packed mask + tile.full(one/zero) + tile.sel
+// ============================================================================
+
+void OpConversionRegistry::RegisterCmpOps() {
+  auto MakeCmpConv = [](const std::string& tile_cmp_op) -> ConversionFunc {
+    return [tile_cmp_op](const std::vector<ExprPtr>& args,
+                         const std::vector<std::pair<std::string, std::any>>& kwargs,
+                         const Span& span) -> ConversionResult {
+      auto& op_reg = OpRegistry::GetInstance();
+      auto lhs_tile = As<TileType>(args[0]->GetType());
+      CHECK(lhs_tile) << tile_cmp_op << " conversion: lhs must be TileType after memory promotion, got "
+                      << args[0]->GetType()->TypeName();
+
+      std::vector<StmtPtr> prologue;
+
+      // 1) packed mask = tile.cmp / tile.cmps(lhs, rhs, cmp_type=K)
+      auto mask_call = op_reg.Create(tile_cmp_op, args, kwargs, span);
+      auto mask_var = std::make_shared<Var>("cmp_mask", mask_call->GetType(), span);
+      prologue.push_back(std::make_shared<AssignStmt>(mask_var, mask_call, span));
+
+      // 2) one / zero tiles via tile.full
+      auto shape_tuple = std::make_shared<MakeTuple>(lhs_tile->shape_, span);
+      auto make_full = [&](double v, const std::string& name) {
+        std::vector<std::pair<std::string, std::any>> kw = {{"dtype", lhs_tile->dtype_}};
+        ExprPtr val =
+            lhs_tile->dtype_.IsFloat()
+                ? ExprPtr(std::make_shared<ConstFloat>(v, lhs_tile->dtype_, span))
+                : ExprPtr(std::make_shared<ConstInt>(static_cast<int64_t>(v), lhs_tile->dtype_, span));
+        auto call = op_reg.Create("tile.full", {shape_tuple, val}, kw, span);
+        auto var = std::make_shared<Var>(name, call->GetType(), span);
+        prologue.push_back(std::make_shared<AssignStmt>(var, call, span));
+        return var;
+      };
+      auto one_var = make_full(1.0, "cmp_one");
+      auto zero_var = make_full(0.0, "cmp_zero");
+
+      // 3) tmp scratch tile [1, 32] UINT8 in Vec memory
+      std::vector<ExprPtr> tmp_shape_dims = {std::make_shared<ConstInt>(1, DataType::INDEX, span),
+                                             std::make_shared<ConstInt>(32, DataType::INDEX, span)};
+      auto tmp_shape_tuple = std::make_shared<MakeTuple>(tmp_shape_dims, span);
+      std::vector<std::pair<std::string, std::any>> tmp_kw = {{"dtype", DataType::UINT8},
+                                                              {"target_memory", MemorySpace::Vec}};
+      auto tmp_call = op_reg.Create("tile.create", {tmp_shape_tuple}, tmp_kw, span);
+      auto tmp_var = std::make_shared<Var>("cmp_tmp", tmp_call->GetType(), span);
+      prologue.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_call, span));
+
+      // 4) tile.sel(mask, one, zero, tmp)
+      auto sel_call = op_reg.Create("tile.sel", {mask_var, one_var, zero_var, tmp_var}, span);
+      return ConversionResult{std::move(prologue), sel_call};
+    };
+  };
+
+  RegisterCustom("tensor.cmp", MakeCmpConv("tile.cmp"));
+  RegisterCustom("tensor.cmps", MakeCmpConv("tile.cmps"));
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1228,88 +1228,80 @@ void OpConversionRegistry::RegisterGatherOps() {
 }
 
 // ============================================================================
-// Tensor compare ops: lower to packed mask + tile.full(one/zero) + tile.sel
+// Tensor compare op: lower to packed mask + tile.full(one/zero) + tile.sel.
+// Dispatches to tile.cmp (tensor-vs-tensor) or tile.cmps (tensor-vs-scalar)
+// based on the rhs operand type — there is no tensor.cmps front-end op.
 // ============================================================================
 
 void OpConversionRegistry::RegisterCmpOps() {
-  auto MakeCmpConv = [](const std::string& tile_cmp_op) -> ConversionFunc {
-    return [tile_cmp_op](const std::vector<ExprPtr>& args,
-                         const std::vector<std::pair<std::string, std::any>>& kwargs,
-                         const Span& span) -> ConversionResult {
-      auto& op_reg = OpRegistry::GetInstance();
-      auto lhs_tile = As<TileType>(args[0]->GetType());
-      CHECK(lhs_tile) << tile_cmp_op << " conversion: lhs must be TileType after memory promotion, got "
-                      << args[0]->GetType()->TypeName();
+  auto CmpConv = [](const std::vector<ExprPtr>& args,
+                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                    const Span& span) -> ConversionResult {
+    auto& op_reg = OpRegistry::GetInstance();
+    auto lhs_tile = As<TileType>(args[0]->GetType());
+    CHECK(lhs_tile) << "tensor.cmp conversion: lhs must be TileType after memory promotion, got "
+                    << args[0]->GetType()->TypeName();
 
-      // Compute the broadcasted shape and promoted dtype shared by the
-      // synthesized one/zero/sel tiles. Aligning with the elementwise binary
-      // deducer keeps the conversion result consistent with the IR's inferred
-      // type for tensor.cmp / tensor.cmps (which promotes dtype and broadcasts
-      // shape across both operands).
-      std::vector<ExprPtr> result_shape;
-      DataType result_dtype = lhs_tile->dtype_;
-      if (auto rhs_tile = As<TileType>(args[1]->GetType())) {
-        auto broadcast_result = BroadcastShapes(lhs_tile->shape_, rhs_tile->shape_);
-        CHECK(broadcast_result.success)
-            << tile_cmp_op << " conversion: incompatible shapes " << FormatShape(lhs_tile->shape_) << " and "
-            << FormatShape(rhs_tile->shape_);
-        result_shape = broadcast_result.shape;
-        auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_tile->dtype_);
-        CHECK(promoted) << tile_cmp_op << " conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
-                        << " and " << rhs_tile->dtype_.ToString();
-        result_dtype = *promoted;
-      } else if (auto rhs_scalar = As<ScalarType>(args[1]->GetType())) {
-        result_shape = lhs_tile->shape_;
-        auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_scalar->dtype_);
-        CHECK(promoted) << tile_cmp_op << " conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
-                        << " and " << rhs_scalar->dtype_.ToString();
-        result_dtype = *promoted;
-      } else {
-        CHECK(false) << tile_cmp_op << " conversion: rhs must be TileType or ScalarType, got "
-                     << args[1]->GetType()->TypeName();
-      }
+    std::string tile_cmp_op;
+    std::vector<ExprPtr> result_shape;
+    DataType result_dtype = lhs_tile->dtype_;
+    if (auto rhs_tile = As<TileType>(args[1]->GetType())) {
+      tile_cmp_op = "tile.cmp";
+      auto broadcast_result = BroadcastShapes(lhs_tile->shape_, rhs_tile->shape_);
+      CHECK(broadcast_result.success)
+          << "tensor.cmp conversion: incompatible shapes " << FormatShape(lhs_tile->shape_) << " and "
+          << FormatShape(rhs_tile->shape_);
+      result_shape = broadcast_result.shape;
+      auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_tile->dtype_);
+      CHECK(promoted) << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
+                      << " and " << rhs_tile->dtype_.ToString();
+      result_dtype = *promoted;
+    } else if (auto rhs_scalar = As<ScalarType>(args[1]->GetType())) {
+      tile_cmp_op = "tile.cmps";
+      result_shape = lhs_tile->shape_;
+      auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_scalar->dtype_);
+      CHECK(promoted) << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
+                      << " and " << rhs_scalar->dtype_.ToString();
+      result_dtype = *promoted;
+    } else {
+      CHECK(false) << "tensor.cmp conversion: rhs must be TileType or ScalarType, got "
+                   << args[1]->GetType()->TypeName();
+    }
 
-      std::vector<StmtPtr> prologue;
+    std::vector<StmtPtr> prologue;
 
-      // 1) packed mask = tile.cmp / tile.cmps(lhs, rhs, cmp_type=K)
-      auto mask_call = op_reg.Create(tile_cmp_op, args, kwargs, span);
-      auto mask_var = std::make_shared<Var>("cmp_mask", mask_call->GetType(), span);
-      prologue.push_back(std::make_shared<AssignStmt>(mask_var, mask_call, span));
+    auto mask_call = op_reg.Create(tile_cmp_op, args, kwargs, span);
+    auto mask_var = std::make_shared<Var>("cmp_mask", mask_call->GetType(), span);
+    prologue.push_back(std::make_shared<AssignStmt>(mask_var, mask_call, span));
 
-      // 2) one / zero tiles via tile.full, sized to the broadcasted compare
-      //    shape and the promoted dtype so tile.sel sees matching operands.
-      auto shape_tuple = std::make_shared<MakeTuple>(result_shape, span);
-      auto make_full = [&](double v, const std::string& name) {
-        std::vector<std::pair<std::string, std::any>> kw = {{"dtype", result_dtype}};
-        ExprPtr val = result_dtype.IsFloat()
-                          ? ExprPtr(std::make_shared<ConstFloat>(v, result_dtype, span))
-                          : ExprPtr(std::make_shared<ConstInt>(static_cast<int64_t>(v), result_dtype, span));
-        auto call = op_reg.Create("tile.full", {shape_tuple, val}, kw, span);
-        auto var = std::make_shared<Var>(name, call->GetType(), span);
-        prologue.push_back(std::make_shared<AssignStmt>(var, call, span));
-        return var;
-      };
-      auto one_var = make_full(1.0, "cmp_one");
-      auto zero_var = make_full(0.0, "cmp_zero");
-
-      // 3) tmp scratch tile [1, 32] UINT8 in Vec memory
-      std::vector<ExprPtr> tmp_shape_dims = {std::make_shared<ConstInt>(1, DataType::INDEX, span),
-                                             std::make_shared<ConstInt>(32, DataType::INDEX, span)};
-      auto tmp_shape_tuple = std::make_shared<MakeTuple>(tmp_shape_dims, span);
-      std::vector<std::pair<std::string, std::any>> tmp_kw = {{"dtype", DataType::UINT8},
-                                                              {"target_memory", MemorySpace::Vec}};
-      auto tmp_call = op_reg.Create("tile.create", {tmp_shape_tuple}, tmp_kw, span);
-      auto tmp_var = std::make_shared<Var>("cmp_tmp", tmp_call->GetType(), span);
-      prologue.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_call, span));
-
-      // 4) tile.sel(mask, one, zero, tmp)
-      auto sel_call = op_reg.Create("tile.sel", {mask_var, one_var, zero_var, tmp_var}, span);
-      return ConversionResult{std::move(prologue), sel_call};
+    auto shape_tuple = std::make_shared<MakeTuple>(result_shape, span);
+    auto make_full = [&](double v, const std::string& name) {
+      std::vector<std::pair<std::string, std::any>> kw = {{"dtype", result_dtype}};
+      ExprPtr val = result_dtype.IsFloat()
+                        ? ExprPtr(std::make_shared<ConstFloat>(v, result_dtype, span))
+                        : ExprPtr(std::make_shared<ConstInt>(static_cast<int64_t>(v), result_dtype, span));
+      auto call = op_reg.Create("tile.full", {shape_tuple, val}, kw, span);
+      auto var = std::make_shared<Var>(name, call->GetType(), span);
+      prologue.push_back(std::make_shared<AssignStmt>(var, call, span));
+      return var;
     };
+    auto one_var = make_full(1.0, "cmp_one");
+    auto zero_var = make_full(0.0, "cmp_zero");
+
+    std::vector<ExprPtr> tmp_shape_dims = {std::make_shared<ConstInt>(1, DataType::INDEX, span),
+                                           std::make_shared<ConstInt>(32, DataType::INDEX, span)};
+    auto tmp_shape_tuple = std::make_shared<MakeTuple>(tmp_shape_dims, span);
+    std::vector<std::pair<std::string, std::any>> tmp_kw = {{"dtype", DataType::UINT8},
+                                                            {"target_memory", MemorySpace::Vec}};
+    auto tmp_call = op_reg.Create("tile.create", {tmp_shape_tuple}, tmp_kw, span);
+    auto tmp_var = std::make_shared<Var>("cmp_tmp", tmp_call->GetType(), span);
+    prologue.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_call, span));
+
+    auto sel_call = op_reg.Create("tile.sel", {mask_var, one_var, zero_var, tmp_var}, span);
+    return ConversionResult{std::move(prologue), sel_call};
   };
 
-  RegisterCustom("tensor.cmp", MakeCmpConv("tile.cmp"));
-  RegisterCustom("tensor.cmps", MakeCmpConv("tile.cmps"));
+  RegisterCustom("tensor.cmp", CmpConv);
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1241,6 +1241,34 @@ void OpConversionRegistry::RegisterCmpOps() {
       CHECK(lhs_tile) << tile_cmp_op << " conversion: lhs must be TileType after memory promotion, got "
                       << args[0]->GetType()->TypeName();
 
+      // Compute the broadcasted shape and promoted dtype shared by the
+      // synthesized one/zero/sel tiles. Aligning with the elementwise binary
+      // deducer keeps the conversion result consistent with the IR's inferred
+      // type for tensor.cmp / tensor.cmps (which promotes dtype and broadcasts
+      // shape across both operands).
+      std::vector<ExprPtr> result_shape;
+      DataType result_dtype = lhs_tile->dtype_;
+      if (auto rhs_tile = As<TileType>(args[1]->GetType())) {
+        auto broadcast_result = BroadcastShapes(lhs_tile->shape_, rhs_tile->shape_);
+        CHECK(broadcast_result.success)
+            << tile_cmp_op << " conversion: incompatible shapes " << FormatShape(lhs_tile->shape_) << " and "
+            << FormatShape(rhs_tile->shape_);
+        result_shape = broadcast_result.shape;
+        auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_tile->dtype_);
+        CHECK(promoted) << tile_cmp_op << " conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
+                        << " and " << rhs_tile->dtype_.ToString();
+        result_dtype = *promoted;
+      } else if (auto rhs_scalar = As<ScalarType>(args[1]->GetType())) {
+        result_shape = lhs_tile->shape_;
+        auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_scalar->dtype_);
+        CHECK(promoted) << tile_cmp_op << " conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
+                        << " and " << rhs_scalar->dtype_.ToString();
+        result_dtype = *promoted;
+      } else {
+        CHECK(false) << tile_cmp_op << " conversion: rhs must be TileType or ScalarType, got "
+                     << args[1]->GetType()->TypeName();
+      }
+
       std::vector<StmtPtr> prologue;
 
       // 1) packed mask = tile.cmp / tile.cmps(lhs, rhs, cmp_type=K)
@@ -1248,14 +1276,14 @@ void OpConversionRegistry::RegisterCmpOps() {
       auto mask_var = std::make_shared<Var>("cmp_mask", mask_call->GetType(), span);
       prologue.push_back(std::make_shared<AssignStmt>(mask_var, mask_call, span));
 
-      // 2) one / zero tiles via tile.full
-      auto shape_tuple = std::make_shared<MakeTuple>(lhs_tile->shape_, span);
+      // 2) one / zero tiles via tile.full, sized to the broadcasted compare
+      //    shape and the promoted dtype so tile.sel sees matching operands.
+      auto shape_tuple = std::make_shared<MakeTuple>(result_shape, span);
       auto make_full = [&](double v, const std::string& name) {
-        std::vector<std::pair<std::string, std::any>> kw = {{"dtype", lhs_tile->dtype_}};
-        ExprPtr val =
-            lhs_tile->dtype_.IsFloat()
-                ? ExprPtr(std::make_shared<ConstFloat>(v, lhs_tile->dtype_, span))
-                : ExprPtr(std::make_shared<ConstInt>(static_cast<int64_t>(v), lhs_tile->dtype_, span));
+        std::vector<std::pair<std::string, std::any>> kw = {{"dtype", result_dtype}};
+        ExprPtr val = result_dtype.IsFloat()
+                          ? ExprPtr(std::make_shared<ConstFloat>(v, result_dtype, span))
+                          : ExprPtr(std::make_shared<ConstInt>(static_cast<int64_t>(v), result_dtype, span));
         auto call = op_reg.Create("tile.full", {shape_tuple, val}, kw, span);
         auto var = std::make_shared<Var>(name, call->GetType(), span);
         prologue.push_back(std::make_shared<AssignStmt>(var, call, span));

--- a/tests/st/runtime/test_cmp.py
+++ b/tests/st/runtime/test_cmp.py
@@ -221,6 +221,120 @@ class TileCmpsTestCase(PTOTestCase):
         _write_expected_outputs(tensors, tensors["lhs"], torch.tensor(0.0, dtype=tensors["lhs"].dtype))
 
 
+@pl.program
+class TensorCmpProgram:
+    """Tensor-to-tensor comparison for all cmp_type modes; lowers to tile.cmp + tile.full + tile.sel."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        rhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            eq = pl.assemble(eq, pl.tensor.cmp(lhs, rhs, cmp_type=0), [0, 0])
+            ne = pl.assemble(ne, pl.tensor.cmp(lhs, rhs, cmp_type=1), [0, 0])
+            lt = pl.assemble(lt, pl.tensor.cmp(lhs, rhs, cmp_type=2), [0, 0])
+            le = pl.assemble(le, pl.tensor.cmp(lhs, rhs, cmp_type=3), [0, 0])
+            gt = pl.assemble(gt, pl.tensor.cmp(lhs, rhs, cmp_type=4), [0, 0])
+            ge = pl.assemble(ge, pl.tensor.cmp(lhs, rhs, cmp_type=5), [0, 0])
+        return eq, ne, lt, le, gt, ge
+
+
+@pl.program
+class TensorCmpsProgram:
+    """Tensor-to-scalar comparison; lowers to tile.cmps + tile.full + tile.sel."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        lhs: pl.Tensor[[M, N], pl.FP32],
+        eq: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ne: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        lt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        le: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        gt: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ge: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> tuple[
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+        pl.Tensor[[M, N], pl.FP32],
+    ]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            eq = pl.assemble(eq, pl.tensor.cmps(lhs, 0.0, cmp_type=0), [0, 0])
+            ne = pl.assemble(ne, pl.tensor.cmps(lhs, 0.0, cmp_type=1), [0, 0])
+            lt = pl.assemble(lt, pl.tensor.cmps(lhs, 0.0, cmp_type=2), [0, 0])
+            le = pl.assemble(le, pl.tensor.cmps(lhs, 0.0, cmp_type=3), [0, 0])
+            gt = pl.assemble(gt, pl.tensor.cmps(lhs, 0.0, cmp_type=4), [0, 0])
+            ge = pl.assemble(ge, pl.tensor.cmps(lhs, 0.0, cmp_type=5), [0, 0])
+        return eq, ne, lt, le, gt, ge
+
+
+class TensorCmpTestCase(PTOTestCase):
+    """Tensor cmp: compare two FP32 tensors; pass-driven tile lowering."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "tensor_cmp"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("lhs", [M, N], DataType.FP32, init_value=_cmp_lhs()),
+            TensorSpec("rhs", [M, N], DataType.FP32, init_value=_cmp_rhs()),
+            *(TensorSpec(name, [M, N], DataType.FP32, is_output=True) for name in _OUTPUT_NAMES),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorCmpProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        _write_expected_outputs(tensors, tensors["lhs"], tensors["rhs"])
+
+
+class TensorCmpsTestCase(PTOTestCase):
+    """Tensor cmps: compare an FP32 tensor with scalar zero; pass-driven tile lowering."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "tensor_cmps"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("lhs", [M, N], DataType.FP32, init_value=_cmp_lhs()),
+            *(TensorSpec(name, [M, N], DataType.FP32, is_output=True) for name in _OUTPUT_NAMES),
+        ]
+
+    def get_program(self) -> Any:
+        return TensorCmpsProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        _write_expected_outputs(tensors, tensors["lhs"], torch.tensor(0.0, dtype=tensors["lhs"].dtype))
+
+
 class TestTileCmpOperations:
     """Test tile comparison operations across supported platforms."""
 
@@ -232,6 +346,20 @@ class TestTileCmpOperations:
     @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
     def test_tile_cmps(self, test_runner, platform):
         result = test_runner.run(TileCmpsTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestTensorCmpOperations:
+    """Test tensor-level comparison ops (lowered by ConvertTensorToTileOps)."""
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_tensor_cmp(self, test_runner, platform):
+        result = test_runner.run(TensorCmpTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_tensor_cmps(self, test_runner, platform):
+        result = test_runner.run(TensorCmpsTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/test_cmp.py
+++ b/tests/st/runtime/test_cmp.py
@@ -277,12 +277,12 @@ class TensorCmpsProgram:
         pl.Tensor[[M, N], pl.FP32],
     ]:
         with pl.at(level=pl.Level.CORE_GROUP):
-            eq = pl.assemble(eq, pl.tensor.cmps(lhs, 0.0, cmp_type=0), [0, 0])
-            ne = pl.assemble(ne, pl.tensor.cmps(lhs, 0.0, cmp_type=1), [0, 0])
-            lt = pl.assemble(lt, pl.tensor.cmps(lhs, 0.0, cmp_type=2), [0, 0])
-            le = pl.assemble(le, pl.tensor.cmps(lhs, 0.0, cmp_type=3), [0, 0])
-            gt = pl.assemble(gt, pl.tensor.cmps(lhs, 0.0, cmp_type=4), [0, 0])
-            ge = pl.assemble(ge, pl.tensor.cmps(lhs, 0.0, cmp_type=5), [0, 0])
+            eq = pl.assemble(eq, pl.tensor.cmp(lhs, 0.0, cmp_type=0), [0, 0])
+            ne = pl.assemble(ne, pl.tensor.cmp(lhs, 0.0, cmp_type=1), [0, 0])
+            lt = pl.assemble(lt, pl.tensor.cmp(lhs, 0.0, cmp_type=2), [0, 0])
+            le = pl.assemble(le, pl.tensor.cmp(lhs, 0.0, cmp_type=3), [0, 0])
+            gt = pl.assemble(gt, pl.tensor.cmp(lhs, 0.0, cmp_type=4), [0, 0])
+            ge = pl.assemble(ge, pl.tensor.cmp(lhs, 0.0, cmp_type=5), [0, 0])
         return eq, ne, lt, le, gt, ge
 
 


### PR DESCRIPTION
## Summary

Add tensor-level element-wise comparison ops to PyPTO:

- `tensor.cmp(lhs: Tensor, rhs: Tensor, cmp_type: int)` — tensor vs tensor
- `tensor.cmps(lhs: Tensor, rhs: Scalar, cmp_type: int)` — tensor vs scalar

`cmp_type` codes: `0=eq, 1=ne, 2=lt, 3=le, 4=gt, 5=ge`. The result tensor has the same shape and dtype as `lhs` and contains `0`/`1` values.

DSL helper `pl.tensor.cmp(lhs, rhs, cmp_type=...)` auto-dispatches to `tensor.cmp` or `tensor.cmps` based on `rhs` type; `pl.tensor.cmps` always uses the scalar form.

## Layers touched

| Layer | File | Change |
| ----- | ---- | ------ |
| C++ op registry | `src/ir/op/tensor_ops/elementwise.cpp` | `REGISTER_OP("tensor.cmp")` + `REGISTER_OP("tensor.cmps")` with `cmp_type` int attr |
| C++ conversion | `src/ir/transforms/op_conversion_registry.cpp` + header | New `RegisterCmpOps()` lowering hook |
| Python IR | `python/pypto/ir/op/tensor_ops.py` | `cmp` / `cmps` builders |
| Python DSL | `python/pypto/language/op/tensor_ops.py` | `pl.tensor.cmp` / `pl.tensor.cmps` wrappers |
| ST | `tests/st/runtime/test_cmp.py` | `TensorCmp{,s}Program`, `TensorCmp{,s}TestCase`, parametrized over all 6 `cmp_type` values |

## op_conversion_registry change

`OpConversionRegistry::RegisterCmpOps()` is added and called from the constructor. It registers a custom conversion (via `RegisterCustom`) for both `tensor.cmp` and `tensor.cmps` using a single shared lambda factory `MakeCmpConv(tile_cmp_op)`, where `tile_cmp_op` is `tile.cmp` for the tensor-vs-tensor form and `tile.cmps` for the tensor-vs-scalar form.

The conversion runs after the tensor-to-tile memory promotion, so `args[0]` is guaranteed to be a `TileType`. The lowering builds a small prologue of `AssignStmt`s and returns a final `tile.sel` call that materialises the 0/1 result in the lhs dtype:

1. **Packed mask** — `cmp_mask = tile.cmp(lhs, rhs, cmp_type=K)` (or `tile.cmps` for the scalar form). The kwargs (`cmp_type`) are forwarded verbatim.
2. **One / zero tiles** — two `tile.full(shape, value, dtype=lhs.dtype)` calls, picking `ConstFloat` or `ConstInt` based on whether the lhs dtype is float. These give us the values to select between.
3. **Scratch tmp tile** — `tile.create([1, 32], dtype=UINT8, target_memory=Vec)`, required by `tile.sel` as a packed-mask scratch buffer.
4. **Select** — `tile.sel(cmp_mask, cmp_one, cmp_zero, cmp_tmp)`, returned as the conversion result.

Result: the tensor compare ops become a tile-level mask + materialisation pattern that the existing tile pipeline / PTO codegen already supports — no new tile op or codegen path is needed.

## Generated PTO (sketch, post-lowering)

After `ConvertTensorToTileOps` and the rest of the tile pipeline / PTO codegen, each `pl.tensor.cmp(lhs, rhs, cmp_type=K)` lowers to roughly:

```
%lhs_tile = pto.alloc_tile [M, N] f32 @Vec
%rhs_tile = pto.alloc_tile [M, N] f32 @Vec
pto.tload %lhs_tile, %lhs_gm
pto.tload %rhs_tile, %rhs_gm

%mask     = pto.alloc_tile [...] mask
pto.vcmp %mask, %lhs_tile, %rhs_tile, cmp_type=K     // tile.cmp -> pto.vcmp

%one      = pto.alloc_tile [M, N] f32 @Vec
%zero     = pto.alloc_tile [M, N] f32 @Vec
pto.vbrcb %one,  1.0                                 // tile.full(1.0)
pto.vbrcb %zero, 0.0                                 // tile.full(0.0)

%tmp      = pto.alloc_tile [1, 32] u8 @Vec           // tile.create scratch
%out_tile = pto.alloc_tile [M, N] f32 @Vec
pto.vsel %out_tile, %mask, %one, %zero, %tmp         // tile.sel

pto.tstore %out_gm, %out_tile
```

For `tensor.cmps`, step 1 becomes `pto.vcmps %mask, %lhs_tile, %scalar, cmp_type=K` and the rhs `tload` is dropped — everything else is identical.

## Testing

`tests/st/runtime/test_cmp.py` adds `TestTensorCmpOperations::test_tensor_cmp` and `::test_tensor_cmps`, each parametrized over `ONBOARD_PLATFORMS` and exercising all six `cmp_type` codes in a single Opaque program (one Out per cmp mode, written back via `pl.assemble` at `CORE_GROUP`).