### PR TITLE
feat(language): manual_dep on Tensor params + pl.no_dep call-site override

### DIFF
--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -643,6 +643,36 @@ inline std::vector<std::pair<std::string, std::any>> WithArgDirectionsAttr(
 }
 
 /**
+ * @brief Reserved attr key for per-arg ``ArgDirection::NoDep`` overrides
+ *
+ * The parser sets this when the user wraps a kernel-call argument in
+ * ``pl.no_dep(...)`` to mark a single arg position as no-dep without
+ * forcing the whole call to a manual dep mode. Value type is
+ * ``std::vector<int32_t>``: the argument indices to be set to NoDep.
+ *
+ * ``DeriveCallDirections`` reads this attr AFTER computing the per-arg
+ * directions and overwrites each indicated slot to ``ArgDirection::NoDep``,
+ * leaving every other position as the auto-derived direction.
+ */
+inline constexpr const char* kAttrArgDirectionOverrides = "arg_direction_overrides";
+
+/**
+ * Build a copy of ``attrs`` with ``kAttrArgDirectionOverrides`` set to
+ * ``no_dep_indices``. Replaces an existing entry if present; otherwise appends.
+ */
+inline std::vector<std::pair<std::string, std::any>> WithArgDirectionOverridesAttr(
+    std::vector<std::pair<std::string, std::any>> attrs, std::vector<int32_t> no_dep_indices) {
+  for (auto& [k, v] : attrs) {
+    if (k == kAttrArgDirectionOverrides) {
+      v = std::move(no_dep_indices);
+      return attrs;
+    }
+  }
+  attrs.emplace_back(kAttrArgDirectionOverrides, std::move(no_dep_indices));
+  return attrs;
+}
+
+/**
  * @brief Expression to create a tuple from multiple expressions
  *
  * Takes a list of expressions and creates a tuple value.

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -405,6 +405,7 @@ using ShapedTypePtr = std::shared_ptr<const ShapedType>;
 class TensorType : public ShapedType {
  public:
   std::optional<TensorView> tensor_view_;  ///< Optional tensor view information
+  bool manual_dep_ = false;                ///< Skip runtime OverlapMap dep tracking; user manages ordering
 
   /**
    * @brief Create a tensor type without memory reference or tensor view
@@ -469,6 +470,36 @@ class TensorType : public ShapedType {
              std::optional<TensorView> tensor_view)
       : ShapedType(dtype, shape, std::move(memref)), tensor_view_(std::move(tensor_view)) {}
 
+  /**
+   * @brief Create a tensor type with manual_dep flag (most-permissive shared_ptr form)
+   *
+   * @param shape Shape dimensions
+   * @param dtype Element data type
+   * @param memref Optional memory reference (shared pointer)
+   * @param tensor_view Optional tensor view information
+   * @param manual_dep When true, the runtime skips OverlapMap dep tracking for this buffer
+   */
+  TensorType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRefPtr> memref,
+             std::optional<TensorView> tensor_view, bool manual_dep)
+      : ShapedType(dtype, std::move(shape), std::move(memref)),
+        tensor_view_(std::move(tensor_view)),
+        manual_dep_(manual_dep) {}
+
+  /**
+   * @brief Create a tensor type with manual_dep flag (constant shape form)
+   *
+   * @param shape Shape dimensions
+   * @param dtype Element data type
+   * @param memref Optional memory reference (shared pointer)
+   * @param tensor_view Optional tensor view information
+   * @param manual_dep When true, the runtime skips OverlapMap dep tracking for this buffer
+   */
+  TensorType(const std::vector<int64_t>& shape, DataType dtype, std::optional<MemRefPtr> memref,
+             std::optional<TensorView> tensor_view, bool manual_dep)
+      : ShapedType(dtype, shape, std::move(memref)),
+        tensor_view_(std::move(tensor_view)),
+        manual_dep_(manual_dep) {}
+
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::TensorType; }
   [[nodiscard]] std::string TypeName() const override { return "TensorType"; }
   [[nodiscard]] std::optional<MemorySpace> GetMemorySpace() const override { return MemorySpace::DDR; }
@@ -480,7 +511,8 @@ class TensorType : public ShapedType {
 
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(ShapedType::GetFieldDescriptors(),
-                          std::make_tuple(reflection::UsualField(&TensorType::tensor_view_, "tensor_view")));
+                          std::make_tuple(reflection::UsualField(&TensorType::tensor_view_, "tensor_view"),
+                                          reflection::UsualField(&TensorType::manual_dep_, "manual_dep")));
   }
 };
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -350,6 +350,17 @@ void BindIR(nb::module_& m) {
       nb::init<const std::vector<int64_t>&, DataType, std::optional<MemRefPtr>, std::optional<TensorView>>(),
       nb::arg("shape"), nb::arg("dtype"), nb::arg("memref") = nb::none(), nb::arg("tensor_view") = nb::none(),
       "Create a tensor type with constant shape, optional memory reference and tensor view");
