### PR TITLE
feat(diagnostics): summarize perf hints on console, detail to log file

### DIFF
--- a/docs/en/dev/passes/92-diagnostics.md
+++ b/docs/en/dev/passes/92-diagnostics.md
@@ -22,7 +22,7 @@ Severity is independent of phase. A `Warning` may run at `PrePipeline`; a `PerfH
 | `Warning` | Likely mistake or pass bug | `LOG_WARN` to stderr, in full | `disabled_diagnostics` set |
 | `PerfHint` | Advisory tuning suggestion | `${ReportInstrument.output_dir}/perf_hints.log` if a report instrument is in the context (always true via `compile()` / `pl.jit`), with stderr getting a one-line `LOG_INFO` summary that points at the file. With no report instrument: each hint printed in full to stderr via `LOG_INFO`. | `disabled_diagnostics` set |
 
-The release default for `PYPTO_LOG_LEVEL` is `INFO`, so the `[perf_hint] N hints …` summary (or, without a report instrument, the full `[perf_hint PH…] …` lines) reaches the console out of the box. Override with `PYPTO_LOG_LEVEL=warn` to mute perf hints on stderr (the file output is independent). The per-hint detail always lands in `perf_hints.log` regardless of log level.
+The release default for `PYPTO_LOG_LEVEL` is `INFO`, so the `[perf_hint] N hints …` summary (or, without a report instrument, the full `[perf_hint PH…] …` lines) reaches the console out of the box. Override with `PYPTO_LOG_LEVEL=warn` to mute perf hints on stderr. When a report instrument is present the per-hint detail still lands in `perf_hints.log` regardless of log level (the file output is independent); without one there is no file, so muting stderr drops perf hints entirely.
 
 ## How a check fires
 

--- a/docs/en/dev/passes/92-diagnostics.md
+++ b/docs/en/dev/passes/92-diagnostics.md
@@ -19,10 +19,10 @@ Severity is independent of phase. A `Warning` may run at `PrePipeline`; a `PerfH
 | Severity | When | Output | Suppression |
 | -------- | ---- | ------ | ----------- |
 | `Error` | IR is invalid | `VerificationError` thrown | Cannot be suppressed |
-| `Warning` | Likely mistake or pass bug | `LOG_WARN` to stderr | `disabled_diagnostics` set |
-| `PerfHint` | Advisory tuning suggestion | `LOG_INFO` to stderr (visible at default release log level) **plus** `${ReportInstrument.output_dir}/perf_hints.log` if a report instrument is in the context | `disabled_diagnostics` set |
+| `Warning` | Likely mistake or pass bug | `LOG_WARN` to stderr, in full | `disabled_diagnostics` set |
+| `PerfHint` | Advisory tuning suggestion | `${ReportInstrument.output_dir}/perf_hints.log` if a report instrument is in the context (always true via `compile()` / `pl.jit`), with stderr getting a one-line `LOG_INFO` summary that points at the file. With no report instrument: each hint printed in full to stderr via `LOG_INFO`. | `disabled_diagnostics` set |
 
-The release default for `PYPTO_LOG_LEVEL` is `INFO`, so `[perf_hint ...]` lines reach the console out of the box. Override with `PYPTO_LOG_LEVEL=warn` to mute them on stderr (the file output is independent).
+The release default for `PYPTO_LOG_LEVEL` is `INFO`, so the `[perf_hint] N hints …` summary (or, without a report instrument, the full `[perf_hint PH…] …` lines) reaches the console out of the box. Override with `PYPTO_LOG_LEVEL=warn` to mute perf hints on stderr (the file output is independent). The per-hint detail always lands in `perf_hints.log` regardless of log level.
 
 ## How a check fires
 
