### PR TITLE
fix(codegen): preserve loop-carried tensor rebinds in orchestration ForStmt

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -41,6 +41,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 
@@ -243,9 +244,187 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
 
     std::string loop_var = GetVarName(for_stmt->loop_var_);
+    // Guard against an empty emit name (e.g. python `for _ in pl.range(...)`
+    // turns into an SSA name that GetSSABaseName strips to ""). Without this
+    // we would emit `for (int64_t  = 0; ...)`, which compiles only by accident.
+    if (loop_var.empty()) {
+      loop_var = ReserveSyntheticEmitName("i");
+      emit_name_map_[for_stmt->loop_var_.get()] = loop_var;
+    }
     std::string start_expr = GenerateExprString(for_stmt->start_);
     std::string stop_expr = GenerateExprString(for_stmt->stop_);
     std::string step_expr = GenerateExprString(for_stmt->step_);
+
+    INTERNAL_CHECK_SPAN(for_stmt->iter_args_.size() == for_stmt->return_vars_.size(), for_stmt->span_)
+        << "Internal error: ForStmt iter_args/return_vars size mismatch";
+
+    // Classify each iter_arg by its yield: trivial (yields back the iter_arg
+    // itself, no body-level rebind) vs rebind (yields a different value, e.g.
+    // a freshly-created tensor). The two need different lowerings:
+    //
+    //   trivial: alias iter_arg/return_var to the init's emit name. The runtime
+    //     dependency tracker keys off Tensor* identity, and OUTPUT_EXISTING /
+    //     INOUT params record the address of the Tensor lvalue passed in. If we
+    //     materialised a fresh `Tensor` value for the carry, the kernel reads
+    //     and writes would see a different `&tensor` than the producer that
+    //     materialised the buffer, breaking dep chains. So for the trivial case
+    //     we keep the legacy aliasing behaviour.
+    //
+    //   rebind: predeclare a mutable carry variable initialised from the init,
+    //     and route YieldStmt to assign back to it. Without this, a python
+    //     rebind like `current = next` inside the loop body would never
+    //     propagate to the next iteration or to code following the loop. See
+    //     issue #1286.
+    //
+    // We need to know which case applies before visiting the body, so we look
+    // up the yield once here.
+    auto yield = transform_utils::GetLastYieldStmt(for_stmt->body_);
+    std::vector<bool> is_rebind(for_stmt->iter_args_.size(), false);
+    if (yield) {
+      INTERNAL_CHECK_SPAN(yield->value_.size() == for_stmt->iter_args_.size(), for_stmt->span_)
+          << "Internal error: ForStmt yield/iter_args size mismatch";
+      // Build the alias-equivalence set for each iter_arg. A Var is in
+      // `iter_arg`'s class if it IS the iter_arg, or it was assigned the
+      // result of `tensor.assemble(<member>, ...)` — assemble writes in place
+      // to its first arg so the result Var is just another name for the same
+      // backing buffer. The transitive closure is computed by repeatedly
+      // walking AssignStmts in the body until no new members are added.
+      // (This mirrors HandleTensorAssembleAssign at codegen-emit time, but
+      // we need it pre-body so we can decide on the carry lowering.)
+      std::vector<std::unordered_set<const Var*>> aliases(for_stmt->iter_args_.size());
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        aliases[i].insert(for_stmt->iter_args_[i].get());
+      }
+      // Collect: (a) AssignStmts producing tensor.assemble aliases, and (b)
+      // nested ForStmts (so we can map their iter_args -> their return_vars,
+      // which are how a parent's carry "comes out of" an inner loop).
+      class AliasingNodeCollector : public IRVisitor {
+       public:
+        std::vector<AssignStmtPtr> assigns_;
+        std::vector<ForStmtPtr> nested_fors_;
+        void VisitStmt_(const AssignStmtPtr& a) override {
+          assigns_.push_back(a);
+          IRVisitor::VisitStmt_(a);
+        }
+        void VisitStmt_(const ForStmtPtr& f) override {
+          nested_fors_.push_back(f);
+          IRVisitor::VisitStmt_(f);
+        }
+      };
+      AliasingNodeCollector collector;
+      collector.VisitStmt(for_stmt->body_);
+      // Index assignments by produced var so rule (d) can climb tuple chains.
+      std::unordered_map<const Var*, AssignStmtPtr> var_to_assign;
+      for (const auto& a : collector.assigns_) {
+        var_to_assign[a->var_.get()] = a;
+      }
+
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (const auto& assign : collector.assigns_) {
+          // (d) TupleGetItemExpr: climb to the tuple-producing call and resolve
+          // the corresponding output arg. Multi-output InCore kernels return
+          // tuples; each `var = ret_tuple[i]` extract should alias the i-th
+          // output-side arg of the call (using the codegen's own indexing).
+          if (auto tge = As<TupleGetItemExpr>(assign->value_)) {
+            auto tuple_var = AsVarLike(tge->tuple_);
+            if (tuple_var) {
+              auto it = var_to_assign.find(tuple_var.get());
+              if (it != var_to_assign.end()) {
+                auto tcall = As<Call>(it->second->value_);
+                if (tcall) {
+                  auto tdirs = tcall->GetArgDirections();
+                  if (tdirs.size() == tcall->args_.size()) {
+                    int64_t out_seen = 0;
+                    int64_t target_idx = static_cast<int64_t>(tge->index_);
+                    for (size_t a = 0; a < tdirs.size(); ++a) {
+                      if (tdirs[a] != ArgDirection::OutputExisting && tdirs[a] != ArgDirection::InOut &&
+                          tdirs[a] != ArgDirection::Output) {
+                        continue;
+                      }
+                      if (out_seen == target_idx) {
+                        auto out_arg = AsVarLike(tcall->args_[a]);
+                        if (out_arg) {
+                          for (auto& cls : aliases) {
+                            if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
+                              cls.insert(assign->var_.get());
+                              changed = true;
+                            }
+                          }
+                        }
+                        break;
+                      }
+                      ++out_seen;
+                    }
+                  }
+                }
+              }
+            }
+            continue;
+          }
+          auto call = As<Call>(assign->value_);
+          if (!call) continue;
+          // (a) tensor.assemble: result var aliases its first arg (the target).
+          if (call->op_->name_ == "tensor.assemble" && !call->args_.empty()) {
+            auto first_arg = AsVarLike(call->args_[0]);
+            if (first_arg) {
+              for (auto& cls : aliases) {
+                if (cls.count(first_arg.get()) && !cls.count(assign->var_.get())) {
+                  cls.insert(assign->var_.get());
+                  changed = true;
+                }
+              }
+            }
+          }
+          // (c) Calls with output_existing/inout args (e.g. InCore kernels):
+          // the result aliases the FIRST output-side arg, mirroring the codegen
+          // alias `const Tensor& result = args[out_idx];` emitted later by
+          // GenerateSingleReturnAlias / GenerateTupleReturnAliases. If that arg
+          // is in an iter_arg's class, the result is in the class too.
+          auto call_dirs = call->GetArgDirections();
+          if (call_dirs.size() == call->args_.size()) {
+            for (size_t a = 0; a < call_dirs.size(); ++a) {
+              if (call_dirs[a] != ArgDirection::OutputExisting && call_dirs[a] != ArgDirection::InOut) {
+                continue;
+              }
+              auto out_arg = AsVarLike(call->args_[a]);
+              if (!out_arg) continue;
+              for (auto& cls : aliases) {
+                if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
+                  cls.insert(assign->var_.get());
+                  changed = true;
+                }
+              }
+              break;  // only the first output-side arg is the alias target
+            }
+          }
+        }
+        // (b) Nested ForStmts: the parent's carry threaded through a nested
+        // loop comes out via the nested loop's return_var. Specifically, for
+        // each (nested iter_arg, nested return_var) pair, if nested iter_arg's
+        // init value is in the parent class, then nested return_var is too.
+        for (const auto& nf : collector.nested_fors_) {
+          for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
+            auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);
+            if (!init_var) continue;
+            const auto* rv = nf->return_vars_[k].get();
+            for (auto& cls : aliases) {
+              if (cls.count(init_var.get()) && !cls.count(rv)) {
+                cls.insert(rv);
+                changed = true;
+              }
+            }
+          }
+        }
+      }
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        auto yield_var = AsVarLike(yield->value_[i]);
+        // True rebind iff yield value is not in the iter_arg's alias class
+        // (i.e. not the iter_arg itself nor any tensor.assemble alias of it).
+        is_rebind[i] = !yield_var || !aliases[i].count(yield_var.get());
+      }
+    }
 
     for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
       const auto& iter_arg = for_stmt->iter_args_[i];
