### PR TITLE
fix(ci): Align Daily CI toolchain pins

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,6 +1,10 @@
 name: Daily CI
 
 on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
     - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
   workflow_dispatch:
@@ -12,8 +16,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.32
-      PTOAS_SHA256: 325198dff677d7d163e16ce0aed27aa08c119764a4f50a60092b0edcd2e0784b
+      PTOAS_VERSION: v0.36
+      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -64,7 +68,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout d5bcc23
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -108,8 +112,8 @@ jobs:
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.32
-      PTOAS_SHA256: 325198dff677d7d163e16ce0aed27aa08c119764a4f50a60092b0edcd2e0784b
+      PTOAS_VERSION: v0.36
+      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
     steps:
       - uses: actions/checkout@v4
         with:
@@ -143,7 +147,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout d5bcc23
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -153,7 +157,7 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=d5bcc23 \
+            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=2c607938 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   notify-on-failure:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,10 +1,6 @@
 name: Daily CI
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
   workflow_dispatch:

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -39,6 +39,17 @@ def _write_files(files: dict[str, str], output_dir: str) -> None:
             f.write(content)
 
 
+def _backend_type_for_platform(platform: str | None, fallback: BackendType) -> BackendType:
+    """Return the codegen backend selected by a runtime platform string."""
+    if platform is None:
+        return fallback
+    if platform in ("a2a3", "a2a3sim"):
+        return BackendType.Ascend910B
+    if platform in ("a5", "a5sim"):
+        return BackendType.Ascend950
+    raise ValueError(f"Invalid platform {platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'.")
+
+
 def compile(  # noqa: PLR0913
     program: _ir_core.Program,
     output_dir: str | None = None,
@@ -82,7 +93,8 @@ def compile(  # noqa: PLR0913
             wall-clock timings.  Results are written to ``output_dir/report/``.
         platform: Target execution platform.  One of ``"a2a3sim"``,
             ``"a2a3"``, ``"a5sim"``, or ``"a5"``.  Defaults to the
-            simulator for the given *backend_type*.
+            simulator for the given *backend_type*.  When set, it also
+            selects the matching codegen backend.
         distributed_config: Optional :class:`DistributedConfig` for L3+
             distributed programs.  When ``None`` (default), auto-detected
             from the program: if L3+ functions are found, a default
@@ -101,7 +113,8 @@ def compile(  # noqa: PLR0913
         >>> c = compiled(a, b)          # return style
         >>> compiled(a, b, c, config=RunConfig(device_id=1))  # specify device
     """
-    _backend_core.set_backend_type(backend_type)
+    effective_backend_type = _backend_type_for_platform(platform, backend_type)
+    _backend_core.set_backend_type(effective_backend_type)
 
     if output_dir is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -207,7 +220,7 @@ def compile(  # noqa: PLR0913
         return DistributedCompiledProgram(
             transformed_program,
             output_dir,
-            backend_type=backend_type,
+            backend_type=effective_backend_type,
             platform=platform,
             distributed_config=distributed_config,
         )
@@ -215,6 +228,6 @@ def compile(  # noqa: PLR0913
     return CompiledProgram(
         program,
         output_dir,
-        backend_type=backend_type,
+        backend_type=effective_backend_type,
         platform=platform,
     )

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -15,7 +15,8 @@ from unittest.mock import patch
 
 import pytest
 import torch
-from pypto import DataType, ir
+from pypto import DataType, backend, ir
+from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _extract_param_infos
 from pypto.runtime import DeviceTensor
 
@@ -304,6 +305,45 @@ class TestCompileReturnsCompiledProgram:
         assert result.output_dir.is_dir()
         # Metadata works on the original program
         assert result.param_names == ["a", "b", "c"]
+
+    def test_compile_platform_selects_codegen_backend(self, tmp_path):
+        """platform='a5sim' should compile with the Ascend950 PTO backend."""
+        import pypto.language as pl  # noqa: PLC0415
+
+        backend.reset_for_testing()
+        try:
+
+            @pl.program
+            class SimpleAdd:
+                @pl.function(type=pl.FunctionType.InCore)
+                def add_kernel(
+                    self,
+                    a: pl.Tensor[[128, 128], pl.FP32],
+                    b: pl.Tensor[[128, 128], pl.FP32],
+                    c: pl.Tensor[[128, 128], pl.FP32],
+                ):
+                    tile_a = pl.tile.load(a, offsets=[0, 0], shapes=[128, 128])
+                    tile_b = pl.tile.load(b, offsets=[0, 0], shapes=[128, 128])
+                    tile_c = pl.tile.add(tile_a, tile_b)
+                    pl.tile.store(tile_c, offsets=[0, 0], output_tensor=c)
+
+            output_dir = str(tmp_path / "compiled_a5")
+            result = ir.compile(
+                SimpleAdd,
+                output_dir=output_dir,
+                dump_passes=False,
+                skip_ptoas=True,
+                platform="a5sim",
+            )
+
+            pto_files = list(result.output_dir.rglob("*.pto"))
+            assert isinstance(result, CompiledProgram)
+            assert result.backend_type == BackendType.Ascend950
+            assert result.platform == "a5sim"
+            assert pto_files
+            assert 'pto.target_arch = "a5"' in pto_files[0].read_text()
+        finally:
+            backend.reset_for_testing()
 
 
 class TestExtractParamInfosScalar:


### PR DESCRIPTION
## Summary
- Align Daily CI PTOAS pins with the regular CI workflow (`v0.36`, `698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc`).
- Update Daily CI `pto-isa` checkout and A5 `--pto-isa-commit` from `d5bcc23` to `2c607938`.
- Make `ir.compile(..., platform=...)` select the matching codegen backend so A5 JIT/ST runs emit `pto.target_arch = "a5"` and use A5 PTOAS flags.

## Failure Analysis
- The A5 CI log showed CANN rejecting PTOAS-generated `pipe_barrier(PIPE_V)` in `test_assemble.py` cases.
- After the PTOAS/pto-isa pin update, direct JIT calls still passed `platform="a5"` into `ir.compile()` while `ir.compile()` kept the default Ascend910B backend. That could generate A2/A3-target PTO and then assemble it with the A5 runtime toolchain.
- With this patch, the same assemble kernels generate PTO with `pto.target_arch = "a5"`; local PTOAS emits legal `pipe_barrier(PIPE_ALL)` for the nested assemble case.

## Testing
- `git diff --check`
- Parsed `.github/workflows/daily_ci.yml` with PyYAML
- `pre-commit run --files python/pypto/ir/compile.py tests/ut/ir/test_compiled_program.py`
- `PYTHONPATH=$(pwd)/python python -m pytest tests/ut/runtime/test_run_config.py tests/ut/backend/test_backend_handler.py tests/ut/ir/test_compiled_program.py::TestCompileReturnsCompiledProgram -v`
- `task-submit --device auto --run "python models/qwen3/14b/qwen3_14b_prefill.py -p a2a3 -d ${TASK_DEVICE}"` passed on a2a3 with latest `pypto-lib`
- Generated and `compile_and_assemble`-validated the three failed A5 assemble kernels (`test_tile_assemble_vec`, `test_tile_assemble_loop_col_broadcast`, `test_tile_assemble_double_loop_broadcast`) with `platform="a5"` and `--pto-isa-commit=2c607938`; all emitted `pto.target_arch = "a5"` and assembled successfully.

## Notes
- A full A5 device-execution `task-submit` run for the three assemble tests hung in the first test after compile/collection, so it was stopped to release the device lock. This did not reproduce the CI compiler failure; the compile-and-assemble path for that failure now passes.

Fixes #1284 