@@ -36,7 +36,7 @@ PassPipeline::Run(program)
  └─ ctx.RunAfterPipeline(program)            (instrument hooks)
 ```
 
-`EmitDiagnostics` routes Warning to `LOG_WARN`, PerfHint to `LOG_INFO`, and additionally appends PerfHint lines to `perf_hints.log` when a `ReportInstrument` is in the active context.
+`EmitDiagnostics` prints Warnings in full via `LOG_WARN`. For PerfHints: when a `ReportInstrument` is in the active context it appends every hint to `perf_hints.log` and emits a single `LOG_INFO` summary line (`[perf_hint] N hints across M sites; see <path>`) to stderr; otherwise it prints each hint in full via `LOG_INFO`.
 
 ## Registering a new check
 
@@ -80,25 +80,31 @@ Adding a new backend implements these alongside the existing virtuals; perf-hint
 
 ### First check: `TileInnermostDimGranularity` (PH001)
 
-Inspects every `tile.load` and `tile.store` op. When the innermost-dimension byte size (`shape[-1] * sizeof(dtype)`) is below `GetRecommendedInnermostDimBytes()`, emits one diagnostic per op pointing at the user-source span.
+Inspects every `tile.load` and `tile.store` op. When the innermost-dimension byte size (`shape[-1] * sizeof(dtype)`) is below `GetRecommendedInnermostDimBytes()`, emits one diagnostic per op pointing at the user-source span. With a `ReportInstrument` in the context the full set goes to `perf_hints.log` and the console only sees the summary line; without one, each hint prints to stderr.
 
-Example output (from `examples/kernels/08_assemble.py` on Ascend950):
+Example: console summary plus `perf_hints.log` content (from `examples/kernels/08_assemble.py` on Ascend950):
 
 ```text
+# stderr:
+[perf_hint] 2 hints across 2 sites; see /tmp/build/perf_hints.log
+
+# /tmp/build/perf_hints.log:
 [perf_hint PH001] TileInnermostDimGranularity: tile.load has innermost dim = 64B; recommended >= 128B for backend a5 (L2 cache line = 512B). Consider increasing tile shape on the innermost axis. at examples/kernels/08_assemble.py:60:4
+[perf_hint PH001] TileInnermostDimGranularity: tile.store has innermost dim = 64B; recommended >= 128B for backend a5 (L2 cache line = 512B). Consider increasing tile shape on the innermost axis. at examples/kernels/08_assemble.py:60:4
 ```
 
 ## User-facing API
 
 ```python
-# Default: perf hints fire on stderr at end of pipeline.
+# No report instrument: each perf hint prints in full on stderr at end of pipeline.
 with passes.PassContext([]):
     pipeline.run(program)
 
-# Persist perf hints to disk too — file lives next to other reports.
+# With a report instrument (the compile()/pl.jit default): full detail goes to
+# perf_hints.log next to the other reports; stderr just gets the one-line summary.
 with passes.PassContext([passes.ReportInstrument("/tmp/build")]):
     pipeline.run(program)
-# → /tmp/build/perf_hints.log
+# → /tmp/build/perf_hints.log  (stderr: "[perf_hint] N hints across M sites; see …")
 
 # Suppress a specific hint.
 disabled = passes.DiagnosticCheckSet()

--- a/docs/zh-cn/dev/passes/92-diagnostics.md
+++ b/docs/zh-cn/dev/passes/92-diagnostics.md
@@ -22,7 +22,7 @@ Severity 与 phase 解耦：`Warning` 可以在 `PrePipeline` 触发，`PerfHint
 | `Warning` | 疑似用户错误或 pass bug | 完整输出至 stderr（`LOG_WARN`） | `disabled_diagnostics` 集合 |
 | `PerfHint` | 建议性调优提示 | 上下文中存在 `ReportInstrument` 时（经 `compile()` / `pl.jit` 时恒为真）每条 hint 写入 `${ReportInstrument.output_dir}/perf_hints.log`，stderr 仅打印一行指向该文件的 `LOG_INFO` 摘要；若无 `ReportInstrument`，则每条 hint 完整输出至 stderr（`LOG_INFO`）。 | `disabled_diagnostics` 集合 |
 
-`PYPTO_LOG_LEVEL` release 默认值为 `INFO`，因此 `[perf_hint] N hints …` 摘要行（无 `ReportInstrument` 时为完整的 `[perf_hint PH…] …` 行）开箱可见。设置 `PYPTO_LOG_LEVEL=warn` 可在 stderr 上静音性能提示（文件输出独立）。无论日志级别如何，逐条详情始终写入 `perf_hints.log`。
+`PYPTO_LOG_LEVEL` release 默认值为 `INFO`，因此 `[perf_hint] N hints …` 摘要行（无 `ReportInstrument` 时为完整的 `[perf_hint PH…] …` 行）开箱可见。设置 `PYPTO_LOG_LEVEL=warn` 可在 stderr 上静音性能提示。上下文中存在 `ReportInstrument` 时，无论日志级别如何逐条详情仍写入 `perf_hints.log`（文件输出独立）；若无 `ReportInstrument` 则没有该文件，静音 stderr 会彻底丢弃性能提示。
 
 ## 触发流程
 

--- a/docs/zh-cn/dev/passes/92-diagnostics.md
+++ b/docs/zh-cn/dev/passes/92-diagnostics.md
@@ -19,10 +19,10 @@ Severity 与 phase 解耦：`Warning` 可以在 `PrePipeline` 触发，`PerfHint
 | Severity | 何时使用 | 输出 | 抑制方式 |
 | -------- | -------- | ---- | -------- |
 | `Error` | IR 不合法 | 抛出 `VerificationError` | 不可抑制 |
