### PR TITLE
fix(printer): emit shortest round-tripping decimal for float literals

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <functional>
 #include <iomanip>
-#include <ios>
 #include <map>
 #include <memory>
 #include <optional>
@@ -326,35 +325,36 @@ class IRPythonPrinter : public IRVisitor {
   std::string PrintTensorView(const TensorView& tensor_view, const std::vector<ExprPtr>& tensor_shape);
 };
 
-// Helper function to format float literals with decimal point.
+// Helper function to format a float literal so it re-parses as a ``ConstFloat``.
 //
-// For non-integer values we emit the *shortest* decimal that parses back to the
-// exact same ``double`` (``std::to_chars`` with no precision argument). This is
+// Emits the *shortest* decimal that parses back to the exact same ``double``
+// (``std::to_chars`` with no precision argument, locale-independent). This is
 // what makes ``ConstFloat`` (and float kwargs / attrs) round-trip bit-exactly
 // through print → parse: the parser stores ``ConstFloat.value_`` as the FP64
 // value it reads, so the printed text must encode the full ``double`` regardless
-// of the constant's ``dtype_``. The shortest-form output keeps simple values
-// readable — ``0.1`` prints as ``0.1`` (not ``0.10000000000000001``) and the
-// FP32-representable Cody-Waite constants emitted by ``LowerCompositeOps`` print
-// with exactly as many digits as their ``double`` needs (e.g.
-// ``0.31830987334251404``).
+// of the constant's ``dtype_``. Output stays compact — ``0.1`` prints as ``0.1``
+// (not ``0.10000000000000001``), large integers as ``1e+16`` rather than a long
+// run of zeros, and the FP32-representable Cody-Waite constants emitted by
+// ``LowerCompositeOps`` with exactly as many digits as their ``double`` needs
+// (e.g. ``0.31830987334251404``). Output may use exponent notation (``1e+16``,
+// ``1e-07``) — still a valid Python float literal.
 //
-// Integer-valued doubles are formatted as ``X.0`` so they re-parse as floats
-// (a bare ``4`` would parse as ``ConstInt``); ``std::to_chars`` would emit ``4``.
+// ``std::to_chars`` emits a bare integer (``"4"``) for integer-valued doubles
+// without an exponent, which would re-parse as ``ConstInt``; append ``.0`` in
+// that case. The append is skipped for exponent forms (``"1e+16"`` already
+// parses as a Python float) and for non-finite values (``"nan"`` / ``"inf"``
+// have no DSL syntax — emitted verbatim, matching the prior behavior; no IR
+// construction path produces them).
 std::string FormatFloatLiteral(double value) {
-  // Check if the value is an integer (no fractional part)
-  if (value == std::floor(value)) {
-    // For integer values, format as X.0
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1) << value;
-    return oss.str();
-  }
-  // For non-integer values, emit the shortest round-tripping decimal.
   char buf[32];
   auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value);
   INTERNAL_CHECK(ec == std::errc()) << "Internal error: std::to_chars failed to format float literal "
                                     << value;
-  return std::string(buf, ptr);
+  std::string text(buf, ptr);
+  if (std::isfinite(value) && text.find_first_of(".eE") == std::string::npos) {
+    text += ".0";
+  }
+  return text;
 }
 
 // DataTypeToPythonString removed — now uses DataTypeToString from dtype.h

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -11,19 +11,20 @@
 
 #include <algorithm>
 #include <any>
+#include <charconv>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iomanip>
 #include <ios>
