### PR TITLE
fix(codegen): Skip no-op X=X alias in orchestration emit

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -337,6 +337,21 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // No-op: tuple elements handled via tuple_var_to_elements_
     } else {
       std::string value_expr = GenerateExprString(assign->value_);
+      // Drop a no-op `X = X;` that arises when VarLineageCollector has
+      // collapsed both LHS and RHS onto the same param-rooted emit name
+      // (both Vars alias the same buffer). Without this guard the catch-all
+      // emit path produces `auto X = X;`, which gcc rejects with
+      // "use of 'X' before deduction of 'auto'".
+      //
+      // FIXME(#1281): this is a codegen-layer band-aid. The cleaner home is
+      // an IR-level copy-propagation pass that drops lineage-redundant
+      // Var-RHS AssignStmts so downstream analyses don't have to reason
+      // about no-op aliases at all (today's Simplify only does scalar
+      // constant propagation, not tensor-Var copy prop). Once such a pass
+      // exists, this guard can go.
+      if (AsVarLike(assign->value_) && value_expr == var_name) {
+        return;
+      }
       code_ << Indent() << GetCppType(assign->var_->GetType()) << " " << var_name << " = " << value_expr
             << ";\n";
     }

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2664,5 +2664,129 @@ class TestArgDirectionsCodegen:
         )
 
 
+SELF_ALIAS_RE = re.compile(r"\bauto\s+(\w+)\s*=\s*\1\s*;")
+
+
+class TestNoOpAliasSkip:
+    """Regression coverage for issue #1281 sub-problem 2.
+
+    When VarLineageCollector collapses several Vars onto the same param-rooted
+    emit name (because they all alias the same buffer), a chained Var-RHS
+    AssignStmt like ``u = t`` reaches the catch-all emit branch with both LHS
+    and RHS resolving to the same C++ identifier. Pre-fix, the codegen emitted
+    ``auto X = X;`` literally, which gcc rejects with
+    ``use of 'X' before deduction of 'auto'``.
+
+    The trigger is: an Orchestration entry that
+
+      1. Calls a kernel with an Out/InOut param,
+      2. Passes the entry's own pl.Out param as the actual arg, and
+      3. Binds the call result to one local AND aliases it to a second local
+         before returning.
+
+    Forms A and B below are control cases that already worked; form C is the
+    one that used to emit the self-alias.
+    """
+
+    def test_form_a_direct_return_no_alias(self):
+        """Control: `return self.kern(...)` — single return path, never tripped the bug."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class FormA:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def entry(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                q_out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                return self.kern(x, q_out)
+
+        code = _generate_orch_code(FormA)
+        assert not SELF_ALIAS_RE.search(code), f"unexpected `auto X = X;` in form A. Code:\n{code}"
+
+    def test_form_b_single_bind_no_alias(self):
+        """Control: `t = self.kern(...); return t` — single AssignStmt, handled by
+        GenerateSingleReturnAlias's existing ``alias_name != out_arg`` guard."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class FormB:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def entry(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                q_out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tensor[[16, 16], pl.FP32] = self.kern(x, q_out)
+                return t
+
+        code = _generate_orch_code(FormB)
+        assert not SELF_ALIAS_RE.search(code), f"unexpected `auto X = X;` in form B. Code:\n{code}"
+
+    def test_form_c_chained_alias_drops_no_op(self):
+        """`t = self.kern(...); u = t; return u` — the bug trigger.
+
+        Pre-fix: emits `auto q_out = q_out;` for the `u = t` AssignStmt because
+        VarLineageCollector collapses both `t` and `u` onto the entry's `q_out`
+        param emit name. Post-fix: the catch-all Var-RHS branch detects
+        LHS-name == RHS-name and drops the AssignStmt entirely.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class FormC:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                ret: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def entry(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                q_out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t: pl.Tensor[[16, 16], pl.FP32] = self.kern(x, q_out)
+                u: pl.Tensor[[16, 16], pl.FP32] = t
+                return u
+
+        code = _generate_orch_code(FormC)
+        assert not SELF_ALIAS_RE.search(code), (
+            f"`auto X = X;` regression — issue #1281 sub-problem 2 is back. Code:\n{code}"
+        )
+        # Sanity: the task submission must still be present; the fix only
+        # drops the no-op alias, not the actual kernel call.
+        assert "pto2_rt_submit_aiv_task" in code, f"task submission missing from form C output. Code:\n{code}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes sub-problem #2 of #1281: orchestration codegen emitted `auto q_out = q_out;` from clean IR, which gcc rejects with `use of 'q_out' before deduction of 'auto'`. This PR is intentionally scoped to the codegen-layer fix and lands alongside #1282, which fixes sub-problem #1 (InlineFunctions) at the IR layer; the two are independent and can land in any order.

## Trigger

Two sequential AssignStmts in the orchestration body, where the first is a Call-RHS that threads the entry's `pl.Out` param into a callee's Out/InOut arg, and the second is a Var-RHS alias of the call result:

```python
@pl.function(type=pl.FunctionType.Orchestration, ...)
def entry(self, x, q_out: pl.Out[...]):
    t = self.kern(x, q_out)   # call result: lineage(t) = q_out
    u = t                     # Var-RHS alias: lineage(u) = q_out (chained)
    return u
```

`VarLineageCollector` collapses every Var rooted in the entry's `pl.Out` param onto that param's emit name — `t`, `u`, and `q_out` all share emit name `"q_out"`. The Call-RHS path already had a symmetric guard in `EmitTensorAlias` (`if (alias_name != out_arg)`), so it suppressed the no-op for Form B. The catch-all Var-RHS `else` branch in `VisitStmt_(AssignStmtPtr)` had no such guard and emitted `auto q_out = q_out;` literally.

## Fix

Add the symmetric guard to the catch-all Var-RHS branch. When the value is a Var and its emit name matches the LHS emit name, drop the AssignStmt — `VarLineageCollector` already records that both Vars alias the same buffer, so the assignment is identity at the C++ level.

This is a codegen-layer band-aid; the FIXME marks the cleaner home as an IR-level copy-propagation pass that drops lineage-redundant Var-RHS AssignStmts before codegen sees them. Today's `Simplify` pass only does scalar constant propagation, not tensor-Var copy prop, so a new pass is needed to retire this guard.

## Tests

New `TestNoOpAliasSkip` class with three tests bracketing the trigger:

| Form | Pattern | Status pre-fix | Status post-fix |
|---|---|---|---|
| A | `return self.kern(...)` | ✓ no `auto X = X;` | ✓ no `auto X = X;` |
| B | `t = self.kern(...); return t` | ✓ guard in `EmitTensorAlias` | ✓ unchanged |
| C | `t = self.kern(...); u = t; return u` | ❌ `auto q_out = q_out;` | ✓ alias dropped |

Form C also asserts the kernel task submission survives, so the new guard cannot over-fire and drop real work.

## Test plan

- [x] `tests/ut/codegen/` (234 pass, includes the 3 new regression tests)
- [x] `tests/ut/ir/transforms/` (1191 pass — no adjacent-pass regressions)
- [x] clang-tidy on the diff (no new issues)
- [x] pre-commit hooks (clang-format, cpplint, ruff, pyright — all pass)

## Related

- Companion to #1282 (sub-problem #1 — InlineFunctions). Both PRs together close #1281 end-to-end.