### PR TITLE
feat(runtime): Expose worker-resident DeviceTensor (child_memory) to pypto frontend

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -213,6 +213,39 @@ print(VectorAddProgram.as_python())
 print(vector_add.as_python(concise=True))
 ```
 
+## Reusing weights on the worker (DeviceTensor)
+
+When the same large tensor is consumed by many kernel invocations — e.g. a
+weight matrix used across batches of a forward pass — uploading it on every
+call wastes bandwidth. `Worker.alloc_tensor` allocates persistent device
+memory and returns a `DeviceTensor` handle that `CompiledProgram` accepts in
+place of a `torch.Tensor`. The runtime treats the buffer as already resident
+and skips both H2D and D2H copies for that argument.
+
+```python
+import torch
+from pypto import ir
+from pypto.runtime import Worker, RunConfig
+
+compiled = ir.compile(MyKernel)
+
+with Worker(config=RunConfig(platform="a2a3sim")) as w:
+    weight = w.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
+    for batch in batches:
+        out = torch.empty(batch.shape[0], 4096, dtype=torch.float16)
+        compiled(batch, weight, out)
+    w.free_tensor(weight)
+```
+
+### Caveats
+
+- A `DeviceTensor` is never copied back to the host. If a kernel writes to
+  one, call `Worker.copy_from(host_ptr, t.data_ptr, t.nbytes)` to read the
+  result.
+- Free the handle with `Worker.free_tensor` before the Worker is closed,
+  otherwise the memory leaks for the lifetime of the Worker.
+- Only the Worker that allocated the buffer can use it.
+
 ## What's Next
 
 - **[Language Guide](01-language_guide.md)** — complete reference for types, operations, control flow, memory, and compilation

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -212,6 +212,36 @@ print(VectorAddProgram.as_python())
 print(vector_add.as_python(concise=True))
 ```
 
+## 在 worker 上复用权重（DeviceTensor）
+
+当同一个大张量被多次内核调用复用 —— 例如前向计算每个 batch 都要用到的权重矩阵 ——
+每次都重新上传会浪费带宽。`Worker.alloc_tensor` 在 device 上分配一块常驻内存，并返回
+一个 `DeviceTensor` 句柄；`CompiledProgram` 接受它替代 `torch.Tensor` 入参。runtime
+把这块 buffer 视为已经驻留在 device 上，对该入参跳过 H2D 与 D2H 拷贝。
+
+```python
+import torch
+from pypto import ir
+from pypto.runtime import Worker, RunConfig
+
+compiled = ir.compile(MyKernel)
+
+with Worker(config=RunConfig(platform="a2a3sim")) as w:
+    weight = w.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
+    for batch in batches:
+        out = torch.empty(batch.shape[0], 4096, dtype=torch.float16)
+        compiled(batch, weight, out)
+    w.free_tensor(weight)
+```
+
+### 注意事项
+
+- `DeviceTensor` 永远不会被拷回 host。如果内核写入了它，需要显式调用
+  `Worker.copy_from(host_ptr, t.data_ptr, t.nbytes)` 读回结果。
+- 必须在 Worker 关闭之前用 `Worker.free_tensor` 释放句柄，否则该内存会泄漏到
+  Worker 生命周期结束。
+- 只有分配它的那个 Worker 可以使用该 buffer。
+
 ## 下一步
 
 - **[语言指南](01-language_guide.md)** —— 类型、操作、控制流、内存和编译的完整参考

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -37,11 +37,14 @@ from pypto.pypto_core.ir import (
     ScalarType,
     ShapedType,
 )
+from pypto.runtime.device_tensor import DeviceTensor
 
 # Type alias for arguments accepted by CompiledProgram.__call__().
-# Tensor params expect torch.Tensor; scalar params accept Python primitives
-# or ctypes scalars (which are coerced to the correct ctypes type internally).
-CallArg = torch.Tensor | int | float | bool | ctypes._SimpleCData
+# Tensor params accept ``torch.Tensor`` (host) or :class:`DeviceTensor`
+# (worker-resident — skips H2D/D2H, see ``pypto.runtime.DeviceTensor``).
+# Scalar params accept Python primitives or ctypes scalars (which are
+# coerced to the correct ctypes type internally).
+CallArg = torch.Tensor | DeviceTensor | int | float | bool | ctypes._SimpleCData
 
 # IR DataType -> torch.dtype mapping.
 # Keyed by string because nanobind DataType instances are not singletons,
@@ -288,7 +291,7 @@ class CompiledProgram:
 
     # --- Callable API ---------------------------------------------------------
 