+  tensor_type_class.def(
+      nb::init<const std::vector<ExprPtr>&, DataType, std::optional<MemRefPtr>, std::optional<TensorView>,
+               bool>(),
+      nb::arg("shape"), nb::arg("dtype"), nb::arg("memref") = nb::none(), nb::arg("tensor_view") = nb::none(),
+      nb::arg("manual_dep") = false,
+      "Create a tensor type with manual_dep flag (skip OverlapMap dep tracking at runtime)");
+  tensor_type_class.def(nb::init<const std::vector<int64_t>&, DataType, std::optional<MemRefPtr>,
+                                 std::optional<TensorView>, bool>(),
+                        nb::arg("shape"), nb::arg("dtype"), nb::arg("memref") = nb::none(),
+                        nb::arg("tensor_view") = nb::none(), nb::arg("manual_dep") = false,
+                        "Create a tensor type with constant shape and manual_dep flag");
   BindFields<TensorType>(tensor_type_class);
 
   // TileType - const shared_ptr

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <any>
 #include <cctype>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -143,11 +144,12 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<nb::float_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<double>(item.second));
     } else if (nb::isinstance<nb::list>(item.second) || nb::isinstance<nb::tuple>(item.second)) {
-      // Lists/tuples currently carry one of:
+      // Lists/tuples carry exactly one of:
       //   - vector<ArgDirection> for attrs["arg_directions"]
       //   - vector<int32_t>      for attrs["arg_direction_overrides"]
       //     (per-arg NoDep override indices set by ``pl.no_dep`` parser)
-      // Distinguish by element type. Reject empty sequences with a helpful error.
+      // Empty sequences are key-disambiguated: kAttrArgDirectionOverrides
+      // gets vector<int32_t>{}, everything else gets vector<ArgDirection>{}.
       auto seq = nb::cast<nb::sequence>(item.second);
       bool empty = true;
       bool first_is_arg_direction = false;
@@ -159,9 +161,11 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
         break;
       }
       if (empty) {
-        // Default to empty vector<ArgDirection> for back-compat with existing
-        // arg_directions=[] usage.
-        kwargs.emplace_back(key, std::vector<ArgDirection>{});
+        if (key == kAttrArgDirectionOverrides) {
+          kwargs.emplace_back(key, std::vector<int32_t>{});
+        } else {
+          kwargs.emplace_back(key, std::vector<ArgDirection>{});
+        }
       } else if (first_is_arg_direction) {
         std::vector<ArgDirection> dirs;
         for (auto elem : seq) {
@@ -178,7 +182,12 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
           if (nb::isinstance<nb::bool_>(elem) || !nb::isinstance<nb::int_>(elem)) {
             throw pypto::TypeError("Unsupported list element type for key: " + key + " (expected int)");
           }
-          idxs.push_back(static_cast<int32_t>(nb::cast<int64_t>(elem)));
+          int64_t v = nb::cast<int64_t>(elem);
+          if (v < std::numeric_limits<int32_t>::min() || v > std::numeric_limits<int32_t>::max()) {
+            throw pypto::ValueError("List value " + std::to_string(v) + " for key: " + key +
+                                    " is out of int32 range");
+          }
+          idxs.push_back(static_cast<int32_t>(v));
         }
         kwargs.emplace_back(key, std::move(idxs));
       } else {
@@ -759,6 +768,16 @@ void BindIR(nb::module_& m) {
         nb::list lst;
         for (auto d : dirs) {
           lst.append(nb::cast(d));
+        }
+        result[key.c_str()] = lst;
+      } else if (value.type() == typeid(std::vector<int32_t>)) {
+        // Used by attrs["arg_direction_overrides"] (per-arg NoDep override
+        // indices). Surface as a Python list[int] so attribute readback
+        // round-trips through the binding.
+        const auto& idxs = AnyCast<std::vector<int32_t>>(value, "converting to Python: " + key);
+        nb::list lst;
+        for (auto i : idxs) {
+          lst.append(nb::cast(i));
         }
         result[key.c_str()] = lst;
       }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -143,17 +143,48 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<nb::float_>(item.second)) {
       kwargs.emplace_back(key, nb::cast<double>(item.second));
     } else if (nb::isinstance<nb::list>(item.second) || nb::isinstance<nb::tuple>(item.second)) {
-      // Lists/tuples currently only used to carry `vector<ArgDirection>` (e.g. attrs["arg_directions"]).
-      // Reject non-ArgDirection sequences to avoid silently dropping metadata.
-      std::vector<ArgDirection> dirs;
-      for (auto elem : nb::cast<nb::sequence>(item.second)) {
-        if (!nb::isinstance<ArgDirection>(elem)) {
-          throw pypto::TypeError("Unsupported list element type for key: " + key +
-                                 " (expected ArgDirection)");
-        }
-        dirs.push_back(nb::cast<ArgDirection>(elem));
+      // Lists/tuples currently carry one of:
+      //   - vector<ArgDirection> for attrs["arg_directions"]
+      //   - vector<int32_t>      for attrs["arg_direction_overrides"]
+      //     (per-arg NoDep override indices set by ``pl.no_dep`` parser)
+      // Distinguish by element type. Reject empty sequences with a helpful error.
+      auto seq = nb::cast<nb::sequence>(item.second);
+      bool empty = true;
+      bool first_is_arg_direction = false;
+      bool first_is_int = false;
+      for (auto elem : seq) {
+        empty = false;
+        first_is_arg_direction = nb::isinstance<ArgDirection>(elem);
+        first_is_int = nb::isinstance<nb::int_>(elem) && !nb::isinstance<nb::bool_>(elem);
+        break;
       }
-      kwargs.emplace_back(key, std::move(dirs));
+      if (empty) {
+        // Default to empty vector<ArgDirection> for back-compat with existing
+        // arg_directions=[] usage.
+        kwargs.emplace_back(key, std::vector<ArgDirection>{});
+      } else if (first_is_arg_direction) {
+        std::vector<ArgDirection> dirs;
+        for (auto elem : seq) {
+          if (!nb::isinstance<ArgDirection>(elem)) {
+            throw pypto::TypeError("Unsupported list element type for key: " + key +
+                                   " (expected ArgDirection)");
+          }
+          dirs.push_back(nb::cast<ArgDirection>(elem));
+        }
+        kwargs.emplace_back(key, std::move(dirs));
+      } else if (first_is_int) {
+        std::vector<int32_t> idxs;
+        for (auto elem : seq) {
+          if (nb::isinstance<nb::bool_>(elem) || !nb::isinstance<nb::int_>(elem)) {
+            throw pypto::TypeError("Unsupported list element type for key: " + key + " (expected int)");
+          }
+          idxs.push_back(static_cast<int32_t>(nb::cast<int64_t>(elem)));
+        }
+        kwargs.emplace_back(key, std::move(idxs));
+      } else {
+        throw pypto::TypeError("Unsupported list element type for key: " + key +
+                               " (expected ArgDirection or int)");
+      }
     } else {
       throw pypto::TypeError("Unsupported kwarg type for key: " + key);
     }

--- a/python/pypto/ir/type.py
+++ b/python/pypto/ir/type.py
@@ -61,6 +61,7 @@ def _tensor_type_init_wrapper(
     dtype: DataType,
     memref: MemRef | None = None,
     tensor_view: _TensorViewBase | None = None,
+    manual_dep: bool = False,
 ):
     """Wrapped __init__ for TensorType that supports integer shapes, optional MemRef and TensorView.
 
@@ -70,10 +71,11 @@ def _tensor_type_init_wrapper(
         dtype: Element data type
         memref: Optional memory reference
         tensor_view: Optional tensor view information
+        manual_dep: When True, the runtime skips OverlapMap dep tracking for this buffer.
     """
     shape_exprs = _normalize_shape(shape)
-    # Always pass all 4 arguments to native constructor (memref and tensor_view can be None)
-    _native_tensor_type_init(self, shape_exprs, dtype, memref, tensor_view)
+    # Pass all 5 arguments to native constructor; the manual_dep overload is selected.
+    _native_tensor_type_init(self, shape_exprs, dtype, memref, tensor_view, manual_dep)
 
 
 def _tile_type_init_wrapper(

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -183,7 +183,7 @@ from .op.unified_ops import (
 from .optimizations import auto_chunk, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
-from .typing import DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
+from .typing import DynVar, InOut, IntLike, ManualDep, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
 Mem = MemorySpace
@@ -237,6 +237,7 @@ __all__ = [
     "DynVar",
     "InOut",
     "IntLike",
+    "ManualDep",
     "Out",
     "dynamic",
     "const",

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -93,7 +93,7 @@ from .op.system_ops import (
     tpush_to_aic,
     tpush_to_aiv,
 )
-from .op.tensor_ops import assemble, create_tensor, dim, expand_clone, full, scatter_update
+from .op.tensor_ops import assemble, create_tensor, dim, expand_clone, full, no_dep, scatter_update
 from .op.tensor_ops import ci as arange
 from .op.tile_ops import (
     MemRefType,
@@ -361,6 +361,7 @@ __all__ = [
     "assemble",
     "dim",
     "full",
+    "no_dep",
     "scatter_update",
     "arange",
     "ChunkConfig",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -20,6 +20,7 @@ from typing import Any, overload
 __all__ = [
     "create_tensor",
     "create",
+    "no_dep",
     "read",
     "write",
     "dim",
@@ -119,6 +120,37 @@ def create(
 
 
 create_tensor = create
+
+
+def no_dep(tensor: Tensor) -> Tensor:
+    """Mark a kernel-call argument as no-dependency (caller-site override).
+
+    This is a parser-recognized marker — at runtime it returns the wrapped
+    tensor unchanged. The parser detects ``pl.no_dep(t)`` at kernel call
+    arg positions and threads the per-arg ``ArgDirection.NoDep`` override
+    into the IR Call's attrs. ``DeriveCallDirections`` then overwrites the
+    auto-derived direction at that slot to NoDep.
+
+    Effect at runtime: the simpler runtime skips the OverlapMap dependency
+    lookup for this argument (creator retention only). Use when ordering
+    is guaranteed by other means and you want to avoid unnecessary
+    serialization that auto-dep would otherwise insert.
+
+    Only valid as a direct argument to a kernel call::
+
+        result = self.my_kernel(pl.no_dep(shared_input), output)
+
+    Outside a kernel call argument list it is a no-op (returns ``tensor``
+    unchanged); the parser only injects the override at recognized call
+    sites.
+
+    Args:
+        tensor: The tensor to pass through. Must be a ``Tensor`` value.
+
+    Returns:
+        The tensor unchanged. The marker is consumed at parse time.
+    """
+    return tensor
 
 
 def read(tensor: Tensor, indices: IntLike | Sequence[IntLike]) -> Scalar:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3395,7 +3395,10 @@ class ASTParser:
                     arg_directions = self._extract_arg_directions_from_attrs(method_name, call, span)
                     if arg_directions is None:
                         arg_directions = []
-                    args = [self.parse_expression(arg) for arg in call.args]
+                    # Detect ``pl.no_dep(...)`` wrappers at call-arg positions and
+                    # collect their indices for the arg_direction_overrides attr.
+                    unwrapped_args, no_dep_indices = self._strip_no_dep_wrappers(call.args)
+                    args = [self.parse_expression(arg) for arg in unwrapped_args]
                     return_types = func_obj.return_types if func_obj else []
                     if func_obj is not None and return_types:
                         return_types = ir.deduce_call_return_type(
@@ -3404,7 +3407,12 @@ class ASTParser:
                             return_types,
                         )
                     return self._make_call_with_return_type(
-                        gvar, args, return_types, span, arg_directions=arg_directions
+                        gvar,
+                        args,
+                        return_types,
+                        span,
+                        arg_directions=arg_directions,
+                        no_dep_indices=no_dep_indices,
                     )
                 else:
                     raise UndefinedVariableError(
@@ -3534,8 +3542,10 @@ class ASTParser:
         return_types: list[ir.Type],
         span: ir.Span,
         arg_directions: list[ir.ArgDirection] | None = None,
+        no_dep_indices: list[int] | None = None,
     ) -> ir.Expr:
-        """Create an ir.Call, attaching the return type and (optional) call-site directions.
+        """Create an ir.Call, attaching the return type, optional call-site directions
+        and optional per-arg ``NoDep`` overrides.
 
         Args:
             gvar: GlobalVar identifying the callee
@@ -3548,6 +3558,10 @@ class ASTParser:
                 with ``attrs['arg_directions']`` populated. When ``None`` or empty
                 the call is constructed without explicit directions (legacy form;
                 ``DeriveCallDirections`` will fill them in later).
+            no_dep_indices: Optional list of arg positions wrapped in ``pl.no_dep(...)``
+                at the call site. Stored as ``attrs['arg_direction_overrides']`` so
+                ``DeriveCallDirections`` can overwrite the auto-derived direction at
+                each indicated slot to ``ArgDirection.NoDep``.
         """
         if not return_types:
             return_type: ir.Type = ir.UnknownType()
@@ -3556,13 +3570,57 @@ class ASTParser:
         else:
             return_type = ir.TupleType(return_types)
 
+        attrs: dict[str, Any] | None = None
         if arg_directions:
             attrs = {"arg_directions": list(arg_directions)}
+        if no_dep_indices:
+            attrs = attrs or {}
+            attrs["arg_direction_overrides"] = list(no_dep_indices)
+
+        if attrs is not None:
             return ir.Call(gvar, args, {}, attrs, return_type, span)
 
         if not return_types:
             return ir.Call(gvar, args, span)
         return ir.Call(gvar, args, return_type, span)
+
+    @staticmethod
+    def _strip_no_dep_wrappers(
+        arg_nodes: list[ast.expr],
+    ) -> tuple[list[ast.expr], list[int]]:
+        """Detect ``pl.no_dep(arg)`` wrappers in a kernel-call argument list.
+
+        Returns a parallel list of unwrapped arg ASTs (so the inner expression
+        is what gets parsed into IR) plus the indices of arguments that were
+        wrapped — these become ``ArgDirection.NoDep`` overrides at codegen
+        time via ``DeriveCallDirections``.
+
+        Recognised forms (single positional arg only, no kwargs):
+            pl.no_dep(t)   — Attribute(value=Name("pl"), attr="no_dep")
+            no_dep(t)      — Name("no_dep")  (in case the user does
+                             ``from pypto.language import no_dep``)
+
+        A trailing ``pl.no_dep`` with multiple args or any keyword is NOT a
+        valid wrapper and is left in place; the parser will hit it later
+        as a normal call and surface a clear error.
+        """
+        unwrapped: list[ast.expr] = []
+        indices: list[int] = []
+        for i, raw in enumerate(arg_nodes):
+            if (
+                isinstance(raw, ast.Call)
+                and len(raw.args) == 1
+                and not raw.keywords
+                and (
+                    (isinstance(raw.func, ast.Attribute) and raw.func.attr == "no_dep")
+                    or (isinstance(raw.func, ast.Name) and raw.func.id == "no_dep")
+                )
+            ):
+                unwrapped.append(raw.args[0])
+                indices.append(i)
+            else:
+                unwrapped.append(raw)
+        return unwrapped, indices
 
     @staticmethod
     def _reject_keyword_args(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3600,6 +3600,11 @@ class ASTParser:
             no_dep(t)      — Name("no_dep")  (in case the user does
                              ``from pypto.language import no_dep``)
 
+        The match is intentionally tight — only the bare ``pl.no_dep``
+        attribute access (or a ``no_dep`` import) qualifies. ``obj.no_dep(x)``
+        on a user-defined object is left in place so the parser surfaces a
+        normal-call error path instead of silently stripping the wrapper.
+
         A trailing ``pl.no_dep`` with multiple args or any keyword is NOT a
         valid wrapper and is left in place; the parser will hit it later
         as a normal call and surface a clear error.
@@ -3612,7 +3617,12 @@ class ASTParser:
                 and len(raw.args) == 1
                 and not raw.keywords
                 and (
-                    (isinstance(raw.func, ast.Attribute) and raw.func.attr == "no_dep")
+                    (
+                        isinstance(raw.func, ast.Attribute)
+                        and raw.func.attr == "no_dep"
+                        and isinstance(raw.func.value, ast.Name)
+                        and raw.func.value.id == "pl"
+                    )
                     or (isinstance(raw.func, ast.Name) and raw.func.id == "no_dep")
                 )
             ):

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1137,9 +1137,19 @@ class TypeResolver:
         """Check if an AST node is the ``pl.ManualDep`` marker.
 
         ``ManualDep`` is a marker class (not callable). It appears in tensor
-        annotations as a bare reference: ``pl.ManualDep`` or ``ManualDep``.
+        annotations as a bare reference: ``pl.ManualDep`` (rooted at the
+        ``pl`` module) or ``ManualDep`` (when imported directly).
+
+        The match is tight on purpose — ``some_obj.ManualDep`` on a user
+        object does not qualify, so a stray attribute named ``ManualDep`` on
+        an unrelated object cannot silently mark a tensor as manual-dep.
         """
-        if isinstance(node, ast.Attribute) and node.attr == "ManualDep":
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "ManualDep"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "pl"
+        ):
             return True
         if isinstance(node, ast.Name) and node.id == "ManualDep":
             return True

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -356,8 +356,23 @@ class TypeResolver:
             return self._resolve_tuple_subscript_type(subscript_node)
 
         # Tensor: [shape, dtype], [shape, dtype, layout_or_memref], [shape, dtype, layout, memref]
+        #         optionally with a trailing ``pl.ManualDep`` marker at any tail position.
         # Tile: [shape, dtype] plus any ordering of TileView/MemRef/MemorySpace,
         # with the constraint that MemRef requires explicit MemorySpace.
+        # Strip ManualDep marker from Tensor annotations before counting.
+        manual_dep = False
+        if type_name == "Tensor" and isinstance(slice_value, ast.Tuple):
+            kept_elts: list[ast.expr] = []
+            for elt in slice_value.elts:
+                if self._is_manual_dep_node(elt):
+                    manual_dep = True
+                else:
+                    kept_elts.append(elt)
+            if manual_dep:
+                # Build a fresh Tuple node with the marker removed; preserve span via copy_location.
+                stripped = ast.Tuple(elts=kept_elts, ctx=slice_value.ctx)
+                ast.copy_location(stripped, slice_value)
+                slice_value = stripped
         valid_counts = (2, 3, 4) if type_name == "Tensor" else (2, 3, 4, 5)
         if not isinstance(slice_value, ast.Tuple) or len(slice_value.elts) not in valid_counts:
             if type_name == "Tensor":
@@ -397,7 +412,7 @@ class TypeResolver:
         if n_elts == 2:
             if type_name == "Tile":
                 return ir.TileType(shape, dtype)
-            return ir.TensorType(shape, dtype)
+            return ir.TensorType(shape, dtype, None, None, manual_dep)
 
         if type_name == "Tile":
             return self._resolve_tile_annotation_args(shape, dtype, list(slice_value.elts[2:]))
@@ -407,13 +422,13 @@ class TypeResolver:
             third = slice_value.elts[2]
             if self._is_memref_node(third):
                 memref = self.resolve_memref(third)
-                return ir.TensorType(shape, dtype, memref)
+                return ir.TensorType(shape, dtype, memref, None, manual_dep)
             if self._is_tensorview_node(third):
                 tensor_view = self._resolve_tensorview(third)
-                return ir.TensorType(shape, dtype, None, tensor_view)
+                return ir.TensorType(shape, dtype, None, tensor_view, manual_dep)
             layout = self.resolve_layout(third)
             tensor_view = ir.TensorView([], layout)
-            return ir.TensorType(shape, dtype, None, tensor_view)
+            return ir.TensorType(shape, dtype, None, tensor_view, manual_dep)
 
         # Tensor 4 args: [shape, dtype, layout_or_tensorview, memref]
         third = slice_value.elts[2]
@@ -430,7 +445,7 @@ class TypeResolver:
                 hint="Use pl.Tensor[[shape], dtype, layout, pl.MemRef(...)]",
             )
         memref = self.resolve_memref(memref_node)
-        return ir.TensorType(shape, dtype, memref, tensor_view)
+        return ir.TensorType(shape, dtype, memref, tensor_view, manual_dep)
 
     def _resolve_tile_annotation_args(
         self, shape: "list[int] | list[ir.Expr]", dtype: DataType, extra_nodes: list[ast.expr]
@@ -1117,6 +1132,18 @@ class TypeResolver:
         return (isinstance(func, ast.Attribute) and func.attr == "TensorView") or (
             isinstance(func, ast.Name) and func.id == "TensorView"
         )
+
+    def _is_manual_dep_node(self, node: ast.expr) -> bool:
+        """Check if an AST node is the ``pl.ManualDep`` marker.
+
+        ``ManualDep`` is a marker class (not callable). It appears in tensor
+        annotations as a bare reference: ``pl.ManualDep`` or ``ManualDep``.
+        """
+        if isinstance(node, ast.Attribute) and node.attr == "ManualDep":
+            return True
+        if isinstance(node, ast.Name) and node.id == "ManualDep":
+            return True
+        return False
 
     def _resolve_tensorview(self, node: ast.expr) -> "ir.TensorView":
         """Resolve a pl.TensorView(...) AST call to ir.TensorView.

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -20,6 +20,7 @@ from typing import TypeAlias
 
 from pypto.language.typing.direction import InOut, Out
 from pypto.language.typing.dynamic import DynVar, dynamic
+from pypto.language.typing.manual_dep import ManualDep
 from pypto.language.typing.memref import MemRef
 from pypto.language.typing.scalar import Scalar
 from pypto.language.typing.tensor import Tensor
@@ -30,4 +31,16 @@ from pypto.pypto_core.ir import Expr
 IntLike: TypeAlias = int | Scalar | Expr
 """Type alias for shape/offset parameters that accept int literals, Scalar DSL values, or raw Expr."""
 
-__all__ = ["DynVar", "InOut", "IntLike", "MemRef", "Out", "Scalar", "Tensor", "Tile", "Tuple", "dynamic"]
+__all__ = [
+    "DynVar",
+    "InOut",
+    "IntLike",
+    "ManualDep",
+    "MemRef",
+    "Out",
+    "Scalar",
+    "Tensor",
+    "Tile",
+    "Tuple",
+    "dynamic",
+]

--- a/python/pypto/language/typing/manual_dep.py
+++ b/python/pypto/language/typing/manual_dep.py
@@ -1,0 +1,33 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""ManualDep marker for tensor annotations.
+
+Usage::
+
+    x: pl.Tensor[[64, 64], pl.FP32, pl.ManualDep]
+    y: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.NZ, pl.ManualDep]]
+
+When set, the tensor opts out of automatic dependency tracking by the
+runtime (skips OverlapMap lookup and TensorMap insert). The user is
+responsible for ordering by other means: disjoint writes guaranteed by
+the kernel, manual scope plus explicit add_dep, or pl.no_dep at call
+sites for per-arg overrides.
+
+This is a marker class with no instances or methods — its presence in a
+Tensor annotation is detected at parse time and threaded into the
+underlying ir.TensorType's manual_dep field.
+"""
+
+
+class ManualDep:
+    """Marker class signalling a tensor opts out of runtime auto-dep tracking."""
+
+
+__all__ = ["ManualDep"]

--- a/python/pypto/language/typing/tensor.py
+++ b/python/pypto/language/typing/tensor.py
@@ -15,22 +15,36 @@ from typing import Any, cast, overload
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Expr, MemRef, TensorLayout
 
+from .manual_dep import ManualDep
+
 
 def _validate_tensor_meta_call(args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
     """Validate TensorMeta.__call__ argument structure."""
-    allowed_kwargs = {"shape", "dtype", "expr", "layout", "memref", "_annotation_only"}
+    allowed_kwargs = {"shape", "dtype", "expr", "layout", "memref", "manual_dep", "_annotation_only"}
     unexpected = set(kwargs) - allowed_kwargs
     if unexpected:
         name = sorted(unexpected)[0]
         raise TypeError(f"Tensor() got an unexpected keyword argument '{name}'")
 
-    if len(args) > 6:
-        raise TypeError(f"Tensor() takes at most 6 positional arguments but {len(args)} were given")
+    if len(args) > 7:
+        raise TypeError(f"Tensor() takes at most 7 positional arguments but {len(args)} were given")
 
-    param_names = ("shape", "dtype", "expr", "layout", "memref", "_annotation_only")
+    param_names = ("shape", "dtype", "expr", "layout", "memref", "manual_dep", "_annotation_only")
     for index, name in enumerate(param_names[: len(args)]):
         if name in kwargs:
             raise TypeError(f"Tensor() got multiple values for argument '{name}'")
+
+
+def _strip_manual_dep_marker(item: tuple) -> tuple[tuple, bool]:
+    """Pull a ``pl.ManualDep`` marker out of a Tensor[...] subscript tuple.
+
+    Returns the remaining tuple (without the marker) and a bool flag.
+    """
+    if not isinstance(item, tuple):
+        return item, False
+    rest = tuple(elt for elt in item if elt is not ManualDep)
+    has_marker = len(rest) != len(item)
+    return rest, has_marker
 
 
 class TensorMeta(type):
@@ -38,15 +52,24 @@ class TensorMeta(type):
 
     def __getitem__(cls, item: tuple) -> "Tensor":
         """Enable Tensor[[shape], dtype], Tensor[[shape], dtype, layout_or_memref],
-        and Tensor[[shape], dtype, layout, memref] syntax.
+        Tensor[[shape], dtype, layout, memref], and an optional ``pl.ManualDep``
+        marker appended at any position to opt out of runtime auto-dep tracking.
 
         Args:
-            item: Tuple of 2, 3, or 4 elements
+            item: Tuple of 2, 3, 4, or 5 elements (5th allowed only when one is
+                ``pl.ManualDep``).
 
         Returns:
-            Tensor instance with shape, dtype, and optional layout/memref
+            Tensor instance with shape, dtype, optional layout/memref and
+            ``manual_dep`` flag.
         """
-        if not isinstance(item, tuple) or len(item) not in (2, 3, 4):
+        if not isinstance(item, tuple):
+            raise TypeError(
+                "Tensor requires [shape, dtype], [shape, dtype, layout_or_memref], "
+                "or [shape, dtype, layout, memref] notation"
+            )
+        item, manual_dep = _strip_manual_dep_marker(item)
+        if len(item) not in (2, 3, 4):
             raise TypeError(
                 "Tensor requires [shape, dtype], [shape, dtype, layout_or_memref], "
                 "or [shape, dtype, layout, memref] notation"
@@ -54,14 +77,21 @@ class TensorMeta(type):
 
         if len(item) == 4:
             shape, dtype, layout, memref = item
-            return cls(shape, dtype, layout=layout, memref=memref, _annotation_only=True)
+            return cls(
+                shape,
+                dtype,
+                layout=layout,
+                memref=memref,
+                manual_dep=manual_dep,
+                _annotation_only=True,
+            )
         if len(item) == 3:
             shape, dtype, third = item
             if isinstance(third, MemRef):
-                return cls(shape, dtype, memref=third, _annotation_only=True)
-            return cls(shape, dtype, layout=third, _annotation_only=True)
+                return cls(shape, dtype, memref=third, manual_dep=manual_dep, _annotation_only=True)
+            return cls(shape, dtype, layout=third, manual_dep=manual_dep, _annotation_only=True)
         shape, dtype = item
-        return cls(shape, dtype, _annotation_only=True)
+        return cls(shape, dtype, manual_dep=manual_dep, _annotation_only=True)
 
     @overload
     def __call__(
@@ -71,6 +101,7 @@ class TensorMeta(type):
         expr: Expr | None = None,
         layout: "TensorLayout | None" = None,
         memref: "MemRef | None" = None,
+        manual_dep: bool = False,
         _annotation_only: bool = False,
     ) -> "Tensor": ...
 
@@ -82,6 +113,7 @@ class TensorMeta(type):
         expr: None = None,
         layout: "TensorLayout | None" = None,
         memref: "MemRef | None" = None,
+        manual_dep: bool = False,
         _annotation_only: bool = False,
     ) -> "Tensor": ...
 
@@ -94,6 +126,7 @@ class TensorMeta(type):
             expr: IR expression to wrap (for runtime mode)
             layout: Optional tensor layout (ND, DN, NZ)
             memref: Optional memory reference
+            manual_dep: When True (annotation only), opts out of runtime auto-dep tracking.
             _annotation_only: Internal flag for annotation-only mode
 
         Returns:
@@ -107,7 +140,8 @@ class TensorMeta(type):
         expr = kwargs.get("expr", args[2] if len(args) > 2 else None)
         layout = kwargs.get("layout", args[3] if len(args) > 3 else None)
         memref = kwargs.get("memref", args[4] if len(args) > 4 else None)
-        annotation_only = kwargs.get("_annotation_only", args[5] if len(args) > 5 else False)
+        manual_dep = kwargs.get("manual_dep", args[5] if len(args) > 5 else False)
+        annotation_only = kwargs.get("_annotation_only", args[6] if len(args) > 6 else False)
 
         if (
             isinstance(shape, tuple)
@@ -119,13 +153,16 @@ class TensorMeta(type):
             real_shape, real_dtype = shape
             return cast(
                 "Tensor",
-                type.__call__(cls, real_shape, real_dtype, None, layout, memref, annotation_only),
+                type.__call__(cls, real_shape, real_dtype, None, layout, memref, manual_dep, annotation_only),
             )
 
         if dtype is not None and expr is None and not annotation_only:
             annotation_only = True
 
-        return cast("Tensor", type.__call__(cls, shape, dtype, expr, layout, memref, annotation_only))
+        return cast(
+            "Tensor",
+            type.__call__(cls, shape, dtype, expr, layout, memref, manual_dep, annotation_only),
+        )
 
 
 class Tensor(metaclass=TensorMeta):
@@ -159,6 +196,7 @@ class Tensor(metaclass=TensorMeta):
         expr: Expr | None = None,
         layout: TensorLayout | None = None,
         memref: MemRef | None = None,
+        manual_dep: bool = False,
         _annotation_only: bool = False,
     ):
         """Initialize Tensor.
@@ -169,6 +207,7 @@ class Tensor(metaclass=TensorMeta):
             expr: IR expression to wrap (for runtime mode)
             layout: Optional tensor layout (ND, DN, NZ)
             memref: Optional memory reference
+            manual_dep: Annotation-only opt-out from runtime auto-dep tracking.
             _annotation_only: Whether this is annotation-only mode
         """
         if _annotation_only:
@@ -176,6 +215,7 @@ class Tensor(metaclass=TensorMeta):
             self.dtype = dtype
             self.layout = layout
             self.memref = memref
+            self.manual_dep = manual_dep
             self._expr = None
         elif expr is not None:
             self._expr = expr
@@ -183,6 +223,7 @@ class Tensor(metaclass=TensorMeta):
             self.dtype = None
             self.layout = None
             self.memref = None
+            self.manual_dep = False
         else:
             raise ValueError(
                 "Tensor must be initialized with either (shape, dtype) for "

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -413,6 +413,13 @@ class TensorType(ShapedType):
     tensor_view: Final[TensorView | None]
     """Optional tensor view information."""
 
+    manual_dep: Final[bool]
+    """When True, the runtime skips OverlapMap dep tracking for this buffer.
+
+    The user is responsible for ordering (e.g. via disjoint writes, manual
+    scope, or pl.no_dep at call sites). Default False.
+    """
+
     @overload
     def __init__(self, shape: Sequence[Expr], dtype: DataType) -> None:
         """Create a tensor type without memory reference.
@@ -483,6 +490,44 @@ class TensorType(ShapedType):
             dtype: Element data type
             memref: Optional memory reference
             tensor_view: Optional tensor view information
+        """
+
+    @overload
+    def __init__(
+        self,
+        shape: Sequence[Expr],
+        dtype: DataType,
+        memref: MemRef | None,
+        tensor_view: TensorView | None,
+        manual_dep: bool,
+    ) -> None:
+        """Create a tensor type with manual_dep flag.
+
+        Args:
+            shape: Shape dimensions as Expr nodes
+            dtype: Element data type
+            memref: Optional memory reference
+            tensor_view: Optional tensor view information
+            manual_dep: When True, runtime skips OverlapMap dep tracking
+        """
+
+    @overload
+    def __init__(
+        self,
+        shape: Sequence[int],
+        dtype: DataType,
+        memref: MemRef | None,
+        tensor_view: TensorView | None,
+        manual_dep: bool,
+    ) -> None:
+        """Create a tensor type with constant shape and manual_dep flag.
+
+        Args:
+            shape: Shape dimensions as integers
+            dtype: Element data type
+            memref: Optional memory reference
+            tensor_view: Optional tensor view information
+            manual_dep: When True, runtime skips OverlapMap dep tracking
         """
 
 class TileView:

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -147,7 +147,11 @@ std::string CoreTypeToSubmitPrefix(CoreType core_type) {
 std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_index,
                                        const TensorTypePtr& tensor_type, const CodegenBase& codegen) {
   std::ostringstream oss;
-  oss << "    Tensor ext_" << var_name << " = from_tensor_arg(orch_args.tensor(" << orch_index << "));\n";
+  oss << "    Tensor ext_" << var_name << " = from_tensor_arg(orch_args.tensor(" << orch_index << ")";
+  if (tensor_type && tensor_type->manual_dep_) {
+    oss << ", /*manual_dep=*/true";
+  }
+  oss << ");\n";
   return oss.str();
 }
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -555,6 +555,25 @@ class CallDirectionMutator : public IRMutator {
       }
     }
 
+    // Apply user-specified per-arg overrides (e.g. pl.no_dep(...) at call site).
+    // Stored as a vector<int32_t> of arg indices that should resolve to NoDep,
+    // overriding the auto-derived direction at those slots.
+    for (const auto& [k, v] : call->attrs_) {
+      if (k != kAttrArgDirectionOverrides) continue;
+      const auto* indices = std::any_cast<std::vector<int32_t>>(&v);
+      if (!indices) {
+        INTERNAL_CHECK_SPAN(false, call->span_)
+            << "Internal error: " << kAttrArgDirectionOverrides << " attr must hold std::vector<int32_t>";
+      }
+      for (int32_t idx : *indices) {
+        INTERNAL_CHECK_SPAN(idx >= 0 && static_cast<size_t>(idx) < dirs.size(), call->span_)
+            << "Internal error: arg_direction_overrides index " << idx << " out of range for call to '"
+            << call->op_->name_ << "' (args size " << call->args_.size() << ")";
+        dirs[static_cast<size_t>(idx)] = ArgDirection::NoDep;
+      }
+      break;
+    }
+
     // Skip rewriting if directions are unchanged.
     if (call->GetArgDirections() == dirs) {
       return call;

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -9,7 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <any>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -18,6 +20,7 @@
 #include <vector>
 
 #include "pypto/codegen/orchestration/orchestration_analysis.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -398,6 +398,11 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
       oss << ", " << PrintMemRef(*tensor_type->memref_.value());
     }
 
+    // Manual-dep marker — emitted last so parser can strip from any tail position.
+    if (tensor_type->manual_dep_) {
+      oss << ", " << prefix_ << ".ManualDep";
+    }
+
     oss << "]";
     return oss.str();
   }

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -1049,6 +1049,16 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
         return false;
       }
     }
+    // Compare manual_dep flag (off-OverlapMap opt-out)
+    if (lhs_tensor->manual_dep_ != rhs_tensor->manual_dep_) {
+      if constexpr (AssertMode) {
+        std::ostringstream msg;
+        msg << "TensorType manual_dep mismatch (" << lhs_tensor->manual_dep_
+            << " != " << rhs_tensor->manual_dep_ << ")";
+        ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
+      }
+      return false;
+    }
     return true;
   } else if (auto lhs_tile = As<TileType>(lhs)) {
     auto rhs_tile = As<TileType>(rhs);

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -441,6 +441,8 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
     } else {
       h = hash_combine(h, static_cast<result_type>(0));  // indicate absence
     }
+    // Hash manual_dep flag
+    h = hash_combine(h, static_cast<result_type>(tensor_type->manual_dep_ ? 1 : 0));
   } else if (auto tile_type = As<TileType>(type)) {
     // Hash dtype
     h = hash_combine(h, static_cast<result_type>(std::hash<uint8_t>{}(tile_type->dtype_.Code())));

--- a/src/ir/verifier/verify_call_directions.cpp
+++ b/src/ir/verifier/verify_call_directions.cpp
@@ -109,7 +109,11 @@ class CallDirectionChecker : public IRVisitor {
       if (i >= effective.size()) continue;
       ParamDirection cd = effective[i];
       if (cd == ParamDirection::In && is_tensor) {
-        if (d != ArgDirection::Input) {
+        // Allow Input (default) or NoDep (caller-site override via pl.no_dep).
+        // Both are read-only at the runtime level; NoDep additionally skips
+        // OverlapMap dep tracking. NoDep is forbidden on Out/InOut params
+        // because it would suppress producer registration for a writer.
+        if (d != ArgDirection::Input && d != ArgDirection::NoDep) {
           std::ostringstream oss;
           oss << "tensor argument at index " << i << " has " << ArgDirectionToString(d)
               << " but callee param direction is In";

--- a/tests/ut/ir/expressions/test_tensor_type_manual_dep.py
+++ b/tests/ut/ir/expressions/test_tensor_type_manual_dep.py
@@ -1,0 +1,147 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for the TensorType.manual_dep flag.
+
+The flag tells the runtime to skip OverlapMap dependency tracking for the
+buffer; the user is responsible for ordering. Phase 1 wiring covers
+construction, structural equality, hashing, printing, and the DSL surface
+(``pl.Tensor[..., pl.ManualDep]``).
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import DataType, ir
+
+
+class TestManualDepConstruction:
+    """Constructor accepts manual_dep; default is False."""
+
+    def test_default_is_false(self):
+        t = ir.TensorType([16, 32], DataType.FP32)
+        assert t.manual_dep is False
+
+    def test_kwarg_true(self):
+        t = ir.TensorType([16, 32], DataType.FP32, manual_dep=True)
+        assert t.manual_dep is True
+
+    def test_with_memref_and_manual_dep(self):
+        span = ir.Span.unknown()
+        memref = ir.MemRef(
+            ir.MemorySpace.DDR,
+            ir.ConstInt(0x1000, DataType.INT64, span),
+            16 * 32 * 4,
+            42,
+        )
+        t = ir.TensorType([16, 32], DataType.FP32, memref=memref, manual_dep=True)
+        assert t.manual_dep is True
+        assert t.memref is not None
+
+    def test_with_tensor_view_and_manual_dep(self):
+        tv = ir.TensorView([], ir.TensorLayout.NZ)
+        t = ir.TensorType([16, 32], DataType.FP32, tensor_view=tv, manual_dep=True)
+        assert t.manual_dep is True
+        assert t.tensor_view is not None
+
+
+class TestStructuralEquality:
+    """Two TensorTypes that differ only in manual_dep are not structurally equal."""
+
+    def test_equal_when_both_default(self):
+        t1 = ir.TensorType([16, 32], DataType.FP32)
+        t2 = ir.TensorType([16, 32], DataType.FP32)
+        ir.assert_structural_equal(t1, t2)  # raises if mismatched
+
+    def test_equal_when_both_true(self):
+        t1 = ir.TensorType([16, 32], DataType.FP32, manual_dep=True)
+        t2 = ir.TensorType([16, 32], DataType.FP32, manual_dep=True)
+        ir.assert_structural_equal(t1, t2)
+
+    def test_unequal_when_only_one_marked(self):
+        t1 = ir.TensorType([16, 32], DataType.FP32, manual_dep=True)
+        t2 = ir.TensorType([16, 32], DataType.FP32, manual_dep=False)
+        with pytest.raises(Exception, match="manual_dep"):
+            ir.assert_structural_equal(t1, t2)
+
+
+class TestStructuralHash:
+    """Different manual_dep produces different structural hashes."""
+
+    def test_distinct_hashes(self):
+        t1 = ir.TensorType([16, 32], DataType.FP32, manual_dep=True)
+        t2 = ir.TensorType([16, 32], DataType.FP32, manual_dep=False)
+        assert ir.structural_hash(t1) != ir.structural_hash(t2)
+
+
+class TestDSLSurface:
+    """pl.Tensor[..., pl.ManualDep] threads to TensorType.manual_dep."""
+
+    def test_annotation_marker(self):
+        T = pl.Tensor[[16, 32], pl.FP32, pl.ManualDep]
+        assert T.manual_dep is True
+
+    def test_no_marker_default_false(self):
+        T = pl.Tensor[[16, 32], pl.FP32]
+        assert T.manual_dep is False
+
+    def test_marker_with_layout(self):
+        T = pl.Tensor[[16, 32], pl.FP32, pl.NZ, pl.ManualDep]
+        assert T.manual_dep is True
+        assert T.layout == ir.TensorLayout.NZ
+
+    def test_function_param_propagates(self):
+        @pl.program
+        class P:
+            @pl.function
+            def f(self, x: pl.Tensor[[16, 32], pl.FP32, pl.ManualDep]):
+                return x
+
+        func = list(P.functions.values())[0]
+        param_type = func.params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        assert param_type.manual_dep is True
+
+    def test_function_param_default_false(self):
+        @pl.program
+        class P:
+            @pl.function
+            def f(self, x: pl.Tensor[[16, 32], pl.FP32]):
+                return x
+
+        func = list(P.functions.values())[0]
+        param_type = func.params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        assert param_type.manual_dep is False
+
+
+class TestPrinterRoundTrip:
+    """Printer emits pl.ManualDep marker and parser strips it back."""
+
+    def test_print_includes_marker(self):
+        @pl.program
+        class P:
+            @pl.function
+            def f(self, x: pl.Tensor[[16, 32], pl.FP32, pl.ManualDep]):
+                return x
+
+        printed = P.as_python()
+        assert "pl.ManualDep" in printed
+
+    def test_print_omits_marker_when_default(self):
+        @pl.program
+        class P:
+            @pl.function
+            def f(self, x: pl.Tensor[[16, 32], pl.FP32]):
+                return x
+
+        printed = P.as_python()
+        assert "pl.ManualDep" not in printed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -960,3 +960,132 @@ class _RewriteUserCall(ir.IRMutator):
 
     def run(self, program):
         return self.visit_program(program)
+
+
+# ---------------------------------------------------------------------------
+# pl.no_dep override
+# ---------------------------------------------------------------------------
+
+
+class TestNoDepOverride:
+    """``pl.no_dep(arg)`` at a kernel call site sets ArgDirection.NoDep at that slot."""
+
+    @pl.program
+    class _Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            b: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            shared: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            c = self.kernel(a, pl.no_dep(shared), c)
+            return c
+
+    def test_no_dep_at_marked_slot(self):
+        new_prog = passes.derive_call_directions()(self._Prog)
+        calls = _user_calls(new_prog)
+        assert len(calls) == 1
+        # 0=a (Input), 1=shared marked NoDep, 2=c (OutputExisting first writer at top level).
+        assert _dirs(calls[0]) == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.NoDep,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+    def test_no_no_dep_keeps_input(self):
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                shared: pl.Tensor[[16, 16], pl.FP32],
+                c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                c = self.kernel(a, shared, c)
+                return c
+
+        new_prog = passes.derive_call_directions()(P)
+        calls = _user_calls(new_prog)
+        assert len(calls) == 1
+        assert _dirs(calls[0]) == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.Input,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+    def test_multiple_no_dep_slots(self):
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                c = self.kernel(pl.no_dep(a), pl.no_dep(b), c)
+                return c
+
+        new_prog = passes.derive_call_directions()(P)
+        calls = _user_calls(new_prog)
+        assert _dirs(calls[0]) == [
+            ir.ArgDirection.NoDep,
+            ir.ArgDirection.NoDep,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+    def test_no_dep_on_inout_param_rejected(self):
+        # The verifier forbids NoDep on Out/InOut params: NoDep is a read-only
+        # opt-out that would suppress producer registration if applied to a
+        # writer. ``derive_call_directions()`` runs the property verifier as
+        # post-condition, so the override surfaces as a build-time failure.
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                return b
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                b = self.kernel(a, pl.no_dep(b))
+                return b
+
+        with pytest.raises(Exception, match="NoDep|InOut"):  # noqa: PT011
+            passes.derive_call_directions()(P)


### PR DESCRIPTION
## Summary

Phase 1 + 2 of the manual-dependency surface plan. Lets the user opt out of the simpler runtime's automatic OverlapMap-based dependency tracking at two granularities:

- **Per-tensor (Phase 1)**: `pl.Tensor[..., pl.ManualDep]` — every reference to that buffer skips OverlapMap lookup and TensorMap insert. Useful when the user can guarantee disjoint writes (e.g. assemble-inside-kernel patterns where each iteration touches a distinct region).
- **Per-arg (Phase 2)**: `pl.no_dep(arg)` — at a single kernel call site, mark one argument as no-dep without affecting the other args. Other arguments still get auto-dep.

Both wirings are additive — default behaviour is unchanged. Already-existing `pl.create_tensor(manual_dep=True)` continues to work as today; this PR completes the symmetry by extending the flag to function parameters and adding the per-arg overlay.

### Phase 1 — `pl.Tensor[..., pl.ManualDep]`

```python
@pl.function(type=pl.FunctionType.Orchestration)
def orch(self, big: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.ManualDep]]):
    for i in pl.parallel(M):
        big = self.write_tile(big, i, big)
    return big
```

Codegen emits `from_tensor_arg(orch_args.tensor(N), /*manual_dep=*/true)` so the runtime treats `big` as opt-out for OverlapMap.

### Phase 2 — `pl.no_dep(arg)`

```python
@pl.function(type=pl.FunctionType.Orchestration)
def orch(self, q, k_cache, out):
    for i in pl.range(BATCH):
        out = self.matmul(q, pl.no_dep(k_cache), out)
    return out
```

Pipeline: parser strips wrapper → `attrs['arg_direction_overrides']` → `DeriveCallDirections` overwrites slot to `NoDep` → codegen already emits `add_no_dep`. The `CallDirectionsResolved` verifier accepts `NoDep` on `In` params and rejects on `Out`/`InOut` (would suppress producer registration for a writer).

## Files changed

**Phase 1 (14 files, +399 / -26):**
- `include/pypto/ir/type.h` — `TensorType.manual_dep_` field + reflection descriptor + new ctor overloads
- `src/ir/transforms/structural_equal.cpp` + `structural_hash.cpp` — distinguish on the flag
- `src/ir/transforms/python_printer.cpp` — emit `pl.ManualDep` marker for round-trip
- `src/codegen/orchestration/orchestration_codegen.cpp` — `from_tensor_arg(.., true)` when set
- `python/bindings/modules/ir.cpp` + `pypto_core/ir.pyi` — new constructor overloads / `Final[bool]` field
- `python/pypto/ir/type.py` — pass-through wrapper
- `python/pypto/language/typing/manual_dep.py` (new) + `tensor.py` + `__init__.py` — `pl.ManualDep` marker, accepted in any tail position of `Tensor[...]`
- `python/pypto/language/parser/type_resolver.py` — strip `pl.ManualDep` from subscript, thread `manual_dep` to `ir.TensorType`
- `tests/ut/ir/expressions/test_tensor_type_manual_dep.py` (new) — 15 tests

**Phase 2 (8 files, +318 / -14):**
- `include/pypto/ir/expr.h` — `kAttrArgDirectionOverrides` + `WithArgDirectionOverridesAttr` helper
- `src/ir/transforms/derive_call_directions_pass.cpp` — apply overrides post-derivation
- `src/ir/verifier/verify_call_directions.cpp` — allow `NoDep` on `In` params
- `python/bindings/modules/ir.cpp` — accept `list[int]` for `arg_direction_overrides` attr
- `python/pypto/language/op/tensor_ops.py` + `__init__.py` — `pl.no_dep` marker
- `python/pypto/language/parser/ast_parser.py` — `_strip_no_dep_wrappers` helper at `self.method(...)` call sites
- `tests/ut/ir/transforms/test_derive_call_directions.py` — 4 new tests

## Test plan

- [x] `pytest tests/ut/ir/ tests/ut/codegen/` → **3221 passed, 29 skipped** (19 new + 3202 existing)
- [x] `cmake --build build --parallel` → clean build on rebased base (currently `d2981ed4 chore(runtime): bump simpler runtime to 551a79c (#1292)`)
- [x] `pre-commit run` on all changed files → clang-format / cpplint / markdownlint / ruff / pyright all pass
- [x] Round-trip: parse → IR → print → parse stable for both `pl.ManualDep` and `pl.no_dep` annotations

## Notes for review

- Both features are user-facing additions only; **no existing IR / golden output / behavior changes**. Default-false omission keeps every existing codegen test bytewise stable.
- Phase 1 marker is a class (`pl.ManualDep`), not a callable — chosen to mirror existing `pl.NZ` / `pl.MemRef` marker style. Subscript syntax doesn't support kwargs, so a sentinel class beats `manual_dep=True` here.
- Phase 2 marker is a function (`pl.no_dep(t)`) returning the tensor unchanged — it's parser-recognized at AST level and never appears in IR. Equivalent to manual `make_call(directions=[..., no_dep, ...])` but ergonomic at call sites.
- `pl.no_dep` on `Out`/`InOut` params is rejected at the verifier (would suppress producer registration). Test `test_no_dep_on_inout_param_rejected` documents the contract.
- Related future work (out of scope): MANUAL scope mode, explicit `add_dep` task edges. Both build on the foundation laid here.