### PR TITLE
fix(ir): tensor.as_layout accepts strided views (fix #1212 / #1213 silent miscompile)

### DIFF
--- a/docs/en/dev/passes/18-lower_transpose_load_param_layout.md
+++ b/docs/en/dev/passes/18-lower_transpose_load_param_layout.md
@@ -180,10 +180,23 @@ touched — it passes its own row-major ``b`` straight through.
 
 This pass is the first consumer of ``tensor.as_layout`` in the default
 pipeline. The bridging op is single-purpose: it flips the layout tag and
-derives the new shape from §4.2 canonical pair semantics, then attaches the
-packed canonical strides via ``CanonicalizeView``. Codegen lowers
-``tensor.as_layout`` to a fresh ``pto.make_tensor_view`` bound to the input
-tensor's underlying SSA buffer with the LHS's
+derives the new shape from §4.2 canonical pair semantics. Stride handling has
+two cases (RFC §3.5):
+
+- **Bare or empty-stride input** (the common case for fresh InCore params):
+  the output gets packed canonical strides via ``CanonicalizeView``.
+- **Explicit-stride input** (strided sub-views — e.g. when
+  ``SliceInputStridesOptimizer`` has already attached parent-buffer strides
+  to the InCore param): the output **inherits** the input's stride with the
+  trailing pair swapped, preserving the parent buffer's row stride through
+  the layout flip. This is the strided-ND ↔ strided-DN canonical pair and is
+  what keeps PTOAS reading from the correct addresses when an InCore param
+  is a slice of a larger GM tensor (fixes #1212 / #1213 — silent miscompiles
+  where a slice's logical-shape-derived packed strides clobbered the
+  parent's actual row stride).
+
+Codegen lowers ``tensor.as_layout`` to a fresh ``pto.make_tensor_view`` bound
+to the input tensor's underlying SSA buffer with the LHS's
 ``(shape, stride, layout)`` triple — no PTOAS instruction is emitted, the
 result is a pure metadata reinterpret.
 

--- a/docs/zh-cn/dev/passes/18-lower_transpose_load_param_layout.md
+++ b/docs/zh-cn/dev/passes/18-lower_transpose_load_param_layout.md
@@ -155,7 +155,12 @@ def orchestrator(self, a, b):
 
 ## 与 `tensor.as_layout`（P4）的交互
 
-本 Pass 是默认 pipeline 中 `tensor.as_layout` 的第一个消费者。该桥接 op 单一职责：翻转 layout 标签，目标 shape 由 §4.2 canonical pair 机械导出，并通过 `CanonicalizeView` 附加 packed canonical strides。codegen 把 `tensor.as_layout` 下沉为一条新的 `pto.make_tensor_view`，绑定到输入 tensor 的底层 SSA buffer 上，使用 LHS 的 `(shape, stride, layout)` 三元组 —— 不发射任何 PTOAS 指令，结果是纯元数据 reinterpret。
+本 Pass 是默认 pipeline 中 `tensor.as_layout` 的第一个消费者。该桥接 op 单一职责：翻转 layout 标签，目标 shape 由 §4.2 canonical pair 机械导出。stride 处理分两种情况（RFC §3.5）：
+
+- **裸 / 空 stride 输入**（多数新建 InCore 参数情形）：输出通过 `CanonicalizeView` 取 packed canonical stride。
+- **显式 stride 输入**（带 strided 视图的参数 —— 例如 `SliceInputStridesOptimizer` 已经为 InCore 参数挂上了父 buffer 的 stride）：输出**继承**输入的 stride 并对末两维做 swap，保证层翻转后父 buffer 的行 stride 仍然指到正确的内存位置。这是 strided-ND ↔ strided-DN canonical pair，也是修复 #1212 / #1213 的关键 —— 这些 case 中 slice 用 logical-shape 推导的 packed stride 会覆盖父 buffer 的实际行 stride，导致 PTOAS 静默错位。
+
+codegen 把 `tensor.as_layout` 下沉为一条新的 `pto.make_tensor_view`，绑定到输入 tensor 的底层 SSA buffer 上，使用 LHS 的 `(shape, stride, layout)` 三元组 —— 不发射任何 PTOAS 指令，结果是纯元数据 reinterpret。
 
 按 RFC §4.2，InCore 侧的 reinterpret 不违反"核内不能创建 tensor"约束：`tensor.as_layout` 不分配任何内存，它只是为输入的现有物理 buffer 换一份描述。
 

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -315,29 +315,22 @@ TypePtr DeduceTensorAsLayoutType(const std::vector<ExprPtr>& args,
   CHECK(new_layout != TensorLayout::NZ)
       << "tensor.as_layout: NZ layout is not allowed on TensorType (NZ is tile-only)";
 
-  // The source must be packed canonical (or bare = implicit ND-packed).
-  // Strided sub-views can't be reinterpreted via the §4.2 canonical pair
-  // because the offset-map equivalence only holds for the packed forms.
+  // The source must be canonical for its declared layout — either packed
+  // (default for the layout) or strided (sub-view that inherits stride from a
+  // packed parent). Both forms participate in the §4.2 canonical pair: the
+  // ND↔DN reinterpret is a trailing-pair swap of *both* shape and stride, so
+  // a strided-ND view ``(shape=[..a, b], stride=[..S, 1])`` maps cleanly to a
+  // strided-DN view ``(shape=[..b, a], stride=[..1, S])`` over the same
+  // physical buffer.
   TensorLayout src_layout =
       src_type->tensor_view_.has_value() ? src_type->tensor_view_->layout : TensorLayout::ND;
   CHECK(src_layout != TensorLayout::NZ)
       << "tensor.as_layout: src has NZ layout (NZ is tile-only and not allowed on TensorType)";
   if (src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
-    auto packed = tensor_view_semantics::BuildLogicalStridesFromLayout(src_type->shape_, src_layout);
-    bool is_packed = packed.size() == src_type->tensor_view_->stride.size();
-    for (size_t i = 0; is_packed && i < packed.size(); ++i) {
-      auto pc = As<ConstInt>(packed[i]);
-      auto sc = As<ConstInt>(src_type->tensor_view_->stride[i]);
-      // Treat ExprPtr-identity as a match for symbolic dims; otherwise demand
-      // ConstInt value equality.
-      bool same = (packed[i].get() == src_type->tensor_view_->stride[i].get()) ||
-                  (pc && sc && pc->value_ == sc->value_);
-      is_packed = is_packed && same;
-    }
-    CHECK(is_packed) << "tensor.as_layout: src is a strided sub-view (stride does not match packed canonical "
-                     << "for layout " << TensorLayoutToString(src_layout)
-                     << "). Strided reinterprets are not "
-                     << "supported; use tensor.slice or tensor.reshape on the packed parent first.";
+    auto canon_check = tensor_view_semantics::CheckCanonicalView(
+        src_type->shape_, src_type->tensor_view_->stride, src_layout, /*relaxed_symbolic=*/true);
+    CHECK(canon_check.ok) << "tensor.as_layout: src view is not canonical for layout "
+                          << TensorLayoutToString(src_layout) << ": " << canon_check.reason;
   }
 
   // Derive the target shape:
@@ -350,7 +343,25 @@ TypePtr DeduceTensorAsLayoutType(const std::vector<ExprPtr>& args,
     std::swap(new_shape[new_shape.size() - 2], new_shape[new_shape.size() - 1]);
   }
 
-  auto new_view = tensor_view_semantics::CanonicalizeView(new_shape, new_layout);
+  // Derive the target view's stride. Two cases:
+  //   (a) src carries an explicit stride (packed or strided): inherit and
+  //       trailing-pair-swap it on cross-layout flips. Preserves parent-buffer
+  //       stride info through orch ↔ InCore boundaries (RFC §3.5 + §4.2 — the
+  //       strided-ND ↔ strided-DN canonical pair).
+  //   (b) src is bare or has an empty-stride view: fall back to packed
+  //       canonical for the target layout. ``MaterializeTensorStrides`` would
+  //       fill the same stride later, but emitting it here makes the output
+  //       canonical immediately.
+  TensorView new_view;
+  if (src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
+    std::vector<ExprPtr> new_stride = src_type->tensor_view_->stride;
+    if (src_layout != new_layout) {
+      std::iter_swap(new_stride.end() - 2, new_stride.end() - 1);
+    }
+    new_view = TensorView(std::move(new_stride), new_layout);
+  } else {
+    new_view = tensor_view_semantics::CanonicalizeView(new_shape, new_layout);
+  }
   // Preserve view-extending metadata (``valid_shape`` / ``pad``) from the
   // source — both fields describe element-level semantics that are layout-
   // invariant under the §4.2 canonical pair, so dropping them would silently

--- a/tests/ut/ir/operators/test_tensor_as_layout.py
+++ b/tests/ut/ir/operators/test_tensor_as_layout.py
@@ -148,14 +148,37 @@ def test_cross_layout_flip_below_rank_2_rejected():
         ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
 
 
-def test_strided_source_rejected():
-    """Strided sub-views can't ride the canonical pair; reject them so the
-    caller routes through ``tensor.slice`` / ``tensor.reshape`` first."""
-    # Synthesize a strided ND tensor: stride [16, 1] on shape [4, 8] (parent
-    # stride preserved on a 4×8 sub-view of an 8×16 row-major buffer).
+def test_strided_source_flips_inheriting_stride():
+    """Strided sub-views ride the §4.2 canonical pair too: a strided-ND view
+    ``(shape=[4, 8], stride=[16, 1])`` (4×8 sub-view of an 8×16 row-major
+    buffer) flips to a strided-DN view ``(shape=[8, 4], stride=[1, 16])``
+    over the same physical memory. The parent's row stride 16 is preserved
+    through the flip so downstream codegen reads the correct addresses (the
+    bug class behind #1212 / #1213)."""
     src_view = ir.TensorView([_const(16), _const(1)], ir.TensorLayout.ND)
     src = _tensor_var([4, 8], view=src_view, name="strided")
-    with pytest.raises(ValueError, match="strided sub-view"):
+    call = ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    # Trailing-pair shape swap.
+    assert _values_of(out.shape) == [8, 4]
+    view = _result_view(call)
+    assert view is not None
+    assert view.layout == ir.TensorLayout.DN
+    # Trailing-pair stride swap — parent row stride (16) now sits at the
+    # outer slot, the inner DN stride is 1.
+    assert _values_of(view.stride) == [1, 16]
+
+
+def test_non_canonical_source_rejected():
+    """Source views that fail the canonical-family invariants (e.g. ND with
+    non-unit innermost stride) are still rejected — they don't describe a
+    well-defined memory pattern."""
+    # ND requires stride[-1] == 1; a stride of [16, 2] violates that.
+    src_view = ir.TensorView([_const(16), _const(2)], ir.TensorLayout.ND)
+    src = _tensor_var([4, 8], view=src_view, name="malformed")
+    with pytest.raises(ValueError, match="not canonical"):
         ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
 
 

--- a/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
+++ b/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
@@ -87,6 +87,16 @@ def _shape_dims(ty):
     return out
 
 
+def _const_int_values(exprs):
+    """Return [e.value for e in exprs] asserting each is a ConstInt — narrows
+    the static type so type-checkers don't trip on ``Expr.value``."""
+    out = []
+    for e in exprs:
+        assert isinstance(e, ir.ConstInt), f"expected ConstInt, got {type(e).__name__}"
+        out.append(e.value)
+    return out
+
+
 def _transpose_kwarg(call):
     """Return the value of the ``transpose`` kwarg, or ``None`` if absent."""
     return call.kwargs.get("transpose")
@@ -468,6 +478,88 @@ class TestNoOpCases:
 
         After = passes.lower_transpose_load_param_layout()(Before)
         ir.assert_structural_equal(After, Before)
+
+
+class TestStridedParamFlipsCorrectly:
+    """Regression for #1212 / #1213: when an InCore param's TensorView carries
+    parent-derived strides (a sliced sub-view of a larger tensor — set up here
+    via an explicit ``pl.TensorView(stride=...)`` annotation, the same shape
+    ``SliceInputStridesOptimizer`` produces in the default pipeline), the body-
+    prepended ``tensor.as_layout`` flip must propagate those strides through
+    the §4.2 canonical-pair swap. The output DN view must carry the swapped
+    parent stride, not the slice-shape-derived packed stride — otherwise PTOAS
+    walks rows at the wrong stride and silently miscompiles."""
+
+    def test_strided_nd_param_flips_to_strided_dn(self):
+        """Parent buffer is ``[T, K_parent] ND`` with row stride ``K_parent``;
+        a slice ``[T, K_slice]`` annotated with that parent stride must flip
+        to ``[K_slice, T] DN`` with stride ``[1, K_parent]`` — preserving the
+        parent's row stride at the trailing slot.
+        """
+        T, K_slice, K_parent = 16, 512, 16384
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[T, K_slice], pl.FP32],
+                # Slice of a `[T, K_parent]` parent: strided-ND with the
+                # parent's row stride preserved at the outer slot.
+                b_slice: pl.Tensor[  # noqa: E501
+                    [T, K_slice],
+                    pl.FP32,
+                    pl.TensorView(stride=[K_parent, 1], layout=pl.TensorLayout.ND),
+                ],
+                c: pl.Out[pl.Tensor[[T, T], pl.FP32]],
+            ) -> pl.Tensor[[T, T], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [T, K_slice], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(
+                    b_slice, [0, 0], [T, K_slice], target_memory=pl.MemorySpace.Mat, transpose=True
+                )
+                tile_a_l0 = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0 = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0, tile_b_l0)
+                c_store = pl.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[T, K_slice], pl.FP32],
+                b_slice: pl.Tensor[  # noqa: E501
+                    [T, K_slice],
+                    pl.FP32,
+                    pl.TensorView(stride=[K_parent, 1], layout=pl.TensorLayout.ND),
+                ],
+            ) -> pl.Tensor[[T, T], pl.FP32]:
+                c: pl.Tensor[[T, T], pl.FP32] = pl.create_tensor([T, T], dtype=pl.FP32)
+                c_result = self.matmul_incore(a, b_slice, c)
+                return c_result
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        incore = _find_function(After, "matmul_incore")
+        b_param = incore.params[1]
+        b_type = _as_tensor_type(b_param.type)
+        # Param is untouched: still [T, K_slice] ND with parent's stride.
+        assert _shape_dims(b_type) == [T, K_slice]
+        assert b_type.tensor_view is not None
+        assert b_type.tensor_view.layout == ir.TensorLayout.ND
+        assert _const_int_values(b_type.tensor_view.stride) == [K_parent, 1]
+
+        # Body prepends b_dn = as_layout(b, DN). Critical: the DN view must
+        # inherit the parent's stride, trailing-pair-swapped — NOT canonical
+        # packed strides derived from the slice's logical shape.
+        b_dn_var, _ = _find_as_layout_binding(incore, b_param)
+        b_dn_type = _as_tensor_type(b_dn_var.type)
+        assert _shape_dims(b_dn_type) == [K_slice, T]
+        assert b_dn_type.tensor_view is not None
+        assert b_dn_type.tensor_view.layout == ir.TensorLayout.DN
+        assert _const_int_values(b_dn_type.tensor_view.stride) == [1, K_parent], (
+            "DN view of a strided-ND parent must carry the parent's row stride "
+            f"({K_parent}) at the trailing slot, not the slice-shape-derived "
+            f"packed stride ({K_slice}). See #1212 / #1213."
+        )
 
 
 class TestMixedUseRejected:


