### PR TITLE
chore(runtime): bump simpler submodule, adapt L2 cid ABI

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -558,7 +558,11 @@ def execute_on_device(
             return
         worker = Worker(level=level, device_id=device_id, platform=platform, runtime=runtime_name)
         worker.init()
-        worker.run(chip_callable, orch_args, cfg)
+        # Simpler's L2 ABI now dispatches by callable id (see runtime PR #710);
+        # register the callable, run it, then close — close() runs finalize()
+        # so explicit unregister is unnecessary here.
+        cid = worker.register(chip_callable)
+        worker.run(cid, orch_args, cfg)
         worker.close()
 
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -326,10 +326,19 @@ def execute_distributed(  # noqa: PLR0912
         chip_bootstrap_configs=chip_bootstrap_configs,
     )
 
-    # 6. Register SubWorker callables
+    # 6. Register SubWorker callables and ChipCallables. Both must happen
+    # before w.init() so the L3 fork inherits the registry via COW (see
+    # runtime PR #710); the emitted host_orch.py then dispatches via cids
+    # — `orch.submit_sub(sub_ids[name], …)` and
+    # `orch.submit_next_level(callables[name], …)` — both indexing into
+    # name→cid dicts.
     sub_ids: dict[str, int] = {}
     for name, fn in sub_worker_fns.items():
         sub_ids[name] = w.register(fn)
+
+    chip_cids: dict[str, int] = {}
+    for name, chip_callable in chip_callables.items():
+        chip_cids[name] = w.register(chip_callable)
 
     w.init()
 
@@ -345,7 +354,7 @@ def execute_distributed(  # noqa: PLR0912
             _unused_args,
             call_config,
             tensors=tensors,
-            callables=chip_callables,
+            callables=chip_cids,
             sub_ids=sub_ids,
             _keep=_keep,
             contexts=w.chip_contexts,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -120,6 +120,12 @@ class Worker:
             runtime=runtime,
         )
         self._initialized = False
+        # Maps id(chip_callable) -> cid returned by simpler Worker.register().
+        # Simpler's L2 ABI now requires every ChipCallable to be registered
+        # before dispatch (see runtime PR #710); we cache per-callable cids
+        # so repeated runs of the same compiled program inside one
+        # `with Worker:` block re-use the same registration.
+        self._cid_cache: dict[int, int] = {}
 
         if auto_init is None:
             auto_init = level == 2
@@ -141,6 +147,12 @@ class Worker:
         """Release device state. Idempotent. The Worker may be re-``init()``'d."""
         if not self._initialized:
             return
+        # Drop per-cid host-side state before tearing down the device so
+        # the underlying ChipWorker.finalize() doesn't observe stale
+        # registrations on a re-init().
+        for cid in self._cid_cache.values():
+            self._impl.unregister_callable(cid)
+        self._cid_cache.clear()
         self._impl.close()
         self._initialized = False
 
@@ -325,7 +337,12 @@ class Worker:
     def _run_chip(self, chip_callable: Any, orch_args: Any, cfg: Any) -> None:
         if not self._initialized:
             raise RuntimeError("Worker is not initialized; call init() or use `with worker:`")
-        self._impl.run(chip_callable, orch_args, cfg)
+        key = id(chip_callable)
+        cid = self._cid_cache.get(key)
+        if cid is None:
+            cid = self._impl.register(chip_callable)
+            self._cid_cache[key] = cid
+        self._impl.run(cid, orch_args, cfg)
 
     # ------------------------------------------------------------------
     # Context manager — publishes ``self`` on the active stack


### PR DESCRIPTION
## Summary

- Bump the `runtime/` submodule from `b733b133` to `5a76f4f8` (32 commits).
- Adapt pypto's two L2 dispatch sites to the new simpler ABI introduced in runtime PR [#710](https://github.com/hw-native-sys/simpler/pull/710) (\`feat(callable): prepared callable\`): \`Worker.run()\` now takes a \`cid\` returned from \`Worker.register(chip_callable)\` instead of the \`ChipCallable\` itself.

## Why this matters

Simpler 5a76f4f8 changed L2 dispatch at the Python wrapper layer:

\`\`\`python
# Before
worker.run(chip_callable, args, cfg)

# After
cid = worker.register(chip_callable)
worker.run(cid, args, cfg)
\`\`\`

Internally \`Worker.run\` now does \`self._chip_worker.run_prepared(int(callable), args, cfg)\`, so passing a \`ChipCallable\` would \`TypeError\` on \`int(callable)\`. Without this PR, every device run from pypto on the new runtime would fail.

The underlying \`ChipWorker.init(...)\` signature also changed (\`init(device_id, bins)\` instead of \`init(host_path, aicpu_path, ...) + set_device(...)\`), but pypto never calls \`ChipWorker\` directly — only the high-level \`simpler.worker.Worker\` — so no change is needed there. Likewise the C++ side is unaffected because pypto does not link against simpler.

## What changed

- **\`python/pypto/runtime/device_runner.py\`** (one-shot path): \`worker.init()\` → \`worker.register(chip_callable)\` → \`worker.run(cid, args, cfg)\` → \`worker.close()\`. \`close()\` runs \`finalize()\` so no explicit \`unregister_callable\` here.
- **\`python/pypto/runtime/worker.py\`** (\`pypto.runtime.Worker\` reuse path): add a per-Worker \`id(chip_callable) -> cid\` cache. \`_run_chip\` registers on cache miss and reuses on hit; \`close()\` drains the cache via \`unregister_callable\` so a re-\`init()\` starts with a clean cid space (simpler's MAX_REGISTERED_CALLABLE_IDS=64).

## What did not change

- All other pypto re-exports from simpler remain compatible: \`CallConfig\`, \`ChipCallable\`, \`ChipStorageTaskArgs\`, \`ContinuousTensor\`, \`CoreCallable\`, \`DataType\`, \`scalar_to_uint64\`, \`make_tensor_arg\`, \`torch_dtype_to_datatype\`, \`PROJECT_ROOT\`, \`simpler_setup.tools.swimlane_converter\`.
- pypto C++ headers / bindings (cmake build is green against the new submodule).
- Optional new fields (\`CallConfig.enable_dep_gen\`, \`Worker.aicpu_dlopen_count\`, \`Worker.host_dlopen_count\`) are not consumed yet.

## Test plan

- [x] \`cmake --build build --parallel\` green against new runtime
- [x] \`PYTHONPATH=python python -m pytest tests/ut/runtime/\` — 72 passed, 15 skipped (skipped require \`simpler\` install). Existing MagicMock-based reuse tests still pass; they assert init/close/run counts which the cid wrapping does not change.
- [ ] End-to-end run on hardware against simpler 5a76f4f8 — needs a device-attached environment; not exercised here.