### PR TITLE
fix(ci): prefer github mirror for pto-isa with gitcode fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,8 @@ jobs:
 
       - name: Clone pto-isa (pypto-lib Qwen3-14B decode)
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout 2c607938
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -61,7 +61,8 @@ jobs:
 
       - name: Clone pto-isa repository
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout d5bcc23
 
@@ -139,7 +140,8 @@ jobs:
 
       - name: Clone pto-isa repository
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout d5bcc23
 

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -108,6 +108,51 @@ def _get_pto_isa_clone_path() -> Path:
     return Path(__file__).parent.parent.parent.parent / "build_output" / "_deps" / "pto-isa"
 
 
+def _clone_pto_isa(clone_path: Path, primary_url: str, fallback_url: str) -> bool:
+    """Clone pto-isa, trying *primary_url* first with a short timeout.
+
+    Returns:
+        ``True`` if the clone succeeded (based on return code), ``False`` otherwise.
+    """
+    clone_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            ["git", "clone", primary_url, str(clone_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_PTO_ISA_PRIMARY_CLONE_TIMEOUT,
+        )
+        if result.returncode == 0:
+            return True
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            f"Cloning pto-isa from {primary_url} timed out after "
+            f"{_PTO_ISA_PRIMARY_CLONE_TIMEOUT}s; falling back to {fallback_url}"
+        )
+    except Exception as e:
+        logger.warning(f"Cloning pto-isa from {primary_url} failed: {e}; falling back to {fallback_url}")
+
+    # Clean up any partial clone before retrying with the fallback.
+    if clone_path.exists():
+        shutil.rmtree(clone_path, ignore_errors=True)
+    try:
+        result = subprocess.run(
+            ["git", "clone", fallback_url, str(clone_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_PTO_ISA_FALLBACK_CLONE_TIMEOUT,
+        )
+        if result.returncode != 0:
+            logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
+            return False
+    except Exception as e:
+        logger.warning(f"Failed to clone pto-isa: {e}")
+        return False
+    return True
+
+
 def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https") -> str | None:
     """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
 
@@ -128,66 +173,14 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     include_dir = clone_path / "include"
 
     if not (clone_path.exists() and include_dir.exists() and include_dir.is_dir()):
-        # Need to clone — try primary URL with a short timeout, fall back on failure.
         if clone_protocol == "https":
             primary_url, fallback_url = _PTO_ISA_HTTPS, _PTO_ISA_HTTPS_FALLBACK
         else:
             primary_url, fallback_url = _PTO_ISA_SSH, _PTO_ISA_SSH_FALLBACK
-        clone_path.parent.mkdir(parents=True, exist_ok=True)
-        primary_failed = True
-        try:
-            result = subprocess.run(
-                ["git", "clone", primary_url, str(clone_path)],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=_PTO_ISA_PRIMARY_CLONE_TIMEOUT,
-            )
-            primary_failed = result.returncode != 0
-        except subprocess.TimeoutExpired:
-            logger.warning(
-                f"Cloning pto-isa from {primary_url} timed out after "
-                f"{_PTO_ISA_PRIMARY_CLONE_TIMEOUT}s; falling back to {fallback_url}"
-            )
-        except Exception as e:
-            logger.warning(f"Cloning pto-isa from {primary_url} failed: {e}; falling back to {fallback_url}")
-
-        if primary_failed and not include_dir.exists():
-            # Clean up any partial clone before retrying with the fallback.
-            if clone_path.exists():
-                shutil.rmtree(clone_path, ignore_errors=True)
-            try:
-                result = subprocess.run(
-                    ["git", "clone", fallback_url, str(clone_path)],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=_PTO_ISA_FALLBACK_CLONE_TIMEOUT,
-                )
-                if result.returncode != 0 and not include_dir.exists():
-                    logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
-                    return None
-            except Exception as e:
-                if not include_dir.exists():
-                    logger.warning(f"Failed to clone pto-isa: {e}")
-                    return None
-
-        try:
-            if commit:
-                result = subprocess.run(
-                    ["git", "checkout", commit],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    cwd=str(clone_path),
-                    timeout=30,
-                )
-                if result.returncode != 0:
-                    raise RuntimeError(f"Failed to checkout pto-isa commit {commit}:\n{result.stderr}")
-        except Exception as e:
-            if not include_dir.exists():
-                logger.warning(f"Failed to clone pto-isa: {e}")
-                return None
+        if not _clone_pto_isa(clone_path, primary_url, fallback_url):
+            return None
+        if commit:
+            _checkout_pto_isa_commit(clone_path, commit)
     elif commit:
         _checkout_pto_isa_commit(clone_path, commit)
     else:

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -33,6 +33,7 @@ import ctypes
 import importlib.util
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Callable
@@ -94,8 +95,12 @@ def _load_binary(path: Path) -> bytes | None:
 # PTO-ISA management
 # ---------------------------------------------------------------------------
 
-_PTO_ISA_HTTPS = "https://gitcode.com/luohuan40/pto-isa.git"
-_PTO_ISA_SSH = "git@gitcode.com:luohuan40/pto-isa.git"
+_PTO_ISA_HTTPS = "https://github.com/hw-native-sys/pto-isa.git"
+_PTO_ISA_SSH = "git@github.com:hw-native-sys/pto-isa.git"
+_PTO_ISA_HTTPS_FALLBACK = "https://gitcode.com/luohuan40/pto-isa.git"
+_PTO_ISA_SSH_FALLBACK = "git@gitcode.com:luohuan40/pto-isa.git"
+_PTO_ISA_PRIMARY_CLONE_TIMEOUT = 60
+_PTO_ISA_FALLBACK_CLONE_TIMEOUT = 300
 
 
 def _get_pto_isa_clone_path() -> Path:
@@ -123,22 +128,51 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     include_dir = clone_path / "include"
 
     if not (clone_path.exists() and include_dir.exists() and include_dir.is_dir()):
-        # Need to clone
-        repo_url = _PTO_ISA_HTTPS if clone_protocol == "https" else _PTO_ISA_SSH
+        # Need to clone — try primary URL with a short timeout, fall back on failure.
+        if clone_protocol == "https":
+            primary_url, fallback_url = _PTO_ISA_HTTPS, _PTO_ISA_HTTPS_FALLBACK
+        else:
+            primary_url, fallback_url = _PTO_ISA_SSH, _PTO_ISA_SSH_FALLBACK
         clone_path.parent.mkdir(parents=True, exist_ok=True)
+        primary_failed = True
         try:
             result = subprocess.run(
-                ["git", "clone", repo_url, str(clone_path)],
+                ["git", "clone", primary_url, str(clone_path)],
                 check=False,
                 capture_output=True,
                 text=True,
-                timeout=300,
+                timeout=_PTO_ISA_PRIMARY_CLONE_TIMEOUT,
             )
-            if result.returncode != 0:
-                # Another process may have succeeded
-                if not include_dir.exists():
+            primary_failed = result.returncode != 0
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                f"Cloning pto-isa from {primary_url} timed out after "
+                f"{_PTO_ISA_PRIMARY_CLONE_TIMEOUT}s; falling back to {fallback_url}"
+            )
+        except Exception as e:
+            logger.warning(f"Cloning pto-isa from {primary_url} failed: {e}; falling back to {fallback_url}")
+
+        if primary_failed and not include_dir.exists():
+            # Clean up any partial clone before retrying with the fallback.
+            if clone_path.exists():
+                shutil.rmtree(clone_path, ignore_errors=True)
+            try:
+                result = subprocess.run(
+                    ["git", "clone", fallback_url, str(clone_path)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=_PTO_ISA_FALLBACK_CLONE_TIMEOUT,
+                )
+                if result.returncode != 0 and not include_dir.exists():
                     logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
                     return None
+            except Exception as e:
+                if not include_dir.exists():
+                    logger.warning(f"Failed to clone pto-isa: {e}")
+                    return None
+
+        try:
             if commit:
                 result = subprocess.run(
                     ["git", "checkout", commit],


### PR DESCRIPTION
## Summary
- Switch pto-isa clone URLs to prefer the GitHub mirror (`hw-native-sys/pto-isa`) with a 60s timeout, falling back to the gitcode mirror on failure
- Apply the same primary/fallback strategy in CI workflows (`ci.yml`, `daily_ci.yml`) and in the Python runtime `device_runner.py`
- Clean up partial clones before retrying with the fallback URL

## Changes
- **`.github/workflows/ci.yml`** — use `timeout 60 git clone` from GitHub, fall back to gitcode on failure
- **`.github/workflows/daily_ci.yml`** — same primary/fallback pattern for both `pypto-lib` and `pypto-lib-daily` jobs
- **`python/pypto/runtime/device_runner.py`** — add `_PTO_ISA_HTTPS_FALLBACK` / `_PTO_ISA_SSH_FALLBACK` URLs; try primary clone with 60s timeout, clean up partial clone on failure, retry with fallback (300s timeout)

## Testing
- [ ] CI workflows clone pto-isa successfully from GitHub mirror
- [ ] Fallback to gitcode works when GitHub mirror is unreachable
- [ ] `device_runner.py` handles timeout and clone failures gracefully