### PR TITLE
fix(codegen): elide no-op pto.tmov for same-space same-address tile.move (#1310)

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2128,6 +2128,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
           auto src_offset = As<ir::ConstInt>((*src_tile->memref_)->byte_offset_);
           auto dst_offset = As<ir::ConstInt>((*dst_tile->memref_)->byte_offset_);
           if (src_offset && dst_offset && src_offset->value_ == dst_offset->value_) {
+            // Alias the destination to the source SSA value so downstream
+            // references use the source's defined buffer, not the destination's
+            // alloc_tile (which would be unwritten after eliding the tmov).
+            codegen.SetCurrentResultBuf(codegen.GetExprAsCode(op->args_[0]));
             return std::string("");  // no-op: same space, same address
           }
         }

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2043,7 +2043,7 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.gemv_bias",       "pto.tgemv.bias",       3},
     // Data movement/layout operations
     {"tile.concat",          "pto.tconcat",          2},
-    {"tile.move",            "pto.tmov",             1},
+    // tile.move has custom codegen (no-op elision for same-space same-address moves)
     {"tile.move_fp",         "pto.tmov.fp",          2},
     // tile.transpose has custom codegen (MakeTileTransposeCodegenPTO): pto.ttrans needs
     // ins(%src, %tmp : tile_type, tile_type) where %tmp is a scratch workspace tile, NOT
@@ -2106,6 +2106,38 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg_i64_to_index_op("tile.get_subblock_idx", "pto.get_subblock_idx");
   reg_i64_to_index_op("tile.get_block_num", "pto.get_block_num");
   reg_i64_to_index_op("tile.get_block_idx", "pto.get_block_idx");
+
+  // tile.move → pto.tmov with no-op elision.
+  // When MemoryReuse inserts a tile.move between two MemRefs that end up at the
+  // same physical address after AllocateMemoryAddr (e.g. acc→acc at the same Acc
+  // offset), the move is a no-op. Elide it to avoid emitting pto.tmov with
+  // unsupported same-space address pairs (fixes #1310).
+  reg("tile.move", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 1) << "tile.move requires 1 argument, got " << op->args_.size();
+
+    auto src_var = AsVarLike(op->args_[0]);
+    auto dst_var = codegen.GetCurrentResultVar();
+    if (src_var && dst_var) {
+      auto src_tile = As<ir::TileType>(src_var->GetType());
+      auto dst_tile = As<ir::TileType>(dst_var->GetType());
+      if (src_tile && dst_tile && src_tile->memref_.has_value() && dst_tile->memref_.has_value()) {
+        auto src_space = src_tile->GetMemorySpace();
+        auto dst_space = dst_tile->GetMemorySpace();
+        if (src_space.has_value() && dst_space.has_value() && *src_space == *dst_space) {
+          auto src_offset = As<ir::ConstInt>((*src_tile->memref_)->byte_offset_);
+          auto dst_offset = As<ir::ConstInt>((*dst_tile->memref_)->byte_offset_);
+          if (src_offset && dst_offset && src_offset->value_ == dst_offset->value_) {
+            return std::string("");  // no-op: same space, same address
+          }
+        }
+      }
+    }
+
+    codegen.Emit("pto.tmov " + GenerateInsOutsClause(op, codegen));
+    return std::string("");
+  });
+
   reg("tile.read", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileReadCodegenPTO(op, codegen);
   });

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1605,5 +1605,86 @@ class TestTileScatterUpdateCodegen:
         assert "rows=32, cols=32" in mlir, f"Expected original dst tile shape in MLIR:\n{mlir}"
 
 