-| `Warning` | 疑似用户错误或 pass bug | `LOG_WARN` 至 stderr | `disabled_diagnostics` 集合 |
-| `PerfHint` | 建议性调优提示 | `LOG_INFO` 至 stderr（默认 release 日志级别可见），并在上下文中存在 `ReportInstrument` 时附加写入 `${ReportInstrument.output_dir}/perf_hints.log` | `disabled_diagnostics` 集合 |
+| `Warning` | 疑似用户错误或 pass bug | 完整输出至 stderr（`LOG_WARN`） | `disabled_diagnostics` 集合 |
+| `PerfHint` | 建议性调优提示 | 上下文中存在 `ReportInstrument` 时（经 `compile()` / `pl.jit` 时恒为真）每条 hint 写入 `${ReportInstrument.output_dir}/perf_hints.log`，stderr 仅打印一行指向该文件的 `LOG_INFO` 摘要；若无 `ReportInstrument`，则每条 hint 完整输出至 stderr（`LOG_INFO`）。 | `disabled_diagnostics` 集合 |
 
-`PYPTO_LOG_LEVEL` release 默认值为 `INFO`，因此 `[perf_hint ...]` 行开箱可见。设置 `PYPTO_LOG_LEVEL=warn` 可在 stderr 上静音（文件输出独立）。
+`PYPTO_LOG_LEVEL` release 默认值为 `INFO`，因此 `[perf_hint] N hints …` 摘要行（无 `ReportInstrument` 时为完整的 `[perf_hint PH…] …` 行）开箱可见。设置 `PYPTO_LOG_LEVEL=warn` 可在 stderr 上静音性能提示（文件输出独立）。无论日志级别如何，逐条详情始终写入 `perf_hints.log`。
 
 ## 触发流程
 
@@ -36,7 +36,7 @@ PassPipeline::Run(program)
  └─ ctx.RunAfterPipeline(program)         （instrument 钩子）
 ```
 
-`EmitDiagnostics` 将 Warning 路由到 `LOG_WARN`，PerfHint 路由到 `LOG_INFO`，并在上下文中存在 `ReportInstrument` 时把 PerfHint 行附加到 `perf_hints.log`。
+`EmitDiagnostics` 将 Warning 以完整形式经 `LOG_WARN` 输出。对 PerfHint：上下文中存在 `ReportInstrument` 时把每条 hint 附加到 `perf_hints.log`，并向 stderr 输出一行 `LOG_INFO` 摘要（`[perf_hint] N hints across M sites; see <path>`）；否则每条 hint 完整经 `LOG_INFO` 输出。
 
 ## 注册新的检查项
 
@@ -80,25 +80,31 @@ Register(DiagnosticCheck::MyCheck,
 
 ### 第一项检查：`TileInnermostDimGranularity` (PH001)
 
-检查每个 `tile.load` / `tile.store` 操作。当最内层维度的字节数（`shape[-1] * sizeof(dtype)`）低于 `GetRecommendedInnermostDimBytes()` 时，对每个 op 发一条 diagnostic，指向用户源代码 span。
+检查每个 `tile.load` / `tile.store` 操作。当最内层维度的字节数（`shape[-1] * sizeof(dtype)`）低于 `GetRecommendedInnermostDimBytes()` 时，对每个 op 发一条 diagnostic，指向用户源代码 span。上下文中存在 `ReportInstrument` 时全部写入 `perf_hints.log`，stderr 仅见摘要行；否则每条 hint 输出到 stderr。
 
-示例输出（`examples/kernels/08_assemble.py`，Ascend950）：
+示例：stderr 摘要 + `perf_hints.log` 内容（`examples/kernels/08_assemble.py`，Ascend950）：
 
 ```text
