### PR TITLE
fix(ci): migrate pto-isa clone URLs from GitHub to gitcode.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Clone pto-isa (pypto-lib Qwen3-14B decode)
         run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout 2c607938
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Clone pto-isa repository
         run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout d5bcc23
 
@@ -139,7 +139,7 @@ jobs:
 
       - name: Clone pto-isa repository
         run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout d5bcc23
 

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -94,8 +94,8 @@ def _load_binary(path: Path) -> bytes | None:
 # PTO-ISA management
 # ---------------------------------------------------------------------------
 
-_PTO_ISA_HTTPS = "https://github.com/PTO-ISA/pto-isa.git"
-_PTO_ISA_SSH = "git@github.com:PTO-ISA/pto-isa.git"
+_PTO_ISA_HTTPS = "https://gitcode.com/luohuan40/pto-isa.git"
+_PTO_ISA_SSH = "git@gitcode.com:luohuan40/pto-isa.git"
 
 
 def _get_pto_isa_clone_path() -> Path:


### PR DESCRIPTION
## Summary
- Migrate all pto-isa repository clone URLs from `github.com/PTO-ISA/pto-isa` to `gitcode.com/luohuan40/pto-isa`
- Updated in CI workflows (`ci.yml`, `daily_ci.yml`), runtime `device_runner.py`, and runtime submodule (docs + setup scripts)

## Files Changed
- `.github/workflows/ci.yml` — pto-isa clone URL
- `.github/workflows/daily_ci.yml` — pto-isa clone URLs (2 locations)
- `python/pypto/runtime/device_runner.py` — HTTPS and SSH clone URLs
- `runtime` — submodule update (docs/getting-started.md, simpler_setup/pto_isa.py)

## Testing
- [ ] CI workflows clone pto-isa successfully from new URL
- [ ] `device_runner.py` auto-clone works with new URL