### PR TITLE
feat: numpy-style rank-reducing index/slice for Tensor & Tile (RFC #1338)

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -265,7 +265,7 @@ with ib.function("tensor_example") as f:
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations |
 | **Unary** | `tile.sqrt` | Element-wise square root |
-| **Transform** | `tile.slice` | Extract a sub-tile with static shape and optional dynamic valid_shape |
+| **Transform** | `tile.slice` | Extract a sub-tile with static shape, optional dynamic valid_shape, and optional `drop_dims` (numpy-style rank reduction over static unit axes; result clamped to a 2D minimum) |
 | - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |
 | - | `tile.reshape` | Reshape tile to new dimensions (element count must match) |
 | - | `tile.transpose` | Swap two axes of a tile |

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -119,6 +119,28 @@ def func(t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32])
     ...
 ```
 
+### Subscript Indexing
+
+`Tensor` and `Tile` subscripts use numpy/torch-style semantics:
+
+- A **scalar** index removes its dimension; a **slice** keeps it.
+- Fewer indices than `rank` implies trailing `:` — `C[i]` on a 4D tensor is `C[i, :, :, :]`.
+- Chained indexing composes — `C[i][j]` is two rank-reducing views.
+- An **all-scalar, full-rank** index reads a scalar (`A[i, j]` on a 2D tensor → `tensor.read` / `tile.read`).
+
+```python
+C[i, j, k, l]   # all scalar, full rank   -> scalar
+C[i, j]         # partial, all scalar      -> 64×64 view (dims 0,1 dropped)
+C[i]            # partial                  -> 64×64×64 view (dim 0 dropped)
+C[i][j]         # chained                  -> works (C[i] is 3D, then [j])
+C[i:i+8, j]     # mixed slice + scalar     -> 8×64×64 view (dim 1 dropped)
+C[i:i+8, :, :, :]  # all slices            -> 8×64×64×64 view
+```
+
+Restrictions (v1): no slice `step`, tile slice lower bounds must be static-foldable, no ellipsis / `None` / negative / advanced indexing. **Tiles are physically 2D**, so a tile result that would naturally be `< 2D` is auto-promoted to 2D (`[N]` → `[1, N]`) with a non-fatal warning — pass an explicit `pl.tile.reshape` if you want a different layout.
+
+Mechanism: a non-trivial subscript lowers to `tensor.slice` / `tile.slice` with full-rank `shape`/`offset` plus a `drop_dims` list of the scalar-indexed axes (see the IR operator docs). The same rules apply on the assignment LHS — `C[i, j] = rhs` reshapes `rhs` back to the full-rank window before `tensor.assemble` (chained writes `C[i][j] = rhs` are not yet supported).
+
 ### Binary Operations
 
 | Python Operator | PyPTO IR | Category |

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -118,6 +118,28 @@ def func(t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32])
     ...
 ```
 
+### 下标索引 (Subscript Indexing)
+
+`Tensor` 和 `Tile` 的下标采用 numpy/torch 风格的语义:
+
+- **标量** 索引会移除该维度; **切片 (slice)** 会保留该维度。
+- 索引个数少于 `rank` 时, 末尾自动补 `:` —— 4D 张量上的 `C[i]` 等价于 `C[i, :, :, :]`。
+- 链式索引可组合 —— `C[i][j]` 是两次降秩视图。
+- **全标量且满秩** 的索引读取一个标量 (2D 张量上的 `A[i, j]` → `tensor.read` / `tile.read`)。
+
+```python
+C[i, j, k, l]   # all scalar, full rank   -> scalar
+C[i, j]         # partial, all scalar      -> 64×64 view (dims 0,1 dropped)
+C[i]            # partial                  -> 64×64×64 view (dim 0 dropped)
+C[i][j]         # chained                  -> works (C[i] is 3D, then [j])
+C[i:i+8, j]     # mixed slice + scalar     -> 8×64×64 view (dim 1 dropped)
+C[i:i+8, :, :, :]  # all slices            -> 8×64×64×64 view
+```
+
+v1 限制: 不支持切片 `step`、tile 切片的下界必须可静态折叠、不支持 ellipsis / `None` / 负索引 / 高级索引。**Tile 物理上是 2D 的**, 所以自然结果 `< 2D` 的 tile 会被自动提升到 2D (`[N]` → `[1, N]`) 并发出非致命警告 —— 若需要不同的布局, 请显式使用 `pl.tile.reshape`。
+
+实现机制: 非平凡的下标会下降为 `tensor.slice` / `tile.slice`, 其 `shape`/`offset` 保持满秩, 并附带一个 `drop_dims` 列表记录被标量索引的轴 (详见 IR 算子文档)。赋值左侧 (LHS) 遵循相同规则 —— `C[i, j] = rhs` 会在 `tensor.assemble` 之前把 `rhs` reshape 回满秩窗口 (尚不支持链式写入 `C[i][j] = rhs`)。
+
 ### 二元操作
 
 | Python 操作符 | PyPTO IR | 类别 |

