### PR TITLE
feat(codegen): support tuple-return worker calls in distributed codegen

### DIFF
--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -142,6 +142,12 @@ class DistributedCodegen : public CodegenBase {
   // assignments that have already been emitted in _alloc_intermediates.
   std::unordered_set<const ir::AssignStmt*> hoisted_allocs_;
   bool host_orch_body_after_hoist_{false};
+
+  // Tuple-return support: maps (tuple_tmp_var_name, element_index) to the
+  // actual Out/InOut parameter tensor name in tensors[...].  Populated by
+  // EmitCallToWorker when the callee has a TupleType return; consumed by
+  // VisitStmt_(AssignStmt) when it encounters TupleGetItemExpr unpacking.
+  std::map<std::pair<std::string, int>, std::string> tuple_element_tensors_;
 };
 
 }  // namespace codegen

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -570,8 +570,13 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // parameter tensor.  In simpler's runtime model, the callee writes in-place
   // to the OUT parameter, so the return value is the same tensor.
   if (!target.empty() && !callee->return_types_.empty()) {
+    // Tuple return is expressed in two ways in the IR:
+    //   1. pl.Tuple[T1, T2] → return_types_ = [TupleType(T1, T2)]  (single entry)
+    //   2. tuple[T1, T2]    → return_types_ = [T1, T2]             (flat entries)
+    // Both produce TupleGetItemExpr for unpacking, so handle both.
     bool is_tuple_return =
-        std::dynamic_pointer_cast<const ir::TupleType>(callee->return_types_.front()) != nullptr;
+        std::dynamic_pointer_cast<const ir::TupleType>(callee->return_types_.front()) != nullptr ||
+        callee->return_types_.size() > 1;
     if (is_tuple_return) {
       // Tuple return: populate tuple_element_tensors_ so that downstream
       // TupleGetItemExpr AssignStmts resolve each element to its Out param.

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -50,6 +50,7 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
   used_levels_.clear();
   hoisted_allocs_.clear();
   host_orch_body_after_hoist_ = false;
+  tuple_element_tensors_.clear();
 
   ClassifyFunctions();
   CHECK(!workers_.empty() || !orchestrators_.empty())
@@ -287,6 +288,23 @@ void DistributedCodegen::VisitStmt_(const ir::AssignStmtPtr& op) {
   // name for downstream tensors[...] references but emit nothing here.
   if (host_orch_body_after_hoist_ && hoisted_allocs_.count(op.get())) {
     declared_vars_.insert(var_name);
+    return;
+  }
+
+  // Handle TupleGetItemExpr: `out_rms = tuple_tmp[i]` produced by multi-return
+  // function call unpacking.  Resolve each element to its actual Out/InOut
+  // parameter tensor recorded in tuple_element_tensors_ during EmitCallToWorker.
+  if (auto tge = std::dynamic_pointer_cast<const ir::TupleGetItemExpr>(op->value_)) {
+    VisitExpr(tge->tuple_);
+    std::string tuple_var = current_expr_value_;
+    current_expr_value_ = "";
+    auto it = tuple_element_tensors_.find(std::make_pair(tuple_var, tge->index_));
+    INTERNAL_CHECK_SPAN(it != tuple_element_tensors_.end(), op->span_)
+        << "Internal error: TupleGetItemExpr unpacking found no Out parameter "
+        << "for tuple var '" << tuple_var << "' index " << tge->index_;
+    emitter_.EmitLine("tensors[\"" + var_name + "\"] = tensors[\"" + it->second + "\"]");
+    declared_vars_.insert(var_name);
+    current_target_var_ = "";
     return;
   }
 
@@ -548,15 +566,35 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // parameter tensor.  In simpler's runtime model, the callee writes in-place
   // to the OUT parameter, so the return value is the same tensor.
   if (!target.empty() && !callee->return_types_.empty()) {
-    // Find the first Out/InOut parameter — that is the tensor the return value aliases
-    for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
-      if (callee->param_directions_[i] == ir::ParamDirection::Out ||
-          callee->param_directions_[i] == ir::ParamDirection::InOut) {
-        VisitExpr(call->args_[i]);
-        std::string out_arg = current_expr_value_;
-        current_expr_value_ = "";
-        emitter_.EmitLine("tensors[\"" + target + "\"] = tensors[\"" + out_arg + "\"]");
-        break;
+    bool is_tuple_return = std::dynamic_pointer_cast<const ir::TupleType>(
+                               callee->return_types_.front()) != nullptr;
+    if (is_tuple_return) {
+      // Tuple return: populate tuple_element_tensors_ so that downstream
+      // TupleGetItemExpr AssignStmts resolve each element to its Out param.
+      // Do NOT emit a tensors["target"] alias here — the individual
+      // TupleGetItemExpr unpacking statements handle per-element aliasing.
+      int out_idx = 0;
+      for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+        if (callee->param_directions_[i] == ir::ParamDirection::Out ||
+            callee->param_directions_[i] == ir::ParamDirection::InOut) {
+          VisitExpr(call->args_[i]);
+          std::string out_arg = current_expr_value_;
+          current_expr_value_ = "";
+          tuple_element_tensors_[std::make_pair(target, out_idx)] = out_arg;
+          ++out_idx;
+        }
+      }
+    } else {
+      // Single return: alias target to the first Out/InOut parameter tensor.
+      for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+        if (callee->param_directions_[i] == ir::ParamDirection::Out ||
+            callee->param_directions_[i] == ir::ParamDirection::InOut) {
+          VisitExpr(call->args_[i]);
+          std::string out_arg = current_expr_value_;
+          current_expr_value_ = "";
+          emitter_.EmitLine("tensors[\"" + target + "\"] = tensors[\"" + out_arg + "\"]");
+          break;
+        }
       }
     }
   }

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
@@ -295,6 +296,9 @@ void DistributedCodegen::VisitStmt_(const ir::AssignStmtPtr& op) {
   // function call unpacking.  Resolve each element to its actual Out/InOut
   // parameter tensor recorded in tuple_element_tensors_ during EmitCallToWorker.
   if (auto tge = std::dynamic_pointer_cast<const ir::TupleGetItemExpr>(op->value_)) {
+    INTERNAL_CHECK_SPAN(ir::AsVarLike(tge->tuple_) != nullptr, op->span_)
+        << "Internal error: TupleGetItemExpr tuple_ must be a Var-like expression "
+        << "for distributed codegen tuple-return unpacking";
     VisitExpr(tge->tuple_);
     std::string tuple_var = current_expr_value_;
     current_expr_value_ = "";
@@ -566,8 +570,8 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // parameter tensor.  In simpler's runtime model, the callee writes in-place
   // to the OUT parameter, so the return value is the same tensor.
   if (!target.empty() && !callee->return_types_.empty()) {
-    bool is_tuple_return = std::dynamic_pointer_cast<const ir::TupleType>(
-                               callee->return_types_.front()) != nullptr;
+    bool is_tuple_return =
+        std::dynamic_pointer_cast<const ir::TupleType>(callee->return_types_.front()) != nullptr;
     if (is_tuple_return) {
       // Tuple return: populate tuple_element_tensors_ so that downstream
       // TupleGetItemExpr AssignStmts resolve each element to its Out param.

--- a/tests/st/distributed/test_l3_tuple_return.py
+++ b/tests/st/distributed/test_l3_tuple_return.py
@@ -1,0 +1,117 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed runtime test: tuple-return worker calls.
+
+Exercises the distributed codegen tuple_element_tensors_ mapping added in
+commit c98c36fc ("feat(codegen): support tuple-return worker calls in
+distributed codegen").
+
+Three hierarchy levels:
+  - HOST Orchestrator: dispatches chip worker, unpacks tuple return
+  - Chip Orchestration: manages InCore kernel dispatch on device
+  - InCore: tile-level kernel computing sum and diff simultaneously
+
+Computation:
+  - out_sum  = a + b
+  - out_diff = a - b
+
+Verifies: tuple-returning chip worker correctly maps each tuple element
+to its corresponding Out parameter tensor via TupleGetItemExpr unpacking
+in the distributed codegen.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+
+@pl.program
+class L3TupleReturnProgram:
+    """L3: HOST orch → CHIP worker with tuple return (sum + diff)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_sum_diff(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_sum = pl.add(tile_a, tile_b)
+        tile_diff = pl.sub(tile_a, tile_b)
+        r_sum = pl.store(tile_sum, [0, 0], out_sum)
+        r_diff = pl.store(tile_diff, [0, 0], out_diff)
+        return r_sum, r_diff
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        s, d = self.tile_sum_diff(a, b, out_sum, out_diff)
+        return s, d
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        s, d = self.chip_orch(a, b, out_sum, out_diff)
+        return s, d
+
+
+class TestL3TupleReturn:
+    """L3 distributed runtime: tuple-return worker calls."""
+
+    def test_execute(self, test_config, device_ids):
+        """End-to-end: compile + execute, verify out_sum = a+b, out_diff = a-b."""
+        compiled = ir.compile(
+            L3TupleReturnProgram,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:1],
+                block_dim=3,
+                aicpu_thread_num=4,
+            ),
+        )
+
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        out_sum = torch.zeros((128, 128), dtype=torch.float32)
+        out_diff = torch.zeros((128, 128), dtype=torch.float32)
+
+        compiled(a, b, out_sum, out_diff)
+
+        expected_sum = torch.full((128, 128), 5.0, dtype=torch.float32)
+        expected_diff = torch.full((128, 128), -1.0, dtype=torch.float32)
+        assert torch.allclose(out_sum, expected_sum, rtol=1e-5, atol=1e-5), (
+            f"Tuple return sum failed: expected a + b = 5.0, "
+            f"got max diff = {(out_sum - expected_sum).abs().max().item()}"
+        )
+        assert torch.allclose(out_diff, expected_diff, rtol=1e-5, atol=1e-5), (
+            f"Tuple return diff failed: expected a - b = -1.0, "
+            f"got max diff = {(out_diff - expected_diff).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -482,7 +482,6 @@ class TestDistributedCodegen:
         alloc_block = code[alloc_idx:host_idx]
         assert "    pass" in alloc_block
 
-
     def test_tuple_return_pl_tuple(self):
         """Tuple-return worker (pl.Tuple) populates per-element tensors aliases."""
 

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -483,6 +483,79 @@ class TestDistributedCodegen:
         assert "    pass" in alloc_block
 
 
+    def test_tuple_return_pl_tuple(self):
+        """Tuple-return worker (pl.Tuple) populates per-element tensors aliases."""
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[64], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                return out_s, out_d
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[64], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                s, d = self.chip_orch(a, b, out_s, out_d)
+                return s, d
+
+        program = passes.convert_to_ssa()(Input)
+        cg = codegen.DistributedCodegen()
+        code = cg.generate(program)
+
+        # Each tuple element should get its own tensors[...] alias
+        assert code.count('tensors["') >= 2
+        # submit_next_level emitted for chip_orch
+        assert "submit_next_level" in code
+        # Two OUTPUT_EXISTING args for the two Out params
+        assert code.count("TensorArgType.OUTPUT_EXISTING") == 2
+
+    def test_tuple_return_builtin_tuple(self):
+        """Tuple-return worker (builtin tuple[...]) also produces per-element aliases."""
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[64], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                return out_s, out_d
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                out_s: pl.Out[pl.Tensor[[64], pl.FP32]],
+                out_d: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                s, d = self.chip_orch(a, b, out_s, out_d)
+                return s, d
+
+        program = passes.convert_to_ssa()(Input)
+        cg = codegen.DistributedCodegen()
+        code = cg.generate(program)
+
+        # Must produce identical structure as the pl.Tuple variant
+        assert code.count('tensors["') >= 2
+        assert "submit_next_level" in code
+        assert code.count("TensorArgType.OUTPUT_EXISTING") == 2
+
+
 class TestSubWorkerSourceGeneration:
     """Test _emit_sub_worker_module for correct param names and imports."""
 


### PR DESCRIPTION
## Summary

Multi-return worker functions emit a `TupleType` return where each element aliases an `Out`/`InOut` parameter tensor. Previously `EmitCallToWorker` only aliased the first `Out` param to the call target, so subsequent `TupleGetItemExpr` unpacking statements (`out_i = tuple_tmp[i]`) had no way to resolve to their backing tensor.

- Add `tuple_element_tensors_` map keyed by `(tuple var name, element index)` that `EmitCallToWorker` populates for each `Out`/`InOut` parameter when the callee returns a tuple.
- `VisitStmt_(AssignStmtPtr)` now detects `TupleGetItemExpr` on the RHS and emits the per-element `tensors[...]` alias from the recorded mapping.
- `INTERNAL_CHECK_SPAN` guards against unexpected lookup misses with a clear diagnostic.
- Single-return path is preserved unchanged.

## Testing

- [x] `cmake --build build --parallel` succeeds
- [x] Add unit coverage for tuple-return worker codegen (follow-up)