+# stderr：
+[perf_hint] 2 hints across 2 sites; see /tmp/build/perf_hints.log
+
+# /tmp/build/perf_hints.log：
 [perf_hint PH001] TileInnermostDimGranularity: tile.load has innermost dim = 64B; recommended >= 128B for backend a5 (L2 cache line = 512B). Consider increasing tile shape on the innermost axis. at examples/kernels/08_assemble.py:60:4
+[perf_hint PH001] TileInnermostDimGranularity: tile.store has innermost dim = 64B; recommended >= 128B for backend a5 (L2 cache line = 512B). Consider increasing tile shape on the innermost axis. at examples/kernels/08_assemble.py:60:4
 ```
 
 ## 用户面 API
 
 ```python
-# 默认：perf hint 在 pipeline 末尾通过 stderr 输出
+# 无 report instrument：每条 perf hint 在 pipeline 末尾完整输出到 stderr
 with passes.PassContext([]):
     pipeline.run(program)
 
-# 同时持久化到磁盘——文件与其他 report 同目录
+# 有 report instrument（compile() / pl.jit 的默认行为）：完整详情写入与其他 report
+# 同目录的 perf_hints.log，stderr 仅得到一行摘要
 with passes.PassContext([passes.ReportInstrument("/tmp/build")]):
     pipeline.run(program)
-# → /tmp/build/perf_hints.log
+# → /tmp/build/perf_hints.log （stderr："[perf_hint] N hints across M sites; see …"）
 
 # 抑制单个 hint
 disabled = passes.DiagnosticCheckSet()

