### PR TITLE
fix(ci): Run distributed st tests in a separate pytest invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,11 @@ jobs:
 
       - name: Test system tests
         timeout-minutes: 15
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938 --ignore=tests/st/distributed
+
+      - name: Test distributed system tests
+        timeout-minutes: 5
+        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
 
       - name: Test swimlane output
         run: |

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -314,6 +314,17 @@ def test_config(request) -> RunConfig:
 
 
 @pytest.fixture(scope="session")
+def device_ids(request) -> list[int]:
+    """Session-scoped fixture returning the full ``--device`` list.
+
+    Distributed tests need access to all allocated device ids (not just the
+    first one stored in ``RunConfig.device_id``) so they can pick a slice
+    that matches the CI runner's dynamic allocation rather than hardcoding.
+    """
+    return _parse_device_option(request.config.getoption("--device"))
+
+
+@pytest.fixture(scope="session")
 def test_runner(test_config) -> TestRunner:
     """Session-scoped fixture providing a test runner instance.
 

--- a/tests/st/distributed/test_l3_distributed.py
+++ b/tests/st/distributed/test_l3_distributed.py
@@ -21,6 +21,8 @@ Verifies: TensorMap dependency inference, cross-fork data visibility,
 DAG ordering (SubWorker runs after chip completes).
 """
 
+import sys
+
 import pypto.language as pl
 import pytest
 import torch
@@ -103,13 +105,13 @@ class L3DependencyInlineProgram:
 class TestL3Dependency:
     """L3 distributed runtime: compile and execute via Worker(level=3)."""
 
-    def test_execute(self, test_config):
+    def test_execute(self, test_config, device_ids):
         """End-to-end: compile + execute via Worker(level=3), verify f = a + b."""
         compiled = ir.compile(
             L3DependencyProgram,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=[9],
+                device_ids=device_ids[:1],
                 num_sub_workers=1,
                 block_dim=3,
                 aicpu_thread_num=4,
@@ -128,13 +130,15 @@ class TestL3Dependency:
             f"got max diff = {(f - expected).abs().max().item()}"
         )
 
-    def test_execute_inline(self, test_config):
+    def test_execute_inline(self, test_config, device_ids):
         """End-to-end: all levels inlined via pl.at(), verify sum = a + b."""
+        if len(device_ids) < 2:
+            pytest.skip(f"test_execute_inline needs 2 devices, got {device_ids}")
         compiled = ir.compile(
             L3DependencyInlineProgram,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=[9, 10],
+                device_ids=device_ids[:2],
                 num_sub_workers=1,
                 block_dim=3,
                 aicpu_thread_num=4,
@@ -161,4 +165,4 @@ class TestL3Dependency:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_parallel_reduce.py
+++ b/tests/st/distributed/test_l3_parallel_reduce.py
@@ -23,6 +23,8 @@ Verifies: multiple independent chip tasks in DAG, SubWorker aggregation
 of two chip outputs, cross-fork data visibility for multi-tensor flows.
 """
 
+import sys
+
 import pypto.language as pl
 import pytest
 import torch
@@ -108,13 +110,13 @@ class L3ParallelReduceProgram:
 class TestL3ParallelReduce:
     """L3 distributed runtime: two independent chip tasks + SubWorker reduce."""
 
-    def test_execute(self, test_config):
+    def test_execute(self, test_config, device_ids):
         """End-to-end: compile + execute, verify f = (a+b) + (a-b) = 2a."""
         compiled = ir.compile(
             L3ParallelReduceProgram,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=[7],
+                device_ids=device_ids[:1],
                 num_sub_workers=1,
                 block_dim=3,
                 aicpu_thread_num=4,
@@ -137,4 +139,4 @@ class TestL3ParallelReduce:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    pytest.main([__file__, "-v", *sys.argv[1:]])


### PR DESCRIPTION
## Summary

The distributed st tests in `tests/st/distributed/` fork chip-worker child processes via `execute_distributed`. Running them in the same pytest process as pipeline tests is unsafe: the pipeline's execute pool initialises device-level ACL state in the parent process (one `Worker` per test), and the fork inherits that state, which conflicts when the child re-inits the device — surfacing as `rtStreamCreate (AICPU) failed: 507899` on CI.

## Changes

- **CI** (`.github/workflows/ci.yml`): split the system-tests step into two pytest invocations. The main step adds `--ignore=tests/st/distributed`; a new step runs `pytest tests/st/distributed` in a fresh pytest process where no prior ACL init has happened in the parent. `ensure_pto_isa_root()` clones on demand from inside `compile_and_assemble`, so the new step does not need a separate setup hook.
- **Tests**: drop hardcoded `device_ids=[9]` / `[9, 10]` in the two distributed tests. Add a `device_ids` session fixture in `tests/st/conftest.py` that returns the parsed `--device` list; slice it as `device_ids[:1]` / `device_ids[:2]`, with `pytest.skip` when fewer than 2 devices are allocated.
- **Entrypoint**: forward `sys.argv` from each test file's `__main__` block so `python test_l3_distributed.py --device=7,9` works directly without going through `python -m pytest`.

## Testing

- [x] Local: `python -m pytest tests/st/distributed/ -v --device=7,9` — 3/3 passed
- [x] Pre-commit hooks (ruff format/check, pyright) passed