@@ -253,8 +432,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
       std::string init_var_name = TryGetVarName(iter_arg->initValue_);
       INTERNAL_CHECK_SPAN(!init_var_name.empty(), for_stmt->span_)
           << "Internal error: ForStmt iter_arg initValue must be a variable, got non-variable expr";
-      emit_name_map_[iter_arg.get()] = init_var_name;
-      emit_name_map_[return_var.get()] = init_var_name;
+      // Function tensor params get rewritten to `ext_<name>` in the emitted C++,
+      // so the bare emit name is not a valid identifier when the init value is
+      // a param. Apply the same translation as everything else that names a
+      // tensor in the emitted code.
+      init_var_name = GetExternalTensorName(init_var_name);
+
+      if (is_rebind[i]) {
+        // Pick a fresh, distinct name for the carry. We can't reuse
+        // ReserveVarEmitName(return_var) because the lineage analyzer has
+        // already populated emit_name_map_[return_var] with the init's param
+        // name (when the iter_arg's init value is a function parameter), which
+        // would emit the self-referential `auto x = x;`. Use the return_var's
+        // raw name_hint (e.g. `current_hidden__rv_v3`) — uniqued against all
+        // declared names.
+        std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
+        code_ << Indent() << GetCppType(return_var->GetType()) << " " << carry_name << " = " << init_var_name
+              << ";\n";
+        emit_name_map_[iter_arg.get()] = carry_name;
+        emit_name_map_[return_var.get()] = carry_name;
+      } else {
+        // Trivial yield: preserve the legacy aliasing — both names route to
+        // the init's emit name. YieldStmt for this slot will be a self-assign
+        // and skipped (see VisitStmt_(YieldStmtPtr) for the equality guard).
+        emit_name_map_[iter_arg.get()] = init_var_name;
+        emit_name_map_[return_var.get()] = init_var_name;
+      }
     }
 
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
@@ -264,7 +467,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
     indent_ += 4;
 
     auto saved = current_return_vars_;