--- a/include/pypto/ir/transforms/pass_context.h
+++ b/include/pypto/ir/transforms/pass_context.h
@@ -39,11 +39,14 @@ class Pass;
 /**
  * @brief Emit a batch of diagnostics from the unified diagnostic channel.
  *
- * Routes Warning severity to LOG_WARN and PerfHint severity to LOG_INFO.
- * If a `ReportInstrument` is in the active context, PerfHint diagnostics are
- * also appended to `${ReportInstrument.output_dir}/perf_hints.log` so build
- * logs persist across runs. Error severity is rejected by INTERNAL_CHECK —
- * errors should be thrown via `VerificationError`, not emitted here.
+ * Warning severity always prints in full via LOG_WARN. PerfHint severity is
+ * appended to `${ReportInstrument.output_dir}/perf_hints.log` when a
+ * `ReportInstrument` is in the active context; in that case the console gets a
+ * single LOG_INFO summary line (`[perf_hint] N hints across M sites; see
+ * <path>`) instead of one line per hint, so build logs stay readable. With no
+ * `ReportInstrument` there is no file, so each PerfHint is printed in full via
+ * LOG_INFO. Error severity is rejected by INTERNAL_CHECK — errors should be
+ * thrown via `VerificationError`, not emitted here.
  *
  * @param diags Diagnostics to emit. May be empty (no-op).
  * @param phase_label Human-readable label for the source phase
@@ -193,10 +196,11 @@ class ReportInstrument : public PassInstrument {
  *
  * Checks declare their phase at registration; this instrument fires each
  * check at every pass boundary and the registry filters by phase. Output is
- * dispatched by `EmitDiagnostics` which routes Warning to `LOG_WARN` and
- * PerfHint to `LOG_INFO`, and additionally appends PerfHint diagnostics to
- * `${ReportInstrument.output_dir}/perf_hints.log` when a `ReportInstrument`
- * is in the active context.
+ * dispatched by `EmitDiagnostics`: Warnings print in full via `LOG_WARN`;
+ * PerfHints are appended to `${ReportInstrument.output_dir}/perf_hints.log`
+ * when a `ReportInstrument` is in the active context, with the console getting
+ * a single `LOG_INFO` summary line in that case (and the full per-hint lines
+ * otherwise).
  *
  * For advanced use outside PassPipeline or fine-grained per-instrument
  * control. PassPipeline::Run runs the registered checks directly without

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -12,9 +12,11 @@
 #include "pypto/ir/transforms/pass_context.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <ios>
 #include <mutex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -185,10 +187,26 @@ std::string FindReportOutputDir() {
 void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& phase_label) {
   if (diags.empty()) return;
 
-  // 1. stderr — every diagnostic, gated by LogLevel.
+  // PerfHint detail is persisted to `${ReportInstrument.output_dir}/perf_hints.log`
+  // only when a ReportInstrument is registered. When that file exists we collapse
+  // perf hints to a single console summary that points at it; otherwise (bare
+  // PassPipeline, some tools/tests) we keep printing each hint so they don't go
+  // dark. Regular warnings always print in full.
+  const std::string dir = FindReportOutputDir();
+  const std::string perf_log_path = dir.empty() ? std::string{} : dir + "/perf_hints.log";
+
+  std::size_t perf_hint_count = 0;
+  for (const auto& d : diags) {
+    if (d.severity == DiagnosticSeverity::PerfHint) ++perf_hint_count;
+  }
+  const bool summarize_perf_hints = perf_hint_count > 0 && !perf_log_path.empty();
+
+  // 1. stderr — every diagnostic, gated by LogLevel; perf hints collapsed to a
+  //    summary line when their detail is going to perf_hints.log instead.
   for (const auto& d : diags) {
     INTERNAL_CHECK(d.severity != DiagnosticSeverity::Error)
         << "Error severity must not flow through DiagnosticInstrument: " << d.rule_name;
+    if (d.severity == DiagnosticSeverity::PerfHint && summarize_perf_hints) continue;
     const std::string line = FormatDiagnosticLine(d, phase_label);
     if (d.severity == DiagnosticSeverity::Warning) {
       LOG_WARN << line;
@@ -196,19 +214,25 @@ void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& ph
       LOG_INFO << line;
     }
   }
+  if (summarize_perf_hints) {
+    std::set<std::string> sites;
+    for (const auto& d : diags) {
+      if (d.severity == DiagnosticSeverity::PerfHint && d.span.is_valid()) {
+        sites.insert(d.span.to_string());
+      }
+    }
+    std::ostringstream summary;
+    summary << "[perf_hint] " << perf_hint_count << (perf_hint_count == 1 ? " hint" : " hints");
+    if (!sites.empty()) {
+      summary << " across " << sites.size() << (sites.size() == 1 ? " site" : " sites");
+    }
+    summary << "; see " << perf_log_path;
+    LOG_INFO << summary.str();
+  }
 
   // 2. File — only PerfHint, only when a ReportInstrument is registered.
-  const std::string dir = FindReportOutputDir();
-  if (dir.empty()) return;
-
-  bool has_perf_hint = false;
-  for (const auto& d : diags) {
-    if (d.severity == DiagnosticSeverity::PerfHint) {
-      has_perf_hint = true;
-      break;
-    }
-  }
-  if (!has_perf_hint) return;
+  // (`summarize_perf_hints` is exactly `perf_hint_count > 0 && !perf_log_path.empty()`.)
+  if (!summarize_perf_hints) return;
 
   // PassContext is thread-local, but multiple threads can run concurrent
   // pipelines whose distinct ReportInstruments happen to share an output
@@ -216,10 +240,9 @@ void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& ph
   static std::mutex perf_hints_log_mu;
   std::scoped_lock lock(perf_hints_log_mu);
 
-  const std::string path = dir + "/perf_hints.log";
-  std::ofstream f(path, std::ios::app);
+  std::ofstream f(perf_log_path, std::ios::app);
   if (!f.is_open()) {
-    LOG_WARN << "Failed to open " << path << " for perf-hint append";
+    LOG_WARN << "Failed to open " << perf_log_path << " for perf-hint append";
     return;
   }
   for (const auto& d : diags) {

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -195,16 +195,23 @@ void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& ph
   const std::string dir = FindReportOutputDir();
   const std::string perf_log_path = dir.empty() ? std::string{} : dir + "/perf_hints.log";
 
+  // Single pre-scan: count perf hints and collect their distinct source sites,
+  // but only when we'll actually write a perf_hints.log to point users at.
   std::size_t perf_hint_count = 0;
-  for (const auto& d : diags) {
-    if (d.severity == DiagnosticSeverity::PerfHint) ++perf_hint_count;
+  std::set<std::string> perf_hint_sites;
+  if (!perf_log_path.empty()) {
+    for (const auto& d : diags) {
+      if (d.severity != DiagnosticSeverity::PerfHint) continue;
+      ++perf_hint_count;
+      if (d.span.is_valid()) perf_hint_sites.insert(d.span.to_string());
+    }
   }
-  const bool summarize_perf_hints = perf_hint_count > 0 && !perf_log_path.empty();
+  const bool summarize_perf_hints = perf_hint_count > 0;  // implies !perf_log_path.empty()
 
   // 1. stderr — every diagnostic, gated by LogLevel; perf hints collapsed to a
   //    summary line when their detail is going to perf_hints.log instead.
   for (const auto& d : diags) {
-    INTERNAL_CHECK(d.severity != DiagnosticSeverity::Error)
+    INTERNAL_CHECK_SPAN(d.severity != DiagnosticSeverity::Error, d.span)
         << "Error severity must not flow through DiagnosticInstrument: " << d.rule_name;
     if (d.severity == DiagnosticSeverity::PerfHint && summarize_perf_hints) continue;
     const std::string line = FormatDiagnosticLine(d, phase_label);
@@ -215,23 +222,16 @@ void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& ph
     }
   }
   if (summarize_perf_hints) {
-    std::set<std::string> sites;
-    for (const auto& d : diags) {
-      if (d.severity == DiagnosticSeverity::PerfHint && d.span.is_valid()) {
-        sites.insert(d.span.to_string());
-      }
-    }
     std::ostringstream summary;
     summary << "[perf_hint] " << perf_hint_count << (perf_hint_count == 1 ? " hint" : " hints");
-    if (!sites.empty()) {
-      summary << " across " << sites.size() << (sites.size() == 1 ? " site" : " sites");
+    if (!perf_hint_sites.empty()) {
+      summary << " across " << perf_hint_sites.size() << (perf_hint_sites.size() == 1 ? " site" : " sites");
     }
     summary << "; see " << perf_log_path;
     LOG_INFO << summary.str();
   }
 
   // 2. File — only PerfHint, only when a ReportInstrument is registered.
-  // (`summarize_perf_hints` is exactly `perf_hint_count > 0 && !perf_log_path.empty()`.)
   if (!summarize_perf_hints) return;
 
   // PassContext is thread-local, but multiple threads can run concurrent
@@ -242,7 +242,13 @@ void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& ph
 
   std::ofstream f(perf_log_path, std::ios::app);
   if (!f.is_open()) {
-    LOG_WARN << "Failed to open " << perf_log_path << " for perf-hint append";
+    // Last resort: the console summary already pointed at this file, but we
+    // can't write it — don't drop the detail; fall back to per-hint stderr.
+    LOG_WARN << "Failed to open " << perf_log_path
+             << " for perf-hint append; emitting hints to stderr instead";
+    for (const auto& d : diags) {
+      if (d.severity == DiagnosticSeverity::PerfHint) LOG_INFO << FormatDiagnosticLine(d, phase_label);
+    }
     return;
   }
   for (const auto& d : diags) {

--- a/tests/ut/pass/test_diagnostic_instrument.py
+++ b/tests/ut/pass/test_diagnostic_instrument.py
@@ -309,6 +309,37 @@ def test_perf_hint_visible_at_default_log_level(capfd):
         assert re.search(r"\[perf_hint PH001\]", combined), f"perf hint not in output:\n{combined}"
 
 
+def test_perf_hint_console_summarized_with_report_instrument(tmp_path, capfd):
+    """With a ReportInstrument present, the console gets a one-line perf-hint
+    summary while the per-hint detail goes only to perf_hints.log.
+
+    Addresses issue #1305's first ask: stop printing one console line per PH001
+    hit. The summary line (``[perf_hint] N hint(s) ... see <path>``) replaces the
+    individual ``[perf_hint PH001] ... at <string>:...`` lines on stderr; the log
+    file still carries every hint verbatim.
+    """
+    report = passes.ReportInstrument(str(tmp_path))
+    _run_pipeline_with_perf_hint([report])
+
+    # Detail still lands in the log file, one line per hit.
+    log = tmp_path / "perf_hints.log"
+    assert log.exists()
+    assert "[perf_hint PH001]" in log.read_text()
+
+    captured = capfd.readouterr()
+    combined = captured.out + captured.err
+    # Native stderr capture is platform-dependent; only assert when present.
+    if combined:
+        assert re.search(r"\[perf_hint\] \d+ hint", combined), (
+            f"expected a one-line perf-hint summary on the console:\n{combined}"
+        )
+        assert "[perf_hint PH001]" not in combined, (
+            f"per-hint lines should be suppressed on the console when a "
+            f"ReportInstrument is present:\n{combined}"
+        )
+        assert "perf_hints.log" in combined, f"summary should point at the log file:\n{combined}"
+
+
 # ---------------------------------------------------------------------------
 # DiagnosticCheckSet is unhashable (mutable via insert/remove)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reduces console noise from performance-hint diagnostics (PH001 and any future `PHxxx`). Today every perf hint is one `LOG_INFO` line on stderr, *and* every perf hint is appended to `${ReportInstrument.output_dir}/perf_hints.log` when a `ReportInstrument` is in the context (always true via `compile()` / `pl.jit`). A tuned kernel can emit ~24 PH001 lines per compile, mostly duplicates — see #1305.

After this change, when perf hints fire **and** a `ReportInstrument` is registered, the console gets **one** line instead of N:

```
[perf_hint] 2 hints across 2 sites; see /tmp/build/perf_hints.log
```

`perf_hints.log` is unchanged — full per-hint detail, one `[perf_hint PH001] …` line each. With no `ReportInstrument` (bare `PassPipeline()`, some tools/tests) each perf hint is still printed in full so they don't go dark. Regular `Warning`-severity diagnostics are untouched (still printed in full via `LOG_WARN`). Log level mapping is unchanged: the summary stays at `LOG_INFO`, so `PYPTO_LOG_LEVEL=warn` still mutes it.

This addresses the **first** ask of #1305 only — the bigger items (memory-space-aware thresholds, DSL source-span mapping, naming the controlling `*_CHUNK` constant, file-level dedup, reporting the `(shape, dtype, target_memory)` tuple) are out of scope here. The new `across M sites` count gives a cheap read on how much real signal hides under the duplicates.

## Changes

- `src/ir/transforms/pass_context.cpp` — `EmitDiagnostics`: compute `perf_hint_count` and `perf_log_path` up front; when both are set, skip the per-hint `LOG_INFO` lines and emit one summary line (count + unique-site count + path); file-append loop unchanged. Added `<cstddef>` (`std::size_t`) and `<set>`.
- `include/pypto/ir/transforms/pass_context.h` — updated `EmitDiagnostics` / `DiagnosticInstrument` doc comments.
- `docs/en/dev/passes/92-diagnostics.md` + `docs/zh-cn/dev/passes/92-diagnostics.md` — severity table, `EmitDiagnostics` description, PH001 example (stderr summary + log content), user-facing API snippet.
- `tests/ut/pass/test_diagnostic_instrument.py` — new `test_perf_hint_console_summarized_with_report_instrument`: asserts `perf_hints.log` keeps full `[perf_hint PH001]` detail while the console shows `[perf_hint] N hint…` and not the per-hint lines.

## Testing

- [x] Build clean (RelWithDebInfo, parallel) — no warnings
- [x] `clang-tidy --diff-base HEAD` — clean
- [x] `tests/ut/pass/test_diagnostic_instrument.py` — 15 passed (incl. the new test; watched it fail against pre-change code first)
- [x] Full `tests/ut/` suite — 4562 passed, 27 skipped
- [x] code-review skill — PASS
- [x] Rebased onto current `upstream/main`, no conflicts

## Related Issues

Addresses the first ask of #1305 (does not close it — the remaining asks stay open).