-#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
@@ -327,19 +328,19 @@ class IRPythonPrinter : public IRVisitor {
 
 // Helper function to format float literals with decimal point.
 //
-// For non-integer values we emit ``max_digits10`` for ``float`` (= 9 digits)
-// — the minimum precision required for an FP32 value to round-trip bit-exactly
-// through print → parse, *provided the parser FP32-snaps* ``ConstFloat.value_``
-// on read. The current parser does NOT snap (it stores the parsed double as-is
-// — see KNOWN_ISSUES.md / the ConstFloat ingest path), so an FP32-truncated
-// value re-parsed by a non-snapping reader can still differ in the lowest bits
-// from the original. The 9-digit emission is the print-side half of the
-// round-trip contract; fixing the parser side closes the loop. PyPTO's default
-// ConstFloat dtype is FP32, so this is the relevant precision for the vast
-// majority of constants the printer sees (e.g. Cody-Waite reduction constants
-// emitted by LowerCompositeOps). The default ``float_format`` (general / %g-style)
-// strips trailing zeros, so simple values like ``0.5`` still print as ``0.5``
-// rather than ``0.500000000``.
+// For non-integer values we emit the *shortest* decimal that parses back to the
+// exact same ``double`` (``std::to_chars`` with no precision argument). This is
+// what makes ``ConstFloat`` (and float kwargs / attrs) round-trip bit-exactly
+// through print → parse: the parser stores ``ConstFloat.value_`` as the FP64
+// value it reads, so the printed text must encode the full ``double`` regardless
+// of the constant's ``dtype_``. The shortest-form output keeps simple values
+// readable — ``0.1`` prints as ``0.1`` (not ``0.10000000000000001``) and the
+// FP32-representable Cody-Waite constants emitted by ``LowerCompositeOps`` print
+// with exactly as many digits as their ``double`` needs (e.g.
+// ``0.31830987334251404``).
+//
+// Integer-valued doubles are formatted as ``X.0`` so they re-parse as floats
+// (a bare ``4`` would parse as ``ConstInt``); ``std::to_chars`` would emit ``4``.
 std::string FormatFloatLiteral(double value) {
   // Check if the value is an integer (no fractional part)
   if (value == std::floor(value)) {
@@ -347,13 +348,13 @@ std::string FormatFloatLiteral(double value) {
     std::ostringstream oss;
     oss << std::fixed << std::setprecision(1) << value;
     return oss.str();
-  } else {
-    // For non-integer values, use enough precision to round-trip an FP32
-    // value bit-exactly through print → parse → implicit float-cast.
-    std::ostringstream oss;
-    oss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
-    return oss.str();
   }
+  // For non-integer values, emit the shortest round-tripping decimal.
+  char buf[32];
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value);
+  INTERNAL_CHECK(ec == std::errc()) << "Internal error: std::to_chars failed to format float literal "
+                                    << value;
+  return std::string(buf, ptr);
 }
 
 // DataTypeToPythonString removed — now uses DataTypeToString from dtype.h

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -19,29 +19,6 @@ and ``tile.cast`` — no sin/cos remain after the pass.
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
-from pypto.pypto_core import passes as _core_passes
-
-
-@pytest.fixture(autouse=True)
-def pass_verification_context():
-    """Override the global roundtrip-verification fixture for this module.
-
-    The parser stores ``ConstFloat.value_`` as a Python ``float`` (FP64) without
-    snapping to the IR's ``FP32`` dtype, so the FP32-representable Cody-Waite
-    constants emitted by ``LowerCompositeOps`` (e.g. ``1/pi`` = ``0.31830988732818603515625``)
-    cannot round-trip bit-exactly through print → parse → ``assert_structural_equal``.
-    The C++ field-based equality compares the raw ``double`` values, which differ
-    after the lossy text trip even though both represent the same FP32 number.
-
-    Falling back to ``BEFORE_AND_AFTER`` keeps property verification on while
-    skipping the roundtrip check that depends on a print/parse-side fix.
-    """
-    instruments: list[_core_passes.PassInstrument] = [
-        _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
-    ]
-    with _core_passes.PassContext(instruments):
-        yield
-
 
 # Primitive tile ops the decomposition is allowed to emit (besides framework
 # infrastructure ops like tile.load / tile.store / tile.move that wrap the


### PR DESCRIPTION
## Summary

- `FormatFloatLiteral` (in `python_printer.cpp`) printed non-integer floats with a fixed 9 significant digits (`std::numeric_limits<float>::max_digits10`). That precision only round-trips when the parser re-snaps the value to FP32 — but the parser stores `ConstFloat.value_` as the FP64 value it reads, so the field-based `assert_structural_equal` compared a different `double` than was emitted. Full-precision FP32 constants (e.g. the Cody-Waite reduction constants emitted by `LowerCompositeOps`) failed the `print → parse → assert_structural_equal` round-trip under the default `roundtrip` verification mode.
- Switch to `std::to_chars` with no precision argument — it emits the **shortest decimal that parses back to the exact same `double`**. This round-trips bit-exactly regardless of the constant's dtype and keeps simple literals readable (`0.1` stays `"0.1"`, not `"0.10000000000000001"`). Integer-valued doubles still print as `X.0` so they re-parse as `ConstFloat` rather than `ConstInt`.
- Removes the now-unnecessary `pass_verification_context` autouse fixture in `tests/ut/ir/transforms/test_lower_composite_ops.py` that downgraded the module to `BEFORE_AND_AFTER` as a workaround — that module now runs under full `roundtrip` verification again.

## Testing

- [x] `cmake --build build --parallel` — clean compile + link
- [x] Full unit suite: `tests/ut/` → 4561 passed, 27 skipped
- [x] Targeted: `test_lower_composite_ops*.py`, `tests/ut/ir/printing/`, `tests/ut/ir/parser/`, `tests/ut/ir/operators/test_tensor_ops.py` → all pass
- [x] `clang-tidy --diff-base` — clean; `clang-format`, `cpplint`, `ruff`, `pyright` (pre-commit) — pass
- [x] Code review completed
- [x] No documentation references float-literal printing precision — no docs update needed

## Related Issues

None (was tracked as a local `KNOWN_ISSUES.md` entry).