+    // Only register return_vars whose yield is a true rebind. Trivial slots
+    // are aliased to the init name and don't need a yield-time assignment;
+    // emitting one would just produce `init = init;`.
     current_return_vars_.clear();
+    for (size_t i = 0; i < for_stmt->return_vars_.size(); ++i) {
+      if (is_rebind[i]) {
+        current_return_vars_.push_back(for_stmt->return_vars_[i]);
+      } else {
+        current_return_vars_.push_back(nullptr);
+      }
+    }
     VisitStmt(for_stmt->body_);
     current_return_vars_ = saved;
 
@@ -349,7 +562,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void VisitStmt_(const YieldStmtPtr& yield_stmt) override {
     for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {
       std::string value_expr = GenerateExprString(yield_stmt->value_[i]);
-      if (i < current_return_vars_.size()) {
+      if (i < current_return_vars_.size() && current_return_vars_[i]) {
+        // Null slots in current_return_vars_ are placeholders for trivial
+        // yields (where the body does not rebind the iter_arg) — skip those.
+        // See VisitStmt_(ForStmtPtr) for how the placeholder is set up.
         auto yield_var = AsVarLike(yield_stmt->value_[i]);
         if (current_return_vars_[i].get() != yield_var.get()) {
           code_ << Indent() << GetVarName(current_return_vars_[i]) << " = " << value_expr << ";\n";

--- a/tests/st/runtime/test_ctrl_flow.py
+++ b/tests/st/runtime/test_ctrl_flow.py
@@ -629,6 +629,86 @@ class TestForLoopBreakContinue(PTOTestCase):
         tensors["c"][192:] = 0.0
 
 
+class TestOrchRangeCarryRebind(PTOTestCase):
+    """Reproducer for issue #1286: orchestration ``pl.range`` with carry-rebind to
+    a freshly-allocated GM tensor.
+
+    The orchestrator runs 4 iterations. Each iteration allocates a fresh
+    ``next_hidden`` tensor via ``pl.create_tensor``, calls an InCore kernel
+    that reads from ``current_hidden`` and writes ``+1`` into ``next_hidden``
+    (no inout/output_existing on ``current_hidden``), then rebinds
+    ``current_hidden = next_hidden``. After 4 iterations the result is
+    copied to ``c``.
+
+    Expected: c == a + 4 (each iter adds 1).
+    Buggy behaviour (current code): each iter sees the loop-entry value of
+    ``current_hidden`` (i.e. the original input ``a``), so c == a + 1 (only
+    the last iteration's +1 is reflected, because ``next_hidden`` is what the
+    final copy reads — actually since we copy ``current_hidden`` after the
+    loop, c == a (no rebind ever observed)).
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "orch_range_carry_rebind"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [16, 64], DataType.FP32, init_value=10.0),
+            TensorSpec("c", [16, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class OrchRangeCarryRebindProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_add_one(
+                self,
+                src: pl.Tensor[[16, 64], pl.FP32],
+                dst: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                tile_in: pl.Tile[[16, 64], pl.FP32] = pl.load(src, [0, 0], [16, 64])
+                tile_out: pl.Tile[[16, 64], pl.FP32] = pl.add(tile_in, 1.0)
+                out: pl.Tensor[[16, 64], pl.FP32] = pl.store(tile_out, [0, 0], dst)
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_copy(
+                self,
+                src: pl.Tensor[[16, 64], pl.FP32],
+                dst: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                tile_in: pl.Tile[[16, 64], pl.FP32] = pl.load(src, [0, 0], [16, 64])
+                out: pl.Tensor[[16, 64], pl.FP32] = pl.store(tile_in, [0, 0], dst)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[16, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # Initialise carry from the input (one copy so we don't write
+                # back into `a` itself).
+                current_hidden: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                current_hidden = self.kernel_copy(a, current_hidden)
+                for _ in pl.range(4):
+                    next_hidden: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                    next_hidden = self.kernel_add_one(current_hidden, next_hidden)
+                    current_hidden = next_hidden  # carry rebind across iterations
+                c = self.kernel_copy(current_hidden, c)
+                return c
+
+        return OrchRangeCarryRebindProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = tensors["a"] + 4.0
+
+
 class TestCtrlFlowOperations:
     """Test suite for control flow operations."""
 
@@ -694,6 +774,12 @@ class TestCtrlFlowOperations:
     def test_for_loop_break_continue(self, test_runner, platform):
         """Test for loop with break and continue."""
         result = test_runner.run(TestForLoopBreakContinue(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_orch_range_carry_rebind(self, test_runner, platform):
+        """Reproducer for issue #1286: orchestration pl.range carry rebind to fresh tensor."""
+        result = test_runner.run(TestOrchRangeCarryRebind(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 


### PR DESCRIPTION
## Summary

Fixes #1286.

The orchestration codegen for `pl.range` (and any `ForStmt` with iter_args) silently dropped python-level rebinds inside the loop body, causing fused multi-layer kernels to byte-exact passthrough their input. Two coupled bugs:

1. **iter_arg / return_var aliased to init's emit name.** For yields that rebind to a *different* tensor (e.g. `current = next` where `next` is a freshly-created `pl.create_tensor`), the carry never updates — every iteration reads the loop-entry value, post-loop reads the same untouched buffer.
2. **`current_return_vars_` cleared before visiting the body.** The `YieldStmt` handler's `i < current_return_vars_.size()` guard was always false, so no rebind assignment was ever emitted.

`pl.unroll` was unaffected because each iteration is fully expanded at compile time, so rebinds chain naturally in the same SSA scope. `pl.unroll` is a workaround but unusable at production scale (40+ layer Qwen3 / DeepSeek explodes binary size and compile time).

## Approach

In `VisitStmt_(ForStmtPtr)`:

- Pre-scan the body to compute, per iter_arg, an **alias-equivalence class** — the set of Vars that name the same backing buffer as the iter_arg. Forward dataflow over body assignments, covering:
  - (a) `tensor.assemble(member, ...)` results
  - (b) Nested `ForStmt` return_vars threaded through the parent's carry
  - (c) `Call` `OutputExisting` / `InOut` first output arg
  - (d) `TupleGetItemExpr` extracts (multi-output InCore kernels)
- A yield is a **true rebind** iff its value is *not* in the iter_arg's class. Only true rebinds get a mutable carry predeclare (`auto carry_name = init;`); trivial yields keep the legacy aliasing so the runtime's `Tensor*` identity-based dep tracker keeps producer/consumer chains intact.
- `current_return_vars_` is now populated with `return_var` for rebind slots and `nullptr` for trivial slots; the `YieldStmt` handler skips null slots and emits `carry = value;` for the rest.

**Drive-by:** `for _ in pl.range(...)` was emitting `for (int64_t  = 0; ...)` (empty loop var name — the SSA-renamed `_` got stripped to "" by `GetSSABaseName`). Falls back to a synthetic `i`. Compiled by accident before because no body referenced the loop var.

## Test plan

- [x] New ST `test_orch_range_carry_rebind` minimally reproduces #1286 (orchestration `pl.range(4)` + `pl.create_tensor` + `current = next`). FAIL → PASS (output goes from `c == a` to `c == a + 4`).
- [x] Full ctrl_flow ST suite: 7 passed / 0 regressions.
- [x] Adjacent ST suites that exercise orchestration For codegen (dyn_orch_shape, assemble, compiled_program, dag): 18 passed / 0 regressions. **Total 25 passed / 0 regressions on a2a3sim.**
- [x] **End-to-end on a2a3 hardware**: Qwen3-14B 4L `decode_full` via `hf_compare`. With the fix, `pl.range` produces **byte-identical numerics** to `pl.unroll` (`out max_abs=1.83e-1`, `cosine=0.99997`, `pass_rate=0.995`). Before the fix `pl.range` gave `diff_max == 0.000e+00` byte-exact identity passthrough.