### PR TITLE
fix(runtime): Bucket tensor/scalar args in execute_compiled

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -739,7 +739,7 @@ class JITFunction:
         contexts = self._build_contexts(tensor_meta, scalar_values, scalar_dtypes, dynamic_dims)
         dynvar_bindings, dynvar_literals = _build_dynvar_bindings(contexts)
         _backfill_entry_dynvar_bindings(self._func, self._get_deps(), dynvar_bindings, dynvar_literals)
-        class_name = f"_jit_{self.__name__}_{self._get_source_hash()}"
+        class_name = f"_jit_{self.__name__}"
         specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
         source = specializer.specialize()
         rename_map = specializer.rename_map
@@ -770,7 +770,7 @@ class JITFunction:
         contexts = self._build_contexts(tensor_meta, scalar_values, scalar_dtypes, dynamic_dims)
         dynvar_bindings, dynvar_literals = _build_dynvar_bindings(contexts)
         _backfill_entry_dynvar_bindings(self._func, self._get_deps(), dynvar_bindings, dynvar_literals)
-        class_name = f"_jit_{self.__name__}_{self._get_source_hash()}"
+        class_name = f"_jit_{self.__name__}"
         specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
         source = specializer.specialize()
         rename_map = specializer.rename_map

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -640,7 +640,14 @@ def execute_compiled(
     chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit)
 
     # Build orch args from user-provided tensors and scalars.
+    #
+    # simpler's ChipStorageTaskArgs requires all add_tensor() calls to precede
+    # any add_scalar() call. Codegen already addresses tensors and scalars from
+    # independent pools (orch_args.tensor(i) / orch_args.scalar(i)), so the
+    # binary ABI is order-agnostic across pools. Dispatch in two passes so the
+    # user-facing source order does not have to obey simpler's constraint.
     orch_args = ChipStorageTaskArgs()
+    # Pass 1: tensors (torch.Tensor + DeviceTensor).
     for i, arg in enumerate(args):
         if isinstance(arg, torch.Tensor):
             if not arg.is_contiguous():
@@ -668,12 +675,16 @@ def execute_compiled(
                 )
             )
         elif isinstance(arg, _SimpleCData):
-            orch_args.add_scalar(scalar_to_uint64(arg))
+            continue  # handled in pass 2
         else:
             raise TypeError(
                 f"Argument at position {i} must be torch.Tensor, DeviceTensor or "
                 f"ctypes scalar, got {type(arg).__name__}"
             )
+    # Pass 2: scalars.
+    for arg in args:
+        if isinstance(arg, _SimpleCData):
+            orch_args.add_scalar(scalar_to_uint64(arg))
 
     # Snapshot profiling state before execution
     swimlane_dir: Path | None = None


### PR DESCRIPTION
## Summary

Two small runtime/JIT fixes:

- **`fix(runtime)`** — `execute_compiled` now buckets dispatch into two passes (tensors first, scalars second). Decouples user-facing orchestration source order from simpler's `ChipStorageTaskArgs` "no add_tensor after add_scalar" constraint. Codegen already addresses tensors and scalars from independent pools (`orch_args.tensor(i)` / `orch_args.scalar(i)`), so the binary ABI is order-agnostic across pools — only the host-side glue needs to obey the contract. Fixes #1228.
- **`refactor(jit)`** — Drop the source hash from the JIT-generated class name (`_jit_<name>_<hash>` → `_jit_<name>`). The class name flows through to `build_output/<class_name>_<timestamp>/`, so directories like `_jit_qkv_proj_35d7286acda195e4_20260507_104348` become `_jit_qkv_proj_20260507_104348`. The source hash is still used as the cache key — only the display name loses it.

## Test plan

- [ ] Reproducer from #1228: `hello_world.py` with interleaved `(x, alpha, y)` orchestration signature on `-p a2a3sim` runs to `PASS`
- [ ] Existing tensor-then-scalar examples continue to pass (bucketing is a strict superset of the prior layout)
- [ ] Inspect a fresh `build_output/` after a JIT compile — directory name no longer contains the 16-hex-char hash
- [ ] No regressions in JIT cache behavior (cache key still uses source hash)

## Related Issues

Fixes #1228