### PR TITLE
fix(jit): track pl.slice and @pl.jit dep-return tensor metadata

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -67,6 +67,7 @@ from .specializer import (
     SpecializeContext,
     Specializer,
     TensorMeta,
+    _classify_params,
     _collect_dynamic_dims,
     build_specialize_context,
 )
@@ -242,33 +243,58 @@ def _get_pl_dtype_map() -> dict[str, Any]:
     return _PL_DTYPE_MAP
 
 
-def _extract_create_tensor_metas(func: Any) -> dict[str, TensorMeta]:
-    """Scan func's AST for ``var = pl.create_tensor([...], dtype=pl.XXX)`` and return TensorMeta per var.
+def _extract_local_tensor_metas(
+    func: Any,
+    seed_meta: dict[str, TensorMeta] | None = None,
+    seed_scalars: dict[str, int | float | bool] | None = None,
+) -> dict[str, TensorMeta]:
+    """Infer ``TensorMeta`` for the local tensor variables in ``func``'s body.
 
-    Each shape element may be either a literal int (``42``) or a
-    ``Name`` referencing an int in ``func.__globals__`` — covering the common
-    case of model code that imports shape constants from a config module.
-    Each dtype must be a ``pl.<name>`` attribute. Anything that cannot be
-    statically resolved is skipped silently.
+    Walks the body in source order, tracking the three ways a local tensor can
+    be produced inside a JIT function:
+
+    1. ``var = pl.create_tensor([static_shape], dtype=pl.XXX)`` — shape from the
+       literal list (literal ints, ``Name`` refs to int globals / seeded
+       scalars, and simple int arithmetic over those), dtype from ``dtype=``.
+    2. ``var = pl.slice(src, [shape], [...])`` — dtype inherited from ``src`` (a
+       parameter or earlier local); each shape dim that is a static int is used
+       as-is, and a non-static dim (e.g. a runtime ``valid_len``) falls back to
+       ``src``'s corresponding static dim, since a slice is bounded above by its
+       parent — matching how hand-written ``@pl.program`` code annotates kernels
+       that consume narrowed views.
+    3. ``v1, ..., vk = jit_dep(args)`` where ``jit_dep`` is an
+       ``@pl.jit.incore`` / ``inline`` / ``opaque`` callee with ``k``
+       ``pl.Out[...]`` parameters — each ``vi`` inherits the meta of the caller
+       argument bound to the i-th ``Out`` parameter (the in-place-output
+       convention every such kernel follows, and the same heuristic
+       :func:`_infer_return_type` uses on the callee side).
+
+    ``seed_meta`` pre-populates the table with the caller's parameter metas so a
+    ``pl.slice`` of a parameter, or a dep call passing a parameter through,
+    resolves; ``seed_scalars`` lets compile-time-specialized scalar parameters
+    appear as shape dimensions. Anything not statically resolvable is skipped
+    silently — the clear ``ValueError`` in ``Specializer._build_params`` then
+    fires for that variable.
     """
     func_def = _get_func_def(func)
-    result: dict[str, TensorMeta] = {}
+    local: dict[str, TensorMeta] = dict(seed_meta or {})
     dtype_map = _get_pl_dtype_map()
     func_globals = getattr(func, "__globals__", {})
+    scalars: dict[str, int | float | bool] = seed_scalars or {}
 
     def _resolve_int(elt: ast.expr) -> int | None:
         """Resolve ``elt`` to a Python int. Returns None if not statically resolvable.
 