+class TestTileMoveAccNoopElision:
+    """Regression test for #1310: pto.tmov acc→acc must be elided.
+
+    When AutoTileMatmulL0 rewrites matmul_acc into an inner K-loop, the fresh
+    IterArg Vars carry different MemRef bases than the outer loop's accumulator.
+    MemoryReuse's YieldFixupMutator inserts tile.move(target_memory=Acc) for
+    these, but after AllocateMemoryAddr both sides share the same physical Acc
+    address. Codegen must elide the no-op pto.tmov to avoid the unsupported
+    acc→acc address-space pair on Ascend 910B.
+    """
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
+        single = ir.Program([target], target.name, optimized.span)
+        return codegen_instance.generate(single)
+
+    @staticmethod
+    def _has_acc_to_acc_tmov(mlir: str) -> bool:
+        """Check if MLIR contains pto.tmov where both ins and outs are loc=acc."""
+        for line in mlir.splitlines():
+            stripped = line.strip()
+            if "pto.tmov" not in stripped:
+                continue
+            ins_part = stripped.split("ins(", 1)
+            outs_part = stripped.split("outs(", 1)
+            if len(ins_part) < 2 or len(outs_part) < 2:
+                continue
+            ins_clause = ins_part[1].split(")", 1)[0]
+            outs_clause = outs_part[1].split(")", 1)[0]
+            if "loc=acc" in ins_clause and "loc=acc" in outs_clause:
+                return True
+        return False
+
+    def test_matmul_acc_in_outer_loop_no_acc_to_acc_tmov(self):
+        """matmul_acc inside an outer accumulation loop must not produce pto.tmov acc→acc.
+
+        K=512 exceeds L0 capacity (256 for BF16), so AutoTileMatmulL0 rewrites
+        each matmul into an inner K-loop with fresh IterArg Vars. MemoryReuse's
+        YieldFixupMutator may insert tile.move acc→acc when the inner loop's
+        yield MemRef has a different base_ pointer than the outer iter-arg init.
+        The codegen must elide this no-op move.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 1024], pl.BF16],
+                w: pl.Tensor[[1024, 64], pl.BF16],
+                dst: pl.Tensor[[16, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # First block: K=512, triggers AutoTileMatmulL0 (K > 256)
+                x0 = pl.load(x, [0, 0], [16, 512], target_memory=pl.MemorySpace.Mat)
+                w0 = pl.load(w, [0, 0], [512, 64], target_memory=pl.MemorySpace.Mat)
+                x0_left = pl.move(x0, target_memory=pl.MemorySpace.Left)
+                w0_right = pl.move(w0, target_memory=pl.MemorySpace.Right)
+                acc: pl.Tile[[16, 64], pl.FP32] = pl.matmul(x0_left, w0_right, out_dtype=pl.FP32)
+                # Second block: matmul_acc accumulating into the same Acc tile
+                x1 = pl.load(x, [0, 512], [16, 512], target_memory=pl.MemorySpace.Mat)
+                w1 = pl.load(w, [512, 0], [512, 64], target_memory=pl.MemorySpace.Mat)
+                x1_left = pl.move(x1, target_memory=pl.MemorySpace.Left)
+                w1_right = pl.move(w1, target_memory=pl.MemorySpace.Right)
+                acc2: pl.Tile[[16, 64], pl.FP32] = pl.matmul_acc(acc, x1_left, w1_right)
+                vec = pl.move(acc2, target_memory=pl.MemorySpace.Vec)
+                return pl.store(vec, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert not self._has_acc_to_acc_tmov(mlir), (
+            f"Generated MLIR contains invalid pto.tmov acc→acc (regression #1310):\n{mlir}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1670,7 +1670,7 @@ class TestTileMoveAccNoopElision:
                 w0 = pl.load(w, [0, 0], [512, 64], target_memory=pl.MemorySpace.Mat)
                 x0_left = pl.move(x0, target_memory=pl.MemorySpace.Left)
                 w0_right = pl.move(w0, target_memory=pl.MemorySpace.Right)
-                acc: pl.Tile[[16, 64], pl.FP32] = pl.matmul(x0_left, w0_right, out_dtype=pl.FP32)
+                acc: pl.Tile[[16, 64], pl.FP32] = pl.matmul(x0_left, w0_right)
                 # Second block: matmul_acc accumulating into the same Acc tile
                 x1 = pl.load(x, [0, 512], [16, 512], target_memory=pl.MemorySpace.Mat)
                 w1 = pl.load(w, [512, 0], [512, 64], target_memory=pl.MemorySpace.Mat)


### PR DESCRIPTION
## Summary

- Elide no-op `pto.tmov` at codegen time when source and destination share the same memory space and physical address (MemRef `byte_offset_`)
- Fixes the `pto.tmov acc→acc` rejection by ptoas on Ascend 910B, triggered by `AutoTileMatmulL0` (PR #1268) creating fresh IterArg Vars with different `base_` pointers
- Add regression test verifying matmul_acc codegen produces no `pto.tmov acc→acc`

Fixes #1310

## Approach

Move `tile.move` from the simple N-ary ops table (`kSimpleOps`) to a custom codegen handler. Before emitting `pto.tmov`, the handler checks:

1. Source and destination have the **same memory space** (e.g., both `Acc`)
2. Source and destination have the **same `byte_offset_`** (physical address after `AllocateMemoryAddr`)

When both conditions hold, the move is a provable no-op and is elided — no `pto.tmov` is emitted. This follows the existing `tile.reshape` no-op-elision pattern.

## Why codegen-level

`YieldFixupMutator` runs **before** `AllocateMemoryAddr` — it cannot know whether two MemRefs with different `base_` pointers will share the same physical address. The codegen level is the first point where concrete addresses are available.

## Test plan

- [x] New regression test `TestTileMoveAccNoopElision::test_matmul_acc_in_outer_loop_no_acc_to_acc_tmov`
- [x] All 33 codegen ops tests pass
- [x] Full test suite: 4409 passed, 27 skipped, 0 failed