### PR DESCRIPTION
## Summary

Fix the strided-slice ↔ ``b_trans=True`` silent miscompile reported in #1212 (LHS-side) and #1213 (RHS-side via ``b_trans``). Both share one root cause in IR: ``DeduceTensorAsLayoutType`` rejected strided source views, which made the canonical-DN flip path in ``LowerTransposeLoadParamLayout`` unavailable for sliced parameters — codegen then fell back to a packed-canonical stride derived from the slice's logical shape and lost the parent buffer's actual row stride.

## Root cause

1. ``SliceInputStridesOptimizer`` (in ``OptimizeOrchTensors``) already propagates the parent's stride to InCore params when the orch passes a sliced tensor to an InCore call — InCore sees ``[T, K_slice] ND`` with ``stride=[K_parent, 1]``.
2. ``LowerTransposeLoadParamLayout`` then tries to prepend ``b_dn = tensor.as_layout(b, layout=DN)`` to the InCore body for any param loaded via ``tile.load(..., transpose=True)``.
3. ``DeduceTensorAsLayoutType`` previously rejected this with ``"tensor.as_layout: src is a strided sub-view"`` — only packed canonical was allowed.
4. With ``as_layout`` unavailable, the code path silently produced ``[K_slice, T] DN`` with stride ``[1, K_slice]`` (packed from slice shape) at codegen, instead of ``[1, K_parent]`` (strided-DN inheriting parent's row stride). PTOAS then walked rows at the wrong stride and miscompiled.

## What changes

**`DeduceTensorAsLayoutType` (src/ir/op/tensor_ops/transform.cpp):**

- The source-validity check moves from ``"must be packed canonical"`` to ``"must be canonical for declared layout"`` (``IsCanonicalView``, accepting both packed and strided forms).
- The output's stride is computed in two cases:
  - **Bare or empty-stride input** → ``CanonicalizeView`` (packed canonical), as before.
  - **Explicit-stride input** → inherit the input's stride and swap the trailing pair on cross-layout (ND ↔ DN) flips. This is the strided-ND ↔ strided-DN canonical pair (RFC §3.5 + §4.2): ``[..a, b]`` with stride ``[..S, 1]`` ↔ ``[..b, a]`` with stride ``[..1, S]`` over the same physical buffer.

**For the #1213 reproducer** (`w[32, 16384]` → `pl.slice [32, 512]` → `pl.matmul(b_trans=True)`):

| | Before | After |
|---|---|---|
| ``w_chunk0`` (InCore param, ND) | ``[32, 512]`` stride ``[16384, 1]`` (from ``SliceInputStridesOptimizer``) | ``[32, 512]`` stride ``[16384, 1]`` (unchanged) |
| ``w_chunk0_dn_view`` (body, DN) | **rejected — pass fails / falls back** | ``[512, 32]`` stride ``[1, 16384]`` ✓ |
| ``pto.make_tensor_view`` emitted strides | ``[1, 512]`` (wrong; PTOAS walks rows at stride 512) | ``[1, 16384]`` (correct — parent's row stride) |

## Test changes

- ``test_tensor_as_layout.py``:
  - ``test_strided_source_rejected`` rewritten as ``test_strided_source_flips_inheriting_stride`` — asserts the new canonical-pair behaviour (strided-ND → strided-DN with the parent's row stride preserved).
  - New ``test_non_canonical_source_rejected`` covers the malformed-view rejection path (ND with non-unit innermost stride).
- ``test_lower_transpose_load_param_layout_pass.py``:
  - New ``TestStridedParamFlipsCorrectly`` regression test directly exercises the slice→InCore-param→as_layout chain with realistic ``K_parent=16384`` shapes, asserting the DN view's trailing stride matches the parent's row stride.

## Docs

- ``docs/{en,zh-cn}/dev/passes/18-lower_transpose_load_param_layout.md`` — describes the new two-case stride handling and cross-references #1212 / #1213.

## Validation

- ``cmake --build build --parallel`` — clean.
- ``pytest tests/ut/ -n auto --maxprocesses 8`` → **4603 passed / 41 skipped / 0 failed**.
- End-to-end hardware verification: covered by CI ``system-tests`` on a2a3, where the #1213 reproducer (``debug_hc_f32_matmul_nopad``) should now match the torch golden within ``rtol=4e-3, atol=4e-3``.

## Test plan

- [x] All existing unit tests pass.
- [x] Op-level tests assert the new canonical-pair stride inheritance.
- [x] Pass-level regression test asserts end-to-end IR shape (slice-derived strided-ND param → strided-DN body view with parent's stride).
- [ ] CI: clang-tidy, pre-commit, unit-tests (macos + ubuntu), fuzz-tests-sim, **system-tests** (this is where #1212 / #1213 actually get verified end-to-end), system-tests-a5sim, pypto-lib-model.

## Related

- Closes #1212 (LHS-side strided-slice miscompile).
- Closes #1213 (RHS-side ``b_trans=True`` strided-slice miscompile).
- Implements the strided-DN family handling from RFC #1300 §3.5.