### PR TITLE
fix(jit): Support multi-return @pl.jit.inline helpers

### DIFF
--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -789,33 +790,63 @@ def _infer_return_type(
     dynvar_names: dict[str, str],
     out_params: list[str],
 ) -> str | None:
-    """Infer the return type annotation string from Out parameters.
+    """Infer the return type annotation string from the return statement.
 
-    Examines the function's return statement.  If it returns a name that
-    is in out_params, uses that param's tensor type (without Out[]).
-    Falls back to the first Out param if the return statement is absent or
-    not a simple name.
+    Examines the function's return statement:
+    - ``return a, b, ...``  -> ``tuple[T_a, T_b, ...]`` when every element is a
+      tensor-typed name we can resolve via ``tensor_meta`` (covers both ``pl.Out``
+      and bare ``pl.Tensor`` params).
+    - ``return name``       -> that name's tensor type (without ``Out[]``) when
+      ``name`` is a tensor-typed param.
+    - ``return f(...)``     -> ``None`` (return type depends on f, which we
+      can't resolve here).
+    - No tensor-typed params -> ``None``.
 
-    Returns None if no Out params exist (return type cannot be inferred).
+    Falls back to the first ``Out`` param's tensor type as a last resort —
+    matches the legacy single-return convention before bare ``pl.Tensor``
+    inline params were supported.
     """
-    if not out_params:
-        return None
-
-    # Try to find a bare return statement
-    returned_name: str | None = None
+    # Find the first return-with-value
+    return_node: ast.Return | None = None
     for node in ast.walk(func_def):
         if isinstance(node, ast.Return) and node.value is not None:
-            if isinstance(node.value, ast.Name):
-                returned_name = node.value.id
+            return_node = node
             break
 
-    target_param = returned_name if returned_name in out_params else out_params[0]
+    # Multi-return: `return a, b, ...` -> emit `tuple[T_a, T_b, ...]`
+    if return_node is not None and isinstance(return_node.value, ast.Tuple):
+        elt_annotations: list[str] = []
+        for elt in return_node.value.elts:
+            if not isinstance(elt, ast.Name) or elt.id not in tensor_meta:
+                return None  # Can't infer this element — drop the annotation
+            meta = tensor_meta[elt.id]
+            elt_annotations.append(
+                _build_tensor_annotation(elt.id, meta, dynamic_dims, dynvar_names, is_out=False)
+            )
+        return f"tuple[{', '.join(elt_annotations)}]"
 
-    if target_param not in tensor_meta:
+    # `return f(...)`: the result type depends on f's declared return types,
+    # which we don't have here. Emit no annotation rather than wrongly assuming
+    # `out_params[0]` — the caller may be a multi-return function.
+    if return_node is not None and isinstance(return_node.value, ast.Call):
         return None
 
-    meta = tensor_meta[target_param]
-    return _build_tensor_annotation(target_param, meta, dynamic_dims, dynvar_names, is_out=False)
+    # `return name`: use that name's tensor type if known.
+    if (
+        return_node is not None
+        and isinstance(return_node.value, ast.Name)
+        and return_node.value.id in tensor_meta
+    ):
+        target_param = return_node.value.id
+        meta = tensor_meta[target_param]
+        return _build_tensor_annotation(target_param, meta, dynamic_dims, dynvar_names, is_out=False)
+
+    # Fallback: first Out param's tensor type (legacy single-return convention).
+    if out_params and out_params[0] in tensor_meta:
+        meta = tensor_meta[out_params[0]]
+        return _build_tensor_annotation(out_params[0], meta, dynamic_dims, dynvar_names, is_out=False)
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1059,14 +1090,33 @@ class Specializer:
         # Classify parameters
         out_params, tensor_params, scalar_dtype_strs = _classify_params(func_def)
 
+        # Inline helpers are spliced at the call site before SSA conversion,
+        # so their parameters are already in-place aliases of the caller's
+        # variables — `pl.Out[...]` is redundant ceremony there. Warn the user
+        # so they migrate to bare `pl.Tensor[...]`, and drop the wrapper from
+        # the generated source so downstream passes see the simpler form.
+        is_inline = ctx.func_type == "inline"
+        if is_inline and out_params:
+            warnings.warn(
+                f"@pl.jit.inline helper '{ctx.func_name}' uses pl.Out[...] on "
+                f"parameter(s) {out_params!r}. pl.Out annotations are deprecated "
+                f"for inline helpers because the body is spliced at the call "
+                f"site before SSA conversion — the parameter is already an "
+                f"in-place alias of the caller's variable. Drop the pl.Out "
+                f"wrapper; bare pl.Tensor[...] works the same.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Collect all param names (excluding self)
         all_param_names = [arg.arg for arg in func_def.args.args if arg.arg != "self"]
 
         # Build decorator
         decorator = self._build_decorator(ctx, func_def)
 
-        # Build parameter list with updated annotations
-        params = self._build_params(all_param_names, out_params, tensor_params, scalar_dtype_strs, ctx)
+        params = self._build_params(
+            all_param_names, out_params, tensor_params, scalar_dtype_strs, ctx, is_inline=is_inline
+        )
 
         # Infer return type
         ret_type = _infer_return_type(
@@ -1184,12 +1234,18 @@ class Specializer:
         tensor_params: list[str],
         scalar_dtype_strs: dict[str, str],
         ctx: SpecializeContext,
+        is_inline: bool = False,
     ) -> list[str]:
-        """Build the annotated parameter strings for the function signature."""
+        """Build the annotated parameter strings for the function signature.
+
+        When ``is_inline`` is True, ``pl.Out[...]`` wrappers are stripped from
+        tensor params — inline helpers don't have a calling convention boundary,
+        so the direction tag carries no information.
+        """
         result: list[str] = []
         for name in all_param_names:
             if name in tensor_params:
-                is_out = name in out_params
+                is_out = (name in out_params) and not is_inline
                 meta = ctx.tensor_meta.get(name)
                 if meta is None:
                     raise ValueError(

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -202,9 +202,10 @@ struct SplicedInlineBody {
 //   3. Split the cloned body into pre-return statements and the trailing
 //      return value(s); reject any non-trailing return.
 SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
-  CHECK(callee->params_.size() == args.size())
-      << "Inline call to '" << callee->name_ << "' has " << args.size() << " argument(s) but callee expects "
-      << callee->params_.size();
+  INTERNAL_CHECK_SPAN(callee->params_.size() == args.size(), callee->span_)
+      << "Internal error: inline call to '" << callee->name_ << "' has " << args.size()
+      << " argument(s) but callee expects " << callee->params_.size()
+      << " (parser/type-checker should have caught arity mismatch before InlineFunctions)";
 
   // 1. Build the seed substitution map for DeepClone:
   //    - Each param Var → its actual-arg Expr. The same substitution is
@@ -300,11 +301,14 @@ std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std
 std::vector<StmtPtr> SpliceInlineCallAsAssign(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
                                               const VarPtr& lhs, const Span& call_site_span) {
   auto body = CloneInlineBody(callee, args);
-  CHECK(body.has_return) << "Inline function '" << callee->name_
-                         << "' is called for its value but has no return statement";
-  CHECK(body.return_values.size() == 1)
-      << "SpliceInlineCallAsAssign requires single-return callee; got " << body.return_values.size()
-      << " return values for '" << callee->name_ << "'";
+  INTERNAL_CHECK_SPAN(body.has_return, call_site_span)
+      << "Internal error: inline function '" << callee->name_
+      << "' is called for its value but has no return statement (parser should reject "
+         "value-use of a void inline function before InlineFunctions runs)";
+  INTERNAL_CHECK_SPAN(body.return_values.size() == 1, call_site_span)
+      << "Internal error: SpliceInlineCallAsAssign requires single-return callee; got "
+      << body.return_values.size() << " return values for '" << callee->name_
+      << "' (caller dispatches multi-return through SpliceInlineCallAsTupleSub)";
 
   ExprPtr final_value = body.return_values[0];
   // Skip the no-op `lhs = lhs` that arises when an arg is also returned —
@@ -328,11 +332,14 @@ std::vector<StmtPtr> SpliceInlineCallAsAssign(const FunctionPtr& callee, const s
 std::vector<StmtPtr> SpliceInlineCallAsTupleSub(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
                                                 std::vector<ExprPtr>& out_substitution) {
   auto body = CloneInlineBody(callee, args);
-  CHECK(body.has_return) << "Inline function '" << callee->name_
-                         << "' is called for its value but has no return statement";
-  CHECK(body.return_values.size() > 1)
-      << "SpliceInlineCallAsTupleSub requires multi-return callee; got " << body.return_values.size()
-      << " return value for '" << callee->name_ << "'";
+  INTERNAL_CHECK_SPAN(body.has_return, callee->span_)
+      << "Internal error: inline function '" << callee->name_
+      << "' is called for its value but has no return statement (parser should reject "
+         "value-use of a void inline function before InlineFunctions runs)";
+  INTERNAL_CHECK_SPAN(body.return_values.size() > 1, callee->span_)
+      << "Internal error: SpliceInlineCallAsTupleSub requires multi-return callee; got "
+      << body.return_values.size() << " return value for '" << callee->name_
+      << "' (caller dispatches single-return through SpliceInlineCallAsAssign)";
   out_substitution = std::move(body.return_values);
   return std::move(body.stmts);
 }
@@ -344,8 +351,10 @@ std::vector<StmtPtr> SpliceInlineCallAsTupleSub(const FunctionPtr& callee, const
 std::vector<StmtPtr> SpliceInlineCallAsReturn(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
                                               const Span& call_site_span) {
   auto body = CloneInlineBody(callee, args);
-  CHECK(body.has_return) << "Inline function '" << callee->name_
-                         << "' is used as a return value but has no return statement";
+  INTERNAL_CHECK_SPAN(body.has_return, call_site_span)
+      << "Internal error: inline function '" << callee->name_
+      << "' is used as a return value but has no return statement (parser should reject "
+         "value-use of a void inline function before InlineFunctions runs)";
   body.stmts.push_back(std::make_shared<const ReturnStmt>(std::move(body.return_values), call_site_span));
   return std::move(body.stmts);
 }
@@ -511,8 +520,15 @@ namespace pass {
  *  5. Drop all Inline functions from the program.
  *
  * Edge cases:
- *  - Multi-return inline: emits `LHS = MakeTuple([rets...])`. Subsequent
- *    Simplify can fold `TupleGetItemExpr(MakeTuple(...), i)` if needed.
+ *  - Multi-return inline: does NOT emit `LHS = MakeTuple([rets...])` —
+ *    orchestration codegen can't lower `MakeTuple`. Instead, the cloned
+ *    return values are recorded in `tuple_subs_` keyed by the LHS Var, and
+ *    downstream `TupleGetItemExpr(LHS, i)` uses are rewritten to the
+ *    corresponding cloned value (see `SpliceInlineCallAsTupleSub`). The LHS
+ *    binding ends up unreferenced and is elided.
+ *  - `return inline_call(...)`: spliced via `SpliceInlineCallAsReturn` to the
+ *    cloned pre-return body followed by a fresh ReturnStmt over the cloned
+ *    trailing values (single or multi).
  *  - Nested Call to inline (e.g. inside a binary expression) is left alone in
  *    v1; the verifier flags any surviving Calls to Inline functions.
  *  - Inline function with no callers is silently dropped in step (5) — that

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -181,9 +181,18 @@ class NestedReturnCounter : public IRVisitor {
   }
 };
 
-// Splice a call site into a SeqStmts. Returns the splice's statements, in order.
+// Result of splicing an inline call's body without yet wiring up its return
+// values into a specific caller statement. The caller picks the wiring form
+// (assign / drop / return / ...) based on its own statement kind.
+struct SplicedInlineBody {
+  std::vector<StmtPtr> stmts;          // Pre-return statements, in order
+  std::vector<ExprPtr> return_values;  // Trailing-return values (empty if has_return is false)
+  bool has_return;                     // Whether the body ended with a ReturnStmt
+};
+
+// Steps 1-3 of an inline splice — call-site-form-agnostic. Used by every
+// SpliceInlineCall* helper.
 //
-// For `LHS = inline_call(arg1, ...)`:
 //   1. Build the substitution seed: params → actual args, locally-defined
 //      Vars → fresh `_inlineN` Vars.
 //   2. DeepClone the callee body with that seed. The clone uses the same
@@ -192,12 +201,7 @@ class NestedReturnCounter : public IRVisitor {
 //      actual, ...)` whenever the actual arg is a Var.
 //   3. Split the cloned body into pre-return statements and the trailing
 //      return value(s); reject any non-trailing return.
-//   4. For the return value(s):
-//        - If lhs is set and return has 1 value: emit `LHS = renamed_ret[0]`
-//        - If lhs is set and return has N values: emit `LHS = MakeTuple(...)`
-//        - If lhs is null (EvalStmt): drop the return
-std::vector<StmtPtr> SpliceInlineCall(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
-                                      const VarPtr& lhs, const Span& call_site_span) {
+SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
   CHECK(callee->params_.size() == args.size())
       << "Inline call to '" << callee->name_ << "' has " << args.size() << " argument(s) but callee expects "
       << callee->params_.size();
@@ -280,26 +284,70 @@ std::vector<StmtPtr> SpliceInlineCall(const FunctionPtr& callee, const std::vect
                                  << "' contains a non-trailing ReturnStmt; only a single trailing return is "
                                     "supported (early-return inside an If/For/While branch is rejected)";
 
-  // 4. Wire up the return value(s) at the call site
-  if (lhs) {
-    CHECK(has_return) << "Inline function '" << callee->name_
-                      << "' is called for its value but has no return statement";
-    ExprPtr final_value;
-    if (return_values.size() == 1) {
-      final_value = return_values[0];
-    } else {
-      // Multi-return: pack into MakeTuple. The LHS is expected to have TupleType.
-      final_value = std::make_shared<MakeTuple>(return_values, call_site_span);
-    }
-    // Skip the no-op `lhs = lhs` that arises when an arg is also returned —
-    // it would otherwise survive into SSA and break structural equality.
-    if (auto var_expr = As<Var>(final_value); var_expr && var_expr.get() == lhs.get()) {
-      return spliced;
-    }
-    spliced.push_back(std::make_shared<const AssignStmt>(lhs, final_value, call_site_span));
-  }
+  return SplicedInlineBody{std::move(spliced), std::move(return_values), has_return};
+}
 
-  return spliced;
+// Splice an EvalStmt-shaped call (no LHS) — drop the return, return only
+// the pre-return statements.
+std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
+  auto body = CloneInlineBody(callee, args);
+  return std::move(body.stmts);
+}
+
+// Splice a single-return call into `LHS = inlined_return_value`. CHECK-fails
+// if the callee returns multiple values — multi-return goes through
+// SpliceInlineCallAsTupleSub, which avoids the dead `LHS = MakeTuple(...)`.
+std::vector<StmtPtr> SpliceInlineCallAsAssign(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
+                                              const VarPtr& lhs, const Span& call_site_span) {
+  auto body = CloneInlineBody(callee, args);
+  CHECK(body.has_return) << "Inline function '" << callee->name_
+                         << "' is called for its value but has no return statement";
+  CHECK(body.return_values.size() == 1)
+      << "SpliceInlineCallAsAssign requires single-return callee; got " << body.return_values.size()
+      << " return values for '" << callee->name_ << "'";
+
+  ExprPtr final_value = body.return_values[0];
+  // Skip the no-op `lhs = lhs` that arises when an arg is also returned —
+  // it would otherwise survive into SSA and break structural equality.
+  if (auto var_expr = As<Var>(final_value); var_expr && var_expr.get() == lhs.get()) {
+    return std::move(body.stmts);
+  }
+  body.stmts.push_back(std::make_shared<const AssignStmt>(lhs, final_value, call_site_span));
+  return std::move(body.stmts);
+}
+
+// Splice a multi-return call without emitting `LHS = MakeTuple(values)`.
+// Instead, hands back the cloned return values via `out_substitution` so the
+// caller (the InlineCallsMutator) can substitute downstream
+// `TupleGetItemExpr(LHS, i)` uses with `values[i]` directly.
+//
+// Why no MakeTuple: orchestration codegen can't lower a MakeTuple expression,
+// and the parser-generated tuple-unpack pattern (`_tuple_tmp = call(); y_i =
+// _tuple_tmp[i]`) means every LHS use is a TupleGetItemExpr — substituting
+// makes the LHS unreferenced and the binding effectively dead.
+std::vector<StmtPtr> SpliceInlineCallAsTupleSub(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
+                                                std::vector<ExprPtr>& out_substitution) {
+  auto body = CloneInlineBody(callee, args);
+  CHECK(body.has_return) << "Inline function '" << callee->name_
+                         << "' is called for its value but has no return statement";
+  CHECK(body.return_values.size() > 1)
+      << "SpliceInlineCallAsTupleSub requires multi-return callee; got " << body.return_values.size()
+      << " return value for '" << callee->name_ << "'";
+  out_substitution = std::move(body.return_values);
+  return std::move(body.stmts);
+}
+
+// Splice a `return inline_call(args...)` statement: emit the cloned pre-return
+// body followed by a fresh ReturnStmt that returns the callee's trailing return
+// values directly. Single-return → ReturnStmt({v}); multi-return →
+// ReturnStmt({v0, v1, ...}). No MakeTuple, no temporary.
+std::vector<StmtPtr> SpliceInlineCallAsReturn(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
+                                              const Span& call_site_span) {
+  auto body = CloneInlineBody(callee, args);
+  CHECK(body.has_return) << "Inline function '" << callee->name_
+                         << "' is used as a return value but has no return statement";
+  body.stmts.push_back(std::make_shared<const ReturnStmt>(std::move(body.return_values), call_site_span));
+  return std::move(body.stmts);
 }
 
 // =============================================================================
@@ -352,22 +400,78 @@ class InlineCallsMutator : public IRMutator {
     return SeqStmts::Flatten(std::move(*handled), op->span_);
   }
 
- private:
-  // Recognise `LHS = inline_call(args...)` or `EvalStmt(inline_call(args...))`
-  // and return the spliced sequence; otherwise return std::nullopt.
-  std::optional<std::vector<StmtPtr>> HandleTopLevelInlineCall(const StmtPtr& stmt) {
-    auto call = transform_utils::GetCallFromStmt(stmt);
-    if (!call) return std::nullopt;
-    auto callee = LookupInlineCallee(call);
-    if (!callee) return std::nullopt;
+  // `return inline_call(...)`. Same SeqStmts caveat as AssignStmt /
+  // EvalStmt: a function body that is a bare ReturnStmt (no enclosing
+  // SeqStmts) reaches this override directly.
+  StmtPtr VisitStmt_(const ReturnStmtPtr& op) override {
+    auto handled = HandleTopLevelInlineCall(op);
+    if (!handled.has_value()) return IRMutator::VisitStmt_(op);
+    changed_ = true;
+    return SeqStmts::Flatten(std::move(*handled), op->span_);
+  }
 
-    if (auto assign = As<AssignStmt>(stmt)) {
-      return SpliceInlineCall(callee, call->args_, assign->var_, assign->span_);
+  // Apply tuple substitutions registered by multi-return inline splices:
+  // `TupleGetItemExpr(LHS_var, i)` → `return_values[i]`. The substituted
+  // expression is then visited again (via VisitExpr) to fold any nested
+  // TupleGetItemExpr's the same way.
+  ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override {
+    // Fast-path the common case: programs without multi-return inline calls
+    // never populate tuple_subs_, so every TupleGetItemExpr in the IR would
+    // otherwise pay an unnecessary VisitExpr+find on the tuple operand.
+    if (tuple_subs_.empty()) return IRMutator::VisitExpr_(op);
+
+    auto recursed_tuple = VisitExpr(op->tuple_);
+    if (auto var = As<Var>(recursed_tuple)) {
+      auto it = tuple_subs_.find(var.get());
+      if (it != tuple_subs_.end() && op->index_ >= 0 && static_cast<size_t>(op->index_) < it->second.size()) {
+        // Visit the replacement so nested substitutions also apply.
+        return VisitExpr(it->second[op->index_]);
+      }
     }
-    if (auto eval = As<EvalStmt>(stmt)) {
-      return SpliceInlineCall(callee, call->args_, /*lhs=*/nullptr, eval->span_);
+    if (recursed_tuple.get() == op->tuple_.get()) return op;
+    return std::make_shared<TupleGetItemExpr>(recursed_tuple, op->index_, op->span_);
+  }
+
+ private:
+  // Recognise `LHS = inline_call(args...)`, `EvalStmt(inline_call(args...))`,
+  // or `ReturnStmt({inline_call(args...)})` and return the spliced sequence;
+  // otherwise return std::nullopt.
+  std::optional<std::vector<StmtPtr>> HandleTopLevelInlineCall(const StmtPtr& stmt) {
+    if (auto call = transform_utils::GetCallFromStmt(stmt)) {
+      if (auto callee = LookupInlineCallee(call)) {
+        if (auto assign = As<AssignStmt>(stmt)) {
+          return SpliceAssignCallSite(callee, call->args_, assign->var_, assign->span_);
+        }
+        if (auto eval = As<EvalStmt>(stmt)) {
+          return SpliceInlineCallAsEval(callee, call->args_);
+        }
+      }
+    }
+    // ReturnStmt's value list isn't covered by GetCallFromStmt — handle it
+    // here. The form is exactly `return inline_call(args...)`: a single Call
+    // expression as the only return value.
+    if (auto ret = As<ReturnStmt>(stmt); ret && ret->value_.size() == 1) {
+      if (auto call = As<Call>(ret->value_[0])) {
+        if (auto callee = LookupInlineCallee(call)) {
+          return SpliceInlineCallAsReturn(callee, call->args_, ret->span_);
+        }
+      }
     }
     return std::nullopt;
+  }
+
+  // Dispatch on callee return arity: single-return → `LHS = value` AssignStmt;
+  // multi-return → record `LHS → values` for downstream TupleGetItemExpr
+  // substitution and emit no LHS assignment.
+  std::vector<StmtPtr> SpliceAssignCallSite(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
+                                            const VarPtr& lhs, const Span& span) {
+    if (callee->return_types_.size() > 1) {
+      std::vector<ExprPtr> sub;
+      auto stmts = SpliceInlineCallAsTupleSub(callee, args, sub);
+      tuple_subs_[lhs.get()] = std::move(sub);
+      return stmts;
+    }
+    return SpliceInlineCallAsAssign(callee, args, lhs, span);
   }
 
   FunctionPtr LookupInlineCallee(const CallPtr& call) const {
@@ -379,6 +483,11 @@ class InlineCallsMutator : public IRMutator {
 
   const std::unordered_map<std::string, FunctionPtr>& inline_fns_;
   bool changed_ = false;
+  // LHS Var → return values, populated by SpliceAssignCallSite for multi-return
+  // call sites. Subsequent TupleGetItemExpr uses of the Var are substituted
+  // with the corresponding value, so the LHS Var ends up with no references
+  // and we never emit a `LHS = MakeTuple(...)` assignment.
+  std::unordered_map<const Var*, std::vector<ExprPtr>> tuple_subs_;
 };
 
 }  // namespace

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -492,5 +492,143 @@ class TestInlineFunctionsParamRebinding:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestInlineReturnAndMultiReturn:
+    """`return inline_call(...)` and tuple-unpack of multi-return inline calls.
+
+    Issue #1304 — these forms previously slipped through InlineFunctions because
+    the mutator only handled ``AssignStmt`` and ``EvalStmt`` call sites and
+    emitted dead ``LHS = MakeTuple(...)`` bindings for multi-return.
+    """
+
+    def test_return_inline_call_single_return(self):
+        """`return inline_call(...)` with a single-return inline: body spliced,
+        outer ReturnStmt rewritten to return the cloned return value directly."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def proj(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                qo: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                return self.proj(a, qo)
+
+        After = passes.inline_functions()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                qo: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                qo = pl.tensor.assemble(qo, a, [0])
+                return qo
+
+        ir.assert_structural_equal(After, Expected)
+
+    def test_return_inline_call_multi_return(self):
+        """`return inline_call(...)` with a multi-return inline: outer
+        ReturnStmt rewritten to return the cloned values directly — no
+        intermediate MakeTuple."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def proj(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                o0: pl.Out[pl.Tensor[[4], pl.FP32]],
+                o1: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                o0 = pl.tensor.assemble(o0, x, [0])
+                o1 = pl.tensor.assemble(o1, x, [0])
+                return o0, o1
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                return self.proj(a, q, k)
+
+        After = passes.inline_functions()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                q = pl.tensor.assemble(q, a, [0])
+                k = pl.tensor.assemble(k, a, [0])
+                return q, k
+
+        ir.assert_structural_equal(After, Expected)
+
+    def test_tuple_unpack_inline_call_multi_return(self):
+        """`y0, y1 = inline_call(...)` — multi-return inline call site
+        substitutes TupleGetItemExpr uses with the return values, leaves no
+        live MakeTuple binding."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def proj(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                o0: pl.Out[pl.Tensor[[4], pl.FP32]],
+                o1: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                o0 = pl.tensor.assemble(o0, x, [0])
+                o1 = pl.tensor.assemble(o1, x, [0])
+                return o0, o1
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                y0, y1 = self.proj(a, q, k)
+                return y0, y1
+
+        After = passes.inline_functions()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                q = pl.tensor.assemble(q, a, [0])
+                k = pl.tensor.assemble(k, a, [0])
+                y0: pl.Tensor[[4], pl.FP32] = q
+                y1: pl.Tensor[[4], pl.FP32] = k
+                return y0, y1
+
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -629,6 +629,56 @@ class TestInlineReturnAndMultiReturn:
 
         ir.assert_structural_equal(After, Expected)
 
+    def test_inline_with_bare_tensor_params_multi_return(self):
+        """Bare `pl.Tensor` inline params (no `pl.Out` wrapper) splice the
+        same way as `pl.Out`-annotated params: rebindings retarget the
+        actual-arg Var and tuple-unpack uses get substituted directly.
+
+        Issue #1304 deprecates `pl.Out` on `@pl.jit.inline` helpers — this
+        test pins the equivalent behavior at the IR level."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def proj(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                o0: pl.Tensor[[4], pl.FP32],
+                o1: pl.Tensor[[4], pl.FP32],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                o0 = pl.tensor.assemble(o0, x, [0])
+                o1 = pl.tensor.assemble(o1, x, [0])
+                return o0, o1
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                y0, y1 = self.proj(a, q, k)
+                return y0, y1
+
+        After = passes.inline_functions()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                q = pl.tensor.assemble(q, a, [0])
+                k = pl.tensor.assemble(k, a, [0])
+                y0: pl.Tensor[[4], pl.FP32] = q
+                y1: pl.Tensor[[4], pl.FP32] = k
+                return y0, y1
+
+        ir.assert_structural_equal(After, Expected)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -9,6 +9,8 @@
 
 """Tests for @pl.jit decorator: decoration, cache hit/miss, and bind_dynamic."""
 
+import warnings
+
 import pypto.language as pl
 import pytest
 from pypto.ir import OptimizationStrategy, PassManager
@@ -677,6 +679,125 @@ class TestInlineFuncIntegration:
         func_names = [f.name for f in post_pass.functions.values()]
         assert "helper" not in func_names, f"helper should be spliced, got {func_names}"
         assert "entry_mixed" in func_names
+
+    def test_inline_multi_return_tuple_unpack(self):
+        """Multi-return @pl.jit.inline + tuple-unpack at call site (issue #1304).
+
+        Pre-fix: ParserSyntaxError ('TupleGetItemExpr requires tuple to have
+        TupleType, got TensorType') because the specializer emitted a single-
+        tensor return annotation.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def two_returns(
+            a: pl.Tensor,
+            o0: pl.Out[pl.Tensor],
+            o1: pl.Out[pl.Tensor],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile = pl.load(a, [0, 0], [32, 32])
+                pl.store(tile, [0, 0], o0)
+                pl.store(tile, [0, 0], o1)
+            return o0, o1
+
+        @jit
+        def entry(
+            a: pl.Tensor,
+            o0: pl.Out[pl.Tensor],
+            o1: pl.Out[pl.Tensor],
+        ):
+            y0, y1 = two_returns(a, o0, o1)
+            return y0, y1
+
+        a = torch.randn(32, 32)
+        o0 = torch.empty(32, 32)
+        o1 = torch.empty(32, 32)
+        post_pass = entry.compile_for_test(a, o0, o1)
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "two_returns" not in func_names
+        assert "entry" in func_names
+
+    def test_inline_multi_return_direct_return(self):
+        """Multi-return @pl.jit.inline + ``return inline_call(...)`` (issue #1304).
+
+        Pre-fix: RuntimeError reporting the inline function as undefined, because
+        InlineCallsMutator only handled AssignStmt/EvalStmt — ReturnStmt-shaped
+        call sites slipped past splicing.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def two_returns(
+            a: pl.Tensor,
+            o0: pl.Out[pl.Tensor],
+            o1: pl.Out[pl.Tensor],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile = pl.load(a, [0, 0], [32, 32])
+                pl.store(tile, [0, 0], o0)
+                pl.store(tile, [0, 0], o1)
+            return o0, o1
+
+        @jit
+        def entry(
+            a: pl.Tensor,
+            o0: pl.Out[pl.Tensor],
+            o1: pl.Out[pl.Tensor],
+        ):
+            return two_returns(a, o0, o1)
+
+        a = torch.randn(32, 32)
+        o0 = torch.empty(32, 32)
+        o1 = torch.empty(32, 32)
+        post_pass = entry.compile_for_test(a, o0, o1)
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "two_returns" not in func_names
+        assert "entry" in func_names
+
+    def test_inline_with_bare_tensor_no_pl_out(self):
+        """@pl.jit.inline helpers with bare ``pl.Tensor`` params (no ``pl.Out``)
+        compile cleanly without DeprecationWarning. The body is spliced
+        identically — `pl.Out` is redundant on inline helpers because the
+        splice happens before SSA.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def two_returns_no_out(
+            a: pl.Tensor,
+            o0: pl.Tensor,  # bare — no pl.Out
+            o1: pl.Tensor,  # bare — no pl.Out
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile = pl.load(a, [0, 0], [32, 32])
+                pl.store(tile, [0, 0], o0)
+                pl.store(tile, [0, 0], o1)
+            return o0, o1
+
+        @jit
+        def entry(
+            a: pl.Tensor,
+            o0: pl.Out[pl.Tensor],
+            o1: pl.Out[pl.Tensor],
+        ):
+            y0, y1 = two_returns_no_out(a, o0, o1)
+            return y0, y1
+
+        a = torch.randn(32, 32)
+        o0 = torch.empty(32, 32)
+        o1 = torch.empty(32, 32)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            post_pass = entry.compile_for_test(a, o0, o1)
+        # Bare pl.Tensor inline params must not emit the deprecation warning.
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            f"Unexpected DeprecationWarning for bare pl.Tensor inline params: "
+            f"{[str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]}"
+        )
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "two_returns_no_out" not in func_names
+        assert "entry" in func_names
 
 
 class TestOpaqueFuncIntegration:

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -11,16 +11,19 @@
 
 import ast
 import textwrap
+import warnings
 
 import pypto.language as pl
 import pytest
 from pypto.jit.specializer import (
     SpecializeContext,
+    Specializer,
     TensorMeta,
     _BodyTransformer,
     _classify_params,
     _collect_dynamic_dims,
     _collect_dynvar_names,
+    _infer_return_type,
     specialize,
 )
 from pypto.pypto_core import DataType, ir
@@ -869,6 +872,138 @@ class TestVariableRebinding:
         out = self._transform(src)
         assert "x_v1" not in out
         assert "y = x" in out
+
+
+class TestInferReturnType:
+    """Coverage for `_infer_return_type` — the JIT specializer's annotation inferer."""
+
+    @staticmethod
+    def _meta(shape=(32, 32), dtype=DataType.FP32) -> TensorMeta:
+        return TensorMeta(shape=shape, dtype=dtype)
+
+    def test_tuple_return_emits_tuple_annotation(self):
+        """`return out0, out1` -> `tuple[T_out0, T_out1]` (issue #1304)."""
+        func_def = _parse_func(
+            """
+            def f(a, out0, out1):
+                return out0, out1
+            """
+        )
+        meta = {"a": self._meta(), "out0": self._meta(), "out1": self._meta()}
+        ann = _infer_return_type(func_def, meta, set(), {}, ["out0", "out1"])
+        assert ann == ("tuple[pl.Tensor[[32, 32], pl.FP32], pl.Tensor[[32, 32], pl.FP32]]")
+
+    def test_tuple_return_with_unknown_element_drops_annotation(self):
+        """Tuple returns with non-tensor elements bail to no annotation."""
+        func_def = _parse_func(
+            """
+            def f(a, out):
+                return out, a_local
+            """
+        )
+        meta = {"a": self._meta(), "out": self._meta()}
+        # `a_local` isn't in tensor_meta — can't infer it.
+        assert _infer_return_type(func_def, meta, set(), {}, ["out"]) is None
+
+    def test_return_call_drops_annotation(self):
+        """`return f(...)` can't be inferred — caller may have multi-return."""
+        func_def = _parse_func(
+            """
+            def f(a, out):
+                return inline_call(a, out)
+            """
+        )
+        meta = {"a": self._meta(), "out": self._meta()}
+        assert _infer_return_type(func_def, meta, set(), {}, ["out"]) is None
+
+    def test_bare_tensor_param_return_inferred(self):
+        """Bare `pl.Tensor` returns (no `pl.Out`) — issue #1304 deprecation case."""
+        func_def = _parse_func(
+            """
+            def f(a, out):
+                return out
+            """
+        )
+        meta = {"a": self._meta(), "out": self._meta()}
+        # No out_params at all (bare pl.Tensor params).
+        ann = _infer_return_type(func_def, meta, set(), {}, [])
+        assert ann == "pl.Tensor[[32, 32], pl.FP32]"
+
+
+class TestSpecializerInlineDeprecation:
+    """`@pl.jit.inline` should emit bare `pl.Tensor[...]` and warn on `pl.Out`."""
+
+    def _spec(self, ctx_args: dict) -> str:
+        ctx = _make_ctx(**ctx_args)
+        return Specializer("Generated", [ctx], {}).specialize()
+
+    def test_inline_strips_pl_out_and_warns(self):
+        """Inline helpers with pl.Out -> bare pl.Tensor + DeprecationWarning."""
+        src = """
+            def util(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+                return out
+        """
+        meta = {
+            "a": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+        }
+        with pytest.warns(DeprecationWarning, match="pl.Out annotations are deprecated"):
+            out = self._spec(
+                {
+                    "func_name": "util",
+                    "source": src,
+                    "func_type": "inline",
+                    "param_names": ["a", "out"],
+                    "tensor_meta": meta,
+                }
+            )
+        # Generated source must use bare pl.Tensor[...] for `out`, not pl.Out[...].
+        assert "out: pl.Tensor[[32, 32], pl.FP32]" in out
+        assert "pl.Out[pl.Tensor[[32, 32], pl.FP32]]" not in out
+
+    def test_inline_with_bare_tensor_no_warning(self):
+        """Bare `pl.Tensor` inline params don't trigger the deprecation warning."""
+        src = """
+            def util(a: pl.Tensor, out: pl.Tensor):
+                return out
+        """
+        meta = {
+            "a": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._spec(
+                {
+                    "func_name": "util",
+                    "source": src,
+                    "func_type": "inline",
+                    "param_names": ["a", "out"],
+                    "tensor_meta": meta,
+                }
+            )
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+    def test_orchestration_keeps_pl_out(self):
+        """Non-inline functions keep `pl.Out[...]` annotations untouched."""
+        src = """
+            def util(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+                return out
+        """
+        meta = {
+            "a": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+        }
+        out = self._spec(
+            {
+                "func_name": "util",
+                "source": src,
+                "func_type": "orchestration",
+                "param_names": ["a", "out"],
+                "tensor_meta": meta,
+            }
+        )
+        assert "pl.Out[pl.Tensor[[32, 32], pl.FP32]]" in out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1304. Two natural call-site forms for multi-return `@pl.jit.inline` helpers under `@pl.jit` previously failed:

- `y0, y1 = inline_two_returns(...)` → `ParserSyntaxError: TupleGetItemExpr requires tuple to have TupleType, got TensorType`
- `return inline_two_returns(...)` → `RuntimeError: Missing functions: ['inline_two_returns']`

Both defects are fixed; the PR also bundles a deprecation of `pl.Out[...]` on `@pl.jit.inline` helper params (the splice runs before SSA conversion, so the param already aliases the caller's variable).

## Changes

**Specializer** (`python/pypto/jit/specializer.py`):
- `_infer_return_type` now emits `tuple[T0, T1, ...]` for `return a, b, ...`; returns `None` for `return f(...)` (callee arity unknown); resolves names against `tensor_meta` directly so bare `pl.Tensor` params work.
- For inline helpers, strip `pl.Out[...]` from generated source and emit a `DeprecationWarning` when the user wrote it. Existing code keeps working unchanged.

**InlineFunctions pass** (`src/ir/transforms/inline_functions_pass.cpp`):
- Extract steps 1-3 of `SpliceInlineCall` into a reusable `CloneInlineBody` primitive; split wiring into focused helpers (`SpliceInlineCallAsAssign` / `Eval` / `Return` / `TupleSub`).
- Add `VisitStmt_(ReturnStmtPtr&)` so `return inline_call(...)` is spliced.
- For multi-return assign call-sites, skip the dead `LHS = MakeTuple(...)` binding and substitute `TupleGetItemExpr(LHS, i)` uses with the cloned return values directly — orchestration codegen can't lower `MakeTuple`, and the parser-generated tuple-unpack pattern only references `LHS` via `TupleGetItemExpr`.

## Tests

- **Specializer unit** — tuple-return annotation, bare `pl.Tensor` params, deprecation warning emission, orchestration helpers untouched.
- **InlineFunctions transform** — `return inline_call(...)` (single + multi-return), tuple-unpack multi-return, bare `pl.Tensor` multi-return splices identically to the `pl.Out` variant.
- **JIT end-to-end** — both call-site forms from the issue compile cleanly; bare `pl.Tensor` inline helpers compile without warnings.

## Test plan

- [x] All targeted suites pass (54 specializer, 18 inline_functions, 131 JIT, 1204 IR transform tests)
- [x] Issue's original repro prints `OK` for all three cases
- [x] Pre-commit hooks green (ruff, clang-format, pyright)