### PR TITLE
Fix: add tile.neg to kRowMajorOps for ACC-to-VEC layout conversion

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -80,6 +80,7 @@ static bool RequiresRowMajorLayout(std::string_view op_name) {
       "tile.sqrt",
       "tile.rsqrt",
       "tile.recip",
+      "tile.neg",
       "tile.not",
       "tile.relu",
       // Tile x Scalar ops


### PR DESCRIPTION
#1309 When infer_tile_memory_space_pass inserts tile.move for a matmul accumulator (col_major, ACC space) feeding into tile.neg, the move previously inherited col_major blayout because tile.neg was not in kRowMajorOps. tile.neg propagates layout via InheritTileViewLayout, so col_major flowed through to downstream ops like tile.exp which require row_major in VEC space, causing PTO verifier failure.