### PR TITLE
ci: update pypto-lib model paths after repo restructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
           PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
           PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python examples/models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d "$DEVICE_ID"
+        run: python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d "$DEVICE_ID"
 
   system-tests-a5sim:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -86,8 +86,8 @@ jobs:
         run: |
           failed=()
           for f in \
-            examples/models/qwen3/14b/qwen3_14b_prefill.py \
-            examples/models/qwen3/32b/qwen3_32b_decode.py; do
+            models/qwen3/14b/qwen3_14b_prefill.py \
+            models/qwen3/32b/qwen3_32b_decode.py; do
             echo "::group::$f"
             if ! python "$f" -p a2a3 -d $DEVICE_ID; then
               failed+=("$f")


### PR DESCRIPTION
## Summary
- pypto-lib moved `examples/models/` to top-level `models/` (hw-native-sys/pypto-lib#217).
- Update the qwen3 clone-and-run jobs in `ci.yml` and `daily_ci.yml` to use the new paths so the Qwen3-14B prefill/decode and 32B decode kernels continue to be found after that PR merges.

## Related Issues
Coordinates with hw-native-sys/pypto-lib#217 — merge that PR around the same time as this one to avoid a CI gap.