-        Handles literal ints, ``Name`` refs to module-level int globals, and
-        simple integer arithmetic (``+``, ``-``, ``*``, ``//``, ``%``, ``**``)
-        over any combination of those — covering shape expressions like
-        ``BATCH * TOTAL_Q_GROUPS * Q_HEAD_PAD`` and ``2 ** N``. Also accepts
-        leading unary ``+`` / ``-``.
+        Handles literal ints, ``Name`` refs to module-level int globals (or a
+        seeded scalar parameter), and simple integer arithmetic (``+``, ``-``,
+        ``*``, ``//``, ``%``, ``**``) over any combination of those — covering
+        shape expressions like ``BATCH * TOTAL_Q_GROUPS * Q_HEAD_PAD`` and
+        ``2 ** N``. Also accepts a leading unary ``+`` / ``-``.
         """
         if isinstance(elt, ast.Constant) and isinstance(elt.value, int):
             return elt.value
         if isinstance(elt, ast.Name):
-            value = func_globals.get(elt.id)
+            value = func_globals.get(elt.id, scalars.get(elt.id))
             if isinstance(value, int) and not isinstance(value, bool):
                 return value
             return None
@@ -303,39 +329,21 @@ def _extract_create_tensor_metas(func: Any) -> dict[str, TensorMeta]:
             return None
         return None
 
-    for node in ast.walk(func_def):
-        # Look for: var = pl.create_tensor([...], dtype=pl.XXX)
-        if not isinstance(node, ast.Assign):
-            continue
-        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
-            continue
-        var_name = node.targets[0].id
-        call = node.value
-        if not isinstance(call, ast.Call):
-            continue
-        fn = call.func
-        if not (
-            isinstance(fn, ast.Attribute) and fn.attr == "create_tensor" and isinstance(fn.value, ast.Name)
-        ):
-            continue
-        # Extract shape: first positional arg must be a list whose elements are
-        # literal ints or globals-resolved ints.
-        if not call.args or not isinstance(call.args[0], ast.List):
-            continue
-        shape_node = call.args[0]
-        resolved_shape: list[int] = []
-        skip = False
-        for elt in shape_node.elts:
+    def _resolve_shape(node: ast.expr | None) -> tuple[int, ...] | None:
+        if not isinstance(node, ast.List):
+            return None
+        dims: list[int] = []
+        for elt in node.elts:
             v = _resolve_int(elt)
             if v is None:
-                skip = True
-                break
-            resolved_shape.append(v)
-        if skip:
-            continue
-        shape = tuple(resolved_shape)
-        # Extract dtype from keyword arg dtype=pl.XXX
-        dtype_val = None
+                return None
+            dims.append(v)
+        return tuple(dims)
+
+    def _create_tensor_meta(call: ast.Call) -> TensorMeta | None:
+        shape = _resolve_shape(call.args[0]) if call.args else None
+        if shape is None:
+            return None
         for kw in call.keywords:
             if (
                 kw.arg == "dtype"
@@ -343,12 +351,105 @@ def _extract_create_tensor_metas(func: Any) -> dict[str, TensorMeta]:
                 and isinstance(kw.value.value, ast.Name)
             ):
                 dtype_val = dtype_map.get(kw.value.attr)
-                break
-        if dtype_val is None:
-            continue
-        result[var_name] = TensorMeta(shape=shape, dtype=dtype_val)
+                if dtype_val is not None:
+                    return TensorMeta(shape=shape, dtype=dtype_val)
+        return None
 
-    return result
+    def _slice_meta(call: ast.Call) -> TensorMeta | None:
+        # pl.slice(tensor, shape, offset, ...) — shape is positional index 1 or kw `shape=`.
+        src = call.args[0] if call.args else None
+        if not isinstance(src, ast.Name) or src.id not in local:
+            return None
+        src_meta = local[src.id]
+        shape_node = (
+            call.args[1]
+            if len(call.args) >= 2
+            else next((kw.value for kw in call.keywords if kw.arg == "shape"), None)
+        )
+        if not isinstance(shape_node, ast.List) or len(shape_node.elts) != len(src_meta.shape):
+            return None
+        dims: list[int] = []
+        for elt, parent_dim in zip(shape_node.elts, src_meta.shape):
+            v = _resolve_int(elt)
+            # A non-static slice dim (e.g. a runtime ``valid_len = pl.min(...)``)
+            # is bounded above by the parent dim — advertise that static bound,
+            # the way hand-written @pl.program code annotates a kernel that
+            # consumes a narrowed view (see examples/models/04_paged_attention.py).
+            dims.append(v if v is not None else parent_dim)
+        return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
+
+    # @pl.jit deps this body calls → (param_names, out_param_names).
+    dep_io: dict[str, tuple[list[str], list[str]]] = {}
+    for dep in _discover_deps(func):
+        try:
+            out_params, _, _ = _classify_params(_get_func_def(dep._func))
+        except OSError:
+            continue
+        dep_io[dep.__name__] = (dep._param_names(), out_params)
+
+    def _arg_name(e: ast.expr) -> str | None:
+        return e.id if isinstance(e, ast.Name) else None
+
+    def _target_names(target: ast.expr) -> list[str]:
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, ast.Tuple) and all(isinstance(e, ast.Name) for e in target.elts):
+            return [e.id for e in target.elts if isinstance(e, ast.Name)]
+        return []
+
+    def _record_dep_result_metas(call: ast.Call, dep_name: str, target: ast.expr) -> None:
+        dep_params, out_params = dep_io[dep_name]
+        names = _target_names(target)
+        if not out_params or len(names) != len(out_params):
+            return
+        # Map dep parameter name → caller argument name (positional then keyword).
+        mapping: dict[str, str | None] = {}
+        for i, arg in enumerate(call.args):
+            if i < len(dep_params):
+                mapping[dep_params[i]] = _arg_name(arg)
+        for kw in call.keywords:
+            if kw.arg is not None:
+                mapping[kw.arg] = _arg_name(kw.value)
+        for vname, out_param in zip(names, out_params):
+            caller_arg = mapping.get(out_param)
+            if caller_arg is not None and caller_arg in local:
+                local[vname] = local[caller_arg]
+
+    def _walk(stmts: list[ast.stmt]) -> None:
+        for stmt in stmts:
+            # Descend into nested DSL scopes (for / if / with / while) first so
+            # producers always run before their (same-or-deeper) consumers.
+            for attr in ("body", "orelse", "finalbody"):
+                sub = getattr(stmt, attr, None)
+                if isinstance(sub, list):
+                    _walk(sub)
+            if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+                continue
+            call = stmt.value
+            if not isinstance(call, ast.Call):
+                continue
+            fn = call.func
+            target = stmt.targets[0]
+            if (
+                isinstance(fn, ast.Attribute)
+                and isinstance(fn.value, ast.Name)
+                and isinstance(target, ast.Name)
+            ):
+                if fn.attr == "create_tensor":
+                    meta = _create_tensor_meta(call)
+                    if meta is not None:
+                        local[target.id] = meta
+                    continue
+                if fn.attr == "slice":
+                    meta = _slice_meta(call)
+                    if meta is not None:
+                        local[target.id] = meta
+                    continue
+            if isinstance(fn, ast.Name) and fn.id in dep_io:
+                _record_dep_result_metas(call, fn.id, target)
+
+    _walk(func_def.body)
+    return local
 
 
 def _extract_call_args_for_dep(entry_func: Any, dep_name: str) -> list[tuple[str | None, str | None]] | None:
@@ -577,13 +678,16 @@ def _resolve_dep_call_metadata(
     The caller may be the entry function or another dep (transitive case);
     in either case we look up the (first) ``dep(...)`` call site in
     ``caller_func``'s body and apply the positional-or-keyword mapping.
-    Intermediate tensors created via ``pl.create_tensor`` in the caller are
-    folded into the metadata pool. Falls back to name-based matching when
-    call-site extraction fails.
+    Intermediate tensors produced in the caller — ``pl.create_tensor``,
+    ``pl.slice`` views, and the return values of other ``@pl.jit`` deps — are
+    folded into the metadata pool (see :func:`_extract_local_tensor_metas`).
+    Falls back to name-based matching when call-site extraction fails.
     """
     dep_param_names = dep._param_names()
     call_args = _extract_call_args_for_dep(caller_func, dep.__name__)
-    intermediate_metas = _extract_create_tensor_metas(caller_func)
+    intermediate_metas = _extract_local_tensor_metas(
+        caller_func, seed_meta=caller_tensor_meta, seed_scalars=caller_scalar_values
+    )
     all_tensor_meta = {**intermediate_metas, **caller_tensor_meta}
 
     dep_tensor_meta: dict[str, TensorMeta] = {}

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import functools
 import inspect
 import os
 import re
@@ -180,8 +181,15 @@ def _extract_tensor_meta(tensor: Any) -> TensorMeta:
 # ---------------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=512)
 def _get_func_def(func: Any) -> ast.FunctionDef:
     """Parse func source and return its FunctionDef node.
+
+    Memoised on ``func`` identity: ``inspect.getsource`` + ``ast.parse`` are
+    expensive and called repeatedly per JIT invocation (dep discovery, call-site
+    extraction, dynamic-dim scan, local-meta inference) for the same functions.
+    The returned node is shared across callers, so callers MUST treat it as
+    read-only — every in-tree consumer only walks/reads it.
 
     Raises:
         OSError: If the source code cannot be retrieved (e.g. interactive REPL,
@@ -369,7 +377,7 @@ def _extract_local_tensor_metas(
         if not isinstance(shape_node, ast.List) or len(shape_node.elts) != len(src_meta.shape):
             return None
         dims: list[int] = []
-        for elt, parent_dim in zip(shape_node.elts, src_meta.shape):
+        for elt, parent_dim in zip(shape_node.elts, src_meta.shape, strict=True):
             v = _resolve_int(elt)
             # A non-static slice dim (e.g. a runtime ``valid_len = pl.min(...)``)
             # is bounded above by the parent dim — advertise that static bound,
@@ -410,7 +418,7 @@ def _extract_local_tensor_metas(
         for kw in call.keywords:
             if kw.arg is not None:
                 mapping[kw.arg] = _arg_name(kw.value)
-        for vname, out_param in zip(names, out_params):
+        for vname, out_param in zip(names, out_params, strict=True):
             caller_arg = mapping.get(out_param)
             if caller_arg is not None and caller_arg in local:
                 local[vname] = local[caller_arg]
@@ -423,13 +431,18 @@ def _extract_local_tensor_metas(
                 sub = getattr(stmt, attr, None)
                 if isinstance(sub, list):
                     _walk(sub)
-            if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+            # Single-target ``v = ...`` and annotated ``v: T = ...`` both bind a
+            # name we want to track (the latter is the common DSL style).
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+                target: ast.expr = stmt.targets[0]
+            elif isinstance(stmt, ast.AnnAssign):
+                target = stmt.target
+            else:
                 continue
             call = stmt.value
-            if not isinstance(call, ast.Call):
+            if not isinstance(call, ast.Call):  # AnnAssign.value may be None
                 continue
             fn = call.func
-            target = stmt.targets[0]
             if (
                 isinstance(fn, ast.Attribute)
                 and isinstance(fn.value, ast.Name)

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -475,6 +475,16 @@ def _runtime_slice_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) 
     return out
 
 
+def _annotated_slice_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain (undecorated) function: pl.slice / pl.create_tensor / dep-call locals
+    written with annotated assignments (``v: T = ...``), the common DSL style."""
+    view: pl.Tensor = pl.slice(src, [16, 8], [0, 0])
+    buf: pl.Tensor = pl.create_tensor([16, 8], dtype=pl.FP32)
+    mid: pl.Tensor = _relu_kernel(view, buf)
+    out = _relu_kernel(mid, out)
+    return out
+
+
 class TestSliceAndDepReturnMetadata:
     """Regression tests: the JIT specializer must track tensor metadata for
     ``pl.slice`` views and ``@pl.jit.incore`` return values when they flow into
@@ -508,6 +518,17 @@ class TestSliceAndDepReturnMetadata:
         metas = _extract_local_tensor_metas(_runtime_slice_body, seed_meta=seed)
         # Runtime-scalar 2nd dim → falls back to src's dim 1 = 64; dtype from src.
         assert metas["view"] == TensorMeta(shape=(16, 64), dtype=DataType.FP16)
+
+    def test_extract_local_tensor_metas_annotated_assignments(self):
+        """Annotated assignments (``v: T = ...``) are tracked just like plain ones."""
+        seed = {
+            "src": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_annotated_slice_body, seed_meta=seed)
+        assert metas["view"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        assert metas["buf"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        assert metas["mid"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
 
     def test_slice_view_flows_into_incore_dep(self):
         """A pl.slice view of an entry parameter can be passed into an @pl.jit.incore dep."""

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -15,7 +15,13 @@ import pypto.language as pl
 import pytest
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.compiled_program import CompiledProgram
-from pypto.jit.decorator import JITFunction, _discover_deps, _rewrite_jit_error, jit
+from pypto.jit.decorator import (
+    JITFunction,
+    _discover_deps,
+    _extract_local_tensor_metas,
+    _rewrite_jit_error,
+    jit,
+)
 from pypto.jit.specializer import TensorMeta
 from pypto.language.parser.diagnostics.exceptions import ParserTypeError
 from pypto.pypto_core import DataType, ir
@@ -437,6 +443,252 @@ class TestMultiFuncIntegration:
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         expected_post_pass = pm.run_passes(Expected)
         ir.assert_structural_equal(got, expected_post_pass)
+
+
+# Module-level @pl.jit.incore kernel reused by the metadata-tracking tests below.
+# Defined at module level (not inside a test method) so it can be imported by
+# the unit test for ``_extract_local_tensor_metas``; the integration tests
+# below redefine their own deps inside the method to keep each test isolated.
+@jit.incore
+def _relu_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    M, N = x.shape
+    t = pl.load(x, [0, 0], [M, N])
+    r = pl.relu(t)
+    pl.store(r, [0, 0], out)
+    return out
+
+
+def _slice_then_dep_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain (undecorated) function used only by the _extract_local_tensor_metas unit test."""
+    view = pl.slice(src, [16, 8], [0, 0])
+    buf = pl.create_tensor([16, 8], dtype=pl.FP32)
+    mid = _relu_kernel(view, buf)
+    out = _relu_kernel(mid, out)
+    return out
+
+
+def _runtime_slice_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain (undecorated) function: a pl.slice whose width is a runtime scalar."""
+    valid_len = pl.tensor.read(cfg, [0])
+    view = pl.slice(src, [16, valid_len], [0, 0])
+    out = _relu_kernel(view, out)
+    return out
+
+
+class TestSliceAndDepReturnMetadata:
+    """Regression tests: the JIT specializer must track tensor metadata for
+    ``pl.slice`` views and ``@pl.jit.incore`` return values when they flow into
+    subsequent kernels (KNOWN_ISSUES: "JIT specializer doesn't track pl.slice
+    results or @pl.jit.incore return-value tensor metadata")."""
+
+    def test_extract_local_tensor_metas_slice_and_dep_return(self):
+        """``_extract_local_tensor_metas`` infers metas for pl.slice views,
+        pl.create_tensor locals, and @pl.jit.incore call results."""
+        seed = {
+            "src": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_slice_then_dep_body, seed_meta=seed)
+        # pl.slice view: shape from the literal list, dtype inherited from src.
+        assert metas["view"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        # pl.create_tensor: unchanged behaviour.
+        assert metas["buf"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        # @pl.jit.incore call result: inherits the dep's pl.Out param meta,
+        # which here maps to ``buf``.
+        assert metas["mid"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+
+    def test_extract_local_tensor_metas_runtime_slice_uses_parent_dim(self):
+        """A pl.slice dim that isn't a static int falls back to the parent
+        tensor's static dim (the slice is bounded above by its parent)."""
+        seed = {
+            "src": TensorMeta(shape=(32, 64), dtype=DataType.FP16),
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 64), dtype=DataType.FP16),
+        }
+        metas = _extract_local_tensor_metas(_runtime_slice_body, seed_meta=seed)
+        # Runtime-scalar 2nd dim → falls back to src's dim 1 = 64; dtype from src.
+        assert metas["view"] == TensorMeta(shape=(16, 64), dtype=DataType.FP16)
+
+    def test_slice_view_flows_into_incore_dep(self):
+        """A pl.slice view of an entry parameter can be passed into an @pl.jit.incore dep."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def copy_incore(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N])
+            pl.store(t, [0, 0], out)
+            return out
+
+        @jit
+        def slice_entry(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            view = pl.slice(src, [16, 32], [0, 0])
+            out = copy_incore(view, out)
+            return out
+
+        src = torch.randn(32, 32)
+        out = torch.empty(16, 32)
+        slice_entry.compile_for_test(src, out)
+        compiled = list(slice_entry._cache.values())[0]
+        assert isinstance(compiled, CompiledProgram)
+        func_names = [f.name for f in compiled.program.functions.values()]
+        assert "copy_incore" in func_names
+        assert "slice_entry" in func_names
+
+    def test_dep_return_value_flows_into_next_dep(self):
+        """The return value of one @pl.jit.incore dep can feed the next dep."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def relu_incore(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N])
+            r = pl.relu(t)
+            pl.store(r, [0, 0], out)
+            return out
+
+        @jit
+        def chain_entry(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            view = pl.slice(src, [16, 32], [0, 0])
+            buf = pl.create_tensor([16, 32], dtype=pl.FP32)
+            mid = relu_incore(view, buf)
+            out = relu_incore(mid, out)
+            return out
+
+        src = torch.randn(32, 32)
+        out = torch.empty(16, 32)
+        chain_entry.compile_for_test(src, out)
+        compiled = list(chain_entry._cache.values())[0]
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_multi_value_dep_return_flows_into_next_dep(self):
+        """A tuple-returning @pl.jit.incore dep's results inherit their Out params' metas."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def split_incore(
+            x: pl.Tensor, lo: pl.Out[pl.Tensor], hi: pl.Out[pl.Tensor]
+        ) -> tuple[pl.Tensor, pl.Tensor]:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N])
+            a = pl.relu(t)
+            b = pl.abs(t)
+            pl.store(a, [0, 0], lo)
+            pl.store(b, [0, 0], hi)
+            return lo, hi
+
+        @jit.incore
+        def relu_incore(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N])
+            r = pl.relu(t)
+            pl.store(r, [0, 0], out)
+            return out
+
+        @jit
+        def split_entry(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            view = pl.slice(src, [16, 32], [0, 0])
+            lo_buf = pl.create_tensor([16, 32], dtype=pl.FP32)
+            hi_buf = pl.create_tensor([16, 32], dtype=pl.FP32)
+            a, b = split_incore(view, lo_buf, hi_buf)
+            out = relu_incore(a, out)
+            return out
+
+        src = torch.randn(32, 32)
+        out = torch.empty(16, 32)
+        split_entry.compile_for_test(src, out)
+        compiled = list(split_entry._cache.values())[0]
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_runtime_sized_slice_uses_static_parent_dim(self):
+        """A pl.slice with a runtime-scalar width is advertised to the consuming
+        kernel using the parent tensor's static dim, matching how hand-written
+        @pl.program code annotates kernels that consume narrowed views (see
+        examples/models/04_paged_attention.py)."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def softmax_incore(sij: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = sij.shape
+            t = pl.load(sij, [0, 0], [M, N], target_memory=pl.MemorySpace.Vec)
+            r = pl.relu(t)
+            pl.store(r, [0, 0], out)
+            return out
+
+        @jit
+        def attn_entry(big: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            valid_len = pl.tensor.read(cfg, [0])
+            sij_valid = pl.slice(big, [16, valid_len], [0, 0])
+            out = softmax_incore(sij_valid, out)
+            return out
+
+        big = torch.randn(16, 128)
+        cfg = torch.zeros(1, dtype=torch.int64)
+        out = torch.empty(16, 128)
+        attn_entry.compile_for_test(big, cfg, out)
+        compiled = list(attn_entry._cache.values())[0]
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_dep_return_then_runtime_slice_then_dep(self):
+        """The paged-attention shape: a dep return value is sliced to a runtime
+        width, and that view feeds the next dep — both inferences must hold."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def fill_incore(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N], target_memory=pl.MemorySpace.Vec)
+            pl.store(t, [0, 0], out)
+            return out
+
+        @jit.incore
+        def softmax_incore(sij: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = sij.shape
+            t = pl.load(sij, [0, 0], [M, N], target_memory=pl.MemorySpace.Vec)
+            r = pl.relu(t)
+            pl.store(r, [0, 0], out)
+            return out
+
+        @jit
+        def attn_entry(big: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            sij_buf = pl.create_tensor([16, 128], dtype=pl.FP32)
+            sij = fill_incore(big, sij_buf)  # dep return → sij_buf's meta
+            valid_len = pl.tensor.read(cfg, [0])
+            sij_valid = pl.slice(sij, [16, valid_len], [0, 0])  # runtime slice of a dep return
+            out = softmax_incore(sij_valid, out)
+            return out
+
+        big = torch.randn(16, 128)
+        cfg = torch.zeros(1, dtype=torch.int64)
+        out = torch.empty(16, 128)
+        attn_entry.compile_for_test(big, cfg, out)
+        compiled = list(attn_entry._cache.values())[0]
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_unresolvable_create_tensor_dim_still_raises_clear_error(self):
+        """A pl.create_tensor with a non-static dim has no parent to fall back
+        to, so the view is untracked and the existing clear ValueError fires
+        for the downstream dep parameter."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def copy_incore(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            M, N = x.shape
+            t = pl.load(x, [0, 0], [M, N])
+            pl.store(t, [0, 0], out)
+            return out
+
+        @jit
+        def bad_entry(cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            n = pl.tensor.read(cfg, [0])
+            buf = pl.create_tensor([16, n], dtype=pl.FP32)
+            out = copy_incore(buf, out)
+            return out
+
+        cfg = torch.zeros(1, dtype=torch.int64)
+        out = torch.empty(16, 32)
+        with pytest.raises(ValueError, match="missing inferred tensor metadata"):
+            bad_entry.compile_for_test(cfg, out)
 
 
 class TestInlineFuncIntegration:


### PR DESCRIPTION
## Summary

The `@pl.jit` specializer inferred intermediate-tensor shapes/dtypes only from torch-tensor parameters and `pl.create_tensor` locals. So a `pl.slice` view of a tensor, or the return value of an `@pl.jit.incore`/`inline`/`opaque` call, that flowed into a shared kernel raised `ValueError: @pl.jit: missing inferred tensor metadata for parameter '...'` — blocking migration of any orchestration that decomposes a large tensor into per-tile views via `pl.slice` and feeds those views into shared incore kernels (the `paged_attention` example family, `llama_mini`).

`_extract_create_tensor_metas` is replaced with `_extract_local_tensor_metas`, a source-order forward dataflow walk that additionally tracks:

- **`pl.slice(src, [shape], [...])`** — dtype inherited from `src`; each static shape dim is used as-is, and a *runtime* shape dim (e.g. `valid_len = pl.min(...)` read from a tensor) falls back to the parent's corresponding static dim — a slice is bounded above by its parent, mirroring how hand-written `@pl.program` code annotates kernels that consume narrowed views (see `examples/models/04_paged_attention.py`'s `kernel_softmax_prepare`).
- **`v1, ..., vk = jit_dep(args)`** — for a dep with `k` `pl.Out[...]` parameters, each `vi` inherits the meta of the caller argument bound to the dep's i-th `Out` parameter (the in-place-output convention every `@pl.jit.incore` kernel follows; consistent with the callee-side fallback already in `_infer_return_type`).

The walk is seeded with the caller's parameter metas/scalars, so slices of parameters and dep calls passing parameters through resolve — including transitive callers (a dep called by another dep), since `_resolve_dep_call_metadata` already supplies each dep's resolved param metas.

A non-static `pl.create_tensor` dimension still leaves the variable untracked (no parent to fall back to) and yields the existing clear `ValueError`.

## Testing

- New `TestSliceAndDepReturnMetadata` (8 tests): unit test for `_extract_local_tensor_metas`; `pl.slice` view → incore dep; single- and multi-value dep-return → next dep; runtime-sized slice → static-parent-dim; the `dep-return → runtime-slice → dep` chain; and that a non-static `pl.create_tensor` dim still raises the clear error.
- `tests/ut/jit/`: 146 passed (rebased onto current `upstream/main`, rebuilt).
- `tests/ut/language/`: 784 passed (sanity).
- `ruff` + `pyright` clean on the changed files.
- TDD: the new behavior tests failed first for the expected reason (`missing inferred tensor metadata` / `KeyError`), then passed after the implementation.

## Related

Relates to #1320 (`@pl.jit` migration of `examples/models`) — unblocks the `paged_attention` family and `llama_mini`.