--- a/examples/models/qwen3_jit/kernels/attention.py
+++ b/examples/models/qwen3_jit/kernels/attention.py
@@ -53,10 +53,12 @@ def rope_kv_cache_update(
         ctx_len = pl.read(seq_lens, [b])
         pos = ctx_len - 1
 
-        cos_lo = rope_cos[pos, 0:HALF_DIM]
-        cos_hi = rope_cos[pos, HALF_DIM:HEAD_DIM]
-        sin_lo = rope_sin[pos, 0:HALF_DIM]
-        sin_hi = rope_sin[pos, HALF_DIM:HEAD_DIM]
+        # Keep the row dim explicit: `rope_cos[pos, ...]` now rank-reduces to 1D
+        # under numpy-style indexing, but col_expand_mul needs a 2D [1, N] operand.
+        cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
+        cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
+        sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
+        sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_kv_cache"):
             for ki in pl.range(NUM_KV_HEADS):

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -227,6 +227,31 @@ std::vector<TypePtr> DeduceCallReturnType(const std::vector<VarPtr>& callee_para
                                           const std::vector<ExprPtr>& args,
                                           const std::vector<TypePtr>& return_types);
 
+/**
+ * @brief Parse and validate the optional ``drop_dims`` operand of a slice op.
+ *
+ * ``tensor.slice`` / ``tile.slice`` accept an optional trailing positional
+ * argument listing axes to remove from the result type (numpy-style rank
+ * reduction). The operand is a ``MakeTuple`` of ``ConstInt``; an empty tuple,
+ * or a null operand, means "drop nothing". Every listed axis must be in
+ * ``[0, full_shape.size())``, appear at most once, and select a statically
+ * unit-sized dimension of ``full_shape`` — rank reduction only erases unit dims.
+ *
+ * @param drop_dims_arg The drop_dims operand, or nullptr if the op has no such argument.
+ * @param full_shape The full (pre-reduction) slice shape.
+ * @param op_name Operator name for error messages (e.g. "tensor.slice").
+ * @return The validated axes in ascending order; empty when nothing is dropped.
+ */
+std::vector<int64_t> ParseSliceDropDims(const ExprPtr& drop_dims_arg, const std::vector<ExprPtr>& full_shape,
+                                        const std::string& op_name);
+
+/**
+ * @brief Remove the axes in ``drop_dims`` (ascending, validated) from ``shape``.
+ *
+ * Returns ``shape`` unchanged when ``drop_dims`` is empty.
+ */
+std::vector<ExprPtr> ApplyDropDims(const std::vector<ExprPtr>& shape, const std::vector<int64_t>& drop_dims);
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -203,6 +203,7 @@ def slice(
     shape: list[int | Expr] | _ir_core.MakeTuple,
     offset: list[int | Expr] | _ir_core.MakeTuple,
     valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
+    drop_dims: list[int] | None = None,
     pad_value: PadValue | int | float | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -210,9 +211,14 @@ def slice(
 
     Args:
         tensor: Input tensor expression
-        shape: New shape dimensions, or a MakeTuple
+        shape: New shape dimensions, or a MakeTuple. Always full-rank — a
+            scalar-indexed axis contributes a unit dim here and is listed in
+            ``drop_dims`` to be erased from the result type.
         offset: Offset dimensions for the slice, or a MakeTuple
         valid_shape: Valid shape dimensions (optional, defaults to empty)
+        drop_dims: Optional axes to erase from the result type (numpy-style rank
+            reduction). Each listed axis must be a static unit dim of ``shape``.
+            ``None`` / ``[]`` is fully backward compatible (drops nothing).
         pad_value: Optional padding mode for out-of-valid-shape elements.
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
             the literal sugars ``0``, ``math.inf``, ``-math.inf`` (normalized
@@ -231,7 +237,15 @@ def slice(
     offset_tuple = _to_make_tuple(offset, actual_span)
 
     args = [tensor, shape_tuple, offset_tuple]
-    if valid_shape is not None:
+    if drop_dims:
+        # drop_dims is the 5th positional operand, so valid_shape (the 4th) must
+        # be present; an empty MakeTuple stands in for "no valid_shape".
+        args.append(_to_make_tuple(valid_shape if valid_shape is not None else [], actual_span))
+        # `drop_dims` may be ints (direct API) or ConstInt exprs (text parser);
+        # _to_make_tuple normalizes either form. Non-ConstInt exprs are rejected
+        # by the deducer with a clear message.
+        args.append(_to_make_tuple(list(drop_dims), actual_span))
+    elif valid_shape is not None:
         args.append(_to_make_tuple(valid_shape, actual_span))
 
     kwargs: dict[str, Any] = {}

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -203,7 +203,7 @@ def slice(
     shape: list[int | Expr] | _ir_core.MakeTuple,
     offset: list[int | Expr] | _ir_core.MakeTuple,
     valid_shape: list[int | Expr] | _ir_core.MakeTuple | None = None,
-    drop_dims: list[int] | None = None,
+    drop_dims: Sequence[int | Expr] | None = None,
     pad_value: PadValue | int | float | None = None,
     span: Span | None = None,
 ) -> Call:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2034,6 +2034,7 @@ def slice(
     shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    drop_dims: list[int] | None = None,
     pad_value: PadValue | int | float | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -2041,10 +2042,17 @@ def slice(
 
     Args:
         tile: Input tile expression
-        shape: Static shape dimensions, or a MakeTuple
+        shape: Static shape dimensions, or a MakeTuple. Always full-rank — a
+            scalar-indexed axis contributes a unit dim here and is listed in
+            ``drop_dims`` to be erased from the result type.
         offset: Offset dimensions for the slice, or a MakeTuple
         valid_shape: Valid shape dimensions, or a MakeTuple. When omitted, shape
             is reused as the valid shape.
+        drop_dims: Optional axes to erase from the result type (numpy-style rank
+            reduction). Each listed axis must be a static unit dim of ``shape``.
+            Because tiles are physically 2D, the result is clamped back to 2D
+            (unit axes prepended) if reduction would take it below 2D.
+            ``None`` / ``[]`` is fully backward compatible (drops nothing).
         pad_value: Optional padding mode for out-of-valid-shape elements.
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
             the literal sugars ``0``, ``math.inf``, ``-math.inf`` (normalized
@@ -2063,15 +2071,28 @@ def slice(
     offset_tuple = _to_make_tuple(offset, actual_span)
     args = [tile, shape_tuple, offset_tuple]
 
+    valid_shape_tuple = None
     if valid_shape is not None:
         valid_shape_tuple = _to_make_tuple(valid_shape, actual_span)
-        if len(valid_shape_tuple.elements) != len(shape_tuple.elements):
+        # An empty tuple is the explicit "no valid_shape" form (used when only
+        # drop_dims is supplied) — skip the rank check for it.
+        if len(valid_shape_tuple.elements) not in (0, len(shape_tuple.elements)):
             raise ValueError(
                 f"valid_shape and shape must have same number of dimensions, "
                 "got "
                 f"{len(valid_shape_tuple.elements)} valid_shape dims and "
                 f"{len(shape_tuple.elements)} shape dims"
             )
+
+    if drop_dims:
+        # drop_dims is the 5th positional operand, so valid_shape (the 4th) must
+        # be present; an empty MakeTuple stands in for "no valid_shape".
+        args.append(valid_shape_tuple if valid_shape_tuple is not None else _to_make_tuple([], actual_span))
+        # `drop_dims` may be ints (direct API) or ConstInt exprs (text parser);
+        # _to_make_tuple normalizes either form. Non-ConstInt exprs are rejected
+        # by the deducer with a clear message.
+        args.append(_to_make_tuple(list(drop_dims), actual_span))
+    elif valid_shape_tuple is not None:
         args.append(valid_shape_tuple)
 
     kwargs: dict[str, Any] = {}

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2034,7 +2034,7 @@ def slice(
     shape: Sequence[int | Expr] | _ir_core.MakeTuple,
     offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
-    drop_dims: list[int] | None = None,
+    drop_dims: Sequence[int | Expr] | None = None,
     pad_value: PadValue | int | float | None = None,
     span: Span | None = None,
 ) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -216,15 +216,20 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
+    drop_dims: list[int] | None = None,
     pad_value: PadValue | int | float | None = None,
 ) -> Tensor:
     """Create a slice of a tensor with new shape and optional valid shape.
 
     Args:
         tensor: Input tensor
-        shape: New shape dimensions
+        shape: New shape dimensions. Always full-rank — a scalar-indexed axis
+            contributes a unit dim here and is listed in ``drop_dims``.
         offset: Offset dimensions for the slice
         valid_shape: Valid shape dimensions. When omitted, the full shape is valid.
+        drop_dims: Optional axes to erase from the result type (numpy-style rank
+            reduction). Each listed axis must be a static unit dim of ``shape``.
+            ``None`` / ``[]`` drops nothing (fully backward compatible).
         pad_value: Optional padding mode for out-of-valid-shape elements.
             ``None`` or ``PadValue.null`` means no padding (the default).
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
@@ -252,6 +257,7 @@ def slice(
         _normalize_intlike(shape),
         _normalize_intlike(offset),
         normalized_valid_shape,
+        drop_dims,
         pad_value=pad_value,
     )
     return Tensor(expr=call_expr)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -216,7 +216,7 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
-    drop_dims: list[int] | None = None,
+    drop_dims: Sequence[int | Expr] | None = None,
     pad_value: PadValue | int | float | None = None,
 ) -> Tensor:
     """Create a slice of a tensor with new shape and optional valid shape.

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1365,16 +1365,22 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
+    drop_dims: list[int] | None = None,
     pad_value: PadValue | int | float | None = None,
 ) -> Tile:
     """Create a slice of a tile with static shape and optional valid shape.
 
     Args:
         tile: Input tile
-        shape: Static shape dimensions (at most 2 for TileType)
+        shape: Static shape dimensions. Always full-rank — a scalar-indexed axis
+            contributes a unit dim here and is listed in ``drop_dims``.
         offset: Offset dimensions for the slice
         valid_shape: Valid shape dimensions. When omitted, shape is reused as the
             logical valid shape.
+        drop_dims: Optional axes to erase from the result type (numpy-style rank
+            reduction). Each listed axis must be a static unit dim of ``shape``.
+            Because tiles are physically 2D, the result is clamped back to 2D
+            if reduction would take it below 2D. ``None`` / ``[]`` drops nothing.
         pad_value: Optional padding mode for out-of-valid-shape elements.
             ``None`` or ``PadValue.null`` means no padding (the default).
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
@@ -1402,6 +1408,7 @@ def slice(
         _normalize_intlike(shape),
         _normalize_intlike(offset),
         normalized_valid_shape,
+        drop_dims,
         pad_value=pad_value,
     )
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1365,7 +1365,7 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
-    drop_dims: list[int] | None = None,
+    drop_dims: Sequence[int | Expr] | None = None,
     pad_value: PadValue | int | float | None = None,
 ) -> Tile:
     """Create a slice of a tile with static shape and optional valid shape.

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -438,7 +438,7 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
-    drop_dims: list[int] | None = None,
+    drop_dims: Sequence[int | _ir_core.Expr] | None = None,
 ) -> T:
     """Slice operation, dispatched by input type.
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -438,12 +438,18 @@ def slice(
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
+    drop_dims: list[int] | None = None,
 ) -> T:
-    """Slice operation, dispatched by input type."""
+    """Slice operation, dispatched by input type.
+
+    ``drop_dims`` lists axes to erase from the result type (numpy-style rank
+    reduction); each must be a static unit dim of ``shape``. ``None`` / ``[]``
+    drops nothing.
+    """
     if isinstance(input, Tensor):
-        return _tensor.slice(input, shape, offset, valid_shape)
+        return _tensor.slice(input, shape, offset, valid_shape, drop_dims)
     if isinstance(input, Tile):
-        return _tile.slice(input, shape, offset, valid_shape)
+        return _tile.slice(input, shape, offset, valid_shape, drop_dims)
     raise TypeError(f"pl.slice: expected Tensor or Tile, got {type(input).__name__}")
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4397,12 +4397,16 @@ class ASTParser:
         return self._parse_sequence_literal(tuple_node)
 
     def parse_subscript(self, subscript: ast.Subscript) -> ir.Expr:
-        """Parse subscript expression: tuple[0], tensor[0:16, :], tile[0:16, :].
+        """Parse a subscript expression: ``tuple[0]``, ``tensor[i, j]``, ``tile[i:j]``, ...
 
         Supports:
         - TupleType: ``t[0]`` -> TupleGetItemExpr
-        - TensorType: ``A[0:16, :]`` -> tensor.slice, ``A[i, j]`` -> tensor.read
-        - TileType: ``A[0:16, :]`` -> tile.slice, ``A[i, j]`` -> tile.read
+        - TensorType / TileType: numpy-style indexing — a scalar index removes its
+          dim, a slice keeps it, missing trailing indices are implicit ``:``.
+          ``A[i, j]`` on a 2D operand (all-scalar, full-rank) -> scalar read;
+          everything else (``A[i]``, ``A[i, j]`` on a >2D operand, ``A[i:i+8, j]``,
+          chained ``A[i][j]``) -> a ``tensor.slice`` / ``tile.slice`` view carrying
+          ``drop_dims``. Tiles are clamped to a 2D minimum (see _parse_tile_subscript).
         """
         span = self.span_tracker.get_span(subscript)
         value_expr = self.parse_expression(subscript.value)
@@ -4585,15 +4589,23 @@ class ASTParser:
         full_shape: list[ir.Expr],
         span: ir.Span,
         kind_name: str,
-    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr]]:
-        """Convert mixed subscript indices into slice shape/offset args."""
+    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr], list[int]]:
+        """Convert mixed/partial subscript indices into slice shape/offset/drop_dims args.
+
+        ``shape``/``offset`` are always full-rank: a scalar index ``i`` at dim
+        ``d`` contributes ``shape[d] = 1, offset[d] = i`` and adds ``d`` to
+        ``drop_dims`` (numpy-style rank reduction); a slice keeps its dim; dims
+        not covered by ``indices`` become implicit ``:`` and are not dropped.
+        """
         shape_exprs: list[int | ir.Expr] = []
         offset_exprs: list[int | ir.Expr] = []
+        drop_dims: list[int] = []
 
         for dim_idx, idx in enumerate(indices):
             if not isinstance(idx, ast.Slice):
                 offset_exprs.append(self.parse_expression(idx))
                 shape_exprs.append(1)
+                drop_dims.append(dim_idx)
                 continue
 
             if idx.step is not None:
@@ -4616,15 +4628,27 @@ class ASTParser:
             upper_expr = full_shape[dim_idx] if idx.upper is None else self.parse_expression(idx.upper)
             shape_exprs.append(self._build_slice_shape_expr(upper_expr, lower_expr))
 
-        return shape_exprs, offset_exprs
+        # Dims past the supplied indices are implicit ``:`` (kept, full extent).
+        for dim_idx in range(len(indices), len(full_shape)):
+            offset_exprs.append(0)
+            shape_exprs.append(full_shape[dim_idx])
+
+        return shape_exprs, offset_exprs, drop_dims
 
     def _build_tile_subscript_slice_args(
         self,
         indices: list[ast.expr],
         tile_type: ir.TileType,
         span: ir.Span,
-    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr], list[int | ir.Expr] | None]:
-        """Convert tile subscripts into static shape/offset args plus optional valid_shape."""
+    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr], list[int | ir.Expr] | None, list[int]]:
+        """Convert tile subscripts into static shape/offset args plus optional valid_shape.
+
+        Same rank-reducing rules as :meth:`_build_subscript_slice_args`: a scalar
+        index at dim ``d`` contributes a unit dim and adds ``d`` to ``drop_dims``;
+        a slice keeps its dim; dims past ``indices`` are implicit ``:``. The
+        ``tile.slice`` deducer clamps the result back to 2D if rank reduction
+        would take it below 2D.
+        """
         static_shape = list(tile_type.shape)
         tile_view = tile_type.tile_view
         logical_shape = (
@@ -4636,6 +4660,7 @@ class ASTParser:
         shape_exprs: list[int | ir.Expr] = []
         offset_exprs: list[int | ir.Expr] = []
         valid_shape_exprs: list[int | ir.Expr] = []
+        drop_dims: list[int] = []
         needs_valid_shape = False
 
         for dim_idx, idx in enumerate(indices):
@@ -4644,6 +4669,7 @@ class ASTParser:
                 offset_exprs.append(index_expr)
                 shape_exprs.append(1)
                 valid_shape_exprs.append(1)
+                drop_dims.append(dim_idx)
                 continue
 
             if idx.step is not None:
@@ -4682,7 +4708,16 @@ class ASTParser:
             valid_shape_exprs.append(valid_extent)
             needs_valid_shape = needs_valid_shape or not self._slice_extents_match(alloc_extent, valid_extent)
 
-        return shape_exprs, offset_exprs, valid_shape_exprs if needs_valid_shape else None
+        # Dims past the supplied indices are implicit ``:`` (kept, full extent).
+        for dim_idx in range(len(indices), len(static_shape)):
+            offset_exprs.append(0)
+            shape_exprs.append(static_shape[dim_idx])
+            valid_shape_exprs.append(logical_shape[dim_idx])
+            needs_valid_shape = needs_valid_shape or not self._slice_extents_match(
+                static_shape[dim_idx], logical_shape[dim_idx]
+            )
+
+        return shape_exprs, offset_exprs, valid_shape_exprs if needs_valid_shape else None, drop_dims
 
     def _parse_tensor_subscript(
         self,
@@ -4691,27 +4726,34 @@ class ASTParser:
         tensor_type: ir.TensorType,
         span: ir.Span,
     ) -> ir.Expr:
-        """Parse tensor subscript: A[0:16, :] -> tensor.slice, A[i, j] -> tensor.read."""
+        """Parse a tensor subscript with numpy-style rank-reducing / partial / chained indexing.
+
+        Each scalar index removes its dim; a slice keeps it; missing trailing
+        indices are implicit ``:``. ``A[i, j]`` on a 2D tensor (all-scalar,
+        full-rank) reads a scalar via ``tensor.read``; everything else (``A[i]``,
+        ``A[i, j]`` on a >2D tensor, ``A[i:i+8, j]``, ``A[i][j]``, ...) is a
+        ``tensor.slice`` view, carrying ``drop_dims`` for the scalar-indexed axes.
+        """
         indices = self._normalize_subscript_indices(subscript, span)
         rank = len(tensor_type.shape)
-        if len(indices) != rank:
+        if len(indices) > rank:
             raise ParserTypeError(
-                f"Tensor subscript requires {rank} indices, got {len(indices)}",
+                f"Tensor subscript has {len(indices)} indices but the tensor is {rank}D",
                 span=span,
-                hint=f"Provide exactly {rank} indices for a {rank}D tensor",
+                hint=f"Provide at most {rank} indices for a {rank}D tensor",
             )
 
         has_slice = any(isinstance(idx, ast.Slice) for idx in indices)
 
-        if not has_slice:
-            # All integer indices -> tensor.read(tensor, [i, j])
+        if not has_slice and len(indices) == rank:
+            # All-scalar, full-rank -> scalar element read.
             idx_exprs: list[int | ir.Expr] = [self.parse_expression(idx) for idx in indices]
             return ir_op.tensor.read(value_expr, idx_exprs, span=span)
 
-        shape_exprs, offset_exprs = self._build_subscript_slice_args(
+        shape_exprs, offset_exprs, drop_dims = self._build_subscript_slice_args(
             indices, list(tensor_type.shape), span, "tensor"
         )
-        return ir_op.tensor.slice(value_expr, shape_exprs, offset_exprs, span=span)
+        return ir_op.tensor.slice(value_expr, shape_exprs, offset_exprs, drop_dims=drop_dims, span=span)
 
     def _parse_tile_subscript(
         self,
@@ -4720,27 +4762,53 @@ class ASTParser:
         tile_type: ir.TileType,
         span: ir.Span,
     ) -> ir.Expr:
-        """Parse tile subscript: A[0:16, :] -> tile.slice, A[i, j] -> tile.read."""
+        """Parse a tile subscript with numpy-style rank-reducing / partial / chained indexing.
+
+        Same rules as :meth:`_parse_tensor_subscript`, plus a tile-only floor:
+        tiles are physically 2D, so a result that would naturally be < 2D is
+        auto-promoted to 2D (unit axes prepended) with a non-fatal warning.
+        """
         indices = self._normalize_subscript_indices(subscript, span)
         rank = len(tile_type.shape)
-        if len(indices) != rank:
+        if len(indices) > rank:
             raise ParserTypeError(
-                f"Tile subscript requires {rank} indices, got {len(indices)}",
+                f"Tile subscript has {len(indices)} indices but the tile is {rank}D",
                 span=span,
-                hint=f"Provide exactly {rank} indices for a {rank}D tile",
+                hint=f"Provide at most {rank} indices for a {rank}D tile",
             )
 
         has_slice = any(isinstance(idx, ast.Slice) for idx in indices)
 
-        if not has_slice:
-            # All integer indices -> tile.read(tile, [i, j])
+        if not has_slice and len(indices) == rank:
+            # All-scalar, full-rank -> scalar element read.
             idx_exprs: list[int | ir.Expr] = [self.parse_expression(idx) for idx in indices]
             return ir_op.tile.read(value_expr, idx_exprs, span=span)
 
-        shape_exprs, offset_exprs, valid_shape_exprs = self._build_tile_subscript_slice_args(
+        shape_exprs, offset_exprs, valid_shape_exprs, drop_dims = self._build_tile_subscript_slice_args(
             indices, tile_type, span
         )
-        return ir_op.tile.slice(value_expr, shape_exprs, offset_exprs, valid_shape_exprs, span=span)
+        natural_rank = rank - len(drop_dims)
+        if drop_dims and natural_rank < 2:
+            kept = [shape_exprs[i] for i in range(rank) if i not in set(drop_dims)]
+            promoted = [1] * (2 - len(kept)) + list(kept)
+            promoted_repr = "[" + ", ".join(self._render_dim_for_msg(d) for d in promoted) + "]"
+            warnings.warn(
+                f"tile subscript reduces to {natural_rank}D; auto-promoting to 2D shape {promoted_repr} "
+                f"— use an explicit tile.reshape if you want a different layout",
+                UserWarning,
+                stacklevel=2,
+            )
+        return ir_op.tile.slice(
+            value_expr, shape_exprs, offset_exprs, valid_shape_exprs, drop_dims=drop_dims, span=span
+        )
+
+    @staticmethod
+    def _render_dim_for_msg(dim: int | ir.Expr) -> str:
+        """Render a shape dim for a warning/error message (constant value, else ``?``)."""
+        if isinstance(dim, int):
+            return str(dim)
+        value = _const_int_value(dim) if isinstance(dim, ir.Expr) else None
+        return str(value) if value is not None else "?"
 
     def _resolve_yield_var_type(self, annotation: ast.expr | None) -> ir.Type:
         """Resolve type annotation for a yield variable.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1107,6 +1107,11 @@ class ASTParser:
         )
         dropped = set(drop_dims)
         kept_dims = [d for d in range(len(extents)) if d not in dropped]
+        natural_rank = len(kept_dims)
+        # The tile.slice deducer floors a sub-2D result back to 2D by prepending
+        # unit axes, so a tile rhs obtained by reading an indexed view is 2D even
+        # when the "natural" rank-reduced rank is < 2 — accept that shape here.
+        floored_rank = max(2, natural_rank) if isinstance(base_type, ir.TileType) else natural_rank
 
         source_expr = self.parse_expression(value_node)
         source_type = source_expr.type
@@ -1117,28 +1122,36 @@ class ASTParser:
                 hint=f"The rhs of 'dst[...] = src' must be a {kind_name} of matching shape",
             )
 
-        if len(source_type.shape) != len(kept_dims):
+        src_rank = len(source_type.shape)
+        if src_rank not in (natural_rank, floored_rank):
+            expected = (
+                f"{natural_rank}D" if natural_rank == floored_rank else f"{natural_rank}D or {floored_rank}D"
+            )
             raise ParserTypeError(
-                f"Subscript-write source must be {len(kept_dims)}D to match the rank-reduced "
-                f"{kind_name} window, got {len(source_type.shape)}D",
+                f"Subscript-write source must be {expected} to match the rank-reduced "
+                f"{kind_name} window, got {src_rank}D",
                 span=span,
                 hint="A scalar index removes its axis from the lhs window; the rhs rank must "
-                "match the remaining axes",
+                "match the remaining axes (tiles may also keep leading unit axes to stay 2D)",
             )
 
-        for src_axis, dim_idx in enumerate(kept_dims):
-            requested_const = _fold_const_slice_extent(extents[dim_idx], 0)
+        # Constant extents the source axes must match — with leading unit axes
+        # prepended when the source carries the tile 2D-floor's padding.
+        lead_units = src_rank - natural_rank
+        expected_extents = [1] * lead_units + [extents[d] for d in kept_dims]
+        for src_axis, want in enumerate(expected_extents):
+            requested_const = _fold_const_slice_extent(want, 0)
             source_const = _fold_const_slice_extent(source_type.shape[src_axis], 0)
             if requested_const is not None and source_const is not None and requested_const != source_const:
                 raise ParserTypeError(
-                    f"Subscript-write shape mismatch on axis {dim_idx}: "
-                    f"slice expects {requested_const} elements, source has {source_const}",
+                    f"Subscript-write shape mismatch on source axis {src_axis}: "
+                    f"window expects {requested_const} elements, source has {source_const}",
                     span=span,
-                    hint=f"Make the source's axis-{src_axis} extent match the slice extent, "
-                    f"or adjust the slice bounds",
+                    hint="Make the source's extents match the rank-reduced lhs window, "
+                    "or adjust the slice bounds",
                 )
 
-        if drop_dims:
+        if src_rank != len(extents):
             # Lift the rank-reduced source back to the full-rank target window
             # (unit dims at the dropped positions) so the assemble's source/window
             # ranks match — mirrors the implicit reshape numpy does on a write.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1102,7 +1102,11 @@ class ASTParser:
             )
 
         indices = self._normalize_subscript_indices(target, span)
-        offsets, extents = self._build_assemble_offsets_and_extents(indices, base_type.shape, span, kind_name)
+        offsets, extents, drop_dims = self._build_assemble_offsets_and_extents(
+            indices, base_type.shape, span, kind_name
+        )
+        dropped = set(drop_dims)
+        kept_dims = [d for d in range(len(extents)) if d not in dropped]
 
         source_expr = self.parse_expression(value_node)
         source_type = source_expr.type
@@ -1113,25 +1117,33 @@ class ASTParser:
                 hint=f"The rhs of 'dst[...] = src' must be a {kind_name} of matching shape",
             )
 
-        if len(source_type.shape) != len(base_type.shape):
+        if len(source_type.shape) != len(kept_dims):
             raise ParserTypeError(
-                f"Subscript-write source must be {len(base_type.shape)}D to match "
-                f"the {kind_name} target, got {len(source_type.shape)}D",
+                f"Subscript-write source must be {len(kept_dims)}D to match the rank-reduced "
+                f"{kind_name} window, got {len(source_type.shape)}D",
                 span=span,
-                hint="The lhs and rhs of 'dst[...] = src' must have the same rank",
+                hint="A scalar index removes its axis from the lhs window; the rhs rank must "
+                "match the remaining axes",
             )
 
-        for dim_idx, (requested, src_extent) in enumerate(zip(extents, source_type.shape)):
-            requested_const = _fold_const_slice_extent(requested, 0)
-            source_const = _fold_const_slice_extent(src_extent, 0)
+        for src_axis, dim_idx in enumerate(kept_dims):
+            requested_const = _fold_const_slice_extent(extents[dim_idx], 0)
+            source_const = _fold_const_slice_extent(source_type.shape[src_axis], 0)
             if requested_const is not None and source_const is not None and requested_const != source_const:
                 raise ParserTypeError(
                     f"Subscript-write shape mismatch on axis {dim_idx}: "
                     f"slice expects {requested_const} elements, source has {source_const}",
                     span=span,
-                    hint=f"Make the source's axis-{dim_idx} extent match the slice extent, "
+                    hint=f"Make the source's axis-{src_axis} extent match the slice extent, "
                     f"or adjust the slice bounds",
                 )
+
+        if drop_dims:
+            # Lift the rank-reduced source back to the full-rank target window
+            # (unit dims at the dropped positions) so the assemble's source/window
+            # ranks match — mirrors the implicit reshape numpy does on a write.
+            reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
+            source_expr = reshape_op(source_expr, list(extents), span=span)
 
         assemble_call = assemble_op(base_expr, source_expr, offsets, span=span)
         var = self._assign_or_let(var_name, assemble_call, span)
@@ -1143,40 +1155,41 @@ class ASTParser:
         target_shape: Sequence[ir.Expr],
         span: ir.Span,
         kind_name: str,
-    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr]]:
-        """Parse a subscript-write index list once into per-axis offsets and extents.
+    ) -> tuple[list[int | ir.Expr], list[int | ir.Expr], list[int]]:
+        """Parse a subscript-write index list into per-axis offsets/extents plus drop_dims.
 
-        For ``a[lower:upper]`` the offset is ``lower`` (defaulting to 0) and the
-        extent is ``upper - lower`` (defaulting to the full target axis when
-        ``upper`` is omitted). For ``a[i]`` the offset is ``i`` and the extent
-        is 1. Extents are folded through the arithmetic simplifier so symbolic
-        bounds like ``i:i+16`` collapse to a constant when possible — this is
-        the same path used by the slice-read sugar.
-
-        All-integer indexing is rejected (no element-write op wiring today),
-        as is ``step``.
+        Same numpy-style rules as the read path: ``a[lower:upper]`` writes the
+        ``lower``..``upper`` window of that axis (offset ``lower``, extent
+        ``upper - lower``, defaulting to the full axis); ``a[i]`` writes a
+        unit-extent window at offset ``i`` and adds that axis to ``drop_dims``
+        (the source is rank-reduced over those axes); dims past ``indices`` are
+        implicit ``:``. ``offsets``/``extents`` are always full-rank. An
+        all-scalar *full-rank* index (a true element write) and ``step`` are
+        still rejected.
         """
-        if len(indices) != len(target_shape):
+        rank = len(target_shape)
+        if len(indices) > rank:
             raise ParserTypeError(
-                f"{kind_name.capitalize()} subscript-write requires {len(target_shape)} indices, "
-                f"got {len(indices)}",
+                f"{kind_name.capitalize()} subscript-write has {len(indices)} indices but the "
+                f"{kind_name} is {rank}D",
                 span=span,
-                hint=f"Provide exactly {len(target_shape)} indices for a {len(target_shape)}D {kind_name}",
+                hint=f"Provide at most {rank} indices for a {rank}D {kind_name}",
             )
-
-        if not any(isinstance(idx, ast.Slice) for idx in indices):
+        if len(indices) == rank and not any(isinstance(idx, ast.Slice) for idx in indices):
             raise UnsupportedFeatureError(
                 f"Element-write 'dst[i, j] = scalar' is not supported for {kind_name} targets",
                 span=span,
-                hint="Use slice indices, e.g. 'dst[i:i+1, j:j+1] = tile_1x1'",
+                hint="Use slice indices (e.g. 'dst[i:i+1, j:j+1] = tile_1x1') or index fewer axes",
             )
 
         offsets: list[int | ir.Expr] = []
         extents: list[int | ir.Expr] = []
+        drop_dims: list[int] = []
         for dim_idx, idx in enumerate(indices):
             if not isinstance(idx, ast.Slice):
                 offsets.append(self.parse_expression(idx))
                 extents.append(1)
+                drop_dims.append(dim_idx)
                 continue
             if idx.step is not None:
                 raise UnsupportedFeatureError(
@@ -1190,7 +1203,10 @@ class ASTParser:
             )
             offsets.append(lower)
             extents.append(self._build_slice_shape_expr(upper, lower))
-        return offsets, extents
+        for dim_idx in range(len(indices), rank):
+            offsets.append(0)
+            extents.append(target_shape[dim_idx])
+        return offsets, extents, drop_dims
 
     def parse_yield_assignment(self, target: ast.Tuple, value: ast.Call) -> None:
         """Parse yield assignment: (a, b) = pl.yield_(x, y).

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2437,8 +2437,14 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.slice", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-    CHECK(op->args_.size() == 3 || op->args_.size() == 4)
-        << "Operation:[tile.slice] requires 3 or 4 arguments (tile, shape, offset[, valid_shape]), but got "
+    // 3-5 args: (tile, shape, offset[, valid_shape[, drop_dims]]). The optional
+    // 5th `drop_dims` operand only affects the result type's rank (already
+    // reflected in the result tile-buf type) — the pto.subview sizes/offset come
+    // from the full-rank shape/offset tuples, so codegen ignores it. An empty
+    // 4th MakeTuple is the "no valid_shape" sentinel that pairs with drop_dims.
+    CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+        << "Operation:[tile.slice] requires 3-5 arguments (tile, shape, offset[, valid_shape[, "
+           "drop_dims]]), but got "
         << op->args_.size();
 
     auto source_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
@@ -2466,9 +2472,11 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
 
     std::string valid_row;
     std::string valid_col;
-    bool has_explicit_valid_shape = op->args_.size() == 4;
+    // valid_shape is the optional 4th operand; an empty MakeTuple means "none"
+    // (the form used when only drop_dims is supplied).
+    auto valid_tuple = op->args_.size() >= 4 ? ir::As<ir::MakeTuple>(op->args_[3]) : nullptr;
+    bool has_explicit_valid_shape = valid_tuple != nullptr && !valid_tuple->elements_.empty();
     if (has_explicit_valid_shape) {
-      auto valid_tuple = ir::As<ir::MakeTuple>(op->args_[3]);
       INTERNAL_CHECK_SPAN(valid_tuple, op->span_) << "tile.slice valid_shape must be a literal tuple";
       INTERNAL_CHECK_SPAN(valid_tuple->elements_.size() >= 2, op->span_)
           << "tile.slice valid_shape must have at least 2 elements";

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -142,9 +143,14 @@ TypePtr DeduceTensorCreateType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.slice requires 3 arguments (input, shape, offset) with optional 4th (valid_shape)
-  CHECK(args.size() == 3 || args.size() == 4)
-      << "tensor.slice requires 3 or 4 arguments (input, shape, offset[, valid_shape]), but got "
+  // tensor.slice: (input, shape, offset[, valid_shape[, drop_dims]]).
+  //   - valid_shape (4th arg): an empty MakeTuple means "no valid_shape".
+  //   - drop_dims (5th arg): a MakeTuple of ConstInt listing axes to erase from
+  //     the result type (numpy-style rank reduction); each listed axis must be a
+  //     static unit dim of `shape`. An empty / absent operand drops nothing, so
+  //     the 3- and 4-arg forms behave exactly as before.
+  CHECK(args.size() >= 3 && args.size() <= 5)
+      << "tensor.slice requires 3-5 arguments (input, shape, offset[, valid_shape[, drop_dims]]), but got "
       << args.size();
 
   // First argument must be TensorType
@@ -182,22 +188,28 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
         << scalar_type->dtype_.ToString();
   }
 
-  // Extract shape dimensions
+  // Extract the full (pre-reduction) shape dimensions.
   // If args[1] is MakeTuple, extract elements directly to preserve constants
   // Otherwise use TupleGetItemExpr for runtime tuples
-  std::vector<ExprPtr> new_shape;
-  new_shape.reserve(shape_tuple_type->types_.size());
+  std::vector<ExprPtr> full_shape;
+  full_shape.reserve(shape_tuple_type->types_.size());
 
   if (auto make_tuple = As<MakeTuple>(args[1])) {
     // MakeTuple: extract elements directly to preserve ConstInt
-    new_shape = make_tuple->elements_;
+    full_shape = make_tuple->elements_;
   } else {
     // Runtime tuple: use TupleGetItemExpr
     for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
-      new_shape.emplace_back(
+      full_shape.emplace_back(
           std::make_shared<TupleGetItemExpr>(args[1], static_cast<int>(i), args[1]->span_));
     }
   }
+
+  // Optional drop_dims (5th arg): axes erased from the result type. Validated
+  // against the full pre-reduction shape (each must be a static unit dim).
+  const ExprPtr drop_dims_arg = args.size() == 5 ? args[4] : nullptr;
+  const std::vector<int64_t> drop_dims = ParseSliceDropDims(drop_dims_arg, full_shape, "tensor.slice");
+  const std::vector<ExprPtr> new_shape = ApplyDropDims(full_shape, drop_dims);
 
   // Read optional pad_value kwarg (default PadValue::null = no padding).
   PadValue pad_value = PadValue::null;
@@ -212,12 +224,31 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
     break;
   }
 
-  // View preserves dtype but has new shape (which can have different rank than input).
-  // If valid_shape is provided as 4th argument or pad_value is set, build a TensorView.
-  if (args.size() == 4) {
+  // valid_shape (4th arg): an empty MakeTuple means "no valid_shape" — that form
+  // exists so callers can pass drop_dims (5th arg) without a custom valid_shape.
+  bool has_valid_shape = false;
+  std::vector<ExprPtr> valid_shape;
+  if (args.size() >= 4) {
     auto valid_shape_tuple = As<MakeTuple>(args[3]);
     CHECK(valid_shape_tuple) << "tensor.slice valid_shape (4th argument) must be a MakeTuple";
-    TensorView tensor_view({}, TensorLayout::ND, valid_shape_tuple->elements_, pad_value);
+    if (!valid_shape_tuple->elements_.empty()) {
+      has_valid_shape = true;
+      if (drop_dims.empty()) {
+        valid_shape = valid_shape_tuple->elements_;
+      } else {
+        // valid_shape is given over the full (pre-reduction) rank; drop the same axes.
+        CHECK(valid_shape_tuple->elements_.size() == full_shape.size())
+            << "tensor.slice valid_shape rank " << valid_shape_tuple->elements_.size()
+            << " must match shape rank " << full_shape.size() << " when drop_dims is set";
+        valid_shape = ApplyDropDims(valid_shape_tuple->elements_, drop_dims);
+      }
+    }
+  }
+
+  // View preserves dtype but has new shape (which can have different rank than input).
+  // If valid_shape is provided or pad_value is set, build a TensorView.
+  if (has_valid_shape) {
+    TensorView tensor_view({}, TensorLayout::ND, valid_shape, pad_value);
     return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
                                         std::make_optional(std::move(tensor_view)));
   }
@@ -373,6 +404,8 @@ REGISTER_OP("tensor.slice")
     .add_argument("input", "Input tensor (TensorType)")
     .add_argument("shape", "New shape dimensions (TupleType of ScalarType(INT64))")
     .add_argument("offset", "Offset dimensions (TupleType of ScalarType(INT64))")
+    .add_argument("valid_shape", "Optional logical valid shape; an empty tuple means none")
+    .add_argument("drop_dims", "Optional axes (MakeTuple of ConstInt) erased from the result type")
     .set_output_memory_inherit_input()
     .set_attr<PadValue>("pad_value")
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -118,9 +119,15 @@ void ValidateIndexTupleElements(const TupleTypePtr& tuple_type, const std::strin
 
 TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.slice requires 3 arguments (input, shape, offset) with optional 4th (valid_shape)
-  CHECK(args.size() == 3 || args.size() == 4)
-      << "tile.slice requires 3 or 4 arguments (input, shape, offset[, valid_shape]), but got "
+  // tile.slice: (input, shape, offset[, valid_shape[, drop_dims]]).
+  //   - valid_shape (4th arg): an empty MakeTuple means "no valid_shape".
+  //   - drop_dims (5th arg): a MakeTuple of ConstInt listing axes to erase from
+  //     the result type (numpy-style rank reduction); each listed axis must be a
+  //     static unit dim of `shape`. An empty / absent operand drops nothing.
+  // Tile floor: tiles are physically 2D, so if rank reduction would take the
+  // result below 2D it is clamped back to 2D by prepending unit axes.
+  CHECK(args.size() >= 3 && args.size() <= 5)
+      << "tile.slice requires 3-5 arguments (input, shape, offset[, valid_shape[, drop_dims]]), but got "
       << args.size();
 
   // First argument must be TileType
@@ -162,24 +169,51 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
   }
 
   std::vector<ExprPtr> valid_shape = new_shape;
-  if (args.size() == 4) {
+  if (args.size() >= 4) {
     auto valid_shape_tuple_type = As<TupleType>(args[3]->GetType());
     CHECK(valid_shape_tuple_type) << "tile.slice requires valid_shape to be TupleType, but got "
                                   << args[3]->GetType()->TypeName();
-    ValidateIndexTupleElements(valid_shape_tuple_type, "tile.slice", "valid_shape");
-    CHECK(valid_shape_tuple_type->types_.size() == shape_tuple_type->types_.size())
-        << "tile.slice requires valid_shape and shape to have the same rank, but got valid_shape rank "
-        << valid_shape_tuple_type->types_.size() << " and shape rank " << shape_tuple_type->types_.size();
+    // An empty tuple is the explicit "no valid_shape" form (so callers can pass
+    // drop_dims as the 5th arg without supplying a custom valid_shape).
+    if (!valid_shape_tuple_type->types_.empty()) {
+      ValidateIndexTupleElements(valid_shape_tuple_type, "tile.slice", "valid_shape");
+      CHECK(valid_shape_tuple_type->types_.size() == shape_tuple_type->types_.size())
+          << "tile.slice requires valid_shape and shape to have the same rank, but got valid_shape rank "
+          << valid_shape_tuple_type->types_.size() << " and shape rank " << shape_tuple_type->types_.size();
 
-    valid_shape.clear();
-    valid_shape.reserve(valid_shape_tuple_type->types_.size());
-    if (auto valid_shape_tuple = As<MakeTuple>(args[3])) {
-      valid_shape = valid_shape_tuple->elements_;
-    } else {
-      for (size_t i = 0; i < valid_shape_tuple_type->types_.size(); ++i) {
-        valid_shape.emplace_back(
-            std::make_shared<TupleGetItemExpr>(args[3], static_cast<int>(i), args[3]->span_));
+      valid_shape.clear();
+      valid_shape.reserve(valid_shape_tuple_type->types_.size());
+      if (auto valid_shape_tuple = As<MakeTuple>(args[3])) {
+        valid_shape = valid_shape_tuple->elements_;
+      } else {
+        for (size_t i = 0; i < valid_shape_tuple_type->types_.size(); ++i) {
+          valid_shape.emplace_back(
+              std::make_shared<TupleGetItemExpr>(args[3], static_cast<int>(i), args[3]->span_));
+        }
       }
+    }
+  }
+
+  // Optional drop_dims (5th arg): axes erased from the result type, validated
+  // against the full pre-reduction shape. Apply to both the static shape and the
+  // valid_shape, then clamp back up to 2D (tiles are physically 2D) by prepending
+  // unit axes if the natural result would be < 2D.
+  const ExprPtr drop_dims_arg = args.size() == 5 ? args[4] : nullptr;
+  const std::vector<int64_t> drop_dims = ParseSliceDropDims(drop_dims_arg, new_shape, "tile.slice");
+  if (!drop_dims.empty()) {
+    new_shape = ApplyDropDims(new_shape, drop_dims);
+    valid_shape = ApplyDropDims(valid_shape, drop_dims);
+    if (new_shape.size() < 2) {
+      // Reuse the dtype of an existing static shape element for the synthetic unit axes.
+      auto first_dim = As<ConstInt>(shape_tuple->elements_[0]);
+      const DataType dim_dtype = first_dim->dtype();
+      const size_t pad = 2 - new_shape.size();
+      std::vector<ExprPtr> unit_axes(pad);
+      for (size_t i = 0; i < pad; ++i) {
+        unit_axes[i] = std::make_shared<ConstInt>(1, dim_dtype, args[1]->span_);
+      }
+      new_shape.insert(new_shape.begin(), unit_axes.begin(), unit_axes.end());
+      valid_shape.insert(valid_shape.begin(), unit_axes.begin(), unit_axes.end());
     }
   }
 
@@ -331,7 +365,12 @@ REGISTER_OP("tile.slice")
     .add_argument("input", "Input tile (TileType)")
     .add_argument("shape", "Static shape dimensions (TupleType of ScalarType(INT64/UINT64/INDEX))")
     .add_argument("offset", "Offset dimensions (TupleType of ScalarType(INT64/UINT64/INDEX))")
-    .add_argument("valid_shape", "Optional logical valid shape (TupleType of ScalarType(INT64/UINT64/INDEX))")
+    .add_argument("valid_shape",
+                  "Optional logical valid shape (TupleType of ScalarType(INT64/UINT64/INDEX)); "
+                  "an empty tuple means none")
+    .add_argument("drop_dims",
+                  "Optional axes (MakeTuple of ConstInt) erased from the result type; the result is "
+                  "clamped to 2D if reduction would take it below 2D")
     .set_output_memory_inherit_input()
     .set_attr<PadValue>("pad_value")
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -274,6 +274,60 @@ std::string FormatShape(const std::vector<ExprPtr>& shape) {
 }
 
 // ============================================================================
+// Slice rank-reduction (drop_dims) helpers
+// ============================================================================
+
+std::vector<int64_t> ParseSliceDropDims(const ExprPtr& drop_dims_arg, const std::vector<ExprPtr>& full_shape,
+                                        const std::string& op_name) {
+  if (!drop_dims_arg) {
+    return {};
+  }
+  auto tuple = As<MakeTuple>(drop_dims_arg);
+  CHECK(tuple) << op_name << " drop_dims must be a MakeTuple of compile-time int constants";
+
+  std::vector<int64_t> axes;
+  axes.reserve(tuple->elements_.size());
+  std::vector<bool> seen(full_shape.size(), false);
+  for (size_t i = 0; i < tuple->elements_.size(); ++i) {
+    auto const_int = As<ConstInt>(tuple->elements_[i]);
+    CHECK(const_int) << op_name << " drop_dims element " << i << " must be a compile-time int constant";
+    int64_t axis = const_int->value_;
+    CHECK(axis >= 0 && axis < static_cast<int64_t>(full_shape.size()))
+        << op_name << " drop_dims index " << axis << " out of range for rank " << full_shape.size();
+    CHECK(!seen[static_cast<size_t>(axis)]) << op_name << " drop_dims index " << axis << " is repeated";
+    seen[static_cast<size_t>(axis)] = true;
+    auto dim = GetConstantDimension(full_shape[static_cast<size_t>(axis)]);
+    CHECK(dim.has_value() && *dim == 1)
+        << op_name << " drop_dims index " << axis
+        << " must select a static unit dimension (rank reduction only erases size-1 dims), but dim " << axis
+        << " is " << (dim.has_value() ? std::to_string(*dim) : std::string("dynamic"));
+    axes.push_back(axis);
+  }
+  std::sort(axes.begin(), axes.end());
+  return axes;
+}
+
+std::vector<ExprPtr> ApplyDropDims(const std::vector<ExprPtr>& shape, const std::vector<int64_t>& drop_dims) {
+  if (drop_dims.empty()) {
+    return shape;
+  }
+  std::vector<bool> drop(shape.size(), false);
+  for (int64_t d : drop_dims) {
+    if (d >= 0 && d < static_cast<int64_t>(shape.size())) {
+      drop[static_cast<size_t>(d)] = true;
+    }
+  }
+  std::vector<ExprPtr> result;
+  result.reserve(shape.size() - drop_dims.size());
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (!drop[i]) {
+      result.push_back(shape[i]);
+    }
+  }
+  return result;
+}
+
+// ============================================================================
 // Cross-function call return type deduction
 // ============================================================================
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -15,6 +15,8 @@ each operation type, compiles them through the PassManager and PTOCodegen,
 and verifies the generated orchestration code.
 """
 
+import warnings
+
 import pypto.language as pl
 import pytest
 from pypto import DataType, backend, codegen, ir
@@ -839,6 +841,32 @@ class TestTileSliceCodegen:
         line = subview_lines[0]
         assert "sizes [16, 16]" in line, f"sizes attribute must be [16, 16], got:\n{line}"
         assert "rows=16, cols=16" in line, f"result tile_buf must carry rows=16, cols=16, got:\n{line}"
+
+    def test_tile_slice_codegen_rank_reducing(self):
+        """A rank-reducing tile subscript `t[i]` (→ tile.slice with drop_dims) reaches
+        PTO codegen and emits pto.subview — the result is clamped to 2D [1, N]."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[32, 32], pl.FP32],
+                dst: pl.Tensor[[1, 32], pl.FP32],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, 32], pl.FP32]:
+                src_tile: pl.Tile[[32, 32], pl.FP32] = pl.load(src, [0, 0], [32, 32])
+                row_tile: pl.Tile[[1, 32], pl.FP32] = src_tile[row]
+                return pl.store(row_tile, [0, 0], dst)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            mlir = self._generate_mlir(Prog)
+        assert "pto.subview" in mlir, f"rank-reducing tile.slice should generate pto.subview, got:\n{mlir}"
+        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
+        assert subview_lines and "sizes [1, 32]" in subview_lines[0], (
+            f"subview sizes attribute must be [1, 32], got:\n{subview_lines}"
+        )
 
     def test_tile_slice_codegen_with_valid_shape(self):
         """tile.slice(..., valid_shape=...) emits pto.subview + pto.tmov + pto.set_validshape."""

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1361,6 +1361,82 @@ def test_tensor_slice_with_valid_shape():
     assert len(result_type.tensor_view.valid_shape) == 2
 
 
+def test_tensor_slice_drop_dims_rank_reduces():
+    """tensor.slice drop_dims erases the listed unit axes from the result type."""
+    span = ir.Span.unknown()
+    tensor_type = ir.TensorType([64, 64, 64, 64], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.slice(tensor_var, [1, 1, 64, 64], [3, 5, 0, 0], drop_dims=[0, 1])
+
+    assert call.op.name == "tensor.slice"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [64, 64]
+    # shape / offset stay full-rank; drop_dims is the 5th operand (empty valid_shape 4th).
+    assert len(call.args) == 5
+
+
+def test_tensor_slice_drop_dims_drops_valid_shape_axes():
+    """drop_dims removes the same axes from a supplied valid_shape."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([64, 64, 64], DataType.FP32), span)
+
+    call = ir.op.tensor.slice(tensor_var, [1, 8, 64], [2, 0, 0], valid_shape=[1, 4, 64], drop_dims=[0])
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [8, 64]
+    assert result_type.tensor_view is not None
+    assert [d.value for d in result_type.tensor_view.valid_shape if isinstance(d, ir.ConstInt)] == [4, 64]
+
+
+def test_tensor_slice_drop_dims_rejects_non_unit_dim():
+    """drop_dims may only erase statically size-1 dimensions."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([64, 64], DataType.FP32), span)
+    with pytest.raises(ValueError, match="static unit dimension"):
+        ir.op.tensor.slice(tensor_var, [8, 64], [0, 0], drop_dims=[0])
+
+
+def test_tensor_slice_drop_dims_rejects_out_of_range():
+    """drop_dims indices must be within the slice rank."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([64, 64], DataType.FP32), span)
+    with pytest.raises(ValueError, match="out of range"):
+        ir.op.tensor.slice(tensor_var, [1, 64], [0, 0], drop_dims=[2])
+
+
+def test_tensor_slice_empty_drop_dims_is_backward_compatible():
+    """drop_dims=None / [] keeps the legacy 3-arg result type (no tensor_view)."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([64, 64], DataType.FP32), span)
+    call_none = ir.op.tensor.slice(tensor_var, [8, 16], [0, 0])
+    call_empty = ir.op.tensor.slice(tensor_var, [8, 16], [0, 0], drop_dims=[])
+    for call in (call_none, call_empty):
+        assert len(call.args) == 3
+        result_type = call.type
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+        assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [8, 16]
+
+
+def test_tensor_slice_drop_dims_print_parse_roundtrip():
+    """A drop_dims slice survives python_print -> pl.parse -> python_print."""
+    src = (
+        "import pypto.language as pl\n\n"
+        "@pl.program\n"
+        "class P:\n"
+        "    @pl.function\n"
+        "    def main(self, x: pl.Tensor[[64, 64, 64, 64], pl.FP32]) -> pl.Tensor[[64, 64], pl.FP32]:\n"
+        "        y: pl.Tensor[[64, 64], pl.FP32] = "
+        "pl.tensor.slice(x, [1, 1, 64, 64], [3, 5, 0, 0], drop_dims=[0, 1])\n"
+        "        return y\n"
+    )
+    prog = pl.parse(src)
+    reparsed = pl.parse(ir.python_print(prog))
+    ir.assert_structural_equal(reparsed, prog)
+
+
 def _make_slice_tensor_var():
     """Build a [16, 32] FP16 tensor Var for slice pad_value tests."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1090,6 +1090,63 @@ class TestTileSliceReshapeOps:
         with pytest.raises(ValueError, match="compile-time constant"):
             tile.slice(tile_var, [8, valid_n], [0, 0])
 
+    def test_tile_slice_drop_dims_rank_reduces(self):
+        """tile.slice drop_dims erases the listed unit axes from the result type."""
+        span = ir.Span.unknown()
+        tile_var = ir.Var("tile", ir.TileType([64, 64, 64, 64], DataType.FP16), span)
+
+        call = tile.slice(tile_var, [1, 64, 64, 64], [3, 0, 0, 0], drop_dims=[0])
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [64, 64, 64]
+        # shape / offset stay full-rank; drop_dims is the 5th operand.
+        assert len(call.args) == 5
+
+    def test_tile_slice_drop_dims_clamps_to_2d(self):
+        """A natural sub-2D result is clamped back to 2D by prepending unit axes."""
+        span = ir.Span.unknown()
+        tile_var = ir.Var("tile", ir.TileType([64, 64, 64, 64], DataType.FP16), span)
+
+        call = tile.slice(tile_var, [1, 1, 1, 64], [1, 2, 3, 0], drop_dims=[0, 1, 2])
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [1, 64]
+
+    def test_tile_slice_drop_dims_rejects_non_unit_dim(self):
+        """tile.slice drop_dims may only erase statically size-1 dimensions."""
+        span = ir.Span.unknown()
+        tile_var = ir.Var("tile", ir.TileType([64, 64], DataType.FP16), span)
+        with pytest.raises(ValueError, match="static unit dimension"):
+            tile.slice(tile_var, [8, 64], [0, 0], drop_dims=[0])
+
+    def test_tile_slice_empty_drop_dims_is_backward_compatible(self):
+        """drop_dims=None / [] keeps the legacy 3-arg behavior."""
+        span = ir.Span.unknown()
+        tile_var = ir.Var("tile", ir.TileType([16, 32], DataType.FP16), span)
+        call_none = tile.slice(tile_var, [8, 16], [0, 0])
+        call_empty = tile.slice(tile_var, [8, 16], [0, 0], drop_dims=[])
+        for call in (call_none, call_empty):
+            assert len(call.args) == 3
+            result_type = call.type
+            assert isinstance(result_type, ir.TileType)
+            assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [8, 16]
+
+    def test_tile_slice_drop_dims_print_parse_roundtrip(self):
+        """A drop_dims tile slice survives python_print -> pl.parse -> python_print."""
+        src = (
+            "import pypto.language as pl\n\n"
+            "@pl.program\n"
+            "class Q:\n"
+            "    @pl.function\n"
+            "    def main(self, x: pl.Tile[[64, 64, 64, 64], pl.FP16]) -> pl.Tile[[1, 64], pl.FP16]:\n"
+            "        y: pl.Tile[[1, 64], pl.FP16] = "
+            "pl.tile.slice(x, [1, 1, 1, 64], [1, 2, 3, 0], drop_dims=[0, 1, 2])\n"
+            "        return y\n"
+        )
+        prog = pl.parse(src)
+        reparsed = pl.parse(ir.python_print(prog))
+        ir.assert_structural_equal(reparsed, prog)
+
     @staticmethod
     def _make_slice_tile_var():
         """Build a [16, 32] FP16 tile Var for slice pad_value tests."""

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -502,18 +502,64 @@ class TestTensorSubscriptWrite:
                 out[0:16:2, :] = src
                 return out
 
-    def test_tensor_subscript_write_wrong_rank(self):
-        """A[0:16] = src on a 2D tensor must reject (rank mismatch)."""
+    def test_tensor_subscript_write_too_many_indices(self):
+        """A[i, j, k] = src on a 2D tensor must reject (more indices than rank)."""
 
-        with pytest.raises(ParserTypeError, match="2 indices"):
+        with pytest.raises(ParserTypeError, match="3 indices but the tensor is 2D"):
 
             @pl.function
-            def bad_rank(
+            def too_many(
                 out: pl.Tensor[[64, 128], pl.FP32],
-                src: pl.Tensor[[16, 128], pl.FP32],
+                src: pl.Tensor[[1, 128], pl.FP32],
             ) -> pl.Tensor[[64, 128], pl.FP32]:
-                out[0:16] = src
+                out[0, 0, 0] = src
                 return out
+
+    def test_tensor_subscript_write_partial(self):
+        """A[0:16] = src on a 2D tensor writes rows 0..16 (trailing axis implicit ':')."""
+
+        @pl.function
+        def partial_write(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 128], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            out[0:16] = src
+            return out
+
+        printed = partial_write.as_python()
+        assert "tensor.assemble" in printed
+
+    def test_tensor_subscript_write_rank_reducing(self):
+        """C[i, j] = rhs2d on a 4D tensor lowers the rhs into a [1, 1, 64, 64] window."""
+
+        @pl.function
+        def reduce_write(
+            C: pl.Tensor[[64, 64, 64, 64], pl.FP32],
+            rhs: pl.Tensor[[64, 64], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 64, 64, 64], pl.FP32]:
+            C[i, j] = rhs
+            return C
+
+        printed = reduce_write.as_python()
+        assert "tensor.assemble" in printed
+        assert "tensor.reshape" in printed  # rhs lifted to the full-rank window
+
+    def test_tensor_subscript_write_rank_reducing_bad_source_rank(self):
+        """C[i, j] = rhs with the wrong rhs rank is rejected."""
+
+        with pytest.raises(ParserTypeError, match="must be 2D to match"):
+
+            @pl.function
+            def bad_src(
+                C: pl.Tensor[[64, 64, 64, 64], pl.FP32],
+                rhs: pl.Tensor[[64, 64, 64], pl.FP32],
+                i: pl.Scalar[pl.INDEX],
+                j: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64, 64, 64, 64], pl.FP32]:
+                C[i, j] = rhs
+                return C
 
     def test_tensor_subscript_write_element_form_unsupported(self):
         """A[i, j] = scalar must be rejected for now (no element-write op wiring)."""

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -9,6 +9,7 @@
 
 """Unit tests for subscript syntax on Tensor and Tile types."""
 
+import warnings
 from typing import cast
 
 import pypto.language as pl
@@ -592,7 +593,7 @@ class TestTensorSubscriptWrite:
     def test_tensor_subscript_write_shape_mismatch_static(self):
         """Static shape mismatch on a slice axis must be reported with axis + extents."""
 
-        with pytest.raises(ParserTypeError, match="shape mismatch on axis 0"):
+        with pytest.raises(ParserTypeError, match="shape mismatch on source axis 0"):
 
             @pl.function
             def bad_shape(
@@ -605,7 +606,7 @@ class TestTensorSubscriptWrite:
     def test_tensor_subscript_write_full_axis_shape_mismatch(self):
         """`out[:, :] = src` requires src to fill the target shape exactly."""
 
-        with pytest.raises(ParserTypeError, match="shape mismatch on axis 1"):
+        with pytest.raises(ParserTypeError, match="shape mismatch on source axis 1"):
 
             @pl.function
             def bad_full(
@@ -647,7 +648,7 @@ class TestTensorSubscriptWrite:
     def test_tensor_subscript_write_symbolic_extent_simplifies_mismatch(self):
         """``out[i:i+8, ...] = src`` simplifies to 8 — must reject when src has 16."""
 
-        with pytest.raises(ParserTypeError, match="shape mismatch on axis 0"):
+        with pytest.raises(ParserTypeError, match="shape mismatch on source axis 0"):
 
             @pl.function
             def bad_symbolic(
@@ -704,6 +705,29 @@ class TestTileSubscriptWrite:
         offset_tuple = assemble_stmt.value.args[2]
         assert isinstance(offset_tuple, ir.MakeTuple)
         assert [cast(ir.ConstInt, e).value for e in offset_tuple.elements] == [0, 0]
+
+    def test_tile_subscript_write_rank_reducing_row(self):
+        """t2d[i] = row_tile (a [1, N] tile, the only shape tile indexing produces)
+        is accepted — the tile 2D-floor is taken into account when checking rhs rank."""
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # the t[j] read auto-promotes to [1, N] + warns
+
+            @pl.function
+            def write_row(
+                x: pl.Tensor[[64, 128], pl.FP32],
+                i: pl.Scalar[pl.INDEX],
+                j: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128])
+                row: pl.Tile[[1, 128], pl.FP32] = t[j]  # a [1, 128] view
+                t[i] = row
+                return pl.store(t, [0, 0], x)
+
+        printed = write_row.as_python()
+        # window [1, 128] == rhs shape [1, 128], so no reshape is inserted.
+        assert "tile.assemble" in printed
+        assert "tile.reshape" not in printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -76,12 +76,12 @@ class TestTensorSubscript:
         assert "tensor.slice" in printed
 
     def test_tensor_mixed_subscript(self):
-        """A[0:16, 0] with mixed int and slice -> tensor.slice with shape [16, 1]."""
+        """A[0:16, 0] with mixed int and slice -> tensor.slice, scalar axis dropped -> [16]."""
 
         @pl.function
         def mixed_sub(
             A: pl.Tensor[[64, 128], pl.FP32],
-        ) -> pl.Tensor[[16, 1], pl.FP32]:
+        ) -> pl.Tensor[[16], pl.FP32]:
             return A[0:16, 0]
 
         assert isinstance(mixed_sub, ir.Function)
@@ -113,15 +113,74 @@ class TestTensorSubscript:
             ) -> pl.Tensor[[8, 128], pl.FP32]:
                 return A[0:16:2, :]
 
-    def test_tensor_subscript_wrong_rank(self):
-        """A[0] on a 2D tensor -> error (rank mismatch)."""
-        with pytest.raises(ParserTypeError, match="2 indices"):
+    def test_tensor_subscript_too_many_indices(self):
+        """A[i, j, k] on a 2D tensor -> error (more indices than rank)."""
+        with pytest.raises(ParserTypeError, match="3 indices but the tensor is 2D"):
 
             @pl.function
-            def bad_rank(
+            def too_many(
                 A: pl.Tensor[[64, 128], pl.FP32],
             ) -> pl.Tensor[[64, 128], pl.FP32]:
-                return A[0]
+                return A[0, 0, 0]
+
+    def test_tensor_partial_index_rank_reduces(self):
+        """A[i] on a 2D tensor -> a 1D view (dim 0 dropped)."""
+
+        @pl.function
+        def partial(
+            A: pl.Tensor[[64, 128], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[128], pl.FP32]:
+            return A[i]
+
+        printed = partial.as_python()
+        assert "tensor.slice" in printed
+        assert "[], [0])" in printed  # drop_dims operand
+
+    def test_tensor_chained_index(self):
+        """C[i][j] on a 4D tensor -> two rank-reducing slices, result 2D."""
+
+        @pl.function
+        def chained(
+            C: pl.Tensor[[64, 64, 64, 64], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            return C[i][j]
+
+        printed = chained.as_python()
+        # Chained indexing lowers to nested slices (C[i] is a 3D view, then [j]).
+        assert printed.count("tensor.slice") == 2
+
+    def test_tensor_two_index_partial(self):
+        """C[i, j] on a 4D tensor -> a single rank-reducing slice, result 2D."""
+
+        @pl.function
+        def two_index(
+            C: pl.Tensor[[64, 64, 64, 64], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            return C[i, j]
+
+        printed = two_index.as_python()
+        assert printed.count("tensor.slice") == 1
+        assert "[], [0, 1])" in printed  # drop_dims operand
+
+    def test_tensor_mixed_slice_and_scalar(self):
+        """C[i:i+8, j] on a 4D tensor -> [8, 64, 64] view (dim 1 dropped)."""
+
+        @pl.function
+        def mixed(
+            C: pl.Tensor[[64, 64, 64, 64], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[8, 64, 64], pl.FP32]:
+            return C[i : i + 8, j]
+
+        printed = mixed.as_python()
+        assert "tensor.slice" in printed
+        assert "[], [1])" in printed  # drop_dims operand
 
 
 class TestTileSubscript:
@@ -282,17 +341,33 @@ class TestTileSubscript:
         printed = read_var.as_python()
         assert "tile.read" in printed
 
-    def test_tile_read_wrong_rank(self):
-        """A[0] on a 2D tile -> error (rank mismatch)."""
-        with pytest.raises(ParserTypeError, match="2 indices"):
+    def test_tile_subscript_too_many_indices(self):
+        """t[i, j, k] on a 2D tile -> error (more indices than rank)."""
+        with pytest.raises(ParserTypeError, match="3 indices but the tile is 2D"):
 
             @pl.function
-            def bad_rank(
+            def too_many(
                 x: pl.Tensor[[64, 128], pl.FP32],
             ) -> pl.Tensor[[64, 128], pl.FP32]:
                 t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128])
-                _elem: pl.Scalar[pl.FP32] = t[0]
-                return pl.store(t, [0, 0], x)
+                bad: pl.Tile[[1, 128], pl.FP32] = t[0, 0, 0]
+                return pl.store(bad, [0, 0], x)
+
+    def test_tile_partial_index_auto_promotes_to_2d(self):
+        """t[i] on a 2D tile -> a [1, 128] view (dim 0 dropped, clamped to 2D) + warning."""
+        with pytest.warns(UserWarning, match="auto-promoting to 2D shape"):
+
+            @pl.function
+            def partial(
+                x: pl.Tensor[[64, 128], pl.FP32],
+                i: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128])
+                row: pl.Tile[[1, 128], pl.FP32] = t[i]
+                return pl.store(row, [0, 0], x)
+
+        printed = partial.as_python()
+        assert "tile.slice" in printed
 
     def test_tile_subscript_step_error(self):
         """A[0:16:2, :] with step on tile should raise error."""


### PR DESCRIPTION
Implements RFC #1338 — numpy/torch-style rank-reducing / partial / chained indexing for `Tensor` and `Tile` in the PyPTO DSL — via an optional `drop_dims` operand on the existing `tensor.slice` / `tile.slice` ops. Delivered phase by phase; each commit is self-contained, tested (`tests/ut/` green), and code-reviewed.

### What works now

- `C[i, j, k, l]` (all scalar, full rank) → scalar (`tensor.read` / `tile.read`) — unchanged
- `C[i, j]` (partial) → `64×64` view (dims 0,1 dropped)
- `C[i]` → `64×64×64` view; `C[i][j]` (chained) → composes to a `64×64` view
- `C[i:i+8, j]` (mixed) → `8×64×64` view; trailing dims are implicit `:`
- Tile floor: a tile result that would naturally be `< 2D` is auto-promoted to `[1, N]` with a non-fatal warning
- LHS: `C[i, j] = rhs` reshapes `rhs` up to the full-rank window before `tensor.assemble` / `tile.assemble`
- Restrictions retained (no `step`, static-foldable tile lower bounds, no ellipsis/None/negative/advanced indexing); too-many-indices errors; chained writes `C[i][j] = rhs` not yet supported

### Commits

1. `feat(ir): Add drop_dims to tensor.slice / tile.slice for rank reduction` — C++ deducers + shared `ParseSliceDropDims`/`ApplyDropDims` helpers + op-registry docs + `python/pypto/ir/op/` & `python/pypto/language/op/` wrappers + op-level tests + print/parse round-trip.
2. `feat(language): numpy-style rank-reducing / partial / chained subscript indexing` — parser read path; updated `qwen3_jit/kernels/attention.py` (`rope_cos[pos:pos+1, ...]` to keep the 2D operand `col_expand_mul` needs).
3. `feat(language): rank-reducing subscript-write for Tensor & Tile` — parser LHS path.
4. `docs(language): document numpy-style rank-reducing subscript indexing` — `docs/{en,zh-cn}/dev/language/00-python_syntax.md` + `docs/en/dev/ir/05-operators.md`.

### Codegen status / follow-up

The common path — a 2D-tile partial index (`t[i]` → `[1, N]`) — compiles end-to-end through the pass pipeline (the `drop_dims` attr is informational once the result type is already 2D). **Not yet handled / tested**, and recommended as a follow-up:
- `tensor.slice` with `drop_dims` at the orchestration layer (the emitted runtime `.view(shapes, offsets)` is full-rank; the result `Tensor` would need reduced rank).
- `tile.slice` with `drop_dims` producing a `>2D` result from a `>2D` tile (`FlattenTileNdTo2D` needs to remap/clear `drop_dims` when it collapses the tile to 2D).

`drop_dims=None`/`[]` keeps the 3-/4-arg call forms exactly as before, so the change is backward compatible at the IR level.

Fixes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)