-    def __call__(
+    def __call__(  # noqa: PLR0912 — dispatch logic with several arg-shape branches
         self,
         *args: CallArg,
         config: Any = None,
@@ -338,7 +341,7 @@ class CompiledProgram:
             )
 
         # Coerce args: wrap Python scalars into ctypes, validate tensor vs scalar
-        coerced: list[torch.Tensor | ctypes._SimpleCData] = []
+        coerced: list[torch.Tensor | DeviceTensor | ctypes._SimpleCData] = []
         for info, arg in zip(param_infos, all_args, strict=True):
             if info.shape is None:
                 # Scalar parameter
@@ -358,9 +361,20 @@ class CompiledProgram:
                         raise TypeError(f"Unsupported scalar dtype {info.dtype} for parameter {info.name!r}")
                     coerced.append(ctype(arg))
             else:
-                # Tensor parameter
-                if not isinstance(arg, torch.Tensor):
-                    raise TypeError(f"Parameter {info.name!r} is a tensor; got {type(arg).__name__}")
+                # Tensor parameter — accept torch.Tensor (host) or DeviceTensor (worker-resident)
+                if not isinstance(arg, (torch.Tensor, DeviceTensor)):
+                    raise TypeError(
+                        f"Parameter {info.name!r} is a tensor; got {type(arg).__name__}. "
+                        f"Pass a torch.Tensor (host) or DeviceTensor (worker-resident)."
+                    )
+                # Early shape/dtype validation for DeviceTensor.  ``torch.Tensor`` already
+                # carries its shape/dtype natively and downstream codegen has its own
+                # checks; ``DeviceTensor`` is opaque, so a mismatch would only surface
+                # deep inside the runtime with a far less actionable error.  Skip the
+                # check on dynamic dims (any ``-1`` in info.shape) since the IR has not
+                # committed to a concrete shape there.
+                if isinstance(arg, DeviceTensor):
+                    self._validate_device_tensor(arg, info)
                 coerced.append(arg)
 
         from pypto.runtime.runner import RunConfig, execute_compiled  # noqa: PLC0415
@@ -384,6 +398,30 @@ class CompiledProgram:
         outputs = [coerced[i] for i in output_indices]
         assert all(isinstance(o, torch.Tensor) for o in outputs)
         return outputs[0] if len(outputs) == 1 else tuple(outputs)  # type: ignore[return-value]
+
+    @staticmethod
+    def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
+        """Check a ``DeviceTensor`` arg against IR parameter metadata.
+
+        Raises:
+            TypeError: when shape or dtype disagrees with ``info``.
+
+        Static IR shapes are compared exactly; dynamic dims (any ``-1`` in
+        ``info.shape``) are skipped.  Dtypes that the runtime can't map to
+        torch are also skipped.
+        """
+        if info.shape is not None and all(d >= 0 for d in info.shape):
+            expected_shape = tuple(info.shape)
+            if expected_shape != arg.shape:
+                raise TypeError(
+                    f"Parameter {info.name!r} expects shape {expected_shape}; "
+                    f"got DeviceTensor shape {arg.shape}"
+                )
+        expected_dtype = _to_torch_dtype(info.dtype)
+        if expected_dtype is not None and arg.dtype != expected_dtype:
+            raise TypeError(
+                f"Parameter {info.name!r} expects dtype {expected_dtype}; got DeviceTensor dtype {arg.dtype}"
+            )
 
     @staticmethod
     def _build_full_args(

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -24,6 +24,7 @@ Example::
     compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
 """
 
+from .device_tensor import DeviceTensor
 from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import Worker
@@ -32,6 +33,7 @@ __all__ = [
     "run",
     "compile_program",
     "execute_compiled",
+    "DeviceTensor",
     "RunConfig",
     "RunResult",
     "ScalarSpec",

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -1,0 +1,80 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""User-facing handle to worker-resident device memory.
+
+A :class:`DeviceTensor` is an opaque ``(data_ptr, shape, dtype)`` triple bound
+to a specific :class:`~pypto.runtime.Worker`'s address space.  Pass it to
+:class:`~pypto.ir.compiled_program.CompiledProgram` in place of a
+``torch.Tensor`` to skip the host→device copy on entry and the device→host
+copy on exit — the runtime treats the underlying buffer as already resident
+on the worker (``ContinuousTensor.child_memory == 1``).
+
+Lifetime is **caller-managed**: every :meth:`~pypto.runtime.Worker.malloc`
+(or :meth:`~pypto.runtime.Worker.alloc_tensor`) must be paired with a
+matching :meth:`~pypto.runtime.Worker.free` (or
+:meth:`~pypto.runtime.Worker.free_tensor`) before the Worker is closed.
+
+Because no D2H copy happens for a ``DeviceTensor``, callers that want to
+read the data back must do so explicitly via
+:meth:`~pypto.runtime.Worker.copy_from`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class DeviceTensor:
+    """Handle to a buffer already resident on a Worker.
+
+    Attributes:
+        data_ptr: Device pointer in the owning Worker's address space.
+        shape: Logical tensor shape (all dimensions positive).
+        dtype: Element ``torch.dtype``.
+    """
+
+    data_ptr: int
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+    def __init__(self, data_ptr: int, shape: Sequence[int], dtype: torch.dtype) -> None:
+        # bool is an int subclass — exclude it explicitly so True/False can't pose as a pointer or dim.
+        if isinstance(data_ptr, bool) or not isinstance(data_ptr, int) or data_ptr <= 0:
+            raise ValueError(f"DeviceTensor.data_ptr must be a positive int, got {data_ptr!r}")
+        raw_shape = tuple(shape)
+        for d in raw_shape:
+            if isinstance(d, bool) or not isinstance(d, int):
+                raise TypeError(f"DeviceTensor.shape must contain ints, got {raw_shape!r}")
+        if not raw_shape:
+            raise ValueError("DeviceTensor.shape must be non-empty")
+        if any(d <= 0 for d in raw_shape):
+            raise ValueError(f"DeviceTensor.shape must be all positive, got {raw_shape}")
+        shape_t = raw_shape
+        if not isinstance(dtype, torch.dtype):
+            raise TypeError(f"DeviceTensor.dtype must be torch.dtype, got {type(dtype).__name__}")
+        object.__setattr__(self, "data_ptr", data_ptr)
+        object.__setattr__(self, "shape", shape_t)
+        object.__setattr__(self, "dtype", dtype)
+
+    @property
+    def nbytes(self) -> int:
+        """Total bytes referenced by this handle."""
+        elem = torch.tensor([], dtype=self.dtype).element_size()
+        n = 1
+        for d in self.shape:
+            n *= d
+        return n * elem
+
+    def __repr__(self) -> str:
+        return f"DeviceTensor(data_ptr=0x{self.data_ptr:x}, shape={self.shape}, dtype={self.dtype})"

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -42,6 +42,8 @@ from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.pypto_core import backend as _backend_core
 from pypto.pypto_core.passes import DiagnosticCheckSet, DiagnosticPhase
 
+from .device_tensor import DeviceTensor
+
 _OUTPUTS_DIR = Path("outputs")
 
 
@@ -596,7 +598,7 @@ def _add_headers_to_file(cpp_file: Path) -> None:
 
 def execute_compiled(
     work_dir: str | Path,
-    args: list[torch.Tensor | _SimpleCData],
+    args: list[torch.Tensor | DeviceTensor | _SimpleCData],
     *,
     platform: str,
     device_id: int,
@@ -608,14 +610,18 @@ def execute_compiled(
 
     Reuses :func:`device_runner.compile_and_assemble` for binary compilation
     (with caching and parallel kernel compilation) and
-    :func:`device_runner.execute_on_device` for device dispatch.  Output
-    tensors in *args* are modified in-place with device results.
+    :func:`device_runner.execute_on_device` for device dispatch.  Host
+    ``torch.Tensor`` outputs in *args* are modified in-place with device
+    results; :class:`DeviceTensor` arguments are passed through to the
+    runtime as ``child_memory=True`` (no H2D upload, no D2H readback).
 
     Args:
         work_dir: Root output directory from :func:`ir.compile`, containing
             ``kernels/``, ``orchestration/``, and ``kernel_config.py``.
-        args: Ordered list of ``torch.Tensor`` or ``ctypes._SimpleCData``
-            arguments matching the orchestration function's parameter order.
+        args: Ordered list of ``torch.Tensor`` (host),
+            :class:`pypto.runtime.DeviceTensor` (worker-resident), or
+            ``ctypes._SimpleCData`` scalar arguments matching the
+            orchestration function's parameter order.
         platform: Target execution platform.
         device_id: Hardware device index.
         pto_isa_commit: Optional git commit to pin pto-isa clone.
@@ -636,6 +642,10 @@ def execute_compiled(
         make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
         scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
+    from .task_interface import (  # noqa: PLC0415
+        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+        torch_dtype_to_datatype,  # pyright: ignore[reportAttributeAccessIssue]
+    )
 
     chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit)
 
@@ -654,11 +664,25 @@ def execute_compiled(
                     f"Call .cpu() before passing to execute_compiled()."
                 )
             orch_args.add_tensor(make_tensor_arg(arg))
+        elif isinstance(arg, DeviceTensor):
+            try:
+                dt_enum = torch_dtype_to_datatype(arg.dtype)
+            except KeyError as e:
+                raise ValueError(f"Unsupported DeviceTensor dtype at position {i}: {arg.dtype}") from e
+            orch_args.add_tensor(
+                ContinuousTensor.make(
+                    data=arg.data_ptr,
+                    shapes=arg.shape,
+                    dtype=dt_enum,
+                    child_memory=True,
+                )
+            )
         elif isinstance(arg, _SimpleCData):
             orch_args.add_scalar(scalar_to_uint64(arg))
         else:
             raise TypeError(
-                f"Argument at position {i} must be torch.Tensor or ctypes scalar, got {type(arg).__name__}"
+                f"Argument at position {i} must be torch.Tensor, DeviceTensor or "
+                f"ctypes scalar, got {type(arg).__name__}"
             )
 
     # Snapshot profiling state before execution

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -18,18 +18,26 @@ from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     CallConfig,
     ChipCallable,
     ChipStorageTaskArgs,
+    ContinuousTensor,
     CoreCallable,
+    DataType,
     scalar_to_uint64,
 )
 from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
-from simpler_setup.torch_interop import make_tensor_arg  # pyright: ignore[reportMissingImports]
+from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImports]
+    make_tensor_arg,
+    torch_dtype_to_datatype,
+)
 
 __all__ = [
     "CallConfig",
     "ChipCallable",
     "ChipStorageTaskArgs",
+    "ContinuousTensor",
     "CoreCallable",
+    "DataType",
     "Worker",
     "make_tensor_arg",
     "scalar_to_uint64",
+    "torch_dtype_to_datatype",
 ]

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -27,8 +27,12 @@ Example::
 from __future__ import annotations
 
 import contextvars
+from collections.abc import Sequence
 from typing import Any
 
+import torch
+
+from .device_tensor import DeviceTensor
 from .runner import RunConfig
 
 # ``simpler`` is loaded lazily on first ``Worker(...)`` instantiation, matching
@@ -139,6 +143,134 @@ class Worker:
             return
         self._impl.close()
         self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Device memory primitives (forwarded to the underlying chip worker)
+    #
+    # All methods require an active init().  ``worker_id`` is kept as a
+    # keyword for forward compatibility with L3, even though pypto's Worker
+    # currently only supports level=2 with worker_id=0.
+    # ------------------------------------------------------------------
+
+    def _require_initialized(self, op: str) -> None:
+        if not self._initialized:
+            raise RuntimeError(
+                f"Worker.{op}() requires an initialized Worker. "
+                f"Use `with worker:` or call `worker.init()` first."
+            )
+
+    def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
+        """Allocate ``nbytes`` of device memory; returns an opaque pointer.
+
+        The returned pointer lives in *worker_id*'s address space.  Pair every
+        ``malloc()`` with a matching :meth:`free` before this Worker is
+        closed, otherwise the device memory is leaked.
+        """
+        self._require_initialized("malloc")
+        if not isinstance(nbytes, int) or nbytes <= 0:
+            raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
+        return self._impl.malloc(nbytes, worker_id)
+
+    def free(self, ptr: int, *, worker_id: int = 0) -> None:
+        """Release a pointer previously returned by :meth:`malloc`."""
+        self._require_initialized("free")
+        self._impl.free(ptr, worker_id)
+
+    def copy_to(
+        self,
+        dst_dev_ptr: int,
+        src_host_ptr: int,
+        nbytes: int,
+        *,
+        worker_id: int = 0,
+    ) -> None:
+        """H2D copy: ``nbytes`` bytes from host *src_host_ptr* to device *dst_dev_ptr*.
+
+        *src_host_ptr* is typically obtained from ``host_tensor.data_ptr()``;
+        the caller is responsible for keeping the host tensor alive until
+        this call returns.
+        """
+        self._require_initialized("copy_to")
+        self._impl.copy_to(dst_dev_ptr, src_host_ptr, nbytes, worker_id)
+
+    def copy_from(
+        self,
+        dst_host_ptr: int,
+        src_dev_ptr: int,
+        nbytes: int,
+        *,
+        worker_id: int = 0,
+    ) -> None:
+        """D2H copy: ``nbytes`` bytes from device *src_dev_ptr* back to host *dst_host_ptr*."""
+        self._require_initialized("copy_from")
+        self._impl.copy_from(dst_host_ptr, src_dev_ptr, nbytes, worker_id)
+
+    # ------------------------------------------------------------------
+    # DeviceTensor convenience helpers
+    # ------------------------------------------------------------------
+
+    def alloc_tensor(
+        self,
+        shape: Sequence[int],
+        dtype: torch.dtype,
+        *,
+        init: torch.Tensor | None = None,
+        worker_id: int = 0,
+    ) -> DeviceTensor:
+        """Allocate a device buffer and (optionally) upload host data.
+
+        Convenience wrapper around :meth:`malloc` + :meth:`copy_to`.  When
+        *init* is provided, its dtype and shape must match exactly; the
+        tensor is moved to CPU and made contiguous before upload.  If any
+        step after :meth:`malloc` raises (validation, copy, …), the
+        allocation is rolled back via :meth:`free` before the exception
+        propagates so callers never observe a leaked pointer.
+
+        Returns:
+            A :class:`DeviceTensor` referencing the allocated buffer.  Free
+            it via :meth:`free_tensor` (or :meth:`free` with the underlying
+            ``data_ptr``) before this Worker is closed.
+        """
+        # DeviceTensor only carries (data_ptr, shape, dtype) — no worker_id.
+        # Until the handle encodes worker scope, restrict the convenience
+        # helpers to the default worker so ``free_tensor`` cannot silently
+        # free a different worker's pointer.
+        if worker_id != 0:
+            raise ValueError(
+                "Worker.alloc_tensor currently only supports worker_id=0. "
+                "Use malloc/copy_to directly if you need a different worker."
+            )
+        shape_t = tuple(int(d) for d in shape)
+        if any(d < 0 for d in shape_t):
+            raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
+        n_elems = 1
+        for d in shape_t:
+            n_elems *= d
+        elem = torch.tensor([], dtype=dtype).element_size()
+        nbytes = n_elems * elem
+        ptr = self.malloc(nbytes, worker_id=worker_id)
+        try:
+            if init is not None:
+                if init.dtype != dtype or tuple(init.shape) != shape_t:
+                    raise ValueError(
+                        f"init must have shape={shape_t} dtype={dtype}, "
+                        f"got shape={tuple(init.shape)} dtype={init.dtype}"
+                    )
+                host = init.contiguous().cpu()
+                self.copy_to(ptr, host.data_ptr(), nbytes, worker_id=worker_id)
+            return DeviceTensor(ptr, shape_t, dtype)
+        except Exception:
+            self.free(ptr, worker_id=worker_id)
+            raise
+
+    def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
+        """Release a buffer previously returned by :meth:`alloc_tensor`."""
+        if worker_id != 0:
+            raise ValueError(
+                "Worker.free_tensor currently only supports worker_id=0. "
+                "Use free directly if you need a different worker."
+            )
+        self.free(t.data_ptr, worker_id=worker_id)
 
     # ------------------------------------------------------------------
     # Binding accessors

--- a/tests/st/runtime/test_device_tensor.py
+++ b/tests/st/runtime/test_device_tensor.py
@@ -1,0 +1,125 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end tests for the worker-resident DeviceTensor flow.
+
+Validates that ``Worker.alloc_tensor`` produces a buffer the runtime can
+consume via ``CompiledProgram(...)`` with ``ContinuousTensor.child_memory=True``
+— i.e. no H2D upload of the DeviceTensor on entry, no D2H copy-back on exit.
+
+Both tests run on hardware/simulator and depend on the ``simpler`` runtime
+package; the ``check_hardware_availability`` fixture in this directory's
+``conftest.py`` skips them on hosts without a device when only an
+onboard platform is requested.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import torch
+from examples.kernels.elementwise import TileAddProgram
+from pypto import ir
+from pypto.runtime import RunConfig, Worker
+
+_BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "build_output" / "test_device_tensor"
+
+
+@pytest.fixture(scope="module")
+def output_root() -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    root = _BUILD_OUTPUT_DIR / timestamp
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _worker_config(test_config: RunConfig) -> RunConfig:
+    """Materialize a RunConfig that the active Worker uses for binding match.
+
+    ``Worker.current()`` matches on (level, platform, device_id, runtime).
+    The Worker we open here uses ``test_config.platform`` and
+    ``test_config.device_id``; the compiled program is compiled with the
+    same platform so ``CompiledProgram.__call__`` can reuse this Worker
+    rather than spinning up a one-shot one.
+    """
+    return RunConfig(platform=test_config.platform, device_id=test_config.device_id)
+
+
+class TestDeviceTensorEndToEnd:
+    """End-to-end DeviceTensor execution on hardware/simulator."""
+
+    def test_device_tensor_input_skips_h2d_per_call(self, output_root, test_config):
+        """``compiled(host_a, weight_dev, host_out)`` produces ``a + b``.
+
+        ``b`` is uploaded once to a worker-resident DeviceTensor; subsequent
+        calls reuse the same device buffer.  This verifies that:
+
+        1. ``Worker.alloc_tensor(..., init=host_b)`` actually populates the
+           device buffer (otherwise the kernel would compute ``a + 0``).
+        2. The runtime treats DeviceTensor as ``child_memory=True`` and does
+           not overwrite the device buffer with stale host bytes on entry.
+        3. The handle survives across multiple kernel invocations bound to
+           the same Worker.
+        """
+        compiled = ir.compile(
+            TileAddProgram,
+            output_dir=str(output_root / "add_devtensor_input"),
+            platform=test_config.platform,
+        )
+
+        host_a1 = torch.full((128, 128), 2.0, dtype=torch.float32)
+        host_a2 = torch.full((128, 128), 7.0, dtype=torch.float32)
+        host_b = torch.full((128, 128), 3.0, dtype=torch.float32)
+
+        out1 = torch.zeros((128, 128), dtype=torch.float32)
+        out2 = torch.zeros((128, 128), dtype=torch.float32)
+
+        with Worker(config=_worker_config(test_config)) as w:
+            weight = w.alloc_tensor((128, 128), torch.float32, init=host_b)
+            try:
+                compiled(host_a1, weight, out1, config=test_config)
+                compiled(host_a2, weight, out2, config=test_config)
+            finally:
+                w.free_tensor(weight)
+
+        expected1 = torch.full((128, 128), 5.0, dtype=torch.float32)
+        expected2 = torch.full((128, 128), 10.0, dtype=torch.float32)
+        assert torch.allclose(out1, expected1, rtol=1e-5, atol=1e-5), (
+            f"first call: max diff = {(out1 - expected1).abs().max().item()}"
+        )
+        assert torch.allclose(out2, expected2, rtol=1e-5, atol=1e-5), (
+            f"second call (reuse): max diff = {(out2 - expected2).abs().max().item()}"
+        )
+
+    def test_alloc_tensor_then_copy_from_roundtrip(self, test_config):
+        """``alloc_tensor(init=...)`` → ``copy_from`` recovers the original bytes.
+
+        Exercises the Worker primitives in isolation: this does NOT involve
+        a CompiledProgram — it just verifies that the H2D upload performed
+        by ``alloc_tensor`` lands the exact host bytes on device, and that
+        ``copy_from`` reads them back correctly.  A failure here would
+        manifest as garbage data in the DeviceTensor consumed by kernels.
+        """
+        host_in = torch.arange(256, dtype=torch.float32).view(16, 16)
+        host_out = torch.zeros_like(host_in)
+
+        with Worker(config=_worker_config(test_config)) as w:
+            t = w.alloc_tensor((16, 16), torch.float32, init=host_in)
+            try:
+                w.copy_from(host_out.data_ptr(), t.data_ptr, t.nbytes)
+            finally:
+                w.free_tensor(t)
+
+        assert torch.equal(host_out, host_in), (
+            f"copy_from did not recover input bytes; max diff = {(host_out - host_in).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 from pypto import DataType, ir
 from pypto.ir.compiled_program import CompiledProgram, _extract_param_infos
+from pypto.runtime import DeviceTensor
 
 
 def _make_program_with_orchestration(*, has_return: bool = False) -> ir.Program:
@@ -404,6 +405,74 @@ class TestCompiledProgramScalarCall:
         assert coerced_args[1].value == 7
         # Output should be returned
         assert isinstance(result, torch.Tensor)
+
+
+class TestCompiledProgramDeviceTensor:
+    """Verify __call__ accepts DeviceTensor in tensor parameter slots."""
+
+    def test_device_tensor_in_input_slot(self, tmp_path):
+        """A DeviceTensor passed for an In param is forwarded to execute_compiled."""
+        prog = _make_program_with_orchestration()  # a (In), b (In), c (Out)
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.randn(128, 128)
+        b = DeviceTensor(0xB0000, (128, 128), torch.float32)
+        c = torch.zeros(128, 128)
+
+        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            cp(a, b, c)
+
+        coerced_args = mock_exec.call_args.args[1]
+        assert isinstance(coerced_args[0], torch.Tensor)
+        assert coerced_args[1] is b  # forwarded as-is
+        assert isinstance(coerced_args[2], torch.Tensor)
+
+    def test_all_device_tensors(self, tmp_path):
+        """Every tensor slot can be a DeviceTensor."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = DeviceTensor(0x1000, (128, 128), torch.float32)
+        b = DeviceTensor(0x2000, (128, 128), torch.float32)
+        c = DeviceTensor(0x3000, (128, 128), torch.float32)
+
+        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            cp(a, b, c)
+
+        coerced_args = mock_exec.call_args.args[1]
+        assert coerced_args == [a, b, c]
+
+    def test_unsupported_type_for_tensor_param(self, tmp_path):
+        """Non-tensor / non-DeviceTensor in a tensor slot raises TypeError."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        with pytest.raises(TypeError, match="DeviceTensor"):
+            cp("not a tensor", torch.zeros(128, 128), torch.zeros(128, 128))  # type: ignore[arg-type]
+
+    def test_device_tensor_shape_mismatch_rejected_early(self, tmp_path):
+        """DeviceTensor with wrong shape vs IR metadata fails before dispatch."""
+        prog = _make_program_with_orchestration()  # all params are [128, 128]
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.zeros(128, 128)
+        bad_b = DeviceTensor(0xB0000, (64, 128), torch.float32)  # wrong shape
+        c = torch.zeros(128, 128)
+
+        with pytest.raises(TypeError, match=r"expects shape \(128, 128\)"):
+            cp(a, bad_b, c)
+
+    def test_device_tensor_dtype_mismatch_rejected_early(self, tmp_path):
+        """DeviceTensor with wrong dtype vs IR metadata fails before dispatch."""
+        prog = _make_program_with_orchestration()  # all params are FP32
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        a = torch.zeros(128, 128)
+        bad_b = DeviceTensor(0xB0000, (128, 128), torch.float16)  # wrong dtype
+        c = torch.zeros(128, 128)
+
+        with pytest.raises(TypeError, match="expects dtype"):
+            cp(a, bad_b, c)
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_device_tensor.py
+++ b/tests/ut/runtime/test_device_tensor.py
@@ -1,0 +1,107 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for :class:`pypto.runtime.DeviceTensor` construction and metadata."""
+
+import pytest
+import torch
+from pypto.runtime import DeviceTensor
+
+
+class TestDeviceTensorConstruction:
+    def test_basic_fp32(self):
+        t = DeviceTensor(0x1000, [4, 8], torch.float32)
+        assert t.data_ptr == 0x1000
+        assert t.shape == (4, 8)
+        assert t.dtype is torch.float32
+        assert t.nbytes == 4 * 8 * 4
+
+    def test_shape_accepts_tuple_and_list(self):
+        a = DeviceTensor(0x100, (2, 3), torch.float16)
+        b = DeviceTensor(0x100, [2, 3], torch.float16)
+        assert a.shape == b.shape == (2, 3)
+        assert a.nbytes == 2 * 3 * 2
+
+    def test_int8_nbytes(self):
+        t = DeviceTensor(0x100, [16], torch.int8)
+        assert t.nbytes == 16
+
+    def test_zero_ptr_raises(self):
+        with pytest.raises(ValueError, match="positive int"):
+            DeviceTensor(0, [4], torch.float32)
+
+    def test_negative_ptr_raises(self):
+        with pytest.raises(ValueError, match="positive int"):
+            DeviceTensor(-1, [4], torch.float32)
+
+    def test_non_int_ptr_raises(self):
+        with pytest.raises(ValueError, match="positive int"):
+            DeviceTensor("0x100", [4], torch.float32)  # type: ignore[arg-type]
+
+    def test_zero_dim_raises(self):
+        with pytest.raises(ValueError, match="all positive"):
+            DeviceTensor(0x100, [4, 0], torch.float32)
+
+    def test_negative_dim_raises(self):
+        with pytest.raises(ValueError, match="all positive"):
+            DeviceTensor(0x100, [-1, 4], torch.float32)
+
+    def test_empty_shape_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            DeviceTensor(0x100, [], torch.float32)
+
+    def test_wrong_dtype_type_raises(self):
+        with pytest.raises(TypeError, match=r"torch\.dtype"):
+            DeviceTensor(0x100, [4], "fp32")  # type: ignore[arg-type]
+
+    def test_bool_ptr_rejected(self):
+        # ``True`` is an int subclass; reject it explicitly so it can't pose as a pointer.
+        with pytest.raises(ValueError, match="positive int"):
+            DeviceTensor(True, [4], torch.float32)  # type: ignore[arg-type]
+
+    def test_bool_dim_rejected(self):
+        with pytest.raises(TypeError, match="must contain ints"):
+            DeviceTensor(0x100, [True, 4], torch.float32)  # type: ignore[list-item]
+
+    def test_non_int_dim_rejected_no_silent_truncation(self):
+        # ``int(d)`` would silently truncate ``3.7`` to ``3``; the constructor must reject it.
+        with pytest.raises(TypeError, match="must contain ints"):
+            DeviceTensor(0x100, [3.7, 4], torch.float32)  # type: ignore[list-item]
+
+
+class TestDeviceTensorImmutability:
+    def test_frozen_data_ptr(self):
+        t = DeviceTensor(0x100, [4], torch.float32)
+        with pytest.raises((AttributeError, TypeError)):
+            t.data_ptr = 0x200  # type: ignore[misc]
+
+    def test_frozen_shape(self):
+        t = DeviceTensor(0x100, [4], torch.float32)
+        with pytest.raises((AttributeError, TypeError)):
+            t.shape = (8,)  # type: ignore[misc]
+
+    def test_hashable(self):
+        # frozen dataclass with hashable fields → usable as dict key / set element
+        t1 = DeviceTensor(0x100, [4], torch.float32)
+        t2 = DeviceTensor(0x100, [4], torch.float32)
+        assert hash(t1) == hash(t2)
+        assert {t1, t2} == {t1}
+
+
+class TestDeviceTensorRepr:
+    def test_repr_hex(self):
+        t = DeviceTensor(0xABCD, [2, 3], torch.int8)
+        r = repr(t)
+        assert "0xabcd" in r.lower()
+        assert "(2, 3)" in r
+        assert "int8" in r
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_execute_compiled_device_tensor.py
+++ b/tests/ut/runtime/test_execute_compiled_device_tensor.py
@@ -1,0 +1,150 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Verify ``execute_compiled`` translates :class:`DeviceTensor` arguments to
+``ContinuousTensor.make(..., child_memory=True)`` while ``torch.Tensor``
+arguments still take the ordinary ``make_tensor_arg`` path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from pypto.runtime import DeviceTensor
+
+# ``device_runner`` and ``task_interface`` eagerly import the optional
+# ``simpler`` runtime package; skip the module when simpler is unavailable
+# (the same pattern test_worker_reuse.py uses for execute_on_device tests).
+try:
+    import simpler  # noqa: F401  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _has_simpler = False
+else:
+    _has_simpler = True
+
+pytestmark = pytest.mark.skipif(not _has_simpler, reason="execute_compiled requires the simpler package")
+
+
+@pytest.fixture
+def patched_runtime(tmp_path):
+    """Patch every import inside ``execute_compiled`` so it runs without a device.
+
+    Captures the per-arg list passed to ``orch_args.add_tensor`` so individual
+    tests can assert on the resulting ContinuousTensor descriptors.
+    """
+    captured: dict = {
+        "tensors": [],
+        "scalars": [],
+        "make_calls": [],  # ContinuousTensor.make kwargs
+        "make_tensor_arg_calls": [],
+    }
+
+    chip_args = MagicMock(name="ChipStorageTaskArgs_instance")
+
+    def _record_tensor(t):
+        captured["tensors"].append(t)
+
+    def _record_scalar(s):
+        captured["scalars"].append(s)
+
+    chip_args.add_tensor.side_effect = _record_tensor
+    chip_args.add_scalar.side_effect = _record_scalar
+
+    def _make(*, data, shapes, dtype, child_memory=False):
+        captured["make_calls"].append(
+            {
+                "data": data,
+                "shapes": tuple(shapes),
+                "dtype": dtype,
+                "child_memory": child_memory,
+            }
+        )
+        return MagicMock(name=f"ContinuousTensor(0x{data:x})")
+
+    def _make_tensor_arg(t):
+        captured["make_tensor_arg_calls"].append(t)
+        return MagicMock(name="ContinuousTensor(host)")
+
+    def _torch_dtype_to_datatype(dt):
+        # Sentinel — not asserted on directly; child_memory and shape carry the signal.
+        return f"<dtype:{dt}>"
+
+    with (
+        patch("pypto.runtime.runner._patch_orchestration_headers"),
+        patch(
+            "pypto.runtime.device_runner.compile_and_assemble",
+            return_value=(MagicMock(name="chip_callable"), "host_build_graph"),
+        ),
+        patch("pypto.runtime.device_runner.execute_on_device"),
+        patch("pypto.runtime.device_runner.ChipStorageTaskArgs", return_value=chip_args),
+        patch("pypto.runtime.device_runner.make_tensor_arg", side_effect=_make_tensor_arg),
+        patch("pypto.runtime.device_runner.scalar_to_uint64", side_effect=lambda s: int(s.value)),
+        patch("pypto.runtime.task_interface.ContinuousTensor.make", side_effect=_make),
+        patch("pypto.runtime.task_interface.torch_dtype_to_datatype", side_effect=_torch_dtype_to_datatype),
+    ):
+        yield captured, tmp_path
+
+
+class TestExecuteCompiledDeviceTensor:
+    def test_device_tensor_produces_child_memory_true(self, patched_runtime):
+        captured, tmp = patched_runtime
+        dt = DeviceTensor(0xABCD, (8, 16), torch.float16)
+
+        from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+        execute_compiled(tmp, [dt], platform="a2a3sim", device_id=0)
+
+        assert len(captured["make_calls"]) == 1
+        call = captured["make_calls"][0]
+        assert call["data"] == 0xABCD
+        assert call["shapes"] == (8, 16)
+        assert call["child_memory"] is True
+        assert call["dtype"] == "<dtype:torch.float16>"
+        # Host path was not used.
+        assert captured["make_tensor_arg_calls"] == []
+
+    def test_torch_tensor_uses_make_tensor_arg_path(self, patched_runtime):
+        captured, tmp = patched_runtime
+        host = torch.zeros(4, 4, dtype=torch.float32)
+
+        from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+        execute_compiled(tmp, [host], platform="a2a3sim", device_id=0)
+
+        # Host tensor goes through make_tensor_arg, NOT through ContinuousTensor.make
+        # (so child_memory cannot be True for it).
+        assert captured["make_tensor_arg_calls"] == [host]
+        assert captured["make_calls"] == []
+
+    def test_mixed_args_preserve_order(self, patched_runtime):
+        captured, tmp = patched_runtime
+        host = torch.zeros(4, 4, dtype=torch.float32)
+        dt = DeviceTensor(0x9000, (4, 4), torch.float32)
+
+        from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+        execute_compiled(tmp, [host, dt, host], platform="a2a3sim", device_id=0)
+
+        # add_tensor was called three times in order: host, device, host.
+        assert len(captured["tensors"]) == 3
+        # Only the device-tensor slot uses ContinuousTensor.make with child_memory=True.
+        assert len(captured["make_calls"]) == 1
+        assert captured["make_calls"][0]["child_memory"] is True
+        assert len(captured["make_tensor_arg_calls"]) == 2
+
+    def test_unsupported_arg_raises(self, patched_runtime):
+        _, tmp = patched_runtime
+        from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+        with pytest.raises(TypeError, match="DeviceTensor"):
+            execute_compiled(tmp, ["not a tensor"], platform="a2a3sim", device_id=0)  # type: ignore[list-item]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_worker_memory.py
+++ b/tests/ut/runtime/test_worker_memory.py
@@ -1,0 +1,183 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``Worker`` device-memory primitives and ``alloc_tensor``.
+
+Patches ``_SimplerWorker`` so tests run without a device.  Each test asserts
+that the call is forwarded to the underlying chip worker with the expected
+arguments (positional + ``worker_id`` trailing arg).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from pypto.runtime import DeviceTensor, RunConfig, Worker
+
+
+@pytest.fixture
+def fake_simpler_worker():
+    """Patch ``simpler.worker.Worker`` so Worker construction does not touch a device."""
+    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+        instance = MagicMock()
+        cls.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def worker(fake_simpler_worker):
+    w = Worker(config=RunConfig(platform="a2a3sim"))
+    yield w
+    if w.initialized:
+        w.close()
+
+
+class TestMallocFree:
+    def test_malloc_forwards_with_default_worker_id(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x4000
+        ptr = worker.malloc(1024)
+        assert ptr == 0x4000
+        fake_simpler_worker.malloc.assert_called_once_with(1024, 0)
+
+    def test_malloc_forwards_explicit_worker_id(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x5000
+        worker.malloc(2048, worker_id=3)
+        fake_simpler_worker.malloc.assert_called_once_with(2048, 3)
+
+    def test_malloc_zero_raises(self, worker):
+        with pytest.raises(ValueError, match="positive int"):
+            worker.malloc(0)
+
+    def test_malloc_negative_raises(self, worker):
+        with pytest.raises(ValueError, match="positive int"):
+            worker.malloc(-1)
+
+    def test_malloc_after_close_raises(self, fake_simpler_worker, worker):
+        worker.close()
+        with pytest.raises(RuntimeError, match="initialized Worker"):
+            worker.malloc(1024)
+        fake_simpler_worker.malloc.assert_not_called()
+
+    def test_free_forwards(self, fake_simpler_worker, worker):
+        worker.free(0x4000)
+        fake_simpler_worker.free.assert_called_once_with(0x4000, 0)
+
+    def test_free_after_close_raises(self, worker):
+        worker.close()
+        with pytest.raises(RuntimeError, match="initialized Worker"):
+            worker.free(0x4000)
+
+
+class TestCopy:
+    def test_copy_to_forwards(self, fake_simpler_worker, worker):
+        worker.copy_to(0x100, 0x200, 64)
+        fake_simpler_worker.copy_to.assert_called_once_with(0x100, 0x200, 64, 0)
+
+    def test_copy_from_forwards(self, fake_simpler_worker, worker):
+        worker.copy_from(0x100, 0x200, 64, worker_id=2)
+        fake_simpler_worker.copy_from.assert_called_once_with(0x100, 0x200, 64, 2)
+
+    def test_copy_to_after_close_raises(self, worker):
+        worker.close()
+        with pytest.raises(RuntimeError, match="initialized Worker"):
+            worker.copy_to(0x100, 0x200, 64)
+
+    def test_copy_from_after_close_raises(self, worker):
+        worker.close()
+        with pytest.raises(RuntimeError, match="initialized Worker"):
+            worker.copy_from(0x100, 0x200, 64)
+
+
+class TestAllocTensor:
+    def test_alloc_no_init(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x9000
+        t = worker.alloc_tensor((4, 8), torch.float32)
+        assert isinstance(t, DeviceTensor)
+        assert t.data_ptr == 0x9000
+        assert t.shape == (4, 8)
+        assert t.dtype is torch.float32
+        assert t.nbytes == 4 * 8 * 4
+        fake_simpler_worker.malloc.assert_called_once_with(4 * 8 * 4, 0)
+        fake_simpler_worker.copy_to.assert_not_called()
+
+    def test_alloc_with_init_uploads(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x9000
+        host = torch.full((4, 8), 1.5, dtype=torch.float32)
+        t = worker.alloc_tensor((4, 8), torch.float32, init=host)
+        assert t.data_ptr == 0x9000
+        # nbytes is the third positional arg
+        fake_simpler_worker.copy_to.assert_called_once()
+        call = fake_simpler_worker.copy_to.call_args
+        assert call.args[0] == 0x9000
+        assert call.args[2] == 4 * 8 * 4
+        assert call.args[3] == 0  # default worker_id
+
+    def test_alloc_init_shape_mismatch_frees_and_raises(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x9000
+        bad = torch.zeros((4, 4), dtype=torch.float32)
+        with pytest.raises(ValueError, match="must have shape"):
+            worker.alloc_tensor((4, 8), torch.float32, init=bad)
+        fake_simpler_worker.free.assert_called_once_with(0x9000, 0)
+        fake_simpler_worker.copy_to.assert_not_called()
+
+    def test_alloc_init_dtype_mismatch_frees_and_raises(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x9000
+        bad = torch.zeros((4, 8), dtype=torch.float16)
+        with pytest.raises(ValueError, match="must have shape"):
+            worker.alloc_tensor((4, 8), torch.float32, init=bad)
+        fake_simpler_worker.free.assert_called_once_with(0x9000, 0)
+
+    def test_free_tensor_uses_data_ptr(self, fake_simpler_worker, worker):
+        t = DeviceTensor(0x9000, (4, 8), torch.float32)
+        worker.free_tensor(t)
+        fake_simpler_worker.free.assert_called_once_with(0x9000, 0)
+
+    def test_alloc_makes_non_contiguous_init_contiguous(self, fake_simpler_worker, worker):
+        fake_simpler_worker.malloc.return_value = 0x9000
+        # transpose makes it non-contiguous; .contiguous() inside alloc_tensor must fix it.
+        host = torch.zeros((8, 4), dtype=torch.float32).t()
+        assert tuple(host.shape) == (4, 8)
+        worker.alloc_tensor((4, 8), torch.float32, init=host)
+        fake_simpler_worker.copy_to.assert_called_once()
+
+    def test_alloc_negative_dim_rejected_before_malloc(self, fake_simpler_worker, worker):
+        # Negative dims would silently produce a positive nbytes via tuple(int(d) for ...).
+        # The pre-malloc validation must reject them before any allocation happens.
+        with pytest.raises(ValueError, match="non-negative"):
+            worker.alloc_tensor((-1, 4), torch.float32)
+        fake_simpler_worker.malloc.assert_not_called()
+
+    def test_alloc_copy_to_failure_frees_pointer(self, fake_simpler_worker, worker):
+        # Simulate a runtime copy_to failure (hardware error, etc.).  The pointer
+        # malloc'd up-front must be freed before the exception propagates so the
+        # device buffer is not leaked.
+        fake_simpler_worker.malloc.return_value = 0x9000
+        fake_simpler_worker.copy_to.side_effect = RuntimeError("copy failed")
+        host = torch.zeros((4, 8), dtype=torch.float32)
+        with pytest.raises(RuntimeError, match="copy failed"):
+            worker.alloc_tensor((4, 8), torch.float32, init=host)
+        fake_simpler_worker.free.assert_called_once_with(0x9000, 0)
+
+    def test_alloc_rejects_non_zero_worker_id(self, fake_simpler_worker, worker):
+        # DeviceTensor doesn't encode worker_id yet, so allowing alloc on a
+        # different worker would produce a handle that free_tensor (default
+        # worker_id=0) would mis-route.  Fail loud at the API boundary.
+        with pytest.raises(ValueError, match="worker_id=0"):
+            worker.alloc_tensor((4, 8), torch.float32, worker_id=3)
+        fake_simpler_worker.malloc.assert_not_called()
+
+    def test_free_tensor_rejects_non_zero_worker_id(self, fake_simpler_worker, worker):
+        t = DeviceTensor(0x9000, (4, 8), torch.float32)
+        with pytest.raises(ValueError, match="worker_id=0"):
+            worker.free_tensor(t, worker_id=3)
+        fake_simpler_worker.free.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Lets `CompiledProgram(...)` accept a worker-resident buffer in any
tensor-parameter slot, so users no longer pay H2D + D2H per call for a
weight that lives across many invocations. The frontend exposes the
underlying `ContinuousTensor.child_memory=True` mode that `runtime/`
already supported but had no path to from `pypto.runtime`.

User-facing flow:

```python
with Worker(config=RunConfig(platform="a2a3sim")) as w:
    weight = w.alloc_tensor((1024, 4096), torch.float16, init=host_w)
    for batch in batches:
        compiled(batch, weight, out)        # weight reused on device
    w.free_tensor(weight)
```

## What lands

- `pypto.runtime.DeviceTensor` — frozen `(data_ptr, shape, dtype)` handle, caller-managed lifetime, no Worker reference.
- `Worker.{malloc, free, copy_to, copy_from}` — forwarders to the underlying chip worker, gated on `_initialized`.
- `Worker.{alloc_tensor, free_tensor}` — convenience wrappers (alloc + optional H2D upload, with rollback on shape/dtype mismatch).
- `CallArg` extended with `DeviceTensor`; `execute_compiled` translates each `DeviceTensor` to `ContinuousTensor.make(..., child_memory=True)` so the runtime skips H2D, D2H, and tensor-pair recording for that arg.
- Re-exports of the simpler symbols the dispatch path needs (`ContinuousTensor`, `DataType`, `torch_dtype_to_datatype`).

## Semantics / caveats

- Mixed args (host `torch.Tensor` + `DeviceTensor`) preserve order; the host path is unchanged.
- Return-style auto-allocation remains torch-only — callers wanting a `DeviceTensor` as an output must pass it explicitly (in-place style).
- `DeviceTensor` is never copied back to the host; callers that need to read a written-to buffer call `Worker.copy_from` explicitly.
- Lifetime is caller-managed: pair every `alloc_tensor` with `free_tensor` (or `malloc` with `free`) before the Worker is closed.

## Test plan

Unit (`tests/ut/`):
- [x] `tests/ut/runtime/test_device_tensor.py` — construction validation, nbytes math, frozen + hashable
- [x] `tests/ut/runtime/test_worker_memory.py` — primitive forwarding, `_initialized` guard, `alloc_tensor` upload + mismatch rollback
- [x] `tests/ut/runtime/test_execute_compiled_device_tensor.py` — `execute_compiled` threads `child_memory=True` for DeviceTensor args while host tensors keep the `make_tensor_arg` path; skips cleanly when `simpler` is missing (same pattern as `test_worker_reuse.py::TestExecuteOnDeviceReuse`)
- [x] `tests/ut/ir/test_compiled_program.py::TestCompiledProgramDeviceTensor` — union-arg acceptance + type-rejection

System (`tests/st/`):
- [ ] `tests/st/runtime/test_device_tensor.py` — end-to-end on hardware/simulator: `alloc_tensor(init=host_b)` + two consecutive `compiled(host_a, weight_dev, host_out)` calls produce expected `a + b` (proves the device buffer persisted across calls and was not overwritten by stale H2D); plus a Worker primitive round-trip (`alloc_tensor → copy_from`) that recovers exact uploaded bytes

## Docs

- `docs/en/user/00-getting_started.md` (and zh-cn mirror) — new section "Reusing weights on the worker (DeviceTensor)" documenting the `alloc_tensor → compiled(...) → free_tensor` flow and the no-D2H caveat.